### PR TITLE
Pet Delivery Beacon

### DIFF
--- a/code/game/objects/items/choice_beacon.dm
+++ b/code/game/objects/items/choice_beacon.dm
@@ -178,12 +178,10 @@
 // Pet Beacon for Monkecoin shop
 
 /obj/item/choice_beacon/pet
-	name = "Deluxe Pet Delivery Beacon"
+	name = "Pet Delivery Beacon"
 	desc = "For those shifts when you need a little piece of home and some company."
-	uses = 3
 	company_message = span_bold("Pet request received. Your friend is on the way.")
 	var/default_name = "Stinko"
-	var/mob_choice = /mob/living/basic/mothroach
 
 /obj/item/choice_beacon/pet/generate_display_names()
 	var/static/list/pet_list
@@ -229,19 +227,7 @@
 
 	uses--
 	if(uses <= 0)
-		do_sparks(3, source = src)
 		qdel(src)
 		return
 
 	to_chat(user, span_notice("[uses] use[uses > 1 ? "s" : ""] remain[uses > 1 ? "" : "s"] on [src]."))
-
-/obj/item/choice_beacon/pet/proc/spawn_mob(mob/living/M,name)
-	var/obj/structure/closet/supplypod/bluespacepod/pod = new()
-	var/mob/your_pet = new mob_choice(pod)
-	pod.explosionSize = list(0,0,0,0)
-	your_pet.name = name
-	your_pet.real_name = name
-	var/msg = "<span class=danger>After making your selection, you notice a strange target on the ground. It might be best to step back!</span>"
-	to_chat(M, msg)
-	new /obj/effect/pod_landingzone(get_turf(src), pod)
-

--- a/code/game/objects/items/choice_beacon.dm
+++ b/code/game/objects/items/choice_beacon.dm
@@ -174,3 +174,49 @@
 	SSblackbox.record_feedback("tally", "chaplain_armor", 1, "[choice_path]")
 	GLOB.holy_armor_type = choice_path
 	return ..()
+
+// Pet Beacon for Monkecoin shop
+
+/obj/item/choice_beacon/pet
+	name = "Deluxe Pet Delivery Beacon"
+	desc = "For those shifts when you need a little piece of home and some company."
+	company_message = span_bold("Pet request received. Your friend is on the way.")
+	var/default_name = "Stinko"
+	var/mob_choice = /mob/living/basic/mothroach
+
+/obj/item/choice_beacon/pet/generate_display_names()
+	var/static/list/pet_list
+	if(!pet_list)
+		// Bug SeeBeeSee on Discord if you want an animal type added
+		pet_list = list()
+		var/list/selectable_pets = list(
+			/mob/living/basic/mothroach,
+			/mob/living/basic/axolotl
+		)
+
+		for(var/mob/living/basic/basic_mob as anything in selectable_pets)
+			pet_list[initial(basic_mob.name)] = basic_mob
+
+	return pet_list
+
+// /obj/item/choice_beacon/pet/proc/generate_options(mob/living/M)
+// 	var/input_name = stripped_input(M, "What would you like your new pet to be named?", "New Pet Name", default_name, MAX_NAME_LEN)
+// 	if(!input_name)
+// 		return
+// 	spawn_mob(M,input_name)
+// 	uses--
+// 	if(!uses)
+// 		qdel(src)
+// 	else
+// 		to_chat(M, "<span class='notice'>[uses] use[uses > 1 ? "s" : ""] remaining on the [src].</span>")
+
+// /obj/item/choice_beacon/pet/proc/spawn_mob(mob/living/M,name)
+// 	var/obj/structure/closet/supplypod/bluespacepod/pod = new()
+// 	var/mob/your_pet = new mob_choice(pod)
+// 	pod.explosionSize = list(0,0,0,0)
+// 	your_pet.name = name
+// 	your_pet.real_name = name
+// 	var/msg = "<span class=danger>After making your selection, you notice a strange target on the ground. It might be best to step back!</span>"
+// 	to_chat(M, msg)
+// 	new /obj/effect/pod_landingzone(get_turf(src), pod)
+

--- a/code/game/objects/items/choice_beacon.dm
+++ b/code/game/objects/items/choice_beacon.dm
@@ -187,13 +187,29 @@
 	var/static/list/pet_list
 	if(!pet_list)
 		// Bug SeeBeeSee on Discord if you want an animal type added
+		// (no, you cannot have a pet goliath or other hostile mob)
 		pet_list = list()
 		var/list/selectable_pets = list(
 			/mob/living/basic/mothroach,
-			/mob/living/basic/axolotl
+			/mob/living/basic/axolotl,
+			/mob/living/basic/mouse,
+			/mob/living/basic/mouse/rat,
+			/mob/living/simple_animal/parrot,
+			/mob/living/simple_animal/butterfly,
+			/mob/living/simple_animal/crab,
+			/mob/living/simple_animal/crab/evil,
+			/mob/living/simple_animal/pet/penguin/baby,
+			/mob/living/simple_animal/pet/fox,
+			/mob/living/simple_animal/pet/cat,
+			/mob/living/simple_animal/pet/cat/kitten,
+			/mob/living/basic/pet/dog/corgi,
+			/mob/living/basic/pet/dog/pug,
+			/mob/living/basic/pet/dog/bullterrier,
+			/mob/living/simple_animal/hostile/lizard,
+			/mob/living/simple_animal/hostile/ant
 		)
 
-		for(var/mob/living/basic/basic_mob as anything in selectable_pets)
+		for(var/mob/living/basic_mob as anything in selectable_pets)
 			pet_list[initial(basic_mob.name)] = basic_mob
 
 	return pet_list

--- a/monkestation/code/modules/loadouts/items/pocket.dm
+++ b/monkestation/code/modules/loadouts/items/pocket.dm
@@ -147,6 +147,10 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 	name = "Newspaper"
 	item_path = /obj/item/newspaper
 
+/datum/loadout_item/pocket_items/pet_beacon
+	name = "Pet Delivery Beacon"
+	item_path = /obj/item/choice_beacon/pet
+
 
 /*
 *	DONATOR

--- a/monkestation/code/modules/store/store_items/pocket.dm
+++ b/monkestation/code/modules/store/store_items/pocket.dm
@@ -100,3 +100,7 @@ GLOBAL_LIST_INIT(store_pockets, generate_store_items(/datum/store_item/pocket))
 /datum/store_item/pocket/newspaper
 	name = "Newspaper"
 	item_path = /obj/item/newspaper
+
+/datum/store_item/pocket/pet_beacon
+	name = "Pet Delivery Beacon"
+	item_path = /obj/item/choice_beacon/pet


### PR DESCRIPTION

## About The Pull Request

Missing your favorite (optionally) furry friend from back home? Need a companion you can (likely) trust above all others? This PR adds in a new item to the Monkecoin shop (under Other), the Pet Delivery Beacon! Allows the user to name and droppod in their favorite pet animal, with an expanded selection from the previous codebase. Pet insurance not included.

## Why It's Good For The Game

I've explicitly tried to avoid any animals that would short-circuit game mechanics/departments (sorry, Cak), in order to keep this PR as a means of personal preference and possible light RP potential. Not everyone likes their job's department pet, and only a few jobs really GET their own pets, who are subject to the crazed machinations of traitors on board. Adding the ability for crew members to have their own pet is solely meant to enhance a given player's personal experience, be it reminiscing over a lost IRL pet, adding to a gimmick, or anything else they can think of. It's worth noting that some animals DO provide a mood buff by being pet, but with the multitude of other means of managing one's mood, I don't personally find this to be game-breaking in any way.

## Changelog

:cl:
add: Added the Pet Delivery Beacon, a version of bluespace item beacons that spawns nameable pets
add: Added Pet Delivery Beacon to the Monkecoin shop (under Other, default price of 1000 coins)
/:cl:

