### PR TITLE
[Fix] IPCs can be delimbed

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -94,6 +94,7 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 #define ismonkey(A) (is_species(A, /datum/species/monkey))
 #define isandroid(A) (is_species(A, /datum/species/android))
 #define isnightmare(A) (is_species(A, /datum/species/shadow/nightmare))
+#define isipc(A) (is_species(A, /datum/species/ipc))
 
 
 //More carbon mobs

--- a/code/datums/wounds/loss.dm
+++ b/code/datums/wounds/loss.dm
@@ -19,14 +19,13 @@
 
 	set_victim(dismembered_part.owner)
 	var/self_msg
-
 	if(dismembered_part.body_zone == BODY_ZONE_CHEST)
-		occur_text = "is split open, causing [victim.p_their()] internal organs to spill out!"
+		occur_text = "is split open, causing [victim.p_their()] internal [dismembered_part.bodytype & BODYTYPE_ROBOTIC? "components": "organs"] to spill out!"
 		self_msg = "is split open, causing your internal organs to spill out!"
 	else if(outright)
 		switch(wounding_type)
 			if(WOUND_BLUNT)
-				occur_text = "is outright smashed to a gross pulp, severing it completely!"
+				occur_text = "is outright smashed to a [dismembered_part.bodytype & BODYTYPE_ROBOTIC? "misshapen heap of scrap": "gross pulp"], severing it completely!"
 			if(WOUND_SLASH)
 				occur_text = "is outright slashed off, severing it completely!"
 			if(WOUND_PIERCE)
@@ -36,11 +35,11 @@
 	else
 		switch(wounding_type)
 			if(WOUND_BLUNT)
-				occur_text = "is shattered through the last bone holding it together, severing it completely!"
+				occur_text = "is shattered through the last [dismembered_part.bodytype & BODYTYPE_ROBOTIC? "bit of wires": "bone"] holding it together, severing it completely!"
 			if(WOUND_SLASH)
-				occur_text = "is slashed through the last tissue holding it together, severing it completely!"
+				occur_text = "is slashed through the last [dismembered_part.bodytype & BODYTYPE_ROBOTIC? "bit of wires": "tissue"] holding it together, severing it completely!"
 			if(WOUND_PIERCE)
-				occur_text = "is pierced through the last tissue holding it together, severing it completely!"
+				occur_text = "is pierced through the last [dismembered_part.bodytype & BODYTYPE_ROBOTIC? "bit of wires": "tissue"] holding it together, severing it completely!"
 			if(WOUND_BURN)
 				occur_text = "is completely incinerated, falling to dust!"
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -449,15 +449,15 @@
 
 		//Handling for bone only/flesh only(none right now)/flesh and bone targets
 		switch(biological_state)
-			// if we're bone only, all cutting attacks go straight to the bone
-			if(BIO_BONE)
+			// if we're fleshless, all cutting attacks go straight to the bone
+			if(BIO_BONE, BIO_INORGANIC)
 				if(wounding_type == WOUND_SLASH)
 					wounding_type = WOUND_BLUNT
 					wounding_dmg *= (easy_dismember ? 1 : 0.6)
 				else if(wounding_type == WOUND_PIERCE)
 					wounding_type = WOUND_BLUNT
 					wounding_dmg *= (easy_dismember ? 1 : 0.75)
-				if((mangled_state & BODYPART_MANGLED_BONE) && try_dismember(wounding_type, wounding_dmg, wound_bonus, bare_wound_bonus))
+				if(((mangled_state & BODYPART_MANGLED_BONE) || biological_state == BIO_INORGANIC) && try_dismember(wounding_type, wounding_dmg, wound_bonus, bare_wound_bonus))
 					return
 			// note that there's no handling for BIO_FLESH since we don't have any that are that right now (slimepeople maybe someday)
 			// standard humanoids

--- a/monkestation/code/modules/surgery/bodyparts/ipc_bodyparts.dm
+++ b/monkestation/code/modules/surgery/bodyparts/ipc_bodyparts.dm
@@ -6,6 +6,7 @@
 	icon_state = "synth_head"
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
+	biological_state = BIO_INORGANIC
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 
 	body_damage_coeff = 1.1	//IPC's Head can dismember	//Monkestation Edit
@@ -28,6 +29,7 @@
 	icon_state = "synth_chest"
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
+	biological_state = BIO_INORGANIC
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 
 	body_damage_coeff = 1	//IPC Chest at default	///Monkestation Edit
@@ -50,6 +52,7 @@
 	limb_id = "synth"
 	icon_state = "synth_l_arm"
 	should_draw_greyscale = FALSE
+	biological_state = BIO_INORGANIC
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 
 	body_damage_coeff = 1.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
@@ -72,6 +75,7 @@
 	limb_id = "synth"
 	icon_state = "synth_r_arm"
 	should_draw_greyscale = FALSE
+	biological_state = BIO_INORGANIC
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 
 	body_damage_coeff = 1.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
@@ -94,6 +98,7 @@
 	limb_id = "synth"
 	icon_state = "synth_l_leg"
 	should_draw_greyscale = FALSE
+	biological_state = BIO_INORGANIC
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 
 	body_damage_coeff = 1.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
@@ -116,9 +121,10 @@
 	limb_id = "synth"
 	icon_state = "synth_r_leg"
 	should_draw_greyscale = FALSE
+	biological_state = BIO_INORGANIC
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 
-	body_damage_coeff = 0.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
+	body_damage_coeff = 1.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
 	max_damage = 30	//Monkestation Edit
 
 	light_brute_msg = "scratched"


### PR DESCRIPTION

## About The Pull Request
Does what the title says

## Why It's Good For The Game
Whether or not you think IPCs are imbalanced, one of the downsides of the species is supposed to be that their limbs come off easily.  Unfortunately due to wounds, this wasn't happening.  Now IPCs can be delimbed.  Additionally added some flavor text to make it less awkward. They still have normal blood spatters for now, but I will be looking into a better blood spatter system.

## Changelog

:cl:
fix: IPCs can now be delimbed.
/:cl:

