### PR TITLE
Botany QoL, fixes and re-balance

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1662,7 +1662,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 //////////////////////////////////Hydroponics stuff///////////////////////////////
-
+FLAG
 /datum/reagent/plantnutriment
 	name = "Generic Nutriment"
 	description = "Some kind of nutriment. You can't really tell what it is. You should probably report it, along with how you obtained it."
@@ -1679,17 +1679,21 @@
 
 /datum/reagent/plantnutriment/eznutriment
 	name = "E-Z Nutrient"
-	description = "Contains electrolytes. It's what plants crave."
+	description = "Contains electrolytes. It's what plants crave. It makes plants slowly gain potency and yield"
 	color = "#376400" // RBG: 50, 100, 0
 	tox_prob = 5
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
+// gives half the potency of saltpetre, and half the yield of diethylamine
 /datum/reagent/plantnutriment/eznutriment/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray)
 	. = ..()
 	if(chems.has_reagent(src.type, 1))
-		mytray.yieldmod = 1
 		mytray.mutmod = 1
 		myseed.adjust_lifespan(round(chems.get_reagent_amount(type) * 0.15))
+		if(myseed)
+			myseed.adjust_potency(round(chems.get_reagent_amount * 0.1))
+			myseed.adjust_yield(round(chems.get_reagent_amount(src.type) * 0.1))
+
 
 /datum/reagent/plantnutriment/left4zednutriment
 	name = "Left 4 Zed"
@@ -1706,7 +1710,7 @@
 
 /datum/reagent/plantnutriment/robustharvestnutriment
 	name = "Robust Harvest"
-	description = "Very potent nutriment that slows plants from mutating."
+	description = "Very potent nutriment that slows plants from mutating whilst also making them grow faster."
 	color = "#9D9D00" // RBG: 157, 157, 0
 	tox_prob = 8
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
@@ -1729,6 +1733,8 @@
 	if(chems.has_reagent(src.type, 1))
 		mytray.yieldmod = 1.3
 		mytray.mutmod = 0
+		myseed.adjust_maturation(round(chems.get_reagent_amount(src.type) * 0.1))
+		myseed.adjust_production(round(chems.get_reagent_amount(src.type) * 0.05))
 
 /datum/reagent/plantnutriment/endurogrow
 	name = "Enduro Grow"
@@ -2260,7 +2266,7 @@
 		generated_values["yield_change"] = (amount * (rand(0,2) * 0.2))
 		return generated_values
 
-// Saltpetre is used for gardening IRL, to simplify highly, it speeds up growth and strengthens plants
+// Saltpetre is used for gardening IRL, to simplify highly, it raises potency and lowers production
 /datum/reagent/saltpetre/on_hydroponics_apply(obj/item/seeds/myseed, datum/reagents/chems, obj/machinery/hydroponics/mytray, mob/user)
 	. = ..()
 	if(chems.has_reagent(src.type, 1))

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1691,7 +1691,7 @@ FLAG
 		mytray.mutmod = 1
 		myseed.adjust_lifespan(round(chems.get_reagent_amount(type) * 0.15))
 		if(myseed)
-			myseed.adjust_potency(round(chems.get_reagent_amount * 0.1))
+			myseed.adjust_potency(round(chems.get_reagent_amount(src.type) * 0.1))
 			myseed.adjust_yield(round(chems.get_reagent_amount(src.type) * 0.1))
 
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1662,7 +1662,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 //////////////////////////////////Hydroponics stuff///////////////////////////////
-FLAG
+
 /datum/reagent/plantnutriment
 	name = "Generic Nutriment"
 	description = "Some kind of nutriment. You can't really tell what it is. You should probably report it, along with how you obtained it."

--- a/monkestation/code/modules/hydroponics/machines/composter.dm
+++ b/monkestation/code/modules/hydroponics/machines/composter.dm
@@ -16,10 +16,21 @@
 	if(istype(attacking_item, /obj/item/food/grown))
 		compost(attacking_item)
 
+	if(istype(attacking_item, /obj/item/storage/bag)) // covers any kind of bag that has a compostible item
+		var/obj/item/storage/bag/bag = attacking_item
+		for(var/obj/item/food/grown/item in bag.contents)
+			if(bag.atom_storage.attempt_remove(item, src))
+				compost(item)
+
+		for(var/obj/item/seeds/item in bag.contents)
+			if(bag.atom_storage.attempt_remove(item, src))
+				compost(item)
+		to_chat(user, span_info("You empty \the [bag] into \the [src]."))
+
 /obj/machinery/composters/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
 	if(biomatter < 40)
-		to_chat(user, span_notice("No enough biomatter to produce Bio-Cube"))
+		to_chat(user, span_notice("Not enough biomatter to produce Bio-Cube"))
 		return
 	new /obj/item/bio_cube(get_turf(src))
 	biomatter -= 40
@@ -60,10 +71,14 @@
 	icon_state = "bio_cube"
 
 	var/total_duration = 60 SECONDS
-	var/scale_multiplier = 1
+	var/scale_multiplier = 0.6
 
 
-/obj/item/bio_cube/attacked_by(obj/item/attacking_item, mob/living/user)
+/obj/item/bio_cube/update_desc()
+	. = ..()
+	desc = "A cube made of pure biomatter, it seems to be bigger than normal making it last [total_duration / 600] minutes. Does wonders on plant trays."
+
+/obj/item/bio_cube/attackby(obj/item/attacking_item, mob/living/user)
 	. = ..()
 	if(istype(attacking_item, /obj/item/bio_cube))
 		var/obj/item/bio_cube/attacking_cube = attacking_item


### PR DESCRIPTION
## About The Pull Request

Everything tested locally, should work just fine

**QOL:**
- Plant bags can now be clicked on a composter to throw all the items that can be composted into it, heard some people wanting that

**fixes:**
- Fixed the bio cubes by making them call attackby instead of attacked_by, because for some reason attacked_by didnt do anything at all

**balance:**
- Made EZ-nutriment and Robust-harvest worth using again by making them 50% weaker than their counter-parts, non-botanists rejoice.


## Why It's Good For The Game

**QOL:**
- Plant bags: QoL's always good to have.

**fixes:**
- Not working code is bad for the codebase, i presume

**balance:**
- EZ-nutriment and robust-harvest were not worth using in the slightest, now non-botanists can actually grow something, but its still better to use diethylamine, ammonia and saltpetre.

## Changelog

:cl:
qol: added mass composting by clicking the composter with a bag
balance: made EZ-nutriment and robust harvest worth using again
fix: fixed the bio cubes smashing together
/:cl:
