### PR TITLE
Buffs shutters

### DIFF
--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -5,9 +5,9 @@
 	icon = 'icons/obj/doors/shutters.dmi'
 	layer = SHUTTER_LAYER
 	closingLayer = SHUTTER_LAYER
-	damage_deflection = 20
+	damage_deflection = 24
 	armor_type = /datum/armor/poddoor_shutters
-	max_integrity = 100
+	max_integrity = 200
 	recipe_type = /datum/crafting_recipe/shutters
 
 /obj/machinery/door/poddoor/shutters/preopen


### PR DESCRIPTION
## About The Pull Request

Buffs shutters, gives them 24 damage deflection and doubles their HP.

## Why It's Good For The Game

Shutters right now are pretty useless, being easily destroyed by thrown makeshift spears which are just cables, glass and a metal rod. That's 5 plasteel for a inconvenient airlock GONE, no materials dropped, from a few hits with a basic spear. A shutter should be able to protect from makeshift weaponry to 'keep out the crowd' whilst still being breachable by fireaxes (which do 30 damage on structures). For reference, an airlock made out of metal still has - More armor, More HP & more deflection when reinforced with plasteel.

Blast doors otoh cost 'only' 15 plasteel and somehow are 100x more protective at 72 deflection and 100% ranged resistance, and no way to open them besides cutting power/being a xenomorph.

## Changelog

:cl:
balance: Shutters have 24 deflect, and 200 HP.
/:cl:

