### PR TITLE
Re-adds Fraxinellas to botany

### DIFF
--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -90,7 +90,7 @@
 	species = "geranium"
 	plantname = "Geranium Plants"
 	product = /obj/item/food/grown/poppy/geranium
-	possible_mutations = list(/datum/hydroponics/plant_mutation/fraxinella)
+	possible_mutations = list(/datum/hydroponics/plant_mutation/fraxinella) //monkestation edit
 
 /obj/item/food/grown/poppy/geranium
 	seed = /obj/item/seeds/poppy/geranium

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -90,7 +90,7 @@
 	species = "geranium"
 	plantname = "Geranium Plants"
 	product = /obj/item/food/grown/poppy/geranium
-	mutatelist = list(/obj/item/seeds/poppy/geranium/fraxinella)
+	possible_mutations = list(/datum/hydroponics/plant_mutation/fraxinella)
 
 /obj/item/food/grown/poppy/geranium
 	seed = /obj/item/seeds/poppy/geranium

--- a/monkestation/code/modules/hydroponics/mutations/base.dm
+++ b/monkestation/code/modules/hydroponics/mutations/base.dm
@@ -172,6 +172,11 @@
 	created_product = /obj/item/food/grown/poppy/geranium
 	created_seed = /obj/item/seeds/poppy/geranium
 
+/datum/hydroponics/plant_mutation/fraxinella
+	mutates_from = list(/obj/item/seeds/poppy/geranium)
+	created_product = /obj/item/food/grown/poppy/geranium/fraxinella
+	created_seed = /obj/item/seeds/poppy/geranium/fraxinella
+
 /datum/hydroponics/plant_mutation/trumpet
 	mutates_from = list(/obj/item/seeds/poppy/lily)
 	created_product = /obj/item/food/grown/trumpet


### PR DESCRIPTION

## About The Pull Request

Lost in the bowels of TG hydroponics hell is the Fraxinella, a (debatably gorgeous) mutation of Geraniums that produces oil and ferments into ash. This simple PR re-introduces Fraxinellas already in the codebase to the plant mutation list, using the current Monkestation hydroponics changes created by Dwasint.

## Why It's Good For The Game

Botany, and service as a whole, benefits from the service plumbing constructor, but generally relies on Chemistry to produce plastic. Bringing Fraxinellas to the table provides another opportunity for botanists to ~~destroy~~ help the station by giving them an avenue to produce their own plastic (Fraxinellas + Nettles), which is particularly useful for plumbing used by Engineering, Medical, and Service. Plus whatever convoluted plans they have that involve oil and/or ash. Surely it couldn't go wrong?

## Changelog

:cl:
add: existing Fraxinella mutation to the current plant mutation list

/:cl:

