### PR TITLE
Cargo Improvements

### DIFF
--- a/code/game/machinery/civilian_bounties.dm
+++ b/code/game/machinery/civilian_bounties.dm
@@ -130,7 +130,7 @@
 	var/list/datum/bounty/crumbs = list(random_bounty(pot_acc.account_job.bounty_types), // We want to offer 2 bounties from their appropriate job catagories
 										random_bounty(pot_acc.account_job.bounty_types), // and 1 guarenteed assistant bounty if the other 2 suck.
 										random_bounty(CIV_JOB_BASIC))
-	COOLDOWN_START(pot_acc, bounty_timer, 5 MINUTES)
+	COOLDOWN_START(pot_acc, bounty_timer, 1 MINUTES)
 	pot_acc.bounties = crumbs
 
 /obj/machinery/computer/piratepad_control/civilian/proc/pick_bounty(choice)

--- a/code/modules/cargo/department_order.dm
+++ b/code/modules/cargo/department_order.dm
@@ -160,7 +160,7 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 	var/max = CARGO_CRATE_VALUE * 15
 	credits = clamp(credits, min, max)
 	var/time_y = (credits - min)/(max - min) + 1 //convert to between 1 and 2
-	time_y = 10 MINUTES * time_y
+	time_y = 5 MINUTES * time_y
 	GLOB.department_order_cooldowns[type] = world.time + time_y
 
 /obj/machinery/computer/department_orders/service
@@ -185,7 +185,7 @@ GLOBAL_LIST_INIT(department_order_cooldowns, list(
 	department_delivery_areas = list(/area/station/science/research)
 	override_access = ACCESS_RD
 	req_one_access = REGION_ACCESS_RESEARCH
-	dep_groups = list("Science", "Livestock")
+	dep_groups = list("Science", "Livestock", "Canisters & Materials")
 
 /obj/machinery/computer/department_orders/security
 	name = "security order console"


### PR DESCRIPTION
one minute cooldown on civilian bounty rerolls
shortens timer for departmental orders
adds canisters and materials to science ordering console

## About The Pull Request
makes cargo a bit more robust
## Why It's Good For The Game
allows cargo to interact more with other departments
## Changelog
one minute cooldown on civilian bounty rerolls from five minutes originally
shortens timer for departmental orders by roughly 5 minutes
adds canisters and materials tab to science ordering console

/:cl:

