### PR TITLE
Fixes roundstart Active turfs caused by the random engines and a mapping related runtime.

### DIFF
--- a/monkestation/_maps/RandomEngines/KiloStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/KiloStation/singularity.dmm
@@ -28,7 +28,7 @@
 /area/station/engineering/supermatter/room)
 "eq" = (
 /obj/structure/cable/multilayer/connected,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "eP" = (
 /obj/structure/cable,
@@ -59,7 +59,7 @@
 	dir = 8
 	},
 /obj/structure/cable/layer1,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "hD" = (
 /turf/open/floor/glass/plasma,
@@ -68,7 +68,7 @@
 /obj/structure/cable,
 /obj/structure/cable/layer1,
 /obj/effect/turf_decal/bot_white/left,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "hV" = (
 /obj/effect/turf_decal/stripes/line,
@@ -83,7 +83,7 @@
 "hW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_white/right,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ic" = (
 /obj/machinery/door/firedoor,
@@ -126,7 +126,7 @@
 /area/station/engineering/supermatter/room)
 "kf" = (
 /obj/machinery/field/generator,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "km" = (
 /obj/structure/cable,
@@ -274,7 +274,7 @@
 /area/station/engineering/supermatter/room)
 "rP" = (
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "rW" = (
 /obj/effect/turf_decal/bot,
@@ -367,7 +367,7 @@
 /area/station/engineering/supermatter/room)
 "zg" = (
 /obj/structure/cable/layer1,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "zs" = (
 /turf/closed/wall/r_wall,
@@ -418,7 +418,7 @@
 "Cu" = (
 /obj/structure/cable,
 /obj/machinery/field/generator,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Dm" = (
 /obj/machinery/particle_accelerator/control_box,
@@ -495,7 +495,7 @@
 /obj/machinery/power/emitter{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "IJ" = (
 /obj/structure/lattice/catwalk,
@@ -588,7 +588,7 @@
 /obj/machinery/power/emitter{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "OT" = (
 /obj/machinery/the_singularitygen/tesla,
@@ -633,7 +633,7 @@
 "Rx" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_white/left,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "RL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -702,7 +702,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "Vk" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Vv" = (
 /obj/structure/sign/warning/secure_area,
@@ -739,7 +739,7 @@
 "XV" = (
 /obj/structure/cable,
 /obj/structure/cable/layer1,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Yj" = (
 /obj/effect/turf_decal/stripes/line{

--- a/monkestation/_maps/RandomEngines/MetaStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/MetaStation/singularity.dmm
@@ -10,7 +10,7 @@
 /area/station/engineering/supermatter/room)
 "bp" = (
 /obj/structure/cable/multilayer/connected,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "bM" = (
 /turf/closed/wall/r_wall,
@@ -52,7 +52,7 @@
 "dT" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_white/left,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "eg" = (
 /turf/open/floor/carpet/black,
@@ -251,7 +251,7 @@
 /area/station/engineering/supermatter/room)
 "vB" = (
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "vI" = (
 /obj/structure/chair/sofa/corp/left,
@@ -269,7 +269,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "wm" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "wo" = (
 /obj/structure/sign/warning/no_smoking,
@@ -285,7 +285,7 @@
 /obj/machinery/power/emitter{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "xA" = (
 /obj/machinery/door/airlock/external,
@@ -342,7 +342,7 @@
 "zA" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_white/right,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "zC" = (
 /turf/open/floor/iron/dark,
@@ -432,7 +432,7 @@
 /obj/machinery/power/emitter{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Fa" = (
 /obj/effect/turf_decal/stripes/line{
@@ -467,7 +467,7 @@
 "GG" = (
 /obj/structure/cable,
 /obj/machinery/power/emitter,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "GM" = (
 /obj/machinery/power/rad_collector,
@@ -477,7 +477,7 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "HO" = (
 /obj/structure/cable,
@@ -524,7 +524,7 @@
 	dir = 1
 	},
 /obj/machinery/field/generator,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "MT" = (
 /turf/closed/wall/r_wall,
@@ -555,7 +555,7 @@
 "NU" = (
 /obj/structure/cable,
 /obj/structure/cable/layer1,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Oh" = (
 /obj/effect/turf_decal/stripes/line,

--- a/monkestation/_maps/RandomEngines/MetaStation/supermatter.dmm
+++ b/monkestation/_maps/RandomEngines/MetaStation/supermatter.dmm
@@ -443,15 +443,6 @@
 "yn" = (
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"yo" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/hidden,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "yt" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -1288,7 +1279,7 @@ af
 UK
 UI
 Bc
-yo
+SS
 kK
 kK
 kK

--- a/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
@@ -12,7 +12,7 @@
 	dir = 1
 	},
 /obj/machinery/field/generator,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cb" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -41,7 +41,7 @@
 "gW" = (
 /obj/structure/cable,
 /obj/structure/cable/layer1,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "hb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58,7 +58,7 @@
 /obj/machinery/power/emitter{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "jH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -106,7 +106,7 @@
 /obj/machinery/power/emitter{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "oA" = (
 /obj/machinery/door/airlock/external,
@@ -130,7 +130,7 @@
 /area/station/engineering/supermatter/room)
 "qw" = (
 /obj/structure/cable/multilayer/connected,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "qx" = (
 /obj/structure/cable,
@@ -188,7 +188,7 @@
 /area/station/engineering/supermatter/room)
 "vK" = (
 /obj/effect/turf_decal/bot_red,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "vY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
@@ -207,7 +207,7 @@
 "wv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_white/right,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "wL" = (
 /obj/machinery/airalarm/directional/west,
@@ -229,7 +229,7 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "yN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -285,7 +285,7 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "FU" = (
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Gn" = (
 /obj/machinery/light/directional/south,
@@ -350,7 +350,7 @@
 "Ou" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/bot_white/left,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "OY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,


### PR DESCRIPTION
## About The Pull Request
This PR will fix this and stop it from happening:

![image](https://github.com/Monkestation/Monkestation2.0/assets/79924768/f6989922-6b4c-42df-ad84-540e5951b636)

![image](https://github.com/Monkestation/Monkestation2.0/assets/79924768/c818c61b-8fe4-4191-bf0e-bec50d27acf1)

This was caused by the wrong type of plating being used in the singularity engine template that the random engines use on Tram, Kilo and Meta station. The plating now have all been swapped to their Airless varient and there are no-more roundstart active turfs when the game rolls this engine on these maps.

This PR also fixes a random runtime that had to do with a double pipe on Metastation and its SM.

![image](https://github.com/Monkestation/Monkestation2.0/assets/79924768/7fe2d34d-1abe-4768-9544-e47d2f4487c3)
(This)

## Why It's Good For The Game
Makes Init go slightly faster.

## Changelog
:cl:
fix: Fixes roundstart active turfs from happening when singulo engine rolls on Tram, Kilo and Meta.
/:cl: