### PR TITLE
NTSS Independence: You people can't behave edition

### DIFF
--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -1,7 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ac" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
-/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south{
+	damage_deflection = 21
+	},
 /obj/structure/closet/secure_closet/ert_sec{
 	name = "Emergency response security locker";
 	desc = "A storage unit containing equipment for responding to emergencies.";
@@ -362,10 +364,20 @@
 /turf/open/floor/plastic,
 /area/shuttle/escape)
 "fP" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/ammo_box/c35/rubber,
-/turf/open/floor/wood/tile,
-/area/shuttle/escape)
+/obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/structure/closet/secure_closet/ert_sec{
+	name = "Emergency response security locker";
+	desc = "A storage unit containing equipment for responding to emergencies.";
+	req_access = list("security")
+	},
+/obj/item/food/burger/cheese,
+/obj/item/gun/ballistic/revolver/mateba,
+/obj/item/ammo_box/a357,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south{
+	damage_deflection = 21
+	},
+/turf/open/floor/iron/dark/textured,
+/area/shuttle/escape/brig)
 "gr" = (
 /obj/item/radio/intercom/directional/south,
 /mob/living/simple_animal/bot/medbot{
@@ -841,17 +853,6 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/ballpit,
 /area/shuttle/escape/luxury)
-"pY" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "escape_cockpit_windows";
-	name = "Cockpit Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium{
-	damage_deflection = 21;
-	desc = "A 'Titan' brand Plastitanium window, there is a small image of a cat etched into the bottom right corner"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "qd" = (
 /obj/machinery/computer/warrant,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -913,7 +914,9 @@
 /obj/structure/sign/poster/contraband/clown{
 	pixel_y = 35
 	},
-/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west{
+	damage_deflection = 21
+	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "ri" = (
@@ -1028,8 +1031,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "tF" = (
-/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
-/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west{
+	damage_deflection = 21
+	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/box/handcuffs{
 	pixel_x = -3;
@@ -1049,6 +1053,9 @@
 	pixel_y = 4
 	},
 /obj/item/gun/grenadelauncher,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south{
+	damage_deflection = 21
+	},
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/escape/brig)
 "tS" = (
@@ -1178,7 +1185,8 @@
 	name = "Shuttle Armory";
 	req_access = list("security");
 	dir = 8;
-	safe = 0
+	safe = 0;
+	damage_deflection = 21
 	},
 /obj/effect/turf_decal/trimline/red/warning,
 /obj/effect/turf_decal/trimline/red/warning{
@@ -1463,9 +1471,10 @@
 /turf/open/floor/carpet/blue,
 /area/shuttle/escape/brig)
 "BW" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/eighties,
-/area/shuttle/escape/luxury)
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/ammo_box/c35/rubber,
+/turf/open/floor/wood/tile,
+/area/shuttle/escape)
 "Cj" = (
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
@@ -2267,6 +2276,17 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/shuttle/escape)
+"Qp" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium{
+	damage_deflection = 21;
+	desc = "A 'Titan' brand Plastitanium window, there is a small image of a cat etched into the bottom right corner"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "Qu" = (
 /obj/structure/bed/roller,
 /obj/item/bedsheet/patriot,
@@ -2921,7 +2941,7 @@ xf
 xf
 iQ
 yq
-fP
+BW
 nU
 xb
 so
@@ -2980,8 +3000,8 @@ kd
 (6,1,1) = {"
 kd
 kd
-pY
-pY
+Qp
+Qp
 uV
 uV
 rX
@@ -3026,7 +3046,7 @@ uV
 (7,1,1) = {"
 Wq
 uV
-pY
+Qp
 xU
 FR
 yH
@@ -3116,7 +3136,7 @@ xj
 xj
 "}
 (9,1,1) = {"
-pY
+Qp
 qd
 KB
 hH
@@ -3141,7 +3161,7 @@ qI
 Yr
 YZ
 bt
-BW
+uC
 Xw
 iO
 cY
@@ -3162,7 +3182,7 @@ xj
 xj
 "}
 (10,1,1) = {"
-pY
+Qp
 dg
 PU
 OU
@@ -3208,7 +3228,7 @@ uV
 OK
 "}
 (11,1,1) = {"
-pY
+Qp
 vq
 tx
 Gs
@@ -3254,7 +3274,7 @@ uV
 kd
 "}
 (12,1,1) = {"
-pY
+Qp
 mG
 zm
 Gs
@@ -3300,7 +3320,7 @@ uV
 kd
 "}
 (13,1,1) = {"
-pY
+Qp
 Sq
 ys
 bp
@@ -3346,7 +3366,7 @@ uV
 Et
 "}
 (14,1,1) = {"
-pY
+Qp
 oZ
 Ho
 Xo
@@ -3355,7 +3375,7 @@ KZ
 rX
 yT
 dC
-ac
+fP
 AB
 iP
 iP
@@ -3401,7 +3421,7 @@ eb
 rX
 hZ
 dC
-ac
+fP
 nZ
 UX
 Kd

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -52,7 +52,8 @@
 /area/shuttle/escape/luxury)
 "bE" = (
 /mob/living/simple_animal/bot/secbot{
-	name = "Officer Beefsky"
+	name = "Officer Beefsky";
+	damage_deflection = 21
 	},
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 4
@@ -175,7 +176,10 @@
 /turf/open/floor/iron/kitchen/diagonal,
 /area/shuttle/escape)
 "dQ" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium{
+	damage_deflection = 21;
+	desc = "A 'Titan' brand Plastitanium window, there is a small image of a cat etched into the bottom right corner"
+	},
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/shuttle/escape/brig)
@@ -203,7 +207,8 @@
 /area/shuttle/escape)
 "dY" = (
 /obj/machinery/porta_turret/centcom_shuttle{
-	dir = 6
+	dir = 6;
+	faction = list("neutral","silicon","turret","clowns")
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
@@ -225,10 +230,13 @@
 /turf/open/ballpit,
 /area/shuttle/escape/luxury)
 "en" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "shuttlewindow";
 	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium{
+	damage_deflection = 21;
+	desc = "A 'Titan' brand Plastitanium window, there is a small image of a cat etched into the bottom right corner"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -324,7 +332,7 @@
 "fy" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/structure/disposalpipe/segment,
-/obj/item/storage/box/fireworks/dangerous,
+/obj/item/gun/ballistic/automatic/pistol/paco/no_mag,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "fA" = (
@@ -355,7 +363,7 @@
 /area/shuttle/escape)
 "fP" = (
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/gun/ballistic/automatic/pistol/m1911,
+/obj/item/ammo_box/c35/rubber,
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "gr" = (
@@ -367,7 +375,8 @@
 /area/shuttle/escape)
 "gH" = (
 /obj/machinery/porta_turret/centcom_shuttle{
-	dir = 5
+	dir = 5;
+	faction = list("neutral","silicon","turret","clowns")
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
@@ -450,7 +459,10 @@
 /area/shuttle/escape/luxury)
 "iP" = (
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium{
+	damage_deflection = 21;
+	desc = "A 'Titan' brand Plastitanium window, there is a small image of a cat etched into the bottom right corner"
+	},
 /turf/open/floor/plating/airless,
 /area/shuttle/escape/brig)
 "iQ" = (
@@ -507,11 +519,13 @@
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/soda_cans/monkey_energy,
 /obj/item/stack/sheet/mineral/coal/ten,
-/obj/item/gun/ballistic/revolver/mateba,
+/obj/item/gun/ballistic/automatic/pistol/paco/no_mag,
+/obj/item/ammo_box/magazine/m35/rubber,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/shuttle/escape)
 "jG" = (
 /obj/machinery/vending/boozeomat/all_access,
+/obj/structure/sign/flag/nanotrasen/directional/north,
 /turf/open/floor/plastic,
 /area/shuttle/escape/luxury)
 "jO" = (
@@ -559,10 +573,13 @@
 /turf/open/floor/plastic,
 /area/shuttle/escape/luxury)
 "kc" = (
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "shuttlewindow";
 	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium{
+	damage_deflection = 21;
+	desc = "A 'Titan' brand Plastitanium window, there is a small image of a cat etched into the bottom right corner"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -570,11 +587,15 @@
 /turf/template_noop,
 /area/template_noop)
 "kn" = (
-/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/north{
+	damage_deflection = 21
+	},
 /obj/item/clothing/accessory/medal/gold,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/east{
+	damage_deflection = 21
+	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape/luxury)
@@ -621,12 +642,18 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/grenade/frag,
 /turf/open/floor/iron/showroomfloor,
 /area/shuttle/escape)
 "ld" = (
 /obj/effect/decal/cleanable/confetti,
 /obj/structure/window/reinforced/spawner/directional/west,
+/mob/living/simple_animal/hostile/retaliate/clown{
+	health = 300;
+	name = "Honk-E-Clown";
+	desc = "This clown looks pretty tough, better stay on his good side...";
+	limb_destroyer = 1;
+	maxHealth = "300"
+	},
 /turf/open/ballpit,
 /area/shuttle/escape/luxury)
 "lk" = (
@@ -728,7 +755,7 @@
 /area/shuttle/escape)
 "nx" = (
 /obj/machinery/porta_turret/syndicate{
-	faction = list("neutral","silicon","turret");
+	faction = list("neutral","silicon","turret","clowns");
 	gender = "female";
 	req_access = list("security");
 	dir = 4
@@ -812,13 +839,18 @@
 "pz" = (
 /obj/effect/decal/cleanable/confetti,
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/item/gun/ballistic/automatic/pistol/aps,
 /turf/open/ballpit,
 /area/shuttle/escape/luxury)
 "pY" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/gun,
-/turf/open/floor/wood/tile,
+/obj/machinery/door/poddoor/preopen{
+	id = "escape_cockpit_windows";
+	name = "Cockpit Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium{
+	damage_deflection = 21;
+	desc = "A 'Titan' brand Plastitanium window, there is a small image of a cat etched into the bottom right corner"
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "qd" = (
 /obj/machinery/computer/warrant,
@@ -900,6 +932,7 @@
 "rw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/box/fireworks,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "rx" = (
@@ -915,14 +948,8 @@
 /area/shuttle/escape/brig)
 "rO" = (
 /obj/effect/decal/cleanable/plastic,
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north,
-/mob/living/simple_animal/hostile/retaliate/clown{
-	health = 300;
-	name = "Honk-E-Clown";
-	desc = "This clown looks pretty tough, better stay on his good side...";
-	limb_destroyer = 1
-	},
+/obj/machinery/door/window/brigdoor/right/directional/east,
 /turf/open/ballpit,
 /area/shuttle/escape/luxury)
 "rX" = (
@@ -930,7 +957,8 @@
 /area/shuttle/escape/brig)
 "si" = (
 /obj/machinery/porta_turret/centcom_shuttle{
-	dir = 10
+	dir = 10;
+	faction = list("neutral","silicon","turret","clowns")
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
@@ -1027,9 +1055,6 @@
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
 	dir = 8
-	},
-/obj/item/gun/ballistic/shotgun/lethal{
-	pixel_y = -10
 	},
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
@@ -1235,14 +1260,16 @@
 	pixel_y = 2;
 	pixel_x = 7
 	},
-/obj/item/gun/ballistic/automatic/pistol/clandestine{
-	pixel_y = 9
-	},
+/obj/item/ammo_box/magazine/m35/rubber,
+/obj/item/gun/ballistic/automatic/pistol/paco/no_mag,
 /turf/open/floor/eighties,
 /area/shuttle/escape/luxury)
 "xT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
+/obj/effect/spawner/structure/window/reinforced/plasma/plastitanium{
+	damage_deflection = 21;
+	desc = "A 'Titan' brand Plastitanium window, there is a small image of a cat etched into the bottom right corner"
+	},
 /turf/open/floor/plating/airless,
 /area/shuttle/escape/brig)
 "xU" = (
@@ -1269,7 +1296,8 @@
 /area/shuttle/escape)
 "yq" = (
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/gun/ballistic/revolver/c38,
+/obj/item/gun/ballistic/automatic/pistol/paco/no_mag,
+/obj/item/ammo_box/magazine/m35/rubber,
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "ys" = (
@@ -1343,8 +1371,8 @@
 /area/shuttle/escape)
 "Al" = (
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/storage/box/fireworks/dangerous,
-/obj/item/gun/ballistic/shotgun/lethal,
+/obj/item/gun/ballistic/automatic/pistol/paco/no_mag,
+/obj/item/ammo_box/magazine/m35/rubber,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "Aq" = (
@@ -1375,13 +1403,17 @@
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "Bf" = (
-/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/west{
+	damage_deflection = 21
+	},
 /obj/item/gun/ballistic/rocketlauncher/unrestricted{
 	name = "\improper Nanotrasen PML-9";
 	desc = "A reusable rocket propelled grenade launcher. The words 'Syndicate this way' and an arrow have been written near the barrel. A sticker near the cheek rest reads, 'FOR DISPLAY PURPOSES ONLY'"
+	},
+/obj/structure/window/reinforced/spawner/directional/north{
+	damage_deflection = 21
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape/luxury)
@@ -1399,11 +1431,12 @@
 	},
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,
 /obj/item/gravity_gun,
+/obj/item/assembly/signaler/anomaly/grav,
 /turf/open/floor/iron/showroomfloor,
 /area/shuttle/escape)
 "Bv" = (
 /obj/machinery/porta_turret/syndicate{
-	faction = list("neutral","silicon","turret");
+	faction = list("neutral","silicon","turret","clowns");
 	gender = "female";
 	req_access = list("security");
 	dir = 5
@@ -1458,7 +1491,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/escape)
 "Cy" = (
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /obj/machinery/door/airlock/command{
 	name = "Honk-E-Clown's Mafia Free Playland and Casino"
 	},
@@ -1601,7 +1633,7 @@
 /area/shuttle/escape)
 "Et" = (
 /obj/machinery/porta_turret/syndicate{
-	faction = list("neutral","silicon","turret");
+	faction = list("neutral","silicon","turret","clowns");
 	gender = "female";
 	req_access = list("security");
 	dir = 10
@@ -1801,7 +1833,9 @@
 /turf/open/floor/eighties,
 /area/shuttle/escape/luxury)
 "HT" = (
-/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/north{
+	damage_deflection = 21
+	},
 /obj/item/reagent_containers/cup/glass/trophy/gold_cup{
 	pixel_x = 16;
 	pixel_y = 2
@@ -1861,7 +1895,8 @@
 /area/shuttle/escape)
 "IQ" = (
 /obj/machinery/porta_turret/centcom_shuttle{
-	dir = 9
+	dir = 9;
+	faction = list("neutral","silicon","turret","clowns")
 	},
 /turf/closed/wall/mineral/plastitanium,
 /area/shuttle/escape)
@@ -1871,12 +1906,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/grenade/frag,
+/obj/item/ammo_box/c35/rubber,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "Jk" = (
-/obj/item/storage/box/fireworks/dangerous,
 /obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/box/fireworks,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "Jm" = (
@@ -2165,7 +2200,7 @@
 /area/shuttle/escape)
 "OK" = (
 /obj/machinery/porta_turret/syndicate{
-	faction = list("neutral","silicon","turret");
+	faction = list("neutral","silicon","turret","clowns");
 	gender = "female";
 	req_access = list("security");
 	dir = 6
@@ -2175,11 +2210,6 @@
 "OQ" = (
 /turf/open/floor/carpet/blue,
 /area/shuttle/escape/brig)
-"OT" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/gun/ballistic,
-/turf/open/floor/wood/tile,
-/area/shuttle/escape)
 "OU" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 10
@@ -2237,14 +2267,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/shuttle/escape)
-"Qp" = (
-/obj/effect/mapping_helpers/airlock/access/all/command/general,
-/obj/structure/sign/flag/nanotrasen/directional/north,
-/obj/machinery/door/airlock/command{
-	name = "Honk-E-Clown's Mafia Free Playland and Casino"
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/shuttle/escape/luxury)
 "Qu" = (
 /obj/structure/bed/roller,
 /obj/item/bedsheet/patriot,
@@ -2282,6 +2304,7 @@
 "Rz" = (
 /obj/machinery/light/directional/east,
 /obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/ammo_box/c35/rubber,
 /turf/open/floor/wood/tile,
 /area/shuttle/escape)
 "RO" = (
@@ -2446,7 +2469,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/shuttle/escape)
 "Ul" = (
-/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/north{
+	damage_deflection = 21
+	},
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/item/ammo_casing/caseless/rocket/heap,
@@ -2588,7 +2613,7 @@
 /area/shuttle/escape)
 "Wq" = (
 /obj/machinery/porta_turret/syndicate{
-	faction = list("neutral","silicon","turret");
+	faction = list("neutral","silicon","turret","clowns");
 	gender = "female";
 	req_access = list("security");
 	dir = 9
@@ -2621,7 +2646,7 @@
 /area/shuttle/escape)
 "Xd" = (
 /obj/machinery/porta_turret/syndicate{
-	faction = list("neutral","silicon","turret");
+	faction = list("neutral","silicon","turret","clowns");
 	gender = "female";
 	req_access = list("security");
 	dir = 8
@@ -2684,6 +2709,7 @@
 /area/shuttle/escape)
 "YI" = (
 /obj/effect/spawner/random/vending/snackvend,
+/obj/structure/sign/flag/nanotrasen/directional/north,
 /turf/open/floor/plastic,
 /area/shuttle/escape/luxury)
 "YN" = (
@@ -2845,8 +2871,8 @@ aG
 uV
 Eg
 uV
-pY
-fP
+nU
+nU
 bT
 mw
 mw
@@ -2894,9 +2920,9 @@ Lf
 xf
 xf
 iQ
+yq
+fP
 nU
-nU
-OT
 xb
 so
 Od
@@ -2954,8 +2980,8 @@ kd
 (6,1,1) = {"
 kd
 kd
-Tw
-Tw
+pY
+pY
 uV
 uV
 rX
@@ -2979,7 +3005,7 @@ YZ
 YZ
 Cy
 YZ
-Qp
+Cy
 YZ
 YZ
 YZ
@@ -3000,7 +3026,7 @@ uV
 (7,1,1) = {"
 Wq
 uV
-Tw
+pY
 xU
 FR
 yH
@@ -3090,7 +3116,7 @@ xj
 xj
 "}
 (9,1,1) = {"
-Tw
+pY
 qd
 KB
 hH
@@ -3136,7 +3162,7 @@ xj
 xj
 "}
 (10,1,1) = {"
-Tw
+pY
 dg
 PU
 OU
@@ -3182,7 +3208,7 @@ uV
 OK
 "}
 (11,1,1) = {"
-Tw
+pY
 vq
 tx
 Gs
@@ -3228,7 +3254,7 @@ uV
 kd
 "}
 (12,1,1) = {"
-Tw
+pY
 mG
 zm
 Gs
@@ -3274,7 +3300,7 @@ uV
 kd
 "}
 (13,1,1) = {"
-Tw
+pY
 Sq
 ys
 bp
@@ -3320,7 +3346,7 @@ uV
 Et
 "}
 (14,1,1) = {"
-Tw
+pY
 oZ
 Ho
 Xo
@@ -3466,8 +3492,8 @@ uV
 uV
 rX
 Vm
-dQ
-dQ
+iP
+iP
 Fp
 iP
 iP
@@ -3485,7 +3511,7 @@ YZ
 YZ
 Cy
 YZ
-Qp
+Cy
 YZ
 YZ
 YZ


### PR DESCRIPTION

## About The Pull Request

This pull request is centered around refining the NTSS Independence. After listening to the glorious, endless feedback loop of the community and their most pressing concerns about the shuttle, several changes have been implemented. The alterations range from weapon modifications to structural tweaks, aiming to optimize player experience and address prominent issues.

## Why It's Good For The Game

1. The Great Gun Grab: Because apparently, some folks can't get through a round without an insatiable urge to murder each other, I've swapped out the fun guns with .35mm "Taco" handguns loaded with rubber bullets. Want to still play cowboy? Sure, but now you'll be doing it without the murder. And let me remind you, the bridge of the NTSS Independence is one of the most secure shuttles in the game, so if you let unauthorized personnel in and they grab a lethal firearm, well, that's on you.

1. Sturdier Glass? Maybe not: I tried, oh how I tried with variable editing, to beef up that security area glass. But the pesky mechanics of space station windows make it a challenge because all windows are actually "window spawners". Mark this as a "To Be Continued..." because I need someone to help me make a more durable glass subtype. 

1. Party Room Free-for-All: Removed the VIP velvet rope from the party room. All are welcome, because... why not? The previous restrictions were about as useful as a chocolate teapot.

1. Clown-Proof Turrets: Those turrets? Now they're on the clown's side. No more unintentional hull breaches if Bozo decides to go for a stroll outside the party room. (Turrets now have the 'clowns' faction)

1. Ball Pit Doorway: Originally envisioned the ball pit as a chute-only entry. It was... ambitious. Now there's a door for your convenience. Enjoy.

1. Explosives Lite: Downgraded the pyrotechnics in the passenger area. So now, when you want to light up the night, it's a tad less... destructive.

In summary, these tweaks cater to our beloved community, balancing fun with responsibility. Will this silence all the complaints? Ha! But at least it might muffle them a bit. As a further reminder the one change I'm not willing to accept is making the shuttle only accessible via Emag.

## Changelog


:cl:

balance: NTSS Independence balance pass

/:cl:

