### PR TITLE
finally makes interaction components able to use items inside of them

### DIFF
--- a/monkestation/code/modules/mech_comp/objects/interactor.dm
+++ b/monkestation/code/modules/mech_comp/objects/interactor.dm
@@ -124,6 +124,8 @@
 		if(!held_item)
 			if(!right_clicks)
 				listed_atom.attack_hand(dummy_human)
+				if(istype(listed_atom, /obj/item)) // yoink it if its an item
+					held_item = listed_atom
 			else
 				dummy_human.istate |= ISTATE_SECONDARY
 				listed_atom.attack_hand_secondary(dummy_human)
@@ -156,7 +158,6 @@
 		else
 			held_item.forceMove(get_turf(src))
 		held_item = null
-
 	held_item = weapon
 	dummy_human.put_in_l_hand(weapon)
 	update_appearance()


### PR DESCRIPTION

## About The Pull Request

Makes the interaction component finally work properly

the only concern now is that it may be a lil bit too much of a killing machine since the dummy dosent have an attack cooldown... but thats probably intended

<details>
<summary> How it used to be:</summary>

![image](https://github.com/Monkestation/Monkestation2.0/assets/82319946/5c9bbf48-9fd4-43d4-879d-50b7cc437201)

</details> 

<details>
<summary> How it is:</summary>

![image](https://github.com/Monkestation/Monkestation2.0/assets/82319946/cfe28879-d2e9-4a61-a498-b0bd135b26ca)

</details> 

## Why It's Good For The Game

Nobody ever uses interaction components because usually a singular hand click is less than worth it, as the item using function was bugged because held_item never registered as non-null
Now when it picks an item up it registers it as an item it has, finally having it able to use it

## Changelog

:cl:
fix: interaction components finally work
/:cl:
