### PR TITLE
fixes mulebot deliveries in multiple places on tram

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -17672,7 +17672,7 @@
 	dir = 8
 	},
 /obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
+	codes_txt = "delivery;dir=8";
 	location = "Chapel";
 	name = "navigation beacon (Chapel Delivery)"
 	},
@@ -28293,7 +28293,7 @@
 	dir = 4
 	},
 /obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
+	codes_txt = "delivery;dir=4";
 	location = "Science";
 	name = "navigation beacon (Science Delivery)"
 	},
@@ -31708,7 +31708,7 @@
 	name = "Medical Delivery Chute"
 	},
 /obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
+	codes_txt = "delivery;dir=4";
 	location = "Medical";
 	name = "navigation beacon (Medical Delivery)"
 	},
@@ -45402,7 +45402,7 @@
 /area/station/engineering/main)
 "pfH" = (
 /obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
+	codes_txt = "delivery;dir=8";
 	location = "Kitchen";
 	name = "navigation beacon (Kitchen Delivery)"
 	},
@@ -65928,7 +65928,7 @@
 /area/station/security/brig)
 "wki" = (
 /obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
+	codes_txt = "delivery;dir=8";
 	location = "Atmoshperics";
 	name = "navigation beacon (Atmoshperics Delivery)"
 	},
@@ -66333,7 +66333,7 @@
 /area/station/medical/pharmacy)
 "wrU" = (
 /obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
+	codes_txt = "delivery;dir=8";
 	location = "Security";
 	name = "navigation beacon (Security Delivery)"
 	},
@@ -70469,7 +70469,7 @@
 	name = "Library Delivery Chute"
 	},
 /obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
+	codes_txt = "delivery;dir=4";
 	location = "Library";
 	name = "navigation beacon (Library Delivery)"
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Whoever made the tram mulebot nav beacons for deliveries, got their lefts and rights mixed up.
(this may work, may not work, strongdmm is broken and its late so i just went into the map file with vs code and changed it.

## Why It's Good For The Game

bots dont get stuck anymore :)
fixes issue #22 
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed tram mulebot deliveries
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
