### PR TITLE
[balance change]simplemob aliens drop organs too except egg organ.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -8,14 +8,15 @@
 	icon_gib = "syndicate_gib"
 	gender = FEMALE
 	speed = 0
-	butcher_results = list(/obj/item/food/meat/slab/xeno = 4,
-							/obj/item/stack/sheet/animalhide/xeno = 1,
-							/obj/item/organ/internal/tongue/alien = 1,
-							/obj/item/organ/internal/eyes/alien = 1,
-							/obj/item/organ/internal/alien/plasmavessel/large = 1,
-							/obj/item/organ/internal/alien/resinspinner = 1,
-							/obj/item/organ/internal/alien/acid = 1,
-							/obj/item/organ/internal/alien/neurotoxin = 1)
+	butcher_results = list(/obj/item/organ/internal/tongue/alien = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/eyes/alien = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/alien/plasmavessel/large = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/alien/resinspinner = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/alien/acid = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/alien/neurotoxin = 1) //Monkestation Edit #105
+	guaranteed_butcher_results = list(/obj/item/food/meat/slab/xeno = 4, //Monkestation Edit #105
+							/obj/item/stack/sheet/animalhide/xeno = 1) //Monkestation Edit #105
+	butcher_difficulty = 75 //Monkestation Edit #105 causes each item to have a 25% chance of spawning on butchering
 	maxHealth = 125
 	health = 125
 	harm_intent_damage = 5
@@ -92,14 +93,15 @@
 	retreat_distance = 5
 	minimum_distance = 5
 	move_to_delay = 4
-	butcher_results = list(/obj/item/food/meat/slab/xeno = 4,
-							/obj/item/stack/sheet/animalhide/xeno = 1,
-							/obj/item/organ/internal/tongue/alien = 1,
-							/obj/item/organ/internal/eyes/alien = 1,
-							/obj/item/organ/internal/alien/plasmavessel/large/queen = 1,
-							/obj/item/organ/internal/alien/resinspinner = 1,
-							/obj/item/organ/internal/alien/acid = 1,
-							/obj/item/organ/internal/alien/neurotoxin = 1)
+	butcher_results = list(/obj/item/organ/internal/tongue/alien = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/eyes/alien = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/alien/plasmavessel/large/queen = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/alien/resinspinner = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/alien/acid = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/alien/neurotoxin = 1) //Monkestation Edit #105
+	guaranteed_butcher_results = list(/obj/item/food/meat/slab/xeno = 4, //Monkestation Edit #105
+							/obj/item/stack/sheet/animalhide/xeno = 1) //Monkestation Edit #105
+	butcher_difficulty = 75 //Monkestation Edit #105 causes each item to have a 25% chance of spawning on butchering
 	projectiletype = /obj/projectile/neurotoxin/damaging
 	projectilesound = 'sound/weapons/pierce.ogg'
 	status_flags = 0
@@ -149,14 +151,15 @@
 	move_to_delay = 4
 	maxHealth = 400
 	health = 400
-	butcher_results = list(/obj/item/food/meat/slab/xeno = 10,
-							/obj/item/stack/sheet/animalhide/xeno = 2,
-							/obj/item/organ/internal/tongue/alien = 1,
-							/obj/item/organ/internal/eyes/alien = 1,
-							/obj/item/organ/internal/alien/plasmavessel/large/queen = 1,
-							/obj/item/organ/internal/alien/resinspinner = 1,
-							/obj/item/organ/internal/alien/acid = 1,
-							/obj/item/organ/internal/alien/neurotoxin = 1)
+	butcher_results = list(/obj/item/organ/internal/tongue/alien = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/eyes/alien = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/alien/plasmavessel/large/queen = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/alien/resinspinner = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/alien/acid = 1, //Monkestation Edit #105
+							/obj/item/organ/internal/alien/neurotoxin = 1) //Monkestation Edit #105
+	guaranteed_butcher_results = list(/obj/item/food/meat/slab/xeno = 4, //Monkestation Edit #105
+							/obj/item/stack/sheet/animalhide/xeno = 1) //Monkestation Edit #105
+	butcher_difficulty = 75 //Monkestation Edit #105 causes each item to have a 25% chance of spawning on butchering
 	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = NO_SPAWN
 

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -9,7 +9,13 @@
 	gender = FEMALE
 	speed = 0
 	butcher_results = list(/obj/item/food/meat/slab/xeno = 4,
-							/obj/item/stack/sheet/animalhide/xeno = 1)
+							/obj/item/stack/sheet/animalhide/xeno = 1,
+							/obj/item/organ/internal/tongue/alien = 1,
+							/obj/item/organ/internal/eyes/alien = 1,
+							/obj/item/organ/internal/alien/plasmavessel/large = 1,
+							/obj/item/organ/internal/alien/resinspinner = 1,
+							/obj/item/organ/internal/alien/acid = 1,
+							/obj/item/organ/internal/alien/neurotoxin = 1)
 	maxHealth = 125
 	health = 125
 	harm_intent_damage = 5
@@ -87,7 +93,13 @@
 	minimum_distance = 5
 	move_to_delay = 4
 	butcher_results = list(/obj/item/food/meat/slab/xeno = 4,
-							/obj/item/stack/sheet/animalhide/xeno = 1)
+							/obj/item/stack/sheet/animalhide/xeno = 1,
+							/obj/item/organ/internal/tongue/alien = 1,
+							/obj/item/organ/internal/eyes/alien = 1,
+							/obj/item/organ/internal/alien/plasmavessel/large/queen = 1,
+							/obj/item/organ/internal/alien/resinspinner = 1,
+							/obj/item/organ/internal/alien/acid = 1,
+							/obj/item/organ/internal/alien/neurotoxin = 1)
 	projectiletype = /obj/projectile/neurotoxin/damaging
 	projectilesound = 'sound/weapons/pierce.ogg'
 	status_flags = 0
@@ -138,7 +150,13 @@
 	maxHealth = 400
 	health = 400
 	butcher_results = list(/obj/item/food/meat/slab/xeno = 10,
-							/obj/item/stack/sheet/animalhide/xeno = 2)
+							/obj/item/stack/sheet/animalhide/xeno = 2,
+							/obj/item/organ/internal/tongue/alien = 1,
+							/obj/item/organ/internal/eyes/alien = 1,
+							/obj/item/organ/internal/alien/plasmavessel/large/queen = 1,
+							/obj/item/organ/internal/alien/resinspinner = 1,
+							/obj/item/organ/internal/alien/acid = 1,
+							/obj/item/organ/internal/alien/neurotoxin = 1)
 	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = NO_SPAWN
 


### PR DESCRIPTION
**About The Pull Request**
makes it possible for players to get xenomorph organs from simplemob variants, the application for this allows more roleplay possibilities as well as building like xenomorphs would, this could be useful for a range of atmos related things and much more.
but mostly this is about roleplay and giving tools to the players that they can use for their roleplay, through natural means.

**Why It's Good For The Game**
player xenomorph antag is a round ending event, as such all this loot rarely gets used because by the time you get it there's 3-5 minutes left of the shift.
also these organs require installing and that usually involves cooperation between players, aka something to roleplay over.

**Changelog**
🆑
add: xenomorph loot to simple mobs, except egg laying organ that could lead to unintended antag creation.
add: the butchering is 25% chance for each so far.
/🆑

