### PR TITLE
Departmental Lathe Replacements

### DIFF
--- a/monkestation/code/modules/cargo/crates/engineering.dm
+++ b/monkestation/code/modules/cargo/crates/engineering.dm
@@ -26,3 +26,83 @@
 	cost = CARGO_CRATE_VALUE * 10
 	contains = list(/obj/item/vent_package = 5)
 	crate_name = "engineering vent crate"
+
+/datum/supply_pack/engineering/servicefab
+	name = "Service Techfab Replacement"
+	desc = "You're telling me botany broke it with a lemon?"
+	cost = CARGO_CRATE_VALUE * 50
+	access_view = ACCESS_HOP
+	contains = list(/obj/item/circuitboard/machine/protolathe/department/service,
+					/obj/item/stock_parts/matter_bin/adv = 2,
+					/obj/item/stock_parts/manipulator/nano = 2,
+					/obj/item/reagent_containers/cup/beaker = 2,
+					/obj/item/stack/sheet/iron/five,
+					/obj/item/stack/cable_coil/five)
+	crate_name = "Replacement Service Techfab"
+
+/datum/supply_pack/engineering/secfab
+	name = "Security Techfab Replacement"
+	desc = "This is coming out of the donut budget."
+	cost = CARGO_CRATE_VALUE * 50
+	access_view = ACCESS_HOS
+	contains = list(/obj/item/circuitboard/machine/protolathe/department/security,
+					/obj/item/stock_parts/matter_bin/adv = 2,
+					/obj/item/stock_parts/manipulator/nano = 2,
+					/obj/item/reagent_containers/cup/beaker = 2,
+					/obj/item/stack/sheet/iron/five,
+					/obj/item/stack/cable_coil/five
+					)
+	crate_name = "Replacement Security Techfab"
+
+/datum/supply_pack/engineering/cargofab
+	name = "Cargo Techfab Replacement"
+	desc = "You better not lodge a mosin bullet in this one too."
+	cost = CARGO_CRATE_VALUE * 50
+	access_view = ACCESS_QM
+	contains = list(/obj/item/circuitboard/machine/protolathe/department/cargo,
+					/obj/item/stock_parts/matter_bin/adv = 2,
+					/obj/item/stock_parts/manipulator/nano = 2,
+					/obj/item/reagent_containers/cup/beaker = 2,
+					/obj/item/stack/sheet/iron/five,
+					/obj/item/stack/cable_coil/five)
+	crate_name = "Replacement Cargo Techfab"
+
+/datum/supply_pack/engineering/medfab
+	name = "Medical Techfab Replacement"
+	desc = "The chemist you say. Meth you say."
+	cost = CARGO_CRATE_VALUE * 50
+	access_view = ACCESS_CMO
+	contains = list(/obj/item/circuitboard/machine/protolathe/department/medical,
+					/obj/item/stock_parts/matter_bin/adv = 2,
+					/obj/item/stock_parts/manipulator/nano = 2,
+					/obj/item/reagent_containers/cup/beaker = 2,
+					/obj/item/stack/sheet/iron/five,
+					/obj/item/stack/cable_coil/five)
+	crate_name = "Replacement Medical Techfab"
+
+/datum/supply_pack/engineering/engilathe
+	name = "Engineering Protolathe Replacement"
+	desc = "You said the atmospherics department melted the last one?"
+	cost = CARGO_CRATE_VALUE * 50
+	access_view = ACCESS_CE
+	contains = list(/obj/item/circuitboard/machine/protolathe/department/engineering,
+					/obj/item/stock_parts/matter_bin/adv = 2,
+					/obj/item/stock_parts/manipulator/nano = 2,
+					/obj/item/reagent_containers/cup/beaker = 2,
+					/obj/item/stack/sheet/iron/five,
+					/obj/item/stack/cable_coil/five)
+	crate_name = "Replacement Engineering Protolathe"
+
+/datum/supply_pack/engineering/scilathe
+	name = "Science Protolathe Replacement"
+	desc = "Try not to feed this one into the E.X.P.E.R.I.M.E.N.T.O.R. yeah?"
+	cost = CARGO_CRATE_VALUE * 50
+	access_view = ACCESS_RD
+	contains = list(/obj/item/circuitboard/machine/protolathe/department/science,
+					/obj/item/stock_parts/matter_bin/adv = 2,
+					/obj/item/stock_parts/manipulator/nano = 2,
+					/obj/item/reagent_containers/cup/beaker = 2,
+					/obj/item/stack/sheet/iron/five,
+					/obj/item/stack/cable_coil/five
+					)
+	crate_name = "Replacement Science Protolathe"

--- a/monkestation/code/modules/cargo/crates/engineering.dm
+++ b/monkestation/code/modules/cargo/crates/engineering.dm
@@ -39,6 +39,7 @@
 					/obj/item/stack/sheet/iron/five,
 					/obj/item/stack/cable_coil/five)
 	crate_name = "Replacement Service Techfab"
+	crate_type = /obj/structure/closet/crate/secure/engineering
 
 /datum/supply_pack/engineering/secfab
 	name = "Security Techfab Replacement"
@@ -53,6 +54,7 @@
 					/obj/item/stack/cable_coil/five
 					)
 	crate_name = "Replacement Security Techfab"
+	crate_type = /obj/structure/closet/crate/secure/engineering
 
 /datum/supply_pack/engineering/cargofab
 	name = "Cargo Techfab Replacement"
@@ -66,6 +68,7 @@
 					/obj/item/stack/sheet/iron/five,
 					/obj/item/stack/cable_coil/five)
 	crate_name = "Replacement Cargo Techfab"
+	crate_type = /obj/structure/closet/crate/secure/engineering
 
 /datum/supply_pack/engineering/medfab
 	name = "Medical Techfab Replacement"
@@ -79,6 +82,7 @@
 					/obj/item/stack/sheet/iron/five,
 					/obj/item/stack/cable_coil/five)
 	crate_name = "Replacement Medical Techfab"
+	crate_type = /obj/structure/closet/crate/secure/engineering
 
 /datum/supply_pack/engineering/engilathe
 	name = "Engineering Protolathe Replacement"
@@ -92,6 +96,7 @@
 					/obj/item/stack/sheet/iron/five,
 					/obj/item/stack/cable_coil/five)
 	crate_name = "Replacement Engineering Protolathe"
+	crate_type = /obj/structure/closet/crate/secure/engineering
 
 /datum/supply_pack/engineering/scilathe
 	name = "Science Protolathe Replacement"
@@ -106,3 +111,4 @@
 					/obj/item/stack/cable_coil/five
 					)
 	crate_name = "Replacement Science Protolathe"
+	crate_type = /obj/structure/closet/crate/secure/engineering

--- a/monkestation/code/modules/cargo/crates/engineering.dm
+++ b/monkestation/code/modules/cargo/crates/engineering.dm
@@ -31,7 +31,7 @@
 	name = "Service Techfab Replacement"
 	desc = "You're telling me botany broke it with a lemon?"
 	cost = CARGO_CRATE_VALUE * 50
-	access_view = ACCESS_HOP
+	access = ACCESS_HOP
 	contains = list(/obj/item/circuitboard/machine/protolathe/department/service,
 					/obj/item/stock_parts/matter_bin/adv = 2,
 					/obj/item/stock_parts/manipulator/nano = 2,
@@ -45,7 +45,7 @@
 	name = "Security Techfab Replacement"
 	desc = "This is coming out of the donut budget."
 	cost = CARGO_CRATE_VALUE * 50
-	access_view = ACCESS_HOS
+	access = ACCESS_HOS
 	contains = list(/obj/item/circuitboard/machine/protolathe/department/security,
 					/obj/item/stock_parts/matter_bin/adv = 2,
 					/obj/item/stock_parts/manipulator/nano = 2,
@@ -60,7 +60,7 @@
 	name = "Cargo Techfab Replacement"
 	desc = "You better not lodge a mosin bullet in this one too."
 	cost = CARGO_CRATE_VALUE * 50
-	access_view = ACCESS_QM
+	access = ACCESS_QM
 	contains = list(/obj/item/circuitboard/machine/protolathe/department/cargo,
 					/obj/item/stock_parts/matter_bin/adv = 2,
 					/obj/item/stock_parts/manipulator/nano = 2,
@@ -74,7 +74,7 @@
 	name = "Medical Techfab Replacement"
 	desc = "The chemist you say. Meth you say."
 	cost = CARGO_CRATE_VALUE * 50
-	access_view = ACCESS_CMO
+	access = ACCESS_CMO
 	contains = list(/obj/item/circuitboard/machine/protolathe/department/medical,
 					/obj/item/stock_parts/matter_bin/adv = 2,
 					/obj/item/stock_parts/manipulator/nano = 2,
@@ -88,7 +88,7 @@
 	name = "Engineering Protolathe Replacement"
 	desc = "You said the atmospherics department melted the last one?"
 	cost = CARGO_CRATE_VALUE * 50
-	access_view = ACCESS_CE
+	access = ACCESS_CE
 	contains = list(/obj/item/circuitboard/machine/protolathe/department/engineering,
 					/obj/item/stock_parts/matter_bin/adv = 2,
 					/obj/item/stock_parts/manipulator/nano = 2,
@@ -102,7 +102,7 @@
 	name = "Science Protolathe Replacement"
 	desc = "Try not to feed this one into the E.X.P.E.R.I.M.E.N.T.O.R. yeah?"
 	cost = CARGO_CRATE_VALUE * 50
-	access_view = ACCESS_RD
+	access = ACCESS_RD
 	contains = list(/obj/item/circuitboard/machine/protolathe/department/science,
 					/obj/item/stock_parts/matter_bin/adv = 2,
 					/obj/item/stock_parts/manipulator/nano = 2,

--- a/monkestation/code/modules/cargo/crates/service.dm
+++ b/monkestation/code/modules/cargo/crates/service.dm
@@ -16,3 +16,15 @@
 					/obj/item/key/janitor)
 	crate_name = "janicart crate"
 	crate_type = /obj/structure/closet/crate/large
+
+/datum/supply_pack/service/birthday
+	name = "Birthday Bash Pack"
+	desc = "This is for that corgi, isn't it..."
+	cost = CARGO_CRATE_VALUE * 6
+	contains = list(/obj/item/toy/balloon = 5,
+					/obj/item/reagent_containers/spray/chemsprayer/party = 2,
+					/obj/item/clothing/head/costume/party = 5,
+					/obj/item/food/cake/birthday,
+					/obj/item/plate/small = 5,
+					/obj/item/a_gift/anything)
+	crate_name = "Birthday Crate"


### PR DESCRIPTION
## About The Pull Request
This adds a way for departments to get a new lathe or techfab in with cooperation from cargo. Additionally, adds the birthday celebration crate.

## Why It's Good For The Game
Allows departments to get back on their feet should the worst happen, or allow cargo to spend excess budget on something fun and powerful. Lets you celebrate birthdays or throw parties with the help of cargo.

## Changelog
Adds departmental lathe/techfabs at 10,000 credits apiece locked to the relevant head access, and also adds a birthday crate for those wishing to celebrate a birthday!

:cl:
add: new crates for departmental lathes, and a birthday crate.
/:cl:

