### PR TITLE
Captains can open the antique gun display case

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -288,7 +288,7 @@
 //The lab cage and captain's display case do not spawn with electronics, which is why req_access is needed.
 /obj/structure/displaycase/captain
 	start_showpiece_type = /obj/item/gun/energy/laser/captain
-	req_access = list(ACCESS_CENT_SPECOPS) //this was intentional, presumably to make it slightly harder for caps to grab their gun roundstart
+	req_access = list(ACCESS_CAPTAIN) //Monkestation Edit
 
 /obj/structure/displaycase/labcage
 	name = "lab cage"


### PR DESCRIPTION

## About The Pull Request
Allows captains to open the antique laser gun display case with their ID card instead of breaking it to get the gun.
## Why It's Good For The Game
Breaking the display case is loud, annoying, brings unwanted attention and can cause the issue of the captain's office being stuck in a permanent fire alarm.
This makes it significantly easier to get your personal gun that for some reason was locked behind Centcom access.
## Changelog
:cl:
qol: Captains can now open the antique gun display case with their ID card.
/:cl:
