### PR TITLE
A fix for IceBox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -19295,16 +19295,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"ggu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/vending/mechcomp,
-/obj/machinery/vending/mechcomp,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "ggD" = (
 /obj/structure/chair{
 	dir = 4
@@ -233845,7 +233835,7 @@ uJn
 kYL
 gLu
 dth
-ggu
+bTF
 wRd
 gka
 swe


### PR DESCRIPTION

## About The Pull Request

Finally removes the vending machines that are in front of IceBox's Power Storage airlock. 
## Why It's Good For The Game

Removes an annoyance for engineers and lessens the risk of being crushed by a vending machine.
## Changelog
:cl:
fix: removes vending machines that are in front of an airlock
/:cl:
