### PR TITLE
Independence refit tweaks

### DIFF
--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -108,7 +108,6 @@
 	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Brig";
-	safe = 0;
 	normalspeed = 0
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -4,7 +4,8 @@
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/structure/closet/secure_closet/ert_sec{
 	name = "Emergency response security locker";
-	desc = "A storage unit containing equipment for responding to emergencies."
+	desc = "A storage unit containing equipment for responding to emergencies.";
+	req_access = list("security")
 	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
@@ -107,7 +108,8 @@
 	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Brig";
-	safe = 0
+	safe = 0;
+	normalspeed = 0
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -583,6 +585,10 @@
 "kx" = (
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Brig";
+	safe = 0
 	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
@@ -1635,7 +1641,8 @@
 "Fp" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Brig";
-	safe = 0
+	safe = 0;
+	normalspeed = 0
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
@@ -1669,7 +1676,8 @@
 /obj/machinery/door/airlock/command/glass{
 	name = "Cockpit";
 	id_tag = "escape_cockpit_blast";
-	safe = 0
+	safe = 0;
+	normalspeed = 0
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/showroomfloor,
@@ -1966,7 +1974,8 @@
 "LH" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Brig";
-	safe = 0
+	safe = 0;
+	normalspeed = 0
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -7,6 +7,9 @@
 	desc = "A storage unit containing equipment for responding to emergencies.";
 	req_access = list("security")
 	},
+/obj/item/food/burger/cheese,
+/obj/item/gun/ballistic/revolver/mateba,
+/obj/item/ammo_box/a357,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "ao" = (
@@ -249,6 +252,7 @@
 	pixel_x = -7;
 	pixel_y = 13
 	},
+/obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "eM" = (
@@ -415,6 +419,9 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 10
+	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "iI" = (
@@ -585,9 +592,8 @@
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 1
 	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Brig";
-	safe = 0
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
@@ -777,6 +783,9 @@
 /area/shuttle/escape)
 "oH" = (
 /obj/effect/turf_decal/trimline/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -1010,6 +1019,7 @@
 	pixel_x = 11;
 	pixel_y = 4
 	},
+/obj/item/gun/grenadelauncher,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "tS" = (
@@ -1025,6 +1035,9 @@
 "tU" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -1462,16 +1475,14 @@
 	dir = 5;
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/trimline/red/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/end{
+	dir = 4
+	},
 /obj/machinery/computer/arcade{
 	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/corner{
-	dir = 1;
-	pixel_y = -16
-	},
-/obj/effect/turf_decal/trimline/red/corner{
-	dir = 8;
-	pixel_y = 16
 	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
@@ -1493,6 +1504,9 @@
 "Dn" = (
 /obj/structure/chair/sofa/bench/right,
 /obj/effect/turf_decal/trimline/red/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
 	dir = 9
 	},
 /turf/open/floor/iron/dark/textured,
@@ -1534,6 +1548,17 @@
 	dir = 1
 	},
 /area/shuttle/escape)
+"DU" = (
+/obj/effect/turf_decal/trimline/red/line,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape/brig)
 "Ed" = (
 /obj/structure/bed/double/pod,
 /obj/item/bedsheet/patriot/double,
@@ -1637,6 +1662,15 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape)
+"Fc" = (
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape/brig)
 "Fp" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Escape Shuttle Brig";
@@ -1902,6 +1936,10 @@
 /obj/structure/sign/poster/contraband/clown{
 	pixel_y = -30
 	},
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "Ki" = (
@@ -2042,6 +2080,9 @@
 /area/shuttle/escape)
 "MZ" = (
 /obj/effect/turf_decal/trimline/red/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
@@ -2324,6 +2365,7 @@
 	req_access = list("security");
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "SZ" = (
@@ -2522,6 +2564,9 @@
 /area/shuttle/escape)
 "VX" = (
 /obj/effect/turf_decal/trimline/red/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
@@ -3102,7 +3147,7 @@ vI
 nZ
 SK
 MZ
-jW
+Fc
 Kg
 rX
 DJ
@@ -3149,7 +3194,7 @@ GT
 iP
 dS
 Yh
-AB
+DU
 rX
 qx
 gY
@@ -3195,7 +3240,7 @@ Hs
 iP
 xi
 OQ
-AB
+DU
 rX
 ft
 El

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -621,6 +621,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/grenade/frag,
 /turf/open/floor/iron/showroomfloor,
 /area/shuttle/escape)
 "ld" = (
@@ -1453,7 +1454,7 @@
 /turf/open/floor/eighties,
 /area/shuttle/escape/luxury)
 "Cw" = (
-/obj/effect/spawner/random/vending/snackvend,
+/obj/machinery/vending/imported,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "Cy" = (
@@ -1870,6 +1871,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/grenade/frag,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "Jk" = (

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -49,6 +49,9 @@
 /mob/living/simple_animal/bot/secbot{
 	name = "Officer Beefsky"
 	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "bF" = (
@@ -102,12 +105,14 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Brig"
+	name = "Escape Shuttle Brig";
+	safe = 0
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "cz" = (
@@ -154,10 +159,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/shuttle/escape)
 "dC" = (
-/obj/effect/turf_decal/trimline/red/line,
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/red/warning,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "dN" = (
@@ -500,10 +505,6 @@
 /obj/machinery/vending/boozeomat/all_access,
 /turf/open/floor/plastic,
 /area/shuttle/escape/luxury)
-"jK" = (
-/obj/effect/turf_decal/trimline/red/line,
-/turf/open/floor/iron/dark/textured,
-/area/shuttle/escape/brig)
 "jO" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Lobby";
@@ -918,7 +919,7 @@
 /area/shuttle/escape)
 "sk" = (
 /obj/item/gun/ballistic/revolver/reverse{
-	name = "\improper Hilarious Revolver";
+	name = "\improper Bananium Revolver";
 	desc = "A suspicious revolver. Eminates a strange, funny aura.";
 	color = "#FFFF00"
 	},
@@ -982,9 +983,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "tF" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/structure/table/reinforced/plastitaniumglass,
@@ -992,6 +990,7 @@
 	pixel_x = -3;
 	pixel_y = 9
 	},
+/obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "tS" = (
@@ -1120,12 +1119,12 @@
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/red/corner,
 /obj/machinery/door/window/survival_pod{
 	name = "Shuttle Armory";
 	req_access = list("security");
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/red/line,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "wF" = (
@@ -1626,7 +1625,8 @@
 /area/shuttle/escape)
 "Fp" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Brig"
+	name = "Escape Shuttle Brig";
+	safe = 0
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
@@ -1954,7 +1954,8 @@
 /area/shuttle/escape)
 "LH" = (
 /obj/machinery/door/airlock/security/glass{
-	name = "Escape Shuttle Brig"
+	name = "Escape Shuttle Brig";
+	safe = 0
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
@@ -2508,6 +2509,7 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/corner,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "Wo" = (
@@ -3168,7 +3170,7 @@ HA
 jW
 Wc
 bE
-jK
+Hs
 iP
 xi
 OQ
@@ -3214,7 +3216,7 @@ Vm
 re
 wf
 tF
-Hs
+AB
 iP
 HW
 BT

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -1,10 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/structure/closet/secure_closet/ert_sec{
+	name = "Emergency response security locker";
+	desc = "A storage unit containing equipment for responding to emergencies."
+	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "ao" = (
@@ -883,6 +884,7 @@
 /area/shuttle/escape)
 "rw" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "rx" = (
@@ -991,6 +993,18 @@
 	pixel_y = 9
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/recharger{
+	active_power_usage = 0;
+	idle_power_usage = 0;
+	use_power = 0;
+	pixel_x = -6;
+	pixel_y = 3
+	},
+/obj/item/storage/box/stingbangs,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 11;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "tS" = (
@@ -1116,15 +1130,16 @@
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "wf" = (
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 1
-	},
 /obj/machinery/door/window/survival_pod{
 	name = "Shuttle Armory";
 	req_access = list("security");
-	dir = 8
+	dir = 8;
+	safe = 0
 	},
-/obj/effect/turf_decal/trimline/red/line,
+/obj/effect/turf_decal/trimline/red/warning,
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "wF" = (
@@ -1271,10 +1286,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "za" = (
-/obj/item/storage/box/handcuffs{
-	pixel_x = -3;
-	pixel_y = 9
-	},
 /obj/machinery/recharger{
 	active_power_usage = 0;
 	idle_power_usage = 0;
@@ -1282,13 +1293,11 @@
 	pixel_x = 38;
 	pixel_y = 3
 	},
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 11;
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
-/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "zm" = (
@@ -1659,7 +1668,8 @@
 "FS" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Cockpit";
-	id_tag = "escape_cockpit_blast"
+	id_tag = "escape_cockpit_blast";
+	safe = 0
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/showroomfloor,
@@ -1818,6 +1828,7 @@
 	pixel_y = 32
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "Jk" = (
@@ -2228,15 +2239,16 @@
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "Sm" = (
-/obj/effect/turf_decal/trimline/red/line,
-/obj/effect/turf_decal/trimline/red/line{
+/obj/machinery/door/window/survival_pod{
+	name = "Officer Seating";
+	req_access = list("security");
+	dir = 4;
+	safe = 0
+	},
+/obj/effect/turf_decal/trimline/red/warning{
 	dir = 1
 	},
-/obj/machinery/door/window/survival_pod{
-	name = "Holding Cell A";
-	req_access = list("security");
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/red/warning,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "So" = (
@@ -2421,9 +2433,10 @@
 /area/shuttle/escape/brig)
 "Vd" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/item/storage/box/stingbangs,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
-/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "Vi" = (

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -4,6 +4,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "ao" = (
@@ -75,7 +76,7 @@
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "ca" = (
-/obj/machinery/vending/cola,
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "cf" = (
@@ -96,9 +97,19 @@
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "cu" = (
-/obj/machinery/vending/cola/red,
-/turf/open/floor/iron/dark/textured_large,
-/area/shuttle/escape)
+/obj/effect/turf_decal/trimline/red/line,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Brig"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape/brig)
 "cz" = (
 /obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 8
@@ -216,6 +227,9 @@
 /obj/machinery/chem_dispenser/drinks{
 	dir = 8
 	},
+/obj/item/storage/box/lethalshot{
+	pixel_y = -13
+	},
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "eI" = (
@@ -243,11 +257,11 @@
 /obj/structure/toilet/secret{
 	dir = 1
 	},
-/obj/machinery/door/window/left/directional/north{
-	name = "restroom"
-	},
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/machinery/door/window/survival_pod{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "fr" = (
@@ -299,6 +313,7 @@
 "fy" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/structure/disposalpipe/segment,
+/obj/item/storage/box/fireworks/dangerous,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "fA" = (
@@ -312,9 +327,6 @@
 /obj/item/reagent_containers/cup/rag{
 	pixel_y = 7
 	},
-/obj/effect/fun_balloon/sentience/emergency_shuttle{
-	group_name = "bar staff on the NTSS Independence"
-	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
@@ -327,8 +339,13 @@
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "fK" = (
-/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /turf/open/floor/plastic,
+/area/shuttle/escape)
+"fP" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/pistol/m1911,
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "gr" = (
 /obj/item/radio/intercom/directional/south,
@@ -370,6 +387,7 @@
 	anchored = 1
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/reagent_containers/cup/glass/waterbottle/large,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "hH" = (
@@ -475,6 +493,7 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/soda_cans/monkey_energy,
 /obj/item/stack/sheet/mineral/coal/ten,
+/obj/item/gun/ballistic/revolver/mateba,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/shuttle/escape)
 "jG" = (
@@ -513,6 +532,7 @@
 "jT" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "jW" = (
@@ -552,10 +572,9 @@
 /turf/open/floor/plastic,
 /area/shuttle/escape/luxury)
 "ku" = (
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	name = "Emergency Surgery";
-	req_access = list("medical")
+/obj/machinery/door/window/survival_pod{
+	req_access = list("medical");
+	dir = 8
 	},
 /turf/open/floor/plastic,
 /area/shuttle/escape)
@@ -776,8 +795,14 @@
 "pz" = (
 /obj/effect/decal/cleanable/confetti,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/gun/ballistic/automatic/pistol/aps,
 /turf/open/ballpit,
 /area/shuttle/escape/luxury)
+"pY" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
 "qd" = (
 /obj/machinery/computer/warrant,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -839,6 +864,7 @@
 /obj/structure/sign/poster/contraband/clown{
 	pixel_y = 35
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "ri" = (
@@ -859,13 +885,14 @@
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "rx" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/item/storage/medkit/regular,
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = 1;
 	pixel_y = 9
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "rO" = (
@@ -890,6 +917,11 @@
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
 "sk" = (
+/obj/item/gun/ballistic/revolver/reverse{
+	name = "\improper Hilarious Revolver";
+	desc = "A suspicious revolver. Eminates a strange, funny aura.";
+	color = "#FFFF00"
+	},
 /turf/open/ballpit,
 /area/shuttle/escape/luxury)
 "so" = (
@@ -950,9 +982,18 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "tF" = (
-/mob/living/simple_animal/hostile/alien/maid/barmaid,
-/turf/open/floor/wood/tile,
-/area/shuttle/escape)
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/box/handcuffs{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape/brig)
 "tS" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -1042,7 +1083,6 @@
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "vI" = (
-/obj/structure/table,
 /obj/machinery/recharger{
 	active_power_usage = 0;
 	idle_power_usage = 0;
@@ -1051,6 +1091,9 @@
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "vL" = (
@@ -1078,6 +1121,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/corner,
+/obj/machinery/door/window/survival_pod{
+	name = "Shuttle Armory";
+	req_access = list("security");
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "wF" = (
@@ -1154,12 +1202,16 @@
 	pixel_y = 2;
 	pixel_x = 7
 	},
+/obj/item/gun/ballistic/automatic/pistol/clandestine{
+	pixel_y = 9
+	},
 /turf/open/floor/eighties,
 /area/shuttle/escape/luxury)
 "xT" = (
-/mob/living/simple_animal/drone/snowflake/bardrone,
-/turf/open/floor/wood/tile,
-/area/shuttle/escape)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape/brig)
 "xU" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/effect/turf_decal/trimline/purple/line{
@@ -1183,8 +1235,9 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/escape)
 "yq" = (
-/obj/machinery/vending/snack/green,
-/turf/open/floor/iron/dark/textured_large,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/revolver/c38,
+/turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "ys" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
@@ -1219,7 +1272,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "za" = (
-/obj/structure/table,
 /obj/item/storage/box/handcuffs{
 	pixel_x = -3;
 	pixel_y = 9
@@ -1236,6 +1288,8 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "zm" = (
@@ -1262,6 +1316,8 @@
 /area/shuttle/escape)
 "Al" = (
 /obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/box/fireworks/dangerous,
+/obj/item/gun/ballistic/shotgun/lethal,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "Aq" = (
@@ -1271,6 +1327,11 @@
 	},
 /turf/open/floor/plastic,
 /area/shuttle/escape/luxury)
+"AA" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted/riot,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
 "AB" = (
 /obj/effect/turf_decal/trimline/red/line,
 /obj/effect/turf_decal/trimline/red/line{
@@ -1310,6 +1371,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,
+/obj/item/gravity_gun,
 /turf/open/floor/iron/showroomfloor,
 /area/shuttle/escape)
 "Bv" = (
@@ -1365,7 +1427,7 @@
 /turf/open/floor/eighties,
 /area/shuttle/escape/luxury)
 "Cw" = (
-/obj/machinery/vending/snack/orange,
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "Cy" = (
@@ -1438,6 +1500,7 @@
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "Ds" = (
+/obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 8
 	},
@@ -1529,11 +1592,11 @@
 	},
 /area/shuttle/escape/brig)
 "EK" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/west,
 /mob/living/simple_animal/bot/medbot{
 	name = "Doctor Patches"
 	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /turf/open/floor/plastic,
 /area/shuttle/escape)
 "EL" = (
@@ -1682,6 +1745,7 @@
 /area/shuttle/escape/brig)
 "HF" = (
 /obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/grenadelauncher,
 /turf/open/floor/eighties,
 /area/shuttle/escape/luxury)
 "HT" = (
@@ -1824,8 +1888,8 @@
 /area/shuttle/escape/brig)
 "Ki" = (
 /obj/machinery/stasis,
-/obj/structure/window/reinforced/spawner/directional/south,
 /obj/item/bedsheet/patriot,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 4
 	},
@@ -1889,14 +1953,17 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "LH" = (
-/obj/machinery/porta_turret/syndicate{
-	faction = list("neutral","silicon","turret");
-	gender = "female";
-	req_access = list("security");
-	dir = 1
+/obj/machinery/door/airlock/security/glass{
+	name = "Escape Shuttle Brig"
 	},
-/turf/closed/wall/mineral/plastitanium,
-/area/shuttle/escape)
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
+/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/shuttle/escape/brig)
 "LM" = (
 /obj/effect/decal/cleanable/confetti,
 /obj/item/a_gift/anything{
@@ -1915,7 +1982,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "Mq" = (
-/obj/structure/window/reinforced/spawner/directional/west,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/item/clothing/suit/apron/surgical,
 /obj/item/clothing/mask/surgical,
@@ -1926,6 +1992,7 @@
 	pixel_y = 29
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 1
 	},
@@ -2045,6 +2112,11 @@
 "OQ" = (
 /turf/open/floor/carpet/blue,
 /area/shuttle/escape/brig)
+"OT" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
 "OU" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 10
@@ -2154,9 +2226,22 @@
 /obj/item/storage/cans/sixsoda,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
+"Sm" = (
+/obj/effect/turf_decal/trimline/red/line,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/obj/machinery/door/window/survival_pod{
+	name = "Holding Cell A";
+	req_access = list("security");
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape/brig)
 "So" = (
 /obj/item/storage/cans/sixbeer,
 /obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/gun/ballistic/revolver/chaplain,
 /turf/open/floor/wood,
 /area/shuttle/escape)
 "Sp" = (
@@ -2334,9 +2419,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "Vd" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/item/storage/box/stingbangs,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "Vi" = (
@@ -2527,7 +2613,7 @@
 /turf/open/floor/iron/white/textured_edge,
 /area/shuttle/escape)
 "YI" = (
-/obj/machinery/vending/liberationstation,
+/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/plastic,
 /area/shuttle/escape/luxury)
 "YN" = (
@@ -2671,8 +2757,8 @@ aG
 uV
 Eg
 uV
-yq
-cu
+Cw
+ca
 uV
 Di
 en
@@ -2689,8 +2775,8 @@ aG
 uV
 Eg
 uV
-nU
-nU
+pY
+fP
 bT
 mw
 mw
@@ -2740,7 +2826,7 @@ xf
 iQ
 nU
 nU
-nU
+OT
 xb
 so
 Od
@@ -2755,7 +2841,7 @@ kd
 kd
 kd
 kd
-LH
+uV
 cf
 WT
 dV
@@ -2784,7 +2870,7 @@ xf
 xf
 xf
 iQ
-nU
+AA
 nU
 nU
 xb
@@ -2806,11 +2892,11 @@ rX
 Vm
 dQ
 iP
-Fp
+LH
 iP
-dQ
+iP
 Vm
-Yv
+xT
 rX
 Sp
 wF
@@ -2898,7 +2984,7 @@ rX
 Pr
 AB
 Vd
-AB
+cu
 iP
 tU
 oH
@@ -2988,7 +3074,7 @@ Ep
 Sp
 Vm
 jT
-AB
+Sm
 vI
 nZ
 SK
@@ -3023,7 +3109,7 @@ xf
 uV
 uV
 uV
-uV
+OK
 "}
 (11,1,1) = {"
 Tw
@@ -3127,7 +3213,7 @@ Sp
 Vm
 re
 wf
-jW
+tF
 Hs
 iP
 HW
@@ -3161,7 +3247,7 @@ xf
 uV
 uV
 uV
-uV
+Et
 "}
 (14,1,1) = {"
 Tw
@@ -3353,7 +3439,7 @@ kd
 kd
 kd
 kd
-LH
+uV
 cf
 Ij
 nb
@@ -3382,7 +3468,7 @@ Lf
 xf
 xf
 xf
-nU
+yq
 jw
 fB
 nU
@@ -3430,8 +3516,8 @@ xf
 iQ
 Lz
 xf
-tF
-xT
+xf
+xf
 xf
 AX
 uV


### PR DESCRIPTION

## About The Pull Request, and why It's Good For The Game

OK!  I remodeled the NTSS Independence, we came on a little strong and it caused a bit more chaos than anticipated.  Dialing it back a bit so the crew can enjoy a slightly less chaotic flight home.

I want people to be able to enjoy the shuttle with a bit less suffering. The changes are as follows:

1. Altered the shuttlebrig, it has its liberation station placed behind a security access door to make it harder to get at the ridiculous guns ("Shuttle Armory"), also it has a cycling airlock to make it slightly harder to tide (probably won't work but what the hell ever).
2. Liberation station in Honk-E-Clown's Mafia Free Playland and Casino has been replaced. I've decided that for the general populace, a random selection of weaker, hand selected/curated guns (notably, with no replacement ammo) should help curtail the incredible levels of violence we experience otherwise.
3. Bar drone and maid removed until further notice, they can be re added when somebody elects to help me with the major issue where they are impervious to destruction so long as they remain on the shuttle(!!!!). This means that they can bait the turrets into committing grievous amounts of friendly fire on the crew., or go on a murder spree



## Images
![image](https://github.com/Monkestation/Monkestation2.0/assets/14065903/4d63cd82-2f94-49af-b970-a80ced8832c8)
![image](https://github.com/Monkestation/Monkestation2.0/assets/14065903/8bc94a2f-7803-41e9-999e-fcf3a29d04cd)




## Changelog


:cl: Kat Blu
balance: Tries to bring NTSS Independence from an 11 to a 9 on the "jesus fuckin christ" scale
/:cl:
