### PR TITLE
misc CWC improvements two

### DIFF
--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -128,6 +128,7 @@
 				next_attack_tick = world.time + rand(50, 100)
 				send_to_playing_players(span_danger("[pick("You hear the scratching of cogs.", "You hear the clanging of pipes.", "You feel your bones start to rust...")]"))
 				sound_to_playing_players('sound/magic/clockwork/narsie_attack.ogg', 100)
+				explosion(GLOB.cult_ratvar, 0, 2, 6)
 				SpinAnimation(4, 0)
 
 				for(var/mob/living/living_player in GLOB.player_list)

--- a/monkestation/_maps/templates/reebe.dmm
+++ b/monkestation/_maps/templates/reebe.dmm
@@ -134,6 +134,10 @@
 	},
 /turf/open/indestructible/reebe_flooring/flat,
 /area/ruin/powered/reebe/city)
+"sN" = (
+/obj/structure/destructible/clockwork/gear_base/powered/tinkerers_cache,
+/turf/open/indestructible/reebe_flooring/flat,
+/area/ruin/powered/reebe/city)
 "tr" = (
 /turf/closed/wall/clockwork/reebe,
 /area/ruin/powered/reebe/city)
@@ -271,6 +275,10 @@
 "OA" = (
 /obj/structure/fluff/clockwork/alloy_shards/medium_gearbit,
 /turf/open/indestructible/reebe_flooring,
+/area/ruin/powered/reebe/city)
+"OL" = (
+/obj/structure/destructible/clockwork/gear_base/stargazer,
+/turf/open/indestructible/reebe_flooring/flat,
 /area/ruin/powered/reebe/city)
 "OQ" = (
 /obj/machinery/computer/camera_advanced/ratvar{
@@ -4932,7 +4940,7 @@ Ni
 cg
 Ni
 oH
-To
+OL
 oH
 Ni
 cg
@@ -5556,7 +5564,7 @@ FD
 cg
 Ni
 oH
-To
+sN
 oH
 To
 al

--- a/monkestation/code/_onclick/hud/alert.dm
+++ b/monkestation/code/_onclick/hud/alert.dm
@@ -24,7 +24,7 @@
 			 as well as [GLOB.main_clock_cult?.members.len] servants all together.<br>"
 
 	if(GLOB.clock_ark?.charging_for)
-		desc += "The Ark will open in [10 MINUTES - GLOB.clock_ark?.charging_for] seconds!<br>"
+		desc += "The Ark will open in [600 - GLOB.clock_ark?.charging_for] seconds!<br>"
 		return //we dont care about anchoring crystals at this point
 
 	if(get_charged_anchor_crystals()) //only put this here if we need to use it

--- a/monkestation/code/modules/antagonists/clock_cult/actions/recall_slab.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/actions/recall_slab.dm
@@ -42,6 +42,7 @@
 
 	if(!item_to_retrieve)
 		to_chat(usr, span_brass("You don't have a slab attuned!"))
+		return
 
 	if(!item_to_retrieve.loc)
 		return

--- a/monkestation/code/modules/antagonists/clock_cult/antag_datums/clock_cult_team.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/antag_datums/clock_cult_team.dm
@@ -67,7 +67,7 @@ GLOBAL_DATUM(main_clock_cult, /datum/team/clock_cult)
 ///check how many human members we have and anything that goes with that
 /datum/team/clock_cult/proc/check_member_count()
 	check_member_distribution()
-	max_human_servants = round(max((get_active_player_count() / 6) + 6, max_human_servants))
+	max_human_servants = round(max((get_active_player_count() / 7) + 5, max_human_servants))
 	var/human_servant_count = length(human_servants)
 	var/main_message = "The Ark will be torn open if [max_human_servants - human_servant_count] more minds are converted to the faith of Rat'var\
 						[get_charged_anchor_crystals() ? "." : "and an Anchoring Crystal is summoned and protected on the station."]"

--- a/monkestation/code/modules/antagonists/clock_cult/antag_datums/clock_cultist.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/antag_datums/clock_cultist.dm
@@ -187,7 +187,7 @@
 
 	else if(iscyborg(converted_silicon))
 		var/mob/living/silicon/robot/converted_borg = converted_silicon
-		converted_borg.set_connected_ai(null)
+		converted_borg.UnlinkSelf()
 		converted_borg.set_clockwork(TRUE)
 
 	if(converted_silicon.laws && istype(converted_silicon.laws, /datum/ai_laws/ratvar))

--- a/monkestation/code/modules/antagonists/clock_cult/dynamic_ruleset.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/dynamic_ruleset.dm
@@ -30,7 +30,7 @@
 
 /datum/dynamic_ruleset/roundstart/clock_cult/pre_execute(population)
 	. = ..()
-	INVOKE_ASYNC(GLOBAL_PROC, PROC_REF(spawn_reebe))
+	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(spawn_reebe))
 	var/cultists = get_antag_cap(population)
 	for(var/cultists_number = 1 to cultists)
 		if(candidates.len <= 0)

--- a/monkestation/code/modules/antagonists/clock_cult/items/replica_fabricator.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/items/replica_fabricator.dm
@@ -40,6 +40,7 @@
 		. += span_brass("Use on other materials to convert them into power, but less efficiently.")
 		. += span_brass("<b>Use</b> in-hand to select what to fabricate.")
 		. += span_brass("<b>Right Click</b> in-hand to fabricate bronze sheets.")
+		. += span_brass("Walls and windows will be built slower while on reebe.")
 
 
 /obj/item/clockwork/replica_fabricator/afterattack(atom/target, mob/user, proximity_flag, click_parameters)

--- a/monkestation/code/modules/antagonists/clock_cult/items/replica_fabricator.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/items/replica_fabricator.dm
@@ -79,9 +79,10 @@
 	else if(!isopenturf(target))
 		return
 
-	var/obj/effect/temp_visual/ratvar/constructing_effect/effect = new(creation_turf, selected_output.creation_delay)
+	var/calculated_creation_delay = selected_output.creation_delay * (on_reebe(user) ? selected_output.reebe_mult : 1)
+	var/obj/effect/temp_visual/ratvar/constructing_effect/effect = new(creation_turf, calculated_creation_delay)
 
-	if(!do_after(user, selected_output.creation_delay, target))
+	if(!do_after(user, calculated_creation_delay, target))
 		qdel(effect)
 		return
 
@@ -218,8 +219,10 @@
 	var/to_create_path
 	/// How long the creation actionbar is
 	var/creation_delay = 1 SECONDS
-	///list of objs this output can replace, normal walls for clock walls, windows for clock windows, ETC
+	/// List of objs this output can replace, normal walls for clock walls, windows for clock windows, ETC
 	var/list/replace_types_of
+	/// Multiplier for creation_delay when used on reebe
+	var/reebe_mult = 1
 
 /// Any extra actions that need to be taken when an object is created
 /datum/replica_fabricator_output/proc/on_create(atom/created_atom, turf/creation_turf, mob/creator)
@@ -249,6 +252,7 @@
 	to_create_path = /turf/closed/wall/clockwork
 	creation_delay = 7 SECONDS
 	replace_types_of = list(/turf/closed/wall)
+	reebe_mult = 1.5
 
 
 /datum/replica_fabricator_output/turf_output/brass_wall/on_create(obj/created_object, turf/creation_turf, mob/creator)
@@ -277,6 +281,7 @@
 	to_create_path = /obj/structure/window/reinforced/clockwork/fulltile
 	creation_delay = 6 SECONDS
 	replace_types_of = list(/obj/structure/window)
+	reebe_mult = 1.2
 
 
 /datum/replica_fabricator_output/brass_window/on_create(obj/created_object, turf/creation_turf, mob/creator)

--- a/monkestation/code/modules/antagonists/clock_cult/items/soul_vessel.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/items/soul_vessel.dm
@@ -11,6 +11,8 @@
 	new_mob_message = span_notice("The Soul Vessel starts making a steady ticking sound.")
 	dead_message = span_deadsay("It's gears are not moving.")
 	recharge_message = span_warning("The gears of the Soul Vessel are already spinning.")
+	///Should we add the clock cultist antag datum on being entered by a player
+	var/give_clock_cultist = TRUE
 
 /obj/item/mmi/posibrain/soul_vessel/Initialize(mapload, autoping)
 	. = ..()
@@ -18,3 +20,16 @@
 	radio.set_on(FALSE)
 	if(!brainmob) //we might be forcing someone into it right away
 		set_brainmob(new /mob/living/brain(src))
+
+/obj/item/mmi/posibrain/soul_vessel/transfer_personality(mob/candidate)
+	. = ..()
+	if(!.)
+		return
+
+	if(give_clock_cultist)
+		brainmob?.mind?.add_antag_datum(/datum/antagonist/clock_cultist)
+
+/obj/item/mmi/posibrain/soul_vessel/activate(mob/user)
+	if(is_banned_from(user.ckey, ROLE_CLOCK_CULTIST))
+		return
+	. = ..()

--- a/monkestation/code/modules/antagonists/clock_cult/items/weaponry.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/items/weaponry.dm
@@ -22,7 +22,7 @@
 	var/static/list/effect_turf_typecache = typecacheof(list(/turf/open/floor/bronze, /turf/open/indestructible/reebe_flooring))
 
 
-/obj/item/clockwork/weapon/attack(mob/living/target, mob/living/user)
+/obj/item/clockwork/weapon/afterattack(mob/living/target, mob/living/user)
 	. = ..()
 	var/turf/gotten_turf = get_turf(user)
 
@@ -102,7 +102,7 @@
 	overlay_icon_state = ""
 	active_background_icon_state = "bg_clock_active"
 	invocation_type = INVOCATION_NONE
-	cooldown_time = 10 SECONDS
+	cooldown_time = 15 SECONDS
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 	///ref to the spear we summon
 	var/obj/item/clockwork/weapon/brass_spear/recalled_spear

--- a/monkestation/code/modules/antagonists/clock_cult/items/weaponry.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/items/weaponry.dm
@@ -29,7 +29,7 @@
 	if(!is_type_in_typecache(gotten_turf, effect_turf_typecache))
 		return
 
-	if(!QDELETED(target) && target.stat != DEAD && !IS_CLOCK(target) && !target.can_block_magic(MAGIC_RESISTANCE_HOLY))
+	if((!QDELETED(target) && (!ismob(target) || (ismob(target) && target.stat != DEAD && !IS_CLOCK(target) && !target.can_block_magic(MAGIC_RESISTANCE_HOLY)))))
 		hit_effect(target, user)
 
 

--- a/monkestation/code/modules/antagonists/clock_cult/items/weaponry.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/items/weaponry.dm
@@ -166,7 +166,7 @@
 
 
 /obj/item/clockwork/weapon/brass_battlehammer/hit_effect(mob/living/target, mob/living/user, thrown = FALSE)
-	if(!thrown && !HAS_TRAIT(src, TRAIT_WIELDED))
+	if((!thrown && !HAS_TRAIT(src, TRAIT_WIELDED)) || !istype(target))
 		return
 
 	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))

--- a/monkestation/code/modules/antagonists/clock_cult/mobs/clock_borgs/clock_borg_models.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/mobs/clock_borgs/clock_borg_models.dm
@@ -52,3 +52,8 @@
 		/obj/item/clock_module/vanguard,
 		/obj/item/clock_module/ocular_warden,
 		/obj/item/clock_module/sentinels_compromise)
+
+/obj/item/robot_model/cargo
+	clock_modules = list(/obj/item/clock_module/abscond,
+		/obj/item/gun/ballistic/bow/clockwork,
+		/obj/item/clock_module/stargazer)

--- a/monkestation/code/modules/antagonists/clock_cult/ratvar.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/ratvar.dm
@@ -83,6 +83,7 @@ GLOBAL_DATUM(cult_ratvar, /obj/ratvar)
 				next_attack_tick = world.time + rand(50, 100)
 				send_to_playing_players(span_danger("[pick("Reality shudders around you.","You hear the tearing of flesh.","The sound of bones cracking fills the air.")]"))
 				sound_to_playing_players('sound/magic/clockwork/ratvar_attack.ogg',100)
+				explosion(GLOB.cult_narsie, 0, 2, 6)
 				SpinAnimation(4, 0)
 
 				for(var/mob/living/living_player in GLOB.player_list)

--- a/monkestation/code/modules/antagonists/clock_cult/scriptures/preservation/summon_marauder.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/scriptures/preservation/summon_marauder.dm
@@ -44,7 +44,9 @@
 	var/mob/living/basic/clockwork_marauder/new_mob = new (get_turf(invoker))
 	new_mob.visible_message(span_notice("[new_mob] flashes into existance!"))
 	new_mob.key = selected.key
-	to_chat(new_mob, span_brass("You are a Clockwork Marauder! You have a [new_mob.shield_health]-hit shield that will protect you against any damage taken. Have a servant repair you with a welder, should you or your shield become too damaged."))
+	new_mob.mind.add_antag_datum(/datum/antagonist/clock_cultist)
+	to_chat(new_mob, span_brass("You are a Clockwork Marauder! You have a [new_mob.shield_health]-hit shield that will protect you against any damage taken. \
+								Have a servant repair you with a welder, should you or your shield become too damaged."))
 	selected = null
 
 

--- a/monkestation/code/modules/antagonists/clock_cult/scriptures/structures/ocular_warden.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/scriptures/structures/ocular_warden.dm
@@ -1,4 +1,4 @@
-#define OCULAR_WARDEN_PLACE_RANGE 3
+#define OCULAR_WARDEN_PLACE_RANGE 4
 
 /datum/scripture/create_structure/ocular_warden
 	name = "Ocular Warden"

--- a/monkestation/code/modules/antagonists/clock_cult/structures/anchor_crystal.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/structures/anchor_crystal.dm
@@ -1,7 +1,7 @@
 GLOBAL_LIST_EMPTY(anchoring_crystals) //list of all anchoring crystals
 
 #define CRYSTAL_SHIELD_DELAY 50 SECONDS //how long until shields start to recharge
-#define CRYSTAL_CHARGE_TIMER 300 //how long in seconds do crystals take to charge, 5 MINTUES
+#define CRYSTAL_CHARGE_TIMER 360 //how long in seconds do crystals take to charge, 6 MINTUES
 #define CRYSTAL_CHARGING 0 //crystal is currently charging
 #define CRYSTAL_LOCATION_ANNOUNCED 1 //the location of the crystal has been anouced to the crew
 #define FULLY_CHARGED 2 //the crystal is fully charged

--- a/monkestation/code/modules/antagonists/clock_cult/structures/eminence_beacon.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/structures/eminence_beacon.dm
@@ -36,9 +36,9 @@
 
 /obj/structure/destructible/clockwork/eminence_beacon/proc/vote_succeed(mob/eminence)
 	vote_active = FALSE
-	//this should not happen, but if it does then tell the admins
 	if(GLOB.current_eminence)
 		message_admins("[type] calling vote_succeed() with a set GLOB.current_eminence, this should not be happening.")
+		return
 
 	if(!eminence)
 		var/list/mob/dead/observer/candidates = poll_ghost_candidates("Do you want to play as the eminence?", ROLE_CLOCK_CULTIST, poll_time = 10 SECONDS)

--- a/monkestation/code/modules/antagonists/clock_cult/structures/ocular_warden.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/structures/ocular_warden.dm
@@ -1,7 +1,7 @@
 #define FIRE_DELAY (2 SECONDS)
 #define FIRE_RANGE 4
-#define BASE_DAMAGE 10
-#define MINIMUM_DAMAGE 5
+#define BASE_DAMAGE 8
+#define MINIMUM_DAMAGE 4
 #define DAMAGE_FALLOFF 1
 #define SHOOT_POWER_USE 5
 
@@ -62,7 +62,7 @@
 
 	// Apply 10 damage (- 1 for each tile away they are), or 5, whichever is larger
 	target.apply_damage(max(BASE_DAMAGE - (get_dist(src, target) * DAMAGE_FALLOFF), MINIMUM_DAMAGE) * delta_time, BURN)
-	to_chat(target, span_warning("You feel as though your soul is being burned!"))
+	to_chat(target, span_boldwarning("You feel as though your soul is being burned!"))
 
 	new /obj/effect/temp_visual/ratvar/ocular_warden(get_turf(target))
 	new /obj/effect/temp_visual/ratvar/ocular_warden(get_turf(src))

--- a/monkestation/code/modules/antagonists/clock_cult/structures/prosperity_prism.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/structures/prosperity_prism.dm
@@ -37,8 +37,8 @@
 
 			new /obj/effect/temp_visual/heal(get_turf(possible_cultist), "#1E8CE1")
 
-			for(var/datum/reagent/negative_chem in possible_cultist?.reagents.reagent_list)
+			for(var/datum/reagent/negative_chem in possible_cultist.reagents?.reagent_list)
 				if(is_type_in_typecache(negative_chem, chems_to_purge))
-					possible_cultist.reagents.remove_reagent(negative_chem.type, 2.5 * seconds_per_tick)
+					possible_cultist.reagents?.remove_reagent(negative_chem.type, 2.5 * seconds_per_tick)
 
 #undef POWER_PER_USE

--- a/monkestation/code/modules/antagonists/clock_cult/structures/sigil/sigil_vitality.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/structures/sigil/sigil_vitality.dm
@@ -83,8 +83,8 @@
 		if(affected_mob.client)
 			new /obj/item/robot_suit/prebuilt/clockwork(get_turf(src))
 			var/obj/item/mmi/posibrain/soul_vessel/new_vessel = new(get_turf(src))
-			new_vessel.transfer_personality(affected_mob)
-			new_vessel.brainmob?.mind?.add_antag_datum(/datum/antagonist/clock_cultist)
+			if(!is_banned_from(affected_mob.ckey, list(JOB_CYBORG, ROLE_CLOCK_CULTIST)))
+				new_vessel.transfer_personality(affected_mob)
 		return
 
 	affected_mob.visible_message(span_clockred("[affected_mob] looks weak as the color fades from their body."), span_clockred("You feel your soul faltering..."))


### PR DESCRIPTION
## About The Pull Request

Gods now make explosions while fighting.
Reebe now starts with 2 stargazers and tinkerer's cache's.
Adds a recall where there should be one in slab_recall.
Makes max clock cultists scale slower.
Improved borg clockwork conversion.
Fixed the clock cultist ruleset reebe loading.
Discousages wall spam on reebe by making walls and windows build slower on reebe.
Makes soul vessels automatically add clock cultist on being entered as well as improves their checking.
Fixes clockwork weapons being able to be used by pacifists to apply effects but not damage.
Nerfs brass spear recall cooldown from 10 to 15 seconds.
Adds clockwork modules for cargo borgs.
Makes marauders actually be clock cultists.
Nerfs ocular warden minimum placement distance from 3 to 4.
Makes anchoring crystals take 6 instead of 5 minutes to charge.
Nerfs ocular warden base damage from 10 to 8 and minimum from 5 to 4.
Makes prosperity prisms no longer spam runtimes on reagentless mobs.
Vitality sigils will no longer put borg or clock cult banned players into soul vessels.

## Why It's Good For The Game

Better good.

## Changelog
:cl:
add: Gods now make explosions while fighting.
balance: Reebe now starts with 2 stargazers and tinkerer's cache's.
fix: Adds a recall where there should be one in slab_recall.
balance: Makes max clock cultists scale slower.
fix: Improved borg clockwork conversion.
fix: Fixed the clock cultist ruleset reebe loading.
balance: Discousages wall spam on reebe by making walls and windows build slower on reebe.
fix: Makes soul vessels automatically add clock cultist on being entered as well as improves their checking.
fix: Fixes clockwork weapons being able to be used by pacifists to apply effects but not damage.
balance: Nerfs brass spear recall cooldown from 10 to 15 seconds.
fix: Adds clockwork modules for cargo borgs.
fix: Makes marauders actually be clock cultists.
balance: Nerfs ocular warden minimum placement distance from 3 to 4.
balance: Makes anchoring crystals take 6 instead of 5 minutes to charge.
balance: Nerfs ocular warden base damage from 10 to 8 and minimum from 5 to 4.
fix: Makes prosperity prisms no longer spam runtimes on reagentless mobs.
fix: Vitality sigils will no longer put borg or clock cult banned players into soul vessels.
/:cl:
