### PR TITLE
Disables Revs from natural spawning

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -124,7 +124,7 @@
 	flags = HIGH_IMPACT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/revs)
 
-	minimum_players = 100 //Originally 30, disabled for now, Monkestation 2.0 change.
+	minimum_players = 100 //Originally 30, changed to 100 so it's disabled for now, Monkestation 2.0 change.
 
 	var/required_heads_of_staff = 3
 	var/finished = FALSE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -124,7 +124,7 @@
 	flags = HIGH_IMPACT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/revs)
 
-	minimum_players = 100
+	minimum_players = 100 //Originally 30, disabled for now, Monkestation 2.0 change.
 
 	var/required_heads_of_staff = 3
 	var/finished = FALSE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -120,7 +120,7 @@
 	weight = 1
 	delay = 1 MINUTES // Prevents rule start while head is offstation.
 	cost = 10
-	requirements = list(101,101,101,101,101,101,101,101,101,101)
+	requirements = list(101,101,70,40,30,20,20,20,20,20)
 	flags = HIGH_IMPACT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/revs)
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -124,7 +124,7 @@
 	flags = HIGH_IMPACT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/revs)
 
-	minimum_players = 100 //Originally 30, changed to 100 so it's disabled for now, Monkestation 2.0 change.
+	minimum_players = 100 //MONKESTATION EDIT Originally 30, changed to 100 so it's disabled for now
 
 	var/required_heads_of_staff = 3
 	var/finished = FALSE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -120,11 +120,11 @@
 	weight = 1
 	delay = 1 MINUTES // Prevents rule start while head is offstation.
 	cost = 10
-	requirements = list(101,101,70,40,30,20,20,20,20,20)
+	requirements = list(101,101,101,101,101,101,101,101,101,101)
 	flags = HIGH_IMPACT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/roundstart/revs)
 
-	minimum_players = 30
+	minimum_players = 100
 
 	var/required_heads_of_staff = 3
 	var/finished = FALSE

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -555,7 +555,7 @@
 	flags = HIGH_IMPACT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/latejoin/provocateur)
 	// I give up, just there should be enough heads with 35 players...
-	minimum_players = 40
+	minimum_players = 35
 	var/datum/team/revolution/revolution
 	var/finished = FALSE
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -550,12 +550,12 @@
 	weight = 1
 	delay = 7 MINUTES
 	cost = 40
-	requirements = list(101,101,70,40,30,20,10,10,10,10)
+	requirements = list(101,101,101,101,101,101,101,101,101,101)
 	antag_cap = 3
 	flags = HIGH_IMPACT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/latejoin/provocateur)
 	// I give up, just there should be enough heads with 35 players...
-	minimum_players = 35
+	minimum_players = 100
 	var/datum/team/revolution/revolution
 	var/finished = FALSE
 

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -550,12 +550,12 @@
 	weight = 1
 	delay = 7 MINUTES
 	cost = 40
-	requirements = list(101,101,101,101,101,101,101,101,101,101)
+	requirements = list(101,101,70,40,30,20,10,10,10,10)
 	antag_cap = 3
 	flags = HIGH_IMPACT_RULESET
 	blocking_rules = list(/datum/dynamic_ruleset/latejoin/provocateur)
 	// I give up, just there should be enough heads with 35 players...
-	minimum_players = 100
+	minimum_players = 40
 	var/datum/team/revolution/revolution
 	var/finished = FALSE
 


### PR DESCRIPTION

## About The Pull Request
Ook wants it disabled. I also want it disabled, because almost everyone hates it and it causes a lot of issues.
## Why It's Good For The Game
Not having revolution will bring in an era of prosperity the likes we have not seen in an age, or something.
## Changelog
:cl:
Gamemodes: Removed revolution from the dynamic pool, it can no longer spawn naturally.
/:cl:
