### PR TITLE
makes silvers edible

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -509,8 +509,9 @@ Behavior that's still missing from this component that original food items had t
 		else if(foodtypes & H.dna.species.liked_food)
 			food_taste_reaction = FOOD_LIKED
 
-	if(HAS_TRAIT(parent, TRAIT_FOOD_SILVER)) // it's not real food
-		food_taste_reaction = isjellyperson(H) ? FOOD_LIKED : FOOD_TOXIC
+	//if(HAS_TRAIT(parent, TRAIT_FOOD_SILVER))
+		//food_taste_reaction = isjellyperson(H) ? FOOD_LIKED : FOOD_TOXIC
+		//monkestation edit: removed to make silvers edible.
 
 	switch(food_taste_reaction)
 		if(FOOD_TOXIC)


### PR DESCRIPTION
## About The Pull Request
Changes food from xenobio silver extracts to not cause disgust when eaten.
## Why It's Good For The Game
Allows a niche xenobio extract more uses beyond powergaming a roburger, gatfruit, or powercrepe.
Returns functionality we had in monke 1.0 
## Changelog
Food from Xenobio silvers are no longer disgusting.
:cl:
remove: Xenobio silver extract spawned food is no longer disgusting.
/:cl:
