### PR TITLE
Reverts some recent changes to mechs.

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1902,8 +1902,8 @@
 		"mech_ccw_armor",
 		"mech_proj_armor",
 	)
-	discount_experiments = list(/datum/experiment/scanning/random/mecha_destroyed_scan = 5000,
-								/datum/experiment/scanning/random/mecha_damage_scan = 3000)
+	required_experiments = list(/datum/experiment/scanning/random/mecha_damage_scan)// do not remove this
+	discount_experiments = list(/datum/experiment/scanning/random/mecha_destroyed_scan = 5000)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
 
 /datum/techweb_node/mech_scattershot

--- a/code/modules/vehicles/mecha/_mecha.dm
+++ b/code/modules/vehicles/mecha/_mecha.dm
@@ -442,7 +442,7 @@
 	if(capacitor)
 		var/datum/armor/stock_armor = get_armor_by_type(armor_type)
 		var/initial_energy = stock_armor.get_rating(ENERGY)
-		set_armor_rating(ENERGY, initial_energy + (capacitor.rating * 5))
+		set_armor_rating(ENERGY, initial_energy + (capacitor.rating * 0)) //monke edit: removes capacitors effecting mech resistance to emps
 
 /obj/vehicle/sealed/mecha/examine(mob/user)
 	. = ..()

--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -16,7 +16,7 @@
 	max_equip_by_category = list(
 		MECHA_UTILITY = 1,
 		MECHA_POWER = 1,
-		MECHA_ARMOR = 3,
+		MECHA_ARMOR = 2,
 	)
 	var/obj/durand_shield/shield
 

--- a/code/modules/vehicles/mecha/combat/gygax.dm
+++ b/code/modules/vehicles/mecha/combat/gygax.dm
@@ -13,13 +13,12 @@
 	destruction_sleep_duration = 40
 	exit_delay = 40
 	encumbrance_gap = 1.4
-	internal_damage_threshold = 18
 	wreckage = /obj/structure/mecha_wreckage/gygax
 	mech_type = EXOSUIT_MODULE_GYGAX
 	max_equip_by_category = list(
 		MECHA_UTILITY = 1,
 		MECHA_POWER = 1,
-		MECHA_ARMOR = 3,
+		MECHA_ARMOR = 2,
 	)
 	step_energy_drain = 3
 

--- a/code/modules/vehicles/mecha/combat/honker.dm
+++ b/code/modules/vehicles/mecha/combat/honker.dm
@@ -11,7 +11,6 @@
 	destruction_sleep_duration = 40
 	exit_delay = 40
 	encumbrance_gap = 2
-	internal_damage_threshold = 20
 	wreckage = /obj/structure/mecha_wreckage/honker
 	mecha_flags = CANSTRAFE | IS_ENCLOSED | HAS_LIGHTS | MMI_COMPATIBLE
 	mech_type = EXOSUIT_MODULE_HONK

--- a/code/modules/vehicles/mecha/combat/phazon.dm
+++ b/code/modules/vehicles/mecha/combat/phazon.dm
@@ -19,7 +19,7 @@
 	max_equip_by_category = list(
 		MECHA_UTILITY = 1,
 		MECHA_POWER = 1,
-		MECHA_ARMOR = 3,
+		MECHA_ARMOR = 2,
 	)
 	phase_state = "phazon-phase"
 

--- a/code/modules/vehicles/mecha/mecha_defense.dm
+++ b/code/modules/vehicles/mecha/mecha_defense.dm
@@ -177,7 +177,7 @@
 
 	if(!equipment_disabled && LAZYLEN(occupants)) //prevent spamming this message with back-to-back EMPs
 		to_chat(occupants, span_warning("Error -- Connection to equipment control unit has been lost."))
-	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/vehicle/sealed/mecha, restore_equipment)), 3 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/obj/vehicle/sealed/mecha, restore_equipment)), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 	equipment_disabled = TRUE
 	set_mouse_pointer()
 


### PR DESCRIPTION

## About The Pull Request
Readds the required research for getting combat mechs.
No more triple armor for mechs(who the fuck thought this was okay)

## Why It's Good For The Game

Currently robotics can and often does just rush mechs at the start of the round, build them, and then fuck over any antagonist they see. This aims to fix this by making mechs first require some actual effort put into making them instead of clicking on a button on a console then assembling a more complex borg. It also reverts some questionable balance changes to mechs, which made fighting them very difficult and unfun.  EMPs are supposed to be mech's Achilles heel, however they barely do anything to the mech on account of the fact that high tier capacitors can greatly reduce the effect, in addition to only stopping the mech's very powerful weapons for 3 seconds, this hopefully fixes that issue.
## Changelog
:cl:
add: The mech breaking experiment is now required once again.
balance: you can no longer put 3 armors on most combat mechs
balance: internal damage thresholds have been reverted to their original levels
balance: mechs no longer get emp shielding from capacitors
balance: mechs are downed slightly longer from emps
/:cl:
