### PR TITLE
Mop and bucket interaction fix 

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -425,11 +425,18 @@
 	if(istype(weapon, /obj/item/mop))
 		if(reagents.total_volume == volume)
 			to_chat(user, "The [src.name] can't hold anymore liquids")
-			return
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 		var/obj/item/mop/attacked_mop = weapon
+
+		if(attacked_mop.reagents.total_volume < 0.1)
+			to_chat(user, span_warning("Your [attacked_mop.name] is already dry!"))
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+
 		to_chat(user, "You wring out the [attacked_mop.name] into the [src.name].")
 		attacked_mop.reagents.trans_to(src, attacked_mop.max_reagent_volume * 0.25)
 		attacked_mop.reagents.remove_all(attacked_mop.max_reagent_volume)
+		return SECONDARY_ATTACK_CONTINUE_CHAIN
 
 /obj/item/reagent_containers/cup/bucket/equipped(mob/user, slot)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Fixed the right click interaction between buckets and mops. Before, right clicking on the bucket with a mop was also trigging the effect of a left click. I added return values to attackby_secondary to stop this fallback behavior.

While I was at it I added a check to see if the mop was empty and made it display a message to inform the user.
## Why It's Good For The Game
It's a fix to a broken mechanic. It stops the mop from instantly rewetting in the buckets contents when you are attempting to wring it out.
## Changelog
:cl:
add: Added new message when trying to wring out a dry mop into a bucket.
fix: Fixed right clicking a mop on a bucket also acting as a left click.
/:cl:
