### PR TITLE
Xeno Tweaks

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -467,7 +467,7 @@
 	required_enemies = list(2,2,1,1,1,1,1,0,0,0)
 	required_candidates = 1
 	minimum_round_time = 40 MINUTES
-	weight = 5
+	weight = 4 //monkestation edit: from 5 to 4
 	cost = 10
 	minimum_players = 25
 	repeatable = TRUE

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -274,8 +274,8 @@
 	if(!.)
 		return
 
-	if((user.istate & ISTATE_SECONDARY)) //Always drop item in hand, if no item, get stun instead.
-		var/obj/item/I = get_active_held_item()
+	if((user.istate & ISTATE_SECONDARY)) //Always drop item in hand, if no item, get stun instead. //monkestation edit: now deal stam damage and knockdown instead
+/*		var/obj/item/I = get_active_held_item()
 		if(I && dropItemToGround(I))
 			playsound(loc, 'sound/weapons/slash.ogg', 25, TRUE, -1)
 			visible_message(span_danger("[user] disarms [src]!"), \
@@ -287,7 +287,16 @@
 			log_combat(user, src, "tackled")
 			visible_message(span_danger("[user] tackles [src] down!"), \
 							span_userdanger("[user] tackles you down!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), null, user)
-			to_chat(user, span_danger("You tackle [src] down!"))
+			to_chat(user, span_danger("You tackle [src] down!"))*/
+		playsound(loc, 'sound/weapons/pierce.ogg', 25, TRUE, -1) //monkestation edit start
+		Knockdown(2 SECONDS)
+		log_combat(user, src, "tackled")
+		visible_message(span_danger("[user] tackles [src] down!"), \
+						span_userdanger("[user] tackles you down!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), null, user)
+		to_chat(user, span_danger("You tackle [src] down!"))
+		var/obj/item/bodypart/affecting = get_bodypart(get_random_valid_zone(user.zone_selected))
+		var/armor_block = run_armor_check(affecting, MELEE,"","",10)
+		apply_damage(30, STAMINA, affecting, armor_block) //monkestation edit end
 		return TRUE
 
 	if((user.istate & ISTATE_HARM))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -294,7 +294,7 @@
 		visible_message(span_danger("[user] tackles [src] down!"), \
 						span_userdanger("[user] tackles you down!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), null, user)
 		to_chat(user, span_danger("You tackle [src] down!"))
-		h_mon.stamina.adjust(-30) //monkestation edit end
+		stamina.adjust(-30) //monkestation edit end
 		return TRUE
 
 	if((user.istate & ISTATE_HARM))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -294,9 +294,7 @@
 		visible_message(span_danger("[user] tackles [src] down!"), \
 						span_userdanger("[user] tackles you down!"), span_hear("You hear aggressive shuffling followed by a loud thud!"), null, user)
 		to_chat(user, span_danger("You tackle [src] down!"))
-		var/obj/item/bodypart/affecting = get_bodypart(get_random_valid_zone(user.zone_selected))
-		var/armor_block = run_armor_check(affecting, MELEE,"","",10)
-		apply_damage(30, STAMINA, affecting, armor_block) //monkestation edit end
+		h_mon.stamina.adjust(-30) //monkestation edit end
 		return TRUE
 
 	if((user.istate & ISTATE_HARM))

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -17,6 +17,7 @@
 			h_mob.stamina.adjust(-40) //monkestation edit
 	return ..()
 
+
 /obj/projectile/neurotoxin/damaging //for ai controlled aliums
 	damage = 30
 	paralyze = 0 SECONDS

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -13,7 +13,7 @@
 		damage = 0
 	if(ishuman(target)) //monkestation edit
 		var/mob/living/carbon/human/h_mob = target //monkestation edit
-		if(h_mob.can_inject()) //monkestation edi
+		if(h_mob.can_inject()) //monkestation edit
 			h_mob.adjustStaminaLoss(40) //monkestation edit
 	return ..()
 

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -3,14 +3,18 @@
 	icon_state = "neurotoxin"
 	damage = 5
 	damage_type = TOX
-	paralyze = 10 SECONDS
+	knockdown = 2 SECONDS //monkestation edit: replaced 10 second paralyze with thise
 	armor_flag = BIO
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/neurotoxin
 
 /obj/projectile/neurotoxin/on_hit(atom/target, blocked = FALSE)
 	if(isalien(target))
-		paralyze = 0 SECONDS
+		knockdown = 0 SECONDS //monkestation edit: from paralyze to knockdown
 		damage = 0
+	if(ishuman(target)) //monkestation edit
+		var/mob/living/carbon/human/h_mob = target //monkestation edit
+		if(h_mob.can_inject()) //monkestation edi
+			h_mob.adjustStaminaLoss(40) //monkestation edit
 	return ..()
 
 /obj/projectile/neurotoxin/damaging //for ai controlled aliums

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -14,7 +14,7 @@
 	if(ishuman(target)) //monkestation edit
 		var/mob/living/carbon/human/h_mob = target //monkestation edit
 		if(h_mob.can_inject()) //monkestation edit
-			h_mob.adjustStaminaLoss(40) //monkestation edit
+			h_mob.apply_damage_type(40, STAMINA) //monkestation edit
 	return ..()
 
 /obj/projectile/neurotoxin/damaging //for ai controlled aliums

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -14,7 +14,7 @@
 	if(ishuman(target)) //monkestation edit
 		var/mob/living/carbon/human/h_mob = target //monkestation edit
 		if(h_mob.can_inject()) //monkestation edit
-			h_mon.stamina.adjust(-40) //monkestation edit
+			h_mob.stamina.adjust(-40) //monkestation edit
 	return ..()
 
 /obj/projectile/neurotoxin/damaging //for ai controlled aliums

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -14,7 +14,7 @@
 	if(ishuman(target)) //monkestation edit
 		var/mob/living/carbon/human/h_mob = target //monkestation edit
 		if(h_mob.can_inject()) //monkestation edit
-			h_mob.apply_damage_type(40, STAMINA) //monkestation edit
+			h_mon.stamina.adjust(-40) //monkestation edit
 	return ..()
 
 /obj/projectile/neurotoxin/damaging //for ai controlled aliums


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes xeno stuns(shoves and neurotoxin) into what they are on bee, also reduces the midround weight of xenos by 1.

## Why It's Good For The Game

TG xenos are by design near impossible to fight, however, that's not very fun for the crew.
Xenos are the only 5 weight midround besides nukies, who have a very high requirement. This effectively just makes other midrounds roll slightly more.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Xeno shoves and neurotoxin spit are now the same as on beestation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
