### PR TITLE
Stops the constant random teslooses and singulooses by making smes immune to emps

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -393,19 +393,7 @@
 
 /obj/machinery/power/smes/emp_act(severity)
 	. = ..()
-	if(. & EMP_PROTECT_SELF)
-		return
-	input_attempt = rand(0,1)
-	inputting = input_attempt
-	output_attempt = rand(0,1)
-	outputting = output_attempt
-	output_level = rand(0, output_level_max)
-	input_level = rand(0, input_level_max)
-	charge -= 1e6/severity
-	if (charge < 0)
-		charge = 0
-	update_appearance()
-	log_smes()
+	return //monke edit: removed to prevent random singulooses/teslooses
 
 /obj/machinery/power/smes/engineering
 	charge = 2.5e6 // Engineering starts with some charge for singulo //sorry little one, singulo as engine is gone


### PR DESCRIPTION

## About The Pull Request
Makes smes immune to apcs

## Why It's Good For The Game
Apparently teslas, even with grounding rods, and singulos will emp the smes. This will cause the smes to stop outputting to the singulo/tesla, resulting in it loosing, which sucks.

## Changelog
:cl:
balance: SMES are now emp immune
/:cl:
