### PR TITLE
made a few change to traitors.

### DIFF
--- a/code/modules/antagonists/traitor/objectives/abstract/target_player.dm
+++ b/code/modules/antagonists/traitor/objectives/abstract/target_player.dm
@@ -12,7 +12,7 @@
 	/// The objective period at which we consider if it is an 'objective'. Set to 0 to accept all objectives.
 	var/objective_period = 15 MINUTES
 	/// The maximum number of objectives we can get within this period.
-	var/maximum_objectives_in_period = 4
+	var/maximum_objectives_in_period = 2
 
 	/// The target that we need to target.
 	var/mob/living/target

--- a/code/modules/antagonists/traitor/objectives/assassination.dm
+++ b/code/modules/antagonists/traitor/objectives/assassination.dm
@@ -48,7 +48,7 @@
 	name = "Assassinate %TARGET% the %JOB TITLE%, and plant a calling card"
 	description = "Kill your target and plant a calling card in the pockets of your victim. If your calling card gets destroyed before you are able to plant it, this objective will fail."
 	progression_reward = 2 MINUTES
-	telecrystal_reward = list(1, 2)
+	telecrystal_reward = list(2, 4)
 
 	var/obj/item/paper/calling_card/card
 
@@ -62,7 +62,7 @@
 	name = "Behead %TARGET%, the %JOB TITLE%"
 	description = "Behead and hold %TARGET%'s head to succeed this objective. If the head gets destroyed before you can do this, you will fail this objective."
 	progression_reward = 2 MINUTES
-	telecrystal_reward = list(1, 2)
+	telecrystal_reward = list(2, 4)
 
 	///the body who needs to hold the head
 	var/mob/living/needs_to_hold_head
@@ -71,7 +71,7 @@
 
 /datum/traitor_objective/target_player/assassinate/behead/heads_of_staff
 	progression_reward = 4 MINUTES
-	telecrystal_reward = list(2, 3)
+	telecrystal_reward = list(3, 5)
 
 	heads_of_staff = TRUE
 

--- a/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -35,7 +35,7 @@
 	progression_minimum = 0 MINUTES
 	progression_maximum = 30 MINUTES
 	progression_reward = list(2 MINUTES, 4 MINUTES)
-	telecrystal_reward = list(1, 2)
+	telecrystal_reward = list(4, 5)
 	target_jobs = list(
 		// Cargo
 		/datum/job/cargo_technician,

--- a/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
+++ b/code/modules/antagonists/traitor/objectives/sleeper_protocol.dm
@@ -127,6 +127,6 @@
 /datum/traitor_objective/sleeper_protocol/everybody //Much harder for non-med and non-robo
 	progression_minimum = 30 MINUTES
 	progression_reward = list(8 MINUTES, 15 MINUTES)
-	telecrystal_reward = 1
+	telecrystal_reward = 3
 
 	inverted_limitation = TRUE


### PR DESCRIPTION
this makes two changes.
Firstly traitor objectives that are eyesnatching,assassination,kidnapping are limited to 2 instead of 4 (of the 6 traitors get)(simply changes RNG to be more fair)
Secondly i felt some objectives gave could use a slight TC boost, so 
assassinations(normal,beheading) now reward 2-4 tc instead of 1-2
assassination head of staff is 3-5 from 2-3.
kidnapping was changed to 4-5 from 1-2.
sleeper protocol gives 3 TC.

with this, traitors should have a more balanced experience and hazardous jobs should feel more rewarding.

why did i not increase payout for taking someone's favorite pen or killing pets? because they are chill objectives, thus no hazard pay.