### PR TITLE
[balance change] blobbernaught slight rebalance suggestion

### DIFF
--- a/code/__DEFINES/blob_defines.dm
+++ b/code/__DEFINES/blob_defines.dm
@@ -105,5 +105,5 @@
 #define BLOBMOB_BLOBBERNAUT_REAGENTATK_VOL 20 // Amounts of strain reagents applied on attack -- basically the main damage stat
 #define BLOBMOB_BLOBBERNAUT_DMG_OBJ 60 // Damage dealth to objects/machines
 #define BLOBMOB_BLOBBERNAUT_HEALING_CORE 0.05 // Percentage multiplier HP restored on Life() when within 2 tiles of the blob core
-#define BLOBMOB_BLOBBERNAUT_HEALING_NODE 0.025 // Same, but for a nearby node
-#define BLOBMOB_BLOBBERNAUT_HEALTH_DECAY 0.0125 // Percentage multiplier HP lost when not near blob tiles or without factory
+#define BLOBMOB_BLOBBERNAUT_HEALING_NODE 0.0125 // Same, but for a nearby node
+#define BLOBMOB_BLOBBERNAUT_HEALTH_DECAY 0.025 // Percentage multiplier HP lost when not near blob tiles or without factory


### PR DESCRIPTION
punishes them a bit more for being away from nodes, and reduces normal node healing so they might actually consider using the superior "heal super fast near CORE" feature. this should slow them down a bit so when they take damage.

all in all, this aims to create some downtime for the blobbernaughts specifically when blob is big enough that its a chore for it to walk all the way back to the CORE, that would provide 4 times the healing+node heal.

Note this is just a suggestion, i don't really care but this is likely the simplest way.