### PR TITLE
Golem QoL

### DIFF
--- a/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
+++ b/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
@@ -62,7 +62,7 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "k" = (
-/obj/machinery/computer/arcade/battle,
+/obj/machinery/computer/operating,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "l" = (
@@ -96,6 +96,11 @@
 /area/ruin/powered/golem_ship)
 "r" = (
 /obj/machinery/computer/shuttle,
+/turf/open/floor/mineral/titanium/purple,
+/area/ruin/powered/golem_ship)
+"s" = (
+/obj/machinery/light/small/directional/north,
+/obj/structure/table/optable,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "t" = (
@@ -133,7 +138,9 @@
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "y" = (
-/obj/machinery/computer/arcade/orion_trail,
+/obj/machinery/computer/arcade/orion_trail{
+	dir = 1
+	},
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "z" = (
@@ -201,6 +208,10 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
+"J" = (
+/obj/item/gun/energy/recharge/kinetic_accelerator,
+/turf/open/floor/mineral/titanium/purple,
+/area/ruin/powered/golem_ship)
 "K" = (
 /obj/machinery/door/airlock/titanium,
 /obj/structure/fans/tiny,
@@ -230,6 +241,15 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
+"R" = (
+/obj/item/borg/upgrade/modkit/trigger_guard,
+/turf/open/floor/mineral/titanium/purple,
+/area/ruin/powered/golem_ship)
+"S" = (
+/obj/structure/table/wood,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/mineral/titanium/purple,
+/area/ruin/powered/golem_ship)
 "T" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/titanium,
@@ -248,6 +268,12 @@
 /obj/machinery/door/airlock/titanium,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
+	},
+/turf/open/floor/mineral/titanium/purple,
+/area/ruin/powered/golem_ship)
+"Z" = (
+/obj/machinery/computer/arcade/battle{
+	dir = 1
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
@@ -329,14 +355,14 @@ a
 a
 a
 b
-L
+s
 l
 j
 l
 l
 j
 l
-l
+Z
 b
 a
 a
@@ -347,7 +373,7 @@ b
 b
 b
 b
-l
+S
 l
 b
 l
@@ -455,7 +481,7 @@ b
 c
 I
 b
-l
+J
 l
 O
 l
@@ -473,7 +499,7 @@ b
 d
 f
 j
-l
+R
 l
 l
 l

--- a/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
+++ b/_maps/RandomRuins/AnywhereRuins/golem_ship.dmm
@@ -162,6 +162,7 @@
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
+/obj/item/stock_parts/manipulator,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "B" = (


### PR DESCRIPTION
gave the poor golems back the operating room equipment, so now they can use the surgery system instead of just using copious amount of pills,etc.
also gave them One proto-kinetic accelerator + modified trigger guard so they actually stand more of a chance at start.
i added this last thing specially for ice world, golems are incredibly slow and some of those bastards are plain unfair with teleportation and incredible speed.
TLDR
operating table
operating computer
surgery duffle bag
wooden table for duffle bag
proto-kinetic accelerator
modified trigger guard
moved one arcade as well as fixed incorrect facing on other arcade.