### PR TITLE
Central Command remodel

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -351,6 +351,17 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"bE" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "bG" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -421,9 +432,9 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "bU" = (
-/obj/structure/bookcase/random,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/vending/boozeomat,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
 "bV" = (
@@ -585,6 +596,9 @@
 "cG" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/storage/cans/sixsoda,
+/obj/structure/sign/painting/library_secure{
+	pixel_x = 32
+	},
 /turf/open/floor/iron/kitchen/diagonal,
 /area/centcom/central_command_areas/fore)
 "cI" = (
@@ -1107,6 +1121,9 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"fc" = (
+/turf/closed/indestructible/riveted,
+/area/centcom/tdome/arena)
 "fd" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
@@ -1498,10 +1515,6 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/ferry)
 "gT" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "gU" = (
@@ -1715,7 +1728,9 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
 "hT" = (
-/obj/machinery/status_display/evac/directional/east,
+/obj/machinery/vending/boozeomat{
+	pixel_x = 32
+	},
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/admin)
 "hW" = (
@@ -3315,6 +3330,9 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
+/obj/structure/sign/painting/library_secure{
+	pixel_x = 32
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "nx" = (
@@ -3424,6 +3442,10 @@
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
+	},
+/obj/structure/sign/painting/large/library{
+	dir = 8;
+	pixel_x = -28
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
@@ -4483,6 +4505,10 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
+/obj/structure/sign/painting/large/library{
+	dir = 8;
+	pixel_x = -28
+	},
 /turf/open/floor/eighties/red{
 	icon = 'goon/icons/turf/floors.dmi';
 	icon_state = "clown_carpet"
@@ -7416,6 +7442,10 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/three)
+"Fb" = (
+/obj/machinery/vending/boozeomat,
+/turf/closed/indestructible/riveted,
+/area/centcom/tdome/administration)
 "Fc" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -8067,17 +8097,23 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
 "IX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = -32
 	},
 /turf/open/floor/iron,
-/area/centcom/tdome/arena)
+/area/centcom/central_command_areas/control)
 "IY" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/structure/sign/painting/library_secure{
+	pixel_y = -32
 	},
-/turf/open/floor/iron,
-/area/centcom/tdome/arena)
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "IZ" = (
 /obj/effect/landmark/thunderdome/one,
 /obj/effect/turf_decal/stripes/line{
@@ -8142,15 +8178,16 @@
 /turf/open/ballpit,
 /area/centcom/central_command_areas/fore)
 "Js" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/centcom/tdome/arena)
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Jt" = (
-/obj/effect/turf_decal/tile/green,
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
-/area/centcom/tdome/arena)
+/area/centcom/tdome/observation)
 "Ju" = (
 /obj/effect/landmark/thunderdome/two,
 /obj/effect/turf_decal/stripes/line{
@@ -8936,12 +8973,12 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/briefing)
 "Na" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Green Team"
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/iron,
-/area/centcom/tdome/observation)
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "Ne" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/trophy/gold_cup,
@@ -9018,6 +9055,9 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"Ns" = (
+/turf/open/space/basic,
+/area/centcom/tdome/arena)
 "Nt" = (
 /obj/structure/filingcabinet/medical,
 /obj/machinery/light/directional/north,
@@ -9461,6 +9501,9 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"Pf" = (
+/turf/closed/indestructible/riveted,
+/area/space)
 "Pg" = (
 /obj/machinery/computer/auxiliary_base/directional/north,
 /obj/structure/table/reinforced,
@@ -10036,6 +10079,9 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/sign/painting/library_secure{
+	pixel_x = 32
+	},
 /turf/open/floor/iron/kitchen/diagonal,
 /area/centcom/central_command_areas/fore)
 "Ro" = (
@@ -10067,15 +10113,12 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
 "Rr" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "Rs" = (
 /obj/structure/closet/secure_closet/security,
@@ -10565,6 +10608,12 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/three)
+"TA" = (
+/obj/structure/sign/painting/library_secure{
+	pixel_x = 32
+	},
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "TB" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -10838,6 +10887,16 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod)
+"UN" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/sign/painting/library{
+	pixel_y = 32
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "UO" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security"
@@ -10984,8 +11043,11 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "Vr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red/half/contrasted{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
@@ -11789,6 +11851,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"YG" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Green Team"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
 "YH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -12099,6 +12171,9 @@
 	name = "Thunderdome Red Team"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "ZS" = (
@@ -49879,19 +49954,19 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Pf
+Pf
+Pf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+uf
 aa
 aa
 aa
@@ -50136,18 +50211,18 @@ aa
 aa
 aa
 QC
-QC
-QC
-QC
-uf
-uf
-uf
-uf
-uf
-uf
-uf
-uf
-uf
+Hm
+OE
+Sl
+ca
+Wn
+eH
+Um
+Wn
+ca
+Wn
+eH
+Um
 uf
 aa
 aa
@@ -50393,20 +50468,20 @@ aa
 aa
 aa
 QC
-Hm
-OE
 Sl
-ca
-Wn
-eH
-Um
-Wn
-ca
-Wn
-eH
-Um
+Sl
+QC
 uf
-aa
+uf
+Wn
+Wn
+uf
+uf
+uf
+Wn
+Wn
+uf
+uf
 aa
 aa
 aa
@@ -50650,21 +50725,21 @@ QC
 QC
 QC
 QC
-Sl
-Sl
-QC
+Jt
+gT
+pI
+tH
+Bp
+RB
+UW
+Bp
+oI
+Bp
+Sz
+Sz
+Js
 uf
 uf
-Wn
-Wn
-uf
-uf
-uf
-Wn
-Wn
-uf
-aa
-aa
 aa
 aa
 aa
@@ -50912,18 +50987,18 @@ Vr
 pI
 tH
 Bp
-RB
-UW
+yG
+Bj
 Bp
 oI
 Bp
 Sz
-Sz
+Js
+Js
+Js
 uf
-aa
-aa
-aa
-aa
+uf
+uf
 aa
 aa
 aa
@@ -51165,22 +51240,22 @@ bi
 bi
 tF
 PT
-Rh
-pI
-tH
-Bp
-yG
-Bj
-Bp
-oI
-Bp
+gT
+QC
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+Sz
+Js
+Js
+Js
 Sz
 Sz
 uf
-uf
-uf
-aa
-aa
 aa
 aa
 aa
@@ -51424,20 +51499,20 @@ QC
 Qi
 oi
 QC
-uf
-uf
-uf
-uf
-uf
-uf
+gQ
+gQ
+gQ
+gQ
+gQ
+gQ
 uf
 Sz
+Fc
 Sz
-Sz
+Js
+Js
 Sz
 uf
-aa
-aa
 aa
 aa
 aa
@@ -51681,20 +51756,20 @@ QC
 PT
 Rh
 QC
-gQ
-gQ
-gQ
-gQ
-gQ
-gQ
+Iz
+Iz
+Iz
+Iz
+Iz
+Iz
 uf
-Sz
-Fc
-Sz
-Sz
 uf
-aa
-aa
+uf
+Rr
+Mv
+Mv
+Mv
+uf
 aa
 aa
 aa
@@ -51938,22 +52013,22 @@ co
 ED
 oi
 QC
-Iz
-Iz
-Iz
-Iz
-Iz
-Iz
+IA
+IT
+IT
+IT
+IT
+Ju
+JD
+JH
+uf
+Sz
+Js
+Js
+Sz
 uf
 uf
 uf
-Mv
-Mv
-uf
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -52195,22 +52270,22 @@ FZ
 gE
 cq
 ZR
-IA
-IT
-IT
-IT
-IT
-Ju
+IB
+IU
+bo
+bo
+IU
+Jv
 JD
 JH
 uf
 Sz
+Js
+Js
 Sz
+Wn
+zA
 uf
-uf
-uf
-aa
-aa
 aa
 aa
 aa
@@ -52453,21 +52528,21 @@ QC
 QC
 QC
 IB
-IU
+bo
+ol
 bo
 bo
-IU
 Jv
 JD
 JH
 uf
 Sz
+Js
+Js
 Sz
 Wn
-zA
+ga
 uf
-aa
-aa
 aa
 aa
 aa
@@ -52710,21 +52785,21 @@ VT
 Op
 QC
 IB
+IU
 bo
-ol
 bo
-bo
+IU
 Jv
 JD
 JH
 uf
 Sz
+Js
+Js
 Sz
 Wn
-ga
+zA
 uf
-aa
-aa
 aa
 aa
 aa
@@ -52966,22 +53041,22 @@ bi
 eI
 hv
 QC
-IB
-IU
-bo
-bo
-IU
-Jv
+IC
+IW
+IW
+IW
+IW
+Jw
 JD
 JH
 uf
 Sz
 Sz
-Wn
-zA
+Sz
+Sz
 uf
-aa
-aa
+uf
+uf
 aa
 aa
 aa
@@ -53223,21 +53298,21 @@ eI
 bi
 cY
 QC
-IC
-IW
-IW
-IW
-IW
-Jw
-JD
-JH
-uf
-Sz
-Sz
+ID
+ID
+ID
+ID
+ID
+ID
 uf
 uf
 uf
-aa
+uf
+uf
+uf
+Fj
+uf
+uf
 aa
 aa
 aa
@@ -53479,22 +53554,22 @@ Id
 Bs
 di
 QC
-QC
-ID
-ID
-ID
-ID
-ID
-ID
+Is
+Jh
+Jh
+IE
+IE
+Jh
+Jh
+IE
+IE
+Is
+Pj
+fB
+bE
+GV
+BQ
 uf
-uf
-uf
-uf
-Fj
-uf
-uf
-aa
-aa
 aa
 aa
 aa
@@ -53736,22 +53811,22 @@ BW
 uv
 uv
 SZ
-Is
-IE
-IX
-Jh
-Jh
-Js
-IE
-Is
+It
+It
+It
+It
+It
+It
+It
+It
+It
+It
 Pj
-fB
-Rr
-GV
-BQ
+Na
+Sz
+Sz
+IY
 uf
-aa
-aa
 aa
 aa
 aa
@@ -53994,12 +54069,14 @@ Kd
 nD
 SZ
 It
-It
-It
-It
-It
-It
-It
+Iu
+IF
+IF
+IF
+IF
+IF
+IF
+Iu
 It
 Pj
 Pr
@@ -54009,8 +54086,6 @@ gn
 uf
 uf
 uf
-aa
-aa
 aa
 aa
 aa
@@ -54250,14 +54325,16 @@ nD
 Kd
 nD
 SZ
-Iu
-IF
-IF
-IF
-IF
-IF
-IF
-Iu
+It
+It
+IG
+IG
+IG
+IG
+IG
+IG
+It
+It
 Pj
 Pr
 Xw
@@ -54266,8 +54343,6 @@ cD
 Wn
 wj
 uf
-aa
-aa
 aa
 aa
 aa
@@ -54473,7 +54548,7 @@ iX
 iF
 iX
 iF
-tL
+UN
 tL
 iu
 iu
@@ -54483,7 +54558,7 @@ iu
 iu
 in
 tL
-tL
+IX
 io
 iu
 io
@@ -54508,12 +54583,14 @@ Kd
 sH
 SZ
 It
-IG
-IG
-IG
-IG
-IG
-IG
+It
+fJ
+fJ
+fJ
+fJ
+fJ
+fJ
+It
 It
 Pj
 Xn
@@ -54523,8 +54600,6 @@ Rw
 Wn
 zA
 uf
-aa
-aa
 aa
 aa
 aa
@@ -54765,12 +54840,14 @@ Kd
 yY
 SZ
 It
+It
 fJ
 fJ
 fJ
 fJ
 fJ
 fJ
+It
 It
 Pj
 Pr
@@ -54780,8 +54857,6 @@ QU
 uf
 Wn
 uf
-aa
-aa
 aa
 aa
 aa
@@ -55022,12 +55097,14 @@ Kd
 yY
 SZ
 It
+It
 fJ
 fJ
 fJ
 fJ
 fJ
 fJ
+It
 It
 Pj
 Pr
@@ -55037,8 +55114,6 @@ Gy
 Wn
 zA
 uf
-aa
-aa
 aa
 aa
 aa
@@ -55279,12 +55354,14 @@ Kd
 yY
 SZ
 It
+It
 fJ
 fJ
 Ji
 Ji
 fJ
 fJ
+It
 It
 Pj
 Xn
@@ -55294,8 +55371,6 @@ dJ
 Wn
 wj
 uf
-aa
-aa
 aa
 aa
 aa
@@ -55536,12 +55611,14 @@ Kd
 yY
 SZ
 It
+It
 fJ
 fJ
 Jj
 Jq
 fJ
 fJ
+It
 It
 Pj
 mE
@@ -55551,8 +55628,6 @@ je
 uf
 Wn
 uf
-aa
-aa
 aa
 aa
 aa
@@ -55793,12 +55868,14 @@ Kd
 yY
 SZ
 It
+It
 fJ
 fJ
 Ji
 Ji
 fJ
 fJ
+It
 It
 Pj
 Pl
@@ -55808,8 +55885,6 @@ qd
 Wn
 wj
 uf
-aa
-aa
 aa
 aa
 aa
@@ -56050,12 +56125,14 @@ Kd
 yY
 SZ
 It
+It
 fJ
 fJ
 fJ
 fJ
 fJ
 fJ
+It
 It
 Pj
 Pr
@@ -56065,8 +56142,6 @@ Gy
 Wn
 zA
 uf
-aa
-aa
 aa
 aa
 aa
@@ -56247,7 +56322,7 @@ aa
 Vx
 fO
 zL
-xO
+TA
 IP
 uR
 dj
@@ -56307,12 +56382,14 @@ Kd
 yY
 SZ
 It
+It
 fJ
 fJ
 fJ
 fJ
 fJ
 fJ
+It
 It
 Pj
 Pr
@@ -56322,8 +56399,6 @@ UV
 uf
 Wn
 uf
-aa
-aa
 aa
 aa
 aa
@@ -56529,7 +56604,7 @@ io
 io
 io
 io
-tL
+UN
 tL
 iu
 iu
@@ -56539,7 +56614,7 @@ iu
 iu
 in
 tL
-tL
+IX
 io
 iu
 io
@@ -56564,12 +56639,14 @@ Kd
 sH
 SZ
 It
-II
-II
-II
-II
-II
-II
+It
+fJ
+fJ
+fJ
+fJ
+fJ
+fJ
+It
 It
 Pj
 Xn
@@ -56579,8 +56656,6 @@ Sg
 Wn
 wj
 uf
-aa
-aa
 aa
 aa
 aa
@@ -56820,14 +56895,16 @@ Wv
 Kd
 nD
 SZ
-Iu
-IF
-IF
-IF
-IF
-IF
-IF
-Iu
+It
+It
+II
+II
+II
+II
+II
+II
+It
+It
 Pj
 Pr
 Xw
@@ -56836,8 +56913,6 @@ JJ
 Wn
 zA
 uf
-aa
-aa
 aa
 aa
 aa
@@ -57078,12 +57153,14 @@ Kd
 nD
 SZ
 It
-It
-It
-It
-It
-It
-It
+Iu
+IF
+IF
+IF
+IF
+IF
+IF
+Iu
 It
 Pj
 Pr
@@ -57093,8 +57170,6 @@ gp
 uf
 uf
 uf
-aa
-aa
 aa
 aa
 aa
@@ -57334,22 +57409,22 @@ BW
 gx
 gx
 SZ
-Is
-IJ
-IY
-Jk
-Jk
-Jt
-IJ
-Is
+It
+It
+It
+It
+It
+It
+It
+It
+It
+It
 Pj
-YO
-Bx
-nx
-ih
+Na
+Sz
+Sz
+IY
 uf
-aa
-aa
 aa
 aa
 aa
@@ -57591,22 +57666,22 @@ Ot
 Ot
 di
 QC
-QC
-Mh
-Mh
-Mh
-Mh
-Mh
-Mh
+Is
+Jk
+Jk
+IJ
+IJ
+Jk
+Jk
+IJ
+IJ
+Is
+Pj
+YO
+Bx
+nx
+ih
 uf
-uf
-uf
-uf
-tC
-uf
-uf
-aa
-aa
 aa
 aa
 aa
@@ -57848,22 +57923,22 @@ cS
 cS
 cS
 Pn
-QC
-IL
-IZ
-IZ
-IZ
-IZ
-Jx
-JD
-JL
-uf
-Sz
-Sz
+fc
+Mh
+Mh
+Mh
+Mh
+Mh
+Mh
+fc
+fc
+fc
 uf
 uf
+Fb
+tC
 uf
-aa
+uf
 aa
 aa
 aa
@@ -58106,22 +58181,22 @@ cS
 cS
 Xd
 QC
-IM
-Ja
-QP
-QP
-Ja
-Jy
+IL
+IZ
+IZ
+IZ
+IZ
+Jx
 JD
 JL
 uf
 Sz
 Sz
-Wn
-zA
+Sz
+Sz
 uf
-aa
-aa
+uf
+uf
 aa
 aa
 aa
@@ -58364,21 +58439,21 @@ TV
 PN
 QC
 IM
+Ja
 QP
-WT
 QP
-QP
+Ja
 Jy
 JD
 JL
 uf
 Sz
+Js
+Js
 Sz
 Wn
-ga
+zA
 uf
-aa
-aa
 aa
 aa
 aa
@@ -58621,21 +58696,21 @@ QC
 QC
 QC
 IM
-Ja
+QP
+WT
 QP
 QP
-Ja
 Jy
 JD
 JL
 uf
 Sz
+Js
+Js
 Sz
 Wn
-zA
+ga
 uf
-aa
-aa
 aa
 aa
 aa
@@ -58876,23 +58951,23 @@ Vs
 tG
 Vs
 MK
-Na
-IN
-Jc
-Jc
-Jc
-Jc
-Jz
+QC
+IM
+Ja
+QP
+QP
+Ja
+Jy
 JD
 JL
 uf
 Sz
+Js
+Js
 Sz
+Wn
+zA
 uf
-uf
-uf
-aa
-aa
 aa
 aa
 aa
@@ -59133,23 +59208,23 @@ FZ
 ZP
 gU
 cZ
-QC
-Mi
-Mi
-Mi
-Mi
-Mi
-Mi
+YG
+IN
+Jc
+Jc
+Jc
+Jc
+Jz
+JD
+JL
+uf
+Sz
+Js
+Js
+Sz
 uf
 uf
 uf
-Mv
-Mv
-uf
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -59391,20 +59466,20 @@ QC
 Ad
 Rh
 QC
-Xg
-Xg
-Xg
-Xg
-Xg
-Xg
+Mi
+Mi
+Mi
+Mi
+Mi
+Mi
 uf
-Sz
-SV
-Sz
-Sz
 uf
-aa
-aa
+uf
+Rr
+Mv
+Mv
+Mv
+uf
 aa
 aa
 aa
@@ -59648,20 +59723,20 @@ QC
 Qi
 cZ
 QC
-uf
-uf
-uf
-uf
-uf
-uf
+Xg
+Xg
+Xg
+Xg
+Xg
+Xg
 uf
 Sz
-Sz
+SV
+Js
+Js
 Sz
 Sz
 uf
-aa
-aa
 aa
 aa
 aa
@@ -59904,21 +59979,21 @@ bi
 tF
 Ad
 Rh
-pI
-tH
-Bp
-ms
-UW
-Bp
-oI
-Bp
+QC
+uf
+uf
+uf
+uf
+uf
+uf
+uf
+Sz
+Js
+Js
+Js
 Sz
 Sz
 uf
-gh
-uf
-aa
-aa
 aa
 aa
 aa
@@ -60164,18 +60239,18 @@ Ah
 pI
 tH
 Bp
-Tt
-Bj
+ms
+UW
 Bp
 oI
 Bp
 Sz
 Sz
-uf
+Sz
 Sz
 uf
-aa
-aa
+uf
+uf
 aa
 aa
 aa
@@ -60418,18 +60493,18 @@ QC
 QC
 Sl
 Sl
-QC
-uf
-uf
-UP
-Wn
-Wn
-uf
-uf
-Wn
-Wn
-uf
+pI
+tH
+Bp
+Tt
+Bj
+Bp
+oI
+Bp
 Sz
+Sz
+uf
+gh
 uf
 aa
 aa
@@ -60675,16 +60750,16 @@ WM
 Yn
 pO
 HE
-Sl
-SU
-QX
-FD
-Oz
-bM
+QC
+uf
+uf
+UP
 Wn
 Wn
-Vl
-bM
+uf
+uf
+Sz
+Sz
 uf
 Sz
 uf
@@ -60933,15 +61008,15 @@ Yn
 Yn
 Yn
 Yn
-Yn
-Yn
-Py
-Yn
-Yn
-uf
-uf
-uf
-uf
+SU
+QX
+FD
+Oz
+bM
+bM
+Wn
+Vl
+bM
 uf
 Sz
 uf
@@ -61191,16 +61266,16 @@ Yn
 Yn
 Yn
 Yn
-NE
-NE
-NE
 Yn
-aa
-aa
-aa
-aa
+Py
+Yn
+Yn
 uf
-fF
+uf
+uf
+uf
+uf
+Sz
 uf
 aa
 aa
@@ -61456,9 +61531,9 @@ aa
 aa
 aa
 aa
-aa
-on
-aa
+uf
+fF
+uf
 aa
 aa
 aa
@@ -61708,13 +61783,13 @@ Yn
 NE
 NE
 NE
-XT
+Yn
 aa
 aa
 aa
 aa
 aa
-aa
+on
 aa
 aa
 aa
@@ -62222,7 +62297,7 @@ Yn
 NE
 NE
 NE
-Yn
+XT
 aa
 aa
 aa
@@ -65816,7 +65891,7 @@ aa
 aa
 aa
 aa
-aa
+Ns
 aa
 aa
 aa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -4309,7 +4309,8 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
-	desc = "WARNING, Nanotrasen declines any responsibility for clown related injury, enter at your own risk"
+	desc = "WARNING, Nanotrasen declines any responsibility for clown related injury, enter at your own risk";
+	name = "Clown Hole (DANGER)"
 	},
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/fore)
@@ -4845,6 +4846,9 @@
 /area/centcom/central_command_areas/fore)
 "tj" = (
 /obj/item/sbeacondrop/clownbomb,
+/mob/living/simple_animal/hostile/retaliate/clown{
+	limb_destroyer = 1
+	},
 /turf/open/ballpit,
 /area/centcom/central_command_areas/fore)
 "tl" = (
@@ -9609,6 +9613,9 @@
 /area/centcom/central_command_areas/admin)
 "OZ" = (
 /obj/machinery/light/directional/west,
+/mob/living/simple_animal/hostile/retaliate/clown{
+	limb_destroyer = 1
+	},
 /turf/open/ballpit,
 /area/centcom/central_command_areas/fore)
 "Pc" = (
@@ -55212,7 +55219,7 @@ kg
 Im
 Ey
 aE
-xK
+Jr
 tj
 xK
 qU
@@ -55470,7 +55477,7 @@ Ck
 Zk
 Vx
 Jr
-xK
+Jr
 Jr
 ez
 OL

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -16,8 +16,8 @@
 /area/centcom/central_command_areas/evacuation)
 "al" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/mail/economy,
 /obj/effect/spawner/random/entertainment/money_large,
+/obj/structure/closet/crate/mail/full,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "ap" = (
@@ -113,6 +113,12 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
+"aE" = (
+/obj/structure/sign/poster/contraband/clown{
+	pixel_y = 3
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/fore)
 "aI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/south,
@@ -523,10 +529,10 @@
 /area/centcom/central_command_areas/evacuation/ship)
 "cm" = (
 /obj/structure/closet/secure_closet/ert_engi,
-/obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/structure/fireaxecabinet/directional/north,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
 "cn" = (
@@ -624,6 +630,11 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"cK" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/basic/frog,
+/turf/open/indestructible/dark,
+/area/centcom/central_command_areas/prison/cells)
 "cL" = (
 /obj/item/gun/energy/pulse/carbine/loyalpin,
 /obj/item/flashlight/seclite,
@@ -710,6 +721,9 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/centcom/central_command_areas/fore)
+"dm" = (
+/turf/open/floor/wood,
+/area/centcom/tdome/administration)
 "dn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -785,6 +799,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"dH" = (
+/obj/structure/sign/painting/library{
+	pixel_y = -32
+	},
+/turf/open/floor/wood,
+/area/centcom/tdome/administration)
 "dJ" = (
 /obj/machinery/button/door/indestructible{
 	id = "thunderdomehea";
@@ -1256,6 +1276,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"fK" = (
+/obj/structure/sign/painting/library{
+	pixel_y = -32
+	},
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/centcom/tdome/administration)
 "fN" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light_switch/directional/south,
@@ -2178,6 +2207,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
+/obj/structure/fireaxecabinet/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "jj" = (
@@ -2881,6 +2911,22 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supplypod)
+"lG" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/structure/window/spawner/directional/south,
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Secure Art Exhibition";
+	req_access = list("library")
+	},
+/obj/structure/sign/painting/library_secure{
+	pixel_x = 32
+	},
+/obj/effect/spawner/random/decoration/statue{
+	spawn_loot_chance = 50
+	},
+/turf/open/floor/carpet/royalblue,
+/area/centcom/tdome/administration)
 "lJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Shuttle Control Office"
@@ -3032,8 +3078,8 @@
 /area/centcom/central_command_areas/courtroom)
 "mm" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/mail/economy,
 /obj/effect/spawner/random/entertainment/money_medium,
+/obj/structure/closet/crate/mail/full,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "mn" = (
@@ -3236,6 +3282,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"mX" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood,
+/area/centcom/tdome/administration)
 "mY" = (
 /obj/structure/chair{
 	dir = 1
@@ -4140,6 +4190,10 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
+"qv" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/closed/indestructible/riveted,
+/area/centcom/tdome/administration)
 "qw" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -4780,6 +4834,15 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"th" = (
+/obj/structure/sign/poster/contraband/clown{
+	pixel_y = -29
+	},
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/centcom/central_command_areas/fore)
 "tj" = (
 /obj/item/sbeacondrop/clownbomb,
 /turf/open/ballpit,
@@ -5908,6 +5971,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/fireaxecabinet/directional/east,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
 "xA" = (
@@ -6057,6 +6121,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"yl" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/crab,
+/turf/open/indestructible/dark,
+/area/centcom/central_command_areas/prison/cells)
 "yn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum,
@@ -6152,11 +6221,11 @@
 "yS" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/emps,
-/obj/item/gun/energy/ionrifle,
 /obj/structure/sign/departments/medbay/alt/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/gun/energy/ionrifle/carbine,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
 "yU" = (
@@ -6706,6 +6775,16 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin)
+"Bn" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/structure/sign/painting/library_secure{
+	pixel_x = 32
+	},
+/obj/effect/spawner/random/decoration/statue{
+	spawn_loot_chance = 50
+	},
+/turf/open/floor/carpet/royalblue,
+/area/centcom/tdome/administration)
 "Bo" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -7337,6 +7416,11 @@
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/evacuation)
+"DS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/butterfly,
+/turf/open/indestructible/dark,
+/area/centcom/central_command_areas/prison/cells)
 "DV" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -7611,8 +7695,8 @@
 /area/centcom/central_command_areas/supply)
 "FW" = (
 /obj/effect/turf_decal/bot,
-/obj/structure/closet/crate/mail/economy,
 /obj/effect/spawner/random/entertainment/money_small,
+/obj/structure/closet/crate/mail/full,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "FX" = (
@@ -9226,6 +9310,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"Ob" = (
+/obj/structure/sign/painting/library{
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/centcom/tdome/administration)
 "Oc" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office"
@@ -9666,6 +9756,19 @@
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod)
+"PD" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/door/window{
+	name = "Secure Art Exhibition";
+	req_access = list("library")
+	},
+/obj/structure/window/spawner/directional/west,
+/obj/structure/table/wood/fancy/royalblue,
+/obj/structure/sign/painting/large/library{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/tdome/administration)
 "PE" = (
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -11025,6 +11128,11 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"Vf" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/hostile/retaliate/goose,
+/turf/open/indestructible/dark,
+/area/centcom/central_command_areas/prison/cells)
 "Vg" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun{
@@ -11381,6 +11489,9 @@
 	},
 /obj/item/bedsheet/ce/double{
 	dir = 4
+	},
+/obj/structure/sign/poster/contraband/clown{
+	pixel_y = -29
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/evacuation)
@@ -12211,7 +12322,7 @@
 /mob/living/basic/pet/dog/corgi/puppy/ian{
 	gender = "female";
 	name = "Fresh Ian";
-	desc = "He's the HoP's beloved corgi puppy. This one is number 604"
+	desc = "The HoP's beloved corgi puppy. This one is number 604"
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/control)
@@ -50029,13 +50140,13 @@ uf
 uf
 uf
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uf
+uf
+uf
+uf
+uf
+uf
+uf
 aa
 aa
 aa
@@ -50286,13 +50397,13 @@ Wn
 eH
 Um
 uf
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+dm
+Ob
+Ob
+Ob
+Ob
+fK
+uf
 aa
 aa
 aa
@@ -50543,13 +50654,13 @@ uf
 Wn
 Wn
 uf
+mX
+Xw
+Xw
+Xw
+Xw
+dH
 uf
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -50797,16 +50908,16 @@ UW
 Bp
 oI
 Bp
-Sz
-Sz
 Js
+Sz
+Sz
+Sz
+Xw
+Xw
+Xw
+Xw
+dH
 uf
-uf
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -51054,16 +51165,16 @@ Bj
 Bp
 oI
 Bp
+Js
+Js
 Sz
-Js
-Js
-Js
+Sz
+Xw
+Xw
+Xw
+Xw
+dH
 uf
-uf
-uf
-aa
-aa
-aa
 aa
 aa
 aa
@@ -51314,13 +51425,13 @@ uf
 Sz
 Js
 Js
-Js
 Sz
-Sz
+Xw
+Xw
+Xw
+Xw
+dH
 uf
-aa
-aa
-aa
 aa
 aa
 aa
@@ -51570,14 +51681,14 @@ gQ
 uf
 Sz
 Fc
-Sz
-Js
 Js
 Sz
+Sz
+Sz
+qv
+PD
+dm
 uf
-aa
-aa
-aa
 aa
 aa
 aa
@@ -51832,9 +51943,9 @@ Mv
 Mv
 Mv
 uf
-aa
-aa
-aa
+Bn
+lG
+uf
 aa
 aa
 aa
@@ -52091,7 +52202,7 @@ Sz
 uf
 uf
 uf
-aa
+uf
 aa
 aa
 aa
@@ -52348,7 +52459,7 @@ Sz
 Wn
 zA
 uf
-aa
+uf
 aa
 aa
 aa
@@ -52605,7 +52716,7 @@ Sz
 Wn
 ga
 uf
-aa
+uf
 aa
 aa
 aa
@@ -52862,7 +52973,7 @@ Sz
 Wn
 zA
 uf
-aa
+uf
 aa
 aa
 aa
@@ -53119,7 +53230,7 @@ Sz
 uf
 uf
 uf
-aa
+uf
 aa
 aa
 aa
@@ -55100,7 +55211,7 @@ Vx
 kg
 Im
 Ey
-Vx
+aE
 xK
 tj
 xK
@@ -55365,7 +55476,7 @@ ez
 OL
 OL
 OL
-OL
+th
 Vx
 lM
 tI
@@ -56894,7 +57005,7 @@ aa
 aa
 Jb
 rs
-ze
+cK
 Dj
 rs
 LS
@@ -59795,7 +59906,7 @@ uf
 Sz
 SV
 Js
-Js
+Sz
 Sz
 Sz
 uf
@@ -59987,13 +60098,13 @@ Zd
 ze
 Dj
 Zd
-ze
+Vf
 Dj
 Zd
-ze
+yl
 Dj
 Zd
-ze
+DS
 Jb
 Vi
 Af
@@ -60052,7 +60163,7 @@ uf
 Sz
 Js
 Js
-Js
+Sz
 Sz
 Sz
 uf
@@ -60306,8 +60417,8 @@ UW
 Bp
 oI
 Bp
-Sz
-Sz
+Js
+Js
 Sz
 Sz
 uf
@@ -60563,7 +60674,7 @@ Bj
 Bp
 oI
 Bp
-Sz
+Js
 Sz
 uf
 gh

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -5,6 +5,12 @@
 "ad" = (
 /turf/open/space,
 /area/space)
+"an" = (
+/mob/living/simple_animal/hostile/retaliate/clown{
+	limb_destroyer = 1
+	},
+/turf/open/ballpit,
+/area/centcom/central_command_areas/fore)
 "ar" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -67,6 +73,20 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"aC" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "aD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -157,6 +177,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"aY" = (
+/obj/structure/sink/kitchen/directional/west,
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "aZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced,
@@ -234,15 +258,17 @@
 /area/centcom/central_command_areas/armory)
 "bk" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Central Command Brig"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/entrance,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "bm" = (
@@ -355,6 +381,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"bZ" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/item/storage/cans/sixsoda,
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "ca" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -414,7 +446,8 @@
 	name = "Thunderdome"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/bar,
+/obj/effect/mapping_helpers/airlock/access/any/admin/bar,
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "cl" = (
@@ -460,11 +493,12 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
 "ct" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
-	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
+/obj/machinery/door/airlock/security/glass{
+	name = "Central Command Courtroom"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/court,
+/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/courtroom)
 "cw" = (
@@ -538,6 +572,13 @@
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/evacuation/ship)
+"cR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/vending/liberationstation,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/prison)
 "cS" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
@@ -590,6 +631,19 @@
 /obj/effect/landmark/start/new_player,
 /turf/closed/indestructible/start_area,
 /area/misc/start)
+"df" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "CentCom"
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "di" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -597,6 +651,28 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"dj" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Green Team"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
+"dm" = (
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/fore)
 "dn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -643,6 +719,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"dy" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome VIP"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "dz" = (
 /obj/item/clipboard,
 /obj/structure/table/reinforced,
@@ -691,12 +778,31 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"dO" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "dV" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/beanbag,
-/obj/item/gun/ballistic/shotgun/doublebarrel,
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/storage/box/lethalshot,
+/obj/item/ammo_casing/shotgun/pulverizer,
+/obj/item/ammo_casing/shotgun/pulverizer,
+/obj/item/ammo_casing/shotgun/pulverizer,
+/obj/item/ammo_casing/shotgun/pulverizer,
+/obj/item/ammo_casing/shotgun/pulverizer,
+/obj/item/ammo_casing/shotgun/pulverizer,
+/obj/item/ammo_casing/shotgun/pulverizer,
+/obj/item/ammo_casing/shotgun/pulverizer,
+/obj/item/ammo_casing/shotgun/pulverizer,
+/obj/item/ammo_casing/shotgun/pulverizer,
+/obj/item/ammo_casing/shotgun/pulverizer,
+/obj/item/ammo_casing/shotgun/pulverizer,
+/obj/item/storage/backpack/duffelbag/syndie/ammo/shotgun,
+/obj/item/gun/ballistic/shotgun/bulldog/unrestricted,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
 "dW" = (
@@ -788,6 +894,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"eo" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
 "ep" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/effect/decal/cleanable/dirt,
@@ -802,6 +913,12 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/courtroom)
+"ew" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "ey" = (
 /obj/structure/flora/bush/leavy,
 /obj/effect/decal/cleanable/cobweb,
@@ -810,6 +927,7 @@
 "eB" = (
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "eD" = (
@@ -818,7 +936,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin)
 "eE" = (
@@ -978,6 +1095,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"fx" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/item/storage/cans/sixsoda,
+/obj/structure/closet/crate/freezer,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "fy" = (
 /obj/structure/signpost/salvation{
 	icon = 'icons/obj/structures.dmi';
@@ -996,8 +1123,8 @@
 /turf/open/floor/iron/smooth_large,
 /area/centcom/central_command_areas/evacuation/ship)
 "fA" = (
-/obj/machinery/vending/cola,
 /obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "fE" = (
@@ -1020,9 +1147,19 @@
 	name = "Bathroom"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/admin)
+"fH" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Supply Pod Storage"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "fI" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -1088,6 +1225,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/grass,
 /area/centcom/tdome/administration)
+"gb" = (
+/obj/structure/table,
+/obj/machinery/processor{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "gd" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/turf_decal/tile/neutral/full,
@@ -1103,9 +1247,10 @@
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/evacuation/ship)
 "gh" = (
-/turf/closed/indestructible/fakedoor{
-	name = "Thunderdome Admin"
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Administration"
 	},
+/turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "gi" = (
 /obj/docking_port/stationary{
@@ -1161,6 +1306,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
+"gr" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar/directional{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
 "gs" = (
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /obj/item/paper/pamphlet/centcom/visitor_info,
@@ -1188,6 +1343,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
+"gx" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/mystery_box_item,
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "gy" = (
 /obj/machinery/shower/directional/east,
 /obj/effect/turf_decal/tile/red{
@@ -1239,6 +1400,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"gK" = (
+/obj/effect/landmark/thunderdome/observe,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/observation)
 "gO" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/briefing)
@@ -1316,7 +1482,18 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/bar,
+/obj/effect/mapping_helpers/airlock/access/any/admin/bar,
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
+"hg" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar/directional{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "hi" = (
@@ -1363,6 +1540,14 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"hu" = (
+/obj/structure/table/wood/fancy/red,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cafe_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "hv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -1427,11 +1612,11 @@
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
 "hN" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/public/glass{
+	name = "ThunderDome"
+	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "hP" = (
@@ -1532,6 +1717,7 @@
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/mask/gas,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/recharger,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "iu" = (
@@ -1551,6 +1737,7 @@
 /obj/item/radio,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/recharger,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "iw" = (
@@ -1574,6 +1761,7 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/recharger,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "iy" = (
@@ -1581,6 +1769,7 @@
 /obj/item/restraints/handcuffs/cable/zipties,
 /obj/item/assembly/flash/handheld,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/recharger,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "iz" = (
@@ -1639,10 +1828,13 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/supply)
 "iG" = (
-/turf/closed/indestructible/fakedoor{
-	name = "CentCom Warehouse"
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/security/glass{
+	name = "Central Command Courtroom"
 	},
-/area/centcom/central_command_areas/supply)
+/obj/effect/mapping_helpers/airlock/access/any/security/court,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/courtroom)
 "iH" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/indestructible/riveted,
@@ -1760,11 +1952,11 @@
 /area/centcom/central_command_areas/supply)
 "ja" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "CentCom Courtroom"
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/courtroom)
@@ -1821,11 +2013,10 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "jh" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "ji" = (
@@ -1911,7 +2102,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/storage,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "js" = (
@@ -2285,7 +2477,9 @@
 	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "la" = (
@@ -2371,9 +2565,12 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "lr" = (
-/turf/closed/indestructible/fakedoor{
-	name = "CentCom"
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/bananium/glass{
+	desc = "People who take escape pods over the shuttle don't get to visit centcomm's pizza tower...";
+	name = "Peppino Pizza"
 	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/centcom/central_command_areas/fore)
 "ls" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2421,7 +2618,6 @@
 	name = "Shuttle Control Office"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "lK" = (
@@ -2429,7 +2625,8 @@
 	name = "CentCom Supply"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/storage,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "lL" = (
@@ -2437,9 +2634,13 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/prison)
 "lM" = (
-/obj/machinery/door/poddoor/shutters,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "pizzatime";
+	name = "Pizza Time shutters";
+	desc = "People who take escape pods over the shuttle don't get to visit centcomm's pizza tower..."
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/centcom/central_command_areas/fore)
 "lN" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -2487,7 +2688,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "lV" = (
@@ -2525,6 +2728,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation/ship)
+"mh" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
 "mi" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 1
@@ -2565,6 +2778,19 @@
 "mo" = (
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/courtroom)
+"mz" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Central Command Brig"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/entrance,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
+/turf/open/floor/iron,
 /area/centcom/central_command_areas/courtroom)
 "mB" = (
 /obj/item/kirbyplants{
@@ -2804,13 +3030,14 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "nq" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
+/obj/machinery/door/airlock/security/glass{
+	name = "Central Command Courtroom"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/court,
+/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/courtroom)
 "nr" = (
@@ -2823,6 +3050,17 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
+"nx" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Backstage"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
 "nA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -2839,7 +3077,9 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "nG" = (
@@ -2873,11 +3113,11 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "nM" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCsecdepartment";
-	name = "XCC Security Checkpoint Shutters"
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "XCC Security Checkpoint Shutters";
+	id = "XCCsecdepartment"
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "nN" = (
@@ -2962,7 +3202,6 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
-/obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
@@ -2993,6 +3232,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"om" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/fore)
 "on" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -3139,7 +3390,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "oJ" = (
@@ -3302,6 +3552,9 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"pn" = (
+/turf/open/floor/iron/dark/diagonal,
+/area/centcom/central_command_areas/supplypod)
 "pr" = (
 /obj/structure/chair,
 /obj/machinery/newscaster/directional/north,
@@ -3314,6 +3567,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"pt" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Shuttle Control Office"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "pB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -3545,6 +3807,14 @@
 	name = "plating"
 	},
 /area/centcom/central_command_areas/control)
+"qx" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/courtroom)
 "qy" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -3587,6 +3857,7 @@
 "qD" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
+/mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "qF" = (
@@ -3618,7 +3889,7 @@
 	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
+/obj/effect/mapping_helpers/airlock/access/any/security/armory,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "qR" = (
@@ -3631,15 +3902,16 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/admin/storage,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "qT" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/public/glass{
+	name = "CentCom"
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "qW" = (
@@ -3668,6 +3940,21 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/courtroom)
+"rh" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
+"ri" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/security{
+	name = "Central Command Legal Affairs"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/court,
+/turf/open/floor/iron,
 /area/centcom/central_command_areas/courtroom)
 "rk" = (
 /turf/open/floor/wood,
@@ -3777,11 +4064,11 @@
 	},
 /area/centcom/central_command_areas/fore)
 "rI" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCsec3";
-	name = "XCC Checkpoint 3 Shutters"
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "XCC Checkpoint 3 Shutters";
+	id = "XCCsec3"
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "rJ" = (
@@ -3851,10 +4138,13 @@
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
 "sa" = (
-/obj/structure/table/wood,
-/obj/item/lighter,
-/obj/item/crowbar/power,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/airlock/command/glass{
+	name = "Chief Engineer"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/supplypod)
 "sb" = (
 /obj/machinery/vending/snack,
@@ -3874,7 +4164,7 @@
 /obj/machinery/door/airlock/centcom{
 	name = "Orbital Drop Pod Loading"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "sm" = (
@@ -3891,7 +4181,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/medical,
+/obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
+/obj/effect/mapping_helpers/airlock/access/any/security,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "sq" = (
@@ -4018,7 +4310,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/security,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "sN" = (
@@ -4086,14 +4379,16 @@
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Supplypod Loading"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/storage,
+/obj/effect/mapping_helpers/airlock/access/any/security,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "sZ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Supplypod Loading"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/storage,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supplypod)
 "ta" = (
@@ -4209,7 +4504,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "ty" = (
@@ -4252,7 +4546,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
 /turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "tI" = (
@@ -4343,20 +4636,19 @@
 "tW" = (
 /turf/open/indestructible/hierophant/two,
 /area/centcom/central_command_areas/admin)
+"tX" = (
+/obj/structure/sign/poster/contraband/tipper_cream_soda{
+	pixel_y = 35
+	},
+/obj/machinery/griddle,
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "ub" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom"
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/control)
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "uc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -4425,6 +4717,10 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"uu" = (
+/obj/machinery/oven,
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "uw" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -4499,7 +4795,7 @@
 	name = "Shuttle Control Office"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "uP" = (
@@ -4508,6 +4804,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"uR" = (
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/centcom/central_command_areas/fore)
 "uV" = (
 /obj/item/paper_bin,
 /obj/item/pen/fourcolor,
@@ -4614,13 +4916,14 @@
 /area/centcom/central_command_areas/control)
 "vu" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
+/obj/machinery/door/airlock/security{
+	name = "Central Command Legal Affairs"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/court,
+/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/courtroom)
 "vA" = (
@@ -4674,7 +4977,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "vG" = (
@@ -4708,12 +5011,12 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "vP" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCcustoms2";
-	name = "XCC Customs 2 Shutters"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "XCC Customs 2 Shutters";
+	id = "XCCcustoms2"
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
@@ -4752,12 +5055,12 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "vU" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCcustoms1";
-	name = "XCC Customs 1 Shutters"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "XCC Customs 1 Shutters";
+	id = "XCCcustoms1"
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
@@ -4862,7 +5165,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "wv" = (
@@ -4924,7 +5227,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "wG" = (
@@ -4945,14 +5249,14 @@
 /area/centcom/central_command_areas/control)
 "wJ" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "CentCom"
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
@@ -5036,7 +5340,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "xd" = (
@@ -5134,6 +5437,11 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"xu" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
 "xy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -5145,6 +5453,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
+"xA" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
 "xB" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -5271,7 +5591,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "yn" = (
@@ -5295,7 +5616,7 @@
 	name = "Briefing Room"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "ys" = (
@@ -5325,6 +5646,17 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"yE" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cafe_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "yH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/wood{
@@ -5369,16 +5701,19 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
+"yT" = (
+/turf/open/ballpit,
+/area/centcom/central_command_areas/fore)
 "yU" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "CentCom"
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
@@ -5456,7 +5791,7 @@
 	name = "Infirmary"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/medical,
+/obj/effect/mapping_helpers/airlock/access/any/medical,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "zl" = (
@@ -5742,6 +6077,12 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation/ship)
+"AC" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "AD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -5799,6 +6140,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"AQ" = (
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "AT" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/indestructible/riveted,
@@ -5947,7 +6292,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "BB" = (
@@ -5958,11 +6305,11 @@
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
 "BE" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "XCCsec3";
-	name = "CC Main Access Shutters"
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "CC Main Access Shutters";
+	id = "XCCsec3"
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "BF" = (
@@ -6042,7 +6389,8 @@
 	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/security,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "BN" = (
@@ -6122,6 +6470,7 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/generic/style_random,
 /obj/machinery/light/directional/south,
+/mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "Cf" = (
@@ -6139,6 +6488,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
+"Ch" = (
+/obj/structure/chair/sofa/corp{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "Co" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
@@ -6175,12 +6530,12 @@
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation/ship)
 "Cz" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "ThunderDome"
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
@@ -6285,6 +6640,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"CX" = (
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "CY" = (
 /obj/structure/chair{
 	dir = 4
@@ -6327,14 +6685,28 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
-"Dq" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"Dp" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"Dq" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/fore)
 "Ds" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -6434,6 +6806,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/evacuation/ship)
+"DO" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
+"DQ" = (
+/obj/effect/turf_decal/siding/wideplating/dark,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/fore)
 "DV" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -6450,11 +6836,19 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
-"Eg" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Booth"
-	},
+"Ea" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/security{
+	name = "Central Command Legal Affairs"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/courtroom)
+"Eg" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/public/glass{
+	name = "ThunderDome"
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "Eq" = (
@@ -6584,13 +6978,13 @@
 /area/space)
 "Fj" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Administration"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/thunderdome,
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome VIP"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "Fk" = (
@@ -6612,11 +7006,11 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/control)
 "Fv" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/public/glass{
+	name = "CentCom"
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "FB" = (
@@ -6629,6 +7023,11 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
+"FD" = (
+/obj/machinery/door/airlock/freezer,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "FE" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -6644,6 +7043,19 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"FG" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/ferry)
 "FO" = (
 /obj/structure/table/reinforced,
 /obj/item/computer_disk/quartermaster,
@@ -6655,6 +7067,18 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"FT" = (
+/obj/structure/table/wood/fancy/red,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cafe_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/obj/machinery/reagentgrinder{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "FX" = (
 /obj/machinery/computer/auxiliary_base/directional/north,
 /obj/structure/table/reinforced,
@@ -6705,6 +7129,15 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation/ship)
+"Gk" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
 "Gs" = (
 /obj/machinery/power/smes/magical,
 /obj/effect/turf_decal/stripes/line,
@@ -6713,6 +7146,15 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
+"Gt" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/diagonal,
+/area/centcom/central_command_areas/evacuation)
+"Gv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/structure/closet/crate/secure/freezer/pizza,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "GB" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/stripes/line,
@@ -6736,15 +7178,18 @@
 /area/centcom/central_command_areas/admin/storage)
 "GC" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Central Command Brig"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/entrance,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "GJ" = (
@@ -6779,6 +7224,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"GX" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Supplypod Loading"
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supplypod)
 "Ha" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -6819,6 +7270,16 @@
 	name = "plating"
 	},
 /area/centcom/tdome/observation)
+"Hn" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/item/storage/cans/sixsoda,
+/obj/structure/closet/crate/freezer,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "Ho" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -6827,12 +7288,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
+/obj/effect/mapping_helpers/airlock/access/any/security/armory,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "Hv" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/courtroom)
+"Hx" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/indestructible,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/ferry)
 "Hz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -6878,6 +7344,17 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation/ship)
+"HV" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "HZ" = (
 /obj/structure/railing{
 	dir = 6;
@@ -6907,6 +7384,18 @@
 /obj/structure/sign/poster/contraband/syndicate_recruitment,
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/admin)
+"Im" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 10
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/fore)
 "Io" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -7139,6 +7628,20 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"Jm" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "Jq" = (
 /obj/machinery/camera/motion/thunderdome{
 	pixel_x = 10
@@ -7252,6 +7755,9 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
+"JU" = (
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "JV" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -7295,7 +7801,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin)
 "Km" = (
@@ -7380,6 +7886,11 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"KU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/gibber/autogibber,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "KV" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -7681,6 +8192,28 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"Mj" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
+"Mm" = (
+/obj/effect/turf_decal/siding/wideplating/dark,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	desc = "WARNING, Nanotrasen declines any responsibility for clown related injury, enter at your own risk"
+	},
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/fore)
 "Mo" = (
 /obj/structure/bed,
 /obj/item/bedsheet/black,
@@ -7770,7 +8303,7 @@
 /obj/machinery/light/directional/north,
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/beerkeg,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/supplypod)
 "MJ" = (
 /obj/structure/chair/office,
@@ -7857,7 +8390,8 @@
 /obj/structure/table/wood,
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/cup/glass/shaker,
-/turf/open/floor/iron/dark,
+/obj/item/lighter,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/supplypod)
 "Nk" = (
 /obj/structure/sign/poster/contraband/syndicate_pistol,
@@ -7949,7 +8483,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "NH" = (
@@ -8005,12 +8540,12 @@
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
 "NU" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "CentCom"
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
@@ -8038,8 +8573,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/mapping_helpers/airlock/access/any/admin/living,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "Od" = (
@@ -8129,6 +8664,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin/storage)
+"Os" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "Ot" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -8148,11 +8689,9 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "Oz" = (
-/obj/machinery/door/airlock/external/ruin,
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/control)
+/obj/machinery/stove,
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "OC" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/plush/space_lizard_plushie{
@@ -8167,7 +8706,7 @@
 	pixel_y = 5
 	},
 /obj/structure/table/wood,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/supplypod)
 "OE" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -8217,6 +8756,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
+"ON" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 4
+	},
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/centcom/central_command_areas/fore)
 "OP" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -8227,7 +8775,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "OR" = (
@@ -8282,6 +8830,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"Pa" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Supply Pod Storage"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod)
 "Pc" = (
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -8457,6 +9016,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"PO" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Chief Engineer"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/iron/dark/diagonal,
+/area/centcom/central_command_areas/evacuation)
 "PR" = (
 /obj/structure/table/wood,
 /obj/item/phone{
@@ -8517,6 +9083,9 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"Qa" = (
+/turf/open/floor/iron/dark/diagonal,
+/area/centcom/central_command_areas/evacuation)
 "Qb" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -8661,6 +9230,10 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
+"QG" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "QH" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/tile/neutral/full,
@@ -8670,6 +9243,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"QJ" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
 "QM" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 8
@@ -8734,7 +9316,7 @@
 	name = "CentCom Security"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/brig,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "Rb" = (
@@ -8767,7 +9349,7 @@
 /obj/machinery/door/airlock/vault{
 	req_access = list("cent_captain")
 	},
-/obj/machinery/door/poddoor/shutters/indestructible,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
 "Rk" = (
@@ -8787,7 +9369,12 @@
 /obj/item/storage/fancy/cigarettes/cigars/cohiba{
 	pixel_y = 3
 	},
-/turf/open/floor/iron/dark,
+/obj/item/crowbar/power,
+/mob/living/simple_animal/parrot/poly{
+	name = "Poly Prime";
+	desc = "Poly the Parrot. Don't tell anyone, but the others are clones."
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/supplypod)
 "Rp" = (
 /obj/machinery/computer/communications,
@@ -9132,6 +9719,14 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/two)
+"Td" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/public/glass{
+	name = "CentCom Courtroom"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/courtroom)
 "Te" = (
 /obj/structure/closet/crate/engineering,
 /obj/item/stack/sheet/mineral/plasma{
@@ -9166,7 +9761,7 @@
 /obj/item/clothing/mask/cigarette/cigar/havana{
 	pixel_x = 2
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/supplypod)
 "Tl" = (
 /obj/structure/table/wood,
@@ -9269,6 +9864,15 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/briefing)
+"TH" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/centcom/central_command_areas/fore)
 "TI" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -9381,6 +9985,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"Uj" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/public/glass{
+	name = "CentCom Courtroom"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "Ul" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -9457,6 +10071,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
+"UD" = (
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "UH" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/personal,
@@ -9489,7 +10107,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/security,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "UR" = (
@@ -9613,6 +10232,14 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"Vt" = (
+/obj/machinery/button/door/directional/west{
+	id = "cafe_counter";
+	name = "Counter Shutters Control";
+	pixel_y = 24
+	},
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "Vu" = (
 /obj/structure/closet/secure_closet/ert_med,
 /obj/machinery/vending/wallmed/directional/south{
@@ -9728,6 +10355,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"VX" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/item/storage/cans/sixsoda,
+/obj/structure/closet/crate/freezer,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "VY" = (
 /obj/machinery/computer/records/security{
 	dir = 8
@@ -9763,7 +10400,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
+/obj/effect/mapping_helpers/airlock/access/any/security,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "Wd" = (
@@ -9780,13 +10419,10 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "Wi" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-22"
-	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/courtroom)
+/obj/structure/table/wood/fancy/red,
+/obj/item/storage/cans/sixsoda,
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "Wl" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
@@ -9860,7 +10496,6 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "Wv" = (
-/obj/structure/chair,
 /obj/effect/landmark/thunderdome/observe,
 /obj/machinery/barsign/all_access/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -9987,7 +10622,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "WR" = (
@@ -10022,7 +10657,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/admin/captain,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin)
 "WX" = (
@@ -10158,7 +10792,8 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "Xu" = (
@@ -10182,7 +10817,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "Xz" = (
@@ -10197,8 +10831,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
 "XC" = (
-/obj/machinery/vending/snack,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/vending/imported/yangyu,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "XD" = (
@@ -10231,6 +10865,12 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"XO" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "XQ" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -10267,6 +10907,13 @@
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
+/area/centcom/tdome/observation)
+"Yh" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Red Team"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "Yi" = (
 /obj/machinery/computer/camera_advanced,
@@ -10335,8 +10982,22 @@
 	locked = 1;
 	name = "CentCom Auxiliary Announcement Closet"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
+"YB" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "YD" = (
 /obj/structure/table/wood,
@@ -10569,6 +11230,18 @@
 /obj/machinery/barsign/all_access/directional/north,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation/ship)
+"ZH" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/fore)
 "ZM" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
@@ -10634,7 +11307,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/admin/storage,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 
@@ -48075,7 +48749,7 @@ Yj
 YQ
 uh
 oh
-mD
+Hx
 ss
 fw
 tr
@@ -48332,7 +49006,7 @@ Yq
 Xq
 Xq
 ef
-mD
+Hx
 wx
 fw
 wB
@@ -49659,7 +50333,7 @@ Bp
 Sz
 Sz
 uf
-gh
+uf
 uf
 aa
 aa
@@ -50676,7 +51350,7 @@ gE
 FZ
 gE
 cq
-QC
+Yh
 IA
 IT
 IT
@@ -50926,7 +51600,7 @@ PT
 Nl
 QC
 QC
-hf
+nx
 QC
 QC
 QC
@@ -51385,7 +52059,7 @@ aa
 aa
 aa
 aa
-iG
+iF
 iR
 oJ
 Qx
@@ -51399,12 +52073,12 @@ iO
 uG
 oJ
 lo
-lJ
+pt
 hz
 iR
 lo
 hz
-lJ
+pt
 hz
 iR
 oJ
@@ -51642,7 +52316,7 @@ aa
 aa
 aa
 aa
-iG
+iF
 iR
 oJ
 Qx
@@ -51674,9 +52348,9 @@ YU
 YU
 mD
 mD
-wu
+FG
 xh
-wu
+FG
 mD
 Ya
 rY
@@ -51686,7 +52360,7 @@ Ya
 rY
 Ya
 Ya
-Dq
+iu
 io
 io
 io
@@ -51943,7 +52617,7 @@ io
 io
 qw
 iu
-MF
+uc
 iu
 lN
 iu
@@ -52156,7 +52830,7 @@ aa
 aa
 aa
 aa
-iG
+iF
 iR
 oJ
 Qx
@@ -52188,9 +52862,9 @@ iu
 iu
 io
 io
-ub
+Oj
 mk
-ub
+Oj
 io
 io
 iu
@@ -52200,7 +52874,7 @@ mQ
 io
 iu
 io
-Oz
+uc
 io
 iu
 io
@@ -52213,10 +52887,10 @@ QC
 bf
 eI
 ch
-ck
+QJ
 BW
-Kd
-Kd
+hg
+hg
 SZ
 Is
 IE
@@ -52413,7 +53087,7 @@ aa
 aa
 aa
 aa
-iG
+iF
 iR
 oJ
 oJ
@@ -52473,7 +53147,7 @@ QC
 QC
 Wv
 Kd
-yY
+gK
 SZ
 It
 It
@@ -52728,9 +53402,9 @@ Xf
 XJ
 Xf
 QC
-yY
+gK
 Kd
-yY
+gK
 SZ
 Iu
 IF
@@ -52935,7 +53609,7 @@ iF
 iF
 iF
 iF
-iF
+iX
 iF
 iF
 iF
@@ -53185,18 +53859,18 @@ aa
 aa
 aa
 Vx
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+KU
+DO
+fx
+Vx
+an
+yT
+an
+Im
+ON
+ON
+ON
+uR
 Vx
 Ul
 Jg
@@ -53442,18 +54116,18 @@ aa
 aa
 aa
 Vx
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Gv
+dO
+Hn
+Vx
+yT
+yT
+yT
+Mm
+TH
+TH
+TH
+uR
 Vx
 Vx
 Vx
@@ -53699,18 +54373,18 @@ aa
 aa
 aa
 Vx
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+QG
+AC
+VX
+Vx
+an
+yT
+an
+DQ
+uR
+uR
+uR
+uR
 Vx
 lM
 tI
@@ -53956,18 +54630,18 @@ aa
 aa
 aa
 Vx
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Vx
+FD
+Vx
+Vx
+om
+ZH
+ZH
+dm
+Dq
+Dq
+Dq
+Dq
 lr
 lM
 lr
@@ -54213,18 +54887,18 @@ aa
 aa
 aa
 Vx
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Oz
+Vt
+gb
+FT
+JU
+JU
+JU
+JU
+JU
+JU
+JU
+JU
 Vx
 lM
 Jg
@@ -54470,18 +55144,18 @@ aa
 aa
 aa
 Vx
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+tX
+CX
+CX
+hu
+JU
+JU
+UD
+gx
+ub
+JU
+bZ
+ub
 Vx
 Vx
 Vx
@@ -54727,18 +55401,18 @@ aa
 aa
 aa
 Vx
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+uu
+aY
+CX
+yE
+JU
+JU
+AQ
+Wi
+ew
+Os
+Ch
+XO
 Vx
 hG
 Jg
@@ -55279,9 +55953,9 @@ Ab
 mR
 Ab
 zG
-Xt
+HV
 MF
-NG
+Dp
 uc
 uc
 uc
@@ -55300,7 +55974,7 @@ XJ
 QC
 Wv
 Kd
-yY
+gK
 SZ
 Iu
 IF
@@ -55555,9 +56229,9 @@ QC
 QC
 QC
 QC
-yY
+gK
 Kd
-yY
+gK
 SZ
 It
 It
@@ -55783,7 +56457,7 @@ io
 io
 io
 Fq
-UO
+YB
 io
 io
 yU
@@ -55802,7 +56476,7 @@ NJ
 io
 iu
 io
-eM
+eo
 ZM
 Vs
 tG
@@ -55813,8 +56487,8 @@ cS
 nj
 ck
 BW
-Kd
-Kd
+gr
+gr
 SZ
 Is
 IJ
@@ -56059,7 +56733,7 @@ uc
 iu
 Ym
 iu
-yc
+xu
 Bo
 FZ
 bD
@@ -56084,7 +56758,7 @@ uf
 uf
 uf
 uf
-Fj
+dy
 uf
 uf
 aa
@@ -56300,9 +56974,9 @@ io
 yj
 io
 io
-Oj
+df
 mk
-Oj
+df
 io
 io
 iu
@@ -57042,7 +57716,7 @@ iE
 iE
 iW
 lL
-jh
+cR
 il
 jw
 lL
@@ -57358,7 +58032,7 @@ Vs
 tG
 Vs
 MK
-QC
+dj
 IN
 Jc
 Jc
@@ -58086,9 +58760,9 @@ Jb
 pc
 Hv
 RI
-ja
+mz
 et
-ja
+mz
 RI
 io
 io
@@ -58351,7 +59025,7 @@ Hv
 cg
 cg
 cg
-UO
+YB
 cg
 cg
 cg
@@ -58865,7 +59539,7 @@ Hv
 cg
 cg
 cg
-Wc
+Jm
 cg
 cg
 cg
@@ -58882,10 +59556,10 @@ cg
 cg
 cg
 cg
-Wc
+aC
 cg
 Yn
-sZ
+GX
 Yn
 QC
 QC
@@ -58902,7 +59576,7 @@ Sl
 Sl
 QC
 uf
-uf
+fH
 Wn
 Wn
 uf
@@ -59110,7 +59784,7 @@ kz
 kX
 lw
 rk
-ct
+Ea
 ps
 rM
 rM
@@ -59119,7 +59793,7 @@ rM
 rM
 zc
 Hv
-qy
+Gk
 qz
 cg
 sN
@@ -59159,7 +59833,7 @@ pO
 HE
 Sl
 SU
-Wn
+rh
 Vl
 bM
 Wn
@@ -59416,7 +60090,7 @@ Yn
 Yn
 Yn
 Yn
-Yn
+Pa
 Yn
 Yn
 uf
@@ -59619,7 +60293,7 @@ aa
 aa
 Hv
 Hv
-vu
+ri
 Hv
 Hv
 Hv
@@ -59634,7 +60308,7 @@ ja
 pc
 Hv
 qA
-qy
+Gk
 fm
 sP
 tT
@@ -59657,8 +60331,8 @@ SG
 Yn
 Yn
 Yn
-sZ
-sZ
+Yn
+Yn
 Yn
 Yn
 Yn
@@ -60135,7 +60809,7 @@ Hv
 NW
 rM
 rM
-ct
+iG
 ps
 ps
 Zx
@@ -61461,8 +62135,8 @@ Yn
 Yn
 Yn
 Yn
-XT
-XT
+NO
+NO
 Yn
 Yn
 Yn
@@ -61718,8 +62392,8 @@ zM
 zM
 zs
 Yn
-aa
-aa
+NO
+NO
 Yn
 Pv
 Pv
@@ -61947,7 +62621,7 @@ rM
 Np
 Hv
 qy
-qz
+mh
 cg
 fE
 tT
@@ -61975,8 +62649,8 @@ Se
 Se
 Tc
 Yn
-aa
-aa
+Yv
+yf
 Yn
 Pm
 Pm
@@ -62220,10 +62894,10 @@ us
 At
 Bb
 fm
-Cd
+Gk
 cg
 MI
-NO
+pn
 Yn
 Se
 Si
@@ -62231,10 +62905,10 @@ Se
 Si
 Se
 Tc
-Yn
-aa
-aa
-Yn
+sZ
+UM
+UM
+sZ
 Xh
 Xh
 Pm
@@ -62460,8 +63134,8 @@ mY
 rM
 NW
 Hv
-qz
-qy
+xA
+Mj
 cg
 sO
 tT
@@ -62477,10 +63151,10 @@ us
 At
 AW
 cg
-qy
+Mj
 cg
 OD
-NO
+pn
 Yn
 Se
 Si
@@ -62488,10 +63162,10 @@ Se
 Si
 Se
 Tc
-Yn
-aa
-aa
-Yn
+sZ
+QO
+QO
+sZ
 Xh
 Xh
 Pm
@@ -62705,7 +63379,7 @@ Hv
 NW
 rM
 rM
-ct
+iG
 ps
 lV
 lW
@@ -62715,11 +63389,11 @@ RI
 ps
 rk
 rk
-Wi
-Hv
-qz
-qy
-cg
+ps
+Td
+HH
+HH
+Uj
 sT
 tU
 tU
@@ -62733,11 +63407,11 @@ tU
 tU
 tU
 Bc
-cg
-qz
-cg
+PO
+Gt
+Qa
 sa
-NO
+pn
 Yn
 Se
 Se
@@ -62746,8 +63420,8 @@ Si
 Se
 Tc
 Yn
-aa
-aa
+Sv
+Ru
 Yn
 Pm
 Pm
@@ -62972,7 +63646,7 @@ gC
 ps
 Ha
 gA
-oD
+qx
 Hv
 cg
 cg
@@ -62994,7 +63668,7 @@ cg
 cg
 cg
 Tj
-Su
+pn
 Yn
 Vk
 Vk
@@ -63003,8 +63677,8 @@ Vk
 Vk
 Oq
 Yn
-aa
-aa
+NO
+NO
 Yn
 Co
 Co
@@ -63260,8 +63934,8 @@ Yn
 Yn
 Yn
 Yn
-aa
-aa
+XT
+XT
 Yn
 Yn
 Yn

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -7454,6 +7454,8 @@
 /obj/effect/spawner/random/exotic/antag_gear,
 /obj/effect/spawner/random/exotic/antag_gear,
 /obj/effect/spawner/random/exotic/syndie,
+/obj/effect/spawner/random/exotic/antag_gear,
+/obj/effect/spawner/random/exotic/antag_gear,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "EV" = (
@@ -9102,9 +9104,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
-"Ns" = (
-/turf/open/space/basic,
-/area/centcom/tdome/arena)
 "Nt" = (
 /obj/structure/filingcabinet/medical,
 /obj/machinery/light/directional/north,
@@ -9547,9 +9546,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
-"Pf" = (
-/turf/closed/indestructible/riveted,
-/area/space)
 "Pg" = (
 /obj/machinery/computer/auxiliary_base/directional/north,
 /obj/structure/table/reinforced,
@@ -10776,6 +10772,9 @@
 /obj/effect/spawner/random/contraband,
 /obj/effect/spawner/random/exotic/antag_gear_weak,
 /obj/effect/spawner/random/exotic/syndie,
+/obj/effect/spawner/random/exotic/antag_gear,
+/obj/effect/spawner/random/exotic/antag_gear,
+/obj/effect/spawner/random/exotic/antag_gear,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "Ua" = (
@@ -10991,6 +10990,9 @@
 /obj/effect/spawner/random/contraband,
 /obj/effect/spawner/random/exotic/languagebook,
 /obj/effect/spawner/random/exotic/syndie,
+/obj/effect/spawner/random/exotic/antag_gear,
+/obj/effect/spawner/random/exotic/antag_gear,
+/obj/effect/spawner/random/exotic/antag_gear,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "UV" = (
@@ -50014,9 +50016,9 @@ aa
 aa
 aa
 aa
-Pf
-Pf
-Pf
+QC
+QC
+QC
 uf
 uf
 uf
@@ -65951,7 +65953,7 @@ aa
 aa
 aa
 aa
-Ns
+aa
 aa
 aa
 aa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1797,6 +1797,16 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
+"if" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/statue/bananium/clown,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "pizzatime";
+	name = "Pizza Time Shutters";
+	desc = "People who take escape pods over the shuttle don't get to visit centcom's pizza tower..."
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "ig" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -2953,7 +2963,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "pizzatime";
-	name = "Pizza Time shutters";
+	name = "Pizza Time Shutters";
 	desc = "People who take escape pods over the shuttle don't get to visit centcom's pizza tower..."
 	},
 /obj/structure/statue/bananium/clown,
@@ -3433,7 +3443,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "pizzatime";
-	name = "Pizza Time shutters";
+	name = "Pizza Time Shutters";
 	desc = "People who take escape pods over the shuttle don't get to visit centcom's pizza tower..."
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -55999,7 +56009,7 @@ uR
 uR
 uR
 Vx
-lM
+if
 Jg
 mM
 Ox

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -9994,7 +9994,6 @@
 /obj/machinery/door/airlock/vault{
 	req_access = list("cent_captain")
 	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
 "Rk" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -188,6 +188,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"aX" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/clonepod/experimental,
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/central_command_areas/control)
 "aZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced,
@@ -918,7 +923,7 @@
 /obj/structure/filingcabinet/medical,
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/control)
 "em" = (
 /obj/structure/table/reinforced,
@@ -2949,7 +2954,7 @@
 /area/centcom/central_command_areas/supplypod/supplypod_temp_holding)
 "lT" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
+	name = "CentCom Cloning Lab"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3280,6 +3285,11 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"nk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/control)
 "nl" = (
 /obj/machinery/computer/security/mining{
 	dir = 4
@@ -3817,6 +3827,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
+"ph" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/computer/cloning{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/central_command_areas/control)
 "pi" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
@@ -7191,6 +7208,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
+"Dp" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/central_command_areas/control)
 "Dq" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/iron/kitchen/diagonal,
@@ -7210,10 +7231,14 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "Dv" = (
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/folder/white,
+/obj/item/pen/blue,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/control)
 "Dy" = (
 /obj/item/kirbyplants{
@@ -7287,7 +7312,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/control)
 "DK" = (
 /obj/machinery/door/airlock/command/glass{
@@ -8767,6 +8792,11 @@
 	},
 /turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/evacuation/ship)
+"LS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/basic/garden_gnome,
+/turf/open/indestructible/dark,
+/area/centcom/central_command_areas/prison/cells)
 "LU" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/computer/records/medical{
@@ -9135,10 +9165,9 @@
 /turf/open/floor/stone,
 /area/centcom/central_command_areas/evacuation/ship)
 "NJ" = (
-/obj/machinery/status_display/ai/directional/south,
 /obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/control)
 "NL" = (
 /obj/item/kirbyplants{
@@ -9457,7 +9486,7 @@
 /obj/item/pen,
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/control)
 "OV" = (
 /obj/structure/sink/directional/west,
@@ -9734,7 +9763,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/control)
 "PT" = (
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -10436,6 +10465,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"SN" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/central_command_areas/control)
 "SO" = (
 /obj/machinery/computer/records/security{
 	dir = 8
@@ -10522,9 +10556,12 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "Ti" = (
-/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/mob/living/simple_animal/pet/cat/runtime{
+	name = "Fresh Runtime";
+	desc = "GCAT, This one is number 817"
+	},
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/control)
 "Tj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -10861,7 +10898,7 @@
 	},
 /obj/item/reagent_containers/hypospray/medipen,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/control)
 "Uw" = (
 /obj/machinery/light/directional/west,
@@ -11124,13 +11161,10 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "VB" = (
-/obj/structure/table/reinforced,
-/obj/item/clipboard,
-/obj/item/folder/white,
-/obj/item/pen/blue,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/control)
 "VF" = (
 /obj/machinery/computer/crew{
@@ -11719,7 +11753,7 @@
 	},
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/control)
 "XT" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -11813,7 +11847,7 @@
 /area/centcom/central_command_areas/admin)
 "Ys" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
+	name = "CentCom Cloning Lab"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -11902,7 +11936,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/medkit/regular,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/centcom/central_command_areas/control)
 "YO" = (
 /obj/item/radio{
@@ -12170,6 +12204,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
+"ZO" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/basic/pet/dog/corgi/puppy/ian{
+	gender = "female";
+	name = "Fresh Ian";
+	desc = "He's the HoP's beloved corgi puppy. This one is number 604"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/centcom/central_command_areas/control)
 "ZP" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -56852,7 +56895,7 @@ rs
 ze
 Dj
 rs
-ze
+LS
 Dj
 rs
 JI
@@ -56892,10 +56935,10 @@ zG
 Xt
 MF
 Ys
-uc
-uc
-uc
-uc
+Dp
+Dp
+Dp
+Dp
 PS
 io
 Of
@@ -57151,7 +57194,7 @@ iu
 io
 YN
 OU
-uc
+Dp
 Ti
 VB
 io
@@ -57409,8 +57452,8 @@ io
 iu
 io
 NJ
-io
-iu
+ZO
+aX
 io
 eM
 ZM
@@ -57665,9 +57708,9 @@ io
 io
 zC
 iu
-uc
-iu
-Ym
+Dp
+SN
+ph
 iu
 yc
 Bo
@@ -57924,7 +57967,7 @@ io
 io
 lT
 io
-io
+nk
 io
 QC
 Sl

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2835,7 +2835,7 @@
 "lr" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/door/airlock/bananium/glass{
-	desc = "People who take escape pods over the shuttle don't get to visit centcomm's pizza tower...";
+	desc = "People who take escape pods over the shuttle don't get to visit centcom's pizza tower...";
 	name = "Peppino Pizza"
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -2908,7 +2908,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "pizzatime";
 	name = "Pizza Time shutters";
-	desc = "People who take escape pods over the shuttle don't get to visit centcomm's pizza tower..."
+	desc = "People who take escape pods over the shuttle don't get to visit centcom's pizza tower..."
 	},
 /obj/structure/statue/bananium/clown,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -3384,7 +3384,7 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "pizzatime";
 	name = "Pizza Time shutters";
-	desc = "People who take escape pods over the shuttle don't get to visit centcomm's pizza tower..."
+	desc = "People who take escape pods over the shuttle don't get to visit centcom's pizza tower..."
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/centcom/central_command_areas/fore)

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -5,11 +5,32 @@
 "ad" = (
 /turf/open/space,
 /area/space)
-"an" = (
-/mob/living/simple_animal/hostile/retaliate/clown{
-	limb_destroyer = 1
+"ag" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Chief Engineer"
 	},
-/turf/open/ballpit,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
+/turf/open/floor/iron/dark/diagonal,
+/area/centcom/central_command_areas/evacuation)
+"al" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/mail/economy,
+/obj/effect/spawner/random/entertainment/money_large,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"ap" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/centcom/central_command_areas/fore)
 "ar" = (
 /obj/structure/chair/office{
@@ -19,6 +40,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"as" = (
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod)
 "at" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Backstage"
@@ -73,20 +98,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
-"aC" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security,
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "aD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -177,10 +188,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
-"aY" = (
-/obj/structure/sink/kitchen/directional/west,
-/turf/open/floor/iron/kitchen/herringbone,
-/area/centcom/central_command_areas/fore)
 "aZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced,
@@ -244,6 +251,10 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"bh" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/circuit/green,
+/area/centcom/central_command_areas/supply)
 "bi" = (
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
@@ -287,6 +298,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"bu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/centcom/central_command_areas/prison)
 "bx" = (
 /turf/open/floor/iron/goonplaque{
 	desc = "This is a plaque commemorating the thunderdome and all those who have died at its pearly blast doors."
@@ -345,6 +370,20 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"bL" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "bM" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -369,6 +408,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"bS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/mob_spawn/corpse/human/clown,
+/turf/open/indestructible/dark,
+/area/centcom/central_command_areas/prison/cells)
+"bT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/prison)
 "bU" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light/directional/south,
@@ -381,12 +432,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
-"bZ" = (
-/obj/structure/table/wood/fancy/red,
-/obj/effect/spawner/random/food_or_drink/pizzaparty,
-/obj/item/storage/cans/sixsoda,
-/turf/open/floor/iron/kitchen/diagonal,
-/area/centcom/central_command_areas/fore)
 "ca" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -446,8 +491,8 @@
 	name = "Thunderdome"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/any/admin/bar,
-/obj/effect/mapping_helpers/airlock/access/any/service/bar,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "cl" = (
@@ -498,7 +543,6 @@
 	name = "Central Command Courtroom"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/court,
-/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/courtroom)
 "cw" = (
@@ -507,6 +551,8 @@
 /obj/item/lighter,
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/camera,
+/obj/item/storage/photo_album,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "cA" = (
@@ -533,8 +579,14 @@
 /obj/item/restraints/handcuffs,
 /obj/item/assembly/flash/handheld,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
+"cG" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/storage/cans/sixsoda,
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "cI" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -572,13 +624,6 @@
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/evacuation/ship)
-"cR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/vending/liberationstation,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/prison)
 "cS" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
@@ -620,6 +665,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"dc" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "dd" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/stripes/line{
@@ -631,19 +680,6 @@
 /obj/effect/landmark/start/new_player,
 /turf/closed/indestructible/start_area,
 /area/misc/start)
-"df" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "CentCom"
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/control)
 "di" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -651,28 +687,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
-"dj" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Green Team"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/iron,
-/area/centcom/tdome/observation)
-"dm" = (
-/obj/effect/turf_decal/siding/wideplating/dark/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wideplating/dark/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/centcom/central_command_areas/fore)
 "dn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -720,16 +734,10 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "dy" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome VIP"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/iron,
-/area/centcom/tdome/administration)
+/area/centcom/central_command_areas/supply)
 "dz" = (
 /obj/item/clipboard,
 /obj/structure/table/reinforced,
@@ -757,11 +765,11 @@
 "dJ" = (
 /obj/machinery/button/door/indestructible{
 	id = "thunderdomehea";
-	name = "Heavy Supply Control";
-	req_access = list("cent_thunder")
+	name = "Heavy Supply Control"
 	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "dK" = (
@@ -779,10 +787,16 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "dO" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/pet/gondola,
+/turf/open/indestructible/dark,
+/area/centcom/central_command_areas/prison/cells)
+"dQ" = (
+/obj/structure/sign/poster/contraband/tipper_cream_soda{
+	pixel_y = 35
 	},
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/obj/machinery/griddle,
+/turf/open/floor/iron/kitchen/herringbone,
 /area/centcom/central_command_areas/fore)
 "dV" = (
 /obj/structure/table/wood,
@@ -829,6 +843,18 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"dY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/turf/open/floor/iron/tgmcemblem{
+	dir = 9
+	},
+/area/centcom/central_command_areas/prison)
 "dZ" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -894,16 +920,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
-"eo" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron,
-/area/centcom/tdome/observation)
 "ep" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/evacuation/ship)
+"er" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "et" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/directions/engineering{
@@ -913,9 +940,9 @@
 	},
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/courtroom)
-"ew" = (
+"ex" = (
 /obj/structure/chair/sofa/corp/right{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/iron/kitchen/diagonal,
 /area/centcom/central_command_areas/fore)
@@ -924,6 +951,16 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
+"ez" = (
+/obj/effect/turf_decal/siding/wideplating/dark,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/fore)
 "eB" = (
 /obj/structure/bookcase/random,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -974,8 +1011,8 @@
 /turf/open/misc/asteroid,
 /area/centcom/central_command_areas/evacuation)
 "eM" = (
-/obj/machinery/vending/cola,
 /obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "eN" = (
@@ -1017,7 +1054,15 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/centcom/central_command_areas/prison)
 "eR" = (
 /obj/effect/turf_decal/siding/wood{
@@ -1058,6 +1103,14 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"fd" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/engineering/material_rare,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "fi" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -1082,6 +1135,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/evacuation)
+"fo" = (
+/turf/open/floor/iron/smooth,
+/area/centcom/central_command_areas/prison)
+"fs" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/indestructible,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/ferry)
 "fv" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
@@ -1095,16 +1156,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
-"fx" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/item/storage/cans/sixsoda,
-/obj/structure/closet/crate/freezer,
-/obj/effect/spawner/random/food_or_drink/pizzaparty,
-/obj/effect/spawner/random/food_or_drink/pizzaparty,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/centcom/central_command_areas/fore)
 "fy" = (
 /obj/structure/signpost/salvation{
 	icon = 'icons/obj/structures.dmi';
@@ -1127,6 +1178,23 @@
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
+"fB" = (
+/obj/item/radio{
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/obj/item/radio{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/item/radio,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "fE" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/stripes/line{
@@ -1140,6 +1208,7 @@
 	name = "Backup Emergency Escape Shuttle"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/open/floor/iron,
 /area/centcom/tdome/administration)
 "fG" = (
@@ -1149,17 +1218,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/admin)
-"fH" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Supply Pod Storage"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
-/turf/open/floor/iron,
-/area/centcom/tdome/administration)
 "fI" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -1178,6 +1236,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"fO" = (
+/obj/machinery/oven,
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "fP" = (
 /obj/structure/sink/directional/west,
 /obj/structure/mirror/directional/east,
@@ -1225,13 +1287,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/grass,
 /area/centcom/tdome/administration)
-"gb" = (
-/obj/structure/table,
-/obj/machinery/processor{
-	pixel_y = 8
-	},
-/turf/open/floor/iron/kitchen/herringbone,
-/area/centcom/central_command_areas/fore)
 "gd" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/turf_decal/tile/neutral/full,
@@ -1246,6 +1301,20 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/evacuation/ship)
+"gg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/centcom/central_command_areas/prison)
 "gh" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Administration"
@@ -1293,6 +1362,7 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "gp" = (
@@ -1304,18 +1374,9 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
-"gr" = (
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
-/obj/structure/chair/stool/bar/directional{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/centcom/tdome/observation)
 "gs" = (
 /obj/item/paper/pamphlet/centcom/visitor_info,
 /obj/item/paper/pamphlet/centcom/visitor_info,
@@ -1344,11 +1405,15 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
 "gx" = (
-/obj/structure/table/wood/fancy/red,
-/obj/effect/spawner/random/food_or_drink/pizzaparty,
-/obj/mystery_box_item,
-/turf/open/floor/iron/kitchen/diagonal,
-/area/centcom/central_command_areas/fore)
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar/directional{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
 "gy" = (
 /obj/machinery/shower/directional/east,
 /obj/effect/turf_decal/tile/red{
@@ -1370,8 +1435,7 @@
 "gC" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
-	name = "CentCom Stand";
-	req_access = list("cent_captain")
+	name = "CentCom Stand"
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -1400,11 +1464,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
-"gK" = (
-/obj/effect/landmark/thunderdome/observe,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/tdome/observation)
 "gO" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/briefing)
@@ -1447,6 +1506,16 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"gV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/turf/open/floor/iron/tgmcemblem{
+	dir = 6
+	},
+/area/centcom/central_command_areas/prison)
 "gX" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/lockbox/loyalty,
@@ -1455,6 +1524,20 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
+"hb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 1
+	},
+/area/centcom/central_command_areas/prison)
 "hc" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -1487,15 +1570,14 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "hg" = (
-/obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
+/obj/structure/table/wood/fancy/red,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cafe_counter";
+	name = "Kitchen Counter Shutters"
 	},
-/obj/structure/chair/stool/bar/directional{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/centcom/tdome/observation)
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "hi" = (
 /obj/item/storage/medkit/regular,
 /obj/structure/table,
@@ -1531,6 +1613,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"hq" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
 "ht" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -1540,14 +1634,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
-"hu" = (
-/obj/structure/table/wood/fancy/red,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "cafe_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/turf/open/floor/iron/kitchen/herringbone,
-/area/centcom/central_command_areas/fore)
 "hv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -1684,7 +1770,15 @@
 	dir = 5
 	},
 /obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 8
+	},
 /area/centcom/central_command_areas/prison)
 "in" = (
 /obj/structure/sign/nanotrasen,
@@ -1698,7 +1792,11 @@
 	dir = 9
 	},
 /obj/machinery/status_display/evac/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner,
+/turf/open/floor/iron/smooth_corner,
 /area/centcom/central_command_areas/prison)
 "ir" = (
 /turf/closed/indestructible/fakeglass,
@@ -1811,6 +1909,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/spawner/random/contraband/armory,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "iE" = (
@@ -1822,19 +1921,21 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/spawner/random/contraband/armory,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "iF" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/supply)
 "iG" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/airlock/security/glass{
-	name = "Central Command Courtroom"
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/court,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/courtroom)
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/fore)
 "iH" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/indestructible/riveted,
@@ -1851,7 +1952,11 @@
 	dir = 9
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner,
+/turf/open/floor/iron/smooth_corner,
 /area/centcom/central_command_areas/prison)
 "iK" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1870,7 +1975,15 @@
 	dir = 5
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 8
+	},
 /area/centcom/central_command_areas/prison)
 "iN" = (
 /obj/machinery/status_display/supply,
@@ -1891,6 +2004,8 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/engineering,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "iR" = (
@@ -1901,10 +2016,10 @@
 /area/centcom/central_command_areas/supply)
 "iS" = (
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
-	dir = 4
+/obj/machinery/mech_bay_recharge_port{
+	dir = 2
 	},
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/centcom/central_command_areas/supply)
 "iT" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1927,6 +2042,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/effect/spawner/random/contraband/armory,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "iW" = (
@@ -1938,6 +2054,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/effect/spawner/random/contraband/armory,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "iX" = (
@@ -1955,9 +2072,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "CentCom Courtroom"
+/obj/machinery/door/airlock/security/glass{
+	name = "Central Command Brig"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/security/entrance,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/courtroom)
 "jb" = (
@@ -1988,13 +2108,13 @@
 "je" = (
 /obj/machinery/button/door/indestructible{
 	id = "thunderdome";
-	name = "Main Blast Doors Control";
-	req_access = list("cent_thunder")
+	name = "Main Blast Doors Control"
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/south,
 /obj/machinery/status_display/ai/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "jf" = (
@@ -2002,6 +2122,7 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
+/obj/effect/spawner/random/engineering/canister,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "jg" = (
@@ -2010,13 +2131,21 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/centcom/central_command_areas/prison)
 "jh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/machinery/vending/liberationstation,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
 "ji" = (
@@ -2033,7 +2162,15 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/centcom/central_command_areas/prison)
 "jk" = (
 /obj/machinery/door/poddoor{
@@ -2086,6 +2223,12 @@
 /area/centcom/central_command_areas/supply)
 "jp" = (
 /obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/structure/closet/crate/freezer,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "jq" = (
@@ -2127,7 +2270,15 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 5
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 8
+	},
 /area/centcom/central_command_areas/prison)
 "jw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2168,7 +2319,15 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/centcom/central_command_areas/prison)
 "jA" = (
 /obj/structure/fans/tiny/invisible,
@@ -2180,7 +2339,15 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/centcom/central_command_areas/prison)
 "jC" = (
 /obj/structure/chair/comfy/shuttle/tactical{
@@ -2203,7 +2370,11 @@
 /area/centcom/central_command_areas/prison)
 "jF" = (
 /obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/corner,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 9
+	},
+/turf/open/floor/iron/smooth_corner,
 /area/centcom/central_command_areas/prison)
 "jG" = (
 /obj/effect/turf_decal/stripes/line,
@@ -2272,7 +2443,7 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "jO" = (
-/obj/machinery/vending/cola,
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod)
 "jP" = (
@@ -2309,16 +2480,38 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/centcom/central_command_areas/prison)
 "kd" = (
 /obj/structure/table/reinforced,
-/obj/machinery/button/showtime{
-	req_access = list("cent_thunder")
-	},
+/obj/machinery/button/showtime,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
+"kg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/structure/closet/crate/secure/freezer/pizza,
+/obj/item/grenade/spawnergrenade/clown,
+/obj/item/grenade/spawnergrenade/clown,
+/obj/item/grenade/spawnergrenade/clown,
+/obj/item/grenade/spawnergrenade/clown,
+/obj/item/grenade/spawnergrenade/clown,
+/obj/item/grenade/spawnergrenade/clown,
+/obj/item/grenade/spawnergrenade/clown,
+/obj/item/grenade/spawnergrenade/clown,
+/obj/item/grenade/spawnergrenade/clown,
+/obj/item/grenade/spawnergrenade/clown,
+/obj/item/grenade/spawnergrenade/clown,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "kh" = (
 /obj/machinery/telecomms/allinone/nuclear,
 /turf/open/indestructible/hierophant,
@@ -2335,6 +2528,9 @@
 "km" = (
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/control)
+"kp" = (
+/turf/open/floor/circuit/green,
+/area/centcom/central_command_areas/supply)
 "kr" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -2415,6 +2611,11 @@
 /obj/item/clipboard,
 /obj/item/folder/blue,
 /obj/item/stamp/law,
+/obj/item/banhammer{
+	force = 2000;
+	name = "Hammer of Justice";
+	desc = "Divine Judgement."
+	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
 "kI" = (
@@ -2424,6 +2625,28 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
+"kK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/turf/open/floor/iron/tgmcemblem{
+	dir = 1
+	},
+/area/centcom/central_command_areas/prison)
+"kN" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/spawner/random/medical/memeorgans,
+/obj/effect/spawner/random/medical/supplies,
+/obj/structure/closet/crate/freezer,
+/turf/open/floor/iron/white,
+/area/centcom/central_command_areas/control)
 "kR" = (
 /obj/structure/sign/warning/secure_area,
 /turf/closed/indestructible/riveted,
@@ -2433,7 +2656,15 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/centcom/central_command_areas/prison)
 "kT" = (
 /obj/structure/table/reinforced,
@@ -2457,7 +2688,15 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/centcom/central_command_areas/prison)
 "kX" = (
 /obj/structure/table/wood,
@@ -2480,6 +2719,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "la" = (
@@ -2518,7 +2758,7 @@
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
 	name = "CentCom Stand";
-	req_access = list("cent_captain")
+	req_access = list("captain")
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
@@ -2558,6 +2798,10 @@
 "lp" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/bureaucracy/stamp,
+/obj/effect/spawner/random/bureaucracy/stamp,
+/obj/effect/spawner/random/bureaucracy/stamp,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "lq" = (
@@ -2618,6 +2862,8 @@
 	name = "Shuttle Control Office"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/any/supply/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "lK" = (
@@ -2640,6 +2886,7 @@
 	name = "Pizza Time shutters";
 	desc = "People who take escape pods over the shuttle don't get to visit centcomm's pizza tower..."
 	},
+/obj/structure/statue/bananium/clown,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/centcom/central_command_areas/fore)
 "lN" = (
@@ -2691,6 +2938,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "lV" = (
@@ -2728,16 +2976,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation/ship)
-"mh" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/flora/bush/pointy/style_random,
-/mob/living/simple_animal/butterfly,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
 "mi" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 1
@@ -2749,6 +2987,7 @@
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 4
 	},
+/obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "mk" = (
@@ -2767,6 +3006,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"mm" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/mail/economy,
+/obj/effect/spawner/random/entertainment/money_medium,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "mn" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -2779,19 +3024,20 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
-"mz" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
+"mu" = (
+/obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8
 	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Central Command Brig"
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/entrance,
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
+/turf/open/floor/iron/dark/diagonal,
+/area/centcom/central_command_areas/evacuation)
+"my" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/medical,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/courtroom)
+/area/centcom/central_command_areas/supply)
 "mB" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -2816,6 +3062,7 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
+/obj/effect/spawner/random/vending,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "mG" = (
@@ -2988,6 +3235,15 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"nc" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 4
+	},
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/centcom/central_command_areas/fore)
 "ni" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -3051,16 +3307,12 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "nx" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Backstage"
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
-/turf/open/floor/iron,
-/area/centcom/tdome/observation)
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "nA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -3080,8 +3332,23 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"nD" = (
+/obj/effect/landmark/thunderdome/observe,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/observation)
+"nE" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "pizzatime";
+	name = "Pizza Time shutters";
+	desc = "People who take escape pods over the shuttle don't get to visit centcomm's pizza tower..."
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "nG" = (
 /obj/machinery/computer/security/mining{
 	dir = 1
@@ -3133,7 +3400,11 @@
 "nT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/status_display/evac/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/turf/open/floor/iron/tgmcemblem,
 /area/centcom/central_command_areas/prison)
 "nV" = (
 /obj/structure/chair{
@@ -3183,6 +3454,15 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"ob" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/engineering/material,
+/obj/effect/spawner/random/engineering/material_cheap,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "oe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -3232,18 +3512,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
-"om" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 9
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/centcom/central_command_areas/fore)
 "on" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -3411,6 +3679,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/fax{
+	fax_name = "Cargo Office";
+	name = "Central Command Logistics Office Fax Machine"
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "oN" = (
@@ -3552,9 +3824,6 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
-"pn" = (
-/turf/open/floor/iron/dark/diagonal,
-/area/centcom/central_command_areas/supplypod)
 "pr" = (
 /obj/structure/chair,
 /obj/machinery/newscaster/directional/north,
@@ -3567,14 +3836,22 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
-"pt" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Shuttle Control Office"
+"pu" = (
+/obj/item/food/spaghetti/copypasta{
+	name = "Spaghetti Code";
+	desc = "Better file a bug report..."
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/any/supply/general,
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/iron,
+/turf/open/ai_visible,
+/area/centcom/ai_multicam_room)
+"pA" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/turf/open/floor/circuit/green,
 /area/centcom/central_command_areas/supply)
 "pB" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3622,6 +3899,14 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"pL" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "pM" = (
 /obj/structure/bookcase/random,
 /obj/machinery/light/directional/north,
@@ -3641,6 +3926,14 @@
 /obj/structure/flora/bush/pale/style_random,
 /turf/open/misc/asteroid,
 /area/centcom/tdome/observation)
+"pP" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/decoration,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "pQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -3681,8 +3974,7 @@
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "pY" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/carpet/executive,
 /area/centcom/tdome/administration)
 "pZ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -3701,11 +3993,11 @@
 "qd" = (
 /obj/machinery/button/door/indestructible{
 	id = "thunderdomegen";
-	name = "General Supply Control";
-	req_access = list("cent_thunder")
+	name = "General Supply Control"
 	},
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "qf" = (
@@ -3807,14 +4099,6 @@
 	name = "plating"
 	},
 /area/centcom/central_command_areas/control)
-"qx" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/courtroom)
 "qy" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -3914,6 +4198,17 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"qU" = (
+/obj/effect/turf_decal/siding/wideplating/dark,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	desc = "WARNING, Nanotrasen declines any responsibility for clown related injury, enter at your own risk"
+	},
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/fore)
 "qW" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -3941,21 +4236,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
-"rh" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/centcom/tdome/administration)
-"ri" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/door/airlock/security{
-	name = "Central Command Legal Affairs"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/court,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/courtroom)
 "rk" = (
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/courtroom)
@@ -3976,6 +4256,11 @@
 "rs" = (
 /obj/effect/landmark/prisonwarp,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/bed/pod{
+	dir = 4
+	},
+/obj/item/pillow/clown,
+/obj/item/bedsheet/clown,
 /turf/open/indestructible/dark,
 /area/centcom/central_command_areas/prison/cells)
 "rt" = (
@@ -4032,6 +4317,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"rC" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "rF" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/bush/grassy/style_random,
@@ -4106,7 +4397,15 @@
 	dir = 4
 	},
 /obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/centcom/central_command_areas/prison)
 "rT" = (
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -4138,18 +4437,19 @@
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
 "sa" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Chief Engineer"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/yellow/warning,
 /turf/open/floor/iron/dark/diagonal,
-/area/centcom/central_command_areas/supplypod)
+/area/centcom/central_command_areas/evacuation)
 "sb" = (
-/obj/machinery/vending/snack,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supplypod)
+/area/centcom/central_command_areas/supply)
 "sc" = (
 /obj/structure/table/wood,
 /obj/structure/plaque/static_plaque/golden{
@@ -4381,14 +4681,15 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security,
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "sZ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Supplypod Loading"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supplypod)
 "ta" = (
@@ -4415,6 +4716,10 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"tj" = (
+/obj/item/sbeacondrop/clownbomb,
+/turf/open/ballpit,
+/area/centcom/central_command_areas/fore)
 "tl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -4518,6 +4823,17 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"tC" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome VIP"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "tD" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -4527,6 +4843,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"tE" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/flashlight/seclite{
+	force = 2000;
+	desc = "The most Robust flashlight"
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/control)
 "tF" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Locker Room"
@@ -4605,7 +4932,15 @@
 	dir = 8
 	},
 /obj/machinery/status_display/evac/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
 /area/centcom/central_command_areas/prison)
 "tS" = (
 /obj/item/kirbyplants{
@@ -4636,18 +4971,17 @@
 "tW" = (
 /turf/open/indestructible/hierophant/two,
 /area/centcom/central_command_areas/admin)
-"tX" = (
-/obj/structure/sign/poster/contraband/tipper_cream_soda{
-	pixel_y = 35
-	},
-/obj/machinery/griddle,
-/turf/open/floor/iron/kitchen/herringbone,
-/area/centcom/central_command_areas/fore)
 "ub" = (
-/obj/structure/chair/sofa/corp/left{
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 10
+	},
+/obj/structure/railing{
 	dir = 1
 	},
-/turf/open/floor/iron/kitchen/diagonal,
+/turf/open/floor/wood,
 /area/centcom/central_command_areas/fore)
 "uc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -4717,10 +5051,16 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"uu" = (
-/obj/machinery/oven,
-/turf/open/floor/iron/kitchen/herringbone,
-/area/centcom/central_command_areas/fore)
+"uv" = (
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/effect/turf_decal/tile/yellow/opposingcorners{
+	dir = 1
+	},
+/obj/structure/chair/stool/bar/directional{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
 "uw" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -4772,6 +5112,24 @@
 /obj/effect/turf_decal/siding/yellow,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"uH" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Shuttle Control Office"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"uJ" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Backstage"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
 "uK" = (
 /obj/machinery/processor,
 /obj/effect/turf_decal/stripes/end,
@@ -4805,10 +5163,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "uR" = (
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
+/turf/open/floor/iron/kitchen/diagonal,
 /area/centcom/central_command_areas/fore)
 "uV" = (
 /obj/item/paper_bin,
@@ -5002,6 +5357,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
+"vM" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/diagonal,
+/area/centcom/central_command_areas/evacuation)
 "vO" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/status_display/evac/directional/east,
@@ -5086,6 +5445,22 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
+"vY" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/glass/bottle/whiskey{
+	pixel_y = 5
+	},
+/obj/item/clothing/mask/cigarette/cigar/havana{
+	pixel_x = 2
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/evacuation)
 "vZ" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -5330,6 +5705,17 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"xb" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
 "xc" = (
 /obj/machinery/door/airlock/external/ruin{
 	name = "Ferry Airlock"
@@ -5437,11 +5823,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
-"xu" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/spawner/random/vending/snackvend,
-/turf/open/floor/iron,
-/area/centcom/tdome/observation)
 "xy" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -5454,17 +5835,11 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
 "xA" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/grassy/style_random,
-/obj/structure/flora/bush/flowers_pp/style_random,
-/obj/structure/flora/bush/pointy/style_random,
-/obj/structure/railing{
-	dir = 4
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
 	},
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "xB" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -5480,10 +5855,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"xK" = (
+/turf/open/ballpit,
+/area/centcom/central_command_areas/fore)
 "xN" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"xO" = (
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "xQ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light/directional/south,
@@ -5545,9 +5926,14 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"ya" = (
+/turf/open/floor/iron/tgmcemblem{
+	dir = 8
+	},
+/area/centcom/central_command_areas/prison)
 "yc" = (
-/obj/machinery/vending/snack,
 /obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "yd" = (
@@ -5646,17 +6032,9 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
-"yE" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Kitchen"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "cafe_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/turf/open/floor/iron/kitchen/herringbone,
-/area/centcom/central_command_areas/fore)
+"yG" = (
+/turf/open/space/basic,
+/area/centcom/central_command_areas/supplypod)
 "yH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/wood{
@@ -5701,9 +6079,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
-"yT" = (
-/turf/open/ballpit,
-/area/centcom/central_command_areas/fore)
 "yU" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -5956,6 +6331,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
+"zL" = (
+/obj/structure/sink/kitchen/directional/west,
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "zM" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
@@ -5967,6 +6346,14 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/briefing)
+"zU" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/courtroom)
 "zZ" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
@@ -6078,11 +6465,13 @@
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation/ship)
 "AC" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/security{
+	name = "Central Command Legal Affairs"
 	},
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/centcom/central_command_areas/fore)
+/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/courtroom)
 "AD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -6097,10 +6486,11 @@
 /area/centcom/tdome/observation)
 "AF" = (
 /obj/structure/table/wood,
-/obj/item/storage/photo_album,
-/obj/item/camera,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/fax{
+	name = "Central Command Admiral's Fax Machine"
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "AG" = (
@@ -6140,10 +6530,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
-"AQ" = (
-/obj/structure/chair/sofa/corp/left,
-/turf/open/floor/iron/kitchen/diagonal,
-/area/centcom/central_command_areas/fore)
 "AT" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/indestructible/riveted,
@@ -6255,6 +6641,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"Bt" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/security{
+	name = "Central Command Legal Affairs"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/court,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/courtroom)
 "Bv" = (
 /obj/machinery/computer/security{
 	dir = 1
@@ -6275,6 +6672,9 @@
 	icon_state = "plant-21"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "By" = (
@@ -6295,6 +6695,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "BB" = (
@@ -6304,6 +6705,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"BD" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "BE" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -6373,6 +6781,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/vending/wallmed/directional/south{
+	use_power = 0
+	},
+/obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "BJ" = (
@@ -6391,6 +6803,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/access/any/security,
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "BN" = (
@@ -6429,6 +6842,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
+"BQ" = (
+/obj/structure/bookcase/random,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "BR" = (
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
@@ -6469,7 +6890,6 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/generic/style_random,
-/obj/machinery/light/directional/south,
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
@@ -6488,11 +6908,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
-"Ch" = (
-/obj/structure/chair/sofa/corp{
-	dir = 8
+"Ck" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
-/turf/open/floor/iron/kitchen/diagonal,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
+"Cn" = (
+/obj/structure/table,
+/obj/machinery/processor{
+	pixel_y = 8
+	},
+/turf/open/floor/iron/kitchen/herringbone,
 /area/centcom/central_command_areas/fore)
 "Co" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -6606,6 +7033,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"CP" = (
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 1
+	},
+/obj/effect/spawner/random/engineering/tank,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "CT" = (
 /obj/structure/table/reinforced,
 /obj/structure/railing{
@@ -6640,9 +7074,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
-"CX" = (
-/turf/open/floor/iron/kitchen/herringbone,
-/area/centcom/central_command_areas/fore)
 "CY" = (
 /obj/structure/chair{
 	dir = 4
@@ -6685,27 +7116,9 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
-"Dp" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/control)
 "Dq" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/turf/open/floor/wood,
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/iron/kitchen/diagonal,
 /area/centcom/central_command_areas/fore)
 "Ds" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -6801,25 +7214,29 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"DK" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Chief Engineer"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/ce,
+/turf/open/floor/iron/dark/diagonal,
+/area/centcom/central_command_areas/evacuation)
 "DL" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/evacuation/ship)
-"DO" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/centcom/central_command_areas/fore)
 "DQ" = (
-/obj/effect/turf_decal/siding/wideplating/dark,
-/obj/effect/turf_decal/siding/wideplating/dark{
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/centcom/central_command_areas/fore)
+/turf/open/floor/iron/dark/diagonal,
+/area/centcom/central_command_areas/evacuation)
 "DV" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-21"
@@ -6836,14 +7253,6 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
-"Ea" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/door/airlock/security{
-	name = "Central Command Legal Affairs"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/courtroom)
 "Eg" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/door/airlock/public/glass{
@@ -6870,6 +7279,17 @@
 /obj/item/kirbyplants,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"Ey" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/item/storage/cans/sixsoda,
+/obj/structure/closet/crate/freezer,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/spawner/random/medical/memeorgans,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "Ez" = (
 /obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs/cable/zipties,
@@ -6903,6 +7323,8 @@
 "EK" = (
 /obj/machinery/status_display/evac/directional/south,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/bureaucracy/paper,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "EL" = (
@@ -6924,6 +7346,16 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
+"EO" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/contraband/armory,
+/obj/structure/closet/crate/secure/gear,
+/obj/effect/spawner/random/contraband,
+/obj/effect/spawner/random/exotic/antag_gear,
+/obj/effect/spawner/random/exotic/antag_gear,
+/obj/effect/spawner/random/exotic/syndie,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "EV" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave{
@@ -6938,6 +7370,14 @@
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation/ship)
+"EW" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Supplypod Loading"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supplypod)
 "EZ" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
@@ -7024,10 +7464,9 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
 "FD" = (
-/obj/machinery/door/airlock/freezer,
-/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/centcom/central_command_areas/fore)
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "FE" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -7043,19 +7482,16 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
-"FG" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
+"FK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/prison)
 "FO" = (
 /obj/structure/table/reinforced,
 /obj/item/computer_disk/quartermaster,
@@ -7067,18 +7503,12 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
-"FT" = (
-/obj/structure/table/wood/fancy/red,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "cafe_counter";
-	name = "Kitchen Counter Shutters"
-	},
-/obj/machinery/reagentgrinder{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/turf/open/floor/iron/kitchen/herringbone,
-/area/centcom/central_command_areas/fore)
+"FW" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/mail/economy,
+/obj/effect/spawner/random/entertainment/money_small,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "FX" = (
 /obj/machinery/computer/auxiliary_base/directional/north,
 /obj/structure/table/reinforced,
@@ -7100,6 +7530,20 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
+"Gc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/centcom/central_command_areas/prison)
 "Gf" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -7129,15 +7573,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation/ship)
-"Gk" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/generic/style_random,
-/mob/living/simple_animal/butterfly,
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
 "Gs" = (
 /obj/machinery/power/smes/magical,
 /obj/effect/turf_decal/stripes/line,
@@ -7146,15 +7581,14 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
-"Gt" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/diagonal,
-/area/centcom/central_command_areas/evacuation)
-"Gv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/structure/closet/crate/secure/freezer/pizza,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/centcom/central_command_areas/fore)
+"Gy" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-21"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/turf/open/floor/iron/dark,
+/area/centcom/tdome/administration)
 "GB" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/stripes/line,
@@ -7174,6 +7608,9 @@
 /obj/item/stack/cable_coil,
 /obj/item/screwdriver/power,
 /obj/structure/cable,
+/obj/item/storage/belt/utility/chief/full{
+	name = "Central Command Engineer's toolbelt"
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin/storage)
 "GC" = (
@@ -7191,6 +7628,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
 /turf/open/floor/iron,
+/area/centcom/central_command_areas/prison)
+"GE" = (
+/turf/open/floor/iron/tgmcemblem/center{
+	dir = 8
+	},
 /area/centcom/central_command_areas/prison)
 "GJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -7210,8 +7652,24 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
+/obj/effect/spawner/random/bureaucracy/briefcase,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"GM" = (
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/fore)
 "GN" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
@@ -7224,12 +7682,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
-"GX" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Supplypod Loading"
+"GV" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/supplypod)
+/area/centcom/tdome/administration)
 "Ha" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -7270,16 +7729,6 @@
 	name = "plating"
 	},
 /area/centcom/tdome/observation)
-"Hn" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/item/storage/cans/sixsoda,
-/obj/structure/closet/crate/freezer,
-/obj/effect/spawner/random/food_or_drink/pizzaparty,
-/obj/effect/spawner/random/food_or_drink/pizzaparty,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/centcom/central_command_areas/fore)
 "Ho" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
@@ -7291,14 +7740,26 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/armory,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/prison)
+"Hs" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/evacuation)
 "Hv" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/courtroom)
-"Hx" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced/indestructible,
-/turf/open/floor/plating,
-/area/centcom/central_command_areas/ferry)
+"Hw" = (
+/turf/open/floor/glass/reinforced/plasma,
+/area/centcom/central_command_areas/evacuation)
 "Hz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -7344,17 +7805,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/evacuation/ship)
-"HV" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/any/medical/general,
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/control)
 "HZ" = (
 /obj/structure/railing{
 	dir = 6;
@@ -7384,17 +7834,25 @@
 /obj/structure/sign/poster/contraband/syndicate_recruitment,
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/admin)
-"Im" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 9
+"If" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/effect/turf_decal/siding/wideplating/dark{
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 10
 	},
-/obj/structure/railing{
-	dir = 1
+/turf/open/floor/iron/smooth_corner{
+	dir = 4
 	},
-/turf/open/floor/wood,
+/area/centcom/central_command_areas/prison)
+"Im" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/centcom/central_command_areas/fore)
 "Io" = (
 /obj/docking_port/stationary{
@@ -7543,6 +8001,17 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"IP" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cafe_counter";
+	name = "Kitchen Counter Shutters"
+	},
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "IT" = (
 /obj/effect/landmark/thunderdome/two,
 /obj/effect/turf_decal/stripes/line{
@@ -7628,26 +8097,18 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
-"Jm" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/evacuation)
 "Jq" = (
 /obj/machinery/camera/motion/thunderdome{
 	pixel_x = 10
 	},
 /turf/open/floor/circuit/green,
 /area/centcom/tdome/arena)
+"Jr" = (
+/mob/living/simple_animal/hostile/retaliate/clown{
+	limb_destroyer = 1
+	},
+/turf/open/ballpit,
+/area/centcom/central_command_areas/fore)
 "Js" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -7696,6 +8157,11 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"JB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/gibber/autogibber,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "JD" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdomehea";
@@ -7729,10 +8195,16 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"JI" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/toy/figure/mime,
+/turf/open/indestructible/dark,
+/area/centcom/central_command_areas/prison/cells)
 "JJ" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "JL" = (
@@ -7755,9 +8227,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
-"JU" = (
-/turf/open/floor/iron/kitchen/diagonal,
-/area/centcom/central_command_areas/fore)
 "JV" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -7772,6 +8241,22 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"JX" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/any/admin/bar,
+/obj/effect/mapping_helpers/airlock/access/any/service/bar,
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
+"Kb" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/structure/table/reinforced,
+/obj/effect/spawner/random/bureaucracy/folder,
+/obj/effect/spawner/random/bureaucracy/pen,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Kd" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
@@ -7804,12 +8289,44 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin)
+"Kg" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/item/storage/cans/sixsoda,
+/obj/structure/closet/crate/freezer,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/spawner/random/food_or_drink/cake_ingredients,
+/obj/effect/spawner/random/medical/memeorgans,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "Km" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/prison)
+"Kq" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "CentCom"
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
+"Ky" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/mob/living/simple_animal/hostile/retaliate/clown{
+	limb_destroyer = 1
+	},
+/turf/open/indestructible/dark,
+/area/centcom/central_command_areas/prison/cells)
 "KC" = (
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/wood,
@@ -7875,6 +8392,13 @@
 "KQ" = (
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/evacuation/ship)
+"KR" = (
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
+/obj/effect/spawner/random/exotic/ripley,
+/turf/open/floor/iron/recharge_floor,
+/area/centcom/central_command_areas/supply)
 "KS" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -7886,11 +8410,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"KU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/machinery/gibber/autogibber,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/centcom/central_command_areas/fore)
 "KV" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 4
@@ -7996,6 +8515,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"Lr" = (
+/obj/machinery/button/door/directional/west{
+	id = "cafe_counter";
+	name = "Counter Shutters Control";
+	pixel_y = 24
+	},
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
 "Lt" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/centcom/central_command_areas/evacuation/ship)
@@ -8172,6 +8699,10 @@
 /obj/structure/speaking_tile,
 /turf/closed/mineral/ash_rock,
 /area/awaymission/errorroom)
+"LZ" = (
+/obj/effect/turf_decal/tile/red/half/contrasted,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
 "Mh" = (
 /obj/machinery/door/poddoor{
 	id = "thunderdome";
@@ -8192,32 +8723,17 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
-"Mj" = (
-/obj/structure/flora/bush/lavendergrass/style_random,
-/obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/flora/bush/generic/style_random,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/evacuation)
-"Mm" = (
-/obj/effect/turf_decal/siding/wideplating/dark,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	desc = "WARNING, Nanotrasen declines any responsibility for clown related injury, enter at your own risk"
-	},
-/turf/open/floor/wood,
+"Mn" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/mystery_box_item,
+/turf/open/floor/iron/kitchen/diagonal,
 /area/centcom/central_command_areas/fore)
 "Mo" = (
 /obj/structure/bed,
-/obj/item/bedsheet/black,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/spawner/random/entertainment/plushie_delux,
+/obj/item/bedsheet/centcom,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "Mp" = (
@@ -8303,8 +8819,14 @@
 /obj/machinery/light/directional/north,
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/beerkeg,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/effect/spawner/random/food_or_drink/donkpockets,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
 /turf/open/floor/iron/dark/diagonal,
-/area/centcom/central_command_areas/supplypod)
+/area/centcom/central_command_areas/evacuation)
 "MJ" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/ert_spawn,
@@ -8351,6 +8873,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
+"MT" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/generic/style_random,
+/obj/machinery/light/directional/south,
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
 "MU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/wood,
@@ -8371,6 +8903,13 @@
 /obj/structure/sign/nanotrasen,
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/briefing)
+"Na" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Green Team"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
 "Ne" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/trophy/gold_cup,
@@ -8391,8 +8930,12 @@
 /obj/item/storage/box/drinkingglasses,
 /obj/item/reagent_containers/cup/glass/shaker,
 /obj/item/lighter,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/yellow/corner,
 /turf/open/floor/iron/dark/diagonal,
-/area/centcom/central_command_areas/supplypod)
+/area/centcom/central_command_areas/evacuation)
 "Nk" = (
 /obj/structure/sign/poster/contraband/syndicate_pistol,
 /turf/closed/indestructible/riveted,
@@ -8664,12 +9207,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin/storage)
-"Os" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 8
-	},
-/turf/open/floor/iron/kitchen/diagonal,
-/area/centcom/central_command_areas/fore)
 "Ot" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -8688,10 +9225,29 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
+"Oy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/turf/open/floor/iron/tgmcemblem{
+	dir = 5
+	},
+/area/centcom/central_command_areas/prison)
 "Oz" = (
-/obj/machinery/stove,
-/turf/open/floor/iron/kitchen/herringbone,
-/area/centcom/central_command_areas/fore)
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/pale/style_random,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/misc/asteroid,
+/area/centcom/tdome/administration)
 "OC" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/plush/space_lizard_plushie{
@@ -8706,8 +9262,12 @@
 	pixel_y = 5
 	},
 /obj/structure/table/wood,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/dark/diagonal,
-/area/centcom/central_command_areas/supplypod)
+/area/centcom/central_command_areas/evacuation)
 "OE" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/structure/flora/bush/grassy/style_random,
@@ -8751,20 +9311,29 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
-"OM" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/supply)
-"ON" = (
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 4
+"OI" = (
+/obj/structure/table/wood/fancy/red,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cafe_counter";
+	name = "Kitchen Counter Shutters"
 	},
+/obj/machinery/reagentgrinder{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/turf/open/floor/iron/kitchen/herringbone,
+/area/centcom/central_command_areas/fore)
+"OL" = (
 /turf/open/floor/eighties/red{
 	icon = 'goon/icons/turf/floors.dmi';
 	icon_state = "clown_carpet"
 	},
 /area/centcom/central_command_areas/fore)
+"OM" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supply)
 "OP" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -8830,17 +9399,19 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
-"Pa" = (
+"OZ" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
-	name = "Supply Pod Storage"
+	name = "CentCom Security"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/supplypod)
+/area/centcom/central_command_areas/ferry)
 "Pc" = (
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -8873,6 +9444,9 @@
 /obj/item/folder/yellow,
 /obj/item/pen/red,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/storage/belt/utility/chief/full{
+	name = "Central Command Engineer's toolbelt"
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
 "Pj" = (
@@ -8922,7 +9496,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/turf/open/floor/iron/grimy,
+/turf/open/floor/carpet/executive,
 /area/centcom/tdome/administration)
 "Ps" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -8940,6 +9514,16 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
+"Pu" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "CentCom Courtroom"
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/courtroom)
 "Pv" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
@@ -8957,6 +9541,17 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"Py" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Supply Pod Storage"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supplypod)
 "Pz" = (
 /obj/structure/table/reinforced,
 /obj/item/paper/pamphlet/centcom/visitor_info,
@@ -9016,13 +9611,18 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
-"PO" = (
-/obj/machinery/door/airlock/command/glass{
-	name = "Chief Engineer"
+"PQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/iron/dark/diagonal,
-/area/centcom/central_command_areas/evacuation)
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line,
+/turf/open/floor/iron/smooth_half{
+	dir = 4
+	},
+/area/centcom/central_command_areas/prison)
 "PR" = (
 /obj/structure/table/wood,
 /obj/item/phone{
@@ -9083,9 +9683,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
-"Qa" = (
-/turf/open/floor/iron/dark/diagonal,
-/area/centcom/central_command_areas/evacuation)
 "Qb" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -9132,6 +9729,13 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"Qh" = (
+/obj/structure/table/wood/fancy/red,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/item/storage/cans/sixsoda,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "Qi" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
@@ -9146,12 +9750,41 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
+"Qp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/dark_red/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 4
+	},
+/area/centcom/central_command_areas/prison)
 "Qr" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/prison)
+"Qs" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "Qt" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical{
@@ -9231,9 +9864,10 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
 "QG" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on/coldroom,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/centcom/central_command_areas/fore)
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "QH" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /obj/effect/turf_decal/tile/neutral/full,
@@ -9243,15 +9877,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
-"QJ" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/obj/effect/mapping_helpers/airlock/access/any/service/kitchen,
-/turf/open/floor/iron,
-/area/centcom/tdome/observation)
 "QM" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 8
@@ -9269,6 +9894,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/centcom/tdome/arena)
+"QQ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/dark_red/filled/line,
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 1
+	},
+/turf/open/floor/iron/tgmcemblem{
+	dir = 10
+	},
+/area/centcom/central_command_areas/prison)
 "QR" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -9294,11 +9929,21 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "QV" = (
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"QX" = (
+/obj/structure/flora/bush/ferny/style_random,
+/obj/structure/railing,
+/turf/open/floor/iron{
+	dir = 6;
+	icon_state = "asteroid8";
+	name = "sand"
+	},
+/area/centcom/tdome/administration)
 "QY" = (
 /obj/item/storage/box/handcuffs,
 /obj/item/ammo_box/a357,
@@ -9363,6 +10008,12 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"Rn" = (
+/obj/structure/chair/sofa/corp{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "Ro" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/donkpockets,
@@ -9372,10 +10023,21 @@
 /obj/item/crowbar/power,
 /mob/living/simple_animal/parrot/poly{
 	name = "Poly Prime";
-	desc = "Poly the Parrot. Don't tell anyone, but the others are clones."
+	desc = "Poly the Parrot. Don't tell anyone, but the others are clones.";
+	limb_destroyer = 1;
+	health = 800
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/item/storage/belt/utility/chief/full{
+	name = "Central Command Engineer's toolbelt"
 	},
 /turf/open/floor/iron/dark/diagonal,
-/area/centcom/central_command_areas/supplypod)
+/area/centcom/central_command_areas/evacuation)
 "Rp" = (
 /obj/machinery/computer/communications,
 /turf/open/floor/iron/dark/herringbone,
@@ -9386,6 +10048,9 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "Rs" = (
@@ -9409,6 +10074,7 @@
 /obj/item/clipboard,
 /obj/item/radio/headset/headset_cent,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "Rx" = (
@@ -9435,6 +10101,11 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/item/storage/medkit/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/medkit/toxin,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
 "RB" = (
@@ -9477,6 +10148,11 @@
 /obj/effect/decal/cleanable/fuel_pool,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
+"RL" = (
+/obj/machinery/door/airlock/freezer,
+/obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "RM" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
@@ -9543,6 +10219,7 @@
 /obj/item/storage/secure/briefcase,
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "Sh" = (
@@ -9569,6 +10246,20 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/centcom/tdome/observation)
+"Sn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/centcom/central_command_areas/prison)
 "So" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/records/medical/laptop,
@@ -9578,6 +10269,7 @@
 "Sp" = (
 /obj/machinery/door/airlock/external/ruin,
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "Sq" = (
@@ -9622,6 +10314,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
+"SA" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "SB" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -9719,14 +10415,6 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/two)
-"Td" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/door/airlock/public/glass{
-	name = "CentCom Courtroom"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/courtroom)
 "Te" = (
 /obj/structure/closet/crate/engineering,
 /obj/item/stack/sheet/mineral/plasma{
@@ -9754,15 +10442,15 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
 "Tj" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/cup/glass/bottle/whiskey{
-	pixel_y = 5
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
-/obj/item/clothing/mask/cigarette/cigar/havana{
-	pixel_x = 2
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
 	},
+/obj/machinery/suit_storage_unit/ce,
 /turf/open/floor/iron/dark/diagonal,
-/area/centcom/central_command_areas/supplypod)
+/area/centcom/central_command_areas/evacuation)
 "Tl" = (
 /obj/structure/table/wood,
 /obj/structure/plaque/static_plaque/thunderdome{
@@ -9857,6 +10545,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"TD" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/airlock/security/glass{
+	name = "Central Command Courtroom"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/security/court,
+/obj/effect/mapping_helpers/airlock/access/any/service/lawyer,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/courtroom)
 "TE" = (
 /obj/structure/chair/comfy/brown{
 	color = "#596479";
@@ -9864,15 +10561,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/briefing)
-"TH" = (
-/obj/structure/chair/stool{
-	dir = 8
-	},
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
-/area/centcom/central_command_areas/fore)
 "TI" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -9953,6 +10641,29 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/admin)
+"TX" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/contraband/armory,
+/obj/structure/closet/crate/secure/gear,
+/obj/effect/spawner/random/contraband,
+/obj/effect/spawner/random/exotic/antag_gear_weak,
+/obj/effect/spawner/random/exotic/syndie,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
+"Ua" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 6
+	},
+/turf/open/floor/iron/smooth_corner{
+	dir = 1
+	},
+/area/centcom/central_command_areas/prison)
 "Ub" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible{
 	dir = 1
@@ -9985,16 +10696,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
-"Uj" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/door/airlock/public/glass{
-	name = "CentCom Courtroom"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/evacuation)
 "Ul" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -10045,6 +10746,20 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"Us" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/line{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/centcom/central_command_areas/prison)
 "Uv" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/bottle/multiver{
@@ -10064,6 +10779,11 @@
 "Ux" = (
 /turf/open/indestructible/hierophant,
 /area/centcom/central_command_areas/admin)
+"Uz" = (
+/turf/open/floor/iron/tgmcemblem{
+	dir = 4
+	},
+/area/centcom/central_command_areas/prison)
 "UA" = (
 /obj/item/cardboard_cutout{
 	starting_cutout = "Private Security Officer"
@@ -10071,10 +10791,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
-"UD" = (
-/obj/structure/chair/sofa/corp/right,
-/turf/open/floor/iron/kitchen/diagonal,
-/area/centcom/central_command_areas/fore)
 "UH" = (
 /obj/machinery/light/directional/west,
 /obj/structure/closet/secure_closet/personal,
@@ -10107,10 +10823,21 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
+"UP" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Supply Pod Storage"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "UR" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -10118,12 +10845,23 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"UT" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/contraband/armory,
+/obj/effect/spawner/random/contraband/armory,
+/obj/structure/closet/crate/secure/gear,
+/obj/effect/spawner/random/contraband,
+/obj/effect/spawner/random/exotic/languagebook,
+/obj/effect/spawner/random/exotic/syndie,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "UV" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
 /obj/item/lighter,
 /obj/machinery/newscaster/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "UW" = (
@@ -10232,14 +10970,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
-"Vt" = (
-/obj/machinery/button/door/directional/west{
-	id = "cafe_counter";
-	name = "Counter Shutters Control";
-	pixel_y = 24
-	},
-/turf/open/floor/iron/kitchen/herringbone,
-/area/centcom/central_command_areas/fore)
 "Vu" = (
 /obj/structure/closet/secure_closet/ert_med,
 /obj/machinery/vending/wallmed/directional/south{
@@ -10355,16 +11085,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
-"VX" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/item/storage/cans/sixsoda,
-/obj/structure/closet/crate/freezer,
-/obj/effect/spawner/random/food_or_drink/pizzaparty,
-/obj/effect/spawner/random/food_or_drink/pizzaparty,
-/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/centcom/central_command_areas/fore)
 "VY" = (
 /obj/machinery/computer/records/security{
 	dir = 8
@@ -10403,6 +11123,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/cmo,
 /obj/effect/mapping_helpers/airlock/access/any/security,
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "Wd" = (
@@ -10419,9 +11140,16 @@
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
 "Wi" = (
-/obj/structure/table/wood/fancy/red,
-/obj/item/storage/cans/sixsoda,
-/turf/open/floor/iron/kitchen/diagonal,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/public/glass{
+	name = "CentCom Courtroom"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/courtroom)
+"Wj" = (
+/obj/machinery/stove,
+/turf/open/floor/iron/kitchen/herringbone,
 /area/centcom/central_command_areas/fore)
 "Wl" = (
 /obj/structure/table/wood,
@@ -10501,6 +11229,21 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"Ww" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 4
+	},
+/obj/structure/bed/double{
+	dir = 4
+	},
+/obj/item/bedsheet/ce/double{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/centcom/central_command_areas/evacuation)
 "Wy" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/ert_spawn,
@@ -10754,8 +11497,7 @@
 "Xn" = (
 /obj/machinery/computer/security/telescreen,
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/turf/open/floor/carpet/executive,
 /area/centcom/tdome/administration)
 "Xo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
@@ -10792,8 +11534,10 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "Xu" = (
@@ -10805,7 +11549,7 @@
 /turf/open/floor/iron/white,
 /area/centcom/tdome/observation)
 "Xw" = (
-/turf/open/floor/iron/grimy,
+/turf/open/floor/carpet/executive,
 /area/centcom/tdome/administration)
 "Xy" = (
 /obj/machinery/door/airlock/external/ruin{
@@ -10865,12 +11609,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
-"XO" = (
-/obj/structure/chair/sofa/corp/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/kitchen/diagonal,
-/area/centcom/central_command_areas/fore)
 "XQ" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -10908,13 +11646,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
-"Yh" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Red Team"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/iron,
-/area/centcom/tdome/observation)
 "Yi" = (
 /obj/machinery/computer/camera_advanced,
 /turf/open/floor/iron/dark/herringbone,
@@ -10925,6 +11656,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"Yk" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/supply)
 "Ym" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -10936,6 +11672,28 @@
 "Yn" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/supplypod)
+"Yo" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/airlock/public/glass{
+	name = "CentCom Courtroom"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/evacuation)
+"Yp" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/centcom/central_command_areas/fore)
 "Yq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 4
@@ -10949,6 +11707,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"Ys" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/medical/general,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/mapping_helpers/airlock/access/any/supply/shipping,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "Yu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
@@ -10985,20 +11757,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/control)
-"YB" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/security/general,
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/control)
 "YD" = (
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/beerkeg,
@@ -11016,6 +11774,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
+"YI" = (
+/obj/structure/flora/bush/lavendergrass/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/grassy/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/obj/structure/flora/bush/pointy/style_random,
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/evacuation)
 "YN" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/medkit/regular,
@@ -11034,6 +11802,9 @@
 /obj/item/radio,
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/administration)
 "YP" = (
@@ -11085,22 +11856,27 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/prison/cells)
 "YY" = (
-/obj/item/storage/medkit/toxin,
-/obj/item/storage/medkit/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/structure/table/reinforced,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
 "Za" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/fore)
+"Zd" = (
+/obj/effect/landmark/prisonwarp,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/bed/pod{
+	dir = 8
+	},
+/obj/item/pillow/clown,
+/obj/item/bedsheet/clown,
+/turf/open/indestructible/dark,
+/area/centcom/central_command_areas/prison/cells)
 "Ze" = (
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
@@ -11144,6 +11920,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"Zk" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/item/storage/cans/sixsoda,
+/obj/structure/closet/crate/freezer,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/spawner/random/food_or_drink/pizzaparty,
+/obj/effect/spawner/random/medical/memeorgans,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/centcom/central_command_areas/fore)
 "Zl" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
@@ -11173,6 +11960,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/armory)
+"Zw" = (
+/obj/structure/chair/stool{
+	dir = 8
+	},
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/centcom/central_command_areas/fore)
 "Zx" = (
 /obj/machinery/computer/records/security{
 	dir = 8
@@ -11180,6 +11976,20 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/courtroom)
+"Zy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth_half{
+	dir = 1
+	},
+/area/centcom/central_command_areas/prison)
 "ZA" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -11230,18 +12040,6 @@
 /obj/machinery/barsign/all_access/directional/north,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation/ship)
-"ZH" = (
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/centcom/central_command_areas/fore)
 "ZM" = (
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
@@ -11271,6 +12069,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/four)
+"ZR" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Thunderdome Red Team"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron,
+/area/centcom/tdome/observation)
 "ZS" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
@@ -11290,6 +12095,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"ZU" = (
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "ZV" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -11311,6 +12120,16 @@
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"ZY" = (
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Security"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 
 (1,1,1) = {"
 fX
@@ -33129,7 +33948,7 @@ Qe
 Qe
 Qe
 Qe
-Qe
+pu
 Di
 aa
 aa
@@ -48749,7 +49568,7 @@ Yj
 YQ
 uh
 oh
-Hx
+fs
 ss
 fw
 tr
@@ -49006,7 +49825,7 @@ Yq
 Xq
 Xq
 ef
-Hx
+fs
 wx
 fw
 wB
@@ -51350,7 +52169,7 @@ gE
 FZ
 gE
 cq
-Yh
+ZR
 IA
 IT
 IT
@@ -51600,7 +52419,7 @@ PT
 Nl
 QC
 QC
-nx
+uJ
 QC
 QC
 QC
@@ -52060,7 +52879,7 @@ aa
 aa
 aa
 iF
-iR
+BD
 oJ
 Qx
 iO
@@ -52073,12 +52892,12 @@ iO
 uG
 oJ
 lo
-pt
+lJ
 hz
 iR
 lo
 hz
-pt
+lJ
 hz
 iR
 oJ
@@ -52317,19 +53136,19 @@ aa
 aa
 aa
 iF
-iR
+pP
 oJ
 Qx
-jp
+dy
 oJ
-jp
+my
 oJ
-jp
+EO
 oJ
-jp
+FW
 uG
 oJ
-lo
+Kb
 iF
 XA
 mJ
@@ -52348,9 +53167,9 @@ YU
 YU
 mD
 mD
-FG
+OZ
 xh
-FG
+OZ
 mD
 Ya
 rY
@@ -52574,23 +53393,23 @@ aa
 aa
 aa
 iF
-iR
+fd
 oJ
 Qx
-jp
+dy
 oJ
 jp
 oJ
-jp
+TX
 oJ
-jp
+al
 uG
 oJ
 EK
 iF
 iF
 iF
-lJ
+uH
 iF
 iN
 ot
@@ -52831,21 +53650,21 @@ aa
 aa
 aa
 iF
-iR
+ob
 oJ
 Qx
-jp
+dy
 oJ
-jp
+Yk
 oJ
-jp
+UT
 oJ
-jp
+mm
 uG
 oJ
 lp
 iF
-mi
+CP
 kj
 kj
 nm
@@ -52887,10 +53706,10 @@ QC
 bf
 eI
 ch
-QJ
+ck
 BW
-hg
-hg
+uv
+uv
 SZ
 Is
 IE
@@ -52901,10 +53720,10 @@ Js
 IE
 Is
 Pj
-YO
+fB
 Rr
-Sz
-ih
+GV
+BQ
 uf
 aa
 aa
@@ -53088,9 +53907,9 @@ aa
 aa
 aa
 iF
-iR
-oJ
-oJ
+kp
+bh
+bh
 oJ
 oJ
 oJ
@@ -53147,7 +53966,7 @@ QC
 QC
 Wv
 Kd
-gK
+nD
 SZ
 It
 It
@@ -53346,8 +54165,8 @@ aa
 aa
 iF
 iS
-iZ
-jf
+KR
+pA
 jq
 ju
 ju
@@ -53355,9 +54174,9 @@ mF
 jN
 jQ
 jN
-jf
-iZ
-lq
+pL
+sb
+QG
 iF
 mj
 jf
@@ -53383,7 +54202,7 @@ Ab
 mR
 Ab
 zF
-Xt
+ZY
 MF
 NG
 uc
@@ -53402,9 +54221,9 @@ Xf
 XJ
 Xf
 QC
-gK
+nD
 Kd
-gK
+nD
 SZ
 Iu
 IF
@@ -53673,7 +54492,7 @@ IG
 It
 Pj
 Xn
-Sz
+Xw
 Sz
 Rw
 Wn
@@ -53859,18 +54678,18 @@ aa
 aa
 aa
 Vx
-KU
-DO
-fx
+JB
+SA
+Kg
 Vx
-an
-yT
-an
-Im
-ON
-ON
-ON
-uR
+Jr
+xK
+Jr
+ub
+nc
+nc
+nc
+OL
 Vx
 Ul
 Jg
@@ -54116,18 +54935,18 @@ aa
 aa
 aa
 Vx
-Gv
-dO
-Hn
+kg
+Im
+Ey
 Vx
-yT
-yT
-yT
-Mm
-TH
-TH
-TH
-uR
+xK
+tj
+xK
+qU
+Zw
+Zw
+Zw
+OL
 Vx
 Vx
 Vx
@@ -54189,7 +55008,7 @@ Pj
 Pr
 Xw
 Sz
-Bx
+Gy
 Wn
 zA
 uf
@@ -54373,18 +55192,18 @@ aa
 aa
 aa
 Vx
-QG
-AC
-VX
+dc
+Ck
+Zk
 Vx
-an
-yT
-an
-DQ
-uR
-uR
-uR
-uR
+Jr
+xK
+Jr
+ez
+OL
+OL
+OL
+OL
 Vx
 lM
 tI
@@ -54631,19 +55450,19 @@ aa
 aa
 Vx
 Vx
-FD
+RL
 Vx
 Vx
-om
-ZH
-ZH
-dm
-Dq
-Dq
-Dq
-Dq
+ap
+Yp
+Yp
+GM
+iG
+iG
+iG
+iG
 lr
-lM
+nE
 lr
 mN
 Ox
@@ -54887,18 +55706,18 @@ aa
 aa
 aa
 Vx
-Oz
-Vt
-gb
-FT
-JU
-JU
-JU
-JU
-JU
-JU
-JU
-JU
+Wj
+Lr
+Cn
+OI
+uR
+uR
+uR
+uR
+uR
+uR
+uR
+uR
 Vx
 lM
 Jg
@@ -54917,7 +55736,7 @@ Jg
 tN
 Ab
 iu
-Qf
+tE
 bV
 km
 nN
@@ -55144,18 +55963,18 @@ aa
 aa
 aa
 Vx
-tX
-CX
-CX
-hu
-JU
-JU
-UD
-gx
-ub
-JU
-bZ
-ub
+dQ
+xO
+xO
+hg
+uR
+uR
+Dq
+Mn
+rC
+uR
+Qh
+rC
 Vx
 Vx
 Vx
@@ -55217,7 +56036,7 @@ Pj
 Pr
 Xw
 Sz
-Bx
+Gy
 Wn
 zA
 uf
@@ -55401,18 +56220,18 @@ aa
 aa
 aa
 Vx
-uu
-aY
-CX
-yE
-JU
-JU
-AQ
-Wi
-ew
-Os
-Ch
-XO
+fO
+zL
+xO
+IP
+uR
+uR
+ZU
+cG
+xA
+ex
+Rn
+er
 Vx
 hG
 Jg
@@ -55729,7 +56548,7 @@ II
 It
 Pj
 Xn
-Sz
+Xw
 Sz
 Sg
 Wn
@@ -55919,16 +56738,16 @@ rs
 ze
 Dj
 rs
-ze
+JI
 Dj
 rs
-ze
+dO
 Dj
 rs
-ze
+Ky
 Dj
 rs
-ze
+bS
 Jb
 uj
 il
@@ -55953,9 +56772,9 @@ Ab
 mR
 Ab
 zG
-HV
+Xt
 MF
-Dp
+Ys
 uc
 uc
 uc
@@ -55974,7 +56793,7 @@ XJ
 QC
 Wv
 Kd
-gK
+nD
 SZ
 Iu
 IF
@@ -56229,9 +57048,9 @@ QC
 QC
 QC
 QC
-gK
+nD
 Kd
-gK
+nD
 SZ
 It
 It
@@ -56429,19 +57248,19 @@ il
 is
 lL
 iJ
-iT
-iT
+Zy
+bu
 jg
-iT
-iT
+Zy
+bu
 jz
-iT
-iT
+Zy
+Zy
 eQ
-iT
-iT
+Zy
+bu
 kS
-ls
+Qp
 lL
 Ra
 kB
@@ -56457,7 +57276,7 @@ io
 io
 io
 Fq
-YB
+UO
 io
 io
 yU
@@ -56476,7 +57295,7 @@ NJ
 io
 iu
 io
-eo
+eM
 ZM
 Vs
 tG
@@ -56485,10 +57304,10 @@ QC
 cW
 cS
 nj
-ck
+JX
 BW
-gr
-gr
+gx
+gx
 SZ
 Is
 IJ
@@ -56501,7 +57320,7 @@ Is
 Pj
 YO
 Bx
-Sz
+nx
 ih
 uf
 aa
@@ -56686,19 +57505,19 @@ iH
 it
 lL
 im
-iU
-iU
-iU
-iU
-jx
-lL
+Gc
+gg
+Gc
+Gc
+If
+fo
 jF
-iU
-iU
-iU
-iU
+Gc
+Gc
+gg
+Gc
 rS
-lt
+hb
 lL
 Ra
 kB
@@ -56733,7 +57552,7 @@ uc
 iu
 Ym
 iu
-xu
+yc
 Bo
 FZ
 bD
@@ -56758,7 +57577,7 @@ uf
 uf
 uf
 uf
-dy
+tC
 uf
 uf
 aa
@@ -56947,9 +57766,9 @@ il
 Ho
 il
 il
-jw
-lL
-jG
+PQ
+fo
+FK
 Mz
 Mz
 Ho
@@ -56974,9 +57793,9 @@ io
 yj
 io
 io
-df
+Kq
 mk
-df
+Kq
 io
 io
 iu
@@ -57202,11 +58021,11 @@ iD
 iD
 iV
 lL
-jh
+bT
 il
-jw
-lL
-jG
+dY
+ya
+QQ
 Mz
 jU
 lL
@@ -57461,8 +58280,8 @@ lL
 lL
 ji
 il
-jE
-lL
+kK
+GE
 nT
 il
 jT
@@ -57716,11 +58535,11 @@ iE
 iE
 iW
 lL
-cR
+jh
 il
-jw
-lL
-jG
+Oy
+Uz
+gV
 Mz
 jU
 lL
@@ -57975,9 +58794,9 @@ il
 Ho
 il
 il
-jw
-lL
-jG
+PQ
+fo
+FK
 Mz
 Mz
 Ho
@@ -58032,7 +58851,7 @@ Vs
 tG
 Vs
 MK
-dj
+Na
 IN
 Jc
 Jc
@@ -58228,19 +59047,19 @@ iH
 iy
 lL
 ip
-iT
-iT
-iT
-iT
-jH
-lL
+Us
+bu
+Us
+Us
+Ua
+fo
 jv
-iT
-iT
-iT
-iT
+Us
+Us
+bu
+Us
 tR
-ls
+Qp
 lL
 Ra
 kB
@@ -58264,7 +59083,7 @@ Ab
 Ab
 yz
 iu
-zJ
+kN
 xN
 Ab
 BJ
@@ -58485,19 +59304,19 @@ il
 iz
 lL
 iM
-iU
-iU
+Sn
+gg
 jj
-iU
-iU
+Sn
+gg
 jB
-iU
-iU
+Sn
+gg
 jV
-iU
-iU
+Sn
+gg
 kV
-lt
+hb
 lL
 Ra
 kB
@@ -58760,9 +59579,9 @@ Jb
 pc
 Hv
 RI
-mz
+ja
 et
-mz
+ja
 RI
 io
 io
@@ -58996,22 +59815,22 @@ aa
 aa
 aa
 Jb
-rs
+Zd
 ze
 Dj
-rs
+Zd
 ze
 Dj
-rs
+Zd
 ze
 Dj
-rs
+Zd
 ze
 Dj
-rs
+Zd
 ze
 Dj
-rs
+Zd
 ze
 Jb
 Vi
@@ -59025,7 +59844,7 @@ Hv
 cg
 cg
 cg
-YB
+UO
 cg
 cg
 cg
@@ -59042,7 +59861,7 @@ cg
 cg
 fm
 cg
-UO
+Qs
 cg
 NO
 NO
@@ -59539,7 +60358,7 @@ Hv
 cg
 cg
 cg
-Jm
+bL
 cg
 cg
 cg
@@ -59556,10 +60375,10 @@ cg
 cg
 cg
 cg
-aC
+Hs
 cg
 Yn
-GX
+sZ
 Yn
 QC
 QC
@@ -59576,10 +60395,10 @@ Sl
 Sl
 QC
 uf
-fH
-Wn
-Wn
 uf
+UP
+Wn
+Wn
 uf
 uf
 Wn
@@ -59784,7 +60603,7 @@ kz
 kX
 lw
 rk
-Ea
+AC
 ps
 rM
 rM
@@ -59793,7 +60612,7 @@ rM
 rM
 zc
 Hv
-Gk
+Cd
 qz
 cg
 sN
@@ -59814,14 +60633,14 @@ qz
 cg
 Rs
 HH
-Yn
+cg
 Pz
 Su
 qI
 NO
-PV
-PV
 NO
+PV
+PV
 NO
 NO
 Uw
@@ -59833,11 +60652,11 @@ pO
 HE
 Sl
 SU
-rh
-Vl
+QX
+FD
+Oz
 bM
 Wn
-SU
 Wn
 Vl
 bM
@@ -60071,15 +60890,15 @@ qz
 cg
 pf
 HH
-Yn
+cg
 Ty
 Su
 qI
+yG
 ly
-sb
 jO
+as
 qI
-NO
 NO
 NO
 NO
@@ -60090,10 +60909,10 @@ Yn
 Yn
 Yn
 Yn
-Pa
+Yn
+Py
 Yn
 Yn
-uf
 uf
 uf
 uf
@@ -60293,7 +61112,7 @@ aa
 aa
 Hv
 Hv
-ri
+Bt
 Hv
 Hv
 Hv
@@ -60303,12 +61122,12 @@ Hv
 Hv
 Hv
 pc
-ja
-ja
+Pu
+Pu
 pc
 Hv
 qA
-Gk
+Cd
 fm
 sP
 tT
@@ -60324,10 +61143,11 @@ us
 At
 AX
 fm
-Cd
+MT
 cg
 Xk
 SG
+cg
 Yn
 Yn
 Yn
@@ -60350,7 +61170,6 @@ NE
 NE
 NE
 Yn
-aa
 aa
 aa
 aa
@@ -60585,6 +61404,7 @@ qy
 cg
 Rs
 HH
+Rs
 Yn
 KF
 KF
@@ -60607,7 +61427,6 @@ NE
 NE
 NE
 Yn
-aa
 aa
 aa
 aa
@@ -60809,7 +61628,7 @@ Hv
 NW
 rM
 rM
-iG
+ct
 ps
 ps
 Zx
@@ -60842,6 +61661,7 @@ fm
 cg
 cg
 sL
+cg
 Yn
 AH
 AH
@@ -60864,7 +61684,6 @@ NE
 NE
 NE
 XT
-aa
 aa
 aa
 aa
@@ -61099,6 +61918,7 @@ pg
 Uf
 CD
 HH
+LZ
 Yn
 OP
 AH
@@ -61106,10 +61926,10 @@ AH
 AH
 OP
 PK
-sZ
+EW
 UM
 UM
-sZ
+EW
 Vn
 PW
 Vn
@@ -61121,7 +61941,6 @@ NE
 NE
 NE
 XT
-aa
 aa
 aa
 aa
@@ -61356,6 +62175,7 @@ Cf
 HH
 HH
 HH
+LZ
 Yn
 OP
 OP
@@ -61363,10 +62183,10 @@ OP
 OP
 OP
 PK
-sZ
+EW
 QO
 QO
-sZ
+EW
 Vn
 PW
 Vn
@@ -61378,7 +62198,6 @@ NE
 NE
 NE
 Yn
-aa
 aa
 aa
 aa
@@ -61612,6 +62431,7 @@ BO
 Cg
 HH
 HH
+HH
 rt
 Yn
 AH
@@ -61635,7 +62455,6 @@ NE
 NE
 NE
 Yn
-aa
 aa
 aa
 aa
@@ -61869,6 +62688,7 @@ BP
 Cf
 HH
 UA
+HH
 zf
 Yn
 XD
@@ -61892,7 +62712,6 @@ NE
 NE
 NE
 Yn
-aa
 aa
 aa
 aa
@@ -62100,7 +62919,7 @@ rM
 rM
 rM
 rk
-ct
+TD
 ps
 rM
 rM
@@ -62126,6 +62945,7 @@ cg
 VY
 Xb
 CE
+HH
 WF
 Yn
 Yn
@@ -62149,7 +62969,6 @@ NE
 NE
 NE
 Yn
-aa
 aa
 aa
 aa
@@ -62384,6 +63203,7 @@ fm
 cg
 cg
 cg
+cg
 Yn
 zM
 zM
@@ -62406,7 +63226,6 @@ NE
 NE
 NE
 XT
-aa
 aa
 aa
 aa
@@ -62621,7 +63440,7 @@ rM
 Np
 Hv
 qy
-mh
+YI
 cg
 fE
 tT
@@ -62641,6 +63460,7 @@ qz
 cg
 Nh
 Ro
+Ww
 Yn
 Se
 Si
@@ -62663,7 +63483,6 @@ NE
 NE
 NE
 XT
-aa
 aa
 aa
 aa
@@ -62894,10 +63713,11 @@ us
 At
 Bb
 fm
-Gk
+Cd
 cg
 MI
-pn
+Hw
+DQ
 Yn
 Se
 Si
@@ -62905,10 +63725,10 @@ Se
 Si
 Se
 Tc
-sZ
+EW
 UM
 UM
-sZ
+EW
 Xh
 Xh
 Pm
@@ -62920,7 +63740,6 @@ NE
 NE
 NE
 Yn
-aa
 aa
 aa
 aa
@@ -63134,8 +63953,8 @@ mY
 rM
 NW
 Hv
-xA
-Mj
+hq
+xb
 cg
 sO
 tT
@@ -63151,10 +63970,11 @@ us
 At
 AW
 cg
-Mj
+xb
 cg
 OD
-pn
+Hw
+DQ
 Yn
 Se
 Si
@@ -63162,10 +63982,10 @@ Se
 Si
 Se
 Tc
-sZ
+EW
 QO
 QO
-sZ
+EW
 Xh
 Xh
 Pm
@@ -63177,7 +63997,6 @@ NE
 NE
 NE
 Yn
-aa
 aa
 aa
 aa
@@ -63379,7 +64198,7 @@ Hv
 NW
 rM
 rM
-iG
+ct
 ps
 lV
 lW
@@ -63390,10 +64209,10 @@ ps
 rk
 rk
 ps
-Td
+Wi
 HH
 HH
-Uj
+Yo
 sT
 tU
 tU
@@ -63407,11 +64226,12 @@ tU
 tU
 tU
 Bc
-PO
-Gt
-Qa
+ag
+vM
+DK
 sa
-pn
+Hw
+DQ
 Yn
 Se
 Se
@@ -63434,7 +64254,6 @@ NE
 NE
 NE
 Yn
-aa
 aa
 aa
 aa
@@ -63646,7 +64465,7 @@ gC
 ps
 Ha
 gA
-qx
+zU
 Hv
 cg
 cg
@@ -63668,7 +64487,8 @@ cg
 cg
 cg
 Tj
-pn
+mu
+vY
 Yn
 Vk
 Vk
@@ -63691,7 +64511,6 @@ NE
 NE
 NE
 Yn
-aa
 aa
 aa
 aa
@@ -63924,8 +64743,9 @@ sV
 cg
 cg
 cg
-XT
-XT
+fm
+fm
+fm
 Yn
 Yn
 Yn
@@ -63948,7 +64768,6 @@ XT
 XT
 Yn
 Yn
-aa
 aa
 aa
 aa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -5554,6 +5554,18 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"wl" = (
+/mob/living/basic/monkey_animatronic,
+/obj/structure/railing{
+	dir = 6;
+	layer = 3.1
+	},
+/obj/structure/railing{
+	dir = 9;
+	layer = 3.1
+	},
+/turf/open/floor/elevated,
+/area/centcom/central_command_areas/fore)
 "wq" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -6317,6 +6329,11 @@
 /obj/structure/flora/bush/generic/style_random,
 /turf/open/floor/grass,
 /area/centcom/tdome/administration)
+"zB" = (
+/turf/open/floor/holofloor/stairs{
+	dir = 4
+	},
+/area/centcom/central_command_areas/fore)
 "zC" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -54786,10 +54803,10 @@ Jr
 OZ
 Jr
 ub
+wl
 nc
 nc
 sf
-OL
 Vx
 Ul
 Jg
@@ -55043,10 +55060,10 @@ xK
 tj
 xK
 qU
+zB
 Zw
 Zw
 Zw
-OL
 Vx
 Vx
 Vx

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -687,6 +687,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/centcom/tdome/observation)
+"dj" = (
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/kitchen/diagonal,
+/area/centcom/central_command_areas/fore)
 "dn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -3024,6 +3028,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/courtroom)
+"ms" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "mu" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8
@@ -3417,8 +3428,8 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "nW" = (
-/obj/machinery/vending/cola,
 /obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "nX" = (
@@ -3710,8 +3721,8 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/fore)
 "oQ" = (
-/obj/machinery/vending/snack,
 /obj/effect/turf_decal/delivery,
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "oU" = (
@@ -4181,13 +4192,13 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/ferry)
 "qS" = (
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/machinery/door/airlock/centcom{
+	name = "CentCom Logistics"
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "qT" = (
@@ -4467,6 +4478,16 @@
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"sf" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/centcom/central_command_areas/fore)
 "sm" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/herringbone,
@@ -6033,8 +6054,12 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/evacuation)
 "yG" = (
-/turf/open/space/basic,
-/area/centcom/central_command_areas/supplypod)
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/centcom/tdome/administration)
 "yH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/wood{
@@ -6333,6 +6358,7 @@
 /area/centcom/central_command_areas/control)
 "zL" = (
 /obj/structure/sink/kitchen/directional/west,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/kitchen/herringbone,
 /area/centcom/central_command_areas/fore)
 "zM" = (
@@ -6440,6 +6466,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
+"Ar" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/control)
 "As" = (
 /obj/machinery/computer/communications{
 	dir = 8
@@ -6448,6 +6479,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
 "At" = (
@@ -6542,6 +6574,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/centcom/central_command_areas/control)
 "AV" = (
@@ -6776,7 +6809,6 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "BI" = (
-/obj/machinery/light/directional/south,
 /obj/structure/noticeboard/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -6784,8 +6816,8 @@
 /obj/machinery/vending/wallmed/directional/south{
 	use_power = 0
 	},
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/iron,
+/obj/machinery/shower/directional/north,
+/turf/open/floor/noslip,
 /area/centcom/central_command_areas/control)
 "BJ" = (
 /obj/machinery/sleeper{
@@ -9154,6 +9186,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/control)
 "Ok" = (
@@ -9400,18 +9433,9 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "OZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/obj/machinery/light/directional/west,
+/turf/open/ballpit,
+/area/centcom/central_command_areas/fore)
 "Pc" = (
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -10011,6 +10035,7 @@
 /obj/structure/chair/sofa/corp{
 	dir = 8
 	},
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/centcom/central_command_areas/fore)
 "Ro" = (
@@ -10315,6 +10340,7 @@
 /area/centcom/tdome/administration)
 "SA" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/centcom/central_command_areas/fore)
 "SB" = (
@@ -12109,7 +12135,7 @@
 /area/centcom/tdome/observation)
 "ZX" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom Security"
+	name = "CentCom Logistics"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -51143,7 +51169,7 @@ Rh
 pI
 tH
 Bp
-Tt
+yG
 Bj
 Bp
 oI
@@ -53166,9 +53192,9 @@ YU
 YU
 mD
 mD
-OZ
+wu
 xh
-OZ
+wu
 mD
 Ya
 rY
@@ -54682,12 +54708,12 @@ SA
 Kg
 Vx
 Jr
-xK
+OZ
 Jr
 ub
 nc
 nc
-nc
+sf
 OL
 Vx
 Ul
@@ -56224,7 +56250,7 @@ zL
 xO
 IP
 uR
-uR
+dj
 ZU
 cG
 xA
@@ -59083,7 +59109,7 @@ Ab
 yz
 iu
 kN
-xN
+Ar
 Ab
 BJ
 iu
@@ -59881,7 +59907,7 @@ Rh
 pI
 tH
 Bp
-RB
+ms
 UW
 Bp
 oI
@@ -60893,7 +60919,7 @@ cg
 Ty
 Su
 qI
-yG
+NO
 ly
 jO
 as


### PR DESCRIPTION
## About the Pull Request, and why It's good for the game

I'm tired of coming to Central Command's docks only for there to be one of two things there:

1. A ginormous explosion
2. Nothing

This PR aims to fix that by changing a lot. Chiefly, making a lot of doors have normal, station side access requirements, adding in easter eggs to explore and find out while you scramble around the map for 60 seconds (or longer if the admins have to screech at someone!) 

## Images

Thunderdome VIP booth (Command access instead of inaccessible) 
![image](https://github.com/Monkestation/Monkestation2.0/assets/14065903/7d28fefc-de8c-4763-9807-0df39e6107c7)

Slight realism update, you can now try out for the Thunderdome team! (Doors still have admin access, but it's a little more believable, how often do they use the thunderdome anyway?) 
![image](https://github.com/Monkestation/Monkestation2.0/assets/14065903/0ac250ea-1998-4af3-8ddc-7691f947eb0b)

A more "Lived in" look for cargo
![image](https://github.com/Monkestation/Monkestation2.0/assets/14065903/81e8d457-eab9-4088-a1a9-1f24346a3cbb)

Enjoy a slice at Peppino's after a hard day at work
![image](https://github.com/Monkestation/Monkestation2.0/assets/14065903/dffef5d2-e8eb-4524-ad7b-6bf0e61d645f)

Central's courtroom is now accessible, now you can get sued for breach of contract when you get to CC! 
![image](https://github.com/Monkestation/Monkestation2.0/assets/14065903/2c7b0154-5a23-4cf1-9833-6c74665ee89a)

And some surprises! shhh


## Changelog
:cl:
add: Large scale remodeling of Central Command
/:cl:
