### PR TITLE
Fluffy Tongue mk III: Artificial Unintelligence

### DIFF
--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -55,7 +55,7 @@
 
 // Monkestation edit: AIs are not immune to the curse
 /obj/item/ai_uwu_upgrade
-	name = "AI UwU-speak \"upgrade\""
+	name = "AI UwU-speak \"Upgrade\""
 	desc = "A debatably legal software package designed to help artificial intelligence accommodate incredibly cringeworthy crewmates. Nanotrasen is not responsible for software malfunctions as a result of use of this upgrade."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "datadisk5"

--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -52,3 +52,26 @@
 	message_admins("[ADMIN_LOOKUPFLW(user)] has upgraded [ADMIN_LOOKUPFLW(AI)] with a [src].")
 	qdel(src)
 	return TRUE
+
+// Monkestation edit: AIs are not immune to the curse
+/obj/item/ai_uwu_upgrade
+	name = "AI UwU-speak \"upgrade\""
+	desc = "A debatably legal software package designed to help artificial intelligence accommodate incredibly cringeworthy crewmates. Nanotrasen is not responsible for software malfunctions as a result of use of this upgrade."
+	icon = 'icons/obj/module.dmi'
+	icon_state = "datadisk5"
+
+/obj/item/ai_uwu_upgrade/pre_attack(atom/A, mob/living/user, proximity)
+	if(!proximity)
+		return ..()
+	if(!isAI(A))
+		return ..()
+	var/mob/living/silicon/ai/AI = A
+	if(isAI(A))
+		AI.uwu_ify()
+		to_chat(AI, span_userdanger("[user] has upgraded you with... something?"))
+		to_chat(AI, "You feel a shudder in your microprocessors. Something isn't right...")
+	to_chat(user, span_notice("You upgrade [AI], and [src] is consumed in the process. God have mercy on your soul."))
+	user.log_message("has upgraded [key_name(AI)] with a [src].", LOG_GAME)
+	message_admins("[ADMIN_LOOKUPFLW(user)] has upgraded [ADMIN_LOOKUPFLW(AI)] with a [src].")
+	qdel(src)
+	return TRUE

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -113,6 +113,9 @@
 	///whether AI is anchored or not, used for checks
 	var/is_anchored = TRUE
 
+	///Command report cooldown
+	COOLDOWN_DECLARE(command_report_cd) // monkestation edit
+
 	// monkestation edit: uwu-speak upgrade
 	var/datum/fluffy_tongue = FALSE
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -113,6 +113,9 @@
 	///whether AI is anchored or not, used for checks
 	var/is_anchored = TRUE
 
+	// monkestation edit: uwu-speak upgrade
+	var/datum/fluffy_tongue = FALSE
+
 /mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, mob/target_ai)
 	. = ..()
 	if(!target_ai) //If there is no player/brain inside.
@@ -240,6 +243,10 @@
 	if(ai_voicechanger)
 		ai_voicechanger.owner = null
 		ai_voicechanger = null
+
+	// it's a mercy to let the curse end in death, honestly
+	if (fluffy_tongue)
+		UnregisterSignal(src, COMSIG_MOB_SAY)
 	return ..()
 
 /// Removes all malfunction-related abilities from the AI
@@ -1140,3 +1147,21 @@
 	return
 
 #undef CALL_BOT_COOLDOWN
+
+/mob/living/silicon/ai/proc/uwu_ify()
+	RegisterSignal(src, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+
+/mob/living/silicon/ai/proc/handle_speech(datum/source, list/speech_args)
+	SIGNAL_HANDLER
+	var/message = speech_args[SPEECH_MESSAGE]
+
+	if(message[1] != "*")
+		message = replacetext(message, "ne", "nye")
+		message = replacetext(message, "nu", "nyu")
+		message = replacetext(message, "na", "nya")
+		message = replacetext(message, "no", "nyo")
+		message = replacetext(message, "ove", "uv")
+		message = replacetext(message, "r", "w")
+		message = replacetext(message, "l", "w")
+	speech_args[SPEECH_MESSAGE] = message
+

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1118,6 +1118,7 @@
 		"mech_punching_face",
 		"clown_firing_pin",
 		"borg_upgrade_cringe",
+		"ai_upgrade_cringe",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 

--- a/monkestation/code/modules/research/designs/electronic_designs.dm
+++ b/monkestation/code/modules/research/designs/electronic_designs.dm
@@ -45,3 +45,17 @@
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SCIENCE
 	)
 	departmental_flags =  DEPARTMENT_BITFLAG_SCIENCE
+
+// Monkestation change: UwU-speak module for AIs too because I hate them more than borg players
+/datum/design/ai_uwu_upgrade
+	name = "AI UwU-speak \"Upgrade\""
+	desc = "A software package that assists AIs in sympathetic accommodation of incredibly cringeworthy crewmembers via communications."
+	id = "ai_upgrade_cringe"
+	build_type = PROTOLATHE | AWAY_LATHE
+	// same price as the borg upgrade, plus some iron
+	materials = list(/datum/material/iron = 1000, /datum/material/gold = 2000, /datum/material/diamond = 1000, /datum/material/bluespace = 500)
+	build_path = /obj/item/ai_uwu_upgrade
+	category = list(
+		RND_CATEGORY_AI + RND_SUBCATEGORY_AI_UPGRADES
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE


### PR DESCRIPTION

## About The Pull Request

Adds a fun new upgrade disk for the AI, so they can join in on the fun with their synced borgs! A great time for the whole station, especially Science.

## Why It's Good For The Game

We're discussing this again? The first PR re-adding Fluffy Tongue and the brand-new module for borgs was, in a word, a resounding success. Borg ~~suicide~~ enjoyment rates rose substantially, and crew morale in shifts where Fluffy Tongue/UwU-speak upgrades were involved rose as well. Giving Science a means to share the fruits of their research with the AI is sure to be a hit.

## Changelog

:cl:
add: Added a fun upgrade disk that lots of AIs will learn to enjoy, eventually! :^)
/:cl:

