### PR TITLE
Nukie base buff. 

### DIFF
--- a/_maps/templates/lazy_templates/nukie_base.dmm
+++ b/_maps/templates/lazy_templates/nukie_base.dmm
@@ -207,10 +207,7 @@
 /area/centcom/syndicate_mothership/control)
 "cT" = (
 /obj/structure/rack,
-/obj/item/katana/cursed{
-	desc = "A gift from your benefactors.";
-	force = 20
-	},
+/obj/item/katana,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/centcom/syndicate_mothership/control)
 "cV" = (
@@ -290,6 +287,7 @@
 /area/centcom/syndicate_mothership/control)
 "dO" = (
 /obj/machinery/light/cold/directional/west,
+/obj/effect/landmark/start/nukeop,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/centcom/syndicate_mothership/control)
 "dV" = (
@@ -368,6 +366,10 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/rag,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/item/food/nachos{
+	pixel_x = 7;
+	pixel_y = -14
+	},
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "eK" = (
@@ -568,14 +570,12 @@
 	},
 /area/centcom/syndicate_mothership/control)
 "gT" = (
-/obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
-/obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/centcom/syndicate_mothership/control)
+/turf/closed/indestructible/syndicate,
+/area/centcom/syndicate_mothership/expansion_fridgerummage)
 "gV" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/end,
 /obj/machinery/vending/hydroseeds{
@@ -648,7 +648,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/wideplating,
-/obj/machinery/door/puzzle/keycard/syndicate_fridge,
+/obj/effect/mapping_helpers/airlock/autoname,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/machinery/door/airlock/freezer,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -671,11 +673,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_mothership/control)
 "is" = (
-/obj/structure/table/wood,
-/obj/item/storage/box/drinkingglasses,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/turf/open/floor/iron,
-/area/centcom/syndicate_mothership/control)
+/turf/closed/indestructible/syndicate,
+/area/centcom/syndicate_mothership/expansion_fridgerummage)
 "iA" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
@@ -1032,6 +1032,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/effect/landmark/start/nukeop,
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "mb" = (
@@ -1066,7 +1067,6 @@
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "mz" = (
-/obj/machinery/vending/cola,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
@@ -1088,35 +1088,9 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "mG" = (
-/obj/structure/closet/crate/freezer{
-	name = "pantry crate"
-	},
 /obj/structure/sign/poster/contraband/moffuchis_pizza{
 	pixel_y = -32
 	},
-/obj/item/reagent_containers/condiment/rice{
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/condiment/rice{
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/condiment/saltshaker,
-/obj/item/reagent_containers/condiment/peppermill,
-/obj/item/food/grown/wheat,
-/obj/item/food/grown/wheat,
-/obj/item/reagent_containers/condiment/sugar,
-/obj/item/reagent_containers/condiment/sugar,
-/obj/item/food/grown/soybeans,
-/obj/item/food/grown/soybeans,
-/obj/item/food/grown/vanillapod,
-/obj/item/food/grown/vanillapod,
-/obj/item/food/grown/herbs,
-/obj/item/food/grown/herbs,
-/obj/item/food/grown/cocoapod,
-/obj/item/food/grown/cocoapod,
-/obj/item/food/grown/aloe,
-/obj/item/food/grown/coffee,
-/obj/item/food/grown/coffee,
 /turf/open/floor/plastic,
 /area/centcom/syndicate_mothership/expansion_fridgerummage)
 "mJ" = (
@@ -1205,10 +1179,11 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/centcom/syndicate_mothership/control)
 "nL" = (
-/obj/structure/chair/office/light{
+/obj/machinery/light/cold/directional/east,
+/obj/effect/landmark/start/nukeop,
+/obj/structure/chair/office/tactical{
 	dir = 1
 	},
-/obj/machinery/light/cold/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "nQ" = (
@@ -1371,6 +1346,7 @@
 "pD" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
+/obj/effect/landmark/start/nukeop,
 /turf/open/floor/iron/smooth_half,
 /area/centcom/syndicate_mothership/control)
 "pF" = (
@@ -1408,6 +1384,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
+/obj/effect/landmark/start/nukeop,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "pW" = (
@@ -1773,6 +1750,8 @@
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 8
 	},
+/obj/effect/landmark/start/nukeop,
+/obj/structure/chair/office/tactical,
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "ti" = (
@@ -1996,8 +1975,12 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/obj/machinery/door/puzzle/keycard/syndicate_bio,
 /obj/structure/fans/tiny,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Sky Bridge"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -2059,8 +2042,12 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/obj/machinery/door/puzzle/keycard/syndicate_chem,
 /obj/structure/fans/tiny,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Sky Bridge"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -2102,6 +2089,23 @@
 /obj/structure/sign/poster/contraband/moffuchis_pizza{
 	pixel_x = -32
 	},
+/turf/open/floor/mineral/titanium,
+/area/centcom/syndicate_mothership/control)
+"xY" = (
+/obj/machinery/door/window/survival_pod{
+	dir = 8;
+	name = "Toilet Door";
+	opacity = 1
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north{
+	name = "Frosted Window";
+	opacity = 1
+	},
+/obj/structure/toilet/greyscale{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/east,
+/obj/effect/landmark/start/nukeop,
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
 "ya" = (
@@ -2202,6 +2206,7 @@
 /area/centcom/syndicate_mothership/control)
 "zi" = (
 /obj/structure/chair/office,
+/obj/effect/landmark/start/nukeop,
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
 "zo" = (
@@ -2396,6 +2401,9 @@
 /obj/machinery/camera/autoname/directional/east{
 	network = list("nukie")
 	},
+/obj/machinery/vending/wallmed{
+	pixel_x = 28
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "Br" = (
@@ -2421,6 +2429,17 @@
 	width = 7
 	},
 /turf/open/floor/plating/icemoon,
+/area/centcom/syndicate_mothership/control)
+"Bw" = (
+/obj/structure/chair/stool/bar/directional/west,
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/light/small/directional/north{
+	dir = 2
+	},
+/turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "BD" = (
 /obj/effect/turf_decal/box,
@@ -3157,6 +3176,7 @@
 /obj/item/bedsheet/syndie{
 	dir = 4
 	},
+/obj/effect/landmark/start/nukeop,
 /turf/open/floor/iron/smooth_half,
 /area/centcom/syndicate_mothership/control)
 "Ld" = (
@@ -3178,8 +3198,12 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/obj/machinery/door/puzzle/keycard/syndicate_bomb,
 /obj/structure/fans/tiny,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Sky Bridge"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/autoname,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
@@ -3443,6 +3467,11 @@
 /obj/structure/flora/tree/dead/style_random,
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
+"OB" = (
+/obj/structure/chair/stool/directional/north,
+/obj/effect/landmark/start/nukeop,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_mothership/control)
 "OD" = (
 /obj/machinery/camera/autoname/directional/north{
 	network = list("nukie")
@@ -3451,6 +3480,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
+/obj/machinery/vending/imported/yangyu,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/centcom/syndicate_mothership/control)
 "OK" = (
@@ -3460,11 +3490,11 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
 "OO" = (
-/obj/item/gun/energy/ionrifle,
 /obj/structure/rack,
 /obj/machinery/camera/autoname/directional/west{
 	network = list("nukie")
 	},
+/obj/item/gun/energy/ionrifle/carbine,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/centcom/syndicate_mothership/control)
 "OR" = (
@@ -3585,6 +3615,7 @@
 /obj/structure/chair/bronze{
 	dir = 8
 	},
+/obj/effect/landmark/start/nukeop_leader,
 /turf/open/floor/carpet,
 /area/centcom/syndicate_mothership/control)
 "PK" = (
@@ -3642,11 +3673,8 @@
 /area/centcom/syndicate_mothership/control)
 "Qy" = (
 /obj/structure/table/wood,
-/obj/item/food/nachos{
-	pixel_x = 7;
-	pixel_y = -14
-	},
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/item/storage/box/drinkingglasses,
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "QM" = (
@@ -3790,6 +3818,12 @@
 "Sv" = (
 /obj/structure/mop_bucket,
 /obj/item/mop,
+/obj/item/clothing/under/costume/maid,
+/obj/item/clothing/neck/maid,
+/obj/item/clothing/head/costume/maidheadband,
+/obj/item/clothing/gloves/maid,
+/obj/item/clothing/accessory/maidapron,
+/obj/item/clothing/under/rank/civilian/janitor/maid,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/centcom/syndicate_mothership/control)
 "SD" = (
@@ -4009,6 +4043,35 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
+"Va" = (
+/obj/structure/closet/crate/freezer{
+	name = "pantry crate"
+	},
+/obj/item/reagent_containers/condiment/rice{
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/condiment/rice{
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/condiment/saltshaker,
+/obj/item/reagent_containers/condiment/peppermill,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/item/reagent_containers/condiment/sugar,
+/obj/item/food/grown/soybeans,
+/obj/item/food/grown/soybeans,
+/obj/item/food/grown/vanillapod,
+/obj/item/food/grown/vanillapod,
+/obj/item/food/grown/herbs,
+/obj/item/food/grown/herbs,
+/obj/item/food/grown/cocoapod,
+/obj/item/food/grown/cocoapod,
+/obj/item/food/grown/aloe,
+/obj/item/food/grown/coffee,
+/obj/item/food/grown/coffee,
+/turf/open/floor/plastic,
+/area/centcom/syndicate_mothership/expansion_fridgerummage)
 "Vb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4043,6 +4106,16 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 8
 	},
+/area/centcom/syndicate_mothership/control)
+"VD" = (
+/obj/machinery/light/cold/directional/south,
+/obj/machinery/button/door/directional/east{
+	id = "FBBZ1";
+	name = "Security Shutters";
+	pixel_x = -7;
+	pixel_y = -28
+	},
+/turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
 "VF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -6396,8 +6469,8 @@ ZZ
 Lx
 uX
 uX
-uX
 gI
+ek
 ek
 mG
 ek
@@ -6498,9 +6571,9 @@ ZZ
 DZ
 gE
 my
-uX
 zN
 ek
+BK
 Id
 ek
 ZE
@@ -6602,7 +6675,7 @@ oR
 eF
 Qy
 is
-ek
+Va
 Gz
 ek
 DZ
@@ -6614,7 +6687,7 @@ XD
 IQ
 bo
 bo
-NM
+xY
 NM
 DZ
 Ox
@@ -6702,7 +6775,7 @@ iG
 DZ
 Su
 IC
-IC
+Bw
 gT
 ek
 ek
@@ -9653,7 +9726,7 @@ uT
 bW
 Zk
 qw
-pM
+VD
 DZ
 DZ
 DZ
@@ -10078,7 +10151,7 @@ IV
 rb
 au
 LB
-iV
+OB
 ov
 Nr
 DZ


### PR DESCRIPTION
## About The Pull Request, and why It's Good For The Game
Hello! 

This PR is to improve the nukie base, because I realized that TG fucking sucks and is made by dickheads.

Improvements:

1. Replaces the cursed katana VVed to do no damage with a normal one (I LOVE TG PLAYER GRIEF DON'T YOU?)

2. Unlocks all the "expansion" rooms because There’s nothing necessarily ground breaking in them, and they generally are “requires a skilled player & time to be effective”
no one buys them, and that’s a shame. Paint a creative picture for us, nukies, (with the crew's blood).

3. opens the security shutters so you can play around in there at roundend easier to poke around 


It'll be really hard to even tell if this PR has an effect because nukies are rare and people are predisposed to declaring war :( 

NOTE: Someone should remove the keys from the uplink because they are now useless, but I don't know how. 

## 

![image](https://github.com/Monkestation/Monkestation2.0/assets/14065903/fce6c808-b91e-4cbc-b6a8-bd8ad184799f)

## Changelog


:cl:

qol: Buffs the nukie base a little

/:cl:
