### PR TITLE
Adds Boat Cloak and Poly Cloak to Merch

### DIFF
--- a/monkestation/code/modules/loadouts/items/neck.dm
+++ b/monkestation/code/modules/loadouts/items/neck.dm
@@ -132,6 +132,14 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 	name = "Maid Neck Cover"
 	item_path = /obj/item/clothing/neck/maid
 
+/datum/loadout_item/neck/boatcloak
+	name = "Boat cloak"
+	item_path = /obj/item/clothing/neck/boatcloak
+
+/datum/loadout_item/neck/polycloak
+	name = "Poly cloak"
+	item_path = /obj/item/clothing/neck/polycloak
+
 /*
 *	DONATOR
 */

--- a/monkestation/code/modules/store/store_items/neck.dm
+++ b/monkestation/code/modules/store/store_items/neck.dm
@@ -74,6 +74,16 @@ GLOBAL_LIST_INIT(store_neck, generate_store_items(/datum/store_item/neck))
 	item_path = /obj/item/clothing/neck/infinity_scarf
 	item_cost = 7500
 
+/datum/store_item/neck/boatcloak
+	name = "Boat cloak"
+	item_path = /obj/item/clothing/neck/boatcloak
+	item_cost = 7500
+
+/datum/store_item/neck/polycloak
+	name = "Poly cloak"
+	item_path = /obj/item/clothing/neck/polycloak
+	item_cost = 7500
+
 /*
 *	NECKTIES
 */


### PR DESCRIPTION

## About The Pull Request

Adds the boat cloak and poly cloak to the monkestore (which came from skyrat during 1.0)

## Why It's Good For The Game

More things to spend monkecoin on

## Changelog



:cl:
add: Added two new cloaks to the nanotrasen merch store
/:cl:

