### PR TITLE
space adapatation nerf removal

### DIFF
--- a/code/datums/mutations/adaptation.dm
+++ b/code/datums/mutations/adaptation.dm
@@ -1,4 +1,4 @@
-/datum/mutation/human/Space_adaptation
+/datum/mutation/human/space_adaptation
 	name = "Space Adaptation"
 	desc = "A strange mutation that renders the host immune to damage from extreme temperatures and pressure."
 	quality = POSITIVE
@@ -6,20 +6,20 @@
 	text_gain_indication = "<span class='notice'>Your body feels warm!</span>"
 	instability = 35
 
-/datum/mutation/human/Space_adaptation/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
+/datum/mutation/human/space_adaptation/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
 	..()
 	if(!(type in visual_indicators))
 		visual_indicators[type] = list(mutable_appearance('icons/effects/genetics.dmi', "fire", -MUTATIONS_LAYER))
 
-/datum/mutation/human/Space_adaptation/get_visual_indicator()
+/datum/mutation/human/space_adaptation/get_visual_indicator()
 	return visual_indicators[type][1]
 
-/datum/mutation/human/Space_adaptation/on_acquiring(mob/living/carbon/human/owner)
+/datum/mutation/human/space_adaptation/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
-	owner.add_traits(list(TRAIT_RESISTCOLD, TRAIT_RESISTHEAT, TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHIGHPRESSURE), GENETIC_MUTATION)
+	owner.add_traits(list(TRAIT_RESISTCOLD, TRAIT_RESISTLOWPRESSURE), GENETIC_MUTATION)
 
-/datum/mutation/human/Space_adaptation/on_losing(mob/living/carbon/human/owner)
+/datum/mutation/human/space_adaptation/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
-	owner.remove_traits(list(TRAIT_RESISTCOLD, TRAIT_RESISTHEAT, TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHIGHPRESSURE), GENETIC_MUTATION)
+	owner.remove_traits(list(TRAIT_RESISTCOLD,TRAIT_RESISTLOWPRESSURE), GENETIC_MUTATION)

--- a/code/datums/mutations/adaptation.dm
+++ b/code/datums/mutations/adaptation.dm
@@ -1,38 +1,40 @@
-/datum/mutation/human/space_adaptation
-	name = "Space Adaptation"
-	desc = "A strange mutation that renders the host immune to damage low temperature and pressure found in space."
+/datum/mutation/human/space_adaptation //Monkestation Edit #176
+	name = "Space Adaptation" //Monkestation Edit #176
+	desc = "A strange mutation that renders the host immune to damage low temperature and pressure found in space." //Monkestation Edit #176
 	quality = POSITIVE
 	difficulty = 16
 	text_gain_indication = "<span class='notice'>Your body feels warm!</span>"
 	instability = 35
+	//Monkestation Edit #176 conflict removed
 
-/datum/mutation/human/space_adaptation/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
+/datum/mutation/human/space_adaptation/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut) //Monkestation Edit #176
 	..()
 	if(!(type in visual_indicators))
 		visual_indicators[type] = list(mutable_appearance('icons/effects/genetics.dmi', "fire", -MUTATIONS_LAYER))
 
-/datum/mutation/human/space_adaptation/get_visual_indicator()
+/datum/mutation/human/space_adaptation/get_visual_indicator() //Monkestation Edit #176
 	return visual_indicators[type][1]
 
-/datum/mutation/human/space_adaptation/on_acquiring(mob/living/carbon/human/owner)
+/datum/mutation/human/space_adaptation/on_acquiring(mob/living/carbon/human/owner) //Monkestation Edit #176
 	if(..())
 		return
-	owner.add_traits(list(TRAIT_RESISTCOLD, TRAIT_RESISTLOWPRESSURE), GENETIC_MUTATION)
+	owner.add_traits(list(TRAIT_RESISTCOLD, TRAIT_RESISTLOWPRESSURE), GENETIC_MUTATION) //Monkestation Edit #176
 
-/datum/mutation/human/space_adaptation/on_losing(mob/living/carbon/human/owner)
+/datum/mutation/human/space_adaptation/on_losing(mob/living/carbon/human/owner) //Monkestation Edit #176
 	if(..())
 		return
-	owner.remove_traits(list(TRAIT_RESISTCOLD,TRAIT_RESISTLOWPRESSURE), GENETIC_MUTATION)
+	owner.remove_traits(list(TRAIT_RESISTCOLD,TRAIT_RESISTLOWPRESSURE), GENETIC_MUTATION) //Monkestation Edit #176
 
-/datum/mutation/human/extreme_adaptation
-	name = "Extreme Adaptation"
-	desc = "A strange mutation that renders the host immune to damage from high temperatures and pressure."
+/datum/mutation/human/extreme_adaptation //Monkestation Edit #176
+	name = "Extreme Adaptation" //Monkestation Edit #176
+	desc = "A strange mutation that renders the host immune to damage from high temperatures and pressure." //Monkestation Edit #176
 	quality = POSITIVE
 	difficulty = 16
 	text_gain_indication = "<span class='notice'>Your body feels warm!</span>"
 	instability = 35
+	//Monkestation Edit #176 conflict removed
 
-/datum/mutation/human/extreme_adaptation/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
+/datum/mutation/human/extreme_adaptation/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut) //Monkestation Edit #176
 	..()
 	if(!(type in visual_indicators))
 		visual_indicators[type] = list(mutable_appearance('icons/effects/genetics.dmi', "fire", -MUTATIONS_LAYER))
@@ -43,9 +45,9 @@
 /datum/mutation/human/extreme_adaptation/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
-	owner.add_traits(list(TRAIT_RESISTHEAT, TRAIT_RESISTHIGHPRESSURE), GENETIC_MUTATION)
+	owner.add_traits(list(TRAIT_RESISTHEAT, TRAIT_RESISTHIGHPRESSURE), GENETIC_MUTATION) //Monkestation Edit #176
 
-/datum/mutation/human/extreme_adaptation/on_losing(mob/living/carbon/human/owner)
+/datum/mutation/human/extreme_adaptation/on_losing(mob/living/carbon/human/owner) //Monkestation Edit #176
 	if(..())
 		return
-	owner.remove_traits(list(TRAIT_RESISTHEAT,TRAIT_RESISTHIGHPRESSURE), GENETIC_MUTATION)
+	owner.remove_traits(list(TRAIT_RESISTHEAT,TRAIT_RESISTHIGHPRESSURE), GENETIC_MUTATION) //Monkestation Edit #176

--- a/code/datums/mutations/adaptation.dm
+++ b/code/datums/mutations/adaptation.dm
@@ -1,6 +1,6 @@
 /datum/mutation/human/space_adaptation
 	name = "Space Adaptation"
-	desc = "A strange mutation that renders the host immune to damage from extreme temperatures and pressure."
+	desc = "A strange mutation that renders the host immune to damage low temperature and pressure found in space."
 	quality = POSITIVE
 	difficulty = 16
 	text_gain_indication = "<span class='notice'>Your body feels warm!</span>"
@@ -23,3 +23,29 @@
 	if(..())
 		return
 	owner.remove_traits(list(TRAIT_RESISTCOLD,TRAIT_RESISTLOWPRESSURE), GENETIC_MUTATION)
+
+/datum/mutation/human/extreme_adaptation
+	name = "Extreme Adaptation"
+	desc = "A strange mutation that renders the host immune to damage from high temperatures and pressure."
+	quality = POSITIVE
+	difficulty = 16
+	text_gain_indication = "<span class='notice'>Your body feels warm!</span>"
+	instability = 35
+
+/datum/mutation/human/extreme_adaptation/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
+	..()
+	if(!(type in visual_indicators))
+		visual_indicators[type] = list(mutable_appearance('icons/effects/genetics.dmi', "fire", -MUTATIONS_LAYER))
+
+/datum/mutation/human/extreme_adaptation/get_visual_indicator()
+	return visual_indicators[type][1]
+
+/datum/mutation/human/extreme_adaptation/on_acquiring(mob/living/carbon/human/owner)
+	if(..())
+		return
+	owner.add_traits(list(TRAIT_RESISTHEAT, TRAIT_RESISTHIGHPRESSURE), GENETIC_MUTATION)
+
+/datum/mutation/human/extreme_adaptation/on_losing(mob/living/carbon/human/owner)
+	if(..())
+		return
+	owner.remove_traits(list(TRAIT_RESISTHEAT,TRAIT_RESISTHIGHPRESSURE), GENETIC_MUTATION)

--- a/code/datums/mutations/adaptation.dm
+++ b/code/datums/mutations/adaptation.dm
@@ -1,53 +1,25 @@
-/datum/mutation/human/temperature_adaptation
-	name = "Temperature Adaptation"
-	desc = "A strange mutation that renders the host immune to damage from extreme temperatures. Does not protect from vacuums."
+/datum/mutation/human/Space_adaptation
+	name = "Space Adaptation"
+	desc = "A strange mutation that renders the host immune to damage from extreme temperatures and pressure."
 	quality = POSITIVE
 	difficulty = 16
 	text_gain_indication = "<span class='notice'>Your body feels warm!</span>"
-	instability = 25
-	conflicts = list(/datum/mutation/human/pressure_adaptation)
+	instability = 35
 
-/datum/mutation/human/temperature_adaptation/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
+/datum/mutation/human/Space_adaptation/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
 	..()
 	if(!(type in visual_indicators))
 		visual_indicators[type] = list(mutable_appearance('icons/effects/genetics.dmi', "fire", -MUTATIONS_LAYER))
 
-/datum/mutation/human/temperature_adaptation/get_visual_indicator()
+/datum/mutation/human/Space_adaptation/get_visual_indicator()
 	return visual_indicators[type][1]
 
-/datum/mutation/human/temperature_adaptation/on_acquiring(mob/living/carbon/human/owner)
+/datum/mutation/human/Space_adaptation/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
-	owner.add_traits(list(TRAIT_RESISTCOLD, TRAIT_RESISTHEAT), GENETIC_MUTATION)
+	owner.add_traits(list(TRAIT_RESISTCOLD, TRAIT_RESISTHEAT, TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHIGHPRESSURE), GENETIC_MUTATION)
 
-/datum/mutation/human/temperature_adaptation/on_losing(mob/living/carbon/human/owner)
+/datum/mutation/human/Space_adaptation/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
-	owner.remove_traits(list(TRAIT_RESISTCOLD, TRAIT_RESISTHEAT), GENETIC_MUTATION)
-
-/datum/mutation/human/pressure_adaptation
-	name = "Pressure Adaptation"
-	desc = "A strange mutation that renders the host immune to damage from both low and high pressure environments. Does not protect from temperature, including the cold of space."
-	quality = POSITIVE
-	difficulty = 16
-	text_gain_indication = "<span class='notice'>Your body feels numb!</span>"
-	instability = 25
-	conflicts = list(/datum/mutation/human/temperature_adaptation)
-
-/datum/mutation/human/pressure_adaptation/New(class_ = MUT_OTHER, timer, datum/mutation/human/copymut)
-	..()
-	if(!(type in visual_indicators))
-		visual_indicators[type] = list(mutable_appearance('icons/effects/genetics.dmi', "pressure", -MUTATIONS_LAYER))
-
-/datum/mutation/human/pressure_adaptation/get_visual_indicator()
-	return visual_indicators[type][1]
-
-/datum/mutation/human/pressure_adaptation/on_acquiring(mob/living/carbon/human/owner)
-	if(..())
-		return
-	owner.add_traits(list(TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHIGHPRESSURE), GENETIC_MUTATION)
-
-/datum/mutation/human/pressure_adaptation/on_losing(mob/living/carbon/human/owner)
-	if(..())
-		return
-	owner.remove_traits(list(TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHIGHPRESSURE), GENETIC_MUTATION)
+	owner.remove_traits(list(TRAIT_RESISTCOLD, TRAIT_RESISTHEAT, TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHIGHPRESSURE), GENETIC_MUTATION)

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -423,24 +423,24 @@
 	name = "\improper DNA injector (Anti-Paranoia)"
 	remove_mutations = list(/datum/mutation/human/paranoia)
 
-/obj/item/dnainjector/spacemut
-	name = "\improper DNA injector (Space Adaptation)"
-	desc = "you will no longer suffer from cold and low atmosphere"
-	add_mutations = list(/datum/mutation/human/space_adaptation)
+/obj/item/dnainjector/spacemut //Monkestation Edit #176
+	name = "\improper DNA injector (Space Adaptation)" //Monkestation Edit #176
+	desc = "you will no longer suffer from cold and low atmosphere" //Monkestation Edit #176
+	add_mutations = list(/datum/mutation/human/space_adaptation) //Monkestation Edit #176
 
-/obj/item/dnainjector/antispace
-	name = "\improper DNA injector (anti-Space Adaptation)"
-	desc = "cures space adaptation"
-	remove_mutations = list(/datum/mutation/human/space_adaptation)
-/obj/item/dnainjector/extrememut
-	name = "\improper DNA injector (Extreme Adaptation)"
-	desc = "makes high temps and atmos not so bad"
-	add_mutations = list(/datum/mutation/human/extreme_adaptation)
+/obj/item/dnainjector/antispace //Monkestation Edit #176
+	name = "\improper DNA injector (anti-Space Adaptation)" //Monkestation Edit #176
+	desc = "cures space adaptation" //Monkestation Edit #176
+	remove_mutations = list(/datum/mutation/human/space_adaptation) //Monkestation Edit #176
+/obj/item/dnainjector/extrememut //Monkestation Edit #176
+	name = "\improper DNA injector (Extreme Adaptation)" //Monkestation Edit #176
+	desc = "makes high temps and atmos not so bad" //Monkestation Edit #176
+	add_mutations = list(/datum/mutation/human/extreme_adaptation) //Monkestation Edit #176
 
-/obj/item/dnainjector/antiextreme
-	name = "\improper DNA injector (Anti-Extreme Adaptation)"
-	desc = "cures extreme Adaptation."
-	remove_mutations = list(/datum/mutation/human/extreme_adaptation)
+/obj/item/dnainjector/antiextreme //Monkestation Edit #176
+	name = "\improper DNA injector (Anti-Extreme Adaptation)" //Monkestation Edit #176
+	desc = "cures extreme Adaptation." //Monkestation Edit #176
+	remove_mutations = list(/datum/mutation/human/extreme_adaptation) //Monkestation Edit #176
 
 /obj/item/dnainjector/radioactive
 	name = "\improper DNA injector (Radioactive)"

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -497,15 +497,10 @@
 	desc = "Will make you not able to control your mind."
 	remove_mutations = list(/datum/mutation/human/telekinesis)
 
-/obj/item/dnainjector/firemut
-	name = "\improper DNA injector (Temp Adaptation)"
-	desc = "Gives you fire."
-	add_mutations = list(/datum/mutation/human/temperature_adaptation)
-
-/obj/item/dnainjector/antifire
-	name = "\improper DNA injector (Anti-Temp Adaptation)"
-	desc = "Cures fire."
-	remove_mutations = list(/datum/mutation/human/temperature_adaptation)
+/obj/item/dnainjector/spacemut
+	name = "\improper DNA injector (Space Adaptation)"
+	desc = "Gives you Space immunity."
+	add_mutations = list(/datum/mutation/human/Space_adaptation)
 
 /obj/item/dnainjector/thermal
 	name = "\improper DNA injector (Thermal Vision)"

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -425,13 +425,22 @@
 
 /obj/item/dnainjector/spacemut
 	name = "\improper DNA injector (Space Adaptation)"
-	desc = "Gives you fire."
+	desc = "you will no longer suffer from cold and low atmosphere"
 	add_mutations = list(/datum/mutation/human/space_adaptation)
 
 /obj/item/dnainjector/antispace
-	name = "\improper DNA injector (Anti-Pressure Adaptation)"
-	desc = "Cures fire."
+	name = "\improper DNA injector (anti-Space Adaptation)"
+	desc = "cures space adaptation"
 	remove_mutations = list(/datum/mutation/human/space_adaptation)
+/obj/item/dnainjector/extrememut
+	name = "\improper DNA injector (Extreme Adaptation)"
+	desc = "makes high temps and atmos not so bad"
+	add_mutations = list(/datum/mutation/human/extreme_adaptation)
+
+/obj/item/dnainjector/antiextreme
+	name = "\improper DNA injector (Anti-Extreme Adaptation)"
+	desc = "cures extreme Adaptation."
+	remove_mutations = list(/datum/mutation/human/extreme_adaptation)
 
 /obj/item/dnainjector/radioactive
 	name = "\improper DNA injector (Radioactive)"

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -426,12 +426,12 @@
 /obj/item/dnainjector/spacemut
 	name = "\improper DNA injector (Space Adaptation)"
 	desc = "Gives you fire."
-	add_mutations = list(/datum/mutation/human/Space_adaptation)
+	add_mutations = list(/datum/mutation/human/space_adaptation)
 
 /obj/item/dnainjector/antispace
 	name = "\improper DNA injector (Anti-Pressure Adaptation)"
 	desc = "Cures fire."
-	remove_mutations = list(/datum/mutation/human/Space_adaptation)
+	remove_mutations = list(/datum/mutation/human/space_adaptation)
 
 /obj/item/dnainjector/radioactive
 	name = "\improper DNA injector (Radioactive)"

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -423,15 +423,15 @@
 	name = "\improper DNA injector (Anti-Paranoia)"
 	remove_mutations = list(/datum/mutation/human/paranoia)
 
-/obj/item/dnainjector/pressuremut
-	name = "\improper DNA injector (Pressure Adaptation)"
+/obj/item/dnainjector/spacemut
+	name = "\improper DNA injector (Space Adaptation)"
 	desc = "Gives you fire."
-	add_mutations = list(/datum/mutation/human/pressure_adaptation)
+	add_mutations = list(/datum/mutation/human/Space_adaptation)
 
-/obj/item/dnainjector/antipressure
+/obj/item/dnainjector/antispace
 	name = "\improper DNA injector (Anti-Pressure Adaptation)"
 	desc = "Cures fire."
-	remove_mutations = list(/datum/mutation/human/pressure_adaptation)
+	remove_mutations = list(/datum/mutation/human/Space_adaptation)
 
 /obj/item/dnainjector/radioactive
 	name = "\improper DNA injector (Radioactive)"
@@ -496,11 +496,6 @@
 	name = "\improper DNA injector (Anti-Tele.)"
 	desc = "Will make you not able to control your mind."
 	remove_mutations = list(/datum/mutation/human/telekinesis)
-
-/obj/item/dnainjector/spacemut
-	name = "\improper DNA injector (Space Adaptation)"
-	desc = "Gives you Space immunity."
-	add_mutations = list(/datum/mutation/human/Space_adaptation)
 
 /obj/item/dnainjector/thermal
 	name = "\improper DNA injector (Thermal Vision)"

--- a/code/modules/antagonists/wishgranter/wishgranter.dm
+++ b/code/modules/antagonists/wishgranter/wishgranter.dm
@@ -27,5 +27,5 @@
 		return
 	H.dna.add_mutation(/datum/mutation/human/hulk)
 	H.dna.add_mutation(/datum/mutation/human/xray)
-	H.dna.add_mutation(/datum/mutation/human/pressure_adaptation)
+	H.dna.add_mutation(/datum/mutation/human/Space_adaptation)
 	H.dna.add_mutation(/datum/mutation/human/telekinesis)

--- a/code/modules/antagonists/wishgranter/wishgranter.dm
+++ b/code/modules/antagonists/wishgranter/wishgranter.dm
@@ -27,5 +27,5 @@
 		return
 	H.dna.add_mutation(/datum/mutation/human/hulk)
 	H.dna.add_mutation(/datum/mutation/human/xray)
-	H.dna.add_mutation(/datum/mutation/human/Space_adaptation)
+	H.dna.add_mutation(/datum/mutation/human/space_adaptation)
 	H.dna.add_mutation(/datum/mutation/human/telekinesis)

--- a/code/modules/antagonists/wishgranter/wishgranter.dm
+++ b/code/modules/antagonists/wishgranter/wishgranter.dm
@@ -27,5 +27,5 @@
 		return
 	H.dna.add_mutation(/datum/mutation/human/hulk)
 	H.dna.add_mutation(/datum/mutation/human/xray)
-	H.dna.add_mutation(/datum/mutation/human/space_adaptation)
+	H.dna.add_mutation(/datum/mutation/human/space_adaptation) //Monkestation Edit #176
 	H.dna.add_mutation(/datum/mutation/human/telekinesis)


### PR DESCRIPTION

**About The Pull Request**
that stuff is painful as it is to do those terrible minigames over and over, space adaptation is not really all that bad.

**Why It's Good For The Game**
being either pressure proof or temp proof is limited in usefulness, considering how much of a chore it is to do those minigames the reward should be there, this simply changes them to be Low or high (pressure/Temp) were in space the low variant is obviously great for space walking but will yield no bonuses against high temperature/high pressure situations that could occour.

**Changelog**
🆑
balance: changes space adaptation to focus about enviorment instead of pressure vs temp so its now high vs low.
/🆑