### PR TITLE
adds tiny fans to shuttles and modular stuff

### DIFF
--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -9,6 +9,7 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Arrivals Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "d" = (

--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -156,60 +156,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron/white,
-/area/shuttle/arrival)
-"ao" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
 /area/shuttle/arrival)
 "ap" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/shuttle/arrival)
-"aq" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/shuttle/arrival)
-"ar" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/shuttle/arrival)
 "as" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
-/area/shuttle/arrival)
-"at" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/shuttle/arrival)
 "au" = (
@@ -253,18 +210,6 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
-"aA" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/shuttle/arrival)
 "aB" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -286,24 +231,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/shuttle/arrival)
-"aE" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/shuttle/arrival)
-"aF" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/vending/wallmed/directional/north{
-	use_power = 0
-	},
-/turf/open/floor/iron,
-/area/shuttle/arrival)
 "aG" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -312,24 +239,9 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/shuttle/arrival)
-"aH" = (
-/obj/structure/closet/wardrobe/black,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/shuttle/arrival)
 "aI" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron,
-/area/shuttle/arrival)
-"aJ" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/shuttle/arrival)
 "aK" = (
@@ -372,34 +284,6 @@
 /obj/machinery/status_display/ai,
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/arrival)
-"aQ" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/shuttle/arrival)
-"aR" = (
-/obj/structure/chair/office,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/shuttle/arrival)
-"aS" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/shuttle/arrival)
 "aT" = (
 /obj/structure/closet/wardrobe/black,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
@@ -409,17 +293,6 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
-	},
-/turf/open/floor/iron,
-/area/shuttle/arrival)
-"aV" = (
-/obj/machinery/computer{
-	dir = 1;
-	name = "Shuttle computer"
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/shuttle/arrival)

--- a/_maps/shuttles/arrival_donut.dmm
+++ b/_maps/shuttles/arrival_donut.dmm
@@ -38,6 +38,7 @@
 /area/shuttle/arrival)
 "k" = (
 /obj/machinery/door/airlock/titanium,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "l" = (

--- a/_maps/shuttles/arrival_kilo.dmm
+++ b/_maps/shuttles/arrival_kilo.dmm
@@ -16,6 +16,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
 "ae" = (
@@ -86,19 +87,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
-"am" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
 "an" = (
 /obj/machinery/power/shuttle_engine/propulsion/left{
 	dir = 8
@@ -123,39 +111,6 @@
 /obj/item/flashlight,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
-"aq" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
-"ar" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
-"as" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/requests_console/directional/east{
-	department = "Arrivals shuttle"
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
 "at" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner{
@@ -177,38 +132,6 @@
 	name = "kilo arrivals shuttle"
 	},
 /turf/open/floor/plating/airless,
-/area/shuttle/arrival)
-"av" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/radio{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/item/radio{
-	pixel_x = 6;
-	pixel_y = 6
-	},
-/obj/item/radio{
-	pixel_y = 4
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/arrival)
-"aw" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
 "ax" = (
 /obj/effect/turf_decal/bot,
@@ -249,18 +172,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
-"aC" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
 "aD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/shuttle{
@@ -271,23 +182,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/arrival)
-"aE" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
-"aF" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
 "aG" = (
 /obj/machinery/power/shuttle_engine/propulsion/right{
@@ -303,35 +197,6 @@
 /obj/item/storage/toolbox/emergency,
 /obj/item/crowbar/red,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/arrival)
-"aI" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
-"aJ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
-"aK" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
 "aL" = (
 /obj/machinery/status_display/ai,
@@ -355,19 +220,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/arrival)
-"aO" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
 "aP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -381,16 +233,6 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/arrival)
-"aR" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/vending/wallmed/directional/west{
-	use_power = 0
-	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
 "aS" = (

--- a/_maps/shuttles/arrival_northstar.dmm
+++ b/_maps/shuttles/arrival_northstar.dmm
@@ -12,6 +12,7 @@
 /obj/machinery/door/airlock/survival_pod/glass{
 	name = "Arrivals Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "d" = (

--- a/_maps/shuttles/arrival_pubby.dmm
+++ b/_maps/shuttles/arrival_pubby.dmm
@@ -9,6 +9,7 @@
 /obj/machinery/door/airlock/titanium{
 	name = "Arrivals Shuttle Airlock"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "d" = (

--- a/_maps/shuttles/cargo_birdboat.dmm
+++ b/_maps/shuttles/cargo_birdboat.dmm
@@ -67,6 +67,7 @@
 	id = "cargoshuttle";
 	name = "cargo shuttle conveyor belt"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "n" = (
@@ -77,6 +78,7 @@
 	name = "Supply Shuttle Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "p" = (
@@ -102,6 +104,7 @@
 	},
 /obj/docking_port/mobile/supply,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "r" = (
@@ -114,6 +117,7 @@
 	id = "cargoshuttle";
 	name = "cargo shuttle conveyor belt"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "u" = (

--- a/_maps/shuttles/cargo_box.dmm
+++ b/_maps/shuttles/cargo_box.dmm
@@ -14,6 +14,7 @@
 	id = "QMLoaddoor2";
 	name = "Supply Dock Loading Door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "g" = (
@@ -21,6 +22,7 @@
 	name = "Supply Shuttle Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "h" = (
@@ -43,6 +45,7 @@
 	},
 /obj/docking_port/mobile/supply,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "j" = (
@@ -54,6 +57,7 @@
 	id = "QMLoaddoor";
 	name = "Supply Dock Loading Door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "l" = (

--- a/_maps/shuttles/cargo_delta.dmm
+++ b/_maps/shuttles/cargo_delta.dmm
@@ -68,6 +68,7 @@
 	id = "cargounload";
 	name = "Supply Dock Unloading Door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "l" = (
@@ -90,6 +91,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "o" = (
@@ -128,6 +130,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "s" = (
@@ -139,6 +142,7 @@
 	dir = 4;
 	id = "cargoload"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "t" = (

--- a/_maps/shuttles/cargo_kilo.dmm
+++ b/_maps/shuttles/cargo_kilo.dmm
@@ -58,6 +58,7 @@
 	id = "QMLoad";
 	name = "off ramp"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "j" = (
@@ -93,6 +94,7 @@
 /obj/docking_port/mobile/supply{
 	dir = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/supply)
 "n" = (
@@ -145,6 +147,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/supply)
 "s" = (
@@ -165,6 +168,7 @@
 	id = "QMLoad2";
 	name = "on ramp"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "u" = (

--- a/_maps/shuttles/cargo_northstar.dmm
+++ b/_maps/shuttles/cargo_northstar.dmm
@@ -25,6 +25,7 @@
 	id = "QMLoaddoor2";
 	name = "Supply Dock Loading Door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 "h" = (
@@ -125,6 +126,7 @@
 	name = "Supply Shuttle Airlock"
 	},
 /obj/docking_port/mobile/supply,
+/obj/structure/fans/tiny,
 /turf/open/floor/pod/dark,
 /area/shuttle/supply)
 "I" = (
@@ -153,6 +155,7 @@
 	id = "QMLoaddoor";
 	name = "Supply Dock Loading Door"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/supply)
 

--- a/_maps/shuttles/cargo_pubby.dmm
+++ b/_maps/shuttles/cargo_pubby.dmm
@@ -47,6 +47,7 @@
 	dir = 4;
 	id = "ShuttleLoad"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "m" = (
@@ -141,6 +142,7 @@
 	dir = 8;
 	id = "ShuttleUnload"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/supply)
 "K" = (
@@ -164,6 +166,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/shuttle/supply)
 "U" = (

--- a/_maps/shuttles/mining_box.dmm
+++ b/_maps/shuttles/mining_box.dmm
@@ -37,6 +37,7 @@
 	name = "mining shuttle";
 	port_direction = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "i" = (

--- a/_maps/shuttles/mining_common_kilo.dmm
+++ b/_maps/shuttles/mining_common_kilo.dmm
@@ -89,6 +89,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "n" = (

--- a/_maps/shuttles/mining_common_meta.dmm
+++ b/_maps/shuttles/mining_common_meta.dmm
@@ -37,6 +37,7 @@
 	name = "lavaland shuttle";
 	port_direction = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "i" = (

--- a/_maps/shuttles/mining_common_northstar.dmm
+++ b/_maps/shuttles/mining_common_northstar.dmm
@@ -77,6 +77,7 @@
 	port_direction = 8;
 	shuttle_id = "mining_common"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/pod/light,
 /area/shuttle/mining)
 "D" = (

--- a/_maps/shuttles/mining_delta.dmm
+++ b/_maps/shuttles/mining_delta.dmm
@@ -73,6 +73,7 @@
 	name = "mining shuttle";
 	port_direction = 8
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/iron/white,
 /area/shuttle/mining)
 "j" = (

--- a/_maps/shuttles/mining_freight.dmm
+++ b/_maps/shuttles/mining_freight.dmm
@@ -87,6 +87,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
 	dir = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "n" = (

--- a/_maps/shuttles/mining_kilo.dmm
+++ b/_maps/shuttles/mining_kilo.dmm
@@ -275,6 +275,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining/large)
 "J" = (

--- a/_maps/shuttles/mining_large.dmm
+++ b/_maps/shuttles/mining_large.dmm
@@ -306,6 +306,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/mining/large)
 "E" = (

--- a/_maps/shuttles/mining_northstar.dmm
+++ b/_maps/shuttles/mining_northstar.dmm
@@ -10,6 +10,7 @@
 	port_direction = 8;
 	shuttle_id = "mining"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/pod/light,
 /area/shuttle/mining)
 "c" = (

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -275,6 +275,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "aG" = (
@@ -676,6 +677,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "df" = (

--- a/_maps/shuttles/pirate_dutchman.dmm
+++ b/_maps/shuttles/pirate_dutchman.dmm
@@ -773,7 +773,7 @@
 /obj/docking_port/mobile/pirate{
 	dir = 8;
 	launch_status = 0;
-	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
+	movement_force = list("KNOCKDOWN"=0,"THROW"=0);
 	name = "Pirate Ship";
 	port_direction = 4;
 	preferred_direction = 8

--- a/_maps/shuttles/pirate_psyker.dmm
+++ b/_maps/shuttles/pirate_psyker.dmm
@@ -579,6 +579,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "Dw" = (

--- a/_maps/shuttles/pirate_silverscale.dmm
+++ b/_maps/shuttles/pirate_silverscale.dmm
@@ -85,6 +85,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/fans/tiny,
 /turf/open/floor/pod/light,
 /area/shuttle/pirate)
 "dI" = (
@@ -471,6 +472,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/fans/tiny,
 /turf/open/floor/pod/light,
 /area/shuttle/pirate)
 "Ae" = (

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -229,6 +229,7 @@
 /obj/machinery/door/airlock/external/ruin{
 	id_tag = "caravanpirate_bolt_starboard"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/ruin/caravan/pirate)
 "qU" = (
@@ -625,6 +626,7 @@
 	port_direction = 8;
 	preferred_direction = 4
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/ruin/caravan/pirate)
 "Ns" = (

--- a/_maps/shuttles/ruin_syndicate_dropship.dmm
+++ b/_maps/shuttles/ruin_syndicate_dropship.dmm
@@ -14,6 +14,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/ruin/caravan/syndicate3)
 "bt" = (
@@ -232,6 +233,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/ruin/caravan/syndicate3)
 "zP" = (

--- a/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
+++ b/_maps/shuttles/ruin_syndicate_fighter_shiv.dmm
@@ -87,6 +87,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/ruin/caravan/syndicate1)
 "YY" = (

--- a/_maps/shuttles/snowdin_mining.dmm
+++ b/_maps/shuttles/snowdin_mining.dmm
@@ -8,6 +8,7 @@
 	shuttle_id = "snowdin_mining";
 	name = "mining elevator"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/snowdin/elevator2)
 "b" = (
@@ -19,6 +20,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Elevator Access"
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/snowdin/elevator2)
 "d" = (

--- a/monkestation/_maps/RandomEngines/KiloStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/KiloStation/singularity.dmm
@@ -301,6 +301,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/fans/tiny,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "zP" = (

--- a/monkestation/_maps/RandomEngines/MetaStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/MetaStation/singularity.dmm
@@ -270,6 +270,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "yn" = (

--- a/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
@@ -117,6 +117,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/cable/layer1,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "oM" = (
@@ -154,6 +155,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/structure/cable,
 /obj/structure/cable/layer1,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "se" = (
@@ -436,6 +438,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "WI" = (

--- a/monkestation/_maps/RandomEngines/TramStation/supermatter.dmm
+++ b/monkestation/_maps/RandomEngines/TramStation/supermatter.dmm
@@ -542,6 +542,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "tj" = (


### PR DESCRIPTION
i know this is gonna trigger some people but...i feel that adding them to shuttles and areas that tend to leak quite often is a good thing.
also from a performance perspective, this is likely the simplest and easiest way, instead of doing actual airlocks, but if someone wants to do that, they can remove the fans as they go.