### PR TITLE
Extra-EXTRA-Sensory Paranoia - The Horde Approaches

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -721,6 +721,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 ///Trait for the gamer quirk.
 #define TRAIT_GAMER "gamer"
 
+/// Trait for the Extra-Sensory Paranoia quirk
+#define TRAIT_PARANOIA "paranoia"
+
 ///Trait for dryable items
 #define TRAIT_DRYABLE "trait_dryable"
 ///Trait for dried items

--- a/code/datums/brain_damage/magic.dm
+++ b/code/datums/brain_damage/magic.dm
@@ -76,60 +76,20 @@
 	var/obj/effect/client_image_holder/stalker_phantom/stalker
 	var/close_stalker = FALSE //For heartbeat
 
-/datum/brain_trauma/magic/stalker_multiple
-	name = "Stalking Phantoms"
-	desc = "Patient is stalked by multiple phantoms only they can see."
-	scan_desc = "extra-EXTRA-sensory paranoia"
-	gain_text = span_warning("You feel like the gods have released the hounds...")
-	lose_text = span_notice("You no longer feel the wrath of the gods watching you.")
-	// var/obj/effect/client_image_holder/stalker_phantom/stalker
-
-	var/list/stalkers = list()
-
-	var/close_stalker = FALSE //For heartbeat
-
 /datum/brain_trauma/magic/stalker/Destroy()
 	QDEL_NULL(stalker)
-	return ..()
-
-/datum/brain_trauma/magic/stalker_multiple/Destroy()
-	for (var/stalker in stalkers)
-		QDEL_NULL(stalker)
 	return ..()
 
 /datum/brain_trauma/magic/stalker/on_gain()
 	create_stalker()
 	return ..()
 
-// I dunno how to make this configurable for admins,
-// so you just get a 10-pack. Deal with it?
-/datum/brain_trauma/magic/stalker_multiple/on_gain()
-	create_stalker_multiple(10)
-	return ..()
-
 /datum/brain_trauma/magic/stalker/proc/create_stalker()
 	var/turf/stalker_source = locate(owner.x + pick(-12, 12), owner.y + pick(-12, 12), owner.z) //random corner
 	stalker = new(stalker_source, owner)
 
-/datum/brain_trauma/magic/stalker_multiple/proc/create_stalker()
-	var/turf/stalker_source = locate(owner.x + pick(-12, 12), owner.y + pick(-12, -6, 0, 6, 12), owner.z) //random corner
-	var/obj/effect/client_image_holder/stalker_phantom/stalker = new(stalker_source, owner)
-	stalkers += stalker
-
-/datum/brain_trauma/magic/stalker_multiple/proc/create_stalker_multiple(count)
-	var/turf/stalker_source = locate(owner.x + pick(-12, 12), owner.y + pick(-12, -6, 0, 6, 12), owner.z) //random corner
-
-	for (var/x = 0; x < count; x++)
-		var/obj/effect/client_image_holder/stalker_phantom/stalker = new(stalker_source, owner)
-		stalkers += stalker
-
 /datum/brain_trauma/magic/stalker/on_lose()
 	QDEL_NULL(stalker)
-	return ..()
-
-/datum/brain_trauma/magic/stalker_multiple/on_lose()
-	for (var/stalker in stalkers)
-		QDEL_NULL(stalker)
 	return ..()
 
 /datum/brain_trauma/magic/stalker/on_life(seconds_per_tick, times_fired)
@@ -157,35 +117,6 @@
 		if(close_stalker)
 			owner.stop_sound_channel(CHANNEL_HEARTBEAT)
 			close_stalker = FALSE
-	..()
-
-/datum/brain_trauma/magic/stalker_multiple/on_life(seconds_per_tick, times_fired)
-	// Dead and unconscious people are not interesting to the psychic stalker.
-	if(owner.stat != CONSCIOUS)
-		return
-
-	// Not even nullspace will keep it at bay.
-	for (var/obj/effect/client_image_holder/stalker_phantom/stalker in stalkers)
-		if(!stalker || !stalker.loc || stalker.z != owner.z)
-			qdel(stalker)
-			create_stalker()
-
-	for (var/obj/effect/client_image_holder/stalker_phantom/stalker in stalkers)
-		if(get_dist(owner, stalker) <= 1)
-			playsound(owner, 'sound/magic/demon_attack1.ogg', 10)
-			owner.visible_message(span_warning("[owner] is torn apart by invisible claws!"), span_userdanger("Ghostly claws tear your body apart!"))
-			owner.take_bodypart_damage(rand(20, 45), wound_bonus=CANT_WOUND)
-		else if(SPT_PROB(30, seconds_per_tick))
-			stalker.forceMove(get_step_towards(stalker, owner))
-		if(get_dist(owner, stalker) <= 8)
-			if(!close_stalker)
-				var/sound/slowbeat = sound('sound/health/slowbeat.ogg', repeat = TRUE)
-				owner.playsound_local(owner, slowbeat, 40, 0, channel = CHANNEL_HEARTBEAT, use_reverb = FALSE)
-				close_stalker = TRUE
-		else
-			if(close_stalker)
-				owner.stop_sound_channel(CHANNEL_HEARTBEAT)
-				close_stalker = FALSE
 	..()
 
 /obj/effect/client_image_holder/stalker_phantom

--- a/code/datums/brain_damage/magic.dm
+++ b/code/datums/brain_damage/magic.dm
@@ -172,7 +172,7 @@
 
 	for (var/obj/effect/client_image_holder/stalker_phantom/stalker in stalkers)
 		if(get_dist(owner, stalker) <= 1)
-			playsound(owner, 'sound/magic/demon_attack1.ogg', 50)
+			playsound(owner, 'sound/magic/demon_attack1.ogg', 10)
 			owner.visible_message(span_warning("[owner] is torn apart by invisible claws!"), span_userdanger("Ghostly claws tear your body apart!"))
 			owner.take_bodypart_damage(rand(20, 45), wound_bonus=CANT_WOUND)
 		else if(SPT_PROB(30, seconds_per_tick))

--- a/code/datums/brain_damage/magic.dm
+++ b/code/datums/brain_damage/magic.dm
@@ -76,20 +76,60 @@
 	var/obj/effect/client_image_holder/stalker_phantom/stalker
 	var/close_stalker = FALSE //For heartbeat
 
+/datum/brain_trauma/magic/stalker_multiple
+	name = "Stalking Phantoms"
+	desc = "Patient is stalked by multiple phantoms only they can see."
+	scan_desc = "extra-EXTRA-sensory paranoia"
+	gain_text = span_warning("You feel like the gods have released the hounds...")
+	lose_text = span_notice("You no longer feel the wrath of the gods watching you.")
+	// var/obj/effect/client_image_holder/stalker_phantom/stalker
+
+	var/list/stalkers = list()
+
+	var/close_stalker = FALSE //For heartbeat
+
 /datum/brain_trauma/magic/stalker/Destroy()
 	QDEL_NULL(stalker)
+	return ..()
+
+/datum/brain_trauma/magic/stalker_multiple/Destroy()
+	for (var/stalker in stalkers)
+		QDEL_NULL(stalker)
 	return ..()
 
 /datum/brain_trauma/magic/stalker/on_gain()
 	create_stalker()
 	return ..()
 
+// I dunno how to make this configurable for admins,
+// so you just get a 10-pack. Deal with it?
+/datum/brain_trauma/magic/stalker_multiple/on_gain()
+	create_stalker_multiple(10)
+	return ..()
+
 /datum/brain_trauma/magic/stalker/proc/create_stalker()
 	var/turf/stalker_source = locate(owner.x + pick(-12, 12), owner.y + pick(-12, 12), owner.z) //random corner
 	stalker = new(stalker_source, owner)
 
+/datum/brain_trauma/magic/stalker_multiple/proc/create_stalker()
+	var/turf/stalker_source = locate(owner.x + pick(-12, 12), owner.y + pick(-12, -6, 0, 6, 12), owner.z) //random corner
+	var/obj/effect/client_image_holder/stalker_phantom/stalker = new(stalker_source, owner)
+	stalkers += stalker
+
+/datum/brain_trauma/magic/stalker_multiple/proc/create_stalker_multiple(count)
+	var/turf/stalker_source = locate(owner.x + pick(-12, 12), owner.y + pick(-12, -6, 0, 6, 12), owner.z) //random corner
+
+	for (var/x = 0; x < count; x++)
+		var/obj/effect/client_image_holder/stalker_phantom/stalker = new(stalker_source, owner)
+		stalkers += stalker
+
 /datum/brain_trauma/magic/stalker/on_lose()
 	QDEL_NULL(stalker)
+	return ..()
+
+/datum/brain_trauma/magic/stalker_multiple/on_lose()
+	for (var/stalker in stalkers)
+		QDEL_NULL(stalker)
 	return ..()
 
 /datum/brain_trauma/magic/stalker/on_life(seconds_per_tick, times_fired)
@@ -117,6 +157,35 @@
 		if(close_stalker)
 			owner.stop_sound_channel(CHANNEL_HEARTBEAT)
 			close_stalker = FALSE
+	..()
+
+/datum/brain_trauma/magic/stalker_multiple/on_life(seconds_per_tick, times_fired)
+	// Dead and unconscious people are not interesting to the psychic stalker.
+	if(owner.stat != CONSCIOUS)
+		return
+
+	// Not even nullspace will keep it at bay.
+	for (var/obj/effect/client_image_holder/stalker_phantom/stalker in stalkers)
+		if(!stalker || !stalker.loc || stalker.z != owner.z)
+			qdel(stalker)
+			create_stalker()
+
+	for (var/obj/effect/client_image_holder/stalker_phantom/stalker in stalkers)
+		if(get_dist(owner, stalker) <= 1)
+			playsound(owner, 'sound/magic/demon_attack1.ogg', 50)
+			owner.visible_message(span_warning("[owner] is torn apart by invisible claws!"), span_userdanger("Ghostly claws tear your body apart!"))
+			owner.take_bodypart_damage(rand(20, 45), wound_bonus=CANT_WOUND)
+		else if(SPT_PROB(30, seconds_per_tick))
+			stalker.forceMove(get_step_towards(stalker, owner))
+		if(get_dist(owner, stalker) <= 8)
+			if(!close_stalker)
+				var/sound/slowbeat = sound('sound/health/slowbeat.ogg', repeat = TRUE)
+				owner.playsound_local(owner, slowbeat, 40, 0, channel = CHANNEL_HEARTBEAT, use_reverb = FALSE)
+				close_stalker = TRUE
+		else
+			if(close_stalker)
+				owner.stop_sound_channel(CHANNEL_HEARTBEAT)
+				close_stalker = FALSE
 	..()
 
 /obj/effect/client_image_holder/stalker_phantom

--- a/monkestation/code/datums/brain_damage/magic.dm
+++ b/monkestation/code/datums/brain_damage/magic.dm
@@ -1,0 +1,65 @@
+/datum/brain_trauma/magic/stalker_multiple
+	name = "Stalking Phantoms"
+	desc = "Patient is stalked by multiple phantoms only they can see."
+	scan_desc = "extra-EXTRA-sensory paranoia"
+	gain_text = span_warning("You feel like the gods have released the hounds...")
+	lose_text = span_notice("You no longer feel the wrath of the gods watching you.")
+
+	var/list/stalkers = list()
+
+	var/close_stalker = FALSE //For heartbeat
+
+/datum/brain_trauma/magic/stalker_multiple/Destroy()
+	for (var/stalker in stalkers)
+		QDEL_NULL(stalker)
+	return ..()
+
+/datum/brain_trauma/magic/stalker_multiple/on_gain()
+	create_stalker_multiple(10)
+	return ..()
+
+/datum/brain_trauma/magic/stalker_multiple/proc/create_stalker()
+	var/turf/stalker_source = locate(owner.x + pick(-12, 12), owner.y + pick(-12, -6, 0, 6, 12), owner.z) //random corner
+	var/obj/effect/client_image_holder/stalker_phantom/stalker = new(stalker_source, owner)
+	stalkers += stalker
+
+/datum/brain_trauma/magic/stalker_multiple/proc/create_stalker_multiple(count)
+	var/turf/stalker_source = locate(owner.x + pick(-12, 12), owner.y + pick(-12, -6, 0, 6, 12), owner.z) //random corner
+
+	for (var/x = 0; x < count; x++)
+		var/obj/effect/client_image_holder/stalker_phantom/stalker = new(stalker_source, owner)
+		stalkers += stalker
+
+/datum/brain_trauma/magic/stalker_multiple/on_lose()
+	for (var/stalker in stalkers)
+		QDEL_NULL(stalker)
+	return ..()
+
+/datum/brain_trauma/magic/stalker_multiple/on_life(seconds_per_tick, times_fired)
+	// Dead and unconscious people are not interesting to the psychic stalker.
+	if(owner.stat != CONSCIOUS)
+		return
+
+	// Not even nullspace will keep it at bay.
+	for (var/obj/effect/client_image_holder/stalker_phantom/stalker in stalkers)
+		if(!stalker || !stalker.loc || stalker.z != owner.z)
+			qdel(stalker)
+			create_stalker()
+
+	for (var/obj/effect/client_image_holder/stalker_phantom/stalker in stalkers)
+		if(get_dist(owner, stalker) <= 1)
+			playsound(owner, 'sound/magic/demon_attack1.ogg', 10)
+			owner.visible_message(span_warning("[owner] is torn apart by invisible claws!"), span_userdanger("Ghostly claws tear your body apart!"))
+			owner.take_bodypart_damage(rand(20, 45), wound_bonus=CANT_WOUND)
+		else if(SPT_PROB(30, seconds_per_tick))
+			stalker.forceMove(get_step_towards(stalker, owner))
+		if(get_dist(owner, stalker) <= 8)
+			if(!close_stalker)
+				var/sound/slowbeat = sound('sound/health/slowbeat.ogg', repeat = TRUE)
+				owner.playsound_local(owner, slowbeat, 40, 0, channel = CHANNEL_HEARTBEAT, use_reverb = FALSE)
+				close_stalker = TRUE
+		else
+			if(close_stalker)
+				owner.stop_sound_channel(CHANNEL_HEARTBEAT)
+				close_stalker = FALSE
+	..()

--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -202,3 +202,19 @@
 /datum/quirk/item_quirk/allergic/post_add()
 	if(isipc(quirk_holder)) //monkestation addition
 		to_chat(quirk_holder, span_boldnotice("Your chassis feels frail."))
+
+/datum/quirk/extra_sensory_paranoia
+	name = "Extra-Sensory Paranoia"
+	desc = "You feel like something wants to kill you..."
+	mob_trait = TRAIT_PARANOIA
+	value = -8
+	icon = "fa-optin-monster" // "fa-ghost"
+
+/datum/quirk/extra_sensory_paranoia/add()
+	var/datum/brain_trauma/magic/stalker/T = new()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.gain_trauma(T, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/extra_sensory_paranoia/remove()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.cure_trauma_type(/datum/brain_trauma/magic/stalker, TRAUMA_RESILIENCE_ABSOLUTE)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5406,6 +5406,7 @@
 #include "monkestation\code\datums\ai\monkey\dukeman_controller.dm"
 #include "monkestation\code\datums\ai_laws\laws_monke.dm"
 #include "monkestation\code\datums\announcers\duke.dm"
+#include "monkestation\code\datums\brain_damage\magic.dm"
 #include "monkestation\code\datums\components\carbon_sprint.dm"
 #include "monkestation\code\datums\components\multi_hit.dm"
 #include "monkestation\code\datums\components\throw_bounce.dm"


### PR DESCRIPTION

## About The Pull Request

Adds the brain trauma Extra-Sensory Paranoia as a roundstart quirk, as per Ook's request. Also, adds an admin-only _multiple_ stalker trauma, Extra-EXTRA-Sensory Paranoia. You know, for fun.

## Why It's Good For The Game

Who doesn't want to have a nice little friend following them around? Keeps you on your toes, and makes you look crazy to other people. Also, it's better than being blind, while still giving some nice quirk points. Just don't stand still for too long...

## Changelog

:cl:
add: Added new quirk that applies a permanent Extra-Sensory Paranoia - no lobotomies for this one.
add: Added a new version of ESP that summons 10 stalkers by default, and can be called by an admin for more.

/:cl:

