### PR TITLE
Reduces Maint Drone Time

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -513,7 +513,7 @@ MAXFINE 2000
 #DRONE_REQUIRED_ROLE Silicon
 
 ## How many played hours of DRONE_REQUIRED_ROLE required to be a Maintenance Done
-#DRONE_ROLE_PLAYTIME 14
+#DRONE_ROLE_PLAYTIME 2
 
 ## Whether native FoV is enabled for all people.
 #NATIVE_FOV


### PR DESCRIPTION

## About The Pull Request
Reduces the amount of silicon hours needed to play maint drone down to 2 hours (from 14), the same needed to play AI.
## Why It's Good For The Game
14 hours is ridiculous, especially considering no other job requires this amount of play time to play. This would also make maint drones a bit more common, due to not needing such a massive time commitment to silicons to play.
## Changelog
:cl:
config: Reduced the amount of time required to play maintanence drones from 14 hours to 2 hours
/:cl:
