### PR TITLE
Ant Alarms

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2827,6 +2827,13 @@
 
 /datum/reagent/ants/expose_obj(obj/exposed_obj, reac_volume)
 	. = ..()
+
+	//Stream cancelled due to ants in your fire alarm.
+	if(istype(exposed_obj,/obj/machinery/firealarm))
+		var/obj/machinery/firealarm/alarm = exposed_obj
+		alarm.ants_remaining = round(reac_volume)
+		alarm.ant_trigger()
+
 	var/turf/open/my_turf = exposed_obj.loc // No dumping ants on an object in a storage slot
 	if(!istype(my_turf)) //Are we actually in an open turf?
 		return

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2831,8 +2831,11 @@
 	//Stream cancelled due to ants in your fire alarm.
 	if(istype(exposed_obj,/obj/machinery/firealarm))
 		var/obj/machinery/firealarm/alarm = exposed_obj
-		alarm.ants_remaining = round(reac_volume)
-		alarm.ant_trigger()
+		if(alarm.ants_remaining)
+			alarm.ants_remaining += round(reac_volume)
+		else
+			alarm.ants_remaining += round(reac_volume)
+			alarm.ant_trigger()
 
 	var/turf/open/my_turf = exposed_obj.loc // No dumping ants on an object in a storage slot
 	if(!istype(my_turf)) //Are we actually in an open turf?


### PR DESCRIPTION

## About The Pull Request

Makes it so splashing a fire alarm with ants will cause the alarm to randomly turn on and off.

Adds defines to construction states since I was there anyway.

## Why It's Good For The Game

🐜 🐜 🐜 🐜 🐜 🐜 
Because it happened to Ook, now it happened to me.
These ants must be immortalized.
🐜 🐜 🐜 🐜 🐜 🐜 

## Changelog
:cl:
add: You may now splash a fire alarm with ants for fun.
code: Added defines to fire alarm construction states
/:cl:
