### PR TITLE
Fixes Duke Having The Wrong Recall Shuttle Line

### DIFF
--- a/monkestation/code/datums/announcers/duke.dm
+++ b/monkestation/code/datums/announcers/duke.dm
@@ -26,7 +26,7 @@
 						ANNOUNCER_RADIATION = 'monkestation/sound/ai/duke/radiation.ogg',
 						ANNOUNCER_SHUTTLECALLED = 'monkestation/sound/ai/duke/shuttle_call.ogg',
 						ANNOUNCER_SHUTTLEDOCK = 'monkestation/sound/ai/duke/shuttle_arrive.ogg',
-						ANNOUNCER_SHUTTLERECALLED = 'sound/ai/intern/shuttlerecalled.ogg',
+						ANNOUNCER_SHUTTLERECALLED = 'monkestation/sound/ai/duke/shuttle_recall.ogg',
 						ANNOUNCER_SPANOMALIES = 'monkestation/sound/ai/duke/spanomalies.ogg')
 
 	custom_alert_message = "<br><span class='alert'>Please stand by for an important message from the Duke.</span><br>"


### PR DESCRIPTION

## About The Pull Request
Fixes duke using the intern recall shuttle line, instead of his own.
## Why It's Good For The Game
The intern is not the duke
## Changelog
:cl:
fix: Fixed the recall shuttle announcement line for Duke
/:cl:
