### PR TITLE
Major random engine changes

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -3831,6 +3831,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/box,
 /obj/machinery/shower/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "arY" = (
@@ -11369,7 +11370,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cyU" = (
@@ -12470,7 +12470,6 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cVl" = (
@@ -16084,6 +16083,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "eoE" = (
@@ -16872,7 +16872,6 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "eDG" = (
@@ -35391,13 +35390,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"lJG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "lJS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -41791,7 +41783,6 @@
 "odB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 8
 	},
@@ -47566,6 +47557,7 @@
 	dir = 1;
 	pixel_y = -32
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "qqv" = (
@@ -68894,7 +68886,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ylw" = (
@@ -99168,7 +99159,7 @@ eTZ
 dhK
 eTZ
 iHV
-hJd
+qVu
 qqo
 aeL
 aeL
@@ -99680,9 +99671,9 @@ hJd
 oYS
 hJd
 qVu
-hJd
+qVu
 eoz
-hJd
+qVu
 arV
 aeL
 aeL
@@ -99938,8 +99929,8 @@ dIn
 eKn
 ylv
 cyH
-lJG
-lJG
+eKn
+eKn
 pfG
 aeL
 aeL

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -3440,10 +3440,6 @@
 /obj/structure/bed/dogbed/ian,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"anH" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "anJ" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 8
@@ -3510,11 +3506,6 @@
 /area/station/ai_monitored/turret_protected/ai)
 "aor" = (
 /obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/trimline/yellow/arrow_cw,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 1
-	},
-/obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "aow" = (
@@ -3840,7 +3831,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/box,
 /obj/machinery/shower/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "arY" = (
@@ -9013,6 +9003,13 @@
 /area/station/engineering/atmospherics_engine)
 "bHA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "bHB" = (
@@ -10997,10 +10994,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "crE" = (
@@ -11115,6 +11110,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/arrow_cw,
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -11369,6 +11369,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "cyU" = (
@@ -11577,13 +11578,6 @@
 "cDK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/structure/cable/layer1,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -12272,11 +12266,6 @@
 /obj/effect/mapping_helpers/mail_sorting/engineering/ce_office,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/layer1,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -12475,7 +12464,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 4
 	},
@@ -13137,6 +13125,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/medical/virology)
+"dhK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "dhL" = (
 /turf/closed/wall,
 /area/station/security/prison/work)
@@ -14647,14 +14641,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/layer1,
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 10
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/corner{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "dNH" = (
@@ -16879,7 +16866,6 @@
 "eCZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 4
 	},
@@ -20602,12 +20588,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/auxlab/firing_range)
-"geA" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "geG" = (
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
@@ -21742,13 +21722,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "gCd" = (
-/obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/item/folder/yellow,
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "gCq" = (
@@ -22470,15 +22449,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "gPP" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "gPV" = (
@@ -22884,13 +22861,6 @@
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/cable/layer1,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "gZE" = (
@@ -24427,14 +24397,6 @@
 	},
 /turf/open/floor/glass,
 /area/station/commons/fitness/recreation)
-"hGK" = (
-/obj/effect/turf_decal/trimline/yellow/arrow_cw,
-/obj/structure/cable/layer1,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "hHf" = (
 /obj/structure/closet/bombcloset/security,
 /turf/open/floor/iron/showroomfloor,
@@ -26767,6 +26729,12 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/misc/grass/jungle,
 /area/station/science/explab)
+"iCd" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "iCe" = (
 /obj/machinery/door/airlock{
 	id_tag = "Toilet2";
@@ -27005,6 +26973,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
+"iHV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/arrow_cw,
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "iIs" = (
 /obj/machinery/door/airlock{
 	name = "Bar Storage"
@@ -27015,16 +26993,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
-"iIH" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "iJd" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -27876,6 +27844,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/right)
+"iYt" = (
+/obj/structure/cable,
+/turf/closed/wall,
+/area/station/engineering/main)
 "iYv" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -32832,18 +32804,6 @@
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
-"kNO" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "kNT" = (
 /turf/open/floor/glass/reinforced/tram,
 /area/station/hallway/primary/tram/center)
@@ -35289,20 +35249,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"lGQ" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "lGV" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -35445,6 +35391,13 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
+"lJG" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "lJS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -35604,17 +35557,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"lNa" = (
-/obj/structure/cable,
-/obj/structure/cable/layer1,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "lNd" = (
 /obj/structure/railing{
 	dir = 4
@@ -38230,12 +38172,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "mLM" = (
-/obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
-/obj/item/stack/rods/fifty,
 /obj/item/radio/intercom/directional/east,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "mLO" = (
@@ -41047,10 +40989,6 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock/cafeteria)
-"nPb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/space/basic,
-/area/space/nearstation)
 "nPe" = (
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
@@ -41087,7 +41025,6 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "nPR" = (
@@ -41099,6 +41036,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/arrow_cw,
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -41306,13 +41248,6 @@
 /area/station/hallway/secondary/command)
 "nTa" = (
 /obj/effect/landmark/start/station_engineer,
-/obj/structure/cable/layer1,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -41853,6 +41788,18 @@
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/security/brig)
+"odB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "odC" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -43017,6 +42964,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "oEN" = (
@@ -43962,6 +43915,22 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/port/central)
+"pat" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "paS" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -45192,6 +45161,9 @@
 	dir = 1
 	},
 /obj/structure/closet/toolcloset,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "pxi" = (
@@ -45252,14 +45224,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/layer1,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/yellow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "pxM" = (
@@ -45841,18 +45806,12 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "pHb" = (
-/obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
-	},
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
 /obj/machinery/firealarm/directional/east,
+/obj/structure/table,
+/obj/item/stack/rods/fifty,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "pHk" = (
@@ -48016,14 +47975,16 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "qyP" = (
-/obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "qyQ" = (
@@ -49228,6 +49189,10 @@
 "qVr" = (
 /turf/closed/wall/r_wall,
 /area/station/science/xenobiology)
+"qVu" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "qVH" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -49308,11 +49273,14 @@
 /area/station/service/barber)
 "qWE" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/plasteel{
+	amount = 10
+	},
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "qWI" = (
@@ -51148,16 +51116,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
-"rGU" = (
-/obj/structure/table,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "rHj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -52939,11 +52897,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/layer1,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -56040,16 +55993,6 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock/cafeteria)
-"trO" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "trY" = (
 /obj/structure/closet/secure_closet/contraband/armory,
 /obj/effect/spawner/random/contraband/armory,
@@ -56777,19 +56720,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal)
-"tHb" = (
-/obj/structure/table,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/plasteel{
-	amount = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "tHt" = (
 /obj/structure/railing{
 	dir = 1
@@ -57518,6 +57448,7 @@
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "tVv" = (
@@ -57675,7 +57606,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "tXS" = (
-/obj/machinery/power/smes/engineering,
 /obj/machinery/light/directional/west,
 /obj/structure/sign/warning/electric_shock{
 	pixel_x = -32
@@ -57685,7 +57615,12 @@
 	dir = 10;
 	network = list("ss13","engineering")
 	},
-/obj/structure/cable,
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "tXU" = (
@@ -58835,10 +58770,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "utj" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot{
+	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "utk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -60157,6 +60093,21 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison)
+"uPS" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 10;
+	pixel_x = -1
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 1
+	},
+/obj/item/flashlight{
+	pixel_x = 1;
+	pixel_y = -5
+	},
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "uPV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -60195,8 +60146,16 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "uQm" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/box/lights/mixed,
+/obj/item/stock_parts/cell/emproof,
+/obj/item/stock_parts/cell/emproof,
+/obj/item/stack/cable_coil,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "uQq" = (
@@ -60592,9 +60551,6 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/lounge)
 "uYH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60960,13 +60916,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/cable/layer1,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/yellow/corner{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "vgZ" = (
@@ -61407,7 +61356,6 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "vnI" = (
@@ -63520,21 +63468,6 @@
 "wbb" = (
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"wbd" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/layer1,
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "wbC" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/bot,
@@ -64164,21 +64097,11 @@
 /turf/open/floor/plating,
 /area/station/service/barber)
 "wng" = (
-/obj/structure/cable,
-/obj/structure/table,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/storage/box/lights/mixed,
-/obj/item/stock_parts/cell/emproof,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/bot{
+	dir = 1
 	},
-/obj/item/stock_parts/cell/emproof,
-/obj/item/stack/cable_coil,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
 "wnh" = (
 /turf/open/floor/iron,
@@ -66228,17 +66151,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
-"xfN" = (
-/obj/structure/cable/layer1,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "xfW" = (
 /obj/structure/table,
 /obj/item/mod/module/plasma_stabilizer,
@@ -66406,11 +66318,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/layer1,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
@@ -67219,6 +67126,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/arrow_cw,
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
@@ -68982,6 +68894,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "ylw" = (
@@ -97442,8 +97355,8 @@ kSp
 lgP
 pkp
 anr
-anH
-uQm
+vyq
+uPS
 tXS
 uQm
 uYH
@@ -97699,11 +97612,11 @@ rzL
 tbe
 wJt
 ans
-geA
-iIH
-lGQ
-iIH
-kNO
+vyq
+vyq
+vyq
+vyq
+uYH
 vnD
 uGy
 wgc
@@ -97711,7 +97624,7 @@ hJd
 nxT
 iMH
 pwX
-hJd
+iCd
 aYn
 hJd
 jpw
@@ -98215,17 +98128,17 @@ wJt
 ans
 eNW
 vyq
-hGK
 vyq
-trO
+vyq
+gPP
 utj
 uGy
 wgc
 hJd
 nxT
 iMH
-tHb
-hJd
+crz
+pat
 oEz
 hJd
 gCd
@@ -98473,7 +98386,7 @@ anu
 voC
 doT
 pxH
-wbd
+doT
 dNB
 pKk
 pLH
@@ -98484,7 +98397,7 @@ aYF
 mLM
 qyP
 nPR
-rGU
+eKn
 pHb
 aeL
 aeL
@@ -98738,7 +98651,7 @@ llN
 iMH
 bWH
 aYF
-aYF
+iYt
 iMH
 xAB
 iMH
@@ -98746,7 +98659,7 @@ aYF
 aeL
 aeL
 aeL
-nPb
+aeL
 aeL
 aeL
 aeL
@@ -99252,9 +99165,9 @@ aqz
 amQ
 eFs
 eTZ
+dhK
 eTZ
-eTZ
-eTZ
+iHV
 hJd
 qqo
 aeL
@@ -99503,15 +99416,15 @@ sOr
 frd
 kHn
 vgR
-lNa
+qVu
 gZB
-xfN
-xfN
+qVu
+qVu
 cDK
-xfN
+qVu
 nTa
-xfN
-eCZ
+hJd
+odB
 eCZ
 cUE
 aeL
@@ -99766,7 +99679,7 @@ hJd
 hJd
 oYS
 hJd
-hJd
+qVu
 hJd
 eoz
 hJd
@@ -100025,8 +99938,8 @@ dIn
 eKn
 ylv
 cyH
-eKn
-eKn
+lJG
+lJG
 pfG
 aeL
 aeL

--- a/monkestation/_maps/RandomEngines/KiloStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/KiloStation/singularity.dmm
@@ -7,6 +7,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"cY" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dq" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/sign/warning/electric_shock/directional/east,
@@ -21,6 +26,10 @@
 /turf/open/floor/iron,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"eq" = (
+/obj/structure/cable/multilayer/connected,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "eP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -44,9 +53,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"gS" = (
+/obj/structure/cable,
+/obj/machinery/power/emitter{
+	dir = 8
+	},
+/obj/structure/cable/layer1,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "hD" = (
 /turf/open/floor/glass/plasma,
 /area/station/engineering/supermatter/room)
+"hQ" = (
+/obj/structure/cable,
+/obj/structure/cable/layer1,
+/obj/effect/turf_decal/bot_white/left,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "hV" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -57,6 +80,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"hW" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "ic" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -73,6 +101,7 @@
 	name = "Departure Shuttle Airlock"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "iW" = (
@@ -81,12 +110,28 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"jc" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/external{
+	name = "Departure Shuttle Airlock"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/obj/structure/cable/layer1,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "jl" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"kf" = (
+/obj/machinery/field/generator,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "km" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -107,24 +152,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "lg" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
-"lt" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/external{
-	name = "Departure Shuttle Airlock"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "lE" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/iron/fifty,
@@ -170,11 +203,20 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "oe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/plasma,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
+"or" = (
+/obj/machinery/power/rad_collector,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "oK" = (
@@ -210,21 +252,26 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
-"qj" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/power/rad_collector,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "ql" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/emitter,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"qW" = (
+/obj/structure/cable/layer1,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "re" = (
 /obj/machinery/light/blacklight/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"ru" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/cable/layer1,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rz" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -254,7 +301,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "th" = (
-/obj/structure/cable,
 /obj/machinery/camera/directional/north{
 	c_tag = "Departures Lounge";
 	name = "shuttle camera"
@@ -277,11 +323,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"vD" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/power/energy_accumulator/grounding_rod,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+"vF" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/layer1,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/end{
@@ -293,6 +340,11 @@
 "xr" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
+"xs" = (
+/obj/structure/cable,
+/obj/structure/cable/layer1,
+/turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "xG" = (
 /obj/machinery/power/terminal{
@@ -313,12 +365,22 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "yw" = (
-/obj/item/stack/cable_coil,
+/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"zg" = (
+/obj/structure/cable/layer1,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "zs" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
+"zu" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/layer1,
+/turf/open/space/basic,
+/area/space/nearstation)
 "zB" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/shieldgen,
@@ -326,8 +388,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "zH" = (
-/obj/machinery/power/smes/engineering,
-/obj/structure/cable,
+/obj/machinery/the_singularitygen,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "zP" = (
@@ -355,6 +416,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "Cu" = (
@@ -386,8 +448,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/cable,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "EU" = (
@@ -403,8 +463,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "Fu" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/power/rad_collector,
 /obj/machinery/light/cold/no_nightlight/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
@@ -420,8 +478,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "HV" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/the_singularitygen/tesla,
+/obj/machinery/power/energy_accumulator/grounding_rod,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "Ib" = (
@@ -463,14 +520,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "KY" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/the_singularitygen,
 /obj/machinery/light/blacklight/directional/east,
+/obj/machinery/power/energy_accumulator/grounding_rod,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "Lc" = (
 /obj/machinery/light/directional/south,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "Le" = (
@@ -492,7 +547,6 @@
 "LZ" = (
 /obj/structure/particle_accelerator/particle_emitter/center,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "Mb" = (
@@ -536,8 +590,7 @@
 /turf/open/floor/plating,
 /area/space/nearstation)
 "OT" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
+/obj/machinery/the_singularitygen/tesla,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "Pj" = (
@@ -547,7 +600,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "PV" = (
@@ -577,6 +629,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"Rx" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot_white/left,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "RL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/iron,
@@ -591,7 +648,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "Su" = (
@@ -599,6 +655,10 @@
 /obj/machinery/power/emitter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
+"SM" = (
+/obj/structure/cable/multilayer/connected,
+/turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "Uk" = (
 /obj/machinery/power/energy_accumulator/tesla_coil,
@@ -635,6 +695,11 @@
 /obj/structure/particle_accelerator/fuel_chamber,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"UU" = (
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "Vk" = (
 /turf/open/floor/plating,
 /area/space/nearstation)
@@ -664,6 +729,16 @@
 /area/station/engineering/supermatter/room)
 "WZ" = (
 /turf/open/space/basic,
+/area/space/nearstation)
+"Xz" = (
+/obj/machinery/power/energy_accumulator/tesla_coil,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
+"XV" = (
+/obj/structure/cable,
+/obj/structure/cable/layer1,
+/turf/open/floor/plating,
 /area/space/nearstation)
 "Yj" = (
 /obj/effect/turf_decal/stripes/line{
@@ -766,9 +841,9 @@ zP
 zP
 zs
 pk
-pk
-pk
-pk
+iW
+iW
+iW
 BT
 ob
 zs
@@ -789,14 +864,14 @@ zs
 zs
 zs
 pk
+Ib
 oK
 oK
 oK
-oK
-oK
+UU
 zs
 th
-fx
+Pj
 zs
 "}
 (5,1,1) = {"
@@ -814,12 +889,12 @@ km
 Zp
 Ib
 Ib
-Ib
-Ib
-Ib
+SM
+qW
+xs
 is
 yw
-fx
+Pj
 zs
 "}
 (6,1,1) = {"
@@ -833,15 +908,15 @@ hV
 Nv
 iW
 eo
-qj
+oK
+or
 VI
 VI
-vD
-Uk
+Xz
 Uk
 HV
 zs
-fx
+yw
 Lc
 zs
 "}
@@ -857,15 +932,15 @@ pk
 iW
 eo
 Fu
+or
 VI
 VI
-vD
-Uk
+Xz
 Uk
 KY
 zs
-lt
-zs
+yw
+Pj
 zs
 "}
 (8,1,1) = {"
@@ -887,8 +962,8 @@ zs
 zs
 zs
 zs
-fx
-Pj
+jc
+zs
 zs
 "}
 (9,1,1) = {"
@@ -904,14 +979,14 @@ DA
 Eh
 WZ
 WZ
-WZ
-lg
-WZ
-WZ
-WZ
-WZ
-rP
-WZ
+IJ
+cY
+cY
+cY
+vF
+vF
+XV
+cY
 WZ
 "}
 (10,1,1) = {"
@@ -926,16 +1001,16 @@ NC
 Fj
 RL
 WZ
-WZ
+zu
+zu
+ru
+zu
+zu
+zu
 IJ
-Ir
-rP
-rP
-rP
-rP
-rP
-Ir
-WZ
+Vk
+cY
+IJ
 "}
 (11,1,1) = {"
 rz
@@ -949,16 +1024,16 @@ aJ
 Fj
 RL
 WZ
-IJ
-rP
-Cu
-IJ
-rP
-rP
-rP
-IJ
-Cu
-rP
+zu
+cY
+Ir
+Vk
+hW
+XV
+Rx
+Vk
+Ir
+cY
 "}
 (12,1,1) = {"
 pa
@@ -966,21 +1041,21 @@ UA
 oK
 NK
 pk
-sz
-sz
+lZ
+lZ
 lZ
 UJ
 RL
 WZ
-IJ
+zu
 rP
+kf
 IJ
 Vk
-lg
-IJ
-lg
+eq
 Vk
 IJ
+kf
 rP
 "}
 (13,1,1) = {"
@@ -995,15 +1070,15 @@ EK
 Fj
 RL
 WZ
-IJ
+zu
 rP
-WZ
+IJ
+Vk
 lg
 IJ
 lg
+Vk
 IJ
-lg
-WZ
 rP
 "}
 (14,1,1) = {"
@@ -1018,14 +1093,14 @@ LZ
 Fj
 RL
 WZ
-IJ
+zu
 rP
 WZ
-IJ
-lg
-Vk
 lg
 IJ
+lg
+IJ
+lg
 WZ
 rP
 "}
@@ -1041,14 +1116,14 @@ RV
 Fj
 RL
 WZ
-IJ
+zu
 rP
 WZ
-lg
 IJ
 lg
-IJ
+Vk
 lg
+IJ
 WZ
 rP
 "}
@@ -1064,15 +1139,15 @@ sz
 Fj
 RL
 WZ
-IJ
+zu
 rP
-IJ
-Vk
+WZ
 lg
 IJ
 lg
-Vk
 IJ
+lg
+WZ
 rP
 "}
 (17,1,1) = {"
@@ -1087,15 +1162,15 @@ IL
 UJ
 RL
 WZ
-IJ
-rP
-Cu
-IJ
-rP
-rP
+zu
 rP
 IJ
-Cu
+Vk
+lg
+IJ
+lg
+Vk
+IJ
 rP
 "}
 (18,1,1) = {"
@@ -1110,16 +1185,16 @@ Ii
 JC
 RL
 WZ
-WZ
+zu
+rP
+Cu
 IJ
-NO
+Vk
+eq
+Vk
+IJ
+Cu
 rP
-rP
-rP
-rP
-rP
-NO
-WZ
 "}
 (19,1,1) = {"
 zs
@@ -1133,16 +1208,16 @@ Ii
 oe
 RN
 tB
-WZ
-WZ
-WZ
+zu
+zu
+gS
+zg
+hQ
+XV
+hW
+Vk
+NO
 lg
-WZ
-WZ
-WZ
-lg
-WZ
-WZ
 "}
 (20,1,1) = {"
 zs

--- a/monkestation/_maps/RandomEngines/KiloStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/KiloStation/singularity.dmm
@@ -44,7 +44,7 @@
 "fN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine"
+	name = "Space Engine Room"
 	},
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 1
@@ -88,7 +88,7 @@
 "ic" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine"
+	name = "Space Engine Room"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
@@ -97,9 +97,7 @@
 /area/station/engineering/supermatter/room)
 "is" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/external{
-	name = "Departure Shuttle Airlock"
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
@@ -112,9 +110,7 @@
 /area/station/engineering/supermatter/room)
 "jc" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock/external{
-	name = "Departure Shuttle Airlock"
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -400,7 +396,7 @@
 "BM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine"
+	name = "Space Engine Room"
 	},
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 4
@@ -443,6 +439,11 @@
 /turf/open/floor/iron,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"En" = (
+/obj/structure/cable,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "EK" = (
 /obj/structure/particle_accelerator/particle_emitter/left,
 /obj/effect/turf_decal/stripes/line{
@@ -1009,7 +1010,7 @@ zu
 zu
 IJ
 Vk
-cY
+En
 IJ
 "}
 (11,1,1) = {"
@@ -1033,7 +1034,7 @@ XV
 Rx
 Vk
 Ir
-cY
+En
 "}
 (12,1,1) = {"
 pa
@@ -1186,7 +1187,7 @@ JC
 RL
 WZ
 zu
-rP
+XV
 Cu
 IJ
 Vk
@@ -1208,7 +1209,7 @@ Ii
 oe
 RN
 tB
-zu
+WZ
 zu
 gS
 zg
@@ -1217,7 +1218,7 @@ XV
 hW
 Vk
 NO
-lg
+WZ
 "}
 (20,1,1) = {"
 zs

--- a/monkestation/_maps/RandomEngines/KiloStation/supermatter.dmm
+++ b/monkestation/_maps/RandomEngines/KiloStation/supermatter.dmm
@@ -88,7 +88,6 @@
 	network = list("ss13","engine")
 	},
 /obj/machinery/light_switch/directional/west,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "fx" = (
@@ -137,7 +136,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gZ" = (
@@ -158,7 +156,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/button/door/directional/west{
 	id = "Secure Storage";
 	name = "Secure Storage Toggle";
@@ -416,6 +413,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/light/directional/east,
 /obj/machinery/status_display/evac/directional/east,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qj" = (
@@ -424,7 +422,6 @@
 /obj/machinery/shower/directional/east{
 	name = "emergency shower"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "ql" = (
@@ -608,6 +605,7 @@
 "vx" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "vD" = (
@@ -1074,7 +1072,6 @@
 /obj/machinery/shower/directional/east{
 	name = "emergency shower"
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "JH" = (
@@ -1155,7 +1152,6 @@
 /area/station/engineering/supermatter/room)
 "LM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -1217,7 +1213,6 @@
 /obj/item/geiger_counter,
 /obj/structure/table,
 /obj/structure/sign/warning/xeno_mining/directional/west,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "NC" = (
@@ -1245,7 +1240,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm/directional/south,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Pp" = (
@@ -1293,13 +1287,6 @@
 "QA" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"QB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "RA" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -1328,6 +1315,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/meter,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Su" = (
@@ -1481,7 +1469,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "WZ" = (
@@ -1737,10 +1724,10 @@ LM
 hj
 fj
 ML
-de
+Fu
 ma
 Fu
-Fu
+de
 xG
 VI
 vD
@@ -1756,8 +1743,8 @@ lV
 vD
 RV
 vx
-QB
-QB
+JH
+JH
 pJ
 Si
 JH

--- a/monkestation/_maps/RandomEngines/KiloStation/supermatter.dmm
+++ b/monkestation/_maps/RandomEngines/KiloStation/supermatter.dmm
@@ -15,6 +15,12 @@
 "aK" = (
 /turf/closed/mineral/random/labormineral,
 /area/space/nearstation)
+"bN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "cc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -35,6 +41,14 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"de" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "dq" = (
 /obj/structure/sign/poster/contraband/missing_gloves{
 	pixel_x = 32
@@ -51,13 +65,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter)
-"dN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light/directional/south,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "eo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
@@ -103,6 +110,10 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"fH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "fN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -189,10 +200,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "hW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ic" = (
@@ -208,6 +218,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "jl" = (
@@ -286,6 +298,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lE" = (
@@ -339,17 +352,19 @@
 /turf/open/space,
 /area/space/nearstation)
 "nb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/south,
-/obj/structure/cable,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "np" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
+"nw" = (
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "nI" = (
@@ -381,14 +396,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"oK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "oN" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
@@ -442,7 +449,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "qQ" = (
@@ -488,6 +494,11 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
+"sF" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "sG" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -587,6 +598,13 @@
 	luminosity = 2
 	},
 /area/station/engineering/supermatter)
+"vs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "vx" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
@@ -665,7 +683,6 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/light/directional/west,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/engine,
@@ -685,7 +702,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xX" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/cable,
@@ -750,15 +766,6 @@
 "zP" = (
 /turf/template_noop,
 /area/template_noop)
-"Ag" = (
-/obj/structure/reflector/single/anchored{
-	dir = 10
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "Ar" = (
 /turf/closed/wall/rust,
 /area/station/engineering/supermatter/room)
@@ -804,12 +811,19 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"Ci" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "Cu" = (
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall,
 /area/station/engineering/supermatter/room)
 "CQ" = (
 /obj/structure/grille/broken,
+/obj/item/pickaxe,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Da" = (
@@ -886,6 +900,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/sign/delamination_counter/directional/north,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Fu" = (
@@ -942,12 +957,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Hb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "Hs" = (
@@ -959,6 +974,15 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
+"Hv" = (
+/obj/effect/turf_decal/box/corners{
+	dir = 1
+	},
+/obj/structure/reflector/single/anchored{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "HV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -991,7 +1015,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "Ii" = (
@@ -1018,6 +1041,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Iy" = (
@@ -1027,6 +1051,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/structure/cable,
+/obj/machinery/power/terminal,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "IA" = (
@@ -1075,6 +1101,7 @@
 "KI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/delivery,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "KN" = (
@@ -1126,10 +1153,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"LI" = (
-/obj/item/pickaxe,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "LM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -1177,13 +1200,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "MY" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Nv" = (
@@ -1317,11 +1337,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "SB" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "SU" = (
@@ -1330,7 +1347,6 @@
 	filter_type = list(/datum/gas/nitrogen)
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Tl" = (
@@ -1350,6 +1366,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Uk" = (
@@ -1468,13 +1485,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "WZ" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Xe" = (
@@ -1536,6 +1550,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Zp" = (
@@ -1570,6 +1585,10 @@
 	req_access = list("engineering")
 	},
 /turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
+"ZP" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 
 (1,1,1) = {"
@@ -1718,7 +1737,7 @@ LM
 hj
 fj
 ML
-Fu
+de
 ma
 Fu
 Fu
@@ -1726,10 +1745,10 @@ xG
 VI
 vD
 vD
+vD
 zp
 pa
 QA
-LI
 CQ
 lV
 "}
@@ -1749,11 +1768,11 @@ LZ
 wG
 Iy
 iW
+Ci
 HV
 zp
 pa
 lf
-aK
 aK
 "}
 (9,1,1) = {"
@@ -1771,11 +1790,11 @@ hD
 xX
 IA
 Wd
+fH
 XR
 Ir
 KY
 zp
-aK
 aK
 aK
 "}
@@ -1795,10 +1814,10 @@ SU
 vD
 Fj
 Fj
+vs
 Fj
 Fj
 zp
-aK
 aK
 aK
 "}
@@ -1818,10 +1837,10 @@ nb
 Cu
 GL
 GL
+nw
 Xe
 oe
 zp
-aK
 aK
 aK
 "}
@@ -1841,10 +1860,10 @@ WZ
 vD
 mt
 oe
+NC
 ue
-Ag
+Hv
 pa
-aK
 aK
 aK
 "}
@@ -1864,10 +1883,10 @@ Hb
 vD
 EH
 EO
+ZP
 va
 IJ
 zp
-aK
 aK
 aK
 "}
@@ -1887,10 +1906,10 @@ MY
 vD
 Fj
 Fj
+vs
 Vk
 Gb
 zp
-aK
 aK
 aK
 "}
@@ -1906,14 +1925,14 @@ GC
 uW
 pk
 Fq
-dN
+nb
 Cu
 GL
 GL
+nw
 np
 Fj
 zp
-aK
 aK
 aK
 "}
@@ -1933,10 +1952,10 @@ SB
 vD
 oe
 oe
+NC
 oe
 oe
 zp
-aK
 aK
 aK
 "}
@@ -1955,11 +1974,11 @@ Tt
 hW
 qK
 If
-XR
+fH
+sF
 xq
 vL
 pa
-aK
 aK
 aK
 "}
@@ -1968,28 +1987,28 @@ ic
 wZ
 hh
 yM
-oK
+yM
 xt
-rj
+yM
 rj
 rj
 Ii
 rz
-hW
+bN
 lg
 Hs
+Kz
 Kz
 Bl
 zp
 zp
 aK
 aK
-aK
 "}
 (19,1,1) = {"
 zp
 NC
-oe
+NC
 LD
 Ib
 Ib
@@ -2002,9 +2021,9 @@ tB
 zp
 lg
 vD
+vD
 pa
 zp
-aK
 aK
 aK
 aK

--- a/monkestation/_maps/RandomEngines/MetaStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/MetaStation/singularity.dmm
@@ -8,6 +8,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"bp" = (
+/obj/structure/cable/multilayer/connected,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "bM" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
@@ -47,11 +51,17 @@
 /area/station/engineering/supermatter/room)
 "dT" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/plating,
 /area/space/nearstation)
 "eg" = (
 /turf/open/floor/carpet/black,
 /area/station/engineering/supermatter/room)
+"ej" = (
+/obj/structure/grille,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "eH" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59,8 +69,6 @@
 /area/station/engineering/supermatter/room)
 "eI" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room"
 	},
@@ -91,6 +99,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"hW" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space/nearstation)
 "iY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -125,7 +138,6 @@
 /area/station/engineering/supermatter/room)
 "nd" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room"
 	},
@@ -140,6 +152,24 @@
 /area/station/engineering/supermatter/room)
 "nM" = (
 /obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
+"ok" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/structure/cable/layer1,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
+"ol" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/space/basic,
 /area/space/nearstation)
 "oW" = (
@@ -159,7 +189,6 @@
 /area/station/engineering/supermatter/room)
 "qz" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room"
 	},
@@ -269,7 +298,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
@@ -316,6 +344,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"zA" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "zC" = (
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
@@ -369,17 +402,36 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
+"BM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
+"Df" = (
+/obj/structure/cable,
+/obj/structure/cable/layer1,
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "DK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"Ew" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "EM" = (
-/obj/structure/cable,
 /obj/structure/lattice/catwalk,
+/obj/structure/cable/layer1,
 /turf/open/space/basic,
 /area/space/nearstation)
 "EP" = (
@@ -402,6 +454,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"Fy" = (
+/obj/structure/grille/broken,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "FN" = (
 /obj/structure/particle_accelerator/end_cap{
 	dir = 4
@@ -444,6 +501,20 @@
 /area/station/engineering/supermatter/room)
 "Jc" = (
 /obj/structure/cable,
+/obj/structure/cable/layer1,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
+"JI" = (
+/obj/machinery/door/airlock/external{
+	name = "Solar Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/fans/tiny,
+/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "JY" = (
@@ -463,7 +534,6 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/space/nearstation)
@@ -492,6 +562,26 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
 /turf/open/floor/carpet/black,
+/area/station/engineering/supermatter/room)
+"NU" = (
+/obj/structure/cable,
+/obj/structure/cable/layer1,
+/turf/open/floor/plating,
+/area/space/nearstation)
+"Oh" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/layer1,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
+"OU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "OV" = (
 /obj/effect/turf_decal/stripes/line{
@@ -523,6 +613,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"Sj" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/multilayer/connected,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "SK" = (
 /obj/structure/table/reinforced,
 /obj/item/pen/fountain,
@@ -553,10 +648,30 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"XP" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "Yf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
+"Yq" = (
+/obj/structure/cable,
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/layer1,
+/turf/open/space/basic,
+/area/space/nearstation)
+"Yy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "Yz" = (
@@ -799,7 +914,7 @@ vY
 GM
 GM
 kO
-Yz
+Yy
 yR
 yR
 yn
@@ -826,9 +941,9 @@ np
 gQ
 zC
 eI
-dc
-to
-hn
+BM
+Ew
+XP
 MT
 zC
 Fw
@@ -837,7 +952,7 @@ Sh
 zC
 MT
 dx
-to
+Ew
 Yf
 lj
 je
@@ -853,9 +968,9 @@ MT
 MT
 kO
 MT
-Yz
-HO
-hn
+OU
+zC
+Sj
 MT
 Vn
 ut
@@ -864,7 +979,7 @@ Bo
 zC
 MT
 dx
-HO
+zC
 Yf
 kO
 je
@@ -880,9 +995,9 @@ je
 je
 je
 kO
-Yz
-HO
-hn
+Yy
+Df
+Oh
 MT
 Gs
 zC
@@ -891,7 +1006,7 @@ zC
 AG
 MT
 dx
-HO
+zC
 Yf
 lj
 je
@@ -908,7 +1023,7 @@ je
 je
 MT
 kO
-BH
+ok
 kO
 MT
 kO
@@ -945,7 +1060,7 @@ An
 An
 MT
 SS
-Jc
+SS
 cP
 MT
 je
@@ -962,7 +1077,7 @@ je
 je
 MT
 kO
-xA
+JI
 kO
 MT
 An
@@ -987,9 +1102,9 @@ je
 je
 je
 je
-je
 An
-EM
+An
+ol
 An
 Bc
 nM
@@ -999,9 +1114,9 @@ KS
 nM
 Bc
 An
-EM
 An
-je
+nM
+An
 je
 je
 je
@@ -1014,21 +1129,21 @@ je
 je
 je
 je
-je
 An
-EM
-EM
-EM
-EM
-EM
-EM
-EM
-EM
-EM
+hW
+ol
+ol
+Yq
+Yq
+Yq
+Yq
+Yq
+Yq
+Yq
 EM
 EM
 An
-je
+Fy
 je
 je
 je
@@ -1041,21 +1156,21 @@ je
 je
 je
 je
-je
 An
-An
-An
-xy
-An
-An
-An
-An
+hW
+EM
 An
 xy
 An
 An
 An
-je
+An
+An
+xy
+An
+EM
+nM
+nM
 je
 je
 je
@@ -1068,9 +1183,9 @@ je
 je
 je
 je
-je
 Bc
-An
+hW
+EM
 An
 ML
 wm
@@ -1080,9 +1195,9 @@ nM
 wm
 ML
 An
-An
-Bc
-je
+EM
+nM
+ej
 je
 je
 je
@@ -1095,21 +1210,21 @@ je
 je
 je
 je
-je
 bM
+hW
+EM
 An
-An
-dT
+wm
 GT
 wm
 nM
 wm
 GT
-dT
+wm
+An
+EM
 An
 An
-bM
-je
 je
 je
 je
@@ -1122,21 +1237,21 @@ je
 je
 je
 je
-je
 bM
-An
-dT
-dT
+hW
+EM
+zA
+wm
 wm
 nM
 nM
 nM
 wm
+wm
 dT
-dT
+EM
 An
-bM
-je
+nM
 je
 je
 je
@@ -1149,21 +1264,21 @@ je
 je
 je
 je
-je
 Bc
-An
-dT
-dT
+hW
+EM
+NU
+bp
 nM
 nM
 vB
 nM
 nM
-dT
-dT
-An
-Bc
-je
+bp
+NU
+EM
+nM
+ej
 je
 je
 je
@@ -1176,21 +1291,21 @@ je
 je
 je
 je
-je
 bM
+hW
 An
 dT
-dT
+wm
 wm
 nM
 nM
 nM
 wm
-dT
-dT
+wm
+zA
 An
+nM
 bM
-je
 je
 je
 je
@@ -1203,21 +1318,21 @@ je
 je
 je
 je
-je
 bM
+hW
 An
 An
-dT
+wm
 GT
 wm
 nM
 wm
 GT
-dT
+wm
 An
 An
-bM
-je
+An
+nM
 je
 je
 je
@@ -1230,8 +1345,8 @@ je
 je
 je
 je
-je
 Bc
+hW
 An
 GG
 ML
@@ -1243,8 +1358,8 @@ wm
 ML
 EP
 An
-Bc
-je
+nM
+ej
 je
 je
 je
@@ -1257,7 +1372,8 @@ je
 je
 je
 je
-je
+An
+hW
 An
 An
 An
@@ -1267,11 +1383,10 @@ An
 An
 An
 An
+hW
 An
-An
-An
-An
-je
+nM
+nM
 je
 je
 je
@@ -1284,21 +1399,21 @@ je
 je
 je
 je
-je
 bM
+hW
+hW
+hW
+hW
+hW
+hW
+hW
+hW
+hW
+hW
+hW
 An
 An
-An
-An
-An
-An
-An
-An
-An
-An
-An
-bM
-je
+Fy
 je
 je
 je
@@ -1311,8 +1426,8 @@ je
 je
 je
 je
-je
 bM
+An
 bM
 An
 Bc
@@ -1324,8 +1439,8 @@ Bc
 Bc
 An
 bM
-bM
-je
+KS
+KS
 je
 je
 je

--- a/monkestation/_maps/RandomEngines/MetaStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/MetaStation/singularity.dmm
@@ -70,7 +70,7 @@
 "eI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
+	name = "Space Engine Room"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
@@ -117,7 +117,7 @@
 "kf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
+	name = "Space Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
@@ -139,7 +139,7 @@
 "nd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
+	name = "Space Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -155,9 +155,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "ok" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance"
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -190,7 +188,7 @@
 "qz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
+	name = "Space Engine Room"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -284,16 +282,13 @@
 /area/station/engineering/supermatter/room)
 "xy" = (
 /obj/structure/cable,
-/obj/structure/lattice/catwalk,
 /obj/machinery/power/emitter{
 	dir = 4
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/space/nearstation)
 "xA" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance"
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -304,7 +299,7 @@
 "yn" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
+	name = "Space Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -314,7 +309,7 @@
 "yo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
+	name = "Space Engine Room"
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
@@ -395,9 +390,7 @@
 /turf/open/floor/carpet/black,
 /area/station/engineering/supermatter/room)
 "BH" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance"
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -435,12 +428,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "EP" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /obj/machinery/power/emitter{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/space/nearstation)
 "Fa" = (
 /obj/effect/turf_decal/stripes/line{
@@ -473,10 +465,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "GG" = (
-/obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /obj/machinery/power/emitter,
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/space/nearstation)
 "GM" = (
 /obj/machinery/power/rad_collector,
@@ -505,9 +496,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "JI" = (
-/obj/machinery/door/airlock/external{
-	name = "Solar Maintenance"
-	},
+/obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -636,7 +625,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
+	name = "Space Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
@@ -1162,9 +1151,9 @@ EM
 An
 xy
 An
-An
-An
-An
+wm
+wm
+wm
 An
 xy
 An
@@ -1186,7 +1175,7 @@ je
 Bc
 hW
 EM
-An
+wm
 ML
 wm
 nM
@@ -1194,7 +1183,7 @@ nM
 nM
 wm
 ML
-An
+wm
 EM
 nM
 ej
@@ -1347,7 +1336,7 @@ je
 je
 Bc
 hW
-An
+hW
 GG
 ML
 wm
@@ -1376,13 +1365,13 @@ An
 hW
 An
 An
+wm
 An
+wm
+wm
+wm
 An
-An
-An
-An
-An
-An
+wm
 hW
 An
 nM

--- a/monkestation/_maps/RandomEngines/MetaStation/supermatter.dmm
+++ b/monkestation/_maps/RandomEngines/MetaStation/supermatter.dmm
@@ -41,19 +41,19 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/button/door/directional/east{
 	id = "engsm";
 	name = "Radiation Shutters Control";
 	req_access = list("engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "cT" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dc" = (
@@ -69,7 +69,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -77,8 +76,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "eg" = (
@@ -126,11 +125,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/status_display/evac/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gY" = (
@@ -139,6 +138,7 @@
 	dir = 1
 	},
 /obj/machinery/meter,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "hn" = (
@@ -165,8 +165,8 @@
 /area/station/engineering/supermatter/room)
 "iY" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "je" = (
@@ -184,7 +184,7 @@
 /obj/structure/reflector/single/anchored{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "kK" = (
 /turf/template_noop,
@@ -200,6 +200,7 @@
 /area/station/engineering/supermatter/room)
 "mO" = (
 /obj/item/wrench,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "nd" = (
@@ -232,7 +233,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Gas to Mix"
@@ -299,7 +299,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/meter,
 /obj/machinery/light/directional/south,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/engine,
@@ -324,7 +323,6 @@
 /area/station/engineering/supermatter/room)
 "tg" = (
 /obj/effect/turf_decal/delivery,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
@@ -335,6 +333,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/light/directional/north,
 /obj/machinery/status_display/evac/directional/north,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "tt" = (
@@ -364,23 +363,22 @@
 	c_tag = "Engineering Supermatter Starboard";
 	network = list("ss13","engine")
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "uU" = (
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
 "vk" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "vB" = (
@@ -525,6 +523,8 @@
 /area/space/nearstation)
 "Ay" = (
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "AG" = (
@@ -552,7 +552,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -560,25 +559,25 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "BH" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Laser Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "BQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/directional/south,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/status_display/evac/directional/south,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "CG" = (
@@ -601,11 +600,18 @@
 	dir = 4;
 	name = "Cooling Loop Bypass"
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
+"Dk" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "DK" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
@@ -625,9 +631,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/power/apc/worn_out/directional/east,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "EU" = (
@@ -658,14 +664,6 @@
 /obj/machinery/power/supermatter_crystal/engine,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"Gs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "GG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -699,17 +697,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "HO" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -724,8 +721,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "IH" = (
@@ -753,7 +750,7 @@
 /area/station/engineering/supermatter/room)
 "Kt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "KS" = (
 /obj/structure/reflector/box/anchored{
@@ -769,8 +766,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Lv" = (
@@ -788,12 +785,12 @@
 	c_tag = "Engineering Supermatter Port";
 	network = list("ss13","engine")
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/airalarm/engine{
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "ML" = (
@@ -837,10 +834,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Engine Coolant Bypass"
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "OC" = (
@@ -855,8 +852,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
+"Pg" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Laser Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "PF" = (
 /obj/machinery/door/firedoor,
@@ -902,7 +907,7 @@
 /obj/structure/reflector/single/anchored{
 	dir = 10
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "Sh" = (
 /obj/structure/sign/warning/electric_shock,
@@ -912,7 +917,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/meter,
 /turf/open/floor/engine,
@@ -941,29 +945,26 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"TL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
-/turf/open/floor/engine,
+"Uv" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "UI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "UK" = (
 /obj/item/crowbar,
-/obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
 "Vk" = (
@@ -980,8 +981,8 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Vu" = (
@@ -1022,6 +1023,13 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"Xa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "Yf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1049,8 +1057,8 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Zt" = (
@@ -1350,14 +1358,14 @@ kO
 MT
 OC
 HO
-hn
-hn
-hn
+Xa
+Xa
+Xa
 ut
 tg
 Bo
 hn
-hn
+Xa
 dx
 CY
 gO
@@ -1377,9 +1385,9 @@ kK
 AZ
 Yz
 Sw
-TL
 PN
-Gs
+PN
+AG
 VC
 ck
 OV
@@ -1403,7 +1411,7 @@ kK
 kK
 MT
 Qq
-BH
+Pg
 kO
 MT
 MT
@@ -1430,8 +1438,8 @@ kK
 kK
 MT
 NN
-Jc
-SS
+zC
+zC
 zC
 zC
 zC
@@ -1440,8 +1448,8 @@ rY
 zC
 zC
 Kt
-Jc
-zC
+Uv
+Dk
 MT
 Jo
 zi
@@ -1457,17 +1465,17 @@ kK
 kK
 MT
 wm
+SS
 Jc
-Jc
-zC
-zC
-zC
-zC
-zC
-zC
-zC
+Uv
+Uv
+Uv
+Uv
+Uv
+Uv
+Uv
 vk
-Jc
+SS
 Ay
 MT
 SZ
@@ -1494,7 +1502,7 @@ zC
 zC
 zC
 tA
-SS
+Jc
 mO
 MT
 Jo
@@ -1510,16 +1518,16 @@ kK
 kK
 kK
 MT
-SS
+zC
 SS
 oW
-Jc
-SS
+zC
+zC
 kJ
 MT
 RU
-SS
-SS
+zC
+zC
 bM
 SS
 zC

--- a/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
@@ -9,7 +9,6 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/space/nearstation)
@@ -34,15 +33,20 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"gW" = (
+/obj/structure/cable,
+/obj/structure/cable/layer1,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "hb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/stack/tile/iron,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "ix" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/north,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "iY" = (
@@ -54,21 +58,24 @@
 /area/space/nearstation)
 "jH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
-/obj/structure/cable/layer1,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"jT" = (
+"jS" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
+/obj/structure/cable/layer1,
+/turf/open/space/basic,
+/area/space/nearstation)
+"jT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/window/plasma/spawner/directional/south,
 /obj/structure/cable/layer1,
 /turf/open/floor/glass/reinforced/plasma,
 /area/station/engineering/supermatter/room)
-"lf" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
+"kr" = (
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "lq" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room"
@@ -91,11 +98,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
-"lG" = (
-/obj/structure/cable,
-/obj/machinery/power/rad_collector,
-/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "mz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -131,11 +133,20 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"qw" = (
+/obj/structure/cable/multilayer/connected,
+/turf/open/floor/plating,
+/area/space/nearstation)
+"qx" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "qQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
 /obj/machinery/power/rad_collector,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "qR" = (
@@ -145,8 +156,7 @@
 	network = list("ss13","engine","engineering")
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/layer1,
-/obj/item/stack/cable_coil,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "ro" = (
@@ -156,8 +166,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
-/obj/structure/cable/layer1,
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
@@ -165,33 +173,24 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
+"tb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/glass/reinforced/plasma,
 /area/station/engineering/supermatter/room)
 "tY" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"ud" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/layer1,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "vK" = (
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plating,
 /area/space/nearstation)
-"vP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
-/obj/structure/cable,
-/obj/machinery/power/rad_collector,
-/obj/structure/cable/layer1,
-/turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
 "vY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/the_singularitygen/tesla,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "wh" = (
@@ -203,16 +202,21 @@
 /obj/structure/window/plasma/spawner/directional/east,
 /turf/open/floor/glass/reinforced/plasma,
 /area/station/engineering/supermatter/room)
+"wv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "wL" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "wX" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
-/obj/structure/cable/layer1,
 /turf/open/floor/plating,
 /area/space/nearstation)
 "xd" = (
@@ -241,6 +245,9 @@
 /obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"zC" = (
+/turf/open/space/basic,
+/area/template_noop)
 "zH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -267,7 +274,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/cable/layer1,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "EU" = (
@@ -275,8 +281,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
-/obj/structure/cable/layer1,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "EX" = (
@@ -294,6 +298,10 @@
 /obj/structure/particle_accelerator/particle_emitter/center,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
+"GS" = (
+/obj/structure/cable/layer1,
+/turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "Hk" = (
 /obj/structure/particle_accelerator/particle_emitter/right,
@@ -321,15 +329,8 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "JJ" = (
-/obj/structure/cable,
-/obj/item/stack/tile/iron,
+/obj/structure/cable/multilayer/connected,
 /turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
-"Lt" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/layer1,
-/turf/open/floor/glass/reinforced/plasma,
 /area/station/engineering/supermatter/room)
 "LM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -344,7 +345,6 @@
 /area/station/engineering/supermatter/room)
 "Ms" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "NO" = (
@@ -359,6 +359,7 @@
 /area/station/engineering/supermatter/room)
 "Ou" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/plating,
 /area/space/nearstation)
 "OY" = (
@@ -368,7 +369,6 @@
 	network = list("ss13","engine","engineering")
 	},
 /obj/machinery/power/energy_accumulator/grounding_rod,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "Pi" = (
@@ -384,15 +384,7 @@
 "PM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/power/energy_accumulator/tesla_coil,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
-/area/station/engineering/supermatter/room)
-"QT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "Rb" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -406,6 +398,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "Sb" = (
@@ -439,9 +432,9 @@
 "Ul" = (
 /turf/closed/wall,
 /area/station/engineering/supermatter/room)
-"Vm" = (
-/obj/structure/lattice,
-/obj/structure/cable,
+"VH" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/layer1,
 /turf/open/space/basic,
 /area/space/nearstation)
 "Wk" = (
@@ -458,10 +451,15 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/space/nearstation)
-"Xo" = (
+"WX" = (
+/obj/structure/lattice/catwalk,
 /obj/structure/cable,
+/turf/template_noop,
+/area/space/nearstation)
+"Xo" = (
 /obj/structure/table,
 /obj/structure/window/plasma/spawner/directional/east,
+/obj/structure/cable/layer1,
 /turf/open/floor/glass/reinforced/plasma,
 /area/station/engineering/supermatter/room)
 "Xx" = (
@@ -727,18 +725,18 @@ TZ
 TZ
 TZ
 TZ
-TZ
-TZ
-TZ
-TZ
-TZ
+WX
+WX
+WX
+WX
+WX
 TZ
 "}
 (12,1,1) = {"
 Ho
 Ms
+tb
 LM
-Lt
 jT
 pe
 er
@@ -749,10 +747,10 @@ Pi
 Pi
 Pi
 Pi
-WI
-WI
-WI
-WI
+jS
+VH
+VH
+zz
 WI
 WI
 "}
@@ -762,18 +760,18 @@ Ms
 wi
 Xo
 YU
-JE
+Pp
 Ho
 Ho
 Ho
 Zh
 Zh
-zz
+jS
 zz
 iY
 zz
-Ou
-Ou
+wv
+gW
 Ou
 zz
 iY
@@ -782,20 +780,20 @@ iY
 Ho
 ix
 EX
+GS
+EX
 Pp
-JE
-JE
 wL
 Ho
 Zh
 Zh
 Zh
-zz
+jS
 zz
 by
 ZS
 FU
-FU
+qw
 FU
 ZS
 by
@@ -807,12 +805,12 @@ mz
 JJ
 JE
 JE
-JE
+qx
 tY
 Zh
 Zh
 Zh
-zz
+jS
 zz
 ZS
 yp
@@ -829,12 +827,12 @@ au
 HO
 se
 RT
-JE
+Pp
 tY
 Zh
 Zh
 Zh
-zz
+jS
 zz
 ZS
 ZS
@@ -856,7 +854,7 @@ tY
 Zh
 Zh
 Zh
-zz
+jS
 zz
 ZS
 zz
@@ -870,7 +868,7 @@ ZS
 Om
 Xx
 yN
-QT
+NO
 NO
 Hk
 JE
@@ -878,7 +876,7 @@ tY
 Zh
 Zh
 Zh
-zz
+jS
 zz
 ZS
 ZS
@@ -890,9 +888,9 @@ ZS
 "}
 (19,1,1) = {"
 Ho
-ud
+Xx
 Sb
-Pp
+JE
 JE
 JE
 JE
@@ -900,9 +898,9 @@ tY
 Zh
 Zh
 Zh
+jS
 zz
-zz
-Vm
+ZS
 yp
 ZS
 zz
@@ -914,7 +912,7 @@ ZS
 Ho
 DV
 Ho
-lf
+Ho
 tY
 Rb
 Ho
@@ -922,12 +920,12 @@ Ho
 Zh
 Zh
 Zh
-zz
+jS
 zz
 by
 ZS
 FU
-FU
+qw
 FU
 ZS
 by
@@ -936,7 +934,7 @@ by
 Ho
 OY
 wh
-lG
+wh
 wh
 Gn
 Ho
@@ -944,13 +942,13 @@ Ho
 Ho
 Zh
 Zh
-zz
+jS
 zz
 oy
 zz
 Ou
-Ou
-Ou
+gW
+wv
 zz
 oy
 "}
@@ -958,21 +956,21 @@ oy
 Ho
 vY
 PM
-vP
+qQ
 qQ
 qQ
 EU
 jH
 ro
 wX
+kr
 Pi
 Pi
 Pi
-Pi
-WI
-WI
-WI
-WI
+jS
+VH
+VH
+zz
 WI
 WI
 "}
@@ -991,12 +989,12 @@ JI
 JI
 JI
 JI
-TZ
-TZ
-TZ
-TZ
-TZ
-TZ
+WI
+WI
+WI
+WI
+WI
+zC
 "}
 (24,1,1) = {"
 Ho

--- a/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
@@ -3,6 +3,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "by" = (
@@ -17,7 +18,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "er" = (
@@ -30,7 +30,6 @@
 /area/station/engineering/supermatter/room)
 "eI" = (
 /obj/structure/particle_accelerator/fuel_chamber,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "gW" = (
@@ -45,7 +44,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "ix" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
@@ -67,7 +65,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "jT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/window/plasma/spawner/directional/south,
 /obj/structure/cable/layer1,
 /turf/open/floor/glass/reinforced/plasma,
@@ -90,13 +87,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "mz" = (
@@ -177,7 +174,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "tb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/glass/reinforced/plasma,
 /area/station/engineering/supermatter/room)
 "tY" = (
@@ -242,7 +238,7 @@
 "zB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/multilayer/connected,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "zC" = (
@@ -333,7 +329,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "LM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/layer1,
 /turf/open/floor/glass/reinforced/plasma,
 /area/station/engineering/supermatter/room)
@@ -342,10 +337,6 @@
 	dir = 4
 	},
 /turf/open/floor/glass/reinforced/plasma,
-/area/station/engineering/supermatter/room)
-"Ms" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "NO" = (
 /obj/effect/turf_decal/stripes/line{
@@ -734,7 +725,7 @@ TZ
 "}
 (12,1,1) = {"
 Ho
-Ms
+JE
 tb
 LM
 jT
@@ -756,7 +747,7 @@ WI
 "}
 (13,1,1) = {"
 Ho
-Ms
+JE
 wi
 Xo
 YU

--- a/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
@@ -3,6 +3,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/cable/layer1,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
@@ -13,6 +14,11 @@
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/space/nearstation)
+"cb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "cK" = (
 /obj/structure/particle_accelerator/end_cap,
 /obj/effect/turf_decal/stripes/line{
@@ -39,9 +45,9 @@
 /area/space/nearstation)
 "hb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/stack/tile/iron,
+/obj/structure/cable/layer1,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "ix" = (
 /obj/machinery/light/directional/north,
@@ -87,21 +93,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "mz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/item/stack/tile/iron,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "oy" = (
 /obj/structure/cable,
@@ -141,6 +139,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"qD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/item/stack/tile/iron{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "qQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/power/rad_collector,
@@ -152,9 +160,7 @@
 	c_tag = "Engineering - Engine Room North-West";
 	network = list("ss13","engine","engineering")
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "ro" = (
 /obj/machinery/door/airlock/external,
@@ -238,7 +244,6 @@
 "zB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "zC" = (
@@ -279,10 +284,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"EX" = (
-/obj/item/stack/tile/iron,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "FU" = (
 /turf/open/floor/plating,
 /area/space/nearstation)
@@ -314,6 +315,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable/layer1,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
@@ -324,10 +326,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/space/basic,
 /area/space/nearstation)
-"JJ" = (
-/obj/structure/cable/multilayer/connected,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "LM" = (
 /obj/structure/cable/layer1,
 /turf/open/floor/glass/reinforced/plasma,
@@ -346,6 +344,7 @@
 /area/station/engineering/supermatter/room)
 "Om" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/multilayer/connected,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "Ou" = (
@@ -384,6 +383,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"Rv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "RT" = (
 /obj/structure/particle_accelerator/particle_emitter/left,
 /obj/effect/turf_decal/stripes/line{
@@ -396,7 +401,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/item/stack/tile/iron,
+/turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "SQ" = (
 /obj/machinery/light/small/directional/south,
@@ -455,6 +461,7 @@
 /area/station/engineering/supermatter/room)
 "Xx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "XF" = (
@@ -770,9 +777,9 @@ iY
 (14,1,1) = {"
 Ho
 ix
-EX
+JE
 GS
-EX
+JE
 Pp
 wL
 Ho
@@ -793,7 +800,7 @@ by
 Ho
 qR
 mz
-JJ
+GS
 JE
 JE
 qx
@@ -856,10 +863,10 @@ zz
 FU
 "}
 (18,1,1) = {"
-Om
+cb
 Xx
 yN
-NO
+qD
 NO
 Hk
 JE
@@ -879,7 +886,7 @@ FU
 "}
 (19,1,1) = {"
 Ho
-Xx
+Rv
 Sb
 JE
 JE

--- a/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
@@ -78,7 +78,7 @@
 /area/space/nearstation)
 "lq" = (
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
+	name = "Space Engine Room"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -388,7 +388,7 @@
 /area/station/engineering/supermatter/room)
 "Rb" = (
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
+	name = "Space Engine Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron,
@@ -834,13 +834,13 @@ Zh
 Zh
 jS
 zz
-ZS
-ZS
-zz
+FU
 ZS
 zz
 ZS
+zz
 ZS
+FU
 "}
 (17,1,1) = {"
 lq
@@ -856,13 +856,13 @@ Zh
 Zh
 jS
 zz
-ZS
+FU
 zz
 ZS
 vK
 ZS
 zz
-ZS
+FU
 "}
 (18,1,1) = {"
 Om
@@ -878,13 +878,13 @@ Zh
 Zh
 jS
 zz
-ZS
-ZS
-zz
+FU
 ZS
 zz
 ZS
+zz
 ZS
+FU
 "}
 (19,1,1) = {"
 Ho

--- a/monkestation/_maps/RandomEngines/TramStation/supermatter.dmm
+++ b/monkestation/_maps/RandomEngines/TramStation/supermatter.dmm
@@ -251,6 +251,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
+"js" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -291,6 +295,7 @@
 /obj/machinery/status_display/ai/directional/west{
 	pixel_y = 32
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "kH" = (
@@ -356,14 +361,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "mg" = (
@@ -408,8 +411,6 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 4
 	},
-/obj/structure/cable/layer1,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "nG" = (
@@ -464,8 +465,12 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 1
 	},
-/obj/structure/cable/multilayer/connected,
+/obj/structure/cable,
 /turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
+"oy" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "oT" = (
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
@@ -512,7 +517,6 @@
 	dir = 8;
 	filter_type = list(/datum/gas/nitrogen)
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "rq" = (
@@ -694,6 +698,7 @@
 	dir = 9;
 	network = list("ss13","engine","engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "yN" = (
@@ -952,8 +957,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/worn_out/directional/north,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "NS" = (
@@ -965,7 +970,6 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 4
 	},
-/obj/structure/cable/layer1,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Oh" = (
@@ -998,6 +1002,14 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"OX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "PE" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -1009,6 +1021,7 @@
 /area/station/engineering/supermatter/room)
 "PF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "PQ" = (
@@ -1036,11 +1049,6 @@
 /obj/effect/baseturf_helper/space,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
-"Rd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "Rq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
@@ -1048,7 +1056,6 @@
 "Rr" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "RS" = (
@@ -1118,7 +1125,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Uw" = (
@@ -1158,6 +1164,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "VB" = (
@@ -1196,6 +1203,7 @@
 /area/station/engineering/supermatter/room)
 "Wn" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "XP" = (
@@ -1228,6 +1236,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/east,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Za" = (
@@ -1610,7 +1619,7 @@ fL
 GF
 uv
 Kh
-Rd
+nT
 yN
 ft
 wW
@@ -1621,8 +1630,8 @@ ft
 "}
 (16,1,1) = {"
 Wn
-XW
-Rq
+ht
+js
 jv
 gR
 fn
@@ -1698,7 +1707,7 @@ Zk
 iM
 uv
 wr
-Rd
+nT
 yN
 ft
 wW
@@ -1719,7 +1728,7 @@ ex
 af
 ex
 uv
-tL
+OX
 nT
 ID
 sm
@@ -1741,7 +1750,7 @@ BI
 oT
 Ku
 uv
-tL
+OX
 bJ
 PE
 dS
@@ -1797,17 +1806,17 @@ ft
 "}
 (24,1,1) = {"
 ft
-ft
-ft
+oy
+oy
 PF
-ft
-ft
-ft
-ft
-ft
-ft
-ft
-ft
+oy
+oy
+oy
+oy
+oy
+oy
+oy
+oy
 ft
 SM
 ft

--- a/monkestation/_maps/RandomEngines/TramStation/supermatter.dmm
+++ b/monkestation/_maps/RandomEngines/TramStation/supermatter.dmm
@@ -4,7 +4,7 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 1
 	},
-/obj/structure/cable/multilayer/connected,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "aj" = (
@@ -38,7 +38,7 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dt" = (
@@ -50,13 +50,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/structure/cable/layer1,
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 4
 	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/corner,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dS" = (
@@ -66,7 +64,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "eo" = (
@@ -81,8 +78,14 @@
 /area/station/engineering/supermatter)
 "ez" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 6
+	},
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "fn" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -108,7 +111,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_cw,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "ft" = (
@@ -138,13 +141,21 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "gv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
+"gL" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "gR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
@@ -152,11 +163,11 @@
 "gV" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw,
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ha" = (
@@ -181,12 +192,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "hL" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
+/obj/structure/cable,
+/obj/machinery/power/terminal,
+/obj/effect/turf_decal/trimline/yellow/corner,
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 9
 	},
-/obj/item/stack/cable_coil,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "io" = (
@@ -197,12 +208,16 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw,
+/obj/structure/cable,
 /turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
+"iF" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "iM" = (
 /obj/structure/window/reinforced/plasma{
@@ -224,20 +239,19 @@
 "iZ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/yellow/corner,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "jr" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "jv" = (
@@ -248,7 +262,7 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "jI" = (
@@ -259,7 +273,6 @@
 	c_tag = "Engineering - Engine Room North-West";
 	network = list("ss13","engine","engineering")
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "jV" = (
@@ -305,7 +318,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ls" = (
@@ -319,7 +331,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "lL" = (
@@ -363,13 +374,27 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "mH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 5
+	},
+/obj/structure/cable,
 /turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
+"nf" = (
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "nk" = (
 /obj/effect/turf_decal/stripes/line{
@@ -411,11 +436,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw,
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
 "oe" = (
@@ -439,7 +464,7 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable/multilayer/connected,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "oT" = (
@@ -450,11 +475,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
 "pt" = (
@@ -470,7 +495,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "qg" = (
@@ -488,6 +512,7 @@
 	dir = 8;
 	filter_type = list(/datum/gas/nitrogen)
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "rq" = (
@@ -505,7 +530,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "rZ" = (
@@ -519,21 +543,20 @@
 /area/station/engineering/supermatter/room)
 "st" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "sz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ta" = (
@@ -585,7 +608,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_cw,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "uv" = (
@@ -599,13 +622,13 @@
 /obj/machinery/status_display/evac/directional/west{
 	pixel_y = -32
 	},
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "vH" = (
@@ -652,6 +675,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 8
+	},
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -665,12 +694,22 @@
 	dir = 9;
 	network = list("ss13","engine","engineering")
 	},
-/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
+"yN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Al" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 8
+	},
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -691,7 +730,6 @@
 	c_tag = "Engineering - Engine Room South-East";
 	network = list("ss13","engine","engineering")
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "BF" = (
@@ -699,6 +737,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "BI" = (
@@ -726,14 +771,12 @@
 	dir = 8
 	},
 /obj/structure/sign/warning/vacuum/external/directional/west,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Dq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Ep" = (
@@ -751,20 +794,19 @@
 /area/station/engineering/supermatter/room)
 "Ex" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "EY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "Fs" = (
@@ -777,6 +819,8 @@
 /area/station/engineering/supermatter/room)
 "FQ" = (
 /obj/machinery/airalarm/directional/west,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "GF" = (
@@ -806,7 +850,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "IH" = (
@@ -820,7 +863,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "JT" = (
@@ -828,13 +870,13 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Kh" = (
@@ -897,13 +939,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Nc" = (
@@ -931,7 +973,7 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 1
 	},
-/obj/structure/cable/multilayer/connected,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "Ov" = (
@@ -943,24 +985,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "OO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 4
 	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
-"OX" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "PE" = (
@@ -970,7 +1005,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "PF" = (
@@ -988,6 +1022,13 @@
 "QA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/meter,
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 10
+	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "QV" = (
@@ -1007,13 +1048,13 @@
 "Rr" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "RS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "SM" = (
@@ -1036,7 +1077,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Tn" = (
@@ -1054,7 +1094,6 @@
 "TD" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "TU" = (
@@ -1075,12 +1114,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "Ul" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Uw" = (
@@ -1090,6 +1128,13 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Cooling Loop Bypass"
 	},
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "UX" = (
@@ -1100,13 +1145,19 @@
 /obj/machinery/status_display/evac/directional/east{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/trimline/yellow/arrow_ccw{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 4
+	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Vm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "VB" = (
@@ -1120,13 +1171,13 @@
 /obj/machinery/status_display/ai/directional/east{
 	pixel_y = -32
 	},
-/obj/structure/cable/layer1,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Wc" = (
@@ -1136,7 +1187,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/arrow_cw,
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Wf" = (
@@ -1151,7 +1202,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "XW" = (
@@ -1170,7 +1220,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/east,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "YM" = (
@@ -1179,7 +1228,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/east,
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "Za" = (
@@ -1221,7 +1269,7 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 1
 	},
-/obj/structure/cable/layer1,
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ZA" = (
@@ -1237,6 +1285,7 @@
 	dir = 10;
 	network = list("ss13","engine","engineering")
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 
@@ -1498,15 +1547,15 @@ UX
 QA
 Ov
 sm
+nf
 VB
-VB
-VB
+iF
 VB
 ft
 "}
 (13,1,1) = {"
 ft
-ht
+XW
 Rq
 ix
 ln
@@ -1522,7 +1571,7 @@ Al
 yL
 ez
 EY
-Dh
+io
 dt
 ft
 "}
@@ -1540,9 +1589,9 @@ ex
 uv
 tL
 qI
-Al
+yN
 sm
-Dh
+VB
 io
 Lu
 Lu
@@ -1561,11 +1610,11 @@ fL
 GF
 uv
 Kh
-nT
-Al
+Rd
+yN
 ft
 wW
-VB
+iF
 VB
 VB
 ft
@@ -1587,7 +1636,7 @@ Ul
 rA
 sm
 LS
-VB
+iF
 VB
 qC
 ft
@@ -1609,7 +1658,7 @@ Rr
 TD
 sm
 pt
-VB
+iF
 pt
 PQ
 ft
@@ -1631,7 +1680,7 @@ jr
 Jg
 sm
 VB
-VB
+iF
 VB
 IH
 ft
@@ -1650,10 +1699,10 @@ iM
 uv
 wr
 Rd
-Al
+yN
 ft
 wW
-VB
+iF
 VB
 VB
 ft
@@ -1671,10 +1720,10 @@ af
 ex
 uv
 tL
-OX
+nT
 ID
 sm
-Dh
+VB
 io
 tj
 io
@@ -1741,7 +1790,7 @@ lv
 Ta
 ft
 tM
-VB
+gL
 lL
 Bo
 ft


### PR DESCRIPTION
## About The Pull Request

Wire map of engines coming in a day or two

**DISCLAIMER**: This PR needs a lot of testing and feedback, please do not merge it without at least a week of test-merging
Also before fully merging if it comes to that, notify me so i can squash commits

This PR adds SMES units that connect to emitters on all random engines, making them able to be setup late into the shift and make sure emitters always have power
It also fixes 2 outta 3 of the singulo/tesla setups having power generation machine spots placed inside of the energy shield tiles (that makes the shields not generate (oh god oh fuck) )
Also adds some indicators for the tesla/singulo setups where power generating machinery is supposed to go, nothing big.

In addition this PR cleans up wires around the SM and deletes 3 outta 4 of the filters on the SM since they used to be there because filters could only filter a single gas, we are way past that and now they just cause gas to block and clog more often.

In even more addition, this PR moves around the tram SMES units as where before they used 2 different wires (red ones to input, yellow to output) now they only use the yellow ones to simplify it a little bit. Tram was the only map to do that and it was confusing.

## Why It's Good For The Game

It allows engineers to set up the SM extremelly late into a round without blowing kisses at it
It also allows engineers to not worry about doing long setups that might cause a temporary power shortage, since the emitters will always have their fair share

## Testing Photographs and Procedure

mildly out of date, all emitters have platings under them now

<details>
<summary>Kilo SM changes</summary>

Before

![Kilo SM - Before](https://github.com/Monkestation/Monkestation2.0/assets/82319946/40ffca24-8996-4c11-90f7-87dded7afb3c)

After

![Kilo SM - After](https://github.com/Monkestation/Monkestation2.0/assets/82319946/51f8c237-e3fa-4762-92ec-ae775d006e06)

</details>

<details>
<summary>Meta SM changes</summary>

Before

![Meta SM - Before](https://github.com/Monkestation/Monkestation2.0/assets/82319946/5ff82ae7-4e11-4b43-b6ef-920ff2ad751f)

After

![Meta SM - After](https://github.com/Monkestation/Monkestation2.0/assets/82319946/23804c66-a5fd-4376-acc9-e5fe942fdef1)

</details>

<details>
<summary>Tram SM changes</summary>

Before

![Tram SM - Before](https://github.com/Monkestation/Monkestation2.0/assets/82319946/d6bf1d4a-fef2-4609-95a2-fb7559b191e0)

After

![Tram SM - After](https://github.com/Monkestation/Monkestation2.0/assets/82319946/b7725173-4a18-404c-9fc1-780ff0af821d)

</details>

<details>
<summary>Kilo tesla/singulo changes</summary>

Before

![Kilo Other - Before](https://github.com/Monkestation/Monkestation2.0/assets/82319946/111c7792-4ebc-4db5-ab11-ab358cec2967)

After

![Kilo Other - After](https://github.com/Monkestation/Monkestation2.0/assets/82319946/872d39c4-dfe8-4053-99d9-04ad510c36dc)

</details>

<details>
<summary>Meta singulo/tesla changes</summary>

Before

![Meta Other - Before](https://github.com/Monkestation/Monkestation2.0/assets/82319946/b048db1d-6cc3-42e4-951f-263ede4cabe4)

After

![Meta Other - After](https://github.com/Monkestation/Monkestation2.0/assets/82319946/f05df972-b84d-4d73-b1a4-f51c24a81c54)

</details>

<details>
<summary>Tram singulo/tesla changes</summary>

Before

![Tram Other - Before](https://github.com/Monkestation/Monkestation2.0/assets/82319946/1c186f53-ee8d-494d-be13-e75e71dd3d95)

After

![Tram Other - After](https://github.com/Monkestation/Monkestation2.0/assets/82319946/e05487ce-0011-4cc3-845e-53ac7536c11f)

</details>

</details>

<details>
<summary>Tram SMES changes</summary>

Before

![Zrzut ekranu (1340)](https://github.com/Monkestation/Monkestation2.0/assets/82319946/aaaddd51-13a8-461f-8f7e-a9dc629db741)

After

![Zrzut ekranu (1339)](https://github.com/Monkestation/Monkestation2.0/assets/82319946/05ce0cbf-fcbe-4caa-84bf-3f5d7d983b7b)

</details>

:cl:
add: Added SMES units to the emitter lines of engines, late-join engineers rejoice!
del: Removes un-necessary filters on the SM
del: Removes the hotwired SMES that wasnt even wired into the powergrid, and was wired into itself in kilostation
qol: Adds white indicators to guide players a _tiny_ bit towards where its intended to place the tesla controllers and grounders
fix: Cleans up some left-over pipes in the sinngulo/tesla maps
fix: Cleans up some duplicate wires on all random engines that had them
spellcheck: replaced "supermatter engine room" on the doors of singularity/tesla setups across all maps
spellcheck: fixed external airlocks having "Departure shuttle airlock" as their names on kilo tesla / singulo setups
spellcheck: fixed external airlocks having "Solar maintnance" as their names on meta tesla / singulo setups
/:cl:
