### PR TITLE
[Priority?]give those sec players monkecoins

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -283,6 +283,7 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt"))
 	for(var/client/C in GLOB.clients)
 		if(C && C.prefs)
 			C.prefs.adjust_metacoins(C.ckey, 75, "Played a Round")
+			C.prefs.adjust_metacoins(C.ckey, C.reward_this_person, "Special Bonus")
 		if(length(C.applied_challenges))
 			if(isliving(C.mob))
 				var/mob/living/client_mob = C.mob

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -479,6 +479,8 @@ SUBSYSTEM_DEF(ticker)
 			livings += living
 			if(living.client && length(living.client?.active_challenges))
 				SSchallenges.apply_challenges(living.client)
+			if(living.job == JOB_SECURITY_OFFICER||living.job == JOB_SECURITY_OFFICER_ENGINEERING || living.job == JOB_SECURITY_OFFICER_MEDICAL || living.job == JOB_SECURITY_OFFICER_SCIENCE || living.job == JOB_SECURITY_OFFICER_SUPPLY || living.job == JOB_WARDEN || living.job == JOB_DETECTIVE || living.job == JOB_HEAD_OF_SECURITY)
+				living.client.reward_this_person += 150
 	if(livings.len)
 		addtimer(CALLBACK(src, PROC_REF(release_characters), livings), 30, TIMER_CLIENT_TIME)
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -479,7 +479,7 @@ SUBSYSTEM_DEF(ticker)
 			livings += living
 			if(living.client && length(living.client?.active_challenges))
 				SSchallenges.apply_challenges(living.client)
-			if(living.job == JOB_SECURITY_OFFICER||living.job == JOB_SECURITY_OFFICER_ENGINEERING || living.job == JOB_SECURITY_OFFICER_MEDICAL || living.job == JOB_SECURITY_OFFICER_SCIENCE || living.job == JOB_SECURITY_OFFICER_SUPPLY || living.job == JOB_WARDEN || living.job == JOB_DETECTIVE || living.job == JOB_HEAD_OF_SECURITY)
+			if(living.mind.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
 				living.client.reward_this_person += 150
 	if(livings.len)
 		addtimer(CALLBACK(src, PROC_REF(release_characters), livings), 30, TIMER_CLIENT_TIME)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -66,6 +66,11 @@ SUBSYSTEM_DEF(ticker)
 	/// Why an emergency shuttle was called
 	var/emergency_reason
 
+	///add bitflags to this that should be rewarded monkecoins, example: DEPARTMENT_BITFLAG_SECURITY
+	var/list/bitflags_to_reward = list(DEPARTMENT_BITFLAG_SECURITY,)
+	///add jobs to this that should get rewarded monkecoins, example: JOB_SECURITY_OFFICER
+	var/list/jobs_to_reward = list(JOB_JANITOR,)
+
 /datum/controller/subsystem/ticker/Initialize()
 	var/list/byond_sound_formats = list(
 		"mid" = TRUE,
@@ -479,8 +484,12 @@ SUBSYSTEM_DEF(ticker)
 			livings += living
 			if(living.client && length(living.client?.active_challenges))
 				SSchallenges.apply_challenges(living.client)
-			if(living.mind.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
-				living.client.reward_this_person += 150
+			for(var/processing_reward_bitflags in bitflags_to_reward)//you really should use department bitflags if possible
+				if(living.mind.assigned_role.departments_bitflags & processing_reward_bitflags)
+					living.client.reward_this_person += 150
+			for(var/processing_reward_jobs in jobs_to_reward)//just in case you really only want to reward a specific job
+				if(living.job == processing_reward_jobs)
+					living.client.reward_this_person += 150
 	if(livings.len)
 		addtimer(CALLBACK(src, PROC_REF(release_characters), livings), 30, TIMER_CLIENT_TIME)
 

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -272,3 +272,5 @@
 	/// Does this client have typing indicators enabled?
 	var/typing_indicators = FALSE
 
+	/// used for rewarding players monkecoins at round end
+	var/reward_this_person = 0

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -192,6 +192,9 @@
 	if(character.client && length(character.client?.active_challenges))
 		SSchallenges.apply_challenges(character.client)
 
+	if(character.job == JOB_SECURITY_OFFICER|| character.job == JOB_SECURITY_OFFICER_ENGINEERING || character.job == JOB_SECURITY_OFFICER_MEDICAL || character.job == JOB_SECURITY_OFFICER_SCIENCE || character.job == JOB_SECURITY_OFFICER_SUPPLY || character.job == JOB_WARDEN || character.job == JOB_DETECTIVE || character.job == JOB_HEAD_OF_SECURITY)
+		character.client.reward_this_person += 150
+
 	#define IS_NOT_CAPTAIN 0
 	#define IS_ACTING_CAPTAIN 1
 	#define IS_FULL_CAPTAIN 2

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -191,8 +191,7 @@
 
 	if(character.client && length(character.client?.active_challenges))
 		SSchallenges.apply_challenges(character.client)
-
-	if(character.job == JOB_SECURITY_OFFICER|| character.job == JOB_SECURITY_OFFICER_ENGINEERING || character.job == JOB_SECURITY_OFFICER_MEDICAL || character.job == JOB_SECURITY_OFFICER_SCIENCE || character.job == JOB_SECURITY_OFFICER_SUPPLY || character.job == JOB_WARDEN || character.job == JOB_DETECTIVE || character.job == JOB_HEAD_OF_SECURITY)
+	if(character.mind.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
 		character.client.reward_this_person += 150
 
 	#define IS_NOT_CAPTAIN 0

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -191,9 +191,12 @@
 
 	if(character.client && length(character.client?.active_challenges))
 		SSchallenges.apply_challenges(character.client)
-	if(character.mind.assigned_role.departments_bitflags & DEPARTMENT_BITFLAG_SECURITY)
-		character.client.reward_this_person += 150
-
+	for(var/processing_reward_bitflags in SSticker.bitflags_to_reward)//you really should use department bitflags if possible
+		if(character.mind.assigned_role.departments_bitflags & processing_reward_bitflags)
+			character.client.reward_this_person += 150
+	for(var/processing_reward_jobs in SSticker.jobs_to_reward)//just in case you really only want to reward a specific job
+		if(character.job == processing_reward_jobs)
+			character.client.reward_this_person += 150
 	#define IS_NOT_CAPTAIN 0
 	#define IS_ACTING_CAPTAIN 1
 	#define IS_FULL_CAPTAIN 2


### PR DESCRIPTION
this gives sec players an extra 150 monkecoins on round end. it also makes it easy for future coders to do the same. "WHO.client.reward_this_person += X" 
quite simple...you could also subtract if you are a meanie and admins with knowledge could add/remove points.
its added with same conditions as "played a round +75" and does not check for living.

the "player joins game" part is also modular to the extend of being possible to add roles/departments to list of players who get +150 points at round end, for playing that role, note that this PR does not inform the players except at the very end it says they get a "special bonus"
by default sec players gets the 150 extra points simply by being sec.