### PR TITLE
splicer names splice a little better

### DIFF
--- a/monkestation/code/modules/hydroponics/machines/splicer.dm
+++ b/monkestation/code/modules/hydroponics/machines/splicer.dm
@@ -84,6 +84,9 @@
 
 /obj/machinery/splicer/proc/splice(obj/item/seeds/first_seed, obj/item/seeds/second_seed)
 
+	if(!first_seed || !second_seed)
+		return
+
 	var/obj/item/seeds/spliced/new_seed = new
 	new_seed.set_potency((first_seed.potency + second_seed.potency) * 0.5)
 	new_seed.set_yield((first_seed.yield + second_seed.yield) * 0.5)
@@ -126,8 +129,8 @@
 		var/obj/item/seeds/spliced/spliced_seed = second_seed
 		new_seed.produce_list |= spliced_seed.produce_list
 
-	var/part1 = copytext(first_seed.plantname, 1, round(length(first_seed.plantname) * 0.70 + 2))
-	var/part2 = copytext(second_seed.plantname, round(length(second_seed.plantname) * 0.40 + 1), 0)
+	var/part1 = copytext(copytext(first_seed.plantname, 1, round(length(first_seed.plantname) * 0.70 + 2)), 1, 50)
+	var/part2 = copytext(copytext(second_seed.plantname, round(length(second_seed.plantname) * 0.40 + 1), 0), -50)
 
 	new_seed.name = "pack of [part1][part2] seeds"
 	new_seed.plantname = "[part1][part2]"

--- a/monkestation/code/modules/hydroponics/machines/splicer.dm
+++ b/monkestation/code/modules/hydroponics/machines/splicer.dm
@@ -126,10 +126,10 @@
 		var/obj/item/seeds/spliced/spliced_seed = second_seed
 		new_seed.produce_list |= spliced_seed.produce_list
 
-	var/part1 = copytext(first_seed.name, 1, round(length(first_seed.name) * 0.70 + 2))
-	var/part2 = copytext(second_seed.name, round(length(second_seed.name) * 0.40 + 1), 0)
+	var/part1 = copytext(first_seed.plantname, 1, round(length(first_seed.plantname) * 0.70 + 2))
+	var/part2 = copytext(second_seed.plantname, round(length(second_seed.plantname) * 0.40 + 1), 0)
 
-	new_seed.name = "[part1][part2]"
+	new_seed.name = "pack of [part1][part2] seeds"
 	new_seed.plantname = "[part1][part2]"
 
 	for(var/datum/plant_gene/trait/traits in first_seed.genes)


### PR DESCRIPTION
## About The Pull Request

This changes the splicer to use the plant name itself, to avoid plants being named stuff like "the pa pack ta pa of th the t of watbanamelon seeds".

It also imposes a max length on plant names.

It also fixes a crash if you click splice with only one seed loaded

![image](https://github.com/Monkestation/Monkestation2.0/assets/31165061/d8a8ff60-b851-47fe-81d3-6b4d81de32fb)


## Why It's Good For The Game

Funne

## Changelog

:cl:
fix: Spliced seed packs should be named slightly more coherently and have a max length
/:cl:
