### PR TITLE
Changes the balance for some quirks, Blocks xenos from sprinting, and fixes some quirk bugs and an IPC exploit.

### DIFF
--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -1132,12 +1132,12 @@
 	name = "Mute"
 	desc = "For some reason you are completely unable to speak."
 	icon = "volume-xmark"
-	value = -4
+	value = -6 //monkestation change 4->6
 	mob_trait = TRAIT_MUTE
 	gain_text = span_danger("You find yourself unable to speak!")
 	lose_text = span_notice("You feel a growing strength in your vocal chords.")
 	medical_record_text = "The patient is unable to use their voice in any capacity."
-	hardcore_value = 4
+	hardcore_value = 6 //monkestation change 4->6
 
 /datum/quirk/body_purist
 	name = "Body Purist"
@@ -1245,3 +1245,25 @@
 /datum/quirk/kleptomaniac/remove()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.cure_trauma_type(/datum/brain_trauma/mild/kleptomania, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/foreigner
+	name = "Foreigner"
+	desc = "You're not from around here. You don't know Galactic Common!"
+	icon = "language"
+	value = -2
+	gain_text = span_notice("The words being spoken around you don't make any sense.")
+	lose_text = span_notice("You've developed fluency in Galactic Common.")
+	medical_record_text = "Patient does not speak Galactic Common and may require an interpreter."
+	mail_goodies = list(/obj/item/taperecorder) // for translation
+
+/datum/quirk/foreigner/add(client/client_source)
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	human_holder.add_blocked_language(/datum/language/common)
+	if(ishumanbasic(human_holder))
+		human_holder.grant_language(/datum/language/uncommon)
+
+/datum/quirk/foreigner/remove()
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	human_holder.remove_blocked_language(/datum/language/common)
+	if(ishumanbasic(human_holder))
+		human_holder.remove_language(/datum/language/uncommon)

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -324,6 +324,15 @@
 	hardcore_value = 4
 	mail_goodies = list(/obj/effect/spawner/random/medical/minor_healing)
 
+/datum/quirk/light_drinker/add() //monkestation addition
+	if(isipc(quirk_holder))
+		quirk_holder.physiology.brute_mod *= 1.3
+		quirk_holder.physiology.burn_mod *= 1.3
+
+/datum/quirk/light_drinker/post_add() //monkestation addition
+	if(isipc(quirk_holder))
+		to_chat(quirk_holder, span_boldnotice("Your chassis feels frail."))
+
 /datum/quirk/heavy_sleeper
 	name = "Heavy Sleeper"
 	desc = "You sleep like a rock! Whenever you're put to sleep or knocked unconscious, you take a little bit longer to wake up."
@@ -374,6 +383,15 @@
 	medical_record_text = "Patient demonstrates a low tolerance for alcohol. (Wimp)"
 	hardcore_value = 3
 	mail_goodies = list(/obj/item/reagent_containers/cup/glass/waterbottle)
+
+/datum/quirk/light_drinker/add() //monkestation addition
+	if(isipc(quirk_holder))
+		quirk_holder.physiology.brute_mod *= 1.1
+		quirk_holder.physiology.burn_mod *= 1.1
+
+/datum/quirk/light_drinker/post_add() //monkestation addition
+	if(isipc(quirk_holder))
+		to_chat(quirk_holder, span_boldnotice("Your chassis feels very slightly weaker."))
 
 /datum/quirk/item_quirk/nearsighted
 	name = "Nearsighted"
@@ -544,6 +562,11 @@
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_CHANGES_APPEARANCE
 	mail_goodies = list(/obj/item/weldingtool/mini, /obj/item/stack/cable_coil/five)
 
+/datum/quirk/prosthetic_limb/add() //monkestation addition
+	if(isipc(quirk_holder))
+		quirk_holder.physiology.brute_mod *= 1.15
+		quirk_holder.physiology.burn_mod *= 1.15
+
 /datum/quirk/prosthetic_limb/add_unique(client/client_source)
 	var/limb_slot = pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
 	var/mob/living/carbon/human/human_holder = quirk_holder
@@ -566,6 +589,8 @@
 /datum/quirk/prosthetic_limb/post_add()
 	to_chat(quirk_holder, span_boldannounce("Your [slot_string] has been replaced with a surplus prosthetic. It is fragile and will easily come apart under duress. Additionally, \
 	you need to use a welding tool and cables to repair it, instead of bruise packs and ointment."))
+	if(isipc(quirk_holder)) //monkestation addition
+		to_chat(quirk_holder, span_boldnotice("Your chassis feels slightly weaker."))
 
 /datum/quirk/quadruple_amputee
 	name = "Quadruple Amputee"
@@ -575,6 +600,11 @@
 	medical_record_text = "During physical examination, patient was found to have all prosthetic limbs."
 	hardcore_value = 6
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_CHANGES_APPEARANCE
+
+/datum/quirk/quadruple_amputee/add() //monkestation addition
+	if(isipc(quirk_holder))
+		quirk_holder.physiology.brute_mod *= 1.3
+		quirk_holder.physiology.burn_mod *= 1.3
 
 /datum/quirk/quadruple_amputee/add_unique(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
@@ -586,6 +616,9 @@
 /datum/quirk/quadruple_amputee/post_add()
 	to_chat(quirk_holder, span_boldannounce("All your limbs have been replaced with surplus prosthetics. They are fragile and will easily come apart under duress. Additionally, \
 	you need to use a welding tool and cables to repair them, instead of bruise packs and ointment."))
+	if(isipc(quirk_holder)) //monkestation addition
+		to_chat(quirk_holder, span_boldnotice("Your chassis feels frail."))
+
 
 /datum/quirk/pushover
 	name = "Pushover"
@@ -922,6 +955,11 @@
 	var/list/blacklist = list(/datum/reagent/medicine/c2,/datum/reagent/medicine/epinephrine,/datum/reagent/medicine/adminordrazine,/datum/reagent/medicine/omnizine/godblood,/datum/reagent/medicine/cordiolis_hepatico,/datum/reagent/medicine/synaphydramine,/datum/reagent/medicine/diphenhydramine)
 	var/allergy_string
 
+/datum/quirk/item_quirk/allergic/add() //monkestation addition
+	if(isipc(quirk_holder))
+		quirk_holder.physiology.brute_mod *= 1.3
+		quirk_holder.physiology.burn_mod *= 1.3
+
 /datum/quirk/item_quirk/allergic/add_unique(client/client_source)
 	var/list/chem_list = subtypesof(/datum/reagent/medicine) - blacklist
 	var/list/allergy_chem_names = list()
@@ -943,6 +981,8 @@
 /datum/quirk/item_quirk/allergic/post_add()
 	quirk_holder.add_mob_memory(/datum/memory/key/quirk_allergy, allergy_string = allergy_string)
 	to_chat(quirk_holder, span_boldnotice("You are allergic to [allergy_string], make sure not to consume any of these!"))
+	if(isipc(quirk_holder)) //monkestation addition
+		to_chat(quirk_holder, span_boldnotice("Your chassis feels frail."))
 
 /datum/quirk/item_quirk/allergic/process(seconds_per_tick)
 	if(!iscarbon(quirk_holder))
@@ -1170,7 +1210,7 @@
 	icon = "diamond-exclamation"
 	//All effects are handled directly in butts.dm
 
-/datum/quirk/kleptomaniac
+/datum/quirk/kleptomaniac //Monkestation addition
 	name = "Kleptomaniac"
 	desc = "The station's just full of free stuff!  Nobody would notice if you just... took it, right?"
 	mob_trait = TRAIT_KLEPTOMANIAC

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -325,9 +325,13 @@
 	mail_goodies = list(/obj/effect/spawner/random/medical/minor_healing)
 
 /datum/quirk/light_drinker/add() //monkestation addition
+	if(!iscarbon(quirk_holder))
+		return
+
+	var/mob/living/carbon/human/human_quirk_holder = quirk_holder
 	if(isipc(quirk_holder))
-		quirk_holder.physiology.brute_mod *= 1.3
-		quirk_holder.physiology.burn_mod *= 1.3
+		human_quirk_holder.physiology.brute_mod *= 1.3
+		human_quirk_holder.physiology.burn_mod *= 1.3
 
 /datum/quirk/light_drinker/post_add() //monkestation addition
 	if(isipc(quirk_holder))
@@ -385,9 +389,13 @@
 	mail_goodies = list(/obj/item/reagent_containers/cup/glass/waterbottle)
 
 /datum/quirk/light_drinker/add() //monkestation addition
+	if(!iscarbon(quirk_holder))
+		return
+
+	var/mob/living/carbon/human/human_quirk_holder = quirk_holder
 	if(isipc(quirk_holder))
-		quirk_holder.physiology.brute_mod *= 1.1
-		quirk_holder.physiology.burn_mod *= 1.1
+		human_quirk_holder.physiology.brute_mod *= 1.1
+		human_quirk_holder.physiology.burn_mod *= 1.1
 
 /datum/quirk/light_drinker/post_add() //monkestation addition
 	if(isipc(quirk_holder))
@@ -563,9 +571,13 @@
 	mail_goodies = list(/obj/item/weldingtool/mini, /obj/item/stack/cable_coil/five)
 
 /datum/quirk/prosthetic_limb/add() //monkestation addition
+	if(!iscarbon(quirk_holder))
+		return
+
+	var/mob/living/carbon/human/human_quirk_holder = quirk_holder
 	if(isipc(quirk_holder))
-		quirk_holder.physiology.brute_mod *= 1.15
-		quirk_holder.physiology.burn_mod *= 1.15
+		human_quirk_holder.physiology.brute_mod *= 1.15
+		human_quirk_holder.physiology.burn_mod *= 1.15
 
 /datum/quirk/prosthetic_limb/add_unique(client/client_source)
 	var/limb_slot = pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG)
@@ -602,9 +614,13 @@
 	quirk_flags = QUIRK_HUMAN_ONLY|QUIRK_CHANGES_APPEARANCE
 
 /datum/quirk/quadruple_amputee/add() //monkestation addition
+	if(!iscarbon(quirk_holder))
+		return
+
+	var/mob/living/carbon/human/human_quirk_holder = quirk_holder
 	if(isipc(quirk_holder))
-		quirk_holder.physiology.brute_mod *= 1.3
-		quirk_holder.physiology.burn_mod *= 1.3
+		human_quirk_holder.physiology.brute_mod *= 1.3
+		human_quirk_holder.physiology.burn_mod *= 1.3
 
 /datum/quirk/quadruple_amputee/add_unique(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder
@@ -956,9 +972,13 @@
 	var/allergy_string
 
 /datum/quirk/item_quirk/allergic/add() //monkestation addition
+	if(!iscarbon(quirk_holder))
+		return
+
+	var/mob/living/carbon/human/human_quirk_holder = quirk_holder
 	if(isipc(quirk_holder))
-		quirk_holder.physiology.brute_mod *= 1.3
-		quirk_holder.physiology.burn_mod *= 1.3
+		human_quirk_holder.physiology.brute_mod *= 1.3
+		human_quirk_holder.physiology.burn_mod *= 1.3
 
 /datum/quirk/item_quirk/allergic/add_unique(client/client_source)
 	var/list/chem_list = subtypesof(/datum/reagent/medicine) - blacklist

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -634,12 +634,9 @@
 	added_trama_ref = WEAKREF(added_trauma)
 
 /datum/quirk/insanity/post_add()
-	if(!quirk_holder.mind || quirk_holder.mind.special_role)
-		return
-	// I don't /think/ we'll need this, but for newbies who think "roleplay as insane" = "license to kill",
-	// it's probably a good thing to have.
-	to_chat(quirk_holder, span_big(span_bold(span_info("Please note that your [lowertext(name)] does NOT give you the right to attack people or otherwise cause any interference to \
-		the round. You are not an antagonist, and the rules will treat you the same as other crewmembers."))))
+	var/rds_policy = get_policy("[type]") || "Please note that your [lowertext(name)] does NOT give you any additional right to attack people or cause chaos."
+	// I don't /think/ we'll need this, but for newbies who think "roleplay as insane" = "license to kill", it's probably a good thing to have.
+	to_chat(quirk_holder, span_big(span_info(rds_policy)))s
 
 /datum/quirk/insanity/remove()
 	QDEL_NULL(added_trama_ref)

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -669,7 +669,7 @@
 /datum/quirk/insanity/post_add()
 	var/rds_policy = get_policy("[type]") || "Please note that your [lowertext(name)] does NOT give you any additional right to attack people or cause chaos."
 	// I don't /think/ we'll need this, but for newbies who think "roleplay as insane" = "license to kill", it's probably a good thing to have.
-	to_chat(quirk_holder, span_big(span_info(rds_policy)))s
+	to_chat(quirk_holder, span_big(span_info(rds_policy)))
 
 /datum/quirk/insanity/remove()
 	QDEL_NULL(added_trama_ref)

--- a/code/datums/quirks/negative_quirks.dm
+++ b/code/datums/quirks/negative_quirks.dm
@@ -324,7 +324,7 @@
 	hardcore_value = 4
 	mail_goodies = list(/obj/effect/spawner/random/medical/minor_healing)
 
-/datum/quirk/light_drinker/add() //monkestation addition
+/datum/quirk/frail/add() //monkestation addition
 	if(!iscarbon(quirk_holder))
 		return
 
@@ -333,7 +333,7 @@
 		human_quirk_holder.physiology.brute_mod *= 1.3
 		human_quirk_holder.physiology.burn_mod *= 1.3
 
-/datum/quirk/light_drinker/post_add() //monkestation addition
+/datum/quirk/frail/post_add() //monkestation addition
 	if(isipc(quirk_holder))
 		to_chat(quirk_holder, span_boldnotice("Your chassis feels frail."))
 

--- a/code/datums/quirks/neutral_quirks.dm
+++ b/code/datums/quirks/neutral_quirks.dm
@@ -34,6 +34,7 @@
 	medical_record_text = "Patient suffers from ageusia and is incapable of tasting food or reagents."
 	mail_goodies = list(/obj/effect/spawner/random/food_or_drink/condiment) // but can you taste the salt? CAN YOU?!
 
+/* // monkestation removal, moved to negative quirks
 /datum/quirk/foreigner
 	name = "Foreigner"
 	desc = "You're not from around here. You don't know Galactic Common!"
@@ -55,6 +56,7 @@
 	human_holder.remove_blocked_language(/datum/language/common)
 	if(ishumanbasic(human_holder))
 		human_holder.remove_language(/datum/language/uncommon)
+*/
 
 /datum/quirk/vegetarian
 	name = "Vegetarian"

--- a/code/datums/quirks/positive_quirks.dm
+++ b/code/datums/quirks/positive_quirks.dm
@@ -122,7 +122,7 @@
 
 /datum/quirk/freerunning
 	name = "Freerunning"
-	desc = "You're great at quick moves! You can climb tables more quickly and take no damage from short falls."
+	desc = "You're great at quick moves! You can climb tables more quickly, can sprint longer distances, and take no damage from short falls." //monkestation change added ", can sprint longer distances,"
 	icon = "running"
 	value = 8
 	mob_trait = TRAIT_FREERUNNING
@@ -243,7 +243,7 @@
 	name = "Self-Aware"
 	desc = "You know your body well, and can accurately assess the extent of your wounds."
 	icon = "bone"
-	value = 8
+	value = 6 //monkestation change 8->6
 	mob_trait = TRAIT_SELF_AWARE
 	medical_record_text = "Patient demonstrates an uncanny knack for self-diagnosis."
 	mail_goodies = list(/obj/item/clothing/neck/stethoscope, /obj/item/skillchip/entrails_reader)
@@ -252,7 +252,7 @@
 	name = "Skittish"
 	desc = "You're easy to startle, and hide frequently. Run into a closed locker to jump into it, as long as you have access. You can walk to avoid this."
 	icon = "trash"
-	value = 8
+	value = 4 //monkestation change 8->4
 	mob_trait = TRAIT_SKITTISH
 	medical_record_text = "Patient demonstrates a high aversion to danger and has described hiding in containers out of fear."
 	mail_goodies = list(/obj/structure/closet/cardboard)
@@ -310,11 +310,11 @@
 	medical_record_text = "Patient displays mastery over throwing balls."
 	mail_goodies = list(/obj/item/toy/beach_ball/baseball, /obj/item/toy/basketball, /obj/item/toy/dodgeball)
 
-/datum/quirk/voracious
+/datum/quirk/voracious //monkestation addition
 	name = "Voracious"
 	desc = "Nothing gets between you and your food. You eat faster and can binge on junk food! Being fat suits you just fine. Also allows you to have an additional food buff."
 	icon = "drumstick-bite"
-	value = 4
+	value = 6
 	mob_trait = TRAIT_VORACIOUS
 	gain_text = span_notice("You feel HONGRY.")
 	lose_text = span_danger("You no longer feel HONGRY.")

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -81,7 +81,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 			continue
 		hearing_movable.Hear(null, src, message_language, message, null, spans, message_mods, range)
 
-/atom/movable/proc/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), face_name = FALSE)
+/atom/movable/proc/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), face_name = FALSE, visible_name = FALSE)
 	//This proc uses text() because it is faster than appending strings. Thanks BYOND.
 	//Basic span
 	var/spanpart1 = "<span class='[radio_freq ? get_radio_span(radio_freq) : "game say"]'>"
@@ -94,6 +94,9 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	if(face_name && ishuman(speaker))
 		var/mob/living/carbon/human/H = speaker
 		namepart = "[H.get_face_name()]" //So "fake" speaking like in hallucinations does not give the speaker away if disguised
+	else if(visible_name && ishuman(speaker))
+		var/mob/living/carbon/human/human_speaker = speaker
+		namepart = "[human_speaker.get_visible_name()]"
 	//End name span.
 	var/endspanpart = "</span>"
 

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -29,7 +29,7 @@
 
 	create_internal_organs()
 
-	add_traits(list(TRAIT_NEVER_WOUNDED, TRAIT_VENTCRAWLER_ALWAYS), INNATE_TRAIT)
+	add_traits(list(TRAIT_NEVER_WOUNDED, TRAIT_VENTCRAWLER_ALWAYS, TRAIT_NO_SPRINT), INNATE_TRAIT) //monkestation change: added TRAIT_NO_SPRINT
 
 	. = ..()
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -277,7 +277,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)
 
 	if(HAS_TRAIT(speaker, TRAIT_SIGN_LANG)) //Checks if speaker is using sign language
-		deaf_message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
+		deaf_message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods, FALSE, TRUE)
 
 		if(speaker != src)
 			if(!radio_freq) //I'm about 90% sure there's a way to make this less cluttered

--- a/monkestation/code/datums/components/carbon_sprint.dm
+++ b/monkestation/code/datums/components/carbon_sprint.dm
@@ -55,8 +55,10 @@
 					dust.appear("sprint_cloud_tiny", direct, get_turf(carbon_parent), 0.3 SECONDS)
 					last_dust = world.time
 				sustained_moves = 0
-
-		carbon_parent.stamina.adjust(-STAMINA_SPRINT_COST)
+		if(HAS_TRAIT(src, TRAIT_FREERUNNING))
+			carbon_parent.stamina.adjust(-STAMINA_SPRINT_COST/2)
+		else
+			carbon_parent.stamina.adjust(-STAMINA_SPRINT_COST)
 
 	else if(sprinting)
 		stopSprint()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Foreigner is now a 2 point negative quirk.
Mute is now a 6 point negative quirk, up from 4.
Self aware is now a 6 point positive quirk, down from 8
Voracious is now a 6 point positive quirk, up from 4
Skittish is now a 2 point positive quirk, down from 8
Empath is now a 2 point positive quirk, down from 8
Freerunning now lets you sprint twice as long, and now only costs 6 points.
IPCs are now dissuaded from taking negative quirks that would not effect them.
Xenos can no longer sprint.
FIX: RDS no longer tells you if your a delayed spawn antag
FIX: Sign Language no longer reveals speaker(signer?)'s identity

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Foreigner makes it very difficult to interact with people without a translator or language keys, this at least deserves 2 points.

Mute, at best(if you take signer), requires you to have gloves on to interface with radio(also you have to have hands free to sign), without signer you are unable to communicate outside of emotes, something that requires more thought than "HELP MAINTS".

Self aware is just a free, very bad, health analyzer that can only see brute and burn damage, 8 points is not worth an item that is pretty easy to acquire, with many spawning outside of medical, dorms, or found in maints.

Voracious allows you to get a large amount of buffs from eating food, this includes potentially huge stamina and health buffs. The only reason i didn't put it higher is because it requires effort from the chef to reach high levels.

Skittish is barely even a boon, if you are running(not sprinting), you will be instantly sent into a locker when you would normally just walk into it, which happens more then you think, needless to say this is not that helpful in game, as if someone is actually chasing you they probably aren't gonna be stopped by opening a locker, while you are gonna be delayed getting out of said locker.

Empath is, on paper, pretty useful, however in practice its borderline useless. Empath allows you to see a few extra things when examining someone, such as: Are they deaf(a question to which the person you are asking about is probably screaming the answer at you already), are they dying of oxygen deprivation(something they will let you know of without needing to examine as well, via the *gasp emote), if their sanity is low(something you can do absolutely nothing with), and if they are freezing/overheating(does not matter due to how body temp is calculated). 

Freerunning was nearly completely useless, it lets you climb on tables faster(made obsolete by sprinting), and not take damage from multi-z falls, which is only useful on two maps.  So as to give it some purpose, I made it make you sprint for longer.

IPCs should not be able to pick quirks like frail or allergy, which do nothing to IPCs.

Xenomorphs already were able to move at mach 1, they should not be able to move at mach 2 via sprinting.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Freerunning now doubles sprint time.
balance: Changes a lot of quirk costs.
balance: IPCs are now punished for taking quirks that don't effect them
balance: Xenomorphs can no longer sprint
fix: Sign language does not reveal your voice.
fix: RDS no longer tells you if your a headrev pre-awakening.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
