### PR TITLE
Adds exclusive Gigantism and Dwarfism quirks

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -29,6 +29,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Prosthetic Limb", "Quadruple Amputee", "Body Purist"),
 		list("Quadruple Amputee", "Paraplegic"),
 		list("Quadruple Amputee", "Frail"),
+		list("Gigantism", "Dwarfism")
 	)
 
 /datum/controller/subsystem/processing/quirks/Initialize()

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -125,8 +125,8 @@
 /datum/mutation/human/dwarfism/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
-	REMOVE_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
-	owner.visible_message(span_danger("[owner] suddenly grows!"), span_notice("Everything around you seems to shrink.."))
+	// REMOVE_TRAIT(owner, TRAIT_DWARF, GENETIC_MUTATION)
+	// owner.visible_message(span_danger("[owner] suddenly grows!"), span_notice("Everything around you seems to shrink.."))
 
 //Clumsiness has a very large amount of small drawbacks depending on item.
 /datum/mutation/human/clumsy
@@ -387,10 +387,10 @@
 /datum/mutation/human/gigantism/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
-	REMOVE_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)
-	owner.resize = 0.8
-	owner.update_transform()
-	owner.visible_message(span_danger("[owner] suddenly shrinks!"), span_notice("Everything around you seems to grow.."))
+	// REMOVE_TRAIT(owner, TRAIT_GIANT, GENETIC_MUTATION)
+	// owner.resize = 0.8
+	// owner.update_transform()
+	// owner.visible_message(span_danger("[owner] suddenly shrinks!"), span_notice("Everything around you seems to grow.."))
 
 /datum/mutation/human/spastic
 	name = "Spastic"

--- a/code/modules/mob/living/carbon/human/init_signals.dm
+++ b/code/modules/mob/living/carbon/human/init_signals.dm
@@ -17,8 +17,5 @@
 
 	// We need to regenerate everything for height
 	regenerate_icons()
-	// Toggle passtable
-	if(HAS_TRAIT(src, TRAIT_DWARF))
-		passtable_on(src, TRAIT_DWARF)
-	else
-		passtable_off(src, TRAIT_DWARF)
+	// No more passtable for you, bub
+

--- a/monkestation/code/datums/quirks/neutral_quirks.dm
+++ b/monkestation/code/datums/quirks/neutral_quirks.dm
@@ -1,0 +1,12 @@
+/datum/quirk/gigantism
+	name = "Gigantism"
+	desc = "Your cells take up more space than others', giving you a larger appearance. You find it difficult to avoid looking down on others. Literally."
+	value = 0
+	icon = FA_ICON_CHEVRON_CIRCLE_UP
+
+/datum/quirk/gigantism/add()
+	. = ..()
+	if (ishuman(quirk_holder))
+		var/mob/living/carbon/human/gojira = quirk_holder
+		if(gojira.dna)
+			gojira.dna.add_mutation(/datum/mutation/human/gigantism)

--- a/monkestation/code/datums/quirks/neutral_quirks.dm
+++ b/monkestation/code/datums/quirks/neutral_quirks.dm
@@ -3,6 +3,7 @@
 	desc = "Your cells take up more space than others', giving you a larger appearance. You find it difficult to avoid looking down on others. Literally."
 	value = 0
 	icon = FA_ICON_CHEVRON_CIRCLE_UP
+	quirk_flags = QUIRK_CHANGES_APPEARANCE
 
 /datum/quirk/gigantism/add()
 	. = ..()

--- a/monkestation/code/datums/quirks/positive_quirks.dm
+++ b/monkestation/code/datums/quirks/positive_quirks.dm
@@ -79,7 +79,7 @@
 /datum/quirk/dwarfism
 	name = "Dwarfism"
 	desc = "Your cells take up less space than others', giving you a smaller appearance. You also find it easier to climb tables. Rock and Stone!"
-	value = 9
+	value = 4
 	icon = FA_ICON_CHEVRON_CIRCLE_DOWN
 
 /datum/quirk/dwarfism/add()

--- a/monkestation/code/datums/quirks/positive_quirks.dm
+++ b/monkestation/code/datums/quirks/positive_quirks.dm
@@ -76,3 +76,15 @@
 		message = replacetext(message, "l", "w")
 	speech_args[SPEECH_MESSAGE] = message
 
+/datum/quirk/dwarfism
+	name = "Dwarfism"
+	desc = "Your cells take up less space than others', giving you a smaller appearance. You also find it easier to climb tables. Rock and Stone!"
+	value = 9
+	icon = FA_ICON_CHEVRON_CIRCLE_DOWN
+
+/datum/quirk/dwarfism/add()
+	. = ..()
+	if (ishuman(quirk_holder))
+		var/mob/living/carbon/human/godzuki = quirk_holder
+		if(godzuki.dna)
+			godzuki.dna.add_mutation(/datum/mutation/human/dwarfism)

--- a/monkestation/code/datums/quirks/positive_quirks.dm
+++ b/monkestation/code/datums/quirks/positive_quirks.dm
@@ -81,6 +81,7 @@
 	desc = "Your cells take up less space than others', giving you a smaller appearance. You also find it easier to climb tables. Rock and Stone!"
 	value = 4
 	icon = FA_ICON_CHEVRON_CIRCLE_DOWN
+	quirk_flags = QUIRK_CHANGES_APPEARANCE
 
 /datum/quirk/dwarfism/add()
 	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5279,6 +5279,7 @@
 #include "monkestation\code\datums\diseases\advance\symptoms\clockwork.dm"
 #include "monkestation\code\datums\keybinding\carbon.dm"
 #include "monkestation\code\datums\keybinding\living.dm"
+#include "monkestation\code\datums\quirks\neutral_quirks.dm"
 #include "monkestation\code\datums\quirks\positive_quirks.dm"
 #include "monkestation\code\datums\station_traits\neutral_traits.dm"
 #include "monkestation\code\datums\status_effects\disorient.dm"


### PR DESCRIPTION

## About The Pull Request

Gigantism makes its return from Monke 1.0, and the long-requested Dwarfism is added as an expensive positive quirk. Gameplay balance around these, particularly dwarfism, is still necessary.

## Why It's Good For The Game

Both Gigantism and Dwarfism have been great mutations for character flavor and roleplaying in the past, but it can be a coin toss as to whether a shift has a 1) geneticist, 2) geneticist that isn't murdering people, and 3) a _nice_ geneticist who fulfills requests. While Gigantism has historically been a neutral quirk (given the added ease of clicking sprites), Dwarfism has been a long-sought but contested quirk request due to potential powergaming value. Instead of just avoiding it entirely, I think it's worth granting the request for the sake of RP and tweak it as needed to reign it in elsewhere.

## Changelog

:cl:
add: Added Gigantism, a neutral quirk we had on the previous codebase.
add: Added Dwarfism, an expensive positive quirk that's been requested _literally_ since I joined the community.
qol: Made the above quirks mutually exclusive
/:cl:

