### PR TITLE
[NERF REMOVAL]Yellow slime core restoration

### DIFF
--- a/code/modules/cargo/exports/xenobio.dm
+++ b/code/modules/cargo/exports/xenobio.dm
@@ -28,7 +28,7 @@
 /datum/export/slime/hypercharged
 	cost = CARGO_CRATE_VALUE * 1.2
 	unit_name = "hypercharged slime core"
-	export_types = list(/obj/item/stock_parts/cell/high/slime_hypercharged)
+	export_types = list(/obj/item/stock_parts/cell/emproof/slime/hypercharged)
 
 /datum/export/slime/epic //EPIIIIIIC
 	cost = CARGO_CRATE_VALUE * 0.44

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -232,6 +232,11 @@
 	var/last_chrg = inputting
 	var/last_onln = outputting
 
+	//check for self-recharging cells in stock parts and use them to self-charge
+	for(var/obj/item/stock_parts/cell/C in component_parts)
+		if(C.self_recharge)
+			charge += min(capacity-charge, C.chargerate) // If capacity-charge is smaller than the attempted charge rate, this avoids overcharging
+
 	//inputting
 	if(terminal && input_attempt)
 		input_available = terminal.surplus()

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -86,14 +86,14 @@ Slimecrossing Items
 	return . | ..()
 
 //Hypercharged slime cell - Charged Yellow
-/obj/item/stock_parts/cell/high/slime_hypercharged
+/obj/item/stock_parts/cell/emproof/slime/hypercharged
 	name = "hypercharged slime core"
 	desc = "A charged yellow slime extract, infused with plasma. It almost hurts to touch."
 	icon = 'icons/mob/simple/slimes.dmi'
 	icon_state = "yellow slime extract"
 	rating = 7
 	custom_materials = null
-	maxcharge = 50000
+	maxcharge = 25000
 	chargerate = 2500
 	charge_light_type = null
 	connector_type = "slimecore"

--- a/code/modules/research/xenobiology/crossbreeding/charged.dm
+++ b/code/modules/research/xenobiology/crossbreeding/charged.dm
@@ -78,10 +78,10 @@ Charged extracts:
 
 /obj/item/slimecross/charged/yellow
 	colour = "yellow"
-	effect_desc = "Creates a hypercharged slime cell battery, which has high capacity but takes longer to recharge."
+	effect_desc = "Creates a hypercharged slime cell battery, which has high capacity and recharges constantly at a very fast rate."
 
 /obj/item/slimecross/charged/yellow/do_effect(mob/user)
-	new /obj/item/stock_parts/cell/high/slime_hypercharged(get_turf(user))
+	new /obj/item/stock_parts/cell/emproof/slime/hypercharged(get_turf(user))
 	user.visible_message(span_notice("[src] sparks violently, and swells with electric power!"))
 	..()
 

--- a/code/modules/spells/spell_types/self/charge.dm
+++ b/code/modules/spells/spell_types/self/charge.dm
@@ -56,5 +56,3 @@
 
 	else
 		to_chat(cast_on, span_notice("[to_charge] doesn't seem to be react to [src]."))
-
-

--- a/code/modules/spells/spell_types/self/charge.dm
+++ b/code/modules/spells/spell_types/self/charge.dm
@@ -56,3 +56,5 @@
 
 	else
 		to_chat(cast_on, span_notice("[to_charge] doesn't seem to be react to [src]."))
+
+


### PR DESCRIPTION
**About The Pull Request**
allows yellow slime cores to self charge, as they were supposed to.

**Why It's Good For The Game**
firstly its not overpowered, there's plenty of ways to make tons of power botany can make potato cells(litterally better with less work), engineering can easily pump 3mw into the station and there are more ways.
secondly this would not replace engineers as that would be against our rules, i refer to Rule 2, stay in your lane.
what this adds to the game is versitility in absurd siturations, such as SM blowing up, engineers with recharging inducer would be great, robotic not spending all the bluespace crystals on power cells is also great.
so yellow slime cores are mainly a way to unfuck the station and make it playable for the crew.

**Changelog**
🆑
change: yellow slime cores+hypercharged variant self charges.
/🆑