### PR TITLE
Adds completed optional objectives to the round-end report

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -328,6 +328,11 @@
 	result += objectives_text
 
 	if(uplink_handler)
+		var/completed_objectives_text = "Completed Uplink Objectives: "
+		for(var/datum/traitor_objective/objective as anything in uplink_handler.completed_objectives)
+			if(objective.objective_state == OBJECTIVE_STATE_COMPLETED)
+				completed_objectives_text += "<br><B>[objective.name]</B> - ([objective.telecrystal_reward] TC, [DISPLAY_PROGRESSION(objective.progression_reward)] Reputation)"
+		result += completed_objectives_text
 		result += "<br>The traitor had a total of [DISPLAY_PROGRESSION(uplink_handler.progression_points)] Reputation and [uplink_handler.telecrystals] Unused Telecrystals."
 
 	var/special_role_text = lowertext(name)


### PR DESCRIPTION

## About The Pull Request

Adds every completed objectives to the round-end report. Not much to say here

screenshot of it working:
![le screenshot, who even pays attention to their names nowadays huh?](https://github.com/Monkestation/Monkestation2.0/assets/82319946/7b56ab53-d7bf-44fe-8787-b89c349bfa76)

## Why It's Good For The Game

I think it looks neat, and gives players insight of who did what.

:cl:
add: Added completed optional objectives to the round-end report for every traitor
/:cl:
