### PR TITLE
Departmental Security Duster Fix

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -123,7 +123,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 
 	//monkestation edit start: add dept sec outfits
 	if(suit)
-		for(var/obj/item/gun/energy/disabler/stored in spawning.contents)
+		for(var/obj/item/gun/ballistic/automatic/pistol/paco/no_mag/stored in spawning.contents)
 			if(spawning.wear_suit)
 				qdel(spawning.wear_suit)
 			spawning.equip_to_slot_or_del(new suit(spawning),ITEM_SLOT_OCLOTHING)


### PR DESCRIPTION

## About The Pull Request
Fixes departmental security dusters not being given to security officers when they spawn in.
Currently security officers spawn with the default duster instead of the one from their assigned department. Hopefully this fixes that issue.
## Why It's Good For The Game
Fix
## Changelog
:cl:
fix: Security officers are now given their departmental duster correctly.
/:cl:
