### PR TITLE
[PERFORMANCE FIX] adds trait that limits potency to 100 and adds it to glowshroom

### DIFF
--- a/code/__DEFINES/botany.dm
+++ b/code/__DEFINES/botany.dm
@@ -90,3 +90,6 @@
 
 /// A list of possible egg laying descriptions
 #define EGG_LAYING_MESSAGES list("lays an egg.","squats down and croons.","begins making a huge racket.","begins clucking raucously.")
+
+/// limiter for potency
+#define TRAIT_LIMIT_POTENCY (1<<0)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -154,6 +154,9 @@ GLOBAL_VAR_INIT(glowshrooms, 0)
 	if(!possible_locs.len)
 		return
 
+	if(myseed.potency > 100 )
+		myseed.potency = 100 //this should limit absurd spread due to borbop's uncapped potency
+
 	var/chance_generation = 100 * (NUM_E ** -((GLOWSHROOM_SPREAD_BASE_DIMINISH_FACTOR + GLOWSHROOM_SPREAD_DIMINISH_FACTOR_PER_GLOWSHROOM * GLOB.glowshrooms) / myseed.potency * (generation - 1))) //https://www.desmos.com/calculator/istvjvcelz
 
 	for(var/i in 1 to myseed.yield)

--- a/code/game/objects/effects/glowshroom.dm
+++ b/code/game/objects/effects/glowshroom.dm
@@ -154,9 +154,6 @@ GLOBAL_VAR_INIT(glowshrooms, 0)
 	if(!possible_locs.len)
 		return
 
-	if(myseed.potency > 100 )
-		myseed.potency = 100 //this should limit absurd spread due to borbop's uncapped potency
-
 	var/chance_generation = 100 * (NUM_E ** -((GLOWSHROOM_SPREAD_BASE_DIMINISH_FACTOR + GLOWSHROOM_SPREAD_DIMINISH_FACTOR_PER_GLOWSHROOM * GLOB.glowshrooms) / myseed.potency * (generation - 1))) //https://www.desmos.com/calculator/istvjvcelz
 
 	for(var/i in 1 to myseed.yield)

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -232,7 +232,7 @@
 	potency = 30 //-> brightness
 	growthstages = 4
 	rarity = 20
-	genes = list(/datum/plant_gene/trait/glow, /datum/plant_gene/trait/plant_type/fungal_metabolism)
+	genes = list(/datum/plant_gene/trait/glow, /datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/potencylimit)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	possible_mutations = list(/datum/hydroponics/plant_mutation/glow_cap, /datum/hydroponics/plant_mutation/shadow_shroom)
 	reagents_add = list(/datum/reagent/uranium/radium = 0.1, /datum/reagent/phosphorus = 0.1, /datum/reagent/consumable/nutriment = 0.04)

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -400,7 +400,14 @@
 /obj/item/seeds/proc/adjust_potency(adjustamt)
 	if(potency == -1)
 		return
-	potency = clamp(potency + adjustamt, 0, MAX_PLANT_POTENCY)
+
+	var/max_potency = MAX_PLANT_YIELD
+	for(var/datum/plant_gene/trait/trait in genes)
+		if(trait.trait_flags & TRAIT_LIMIT_POTENCY)
+			max_potency = 100
+			break
+
+	potency = clamp(potency + adjustamt, 0, max_potency)
 	var/datum/plant_gene/core/C = get_gene(/datum/plant_gene/core/potency)
 	if(C)
 		C.value = potency

--- a/monkestation/code/modules/hydroponics/plant_genes.dm
+++ b/monkestation/code/modules/hydroponics/plant_genes.dm
@@ -1,0 +1,19 @@
+/*
+ * this limits potency, it is used for plants that have strange behavior above 100 potency.
+ *
+ */
+/datum/plant_gene/trait/potencylimit
+	name = "potency limiter"
+	icon = "lightbulb"
+	rate = 0.03
+	description = "limits potency to 100, used for some plants to avoid lag and similar issues."
+	mutability_flags = PLANT_GENE_GRAFTABLE
+
+/datum/plant_gene/trait/potencylimit/on_new_plant(obj/item/our_plant, newloc)
+	. = ..()
+	if(!.)
+		return
+
+	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
+	if(our_seed.potency > 100 )
+		our_seed.potency = 100 //very simple

--- a/monkestation/code/modules/hydroponics/plant_genes.dm
+++ b/monkestation/code/modules/hydroponics/plant_genes.dm
@@ -13,7 +13,3 @@
 	. = ..()
 	if(!.)
 		return
-
-	//var/obj/item/seeds/our_seed = our_plant.get_plant_seed()   //this code is pointless, the trait does the work.
-	//if(our_seed.potency > 100 )
-	//	our_seed.potency = 100 //very simple

--- a/monkestation/code/modules/hydroponics/plant_genes.dm
+++ b/monkestation/code/modules/hydroponics/plant_genes.dm
@@ -5,8 +5,8 @@
 /datum/plant_gene/trait/potencylimit
 	name = "potency limiter"
 	icon = "lightbulb"
-	rate = 0.03
 	description = "limits potency to 100, used for some plants to avoid lag and similar issues."
+	trait_flags = TRAIT_LIMIT_POTENCY
 	mutability_flags = PLANT_GENE_GRAFTABLE
 
 /datum/plant_gene/trait/potencylimit/on_new_plant(obj/item/our_plant, newloc)
@@ -14,6 +14,6 @@
 	if(!.)
 		return
 
-	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
-	if(our_seed.potency > 100 )
-		our_seed.potency = 100 //very simple
+	//var/obj/item/seeds/our_seed = our_plant.get_plant_seed()   //this code is pointless, the trait does the work.
+	//if(our_seed.potency > 100 )
+	//	our_seed.potency = 100 //very simple

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5367,6 +5367,7 @@
 #include "monkestation\code\modules\displacement\displacements\large\assets.dm"
 #include "monkestation\code\modules\food_and_drinks\recipes\boiling.dm"
 #include "monkestation\code\modules\hydroponics\botanical_lexicon.dm"
+#include "monkestation\code\modules\hydroponics\plant_genes.dm"
 #include "monkestation\code\modules\hydroponics\seeds.dm"
 #include "monkestation\code\modules\hydroponics\machines\composter.dm"
 #include "monkestation\code\modules\hydroponics\machines\infuser.dm"


### PR DESCRIPTION
its a simple fix really, if someone makes a glowshroom with more then 100 potency, it'll default it back down to 100 as a limiter.
even at 100 its already stupid, 100 potency is 46 tile spread distance in any direction.
if you had 5000 potency, thats 2300tiles in any direction.
i have not tested this and i'd like to know if yield has any bearing on this and if the uncapped stats thing also affects yield, that might need work too.
but yea honestly we might wanna consider limiting its spread to something like 20 tiles...remember every glowshroom runs code independently every 20 seconds.