### PR TITLE
Ports over ghosts being able to jump to explsions from 1.0 as well as gives gambling spawns a low chance at dice of fate

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -343,6 +343,11 @@ SUBSYSTEM_DEF(explosions)
 		message_admins("Explosion with size (Devast: [devastation_range], Heavy: [heavy_impact_range], Light: [light_impact_range], Flame: [flame_range]) in [ADMIN_VERBOSEJMP(epicenter)]. Possible cause: [explosion_cause]. Last fingerprints: [who_did_it].")
 		log_game("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range], [flame_range]) in [loc_name(epicenter)].  Possible cause: [explosion_cause]. Last fingerprints: [who_did_it_game_log].")
 
+	//monkestation edit start
+	deadchat_broadcast("Explosion with size: Devast: [devastation_range], Heavy: [heavy_impact_range], Light: [light_impact_range], Flame: [flame_range].", \
+						turf_target = epicenter, message_type = DEADCHAT_ANNOUNCEMENT)
+	//monkestation edit end
+
 	var/x0 = epicenter.x
 	var/y0 = epicenter.y
 	var/z0 = epicenter.z

--- a/code/game/objects/effects/spawners/random/entertainment.dm
+++ b/code/game/objects/effects/spawners/random/entertainment.dm
@@ -45,6 +45,13 @@
 		/obj/item/reagent_containers/cup/glass/bottle/vodka/badminka = 1,
 	)
 
+//monkestation edit start
+/obj/effect/spawner/random/entertainment/gambling/Initialize(mapload)
+	if(prob(0.2)) //one in 500
+		loot = list(/obj/item/dice/d20/fate/one_use = 1)
+	. = ..()
+//monkestation edit end
+
 /obj/effect/spawner/random/entertainment/coin
 	name = "coin spawner"
 	icon_state = "coin"


### PR DESCRIPTION

## About The Pull Request

Allows ghosts to see explosion size as well as jump to them.
Gambling loot spawners now have a one in 500 chance of making a die of fate.

## Why It's Good For The Game

Ports good, ook said he wants more ways to get dice of fate(I think)

## Changelog

:cl:
add: Ghosts can now jump to explosions
tweak: Gambling loot now has a very low chance at being a die of fate
/:cl:
