### PR TITLE
Update golem_roles.dm

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/golem_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/golem_roles.dm
@@ -73,7 +73,7 @@
 		var/mob/living/carbon/human/human_spawn = new_spawn
 		human_spawn.set_cloned_appearance()
 
-///obj/effect/mob_spawn/ghost_role/human/golem/proc/try_keep_home(mob/new_spawn)
+/obj/effect/mob_spawn/ghost_role/human/golem/proc/try_keep_home(mob/new_spawn)
 //	var/static/list/allowed_areas = typecacheof(list(/area/icemoon, /area/lavaland, /area/ruin)) + typecacheof(/area/misc/survivalpod)
 // this is dumb, im removing it.
 //	ADD_TRAIT(new_spawn, TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION, INNATE_TRAIT)

--- a/code/modules/mob_spawn/ghost_roles/golem_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/golem_roles.dm
@@ -73,11 +73,11 @@
 		var/mob/living/carbon/human/human_spawn = new_spawn
 		human_spawn.set_cloned_appearance()
 
-/obj/effect/mob_spawn/ghost_role/human/golem/proc/try_keep_home(mob/new_spawn)
-	var/static/list/allowed_areas = typecacheof(list(/area/icemoon, /area/lavaland, /area/ruin)) + typecacheof(/area/misc/survivalpod)
-
-	ADD_TRAIT(new_spawn, TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION, INNATE_TRAIT)
-	new_spawn.AddComponent(/datum/component/hazard_area, area_whitelist = allowed_areas)
+///obj/effect/mob_spawn/ghost_role/human/golem/proc/try_keep_home(mob/new_spawn)
+//	var/static/list/allowed_areas = typecacheof(list(/area/icemoon, /area/lavaland, /area/ruin)) + typecacheof(/area/misc/survivalpod)
+// this is dumb, im removing it.
+//	ADD_TRAIT(new_spawn, TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION, INNATE_TRAIT)
+//	new_spawn.AddComponent(/datum/component/hazard_area, area_whitelist = allowed_areas)
 
 /obj/effect/mob_spawn/ghost_role/human/golem/attack_hand(mob/user, list/modifiers)
 	. = ..()


### PR DESCRIPTION
removes a dumb restriction that makes golems who are already very slow, 4 times slower because they dared to be near mining outpost or likewise...also it works by calling a component every time the user tries an action, so performance.
....supposedly, i could be dumb of course.