### PR TITLE
[READY] Oozeling Changes

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -941,6 +941,7 @@
 /obj/item/organ/internal/lungs/oozeling
 	name = "oozeling vacuole"
 	desc = "A large organelle designed to store oxygen and filter toxins."
+
 	safe_oxygen_min = 4 //We don't need much oxygen to subsist.
 
 #undef BREATH_RELATIONSHIP_INITIAL_GAS

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -809,7 +809,7 @@
 	desc = "A large organelle designed to store oxygen and other important gasses."
 
 	safe_plasma_max = 0 //We breathe this to gain POWER.
-	safe_oxygen_min = 4 //We don't need much oxygen to subsist.
+	safe_oxygen_min = 2 //We don't need much oxygen to subsist.
 
 /obj/item/organ/internal/lungs/slime/check_breath(datum/gas_mixture/breath, mob/living/carbon/human/breather_slime)
 	. = ..()

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -808,8 +808,8 @@
 	name = "vacuole"
 	desc = "A large organelle designed to store oxygen and other important gasses."
 
+	safe_oxygen_min = 4 //We don't need much oxygen to subsist.
 	safe_plasma_max = 0 //We breathe this to gain POWER.
-	safe_oxygen_min = 2 //We don't need much oxygen to subsist.
 
 /obj/item/organ/internal/lungs/slime/check_breath(datum/gas_mixture/breath, mob/living/carbon/human/breather_slime)
 	. = ..()

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -809,6 +809,7 @@
 	desc = "A large organelle designed to store oxygen and other important gasses."
 
 	safe_plasma_max = 0 //We breathe this to gain POWER.
+	safe_oxygen_min = 4 //We don't need much oxygen to subsist.
 
 /obj/item/organ/internal/lungs/slime/check_breath(datum/gas_mixture/breath, mob/living/carbon/human/breather_slime)
 	. = ..()

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -808,7 +808,6 @@
 	name = "vacuole"
 	desc = "A large organelle designed to store oxygen and other important gasses."
 
-	safe_oxygen_min = 4 //We don't need much oxygen to subsist.
 	safe_plasma_max = 0 //We breathe this to gain POWER.
 
 /obj/item/organ/internal/lungs/slime/check_breath(datum/gas_mixture/breath, mob/living/carbon/human/breather_slime)

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -941,6 +941,7 @@
 /obj/item/organ/internal/lungs/oozeling
 	name = "oozeling vacuole"
 	desc = "A large organelle designed to store oxygen and filter toxins."
+	safe_oxygen_min = 4 //We don't need much oxygen to subsist.
 
 #undef BREATH_RELATIONSHIP_INITIAL_GAS
 #undef BREATH_RELATIONSHIP_CONVERT

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
@@ -1,5 +1,6 @@
 /datum/species/oozeling
 	name = "\improper Oozeling"
+	plural_form = "Slimepeople"
 	id = SPECIES_OOZELING
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 
@@ -13,6 +14,7 @@
 		TRAIT_NOFIRE,
 		//TRAIT_ALWAYS_CLEAN,
 		TRAIT_EASYDISMEMBER,
+		TRAIT_NOBLOOD,
 		)
 
 	hair_color = "mutcolor"
@@ -38,8 +40,8 @@
 	)
 
 /datum/species/oozeling/get_species_description()
-	return "Hailing from a planet that was lost long ago, the moths travel \
-		the galaxy as a nomadic people aboard a colossal fleet of ships, seeking a new homeland."
+	return "A species of sentient semi-solids. \
+		They require nutriment in order to maintain their body mass."
 
 /datum/species/oozeling/random_name(gender, unique, lastname, attempts)
 	. = "[pick(GLOB.oozeling_first_names)]"

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
@@ -25,6 +25,7 @@
 	var/datum/action/innate/regenerate_limbs/regenerate_limbs
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
+	burnmod = 0.6 // = 3/5x generic burn damage
 	species_language_holder = /datum/language_holder/oozeling
 	//swimming_component = /datum/component/swimming/dissolve
 	toxic_food = NONE

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
@@ -19,7 +19,6 @@
 
 	hair_color = "mutcolor"
 	hair_alpha = 150
-	mutanttongue = /obj/item/organ/internal/tongue/jelly //making new organs is hard ok?
 	mutantlungs = /obj/item/organ/internal/lungs/oozeling
 	meat = /obj/item/food/meat/slab/human/mutant/slime
 	exotic_blood = /datum/reagent/toxin/slimeooze

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
@@ -19,6 +19,7 @@
 
 	hair_color = "mutcolor"
 	hair_alpha = 150
+	mutanttongue = /obj/item/organ/internal/tongue/jelly //making new organs is hard ok?
 	mutantlungs = /obj/item/organ/internal/lungs/oozeling
 	meat = /obj/item/food/meat/slab/human/mutant/slime
 	exotic_blood = /datum/reagent/toxin/slimeooze
@@ -26,7 +27,7 @@
 	burnmod = 0.6 // = 3/5x generic burn damage
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
-	inherent_factions = list(FACTION_SLIME)
+	inherent_factions = list(FACTION_SLIME) //an oozeling wont be eaten by their brethren
 	species_language_holder = /datum/language_holder/oozeling
 	ass_image = 'icons/ass/assslime.png'
 	//swimming_component = /datum/component/swimming/dissolve

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
@@ -201,3 +201,49 @@
 		M.heal_bodypart_damage(5*REM)
 		. = 1
 	..()
+
+/datum/species/oozeling/create_pref_unique_perks()
+	var/list/to_add = list()
+
+	to_add += list(
+		list(
+			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+			SPECIES_PERK_ICON = "wind",
+			SPECIES_PERK_NAME = "Plasma Respiration",
+			SPECIES_PERK_DESC = "[plural_form] can breathe plasma, and restore blood by doing so.",
+		),
+		list(
+			SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
+			SPECIES_PERK_ICON = "tint",
+			SPECIES_PERK_NAME = initial(exotic_blood.name),
+			SPECIES_PERK_DESC = "[name] blood is [initial(exotic_blood.name)], which can make recieving medical treatment harder.",
+		),
+		list(
+			SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
+			SPECIES_PERK_ICON = "wind",
+			SPECIES_PERK_NAME = "Anaerobic Lineage",
+			SPECIES_PERK_DESC = "[plural_form] don't require much oxygen to live."
+		),
+		list(
+			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
+			SPECIES_PERK_ICON = "skull",
+			SPECIES_PERK_NAME = "Self-Consumption",
+			SPECIES_PERK_DESC = "Once hungry enough, [plural_form] will begin to consume their own blood and limbs.",
+		),
+		list(
+			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
+			SPECIES_PERK_ICON = "tint",
+			SPECIES_PERK_NAME = "Liquid Being",
+			SPECIES_PERK_DESC = "[plural_form] will melt away when in contact with water.",
+		),
+		list(
+			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
+			SPECIES_PERK_ICON = "briefcase-medical",
+			SPECIES_PERK_NAME = "Oozeling Biology",
+			SPECIES_PERK_DESC = "[plural_form] take specialized medical knowledge to be \
+				treated. Do not expect speedy revival, if you are lucky enough to get \
+				one at all.",
+		),
+	)
+
+	return to_add

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
@@ -1,6 +1,6 @@
 /datum/species/oozeling
 	name = "\improper Oozeling"
-	plural_form = "Slimepeople"
+	plural_form = "Oozelings"
 	id = SPECIES_OOZELING
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
@@ -237,13 +237,13 @@
 			SPECIES_PERK_DESC = "[plural_form] will melt away when in contact with water.",
 		),
 		list(
-			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
-			SPECIES_PERK_ICON = "briefcase-medical",
-			SPECIES_PERK_NAME = "Oozeling Biology",
-			SPECIES_PERK_DESC = "[plural_form] take specialized medical knowledge to be \
-				treated. Do not expect speedy revival, if you are lucky enough to get \
-				one at all.",
-		),
+            SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
+            SPECIES_PERK_ICON = "briefcase-medical",
+            SPECIES_PERK_NAME = "Oozeling Biology",
+            SPECIES_PERK_DESC = "[plural_form] take specialized medical knowledge to be \
+                treated. Do not expect speedy revival, if you are lucky enough to get \
+                one at all.",
+        ),
 	)
 
 	return to_add

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
@@ -213,6 +213,12 @@
 			SPECIES_PERK_DESC = "[plural_form] can breathe plasma, and restore blood by doing so.",
 		),
 		list(
+			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,
+			SPECIES_PERK_ICON = "burn",
+			SPECIES_PERK_NAME = "incombustible",
+			SPECIES_PERK_DESC = "[plural_form] cannot be set aflame.",
+		),
+		list(
 			SPECIES_PERK_TYPE = SPECIES_NEUTRAL_PERK,
 			SPECIES_PERK_ICON = "tint",
 			SPECIES_PERK_NAME = initial(exotic_blood.name),

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
@@ -23,9 +23,9 @@
 	meat = /obj/item/food/meat/slab/human/mutant/slime
 	exotic_blood = /datum/reagent/toxin/slimeooze
 	var/datum/action/innate/regenerate_limbs/regenerate_limbs
+	burnmod = 0.6 // = 3/5x generic burn damage
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
-	burnmod = 0.6 // = 3/5x generic burn damage
 	species_language_holder = /datum/language_holder/oozeling
 	//swimming_component = /datum/component/swimming/dissolve
 	toxic_food = NONE

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/oozeling.dm
@@ -26,7 +26,9 @@
 	burnmod = 0.6 // = 3/5x generic burn damage
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
+	inherent_factions = list(FACTION_SLIME)
 	species_language_holder = /datum/language_holder/oozeling
+	ass_image = 'icons/ass/assslime.png'
 	//swimming_component = /datum/component/swimming/dissolve
 	toxic_food = NONE
 	disliked_food = NONE


### PR DESCRIPTION
## About The Pull Request
Adds 3 traits to Oozelings and changes their description.
## Why It's Good For The Game

Makes Oozelings less sucky
May nerf them afterwards depending on how this turns out

## Changelog


:cl:
add: Oozelings now take 3/5 burn damage
add: Added a plural form of Oozeling for the Oozeling description
add: Added a proper Oozeling description
add: Oozelings now don't suffer bleed from wounding
add: Slimes are now friendly to Oozelings
add: An assigned ass png for ass scanning
add: Oozelings now only need 4 mols of oxygen to breath
add: Proper listed positive and negative Oozeling perks on the species list 
/:cl:
