### PR TITLE
Better Boots For Miners, Better Bags For All

### DIFF
--- a/code/datums/storage/subtypes/pockets.dm
+++ b/code/datums/storage/subtypes/pockets.dm
@@ -74,6 +74,8 @@
 /datum/storage/pockets/shoes/New()
 	. = ..()
 	set_holdable(list(
+		/obj/item/t_scanner/adv_mining_scanner,
+		/obj/item/t_scanner/adv_mining_scanner/lesser,
 		/obj/item/knife,
 		/obj/item/switchblade,
 		/obj/item/boxcutter,

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -19,8 +19,8 @@
 
 //  Generic non-item
 /obj/item/storage/bag
-	slot_flags = ITEM_SLOT_BELT
-	w_class = WEIGHT_CLASS_BULKY
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
+	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/storage/bag/Initialize(mapload)
 	. = ..()
@@ -121,8 +121,6 @@
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "satchel"
 	worn_icon_state = "satchel"
-	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
-	w_class = WEIGHT_CLASS_NORMAL
 	///If this is TRUE, the holder won't receive any messages when they fail to pick up ore through crossing it
 	var/spam_protection = FALSE
 	var/mob/listeningTo
@@ -521,7 +519,6 @@
 	icon_state = "construction_bag"
 	worn_icon_state = "construction_bag"
 	desc = "A bag for storing small construction components."
-	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
 	resistance_flags = FLAMMABLE
 
 /obj/item/storage/bag/construction/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request

Reverts Boots (Somewhat) And Bags To How They Used To Be.
Boots can now also hold both types of automatic mining scanners (not manual)
All bags (plant, mining, construction, xenobio etc) now count as normal weight items (from bulky) and fit in pockets

## Why It's Good For The Game

On bee, boots could hold scanners which was a important space save for miners
Also on bee all bags were normal sized and could fit in pockets... Tg made all of them (except mining satchels) bulky... and belt only.
This also helps prepare for when I start adding more incentives to mining to interact with the station, As ill be including a new bag type, new plants, and other stuff to carry back, that nobody will want to carry back if they are required to use a bulky, belt only plant bag.

## Changelog
:cl:
balance: All bag types (plants, mining, xenobio, etc) are now normal sized items and fit in pockets and bags
balance: Mining scanners (automatic ones only) now fit into boots! Miners Rejoice!
/:cl:
