### PR TITLE
Takes the meathook shotgun out of tendrils and portals...

### DIFF
--- a/code/game/objects/structures/icemoon/cave_entrance.dm
+++ b/code/game/objects/structures/icemoon/cave_entrance.dm
@@ -162,7 +162,7 @@ GLOBAL_LIST_INIT(ore_probability, list(
 			new /obj/item/borg/upgrade/modkit/lifesteal(loc)
 			new /obj/item/bedsheet/cult(loc)
 		if(13)
-			new /obj/item/gun/ballistic/shotgun/hook(loc)
+			new /obj/item/gun/magic/hook (loc)
 		if(14)
 			new /obj/item/guardiancreator/miner(loc)
 		if(15)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -32,7 +32,7 @@
 		if(6)
 			new /obj/item/clothing/gloves/gauntlets(src)
 		if(7)
-			new /obj/item/gun/ballistic/shotgun/hook(src)
+			new /obj/item/gun/magic/hook (src)
 		if(8)
 			new /obj/item/rod_of_asclepius(src)
 		if(9)


### PR DESCRIPTION

## About The Pull Request

Yeah so... when I adjusted the tendril and portal drops, I thought "hey why not replace the disk drops with the meathook shotgun...

...Yeah I clearly didn't think that through, as I realize now its not only better than the chef traitors meathook (which ill add originated from tendrils) because it not only has the meathook part, it also has four shots total, semi auto...

So im just going... to replace it with the regular meathook... yeahh... my bad...

## Why It's Good For The Game

Four round semi auto shotgun with a stunning meathook shot is... comically overpowered honestly
I don't know why I put it in there... never should have sorry...
Replaces it with standard meathook because that has actual utility on lavaland and doesn't come with the comically strong shotgun part that has no use other than killing people

## Changelog
:cl:
del: Removed the meathook shotgun from tendrils and portals... oops how'd that get in there?
add: adds the meathook back into tendrils, without the shotgun part. Use it to reposition fauna or people!
/:cl:
