### PR TITLE
OSHAN patch.

### DIFF
--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -186,7 +186,15 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
 "adv" = (
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "adV" = (
 /obj/machinery/airalarm/all_access{
@@ -518,6 +526,13 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
+"alg" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/purple,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "alo" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/spawner/random/structure/grille,
@@ -545,7 +560,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "amz" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1303,12 +1318,34 @@
 	dir = 4
 	},
 /area/station/engineering/atmos/hfr_room)
+"aLK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "aLM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/station/cargo/sorting)
+"aLO" = (
+/obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#00ff00";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "aMo" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/reagent_containers/cup/soda_cans/monkestation/lemonade{
@@ -1454,6 +1491,12 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
+"aQU" = (
+/obj/structure/cable,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/brown,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "aRb" = (
 /obj/machinery/announcement_system,
 /turf/open/floor/circuit,
@@ -1735,6 +1778,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/yellow,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "aVv" = (
@@ -2004,12 +2048,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
-"bcF" = (
-/obj/machinery/duct/industrial/waste,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/glass/reinforced,
-/area/station/engineering/main)
 "bcL" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -2102,12 +2140,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/brown,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "beP" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
-	color = "#009dc4"
+	color = "#00ff00"
 	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8;
@@ -2568,6 +2607,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/brown,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "bpX" = (
@@ -2760,6 +2800,7 @@
 "buF" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "bva" = (
@@ -2805,6 +2846,12 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
+"bvZ" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "bwi" = (
 /obj/machinery/light_switch/directional/north{
 	pixel_y = -21;
@@ -3237,6 +3284,14 @@
 /obj/structure/flora/ocean/longseaweed,
 /turf/open/floor/holofloor/beach/water,
 /area/station/maintenance/starboard/aft)
+"bFB" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "bFI" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4"
@@ -3444,7 +3499,11 @@
 /area/station/science/cytology)
 "bJU" = (
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/iron,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "bKz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -3748,6 +3807,7 @@
 	dir = 4
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/purple,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "bTl" = (
@@ -3949,6 +4009,7 @@
 	invisibility = 101
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "cbs" = (
@@ -4045,6 +4106,7 @@
 	invisibility = 101
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
 "cdv" = (
@@ -4104,6 +4166,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/yellow,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "ceK" = (
@@ -4871,14 +4934,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"cDf" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/stripes,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/main)
 "cDm" = (
 /obj/item/pen,
 /obj/structure/table/reinforced,
@@ -4989,7 +5044,10 @@
 /area/station/cargo/storage)
 "cGg" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "cGK" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -5283,7 +5341,11 @@
 /obj/machinery/cryopod{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 4;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "cQf" = (
 /obj/machinery/light_switch/directional/south,
@@ -6061,6 +6123,7 @@
 	dir = 4
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/dark_blue,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "diP" = (
@@ -6636,6 +6699,7 @@
 /area/station/maintenance/starboard/aft)
 "dtJ" = (
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/lobby)
 "dtY" = (
@@ -6994,6 +7058,13 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/storage)
+"dFw" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "dFW" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -7117,7 +7188,13 @@
 /area/station/commons/toilet/restrooms)
 "dIo" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "dIv" = (
 /obj/structure/cable,
@@ -7231,7 +7308,14 @@
 /area/station/maintenance/port/aft)
 "dMh" = (
 /obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "dMj" = (
 /obj/structure/fans/tiny/forcefield{
@@ -8198,6 +8282,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "enB" = (
@@ -8464,6 +8551,7 @@
 /area/station/security/courtroom)
 "eup" = (
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
 "euB" = (
@@ -8891,6 +8979,7 @@
 "eEZ" = (
 /obj/machinery/light/floor/has_bulb,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
 "eFa" = (
@@ -9783,6 +9872,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
+"fbr" = (
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 10;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "fbt" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
@@ -10197,6 +10293,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
+"flW" = (
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "fmI" = (
 /obj/structure/spider/stickyweb/sealed,
 /turf/open/floor/plating,
@@ -10473,6 +10576,9 @@
 	dir = 4
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "fvi" = (
@@ -11301,6 +11407,7 @@
 	invisibility = 101
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/lobby)
 "fUp" = (
@@ -11461,7 +11568,6 @@
 /area/station/maintenance/starboard/aft)
 "fYs" = (
 /obj/structure/cable,
-/obj/machinery/light/floor/has_bulb,
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
 	dir = 1
@@ -11469,6 +11575,7 @@
 /obj/effect/turf_decal/trimline/white/line{
 	color = "#009dc4"
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "fYz" = (
@@ -12093,12 +12200,12 @@
 /area/ocean)
 "gpl" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
-	color = "#009dc4"
-	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
@@ -12383,7 +12490,11 @@
 	dir = 2
 	},
 /obj/machinery/disposal/bin,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "gym" = (
 /obj/machinery/medical_kiosk,
@@ -13049,6 +13160,16 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/storage/emergency/starboard)
+"gSq" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 5;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "gSr" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/cable,
@@ -13123,6 +13244,7 @@
 	invisibility = 101
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/dark_blue,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "gUq" = (
@@ -13329,7 +13451,15 @@
 	dir = 4
 	},
 /obj/machinery/disposal/bin,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#00ff00";
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "gYZ" = (
 /obj/machinery/light/directional/north,
@@ -14166,6 +14296,16 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
+"hxr" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "hxC" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/white/filled/corner{
@@ -14262,6 +14402,9 @@
 "hzM" = (
 /obj/structure/cable,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "hzR" = (
@@ -14683,6 +14826,16 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/security/warden)
+"hLm" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/brown,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "hLn" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -16002,12 +16155,12 @@
 /area/station/service/cafeteria)
 "iwy" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4";
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#00ff00";
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -16016,6 +16169,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/yellow,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "iwO" = (
@@ -16109,6 +16263,7 @@
 "iAd" = (
 /obj/structure/bed/double,
 /obj/item/bedsheet/patriot/double,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet/neon/simple/blue,
 /area/station/commons/dorms)
 "iAr" = (
@@ -18427,6 +18582,20 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/executive,
 /area/station/command/bridge)
+"jNq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 4;
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#00ff00";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "jNs" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -18971,7 +19140,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "kam" = (
 /obj/structure/cable,
@@ -19131,6 +19300,14 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"keV" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "kfc" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -19748,6 +19925,7 @@
 "kwp" = (
 /obj/structure/cable,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/purple,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "kwv" = (
@@ -20180,6 +20358,17 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
+"kHS" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "kHX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21789,7 +21978,14 @@
 	name = "Conveyor Access"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "lxS" = (
 /obj/machinery/gibber,
@@ -22580,6 +22776,19 @@
 /obj/item/phone,
 /turf/open/floor/carpet/blue,
 /area/station/security/checkpoint/customs)
+"lRz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "lRA" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/item/storage/secure/briefcase,
@@ -22857,6 +23066,7 @@
 	dir = 8
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/red,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
 "mal" = (
@@ -25696,6 +25906,12 @@
 "nBV" = (
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/hop)
+"nBX" = (
+/obj/machinery/duct/industrial/waste,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/glass/reinforced,
+/area/station/engineering/main)
 "nCm" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Head of Personel's office"
@@ -25854,6 +26070,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/floor/has_bulb,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/trimline/yellow,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "nGM" = (
@@ -25879,6 +26096,7 @@
 	dir = 8
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/dark_blue,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "nHn" = (
@@ -26766,10 +26984,10 @@
 /obj/machinery/duct/industrial/waste,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
+	color = "#00ff00"
 	},
 /obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4";
+	color = "#00ff00";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -27206,7 +27424,15 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 4;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "orQ" = (
 /obj/structure/disposalpipe/trunk{
@@ -27780,6 +28006,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "oHO" = (
@@ -28453,6 +28682,7 @@
 	dir = 1
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/lobby)
 "pdU" = (
@@ -28692,6 +28922,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/dorms)
 "pkS" = (
@@ -28961,7 +29194,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "pqp" = (
 /turf/open/floor/iron/kitchen,
@@ -31073,7 +31310,7 @@
 /obj/item/clothing/under/misc/mailman,
 /obj/item/storage/bag/mail,
 /obj/effect/turf_decal/tile/brown/fourcorners,
-/turf/open/space/basic,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "qsG" = (
 /obj/structure/cable,
@@ -31585,6 +31822,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"qIQ" = (
+/obj/structure/cable,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "qJg" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access"
@@ -31906,6 +32151,7 @@
 "qPO" = (
 /obj/structure/bed/double,
 /obj/item/bedsheet/clown/double,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/eighties/red{
 	icon = 'goon/icons/turf/floors.dmi';
 	icon_state = "clown_carpet"
@@ -32627,6 +32873,7 @@
 /area/station/ai_monitored/turret_protected/ai)
 "rio" = (
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/red,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
 "riE" = (
@@ -32641,6 +32888,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "riL" = (
@@ -33483,6 +33733,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "rEH" = (
@@ -33663,6 +33916,9 @@
 	dir = 9
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "rJS" = (
@@ -33686,6 +33942,9 @@
 	dir = 6
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "rKi" = (
@@ -33866,7 +34125,10 @@
 /area/station/service/chapel)
 "rOJ" = (
 /obj/machinery/computer/cryopod/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "rOK" = (
 /obj/structure/disposalpipe/segment{
@@ -34949,7 +35211,7 @@
 	},
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
-	color = "#009dc4"
+	color = "#00ff00"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/dorms)
@@ -35087,6 +35349,7 @@
 /area/station/medical/treatment_center)
 "sBe" = (
 /obj/structure/table/wood,
+/obj/item/food/ready_donk/mac_n_cheese,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "sBo" = (
@@ -35764,6 +36027,15 @@
 /obj/item/electronics/apc,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"sTz" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/purple,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "sTK" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/blue/diagonal_centre,
@@ -36328,6 +36600,7 @@
 	desc = "As seen in your favourite Japanese cartoon.";
 	name = "anime katana"
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/eighties,
 /area/station/service/abandoned_gambling_den/gaming)
 "tme" = (
@@ -36903,6 +37176,7 @@
 	},
 /obj/machinery/light/floor/has_bulb,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/trimline/yellow,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "tEG" = (
@@ -37369,6 +37643,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/yellow,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "tPK" = (
@@ -37436,7 +37711,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "tSc" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -37999,7 +38274,15 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#00ff00";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "ufy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39474,6 +39757,7 @@
 	dir = 4
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/dark_blue,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "uSL" = (
@@ -39708,7 +39992,15 @@
 /obj/machinery/cryopod{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 6;
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 6;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "uZa" = (
 /obj/structure/falsewall,
@@ -40034,7 +40326,13 @@
 /area/station/command/bridge)
 "vhM" = (
 /obj/structure/closet/firecloset,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/dark_red/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "vhO" = (
 /obj/effect/turf_decal/stripes,
@@ -40384,7 +40682,14 @@
 "vrg" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "vrl" = (
 /obj/structure/cable,
@@ -40712,6 +41017,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "vAv" = (
@@ -42556,7 +42864,14 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "wCH" = (
 /obj/structure/bed/pod{
@@ -42579,6 +42894,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"wCL" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/yellow,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central/fore)
 "wCO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
@@ -43340,7 +43662,14 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Auxiliary Tool Storage"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "wZI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
@@ -43563,7 +43892,15 @@
 /area/station/hallway/primary/central)
 "xdP" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "xdZ" = (
 /turf/open/floor/plating,
@@ -43673,7 +44010,15 @@
 "xix" = (
 /obj/machinery/camera/directional/east,
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#00ff00";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "xiB" = (
 /obj/structure/table,
@@ -43713,7 +44058,11 @@
 /area/station/science/lab)
 "xji" = (
 /obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
 "xjU" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44898,6 +45247,17 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/commons/lounge)
+"xPJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 9;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "xPK" = (
 /mob/living/basic/chicken/brown,
 /turf/open/misc/sandy_dirt,
@@ -45500,16 +45860,27 @@
 "yfT" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
-	color = "#009dc4"
-	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8;
 	color = "#009dc4"
 	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"yfX" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central/fore)
 "ygb" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -45598,6 +45969,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/commons/lounge)
+"yhN" = (
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "yhQ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -63842,7 +64223,7 @@ jeZ
 vwP
 xEU
 rfc
-kwp
+qIQ
 nxP
 xwm
 qeN
@@ -63896,16 +64277,16 @@ wVt
 hzM
 sTn
 ngm
-hzM
+aQU
 sTn
 tjR
-gUe
+hLm
 owJ
 sTn
-hzM
+aQU
 sTn
 nTa
-gUe
+hLm
 epx
 qaa
 uNE
@@ -64612,7 +64993,7 @@ vwP
 vwP
 vwP
 xEU
-kwp
+qIQ
 nxP
 wJX
 qet
@@ -65640,7 +66021,7 @@ jSp
 lHt
 yke
 umh
-kwp
+qIQ
 nxP
 ljv
 aTw
@@ -66412,7 +66793,7 @@ wlx
 nLV
 umh
 rfc
-nxP
+kHS
 pkw
 dMh
 vhM
@@ -66668,13 +67049,13 @@ eBe
 pse
 nLV
 umh
-kwp
-nxP
+qIQ
+kHS
 ahh
-adv
-adv
-adv
-adv
+hxr
+lel
+lel
+lel
 wCE
 pkw
 xmh
@@ -66928,11 +67309,11 @@ jQZ
 rfc
 iwy
 wZC
-adv
-adv
-adv
-adv
-tRB
+yhN
+flW
+lel
+lel
+lRz
 pkw
 xUe
 upR
@@ -67183,11 +67564,11 @@ lHt
 nLV
 tXk
 rfc
-nxP
+kHS
 ahh
-adv
+hxr
 amw
-xdP
+xPJ
 xdP
 ufr
 pkw
@@ -67440,10 +67821,10 @@ rOB
 nLV
 umh
 rfc
-nxP
+kHS
 pkw
-xji
-tRB
+aLO
+jNq
 xix
 pkw
 nbX
@@ -67697,7 +68078,7 @@ nLV
 nLV
 umh
 rfc
-nxP
+kHS
 pkw
 pkw
 orx
@@ -67953,12 +68334,12 @@ mFh
 fgS
 gGL
 vSI
-kwp
-nxP
+qIQ
+kHS
 pkw
 gyj
 pqf
-adv
+fbr
 vrg
 ugV
 upR
@@ -68211,10 +68592,10 @@ tXC
 tXC
 gAV
 rfc
-nxP
+kHS
 pkw
 xji
-tRB
+aLK
 cGg
 pkw
 fGs
@@ -68468,11 +68849,11 @@ hHy
 tXC
 wgD
 tYL
-nxP
+kHS
 pkw
-adv
+dFw
 tRB
-adv
+bvZ
 ahh
 wXG
 ske
@@ -68727,9 +69108,9 @@ iyS
 veZ
 oij
 lxM
-xdP
+keV
 jZX
-adv
+bvZ
 ahh
 vxY
 ske
@@ -68982,9 +69363,9 @@ tXC
 tXC
 faF
 cbq
-nxP
+kHS
 pkw
-adv
+dFw
 bJU
 rOJ
 pkw
@@ -69239,9 +69620,9 @@ bhD
 rXT
 gAV
 wDZ
-nxP
+kHS
 ahh
-uYW
+gSq
 cPJ
 uYW
 pkw
@@ -69496,7 +69877,7 @@ qza
 aES
 iyS
 wDZ
-nxP
+kHS
 pkw
 pkw
 pkw
@@ -78748,7 +79129,7 @@ bUu
 bUu
 bUu
 jXE
-kwp
+qIQ
 nxP
 tYA
 cXb
@@ -79325,7 +79706,7 @@ pPs
 pkw
 fIP
 hxC
-diH
+yfX
 iFe
 gZg
 tPb
@@ -80867,7 +81248,7 @@ qZP
 pxQ
 fBH
 ukS
-diH
+yfX
 iFe
 gZg
 lpu
@@ -81638,7 +82019,7 @@ aIc
 jBo
 jMN
 vYQ
-diH
+yfX
 iFe
 gZg
 tPb
@@ -82099,14 +82480,14 @@ jAU
 dUR
 kPm
 iMu
-rKc
+sTz
 cOB
 wFP
 wFP
 wSx
 wFP
 oaW
-vAr
+alg
 pIW
 lQS
 tzD
@@ -82409,7 +82790,7 @@ vjk
 dXN
 fvi
 glV
-diH
+yfX
 iFe
 vUJ
 seY
@@ -83680,7 +84061,7 @@ jRC
 aVs
 szt
 klb
-enq
+wCL
 yew
 ikz
 wws
@@ -86233,7 +86614,7 @@ kFZ
 xQn
 eMG
 tCB
-bcF
+nBX
 sgQ
 asg
 sli
@@ -87004,7 +87385,7 @@ aNi
 aNi
 aNi
 qay
-cDf
+bFB
 jvI
 jRw
 auZ

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -15308,7 +15308,6 @@
 /area/station/command/bridge)
 "inW" = (
 /obj/structure/closet/secure_closet/warden,
-/obj/item/gun/energy/laser,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/radio/headset/heads/hos/alt{
 	name = "\proper the Warden's bowman headset";
@@ -15319,6 +15318,17 @@
 	layer = 2.9
 	},
 /obj/item/flashlight/seclite,
+/obj/item/gun/ballistic/automatic/pistol/paco,
+/obj/item/ammo_box/magazine/m35/rubber{
+	pixel_y = -3;
+	pixel_x = -8;
+	layer = 3.1
+	},
+/obj/item/ammo_box/magazine/m35{
+	pixel_y = 10;
+	pixel_x = -8;
+	layer = 3.1
+	},
 /turf/open/floor/pod/dark,
 /area/station/security/warden)
 "iok" = (
@@ -24454,9 +24464,40 @@
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/table/reinforced,
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/item/gun/energy/e_gun/dragnet,
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/item/ammo_box/magazine/m35/rubber{
+	pixel_y = -3
+	},
+/obj/item/ammo_box/magazine/m35/rubber{
+	pixel_y = -3;
+	pixel_x = -8;
+	layer = 3.1
+	},
+/obj/item/ammo_box/magazine/m35/rubber{
+	pixel_y = -3;
+	pixel_x = -4
+	},
+/obj/item/ammo_box/magazine/m35{
+	pixel_y = 10;
+	pixel_x = -8;
+	layer = 3.1
+	},
+/obj/item/ammo_box/magazine/m35{
+	pixel_y = 10;
+	pixel_x = -4
+	},
+/obj/item/ammo_box/magazine/m35{
+	pixel_y = 10;
+	pixel_x = 2;
+	layer = 2.9
+	},
+/obj/item/ammo_box/c35{
+	pixel_x = 5;
+	pixel_y = 13
+	},
+/obj/item/ammo_box/c35/rubber{
+	pixel_x = 5
+	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "njm" = (
@@ -33109,6 +33150,8 @@
 	layer = 3.1;
 	pixel_y = 12
 	},
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/item/gun/energy/e_gun/dragnet,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "rPw" = (

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -8030,6 +8030,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"eoL" = (
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 1
+	},
+/turf/open/floor/carpet/orange,
+/area/station/command/heads_quarters/ce)
 "epb" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/camera/autoname/directional/south,
@@ -8095,6 +8101,12 @@
 	pixel_y = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/circuitboard/aicore,
+/obj/item/computer_disk/ordnance,
+/obj/machinery/keycard_auth{
+	pixel_x = 4;
+	pixel_y = 9
+	},
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/rd)
 "eqz" = (
@@ -18197,6 +18209,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/machinery/computer/station_alert,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "jRC" = (
@@ -21346,12 +21359,8 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "lxn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/table/wood,
-/obj/item/computer_disk/ordnance,
-/obj/item/circuitboard/aicore,
-/obj/machinery/keycard_auth{
-	pixel_x = 4;
-	pixel_y = 9
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 4
 	},
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/rd)
@@ -41375,6 +41384,9 @@
 	dir = 1;
 	pixel_y = -30
 	},
+/obj/machinery/computer/apc_control{
+	dir = 8
+	},
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/ce)
 "wvm" = (
@@ -41383,6 +41395,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
+/obj/item/aicard,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/server)
 "wvr" = (
@@ -87066,7 +87079,7 @@ gly
 bwi
 tan
 rdE
-hCY
+eoL
 lXt
 hUd
 oDZ

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -17852,6 +17852,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
+"jzw" = (
+/mob/living/basic/cockroach{
+	name = "Manuel"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "jzK" = (
 /obj/structure/window/spawner/directional/south,
 /obj/machinery/light_switch/directional/west,
@@ -61332,7 +61338,7 @@ nyQ
 rkn
 khq
 aej
-aej
+jzw
 jkc
 ipq
 rCP

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -384,15 +384,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
 "aih" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_blue/line,
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/structure/chair/comfy,
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "aiQ" = (
 /obj/item/grenade/barrier{
 	pixel_x = -3;
@@ -441,7 +436,7 @@
 "ajo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/effect/turf_decal/trimline/dark_red/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "ajB" = (
@@ -1551,7 +1546,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/hos)
 "aTD" = (
-/turf/open/floor/carpet/orange,
+/turf/open/floor/carpet/neon/simple/red,
 /area/station/commons/dorms)
 "aTV" = (
 /obj/structure/cable,
@@ -1683,11 +1678,13 @@
 "aVv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 5
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
+	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -2529,10 +2526,10 @@
 "brr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "brz" = (
@@ -3474,7 +3471,7 @@
 /area/station/tcommsat/server)
 "bOl" = (
 /obj/structure/window/reinforced/tinted,
-/turf/open/floor/carpet/orange,
+/turf/open/floor/carpet/neon/simple/white,
 /area/station/commons/dorms)
 "bOH" = (
 /obj/machinery/teleport/station,
@@ -3526,7 +3523,7 @@
 	dir = 4
 	},
 /obj/machinery/button/door/directional/west{
-	id = "Dorm1";
+	id = "Dorm2";
 	name = "Dormitory Door Lock";
 	normaldoorcontrol = 1;
 	specialfunctions = 4
@@ -5551,7 +5548,7 @@
 /area/station/tcommsat/server)
 "cYt" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
 	dir = 9
 	},
 /turf/open/floor/iron/dark/textured,
@@ -5833,10 +5830,10 @@
 	},
 /area/station/ai_monitored/turret_protected/ai)
 "dhc" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
 	dir = 5
 	},
-/obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "dhy" = (
@@ -7166,13 +7163,10 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/central)
 "dPe" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/obj/machinery/grill,
+/obj/item/stack/sheet/mineral/coal/ten,
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "dPH" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/fitness)
@@ -12472,7 +12466,7 @@
 "gKa" = (
 /obj/structure/dresser,
 /obj/machinery/light/directional/north,
-/turf/open/floor/carpet/orange,
+/turf/open/floor/carpet/neon/simple/blue,
 /area/station/commons/dorms)
 "gKb" = (
 /obj/structure/table/wood,
@@ -12497,10 +12491,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/warning,
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "gLF" = (
@@ -15119,6 +15116,9 @@
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning,
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
 "iip" = (
@@ -15725,7 +15725,7 @@
 "iAd" = (
 /obj/structure/bed/double,
 /obj/item/bedsheet/patriot/double,
-/turf/open/floor/carpet/orange,
+/turf/open/floor/carpet/neon/simple/blue,
 /area/station/commons/dorms)
 "iAr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21477,6 +21477,9 @@
 /obj/structure/drain,
 /turf/open/floor/engine,
 /area/station/hallway/secondary/entry)
+"lAH" = (
+/turf/open/floor/carpet/neon/simple/white,
+/area/station/commons/dorms)
 "lAM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -22653,7 +22656,7 @@
 /area/station/science/xenobiology)
 "mlb" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/dark_red/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -25472,7 +25475,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock{
-	id_tag = "Dorm2";
+	id_tag = "Dorm3";
 	name = "Cabin 3"
 	},
 /obj/machinery/door/firedoor,
@@ -25840,6 +25843,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
 "nVV" = (
@@ -27993,7 +27999,7 @@
 /area/station/service/chapel)
 "phv" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/orange,
+/turf/open/floor/carpet/neon/simple/blue,
 /area/station/commons/dorms)
 "phA" = (
 /obj/structure/table/reinforced,
@@ -28033,6 +28039,9 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
@@ -28610,7 +28619,7 @@
 /obj/machinery/door/airlock{
 	name = "Bedroom"
 	},
-/turf/open/floor/carpet/orange,
+/turf/open/floor/carpet/neon/simple/white,
 /area/station/commons/dorms)
 "pzs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30152,7 +30161,7 @@
 /area/station/commons/lounge)
 "qnG" = (
 /obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
+	name = "Jim Norton's Quebecois Coffee"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33532,18 +33541,16 @@
 /turf/open/floor/engine,
 /area/station/cargo/miningoffice)
 "scA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_blue/line,
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/obj/docking_port/stationary/escape_pod,
+/turf/open/floor/engine,
+/area/station/cargo/miningoffice)
 "scY" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -37464,6 +37471,20 @@
 "unE" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/rack,
+/obj/item/gun/ballistic/automatic/pistol/paco{
+	pixel_y = 1;
+	pixel_x = 2;
+	layer = 3.3
+	},
+/obj/item/gun/ballistic/automatic/pistol/paco{
+	pixel_y = -4;
+	pixel_x = 7
+	},
+/obj/item/gun/ballistic/automatic/pistol/paco{
+	pixel_y = -1;
+	pixel_x = 4;
+	layer = 3.2
+	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "unH" = (
@@ -37576,10 +37597,10 @@
 "urC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
+/obj/effect/turf_decal/trimline/dark_red/warning,
+/obj/effect/turf_decal/trimline/dark_red/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "urU" = (
@@ -38258,6 +38279,9 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
@@ -40925,13 +40949,10 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/pharmacy)
 "wki" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/obj/machinery/light/directional/north,
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "wkq" = (
 /obj/structure/cable,
 /obj/machinery/duct/industrial/waste,
@@ -59933,7 +59954,7 @@ bmW
 wed
 lUz
 iAd
-aTD
+lAH
 aTD
 vwP
 qPO
@@ -60446,7 +60467,7 @@ bmW
 bmW
 uRq
 vwP
-uFj
+dPe
 ksj
 eip
 vwP
@@ -60703,7 +60724,7 @@ vwP
 miY
 vwP
 vwP
-jCa
+wki
 ksj
 sBe
 vwP
@@ -60960,7 +60981,7 @@ jJy
 bmW
 vXi
 vwP
-pZJ
+aih
 ksj
 iVc
 vwP
@@ -65652,7 +65673,7 @@ ont
 dGk
 hcx
 hcx
-dGk
+scA
 nip
 qRY
 fUp
@@ -76905,10 +76926,10 @@ lTb
 rAT
 hil
 qpf
-aih
+tXk
 tYL
 amG
-wki
+nxP
 kJb
 bfN
 lGH
@@ -77162,10 +77183,10 @@ lTb
 rAT
 gzg
 qpf
-scA
+umh
 rfc
 rfc
-wki
+nxP
 kJb
 xmh
 csW
@@ -77422,7 +77443,7 @@ qpf
 aVv
 tJu
 rfc
-wki
+nxP
 kJb
 xmh
 xCU
@@ -77679,7 +77700,7 @@ bUu
 bUu
 jXE
 kwp
-wki
+nxP
 tYA
 cXb
 csW
@@ -77936,7 +77957,7 @@ ujn
 uUF
 jXE
 rfc
-wki
+nxP
 tYA
 xmh
 xCU
@@ -78193,7 +78214,7 @@ ryk
 iug
 jXE
 rfc
-dPe
+hJv
 lfy
 vnz
 qTR
@@ -78450,7 +78471,7 @@ dLk
 qqU
 cph
 rfc
-wki
+ePC
 sri
 aVl
 aVl
@@ -78707,7 +78728,7 @@ bUu
 bUu
 jXE
 kwp
-wki
+ePC
 sri
 qxz
 wld
@@ -78964,7 +78985,7 @@ cqr
 red
 jXE
 rfc
-wki
+ePC
 sri
 kvc
 cCH
@@ -79221,7 +79242,7 @@ xBe
 red
 jXE
 rfc
-wki
+ePC
 sri
 wSA
 uib
@@ -79478,7 +79499,7 @@ red
 red
 fpx
 rfc
-wki
+ePC
 sri
 aVl
 aVl

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -428,18 +428,6 @@
 	pixel_x = -3;
 	pixel_y = -2
 	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 2
-	},
 /obj/item/clothing/suit/armor/riot{
 	pixel_x = -3;
 	pixel_y = 2
@@ -460,6 +448,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"ajg" = (
+/obj/structure/cable/industrial,
+/turf/open/floor/engine,
+/area/station/commons/fitness/recreation/entertainment)
 "ajo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2159,19 +2151,11 @@
 /obj/item/clothing/head/helmet/toggleable/riot{
 	pixel_y = 2
 	},
-/obj/item/clothing/head/helmet/toggleable/riot{
-	pixel_x = -3;
-	pixel_y = 2
-	},
 /obj/item/clothing/head/helmet/alt{
 	pixel_x = 3;
 	pixel_y = -2
 	},
 /obj/item/clothing/head/helmet/alt{
-	pixel_y = -2
-	},
-/obj/item/clothing/head/helmet/alt{
-	pixel_x = -3;
 	pixel_y = -2
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -3389,6 +3373,7 @@
 	pixel_x = -3;
 	pixel_y = 2
 	},
+/obj/item/book/manual/wiki/detective,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "bIa" = (
@@ -3539,14 +3524,10 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "bLV" = (
 /obj/structure/rack,
-/obj/item/gun/energy/ionrifle,
 /obj/item/clothing/suit/hooded/ablative,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
-	},
-/obj/item/gun/energy/ionrifle/carbine{
-	layer = 2.9
 	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
@@ -3555,6 +3536,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"bMt" = (
+/obj/structure/table/wood,
+/obj/item/book/random,
+/turf/open/floor/wood,
+/area/station/service/library)
 "bMv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6280,6 +6266,12 @@
 /obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/ce)
+"dln" = (
+/obj/structure/table/glass,
+/obj/item/clothing/gloves/latex/nitrile,
+/obj/item/book/manual/wiki/surgery,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/surgery/theatre)
 "dls" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9735,6 +9727,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"eWV" = (
+/obj/machinery/button/door{
+	pixel_x = 26;
+	pixel_y = -5;
+	id = "atmoescape";
+	name = "Engineering Escape Pod Bay Control"
+	},
+/turf/open/floor/engine,
+/area/station/commons/fitness/recreation/entertainment)
 "eWY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/layer2{
 	dir = 1
@@ -10348,6 +10349,13 @@
 	},
 /turf/open/floor/plating/ocean,
 /area/ocean/generated_above)
+"flq" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/table/reinforced/rglass,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/book/manual/wiki/atmospherics,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "flv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -10705,6 +10713,11 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/medical/virology)
+"fxI" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
 "fxK" = (
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -11057,6 +11070,7 @@
 /obj/item/healthanalyzer,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/science,
+/obj/item/book/manual/wiki/infections,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "fHr" = (
@@ -11236,6 +11250,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"fNi" = (
+/obj/machinery/door/poddoor{
+	name = "Engineering Escape Pod Bay";
+	id = "atmoescape"
+	},
+/turf/open/floor/plating/ocean,
+/area/station/commons/fitness/recreation/entertainment)
 "fNr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate_empty,
@@ -11833,6 +11854,7 @@
 /obj/structure/table/glass/plasmaglass,
 /obj/item/electronics/tracker,
 /obj/item/electronics,
+/obj/item/book/manual/wiki/grenades,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "gbq" = (
@@ -13631,6 +13653,17 @@
 	},
 /obj/structure/sign/poster/official/ue_no{
 	pixel_y = 36
+	},
+/obj/item/book/manual/wiki/engineering_construction{
+	pixel_y = 7;
+	pixel_x = -10
+	},
+/obj/item/book/manual/wiki/engineering_guide{
+	pixel_y = 7;
+	pixel_x = -5
+	},
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_y = 7
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
@@ -15524,6 +15557,10 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/executive,
 /area/station/commons/vacant_room/commissary)
+"iaG" = (
+/obj/item/book/manual/wiki,
+/turf/open/floor/grass,
+/area/station/service/hydroponics)
 "iaP" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -15626,6 +15663,7 @@
 "ieu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/book/manual/wiki/tcomms,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "iex" = (
@@ -15686,6 +15724,8 @@
 	},
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/effect/turf_decal/tile/purple/opposingcorners,
+/obj/item/book/manual/wiki/research_and_development,
+/obj/item/book/manual/wiki/telescience,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 1
 	},
@@ -16789,9 +16829,6 @@
 /obj/structure/fans/tiny/forcefield,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/docking_port/stationary/escape_pod{
-	dir = 2
-	},
 /turf/open/floor/engine,
 /area/station/commons/fitness/recreation/entertainment)
 "iLH" = (
@@ -16966,6 +17003,8 @@
 	pixel_x = 2
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/book/manual/wiki/grenades,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
 "iPw" = (
@@ -16975,7 +17014,8 @@
 /area/station/engineering/atmos)
 "iPT" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/iron/dark,
+/obj/structure/cable/industrial,
+/turf/open/floor/plating,
 /area/station/commons/fitness/recreation/entertainment)
 "iQd" = (
 /obj/machinery/light_switch/directional/north,
@@ -17447,6 +17487,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 6
 	},
+/obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "jeZ" = (
@@ -17709,6 +17750,8 @@
 	dir = 6
 	},
 /obj/item/binoculars,
+/obj/item/book/manual/wiki/experimentor,
+/obj/item/book/manual/wiki/robotics_cyborgs,
 /turf/open/floor/noslip{
 	icon_state = "textured_white";
 	color = "#D381C9"
@@ -17891,6 +17934,15 @@
 /obj/structure/altar_of_gods,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
+"jqX" = (
+/obj/structure/cable/industrial,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/docking_port/stationary/escape_pod{
+	dir = 2
+	},
+/turf/open/floor/engine,
+/area/station/commons/fitness/recreation/entertainment)
 "jrg" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/turf_decal/bot,
@@ -19398,6 +19450,14 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"kek" = (
+/obj/effect/turf_decal/tile/green/fourcorners,
+/obj/effect/landmark/start/botanist,
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/service/hydroponics)
 "kep" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/machinery/meter,
@@ -20170,6 +20230,7 @@
 /area/station/science/xenobiology)
 "kzj" = (
 /obj/machinery/door/airlock/external,
+/obj/structure/fans/tiny/forcefield,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation/entertainment)
 "kzJ" = (
@@ -26026,6 +26087,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
+"nyZ" = (
+/obj/item/book/manual/wiki/ordnance,
+/turf/open/floor/carpet/blue,
+/area/station/commons/fitness/recreation/entertainment)
 "nzt" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight,
@@ -26863,6 +26928,13 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/eighties/red,
 /area/station/service/electronic_marketing_den)
+"nXq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/turf/open/floor/engine,
+/area/station/commons/fitness/recreation/entertainment)
 "nXC" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
@@ -27248,6 +27320,7 @@
 "oiG" = (
 /obj/structure/table/wood,
 /obj/structure/cable,
+/obj/item/book/manual/wiki/barman_recipes,
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar)
 "oiN" = (
@@ -31372,11 +31445,8 @@
 /area/station/engineering/atmos)
 "qpT" = (
 /obj/effect/turf_decal/tile/green,
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/effect/landmark/start/botanist,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/vending/wardrobe/hydro_wardrobe,
 /turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics)
 "qqb" = (
@@ -33141,10 +33211,6 @@
 	pixel_y = 3
 	},
 /obj/item/gun/energy/disabler,
-/obj/item/gun/energy/disabler{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
@@ -34236,6 +34302,7 @@
 /obj/item/reagent_containers/cup/watering_can,
 /obj/item/reagent_containers/cup/watering_can,
 /obj/item/reagent_containers/cup/watering_can,
+/obj/item/botanical_lexicon,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "rLM" = (
@@ -34587,6 +34654,7 @@
 /obj/item/book/manual/wiki/telescience,
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/book/manual/wiki/tgc,
 /turf/open/floor/carpet/blue,
 /area/station/security/checkpoint/customs)
 "rUO" = (
@@ -36617,6 +36685,13 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood,
 /area/station/service/library)
+"tev" = (
+/obj/machinery/door/poddoor{
+	name = "Engineering Escape Pod Bay";
+	id = "engieescape"
+	},
+/turf/open/floor/plating/ocean,
+/area/station/commons/fitness/recreation/entertainment)
 "teK" = (
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood,
@@ -37381,6 +37456,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/vending/wardrobe/engi_wardrobe,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "tCC" = (
@@ -37394,6 +37470,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"tDE" = (
+/obj/structure/cable/industrial,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/engine,
+/area/station/commons/fitness/recreation/entertainment)
 "tDH" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/camera/autoname/directional/north,
@@ -38846,11 +38928,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/rack,
 /obj/item/gun/ballistic/automatic/pistol/paco{
-	pixel_y = 1;
-	pixel_x = 2;
-	layer = 3.3
-	},
-/obj/item/gun/ballistic/automatic/pistol/paco{
 	pixel_y = -4;
 	pixel_x = 7
 	},
@@ -40143,9 +40220,7 @@
 	pixel_y = -2
 	},
 /obj/item/reagent_containers/cup/soup_pot,
-/obj/item/book/manual/wiki/cooking_to_serve_man{
-	pixel_x = -3
-	},
+/obj/item/book/manual/wiki/cooking_to_serve_man,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "uVd" = (
@@ -41412,6 +41487,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
 	dir = 1
 	},
+/obj/item/book/manual/wiki/plumbing,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "vDY" = (
@@ -44386,6 +44462,7 @@
 /obj/item/stack/ducts/fifty,
 /obj/item/stack/ducts/fifty,
 /obj/effect/turf_decal/stripes/line,
+/obj/item/book/manual/wiki/plumbing,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
 "xke" = (
@@ -59408,7 +59485,7 @@ qhM
 uSV
 vrw
 ejy
-dwb
+kek
 nzU
 vrw
 jle
@@ -61207,7 +61284,7 @@ bFK
 vrw
 gUq
 utm
-utm
+iaG
 pZD
 lFv
 ven
@@ -74279,7 +74356,7 @@ qAg
 met
 yaj
 tpo
-eOc
+dln
 tVl
 jvq
 pfW
@@ -85158,14 +85235,14 @@ qlH
 pDq
 oPd
 wur
-wQf
+bMt
 gKb
 rZh
 xbU
 qzb
 rZh
 lFB
-wQf
+bMt
 uVL
 mdW
 aah
@@ -91214,7 +91291,7 @@ bou
 lvw
 hIX
 lvw
-kVP
+flq
 sks
 wUM
 qkb
@@ -95069,7 +95146,7 @@ lvw
 lvw
 lZJ
 sks
-xOe
+fxI
 gvw
 qax
 kgQ
@@ -95878,9 +95955,9 @@ meJ
 meJ
 etN
 meJ
-aah
-aah
-aah
+meJ
+meJ
+meJ
 aah
 aah
 aah
@@ -96135,9 +96212,9 @@ meJ
 meJ
 etN
 meJ
-aah
-aah
-aah
+meJ
+meJ
+meJ
 aah
 aah
 aah
@@ -96387,14 +96464,14 @@ acm
 aDn
 ngn
 uxK
-nez
+iPT
+iPT
+iPT
+iPT
+iPT
+iPT
 meJ
 meJ
-etN
-meJ
-aah
-aah
-aah
 aah
 aah
 aah
@@ -96626,7 +96703,7 @@ biq
 iri
 geV
 rsS
-bGX
+nyZ
 bGX
 nHa
 tzh
@@ -96644,14 +96721,14 @@ uCv
 jpE
 uCv
 rxa
-nez
+tDE
+uCv
+uCv
+nXq
+uCv
+tev
 meJ
 meJ
-etN
-aah
-aah
-aah
-aah
 aah
 aah
 aah
@@ -96901,14 +96978,14 @@ niB
 niB
 niB
 iLF
-nez
+jqX
+uCv
+uCv
+nXq
+uCv
+tev
 meJ
 meJ
-etN
-aah
-aah
-aah
-aah
 aah
 aah
 aah
@@ -97156,16 +97233,16 @@ acm
 uCv
 uCv
 niB
-uCv
+eWV
 rxa
-pSy
+ajg
+uCv
+uCv
+nXq
+uCv
+fNi
 meJ
 meJ
-etN
-aah
-aah
-aah
-aah
 aah
 aah
 aah
@@ -97415,14 +97492,14 @@ uxK
 kjZ
 uxK
 uxK
-pSy
+iPT
+iPT
+iPT
+iPT
+iPT
+iPT
 meJ
 meJ
-etN
-aah
-aah
-aah
-aah
 aah
 aah
 aah
@@ -97676,10 +97753,10 @@ pSy
 meJ
 meJ
 etN
-aah
-aah
-aah
-aah
+meJ
+meJ
+meJ
+meJ
 aah
 aah
 aah
@@ -97933,10 +98010,10 @@ pSy
 meJ
 meJ
 etN
-aah
-aah
-aah
-aah
+meJ
+meJ
+meJ
+meJ
 aah
 aah
 aah

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -1321,7 +1321,7 @@
 /obj/effect/turf_decal/trimline/brown/end{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured/airless,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
 "aNi" = (
 /turf/open/floor/engine,
@@ -1502,8 +1502,20 @@
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 5
 	},
+/obj/effect/spawner/random/trash,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"aSx" = (
+/obj/machinery/button/door/directional/east{
+	name = "Door Lock";
+	pixel_y = -9;
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	id = "poopoofart"
+	},
+/obj/structure/sink/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "aSy" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
@@ -2265,6 +2277,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/theatre)
 "bkF" = (
@@ -3413,10 +3426,8 @@
 /turf/open/floor/iron/grimy,
 /area/station/hallway/secondary/service)
 "bLk" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/station/security/office)
 "bLn" = (
 /obj/structure/table/wood,
@@ -3498,7 +3509,7 @@
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/textured/airless,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
 "bNx" = (
 /obj/effect/landmark/event_spawn,
@@ -3661,7 +3672,7 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 5
 	},
-/turf/open/floor/iron/dark/textured/airless,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
 "bSC" = (
 /obj/machinery/door/airlock/public/glass{
@@ -4569,7 +4580,7 @@
 /obj/structure/railing/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/textured/airless,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
 "cwX" = (
 /obj/structure/disposalpipe/segment{
@@ -4964,7 +4975,7 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "cHK" = (
-/turf/open/floor/iron/dark/textured/airless,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
 "cHQ" = (
 /obj/structure/disposalpipe/segment,
@@ -5871,7 +5882,6 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 6
 	},
@@ -6396,6 +6406,10 @@
 	name = "Privacy Shutter"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "drf" = (
@@ -6684,15 +6698,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"dyT" = (
+"dyN" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/brown/filled/warning,
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "dzq" = (
@@ -7508,7 +7522,13 @@
 /turf/open/floor/iron/vaporwave,
 /area/station/service/library)
 "dXk" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/plating,
 /area/station/security/office)
 "dXv" = (
@@ -9644,11 +9664,20 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "fbb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/locker)
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/station/science/lobby)
 "fbh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9944,6 +9973,12 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
+"fig" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/locker)
 "fij" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -10414,6 +10449,15 @@
 /obj/structure/flora/rock/pile/jungle/style_random,
 /turf/open/misc/grass/jungle,
 /area/station/maintenance/port/central)
+"fyz" = (
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/item/wrench/cyborg{
+	desc = "An advanced robotic wrench, powered by internal hydraulics. This one looks like it fell off an engineering cyborg."
+	},
+/turf/open/floor/engine,
+/area/station/commons/storage/emergency/starboard)
 "fyB" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/siding/purple,
@@ -10529,6 +10573,7 @@
 	id = "engiewindow";
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
 "fCq" = (
@@ -10539,17 +10584,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/library)
-"fCv" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/warning,
-/turf/open/floor/iron/dark/diagonal,
-/area/station/construction/storage_wing)
 "fCx" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor/auto{
@@ -12188,9 +12222,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "gwK" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/maintenance/port/aft)
 "gwO" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/medbay/lobby)
@@ -13505,10 +13539,9 @@
 	dir = 8
 	},
 /obj/machinery/button/door/directional/west{
-	id = "engiewindow";
+	id = "robopriv";
 	name = "Window Blinds";
 	pixel_y = 28;
-	req_access = list("engineering");
 	pixel_x = -8
 	},
 /turf/open/floor/noslip{
@@ -13526,6 +13559,9 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
@@ -13563,6 +13599,7 @@
 /obj/item/multitool,
 /obj/item/storage/toolbox/electrical,
 /obj/item/clothing/gloves/color/yellow,
+/obj/machinery/light/no_nightlight/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
 "hjl" = (
@@ -14268,7 +14305,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured/airless,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
 "hFe" = (
 /obj/machinery/duct/industrial/waste,
@@ -16849,10 +16886,6 @@
 /obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/cargo/miningoffice)
-"jco" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/locker)
 "jcp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -18187,9 +18220,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "jME" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/spawner/random/structure/crate_loot,
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
 /area/station/security/office)
 "jMI" = (
 /obj/machinery/light/directional/west,
@@ -19052,7 +19086,7 @@
 	dir = 10
 	},
 /obj/structure/railing/corner,
-/turf/open/floor/iron/dark/textured/airless,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
 "kie" = (
 /obj/machinery/duct/industrial/waste,
@@ -19814,6 +19848,7 @@
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "kDN" = (
@@ -21159,8 +21194,8 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/obj/item/storage/medkit,
 /obj/item/key/security,
+/obj/item/storage/medkit/regular,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "llX" = (
@@ -21711,7 +21746,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured/airless,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
 "lBw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22291,6 +22326,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/medical/storage)
 "lQl" = (
@@ -22912,7 +22948,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured/airless,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
 "mnj" = (
 /obj/structure/cable,
@@ -23053,6 +23089,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
+"mqN" = (
+/obj/structure/sink/directional/south,
+/obj/machinery/button/door/directional/north{
+	pixel_x = -8;
+	id = "peepeepoopoo";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = 32;
+	name = "Restroom Lock"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/locker)
 "mrC" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/flasher/directional/east{
@@ -23077,6 +23126,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured_edge,
 /area/station/command/bridge)
+"mrI" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/station/construction/storage_wing)
 "mrJ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -23861,6 +23921,10 @@
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "mPt" = (
@@ -25521,7 +25585,6 @@
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/mod/control/pre_equipped/engineering,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
@@ -25606,6 +25669,14 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"nHZ" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/effect/spawner/random/structure/grille,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "nIg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -26157,7 +26228,7 @@
 	pixel_x = 6
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/textured/airless,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/lab)
 "nZc" = (
 /obj/structure/disposalpipe/segment,
@@ -26359,6 +26430,20 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"ofQ" = (
+/obj/effect/turf_decal/stripes{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
+	dir = 8
+	},
+/obj/machinery/light/no_nightlight/directional/west,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "ofT" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -27073,6 +27158,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 9
 	},
+/obj/machinery/light/no_nightlight/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "owD" = (
@@ -27194,6 +27280,10 @@
 	dir = 10
 	},
 /obj/structure/table,
+/obj/item/reagent_containers/cup/glass/mug/nanotrasen{
+	pixel_y = 14;
+	pixel_x = -9
+	},
 /turf/open/floor/wood/large,
 /area/station/security/warden)
 "ozO" = (
@@ -27754,6 +27844,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 10
 	},
+/obj/machinery/light/no_nightlight/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "oTx" = (
@@ -27780,6 +27871,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
+"oUd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plastic,
+/area/station/hallway/primary/central)
 "oUi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -28721,6 +28824,7 @@
 	dir = 4;
 	invisibility = 101
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "ptY" = (
@@ -28961,6 +29065,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/theatre)
 "pCM" = (
@@ -30391,6 +30496,9 @@
 /area/station/maintenance/starboard/aft)
 "qmt" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "interropriv"
+	},
 /turf/open/floor/plating,
 /area/station/security/interrogation)
 "qmF" = (
@@ -30772,6 +30880,12 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"quS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/locker)
 "quU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31907,6 +32021,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/station/maintenance/starboard/aft)
+"rbq" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/medbay/lobby)
 "rbt" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -32579,6 +32702,10 @@
 "rsS" = (
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation/entertainment)
+"rta" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/locker)
 "rtb" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32623,12 +32750,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
-"rus" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/locker)
 "ruE" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -32678,15 +32799,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "rvH" = (
-/obj/machinery/button/door/directional/east{
-	name = "Door Lock";
-	pixel_y = -9;
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/obj/structure/sink/directional/south,
+/obj/machinery/shower/directional/south,
+/obj/structure/drain/big,
 /turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
+/area/station/commons/toilet/locker)
 "rvJ" = (
 /obj/effect/turf_decal/stripes{
 	dir = 10
@@ -33705,7 +33821,6 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/item/mod/control/pre_equipped/engineering,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
@@ -34312,6 +34427,15 @@
 /obj/item/book/manual/wiki/security_space_law,
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 6
+	},
+/obj/machinery/button/door{
+	desc = "Controls the shutters over the brig windows.";
+	id = "interropriv";
+	name = "Interrogation Privacy Shutter";
+	pixel_x = 9;
+	pixel_y = 9;
+	req_access = list("security");
+	layer = 3.1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/interrogation)
@@ -35158,6 +35282,19 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/storage/emergency/starboard)
+"sOH" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/dorms)
 "sON" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
@@ -36373,6 +36510,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "tCC" = (
@@ -36780,11 +36918,11 @@
 /turf/open/floor/wood/large,
 /area/station/security/checkpoint/customs)
 "tMf" = (
-/obj/item/wrench/cyborg{
-	desc = "An advanced robotic wrench, powered by internal hydraulics. This one looks like it fell off an engineering cyborg."
+/obj/machinery/computer/records/security{
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/station/commons/storage/emergency/starboard)
+/turf/open/floor/wood/parquet,
+/area/station/command/heads_quarters/hop)
 "tMt" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners{
@@ -37352,7 +37490,6 @@
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 10
 	},
@@ -37583,6 +37720,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
+"ugJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "ugV" = (
 /obj/structure/disposalpipe/junction{
 	dir = 4
@@ -38722,6 +38866,17 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"uNt" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/treatment_center)
 "uNu" = (
 /obj/effect/turf_decal/stripes,
 /obj/structure/disposalpipe/segment,
@@ -40512,6 +40667,10 @@
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "vLh" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/plating,
 /area/station/security/office)
 "vMb" = (
@@ -40611,12 +40770,14 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "vOP" = (
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/machinery/door/poddoor/preopen{
+	id = "hop";
+	name = "Privacy Shutters"
 	},
 /turf/open/floor/plating,
-/area/station/security/office)
+/area/station/command/bridge)
 "vPb" = (
 /turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
@@ -40660,19 +40821,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"vQL" = (
-/obj/structure/sink/directional/south,
-/obj/machinery/button/door/directional/north{
-	pixel_x = -8;
-	id = "peepeepoopoo";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_y = 32;
-	name = "Restroom Lock"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/locker)
 "vQW" = (
 /obj/structure/reflector/box{
 	dir = 1
@@ -40704,10 +40852,18 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
 "vRp" = (
-/obj/machinery/shower/directional/south,
-/obj/structure/drain/big,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/locker)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "vSw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -40892,7 +41048,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured/airless,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
 "vWE" = (
 /obj/structure/table,
@@ -42918,7 +43074,6 @@
 	name = "Private Study";
 	req_access = list("library")
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/library,
 /turf/open/floor/wood,
 /area/station/service/library)
 "xbZ" = (
@@ -43387,6 +43542,7 @@
 	name = "Engineering Lockdown"
 	},
 /obj/effect/decal/cleanable/blood/splatter/over_window,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
 "xqE" = (
@@ -43683,9 +43839,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "xwZ" = (
-/obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
-/area/station/security/office)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/plastic,
+/area/station/hallway/primary/central)
 "xxc" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/spawner/random/structure/table_or_rack,
@@ -58924,7 +59088,7 @@ pqp
 fbw
 eYH
 fYK
-vRp
+rvH
 pzs
 esx
 fYK
@@ -59181,9 +59345,9 @@ pqp
 fbw
 eYH
 fYK
-vRp
-rus
-jco
+rvH
+fig
+rta
 rdF
 utN
 fYK
@@ -59438,12 +59602,12 @@ pqp
 fbw
 lll
 fYK
-vRp
+rvH
 yjV
-fbb
+quS
 fYK
-vQL
-fbb
+mqN
+quS
 fYK
 xlX
 iAJ
@@ -60922,7 +61086,7 @@ xHH
 wop
 pVn
 vwP
-rvH
+aSx
 bmW
 uRq
 vwP
@@ -61514,7 +61678,7 @@ csw
 sCM
 jja
 qLh
-dyT
+mrI
 vto
 aOq
 lOa
@@ -61771,7 +61935,7 @@ jwO
 vNp
 lHr
 ell
-fCv
+dyN
 vto
 beO
 vUV
@@ -62216,7 +62380,7 @@ pcB
 kZH
 kZH
 kZH
-kZH
+sOH
 kZH
 sga
 flc
@@ -71219,7 +71383,7 @@ sdC
 qUv
 qLe
 mxp
-kAH
+rbq
 cIO
 bDs
 aWW
@@ -73356,7 +73520,7 @@ kQD
 wEE
 hXY
 vzd
-uvd
+gwK
 gud
 aoV
 yfj
@@ -73870,8 +74034,8 @@ vzd
 vzd
 vzd
 vzd
-tAz
-jwg
+ugJ
+nHZ
 ajQ
 cRO
 nbM
@@ -74128,7 +74292,7 @@ wCi
 bLk
 jME
 dXk
-vOP
+ajQ
 ajQ
 gap
 lEA
@@ -74619,8 +74783,8 @@ psu
 tVq
 ddr
 ddr
-hwj
-hwj
+vOP
+vOP
 ddr
 vyd
 udW
@@ -74876,7 +75040,7 @@ pla
 pla
 pla
 frr
-pLb
+tMf
 vMb
 pla
 iiO
@@ -75154,9 +75318,9 @@ asq
 eFu
 tRe
 ajQ
-xwZ
+ajQ
 vLh
-lVR
+ajQ
 ajQ
 ldm
 dDy
@@ -75331,7 +75495,7 @@ uHW
 abL
 ikH
 wvy
-kAH
+rbq
 cIO
 cIO
 cIO
@@ -75412,7 +75576,7 @@ tIg
 llG
 ajQ
 sym
-vLh
+lVR
 kdr
 ajQ
 vRb
@@ -75834,7 +75998,7 @@ pyE
 jvd
 gTr
 wCH
-vUo
+uNt
 gct
 rzA
 vUo
@@ -77642,7 +77806,7 @@ lTb
 rAT
 gzg
 qpf
-umh
+vRp
 rfc
 rfc
 nxP
@@ -81030,7 +81194,7 @@ ucp
 tmC
 oJO
 ruE
-tMf
+tTt
 rlw
 tTt
 etZ
@@ -81287,7 +81451,7 @@ hew
 hRk
 iLN
 xke
-mhc
+fyz
 mhc
 mhc
 knd
@@ -81777,7 +81941,7 @@ mwr
 fHr
 bpX
 lrt
-sYe
+oUd
 sYe
 sYe
 sYe
@@ -83070,7 +83234,7 @@ vda
 xJU
 xJU
 xJU
-xJU
+xwZ
 xJU
 xJU
 fcw
@@ -84592,7 +84756,7 @@ tGQ
 tGQ
 tGQ
 tGQ
-tGQ
+fbb
 tGQ
 tSc
 oTY
@@ -85390,14 +85554,14 @@ nZR
 ohC
 ohC
 nTi
-gwK
-gwK
-gwK
-gwK
-gwK
 jvI
-gwK
-gwK
+jvI
+jvI
+jvI
+jvI
+jvI
+jvI
+jvI
 nTi
 eZx
 ijg
@@ -85899,7 +86063,7 @@ nTi
 nTi
 nTi
 nTi
-gwK
+jvI
 eXg
 qSp
 jbU
@@ -86153,7 +86317,7 @@ lSE
 iaV
 qSp
 nFQ
-rWz
+ofQ
 rWz
 rWz
 rHE
@@ -86415,7 +86579,7 @@ aNi
 aNi
 aNi
 dnr
-gwK
+jvI
 jRw
 auZ
 auZ
@@ -86672,7 +86836,7 @@ pGN
 urf
 aNi
 dnr
-gwK
+jvI
 cME
 cbM
 rvE
@@ -86929,7 +87093,7 @@ ijM
 fAb
 kdz
 wBn
-gwK
+jvI
 pPD
 aWk
 kda

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -20262,6 +20262,14 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics)
+"kBB" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/effect/turf_decal/board_number,
+/obj/machinery/suit_storage_unit/atmos,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "kBH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -89023,7 +89031,7 @@ aah
 aah
 aah
 aah
-tct
+aah
 aah
 aah
 aah
@@ -89280,7 +89288,7 @@ aah
 aah
 aah
 aah
-tct
+aah
 aah
 aah
 aah
@@ -89537,7 +89545,7 @@ aah
 aah
 aah
 aah
-tct
+aah
 aah
 aah
 aah
@@ -91328,7 +91336,7 @@ aah
 aah
 aah
 aah
-ojo
+aah
 aah
 aah
 aah
@@ -91452,7 +91460,7 @@ jWP
 hDV
 rab
 ujh
-hZJ
+kBB
 lvw
 hIX
 lZe
@@ -91966,7 +91974,7 @@ xwe
 nsF
 hMk
 ujh
-hZJ
+kBB
 lvw
 hIX
 lZe

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -3274,7 +3274,13 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics/upper)
 "bHT" = (
 /obj/structure/table/wood,
@@ -5257,6 +5263,9 @@
 	id = "elock";
 	name = "Engineering Lockdown"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "engie"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "cQP" = (
@@ -6675,6 +6684,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"dyT" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/station/construction/storage_wing)
 "dzq" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured,
@@ -8274,6 +8294,9 @@
 "esx" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
 "esy" = (
@@ -9621,8 +9644,9 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "fbb" = (
-/obj/machinery/shower/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
 "fbh" = (
@@ -9747,6 +9771,9 @@
 /obj/machinery/camera/autoname/directional/south,
 /obj/machinery/shower/directional/north,
 /obj/structure/drain,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "fdr" = (
@@ -10512,6 +10539,17 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/library)
+"fCv" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron/dark/diagonal,
+/area/station/construction/storage_wing)
 "fCx" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor/auto{
@@ -11586,7 +11624,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/miningoffice)
 "geH" = (
 /obj/item/storage/secure/safe/directional/north,
@@ -11865,6 +11909,9 @@
 	id = "rndlab2";
 	name = "Secondary Research and Development Shutter"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "gop" = (
@@ -11971,7 +12018,13 @@
 	name = "Central Access"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "grG" = (
 /obj/structure/chair/sofa/middle{
@@ -12868,6 +12921,9 @@
 	name = "Secondary Research and Development Shutter"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "gTr" = (
@@ -16641,7 +16697,13 @@
 	name = "Ore Redemtion Window";
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/miningoffice)
 "iWY" = (
 /obj/structure/sink/directional/south,
@@ -16787,6 +16849,10 @@
 /obj/machinery/rnd/production/techfab/department/cargo,
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/cargo/miningoffice)
+"jco" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/locker)
 "jcp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
@@ -17969,6 +18035,9 @@
 "jJy" = (
 /obj/machinery/shower/directional/south,
 /obj/structure/drain,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "jJD" = (
@@ -19316,6 +19385,9 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "engie"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
@@ -22717,8 +22789,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "miY" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Showers"
+/obj/machinery/door/airlock/bathroom{
+	name = "Toilets";
+	desc = "A professional 'Ranked Competitive Shitting' arena.";
+	id_tag = "poopoofart"
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
@@ -23248,6 +23322,9 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /obj/structure/disposalpipe/segment{
 	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci"
 	},
 /turf/open/floor/iron/stairs{
 	dir = 8
@@ -27698,6 +27775,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "oUi" = (
@@ -28456,6 +28536,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "elock";
 	name = "Engineering Lockdown"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "engie"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
@@ -30614,6 +30697,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "qsJ" = (
@@ -30661,6 +30747,9 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/shower/directional/south,
 /obj/structure/drain,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "quh" = (
@@ -31114,6 +31203,9 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "qJu" = (
@@ -31928,9 +32020,11 @@
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/ce)
 "rdF" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Showers"
+/obj/machinery/door/airlock/bathroom{
+	name = "Toilet";
+	id_tag = "peepeepoopoo"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
 "rdL" = (
@@ -32529,6 +32623,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
+"rus" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/locker)
 "ruE" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -32578,9 +32678,15 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "rvH" = (
-/obj/machinery/shower/directional/south,
+/obj/machinery/button/door/directional/east{
+	name = "Door Lock";
+	pixel_y = -9;
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/obj/structure/sink/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/station/commons/toilet/locker)
+/area/station/commons/dorms)
 "rvJ" = (
 /obj/effect/turf_decal/stripes{
 	dir = 10
@@ -36982,6 +37088,9 @@
 	id = "rndlab2";
 	name = "Secondary Research and Development Shutter"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "tVQ" = (
@@ -37143,12 +37252,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "tZm" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Showers"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/door/airlock/bathroom{
+	name = "Showers"
+	},
 /turf/open/floor/bamboo,
 /area/station/commons/toilet/locker)
 "tZy" = (
@@ -37932,6 +38041,7 @@
 /area/station/service/hydroponics)
 "utN" = (
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
 "utU" = (
@@ -40550,6 +40660,19 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"vQL" = (
+/obj/structure/sink/directional/south,
+/obj/machinery/button/door/directional/north{
+	pixel_x = -8;
+	id = "peepeepoopoo";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = 32;
+	name = "Restroom Lock"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/locker)
 "vQW" = (
 /obj/structure/reflector/box{
 	dir = 1
@@ -40582,7 +40705,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "vRp" = (
 /obj/machinery/shower/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/drain/big,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
 "vSw" = (
@@ -40793,6 +40916,9 @@
 "vXi" = (
 /obj/machinery/shower/directional/north,
 /obj/structure/drain,
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "vXo" = (
@@ -43749,7 +43875,13 @@
 	invisibility = 101
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "xCE" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
@@ -43885,6 +44017,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "engie"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "xHk" = (
@@ -44356,6 +44491,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "engie"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "xUa" = (
@@ -44393,6 +44531,9 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "sci"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "xUj" = (
@@ -44416,7 +44557,13 @@
 	dir = 4;
 	invisibility = 101
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics)
 "xUD" = (
 /obj/structure/cable,
@@ -59034,9 +59181,9 @@ pqp
 fbw
 eYH
 fYK
-rvH
-pzs
-qNu
+vRp
+rus
+jco
 rdF
 utN
 fYK
@@ -59291,12 +59438,12 @@ pqp
 fbw
 lll
 fYK
-fbb
+vRp
 yjV
-qNu
+fbb
 fYK
-iWY
-qNu
+vQL
+fbb
 fYK
 xlX
 iAJ
@@ -60775,7 +60922,7 @@ xHH
 wop
 pVn
 vwP
-bmW
+rvH
 bmW
 uRq
 vwP
@@ -61367,7 +61514,7 @@ csw
 sCM
 jja
 qLh
-grB
+dyT
 vto
 aOq
 lOa
@@ -61624,7 +61771,7 @@ jwO
 vNp
 lHr
 ell
-grB
+fCv
 vto
 beO
 vUV

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -383,6 +383,15 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
+"aig" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "aih" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -478,14 +487,6 @@
 "ake" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
-"akh" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "akj" = (
 /obj/machinery/door/airlock/command{
 	name = "E.V.A. Storage"
@@ -543,8 +544,9 @@
 /turf/open/floor/iron,
 /area/mine/storage/public)
 "amz" = (
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/dark,
+/obj/structure/bed/double,
+/obj/item/bedsheet/clown/double,
+/turf/open/floor/eighties,
 /area/station/commons/dorms)
 "amG" = (
 /obj/machinery/duct/industrial/waste,
@@ -1305,16 +1307,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "aMJ" = (
-/obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/lounge)
 "aNi" = (
 /turf/open/floor/engine,
 /area/station/engineering/main)
@@ -1720,8 +1718,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "aWp" = (
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood,
 /area/station/commons/dorms)
 "aWJ" = (
 /turf/open/floor/fakebasalt,
@@ -2010,7 +2007,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "bey" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -2050,7 +2047,7 @@
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "bfs" = (
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
@@ -2221,11 +2218,17 @@
 	},
 /area/station/engineering/main)
 "bkB" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Showers"
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "bkC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -2705,7 +2708,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "bvJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3347,10 +3350,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/mine/storage/public)
-"bKk" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/red,
-/area/station/security/office)
 "bKz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -3455,20 +3454,8 @@
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "bOl" = (
-/obj/machinery/button/door/directional/west{
-	id = "Cabin4";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/dorms,
-/obj/item/pillow/random,
-/obj/effect/landmark/start/assistant,
-/obj/machinery/light/small/directional/south,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "bOH" = (
 /obj/machinery/teleport/station,
 /turf/open/floor/mineral/titanium/purple,
@@ -3571,16 +3558,6 @@
 	color = "#999999"
 	},
 /area/station/science/robotics)
-"bRX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/south,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "bSj" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -3808,19 +3785,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/security/warden)
-"bZH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "bZJ" = (
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/grass,
@@ -4502,11 +4466,6 @@
 	},
 /turf/open/floor/iron/dark/textured/airless,
 /area/station/science/lobby)
-"cwT" = (
-/obj/effect/spawner/random/trash,
-/obj/vehicle/ridden/secway,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "cwX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -4587,6 +4546,11 @@
 /mob/living/basic/cockroach,
 /turf/open/floor/iron,
 /area/station/maintenance/port/central)
+"czZ" = (
+/obj/effect/spawner/random/trash,
+/obj/vehicle/ridden/secway,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "cAb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -5790,6 +5754,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"dgW" = (
+/obj/machinery/suit_storage_unit/security,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "dgX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/base_turf_modifier/pit,
@@ -6011,7 +5979,6 @@
 "dls" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/north,
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
 	dir = 1
@@ -6220,13 +6187,13 @@
 /area/station/cargo/miningoffice)
 "dpV" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 8;
 	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -6635,6 +6602,10 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"dBG" = (
+/obj/vehicle/ridden/secway,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "dCe" = (
 /obj/structure/table/glass,
 /obj/structure/showcase/machinery/tv{
@@ -7389,6 +7360,11 @@
 "dXQ" = (
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"dXV" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/dorms)
 "dYc" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/portable_atmospherics/pump,
@@ -8564,6 +8540,19 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/central)
+"eDV" = (
+/obj/machinery/duct/industrial/waste,
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "eDZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct/industrial/waste,
@@ -8579,17 +8568,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/office)
-"eEZ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 1;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "eFa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9093,19 +9071,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "eQp" = (
-/obj/machinery/button/door/directional/west{
-	id = "Cabin7";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/dorms,
-/obj/item/pillow/random,
-/obj/effect/landmark/start/assistant,
-/obj/machinery/light/small/directional/south,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/dark,
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/eighties,
 /area/station/commons/dorms)
 "eQt" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -9240,6 +9207,12 @@
 	},
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
+"eTU" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "eUn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -9255,6 +9228,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"eUw" = (
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "eUC" = (
 /obj/machinery/air_sensor/oxygen_tank,
 /turf/open/floor/engine/o2,
@@ -9453,6 +9432,10 @@
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"faH" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/eighties,
+/area/station/commons/dorms)
 "faI" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/autolathe,
@@ -9850,6 +9833,15 @@
 "fla" = (
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
+"flh" = (
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured/airless,
+/area/station/science/lobby)
 "flp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
@@ -9870,6 +9862,12 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
+"fmY" = (
+/obj/machinery/door/airlock/bathroom{
+	name = "Showers"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "fnj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -9984,13 +9982,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"fpz" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "fpN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10301,7 +10292,7 @@
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "fBH" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/dark_red/filled/end{
@@ -10319,6 +10310,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
+"fCr" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "Dorm3";
+	name = "Dormitory Door Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "fCx" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor/auto{
@@ -10681,15 +10684,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/service/library)
-"fOs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "fOt" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -11041,6 +11035,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/cargo/miningoffice)
+"fXI" = (
+/obj/structure/curtain/cloth,
+/obj/structure/drain,
+/obj/machinery/shower/directional/north,
+/turf/open/floor/iron/freezer,
+/area/station/commons/dorms)
 "fXR" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -11103,12 +11103,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -11159,13 +11159,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "gau" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/warning{
 	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/white/line{
+/obj/effect/turf_decal/trimline/white/filled/warning{
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
@@ -11365,6 +11364,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"geE" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "geH" = (
 /obj/item/storage/secure/safe/directional/north,
 /obj/machinery/light/small/directional/west,
@@ -11742,6 +11748,10 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/iron,
 /area/station/service/library)
+"gtc" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "gtg" = (
 /obj/effect/turf_decal/tile/green/opposingcorners{
 	dir = 1
@@ -11822,6 +11832,15 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"gut" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "guV" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -11851,10 +11870,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
-"gvJ" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "gvP" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
@@ -11961,14 +11976,6 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
-"gzu" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/security/office)
 "gzx" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage/tech)
@@ -12056,19 +12063,10 @@
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
 "gAV" = (
-/obj/machinery/button/door/directional/west{
-	id = "Cabin6";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/dorms,
-/obj/item/pillow/random,
-/obj/machinery/light/small/directional/south,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "gBb" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -12097,17 +12095,15 @@
 "gCo" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
-/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "gCN" = (
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 1;
-	color = "#009dc4"
-	},
+/obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "gCU" = (
@@ -12707,17 +12703,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"gWl" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "gWr" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera/autoname/directional/south,
@@ -12934,6 +12919,10 @@
 	dir = 1
 	},
 /area/station/science/lobby)
+"haT" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "hbe" = (
 /obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/stripes{
@@ -13270,6 +13259,12 @@
 /obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics)
+"hkE" = (
+/obj/machinery/door/airlock{
+	name = "Bedroom"
+	},
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "hkS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -14016,6 +14011,19 @@
 	},
 /turf/open/floor/carpet/executive,
 /area/station/commons/vacant_room/commissary)
+"hGO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "hHb" = (
 /obj/machinery/modular_computer/console/preset/cargochat/science{
 	dir = 4
@@ -14964,18 +14972,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
-"ijx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "ijM" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -15366,14 +15362,17 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/robotics/lab)
 "iul" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/line{
+/obj/machinery/duct/industrial/waste,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
+/area/station/hallway/primary/central)
 "iut" = (
 /turf/open/floor/wood/parquet,
 /area/station/medical/medbay/central)
@@ -15844,22 +15843,6 @@
 /obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/office)
-"iJW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 10;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/corner{
-	color = "#009dc4";
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
-"iKt" = (
-/turf/open/floor/carpet/red,
-/area/station/security/office)
 "iKC" = (
 /obj/structure/cable,
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/east,
@@ -16079,7 +16062,10 @@
 /area/station/tcommsat/server)
 "iPh" = (
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/airlock{
+	name = "Bedroom"
+	},
+/turf/open/floor/eighties,
 /area/station/commons/dorms)
 "iPl" = (
 /obj/effect/turf_decal/trimline/red/filled/warning,
@@ -16250,14 +16236,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "iVc" = (
-/obj/effect/turf_decal/trimline/brown/warning{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/brown/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured/airless,
-/area/station/science/lobby)
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "iVp" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/disposalpipe/segment{
@@ -16321,12 +16305,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/hydroponics/upper)
-"iXZ" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "iYi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17341,17 +17319,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
-"jAS" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4";
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "jAU" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
@@ -17408,10 +17375,6 @@
 "jBo" = (
 /turf/open/ballpit,
 /area/station/security/checkpoint/customs)
-"jBC" = (
-/obj/machinery/suit_storage_unit/security,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "jBM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -17419,8 +17382,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "jCa" = (
+/obj/structure/chair/sofa/right,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood,
 /area/station/commons/dorms)
 "jCm" = (
 /mob/living/simple_animal/hostile/retaliate/clown{
@@ -18535,6 +18499,17 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
+"kgo" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm1";
+	name = "Cabin 1"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "kgt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 5
@@ -18796,6 +18771,9 @@
 	},
 /turf/open/floor/engine,
 /area/station/commons/storage/emergency/starboard)
+"knm" = (
+/turf/open/floor/circuit/telecomms/server,
+/area/station/science/server)
 "kno" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -18917,6 +18895,10 @@
 /obj/machinery/mecha_part_fabricator/maint,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"kqD" = (
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "kqQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -18959,9 +18941,18 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "ksj" = (
+/obj/machinery/duct/industrial/waste,
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "ksq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/sign/poster/traitor/random{
@@ -19393,6 +19384,19 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"kDT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "kDW" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/light/directional/north,
@@ -19557,11 +19561,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "kIu" = (
-/obj/effect/turf_decal/trimline/brown/end{
-	dir = 1
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
 	},
-/turf/open/floor/iron/dark/textured/airless,
-/area/station/science/lobby)
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "kIM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19884,14 +19888,10 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/cmo)
 "kOZ" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/white/corner{
-	color = "#009dc4";
-	dir = 8
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -20274,7 +20274,7 @@
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "kZY" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/upper)
@@ -21315,25 +21315,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"lDp" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#009dc4";
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/service/hydroponics/garden)
 "lDr" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/robotics/lab)
-"lDs" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "lDH" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -21650,10 +21636,12 @@
 "lLz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 10
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 10;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/green/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -22039,15 +22027,9 @@
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "lWJ" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Crew Quarters Access"
-	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 8;
-	color = "#009dc4"
-	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/dark/textured,
-/area/station/commons/dorms)
+/area/station/cargo/storage)
 "lXc" = (
 /obj/structure/cable,
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/south,
@@ -22141,6 +22123,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"mao" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/courtroom)
 "maA" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -22181,6 +22170,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"mbD" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "mbF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22558,19 +22555,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/storage/primary)
-"mpU" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/brown/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "mqy" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 9
@@ -22863,6 +22847,17 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/interrogation)
+"mxH" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "mxN" = (
 /obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/stripes/full,
@@ -23518,11 +23513,6 @@
 /obj/machinery/camera/directional/east,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"mTh" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "mTo" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -23671,14 +23661,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/central)
 "mWr" = (
-/obj/machinery/duct/industrial/waste,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/warning{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -23799,6 +23790,18 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
+"mZO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "mZW" = (
 /obj/structure/cable,
 /obj/machinery/duct/industrial/waste,
@@ -24295,6 +24298,17 @@
 /obj/item/reagent_containers/cup/glass/bottle/hooch,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
+"nli" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "nlQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24686,6 +24700,17 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/medical/medbay/central)
+"nwN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "nwZ" = (
 /obj/structure/flora/grass/jungle/a/style_random,
 /mob/living/simple_animal/hostile/jungle/mook,
@@ -24734,17 +24759,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/courtroom)
 "nxP" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "nxY" = (
 /obj/machinery/light/directional/south,
 /obj/structure/table/reinforced/rglass,
@@ -24795,10 +24812,6 @@
 /obj/structure/sign/departments/botany,
 /turf/closed/wall,
 /area/station/service/hydroponics)
-"nyO" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark/textured,
-/area/station/cargo/storage)
 "nyQ" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured,
@@ -24873,19 +24886,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"nBb" = (
-/obj/machinery/duct/industrial/waste,
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "nBu" = (
 /obj/machinery/griddle,
 /turf/open/floor/iron/kitchen,
@@ -25202,8 +25202,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
 "nKk" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm2";
+	name = "Cabin 3"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
 /area/station/commons/dorms)
 "nKI" = (
 /obj/structure/cable,
@@ -25646,6 +25653,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/glass/reinforced,
 /area/station/engineering/main)
+"nZU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "oas" = (
 /turf/open/floor/iron/sepia,
 /area/station/commons/fitness/recreation)
@@ -26520,7 +26537,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "ovW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -26596,19 +26613,6 @@
 /mob/living/basic/cockroach,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"oyi" = (
-/obj/machinery/duct/industrial/waste,
-/obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "oyj" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/structure/reagent_dispensers/watertank,
@@ -26622,12 +26626,8 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "oyo" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "oyB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -27541,7 +27541,7 @@
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "pdS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -27746,12 +27746,21 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "piw" = (
-/obj/structure/chair{
-	dir = 8
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
 	},
-/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
-/area/station/security/courtroom)
+/area/station/hallway/primary/central)
+"piU" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "piW" = (
 /obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/trunk{
@@ -28190,10 +28199,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
-"puf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/server)
 "pug" = (
 /turf/closed/wall,
 /area/station/commons/fitness)
@@ -28311,6 +28316,19 @@
 /obj/structure/closet/crate,
 /turf/open/floor/carpet/executive,
 /area/station/command/bridge)
+"pAc" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "pAg" = (
 /obj/machinery/computer/security/mining{
 	dir = 4
@@ -29331,8 +29349,9 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "pZJ" = (
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/iron/dark,
+/obj/structure/chair/sofa/left,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/turf/open/floor/wood,
 /area/station/commons/dorms)
 "pZL" = (
 /obj/structure/cable/industrial,
@@ -29702,6 +29721,14 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
+"qjj" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/security/office)
 "qjI" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/mineral/titanium,
@@ -29759,6 +29786,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/aft)
+"qlN" = (
+/obj/effect/turf_decal/trimline/brown/end{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured/airless,
+/area/station/science/lobby)
 "qmb" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -29785,10 +29818,13 @@
 /area/station/command/heads_quarters/captain/private)
 "qmM" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/green/warning,
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "qmR" = (
@@ -30586,6 +30622,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/storage)
+"qJK" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/commons/dorms)
 "qJM" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/disposalpipe/segment{
@@ -30963,6 +31005,14 @@
 "qSp" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
+"qSu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "qSx" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -31107,6 +31157,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/command/bridge)
+"qWn" = (
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/service/hydroponics/garden)
 "qWq" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -31241,20 +31298,9 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/robotics/lab)
 "qZZ" = (
-/obj/machinery/button/door/directional/east{
-	id = "Cabin2";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_x = -24
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/dorms,
-/obj/item/pillow/random,
-/obj/effect/landmark/start/assistant,
 /obj/machinery/light/small/directional/south,
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/dark,
+/turf/closed/wall,
 /area/station/commons/dorms)
 "rab" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
@@ -31262,6 +31308,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"rak" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm2";
+	name = "Cabin 2"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "rbo" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -31689,18 +31746,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "rmF" = (
-/obj/machinery/button/door/directional/west{
-	id = "Cabin5";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
 	},
-/obj/structure/bed,
-/obj/item/bedsheet/dorms,
-/obj/item/pillow/random,
-/obj/machinery/light/small/directional/south,
-/obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron/dark,
 /area/station/commons/dorms)
 "rmK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31747,7 +31797,9 @@
 /turf/open/floor/plating/ocean,
 /area/ocean)
 "rnM" = (
-/turf/open/floor/iron/dark,
+/obj/structure/bed/double,
+/obj/item/bedsheet/patriot/double,
+/turf/open/floor/carpet/orange,
 /area/station/commons/dorms)
 "rob" = (
 /obj/effect/landmark/start/assistant,
@@ -31860,11 +31912,6 @@
 /obj/item/gps,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
-"rrt" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/dark/textured,
-/area/station/cargo/storage)
 "rrB" = (
 /turf/closed/wall/r_wall,
 /area/station/security/warden)
@@ -31944,13 +31991,13 @@
 "rtP" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -33223,18 +33270,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/robotics/lab)
-"sed" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#009dc4";
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#009dc4";
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
 "seR" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Toilet"
@@ -33293,7 +33328,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "sgm" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/ai_all,
@@ -33389,6 +33424,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room)
+"sjd" = (
+/obj/machinery/door/airlock{
+	name = "Bedroom"
+	},
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "sjq" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -33559,6 +33603,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"sow" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "spI" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -33569,10 +33619,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/theatre)
-"spJ" = (
-/obj/vehicle/ridden/secway,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "sqk" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -33818,16 +33864,16 @@
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation/entertainment)
 "sxq" = (
-/obj/effect/turf_decal/trimline/white/filled/warning{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8;
 	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4";
-	dir = 4
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "sxv" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -33961,8 +34007,13 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "sBe" = (
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "sBo" = (
 /obj/machinery/camera/directional/north,
 /turf/open/floor/engine,
@@ -34050,17 +34101,16 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
 "sDA" = (
-/obj/machinery/light/directional/west,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/warning{
 	dir = 8;
 	color = "#009dc4"
 	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "sDD" = (
 /obj/structure/sign/poster/official/safety_eye_protection,
 /turf/closed/wall,
@@ -34458,6 +34508,19 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
+"sOn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "sOr" = (
 /obj/machinery/light/directional/west,
 /obj/structure/tank_dispenser,
@@ -34770,19 +34833,6 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"sYl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "sYn" = (
 /turf/open/floor/wood,
 /area/station/cargo/miningoffice)
@@ -34929,8 +34979,9 @@
 	color = "#009dc4";
 	dir = 8
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "tdG" = (
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
@@ -35382,6 +35433,13 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"tux" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "tuL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -36438,8 +36496,9 @@
 /area/station/engineering/atmos)
 "tWp" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron/dark,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/textured,
 /area/station/commons/dorms)
 "tWr" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
@@ -36449,15 +36508,6 @@
 /obj/structure/fans/tiny/forcefield,
 /turf/open/floor/engine,
 /area/station/science/ordnance/office)
-"tWM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line,
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "tXg" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 10
@@ -36493,16 +36543,9 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "tYl" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "tYt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37027,13 +37070,9 @@
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "umh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
+/obj/structure/cable,
+/turf/closed/wall,
+/area/station/commons/dorms)
 "umt" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Office Maintenance"
@@ -37629,16 +37668,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/command/bridge)
 "uEb" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/obj/structure/dresser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/eighties,
+/area/station/commons/dorms)
 "uEz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37722,7 +37755,7 @@
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "uGD" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/grass,
@@ -37757,19 +37790,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"uHM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "uHW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -38227,13 +38247,6 @@
 "uTC" = (
 /turf/closed/wall/r_wall,
 /area/station/science/cytology)
-"uUl" = (
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 4;
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
 "uUo" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/red/filled/warning,
@@ -39720,18 +39733,7 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
 "vMl" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Crew Quarters Access"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 1;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/carpet/orange,
 /area/station/commons/dorms)
 "vMy" = (
 /turf/open/floor/iron/stairs,
@@ -39813,17 +39815,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/office)
-"vPa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/warning,
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "vPb" = (
-/turf/open/floor/circuit/telecomms/server,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/science/server)
 "vPp" = (
 /obj/structure/cable,
@@ -40395,13 +40389,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
-"wgo" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
 "wgE" = (
 /obj/structure/fans/tiny/forcefield{
 	dir = 8
@@ -40628,10 +40615,10 @@
 	name = "Central Access"
 	},
 /obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning,
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "wny" = (
@@ -40674,6 +40661,13 @@
 /obj/machinery/ticket_machine/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"wpY" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "wqs" = (
 /turf/open/floor/holofloor/beach/water,
 /area/station/maintenance/starboard/aft)
@@ -40815,11 +40809,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
-"wtE" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "wtF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -40997,6 +40986,13 @@
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
+"wys" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "wyJ" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -41060,7 +41056,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "wAI" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured,
@@ -41077,7 +41073,8 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "wBl" = (
-/obj/machinery/duct/industrial/waste,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4"
 	},
@@ -41086,7 +41083,7 @@
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "wBn" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/stripes,
@@ -41349,17 +41346,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/command/bridge)
-"wIL" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "wJz" = (
 /obj/effect/spawner/liquids_spawner{
 	reagent_list = list(/datum/reagent/ammonia/urine=400)
@@ -41367,16 +41353,17 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/upper)
 "wJB" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4"
+/obj/structure/chair/wood{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 1;
-	color = "#009dc4"
+/obj/machinery/button/door/directional/west{
+	id = "Dorm1";
+	name = "Dormitory Door Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "wJN" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/disposalpipe/segment{
@@ -41394,12 +41381,19 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "wJX" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
+/obj/structure/toilet{
+	dir = 4;
+	pixel_y = 7
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
+/obj/structure/sink/directional/north,
+/obj/structure/mirror{
+	pixel_y = -28
+	},
+/obj/machinery/light/small/directional/south{
+	pixel_x = 11
+	},
+/turf/open/floor/iron/freezer,
+/area/station/commons/dorms)
 "wKB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -41447,17 +41441,7 @@
 /turf/open/floor/iron/textured,
 /area/station/science/robotics/lab)
 "wMb" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Crew Quarters Access"
-	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 1;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/eighties,
 /area/station/commons/dorms)
 "wMh" = (
 /obj/machinery/duct/industrial/waste,
@@ -41520,6 +41504,14 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"wOp" = (
+/obj/structure/dresser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "wOq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -42187,10 +42179,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 5
 	},
-/obj/effect/turf_decal/trimline/brown/line{
+/obj/effect/turf_decal/trimline/brown/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -42277,11 +42269,14 @@
 /turf/open/floor/iron,
 /area/mine/storage/public)
 "xjU" = (
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "xjX" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/closet/secure_closet/chemical,
@@ -42392,19 +42387,27 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "xmS" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/white/corner{
 	color = "#009dc4"
 	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 9;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "xmT" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"xnt" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/clown/double,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "xnz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -43097,13 +43100,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
-"xFG" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "xGw" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -43477,6 +43473,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
+"xQt" = (
+/obj/structure/dresser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "xQD" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -43764,17 +43765,6 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/main)
-"xYk" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "xYm" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/trash,
@@ -44001,6 +43991,18 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/service/library)
+"yfA" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/vacant_room)
 "yfT" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -58722,17 +58724,17 @@ weo
 pVn
 lUz
 lUz
-vwP
 lUz
 lUz
 lUz
-vwP
-lUz
-vwP
 lUz
 lUz
 lUz
-kJb
+lUz
+lUz
+lUz
+lUz
+lUz
 kJb
 kJb
 rdt
@@ -58978,18 +58980,18 @@ fdQ
 vwP
 wri
 lUz
-rnM
-bOl
-rnM
+haT
+nxP
+wJX
 qZZ
-rnM
+wpY
 rmF
-rnM
-gAV
-rnM
-eQp
+wJX
 vwP
-xmS
+faH
+eQp
+wJX
+vwP
 uRZ
 kwc
 rdt
@@ -59235,20 +59237,20 @@ vwP
 vwP
 bmW
 lUz
-rnM
-rnM
-rnM
-rnM
-rnM
-rnM
-rnM
-rnM
-rnM
-rnM
+xQt
+nxP
+fXI
 vwP
-aMJ
+wOp
+rmF
+fXI
+vwP
+uEb
+eQp
+fXI
+vwP
 kwp
-xFG
+iVc
 rdt
 cda
 jLV
@@ -59319,7 +59321,7 @@ afn
 vfM
 vfM
 fKI
-gCo
+eTU
 rkn
 pII
 aej
@@ -59491,21 +59493,21 @@ vwP
 vwP
 bmW
 bmW
-bkB
+lUz
 rnM
-rnM
-rnM
-rnM
-rnM
-rnM
-rnM
-rnM
-rnM
-xjU
+vMl
+vMl
+vwP
+xnt
+eUw
+eUw
+vwP
+amz
 wMb
-gCN
+wMb
+vwP
 rfc
-xFG
+iVc
 nPn
 epv
 iDn
@@ -59749,18 +59751,18 @@ mQt
 bmW
 fvS
 vwP
-rnM
-rnM
-rnM
-rnM
-rnM
-rnM
-rnM
+vwP
+hkE
+vwP
+vwP
+vwP
+sjd
+vwP
+umh
+umh
 iPh
-iPh
-wgo
-vMl
-wJB
+umh
+umh
 rfc
 gtk
 rdt
@@ -60006,20 +60008,20 @@ bmW
 bmW
 uRq
 vwP
-rnM
-rnM
-rnM
-rnM
-rnM
-rnM
-rnM
-iPh
-rnM
-amz
+sBe
+aWp
+fCr
 vwP
-tYl
+sBe
+aWp
+wJB
+umh
+sBe
+aWp
+wJB
+vwP
 rfc
-xFG
+iVc
 rdt
 nKi
 kJF
@@ -60264,19 +60266,19 @@ miY
 vwP
 vwP
 jCa
-rnM
-rnM
-rnM
-rnM
-rnM
-rnM
-iPh
-rnM
 aWp
+tYl
 vwP
-uEb
+jCa
+aWp
+tYl
+umh
+jCa
+aWp
+tYl
+vwP
 kwp
-xFG
+iVc
 rdt
 rdt
 rdt
@@ -60521,20 +60523,20 @@ bmW
 bmW
 vwP
 pZJ
-rnM
-uUl
-rnM
-rnM
-ksj
-rnM
-tWp
-rnM
-rnM
+aWp
+sow
 vwP
-kOZ
+pZJ
+aWp
+sow
+umh
+pZJ
+aWp
+sow
+vwP
 oHD
 vTm
-lLz
+nwN
 mnS
 lVC
 lrZ
@@ -60542,8 +60544,8 @@ lrZ
 lrZ
 lrZ
 hMM
-sYl
-sYl
+hGO
+hGO
 tKO
 nvl
 nvl
@@ -60551,7 +60553,7 @@ nvl
 nvl
 nvl
 nvl
-iJW
+lLz
 tJW
 gun
 lrZ
@@ -60779,17 +60781,17 @@ fvS
 vwP
 vwP
 nKk
-lWJ
-nKk
 vwP
 vwP
 vwP
+rak
 vwP
 vwP
 vwP
+kgo
 vwP
 vwP
-gau
+dls
 rKc
 pIW
 lQS
@@ -60858,9 +60860,9 @@ vUV
 lwj
 byv
 fKI
-nyO
+lWJ
 nyQ
-rrt
+gCo
 wAI
 mLC
 dqy
@@ -61033,9 +61035,9 @@ wri
 bmW
 bmW
 bmW
-vwP
+fmY
 xmS
-xYk
+sDA
 sxq
 beP
 beP
@@ -61043,7 +61045,7 @@ sDA
 beP
 beP
 beP
-xYk
+sxq
 wAH
 uGB
 vSI
@@ -61051,19 +61053,19 @@ bBP
 nDl
 kBt
 oQa
-dpV
-oyi
-dpV
-dpV
-dpV
-dpV
-nBb
-dpV
+bkB
 rtP
-nxP
-nxP
-nxP
-nxP
+bkB
+bkB
+bkB
+bkB
+ksj
+bkB
+eDV
+dpV
+dpV
+dpV
+dpV
 ubI
 cUp
 nIO
@@ -61299,13 +61301,13 @@ kZH
 kZH
 kZH
 sga
-wFP
-vAr
-pIW
-lQS
+dXV
+tWp
+wBl
+qJK
 fDR
 qkH
-wBl
+piw
 xwm
 xwm
 xwm
@@ -61562,7 +61564,7 @@ bec
 uGB
 vSI
 tYL
-wBl
+piw
 xwm
 auY
 dcF
@@ -61817,9 +61819,9 @@ ort
 nGD
 nGD
 nGD
-bZH
+kDT
 rfc
-wBl
+piw
 xwm
 oas
 agP
@@ -61884,8 +61886,8 @@ jfI
 tNT
 qhS
 eDo
-mpU
 xgr
+pAc
 imV
 kJB
 mkz
@@ -62070,13 +62072,13 @@ uzZ
 ceK
 pyU
 dtb
-sed
+yfA
 uFU
 nGD
 eso
 kdC
 rfc
-mWr
+iul
 lQt
 agP
 hyQ
@@ -62105,13 +62107,13 @@ nyD
 cCg
 qbR
 pAj
-umh
+qSu
 tRg
 hrr
 hrr
 hrr
 hrr
-umh
+qSu
 tzl
 eco
 xUj
@@ -62330,10 +62332,10 @@ mHp
 sJd
 jeZ
 nGD
-ijx
+mZO
 rfc
 kwp
-wBl
+piw
 xwm
 qeN
 oas
@@ -62361,17 +62363,17 @@ rfc
 wDZ
 jgV
 pHV
-gWl
-lDs
+nli
+aMJ
 kAd
 bTn
 auj
 bTn
 bTn
-fpz
-wtE
+tux
+gAV
 qEO
-qmM
+mbD
 sTn
 sTn
 sTn
@@ -62382,7 +62384,7 @@ sTn
 sTn
 ltK
 qJW
-eEZ
+qmM
 hzM
 sTn
 ngm
@@ -62396,7 +62398,7 @@ hzM
 sTn
 nTa
 gUe
-bRX
+nZU
 qaa
 uNE
 lap
@@ -62405,7 +62407,7 @@ kBn
 mue
 qaa
 cov
-lDp
+qWn
 oII
 qIf
 bZJ
@@ -62587,7 +62589,7 @@ shX
 tTb
 iWI
 nGD
-fZv
+sOn
 rfc
 lNF
 mQx
@@ -62617,17 +62619,17 @@ lck
 bMn
 kkW
 lca
-akh
-wIL
-oyo
+kOZ
+wmV
+geE
 gDA
 pXi
 hwW
 pXi
 pXi
-wJX
-mTh
-wmV
+wys
+piU
+mxH
 jEi
 eLS
 eLS
@@ -62653,7 +62655,7 @@ sJj
 iaP
 gxe
 ngm
-iul
+aig
 qaa
 uDo
 bcQ
@@ -62844,9 +62846,9 @@ rQX
 kgA
 svS
 nGD
-bZH
+kDT
 rfc
-wBl
+piw
 fue
 fue
 fue
@@ -62883,7 +62885,7 @@ hrr
 xVm
 xVm
 fRb
-iXZ
+kIu
 yhH
 qNW
 vkw
@@ -62910,7 +62912,7 @@ twN
 twN
 jfI
 ngm
-iul
+aig
 qaa
 mtV
 afN
@@ -63101,9 +63103,9 @@ nGD
 nGD
 nGD
 nGD
-ijx
+mZO
 kwp
-wBl
+piw
 fue
 qet
 gMt
@@ -63167,7 +63169,7 @@ lYm
 twN
 jfI
 gtt
-iul
+aig
 qaa
 qry
 jJI
@@ -63360,7 +63362,7 @@ uRG
 ewl
 lhq
 rfc
-wBl
+piw
 ljv
 ewL
 gMt
@@ -63424,7 +63426,7 @@ xmK
 twN
 jfI
 ngm
-iul
+aig
 qaa
 uAo
 dYT
@@ -63615,7 +63617,7 @@ lHt
 jSp
 lHt
 yke
-gau
+dls
 tYL
 nDl
 ilm
@@ -63681,7 +63683,7 @@ cLN
 twN
 jfI
 ngm
-iul
+aig
 qaa
 weQ
 uVd
@@ -63872,9 +63874,9 @@ wlx
 gIZ
 nVx
 ukf
-gau
+dls
 rfc
-mWr
+iul
 nMK
 svH
 svH
@@ -64129,9 +64131,9 @@ lHt
 jSp
 lHt
 yke
-gau
+dls
 kwp
-wBl
+piw
 ljv
 aTw
 uth
@@ -64388,7 +64390,7 @@ wlx
 nMG
 mhY
 rfc
-wBl
+piw
 fue
 qet
 ewL
@@ -64643,9 +64645,9 @@ gIZ
 jSp
 oUo
 nLV
-gau
+dls
 rfc
-wBl
+piw
 fue
 fue
 fue
@@ -64900,9 +64902,9 @@ wlx
 lHt
 wlx
 nLV
-gau
+dls
 rfc
-wBl
+piw
 pkw
 dMh
 vhM
@@ -65157,9 +65159,9 @@ lHt
 eBe
 pse
 nLV
-gau
+dls
 kwp
-wBl
+piw
 ahh
 adv
 adv
@@ -65414,9 +65416,9 @@ wlx
 ecM
 eBe
 nLV
-dls
+fZv
 rfc
-jAS
+gau
 wZC
 adv
 adv
@@ -65671,9 +65673,9 @@ lHt
 wlx
 lHt
 nLV
-uHM
+mWr
 rfc
-wBl
+piw
 ahh
 adv
 amw
@@ -65928,9 +65930,9 @@ bIJ
 lHt
 rOB
 nLV
-gau
+dls
 rfc
-wBl
+piw
 pkw
 xji
 tRB
@@ -66185,9 +66187,9 @@ nLV
 nLV
 nLV
 nLV
-gau
+dls
 rfc
-wBl
+piw
 pkw
 pkw
 orx
@@ -66444,7 +66446,7 @@ fgS
 gGL
 vSI
 kwp
-wBl
+piw
 pkw
 gyj
 pqf
@@ -66699,9 +66701,9 @@ tXC
 tXC
 tXC
 tXC
-tWM
+gCN
 rfc
-wBl
+piw
 pkw
 xji
 tRB
@@ -66956,9 +66958,9 @@ uUY
 eGO
 hHy
 tXC
-fOs
+xjU
 tYL
-wBl
+piw
 pkw
 adv
 tRB
@@ -67213,7 +67215,7 @@ sRK
 tme
 keD
 mMl
-vPa
+gut
 veZ
 oij
 lxM
@@ -67472,7 +67474,7 @@ tXC
 tXC
 faF
 cbq
-wBl
+piw
 pkw
 adv
 bJU
@@ -67727,9 +67729,9 @@ ftA
 uPO
 bhD
 rXT
-tWM
+gCN
 wDZ
-wBl
+piw
 ahh
 uYW
 cPJ
@@ -67800,11 +67802,11 @@ rrB
 rrB
 rrB
 rrB
-cwT
-gvJ
-jBC
-jBC
-sBe
+czZ
+gtc
+dgW
+dgW
+bOl
 udB
 llX
 kkp
@@ -67984,9 +67986,9 @@ gyG
 iip
 qza
 aES
-vPa
+gut
 wDZ
-wBl
+piw
 pkw
 pkw
 pkw
@@ -68057,11 +68059,11 @@ lKN
 ydD
 ofT
 rrB
-spJ
-sBe
-sBe
-sBe
-sBe
+dBG
+bOl
+bOl
+bOl
+bOl
 okD
 gvZ
 uPB
@@ -68241,9 +68243,9 @@ qHJ
 nya
 tfm
 rIM
-vPa
+gut
 wDZ
-wBl
+piw
 tYA
 nwZ
 iEa
@@ -68498,9 +68500,9 @@ iVp
 tfm
 qza
 vAD
-tWM
+gCN
 cbq
-wBl
+piw
 tYA
 iEa
 pKF
@@ -73715,9 +73717,9 @@ upz
 trt
 ehb
 naf
-gzu
+qjj
 voj
-bKk
+kqD
 rhn
 wCS
 rMy
@@ -73973,7 +73975,7 @@ aus
 eJj
 wfC
 oUp
-iKt
+oyo
 xRW
 vWE
 ajQ
@@ -75507,7 +75509,7 @@ lkF
 nbU
 fXB
 gPZ
-piw
+mao
 gPZ
 gPZ
 onf
@@ -80314,8 +80316,8 @@ fgS
 rdb
 wdA
 wdA
+knm
 vPb
-puf
 bYP
 wvm
 hwz
@@ -80572,7 +80574,7 @@ rdb
 wdA
 qQF
 adu
-puf
+vPb
 koq
 jcU
 jcU
@@ -81086,7 +81088,7 @@ gzZ
 wdA
 qQF
 adu
-puf
+vPb
 iLR
 cJw
 cJw
@@ -81342,8 +81344,8 @@ nRM
 gzZ
 wdA
 wdA
+knm
 vPb
-puf
 mrJ
 gIk
 wBt
@@ -83928,9 +83930,9 @@ mne
 cHK
 cHK
 cHK
-kIu
-iVc
-iVc
+qlN
+flh
+flh
 mHR
 cmR
 ezI

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -14312,6 +14312,10 @@
 	pixel_x = 13;
 	pixel_y = 1
 	},
+/obj/item/storage/box/coffeepack{
+	pixel_x = 15;
+	pixel_y = 10
+	},
 /turf/open/floor/wood/large,
 /area/station/security/warden)
 "hLn" = (
@@ -29626,6 +29630,7 @@
 	},
 /obj/machinery/light_switch/directional/north,
 /obj/item/storage/box/zipties,
+/obj/item/storage/box/coffeepack/robusta,
 /turf/open/floor/wood/large,
 /area/station/security/warden)
 "pZg" = (
@@ -40458,6 +40463,7 @@
 	req_access = list("armory")
 	},
 /obj/effect/spawner/random/maintenance/three,
+/obj/item/grenade/clusterbuster/random,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "vWn" = (

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -31867,6 +31867,13 @@
 /obj/effect/turf_decal/tile/green/half/contrasted,
 /turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics)
+"qBI" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 6
+	},
+/turf/open/floor/plating/ocean,
+/area/ocean/generated_above)
 "qBL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -89775,7 +89782,7 @@ aah
 aah
 aah
 aah
-aah
+qBI
 aah
 aah
 aah
@@ -90033,7 +90040,7 @@ aah
 aah
 aah
 aah
-aah
+qBI
 aah
 aah
 aah

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -31612,11 +31612,6 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/robotics/lab)
-"qZZ" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/camera/autoname/directional/south,
-/turf/closed/wall,
-/area/station/commons/dorms)
 "rab" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -59452,7 +59447,7 @@ lUz
 phv
 bOl
 lln
-qZZ
+vwP
 qbg
 rmF
 lln

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -383,15 +383,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
-"aig" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "aih" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -544,10 +535,9 @@
 /turf/open/floor/iron,
 /area/mine/storage/public)
 "amz" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/clown/double,
-/turf/open/floor/eighties,
-/area/station/commons/dorms)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "amG" = (
 /obj/machinery/duct/industrial/waste,
 /turf/open/floor/iron/dark/textured,
@@ -1009,6 +999,12 @@
 /obj/structure/sign/warning/no_smoking,
 /turf/open/floor/plating,
 /area/station/science/genetics)
+"aDS" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/shower/directional/south,
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "aEw" = (
 /obj/structure/sign/poster/official/high_class_martini,
 /turf/closed/wall,
@@ -1307,12 +1303,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "aMJ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
+/obj/machinery/shower/directional/south,
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "aNi" = (
 /turf/open/floor/engine,
 /area/station/engineering/main)
@@ -1719,7 +1713,7 @@
 /area/station/engineering/main)
 "aWp" = (
 /turf/open/floor/wood,
-/area/station/commons/dorms)
+/area/station/service/abandoned_gambling_den/gaming)
 "aWJ" = (
 /turf/open/floor/fakebasalt,
 /area/station/maintenance/starboard/upper)
@@ -2038,13 +2032,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "beP" = (
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/warning{
 	dir = 8;
 	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/dorms)
@@ -2055,6 +2050,19 @@
 "bfx" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/virology)
+"bfA" = (
+/obj/machinery/duct/industrial/waste,
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "bfN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2218,17 +2226,18 @@
 	},
 /area/station/engineering/main)
 "bkB" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 5
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/aft)
 "bkC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -2375,6 +2384,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"bnm" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "bnB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/camera/autoname/directional/south,
@@ -3454,8 +3468,18 @@
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "bOl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
+/area/station/hallway/primary/central)
 "bOH" = (
 /obj/machinery/teleport/station,
 /turf/open/floor/mineral/titanium/purple,
@@ -3465,6 +3489,12 @@
 /obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
+"bOL" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "bOM" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -3995,6 +4025,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar)
+"cfp" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "cfu" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -4546,11 +4583,6 @@
 /mob/living/basic/cockroach,
 /turf/open/floor/iron,
 /area/station/maintenance/port/central)
-"czZ" = (
-/obj/effect/spawner/random/trash,
-/obj/vehicle/ridden/secway,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "cAb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -4787,6 +4819,19 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"cFt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm1";
+	name = "Cabin 1"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "cFC" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/kitchen,
@@ -4892,6 +4937,13 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/purple,
 /area/station/science/server)
+"cJz" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/courtroom)
 "cKa" = (
 /obj/machinery/atmospherics/components/binary/crystallizer{
 	dir = 4
@@ -5175,6 +5227,16 @@
 /obj/effect/turf_decal/trimline/blue/corner,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/theatre)
+"cRy" = (
+/obj/structure/curtain/cloth,
+/obj/structure/drain,
+/obj/machinery/shower/directional/north,
+/obj/machinery/door/window/brigdoor{
+	name = "Shower";
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/station/commons/dorms)
 "cRO" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -5754,10 +5816,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
-"dgW" = (
-/obj/machinery/suit_storage_unit/security,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "dgX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/base_turf_modifier/pit,
@@ -5981,9 +6039,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
@@ -6187,13 +6246,13 @@
 /area/station/cargo/miningoffice)
 "dpV" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -6602,10 +6661,6 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"dBG" = (
-/obj/vehicle/ridden/secway,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "dCe" = (
 /obj/structure/table/glass,
 /obj/structure/showcase/machinery/tv{
@@ -6886,6 +6941,20 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/robotics)
+"dJu" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/sink/directional/north,
+/obj/structure/mirror{
+	pixel_y = -28
+	},
+/obj/machinery/light/small/directional/south{
+	pixel_x = 11
+	},
+/turf/open/floor/iron/freezer,
+/area/station/commons/dorms)
 "dJB" = (
 /mob/living/basic/chicken,
 /turf/open/misc/sandy_dirt,
@@ -7360,11 +7429,6 @@
 "dXQ" = (
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"dXV" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/dorms)
 "dYc" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/portable_atmospherics/pump,
@@ -8371,6 +8435,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"eAK" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock{
+	name = "Bedroom"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "eAY" = (
 /obj/effect/turf_decal/stripes{
 	dir = 6
@@ -8540,19 +8612,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/central)
-"eDV" = (
-/obj/machinery/duct/industrial/waste,
-/obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "eDZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct/industrial/waste,
@@ -9072,8 +9131,9 @@
 /area/station/engineering/storage/tech)
 "eQp" = (
 /obj/structure/window/reinforced/tinted,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/eighties,
-/area/station/commons/dorms)
+/area/station/service/abandoned_gambling_den/gaming)
 "eQt" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/vending/imported/yangyu,
@@ -9085,6 +9145,13 @@
 /obj/structure/sign/warning/electric_shock,
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"eQO" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "eRl" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -9207,12 +9274,6 @@
 	},
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
-"eTU" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron/dark/textured,
-/area/station/cargo/storage)
 "eUn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -9228,12 +9289,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"eUw" = (
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
-/area/station/commons/dorms)
 "eUC" = (
 /obj/machinery/air_sensor/oxygen_tank,
 /turf/open/floor/engine/o2,
@@ -9263,6 +9318,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"eVE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "eWH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -9400,6 +9465,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
+"eZT" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "eZW" = (
 /obj/structure/table,
 /obj/machinery/plantgenes,
@@ -9432,10 +9502,6 @@
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"faH" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/eighties,
-/area/station/commons/dorms)
 "faI" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/autolathe,
@@ -9674,6 +9740,12 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
+"fgt" = (
+/obj/machinery/door/airlock{
+	name = "Bedroom"
+	},
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "fgA" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -9784,6 +9856,11 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/storage/emergency/starboard)
+"fjN" = (
+/obj/structure/dresser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "fjQ" = (
 /obj/structure/grille,
 /obj/effect/spawner/structure/window/plasma,
@@ -9833,15 +9910,6 @@
 "fla" = (
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
-"flh" = (
-/obj/effect/turf_decal/trimline/brown/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured/airless,
-/area/station/science/lobby)
 "flp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
@@ -9862,12 +9930,6 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
-"fmY" = (
-/obj/machinery/door/airlock/bathroom{
-	name = "Showers"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
 "fnj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -9982,6 +10044,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"fpL" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "fpN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10215,6 +10284,11 @@
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
+"fze" = (
+/obj/structure/chair/sofa/right,
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "fzi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/flora/bush/jungle/b/style_random,
@@ -10291,6 +10365,7 @@
 	dir = 8;
 	color = "#009dc4"
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/dorms)
 "fBH" = (
@@ -10310,18 +10385,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
-"fCr" = (
-/obj/structure/chair/wood{
-	dir = 4
+"fCa" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
 	},
-/obj/machinery/button/door/directional/west{
-	id = "Dorm3";
-	name = "Dormitory Door Lock";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/turf/open/floor/wood,
-/area/station/commons/dorms)
+/turf/open/floor/iron/dark/textured,
+/area/station/security/office)
 "fCx" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor/auto{
@@ -10408,6 +10479,9 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
+"fFE" = (
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "fFI" = (
 /turf/open/floor/carpet/executive,
 /area/station/commons/vacant_room/commissary)
@@ -10806,6 +10880,14 @@
 "fQG" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/office)
+"fQY" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "fRb" = (
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/west,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -11035,12 +11117,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/cargo/miningoffice)
-"fXI" = (
-/obj/structure/curtain/cloth,
-/obj/structure/drain,
-/obj/machinery/shower/directional/north,
-/turf/open/floor/iron/freezer,
-/area/station/commons/dorms)
 "fXR" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -11103,12 +11179,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
 	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -11159,16 +11235,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "gau" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4";
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
-	},
+/obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/maintenance/port/aft)
 "gaz" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -11364,13 +11433,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"geE" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "geH" = (
 /obj/item/storage/secure/safe/directional/north,
 /obj/machinery/light/small/directional/west,
@@ -11523,6 +11585,11 @@
 "giY" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/fore)
+"gjB" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "gks" = (
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/plating,
@@ -11748,10 +11815,6 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/iron,
 /area/station/service/library)
-"gtc" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "gtg" = (
 /obj/effect/turf_decal/tile/green/opposingcorners{
 	dir = 1
@@ -11830,15 +11893,6 @@
 /obj/effect/turf_decal/trimline/white/corner{
 	color = "#009dc4"
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
-"gut" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "guV" = (
@@ -12063,10 +12117,14 @@
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
 "gAV" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/warning,
 /turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
+/area/station/hallway/primary/central)
 "gBb" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -12095,17 +12153,14 @@
 "gCo" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "gCN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line,
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/obj/machinery/shower/directional/north,
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "gCU" = (
 /obj/machinery/button/ticket_machine{
 	pixel_y = 22;
@@ -12594,6 +12649,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
+"gSX" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/commons/dorms)
 "gTr" = (
 /turf/closed/wall,
 /area/station/medical/storage)
@@ -12919,10 +12980,6 @@
 	dir = 1
 	},
 /area/station/science/lobby)
-"haT" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
 "hbe" = (
 /obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/stripes{
@@ -13091,6 +13148,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"heS" = (
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "hfr" = (
 /obj/structure/table/wood/poker,
 /obj/item/reagent_containers/cup/glass/drinkingglass{
@@ -13259,12 +13319,6 @@
 /obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics)
-"hkE" = (
-/obj/machinery/door/airlock{
-	name = "Bedroom"
-	},
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
 "hkS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -14011,19 +14065,6 @@
 	},
 /turf/open/floor/carpet/executive,
 /area/station/commons/vacant_room/commissary)
-"hGO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "hHb" = (
 /obj/machinery/modular_computer/console/preset/cargochat/science{
 	dir = 4
@@ -14131,6 +14172,17 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/main)
+"hLc" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "hLd" = (
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
@@ -14711,6 +14763,20 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/executive,
 /area/station/commons/vacant_room/commissary)
+"iaH" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/sink/directional/north,
+/obj/structure/mirror{
+	pixel_y = -28
+	},
+/obj/machinery/light/small/directional/south{
+	pixel_x = 11
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/abandoned_gambling_den/gaming)
 "iaP" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -14804,6 +14870,11 @@
 	},
 /turf/open/floor/plating/ocean,
 /area/ocean)
+"ids" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "idx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
@@ -14883,6 +14954,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
+"ifP" = (
+/obj/effect/turf_decal/trimline/brown/end{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured/airless,
+/area/station/science/lobby)
 "ige" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -15362,20 +15439,28 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/robotics/lab)
 "iul" = (
-/obj/machinery/duct/industrial/waste,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4";
-	dir = 1
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = -32
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "iut" = (
 /turf/open/floor/wood/parquet,
 /area/station/medical/medbay/central)
+"iuC" = (
+/obj/machinery/door/airlock{
+	name = "Bedroom"
+	},
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "iuY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -15511,6 +15596,9 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"iAq" = (
+/turf/closed/wall/r_wall,
+/area/station/service/abandoned_gambling_den/gaming)
 "iAr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16062,11 +16150,8 @@
 /area/station/tcommsat/server)
 "iPh" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Bedroom"
-	},
-/turf/open/floor/eighties,
-/area/station/commons/dorms)
+/turf/closed/wall,
+/area/station/service/abandoned_gambling_den/gaming)
 "iPl" = (
 /obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/iron/dark/textured,
@@ -16236,12 +16321,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "iVc" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/obj/structure/bed/double,
+/obj/item/bedsheet/clown/double,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "iVp" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/disposalpipe/segment{
@@ -16569,6 +16653,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/central)
+"jft" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/arcade/orion_trail{
+	desc = "For gamers only. Casuals need not apply.";
+	icon_screen = "library";
+	icon_state = "oldcomp";
+	name = "Gamer Computer";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "jfu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16968,6 +17064,17 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
+"jpW" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "jpZ" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -17029,6 +17136,18 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
+"jsP" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "jsU" = (
 /obj/structure/displaycase/captain{
 	pixel_y = 5
@@ -18422,6 +18541,13 @@
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"keu" = (
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/service/hydroponics/garden)
 "keB" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/ai/directional/west,
@@ -18499,17 +18625,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
-"kgo" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm1";
-	name = "Cabin 1"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/station/commons/dorms)
 "kgt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 5
@@ -18771,9 +18886,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/commons/storage/emergency/starboard)
-"knm" = (
-/turf/open/floor/circuit/telecomms/server,
-/area/station/science/server)
 "kno" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -18895,10 +19007,6 @@
 /obj/machinery/mecha_part_fabricator/maint,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"kqD" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/red,
-/area/station/security/office)
 "kqQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -18941,18 +19049,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "ksj" = (
-/obj/machinery/duct/industrial/waste,
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/dorms)
 "ksq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/sign/poster/traitor/random{
@@ -19175,6 +19277,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"kys" = (
+/obj/machinery/duct/industrial/waste,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "kyM" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -19384,19 +19499,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
-"kDT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "kDW" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/light/directional/north,
@@ -19561,11 +19663,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "kIu" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
 /turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
+/area/station/maintenance/port/aft)
 "kIM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19852,6 +19951,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
+"kOE" = (
+/obj/machinery/door/airlock/bathroom{
+	name = "Showers"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "kOH" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -19888,10 +19993,14 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/cmo)
 "kOZ" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/obj/effect/turf_decal/trimline/green/warning{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -20181,6 +20290,12 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"kWb" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "kWz" = (
 /obj/machinery/camera/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -22027,9 +22142,9 @@
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "lWJ" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark/textured,
-/area/station/cargo/storage)
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "lXc" = (
 /obj/structure/cable,
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/south,
@@ -22123,13 +22238,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
-"mao" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark/textured,
-/area/station/security/courtroom)
 "maA" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -22170,14 +22278,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
-"mbD" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/warning,
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "mbF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22285,6 +22385,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/commons/storage/emergency/starboard)
+"mhD" = (
+/obj/effect/spawner/random/trash,
+/obj/vehicle/ridden/secway,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "mhX" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -22428,6 +22533,14 @@
 	},
 /turf/open/floor/plating/ocean,
 /area/station/cargo/storage)
+"mma" = (
+/obj/structure/dresser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "mne" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22847,17 +22960,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/interrogation)
-"mxH" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "mxN" = (
 /obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/stripes/full,
@@ -23004,6 +23106,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"mEX" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "mFh" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -23661,15 +23767,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/central)
 "mWr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/machinery/duct/industrial/waste,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
 	color = "#009dc4";
 	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -23790,18 +23895,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
-"mZO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "mZW" = (
 /obj/structure/cable,
 /obj/machinery/duct/industrial/waste,
@@ -24298,17 +24391,6 @@
 /obj/item/reagent_containers/cup/glass/bottle/hooch,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
-"nli" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "nlQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24642,8 +24724,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 8
+	dir = 8;
+	color = "#009dc4"
 	},
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 4;
@@ -24700,17 +24782,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/medical/medbay/central)
-"nwN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/green/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "nwZ" = (
 /obj/structure/flora/grass/jungle/a/style_random,
 /mob/living/simple_animal/hostile/jungle/mook,
@@ -24856,6 +24927,17 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
+"nAk" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "nAn" = (
 /mob/living/carbon/human/species/monkey,
 /obj/machinery/door/window/right/directional/south{
@@ -24954,11 +25036,8 @@
 /area/station/security/office)
 "nDl" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4";
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -25584,6 +25663,17 @@
 "nWK" = (
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
+"nWL" = (
+/obj/structure/toilet/secret{
+	dir = 4
+	},
+/obj/item/bikehorn/rubberducky{
+	pixel_x = -9;
+	pixel_y = 12;
+	name = "The Watcher"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "nXd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -25642,6 +25732,11 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"nZl" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "nZx" = (
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron/dark,
@@ -25653,16 +25748,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/glass/reinforced,
 /area/station/engineering/main)
-"nZU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/south,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "oas" = (
 /turf/open/floor/iron/sepia,
 /area/station/commons/fitness/recreation)
@@ -26626,8 +26711,16 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "oyo" = (
-/turf/open/floor/carpet/red,
-/area/station/security/office)
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "oyB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -26953,6 +27046,19 @@
 /obj/effect/turf_decal/tile/blue/diagonal_centre,
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
+"oID" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "oII" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/white/filled/warning{
@@ -27047,6 +27153,15 @@
 /obj/item/storage/secure/safe/caps_spare/directional/west,
 /turf/open/floor/carpet/executive,
 /area/station/command/bridge)
+"oMU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "oNt" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/executive,
@@ -27438,6 +27553,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
+"oYP" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "oZR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -27734,6 +27853,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
+"pis" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/dorms)
 "piv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27746,21 +27869,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "piw" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4"
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 1;
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
-"piU" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
+/area/station/commons/dorms)
 "piW" = (
 /obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/trunk{
@@ -28248,6 +28362,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
+"pww" = (
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "pwU" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/stripes/line{
@@ -28316,19 +28433,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/carpet/executive,
 /area/station/command/bridge)
-"pAc" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "pAg" = (
 /obj/machinery/computer/security/mining{
 	dir = 4
@@ -28346,6 +28450,11 @@
 /obj/structure/disposalpipe/junction/yjunction,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/primary/central)
+"pBs" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/patriot/double,
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "pBO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -29172,6 +29281,13 @@
 	color = "#999999"
 	},
 /area/station/science/robotics)
+"pVJ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "pWA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -29521,6 +29637,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/office)
+"qdA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "qdG" = (
 /obj/machinery/duct/industrial/waste,
 /turf/open/floor/plating,
@@ -29721,14 +29848,6 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
-"qjj" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/security/office)
 "qjI" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/mineral/titanium,
@@ -29786,12 +29905,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/aft)
-"qlN" = (
-/obj/effect/turf_decal/trimline/brown/end{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured/airless,
-/area/station/science/lobby)
 "qmb" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -29818,13 +29931,10 @@
 /area/station/command/heads_quarters/captain/private)
 "qmM" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 1;
-	color = "#009dc4"
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4"
-	},
+/obj/effect/turf_decal/trimline/green/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "qmR" = (
@@ -30622,12 +30732,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/storage)
-"qJK" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/commons/dorms)
 "qJM" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/disposalpipe/segment{
@@ -30751,6 +30855,18 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/commons/fitness/recreation/entertainment)
+"qMo" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "Dorm3";
+	name = "Dormitory Door Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "qMB" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -31005,14 +31121,6 @@
 "qSp" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
-"qSu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "qSx" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -31157,13 +31265,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/command/bridge)
-"qWn" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#009dc4";
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/service/hydroponics/garden)
 "qWq" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -31308,17 +31409,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"rak" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm2";
-	name = "Cabin 2"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/station/commons/dorms)
 "rbo" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -31473,6 +31563,18 @@
 	dir = 4
 	},
 /area/station/security/office)
+"rfU" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/vacant_room)
 "rfV" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -31746,11 +31848,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "rmF" = (
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/carpet/orange,
 /area/station/commons/dorms)
 "rmK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31797,9 +31896,7 @@
 /turf/open/floor/plating/ocean,
 /area/ocean)
 "rnM" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/patriot/double,
-/turf/open/floor/carpet/orange,
+/turf/open/floor/wood,
 /area/station/commons/dorms)
 "rob" = (
 /obj/effect/landmark/start/assistant,
@@ -31991,13 +32088,13 @@
 "rtP" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 8;
 	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -33424,15 +33521,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room)
-"sjd" = (
-/obj/machinery/door/airlock{
-	name = "Bedroom"
-	},
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
-/area/station/commons/dorms)
 "sjq" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -33603,12 +33691,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
-"sow" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/commons/dorms)
 "spI" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -34007,10 +34089,14 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "sBe" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -1;
-	pixel_y = 5
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "Dorm1";
+	name = "Dormitory Door Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
@@ -34189,6 +34275,12 @@
 /obj/item/hand_tele,
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/captain/private)
+"sFJ" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/dorms)
 "sFK" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -34508,19 +34600,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
-"sOn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "sOr" = (
 /obj/machinery/light/directional/west,
 /obj/structure/tank_dispenser,
@@ -34980,6 +35059,7 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/dorms)
 "tdG" = (
@@ -35433,13 +35513,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"tux" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "tuL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -36023,6 +36096,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"tJw" = (
+/obj/structure/dresser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "tJx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -36346,6 +36424,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/storage)
+"tSM" = (
+/turf/open/floor/circuit/telecomms/server,
+/area/station/science/server)
 "tSW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36495,11 +36576,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "tWp" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/floor/has_bulb,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark/textured,
-/area/station/commons/dorms)
+/area/station/commons/lounge)
 "tWr" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark/textured,
@@ -36543,9 +36626,14 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "tYl" = (
-/obj/structure/table/wood,
+/obj/structure/chair/sofa/left,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/structure/sign/poster/contraband/pwr_game{
+	pixel_y = 36
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
-/area/station/commons/dorms)
+/area/station/service/abandoned_gambling_den/gaming)
 "tYt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36683,6 +36771,19 @@
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
 	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
+"ubL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -37070,9 +37171,14 @@
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "umh" = (
-/obj/structure/cable,
-/turf/closed/wall,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured/airless,
+/area/station/science/lobby)
 "umt" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Office Maintenance"
@@ -37310,6 +37416,18 @@
 /obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/server)
+"usO" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "Dorm1";
+	name = "Dormitory Door Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "ute" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -37668,9 +37786,15 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/command/bridge)
 "uEb" = (
-/obj/structure/dresser,
-/obj/machinery/light/directional/north,
-/turf/open/floor/eighties,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/commons/dorms)
 "uEz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37743,6 +37867,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/genetics,
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
+"uGq" = (
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "uGB" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -38867,6 +38995,15 @@
 /mob/living/basic/chicken,
 /turf/open/misc/sandy_dirt,
 /area/station/service/hydroponics/upper)
+"vkb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "vkl" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 8
@@ -39551,6 +39688,17 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"vFf" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm2";
+	name = "Cabin 2"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "vFg" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -39733,8 +39881,12 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
 "vMl" = (
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "vMy" = (
 /turf/open/floor/iron/stairs,
 /area/station/service/chapel)
@@ -40661,13 +40813,6 @@
 /obj/machinery/ticket_machine/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"wpY" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
-/area/station/commons/dorms)
 "wqs" = (
 /turf/open/floor/holofloor/beach/water,
 /area/station/maintenance/starboard/aft)
@@ -40986,13 +41131,6 @@
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
-"wys" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "wyJ" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -41013,6 +41151,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"wyZ" = (
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "wzb" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible/layer2{
@@ -41353,17 +41497,16 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/upper)
 "wJB" = (
-/obj/structure/chair/wood{
-	dir = 4
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
 	},
-/obj/machinery/button/door/directional/west{
-	id = "Dorm1";
-	name = "Dormitory Door Lock";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
 	},
-/turf/open/floor/wood,
-/area/station/commons/dorms)
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "wJN" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/disposalpipe/segment{
@@ -41371,6 +41514,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"wJP" = (
+/obj/machinery/door/window/brigdoor{
+	name = "Toilet";
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/abandoned_gambling_den/gaming)
 "wJR" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 5
@@ -41381,19 +41531,20 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "wJX" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_y = 7
-	},
-/obj/structure/sink/directional/north,
-/obj/structure/mirror{
-	pixel_y = -28
-	},
-/obj/machinery/light/small/directional/south{
-	pixel_x = 11
-	},
-/turf/open/floor/iron/freezer,
+/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/shower/directional/north,
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
+"wKb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "wKB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -41441,8 +41592,9 @@
 /turf/open/floor/iron/textured,
 /area/station/science/robotics/lab)
 "wMb" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/eighties,
-/area/station/commons/dorms)
+/area/station/service/abandoned_gambling_den/gaming)
 "wMh" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
@@ -41504,14 +41656,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"wOp" = (
-/obj/structure/dresser,
-/obj/machinery/light/directional/north,
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
-/area/station/commons/dorms)
 "wOq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -42179,10 +42323,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 5
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/corner{
+/obj/effect/turf_decal/trimline/brown/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -42252,6 +42396,19 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/science/genetics)
+"xiH" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
+/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
+/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
+/obj/item/reagent_containers/cup/soda_cans/pwr_game,
+/obj/item/reagent_containers/cup/soda_cans/pwr_game,
+/obj/item/reagent_containers/cup/soda_cans/pwr_game,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "xiT" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
@@ -42269,11 +42426,13 @@
 /turf/open/floor/iron,
 /area/mine/storage/public)
 "xjU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -42400,14 +42559,6 @@
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"xnt" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/clown/double,
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
-/area/station/commons/dorms)
 "xnz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42693,6 +42844,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"xue" = (
+/obj/vehicle/ridden/secway,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "xur" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43393,6 +43548,18 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"xOB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "xOR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 10
@@ -43473,11 +43640,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
-"xQt" = (
-/obj/structure/dresser,
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
 "xQD" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -43705,6 +43867,14 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
+"xWA" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/clown/double,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "xWF" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Station Reception"
@@ -43991,18 +44161,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/service/library)
-"yfA" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#009dc4";
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#009dc4";
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
 "yfT" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -58730,11 +58888,11 @@ lUz
 lUz
 lUz
 lUz
-lUz
-lUz
-lUz
-lUz
-lUz
+iAq
+iAq
+iAq
+iAq
+iAq
 kJb
 kJb
 rdt
@@ -58977,21 +59135,21 @@ nOV
 jMP
 weo
 fdQ
-vwP
-wri
+weo
+uSV
 lUz
-haT
-nxP
-wJX
-qZZ
-wpY
 rmF
-wJX
-vwP
-faH
+nxP
+dJu
+qZZ
+ksj
+piw
+dJu
+fue
+nZl
 eQp
-wJX
-vwP
+iaH
+fue
 uRZ
 kwc
 rdt
@@ -59235,22 +59393,22 @@ uSV
 fXD
 vwP
 vwP
-bmW
+vwP
 lUz
-xQt
+tJw
 nxP
-fXI
+cRy
 vwP
-wOp
-rmF
-fXI
-vwP
-uEb
+mma
+piw
+cRy
+fue
+fjN
 eQp
-fXI
-vwP
+wJP
+fue
 kwp
-iVc
+vMl
 rdt
 cda
 jLV
@@ -59321,7 +59479,7 @@ afn
 vfM
 vfM
 fKI
-eTU
+gCo
 rkn
 pII
 aej
@@ -59492,22 +59650,22 @@ uSV
 vwP
 vwP
 bmW
-bmW
+nWL
 lUz
-rnM
-vMl
-vMl
+pBs
+fFE
+fFE
 vwP
-xnt
-eUw
-eUw
-vwP
-amz
-wMb
-wMb
-vwP
-rfc
+xWA
+wyZ
+wyZ
+fue
 iVc
+heS
+wMb
+fue
+rfc
+vMl
 nPn
 epv
 iDn
@@ -59752,17 +59910,17 @@ bmW
 fvS
 vwP
 vwP
-hkE
+fgt
 vwP
 vwP
 vwP
-sjd
+iuC
 vwP
-umh
-umh
 iPh
-umh
-umh
+iPh
+eAK
+iPh
+iPh
 rfc
 gtk
 rdt
@@ -60008,20 +60166,20 @@ bmW
 bmW
 uRq
 vwP
-sBe
-aWp
-fCr
+fQY
+rnM
+qMo
 vwP
+fQY
+rnM
 sBe
-aWp
-wJB
-umh
-sBe
-aWp
-wJB
-vwP
+iPh
+iul
+amz
+usO
+fue
 rfc
-iVc
+vMl
 rdt
 nKi
 kJF
@@ -60266,19 +60424,19 @@ miY
 vwP
 vwP
 jCa
-aWp
-tYl
+rnM
+lWJ
 vwP
 jCa
+rnM
+lWJ
+iPh
+fze
 aWp
-tYl
-umh
-jCa
-aWp
-tYl
-vwP
+jft
+fue
 kwp
-iVc
+vMl
 rdt
 rdt
 rdt
@@ -60518,25 +60676,25 @@ xHH
 wop
 weo
 vwP
+aMJ
 bmW
-bmW
-bmW
+gCN
 vwP
 pZJ
-aWp
-sow
+rnM
+bOL
 vwP
 pZJ
-aWp
-sow
-umh
-pZJ
-aWp
-sow
-vwP
+rnM
+bOL
+iPh
+tYl
+bnm
+xiH
+fue
 oHD
 vTm
-nwN
+qdA
 mnS
 lVC
 lrZ
@@ -60544,15 +60702,15 @@ lrZ
 lrZ
 lrZ
 hMM
-hGO
-hGO
+nvl
+nvl
 tKO
-nvl
-nvl
-nvl
-nvl
-nvl
-nvl
+dls
+dls
+dls
+dls
+dls
+dls
 lLz
 tJW
 gun
@@ -60775,23 +60933,23 @@ xHH
 wop
 pVn
 vwP
-mQt
+aDS
 bmW
-fvS
+wJX
 vwP
 vwP
 nKk
 vwP
 vwP
 vwP
-rak
+vFf
 vwP
-vwP
-vwP
-kgo
-vwP
-vwP
-dls
+fue
+fue
+cFt
+fue
+fue
+kOZ
 rKc
 pIW
 lQS
@@ -60860,9 +61018,9 @@ vUV
 lwj
 byv
 fKI
-lWJ
+mEX
 nyQ
-gCo
+ids
 wAI
 mLC
 dqy
@@ -61035,37 +61193,37 @@ wri
 bmW
 bmW
 bmW
-fmY
+kOE
 xmS
 sDA
 sxq
-beP
-beP
+uEb
+uEb
 sDA
+uEb
+uEb
+uEb
 beP
-beP
-beP
-sxq
 wAH
 uGB
 vSI
 bBP
-nDl
+oyo
 kBt
 oQa
-bkB
+dpV
+bfA
+dpV
+dpV
+dpV
+dpV
+kys
+dpV
 rtP
-bkB
-bkB
-bkB
-bkB
-ksj
-bkB
-eDV
-dpV
-dpV
-dpV
-dpV
+jsP
+jsP
+jsP
+jsP
 ubI
 cUp
 nIO
@@ -61301,13 +61459,13 @@ kZH
 kZH
 kZH
 sga
-dXV
-tWp
+pis
+sFJ
 wBl
-qJK
+gSX
 fDR
 qkH
-piw
+wJB
 xwm
 xwm
 xwm
@@ -61564,7 +61722,7 @@ bec
 uGB
 vSI
 tYL
-piw
+wJB
 xwm
 auY
 dcF
@@ -61819,9 +61977,9 @@ ort
 nGD
 nGD
 nGD
-kDT
+ubL
 rfc
-piw
+wJB
 xwm
 oas
 agP
@@ -61886,8 +62044,8 @@ jfI
 tNT
 qhS
 eDo
+bkB
 xgr
-pAc
 imV
 kJB
 mkz
@@ -62072,13 +62230,13 @@ uzZ
 ceK
 pyU
 dtb
-yfA
+rfU
 uFU
 nGD
 eso
 kdC
 rfc
-iul
+mWr
 lQt
 agP
 hyQ
@@ -62107,13 +62265,13 @@ nyD
 cCg
 qbR
 pAj
-qSu
+tWp
 tRg
 hrr
 hrr
 hrr
 hrr
-qSu
+tWp
 tzl
 eco
 xUj
@@ -62332,10 +62490,10 @@ mHp
 sJd
 jeZ
 nGD
-mZO
+xOB
 rfc
 kwp
-piw
+wJB
 xwm
 qeN
 oas
@@ -62363,17 +62521,17 @@ rfc
 wDZ
 jgV
 pHV
-nli
-aMJ
+nAk
+pVJ
 kAd
 bTn
 auj
 bTn
 bTn
-tux
-gAV
+eQO
+eZT
 qEO
-mbD
+qmM
 sTn
 sTn
 sTn
@@ -62384,7 +62542,7 @@ sTn
 sTn
 ltK
 qJW
-qmM
+hLc
 hzM
 sTn
 ngm
@@ -62398,7 +62556,7 @@ hzM
 sTn
 nTa
 gUe
-nZU
+eVE
 qaa
 uNE
 lap
@@ -62407,7 +62565,7 @@ kBn
 mue
 qaa
 cov
-qWn
+keu
 oII
 qIf
 bZJ
@@ -62589,7 +62747,7 @@ shX
 tTb
 iWI
 nGD
-sOn
+fZv
 rfc
 lNF
 mQx
@@ -62619,17 +62777,17 @@ lck
 bMn
 kkW
 lca
-kOZ
+nDl
 wmV
-geE
+cfp
 gDA
 pXi
 hwW
 pXi
 pXi
-wys
-piU
-mxH
+fpL
+gjB
+jpW
 jEi
 eLS
 eLS
@@ -62655,7 +62813,7 @@ sJj
 iaP
 gxe
 ngm
-aig
+vkb
 qaa
 uDo
 bcQ
@@ -62846,9 +63004,9 @@ rQX
 kgA
 svS
 nGD
-kDT
+ubL
 rfc
-piw
+wJB
 fue
 fue
 fue
@@ -62885,7 +63043,7 @@ hrr
 xVm
 xVm
 fRb
-kIu
+kWb
 yhH
 qNW
 vkw
@@ -62912,7 +63070,7 @@ twN
 twN
 jfI
 ngm
-aig
+vkb
 qaa
 mtV
 afN
@@ -63103,9 +63261,9 @@ nGD
 nGD
 nGD
 nGD
-mZO
+xOB
 kwp
-piw
+wJB
 fue
 qet
 gMt
@@ -63169,7 +63327,7 @@ lYm
 twN
 jfI
 gtt
-aig
+vkb
 qaa
 qry
 jJI
@@ -63362,7 +63520,7 @@ uRG
 ewl
 lhq
 rfc
-piw
+wJB
 ljv
 ewL
 gMt
@@ -63426,7 +63584,7 @@ xmK
 twN
 jfI
 ngm
-aig
+vkb
 qaa
 uAo
 dYT
@@ -63617,9 +63775,9 @@ lHt
 jSp
 lHt
 yke
-dls
+kOZ
 tYL
-nDl
+oyo
 ilm
 kOf
 kOf
@@ -63683,7 +63841,7 @@ cLN
 twN
 jfI
 ngm
-aig
+vkb
 qaa
 weQ
 uVd
@@ -63874,9 +64032,9 @@ wlx
 gIZ
 nVx
 ukf
-dls
+kOZ
 rfc
-iul
+mWr
 nMK
 svH
 svH
@@ -64131,9 +64289,9 @@ lHt
 jSp
 lHt
 yke
-dls
+kOZ
 kwp
-piw
+wJB
 ljv
 aTw
 uth
@@ -64390,7 +64548,7 @@ wlx
 nMG
 mhY
 rfc
-piw
+wJB
 fue
 qet
 ewL
@@ -64645,9 +64803,9 @@ gIZ
 jSp
 oUo
 nLV
-dls
+kOZ
 rfc
-piw
+wJB
 fue
 fue
 fue
@@ -64902,9 +65060,9 @@ wlx
 lHt
 wlx
 nLV
-dls
+kOZ
 rfc
-piw
+wJB
 pkw
 dMh
 vhM
@@ -65159,9 +65317,9 @@ lHt
 eBe
 pse
 nLV
-dls
+kOZ
 kwp
-piw
+wJB
 ahh
 adv
 adv
@@ -65416,9 +65574,9 @@ wlx
 ecM
 eBe
 nLV
-fZv
+bOl
 rfc
-gau
+xjU
 wZC
 adv
 adv
@@ -65673,9 +65831,9 @@ lHt
 wlx
 lHt
 nLV
-mWr
+oID
 rfc
-piw
+wJB
 ahh
 adv
 amw
@@ -65930,9 +66088,9 @@ bIJ
 lHt
 rOB
 nLV
-dls
+kOZ
 rfc
-piw
+wJB
 pkw
 xji
 tRB
@@ -66187,9 +66345,9 @@ nLV
 nLV
 nLV
 nLV
-dls
+kOZ
 rfc
-piw
+wJB
 pkw
 pkw
 orx
@@ -66446,7 +66604,7 @@ fgS
 gGL
 vSI
 kwp
-piw
+wJB
 pkw
 gyj
 pqf
@@ -66701,9 +66859,9 @@ tXC
 tXC
 tXC
 tXC
-gCN
+wKb
 rfc
-piw
+wJB
 pkw
 xji
 tRB
@@ -66958,9 +67116,9 @@ uUY
 eGO
 hHy
 tXC
-xjU
+oMU
 tYL
-piw
+wJB
 pkw
 adv
 tRB
@@ -67215,7 +67373,7 @@ sRK
 tme
 keD
 mMl
-gut
+gAV
 veZ
 oij
 lxM
@@ -67474,7 +67632,7 @@ tXC
 tXC
 faF
 cbq
-piw
+wJB
 pkw
 adv
 bJU
@@ -67729,9 +67887,9 @@ ftA
 uPO
 bhD
 rXT
-gCN
+wKb
 wDZ
-piw
+wJB
 ahh
 uYW
 cPJ
@@ -67802,11 +67960,11 @@ rrB
 rrB
 rrB
 rrB
-czZ
-gtc
-dgW
-dgW
-bOl
+mhD
+oYP
+gau
+gau
+kIu
 udB
 llX
 kkp
@@ -67986,9 +68144,9 @@ gyG
 iip
 qza
 aES
-gut
+gAV
 wDZ
-piw
+wJB
 pkw
 pkw
 pkw
@@ -68059,11 +68217,11 @@ lKN
 ydD
 ofT
 rrB
-dBG
-bOl
-bOl
-bOl
-bOl
+xue
+kIu
+kIu
+kIu
+kIu
 okD
 gvZ
 uPB
@@ -68243,9 +68401,9 @@ qHJ
 nya
 tfm
 rIM
-gut
+gAV
 wDZ
-piw
+wJB
 tYA
 nwZ
 iEa
@@ -68500,9 +68658,9 @@ iVp
 tfm
 qza
 vAD
-gCN
+wKb
 cbq
-piw
+wJB
 tYA
 iEa
 pKF
@@ -73717,9 +73875,9 @@ upz
 trt
 ehb
 naf
-qjj
+fCa
 voj
-kqD
+uGq
 rhn
 wCS
 rMy
@@ -73975,7 +74133,7 @@ aus
 eJj
 wfC
 oUp
-oyo
+pww
 xRW
 vWE
 ajQ
@@ -75509,7 +75667,7 @@ lkF
 nbU
 fXB
 gPZ
-mao
+cJz
 gPZ
 gPZ
 onf
@@ -80316,7 +80474,7 @@ fgS
 rdb
 wdA
 wdA
-knm
+tSM
 vPb
 bYP
 wvm
@@ -81344,7 +81502,7 @@ nRM
 gzZ
 wdA
 wdA
-knm
+tSM
 vPb
 mrJ
 gIk
@@ -83930,9 +84088,9 @@ mne
 cHK
 cHK
 cHK
-qlN
-flh
-flh
+ifP
+umh
+umh
 mHR
 cmR
 ezI

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -271,7 +271,7 @@
 "afn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "aft" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -476,8 +476,16 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ake" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
+"akh" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "akj" = (
 /obj/machinery/door/airlock/command{
 	name = "E.V.A. Storage"
@@ -501,7 +509,7 @@
 	dir = 4;
 	invisibility = 101
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "alb" = (
 /obj/machinery/light/small/directional/south,
@@ -520,12 +528,13 @@
 "alR" = (
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/airlock/maintenance,
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/dark,
 /area/station/medical/surgery/theatre)
 "amg" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/crate_empty,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "amw" = (
 /obj/structure/disposalpipe/segment{
@@ -551,6 +560,9 @@
 	},
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
@@ -1060,7 +1072,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
 /obj/item/stock_parts/cell,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "aGz" = (
 /obj/structure/disposalpipe/segment{
@@ -1294,10 +1306,13 @@
 /area/station/engineering/break_room)
 "aMJ" = (
 /obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "aNi" = (
@@ -1356,11 +1371,11 @@
 	},
 /area/station/science/robotics)
 "aOZ" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line,
-/obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "aPd" = (
@@ -1374,10 +1389,10 @@
 /area/station/science/lab)
 "aPz" = (
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/trimline/green/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -1401,7 +1416,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "aRb" = (
 /obj/machinery/announcement_system,
@@ -1443,7 +1458,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "aSf" = (
 /obj/structure/disposalpipe/segment{
@@ -1986,10 +2001,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "bec" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 6
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 6;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -2024,11 +2041,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "beP" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -2170,7 +2189,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "bkh" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2225,13 +2244,15 @@
 	},
 /area/station/science/robotics)
 "bkJ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 4;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "bkP" = (
@@ -2259,7 +2280,7 @@
 /area/station/medical/surgery/aft)
 "blk" = (
 /obj/machinery/rnd/bepis,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "blt" = (
 /obj/structure/cable,
@@ -2324,11 +2345,13 @@
 /turf/open/floor/plating,
 /area/station/security/warden)
 "bmq" = (
-/obj/effect/turf_decal/trimline/dark_blue/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -2673,10 +2696,12 @@
 /area/station/engineering/break_room)
 "bvF" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -2803,7 +2828,7 @@
 /obj/machinery/conveyor/auto{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "byC" = (
 /obj/structure/window/spawner/directional/south,
@@ -2964,7 +2989,8 @@
 /area/station/ai_monitored/command/storage/eva)
 "bCl" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/dark_blue/filled/end{
+/obj/effect/turf_decal/trimline/white/filled/end{
+	color = "#009dc4";
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -2983,6 +3009,9 @@
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -3094,7 +3123,7 @@
 /area/station/hallway/secondary/entry)
 "bEQ" = (
 /obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "bER" = (
 /obj/structure/bed/double/pod{
@@ -3116,9 +3145,12 @@
 /turf/open/floor/holofloor/beach/water,
 /area/station/maintenance/starboard/aft)
 "bFI" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -3278,11 +3310,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/green/warning{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -3315,6 +3347,10 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/mine/storage/public)
+"bKk" = (
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "bKz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -3440,7 +3476,7 @@
 "bOK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/suit_storage_unit/industrial/loader,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "bOM" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -3535,6 +3571,16 @@
 	color = "#999999"
 	},
 /area/station/science/robotics)
+"bRX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "bSj" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -3762,6 +3808,19 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/security/warden)
+"bZH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "bZJ" = (
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/grass,
@@ -3927,6 +3986,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "cem" = (
@@ -3971,10 +4033,10 @@
 /area/station/service/bar)
 "cfu" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/trimline/brown/line{
 	dir = 6
 	},
 /turf/open/floor/iron/dark/textured,
@@ -4035,7 +4097,7 @@
 	dir = 5
 	},
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "chZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4330,13 +4392,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "crT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/brown/warning{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "csw" = (
@@ -4350,6 +4412,12 @@
 	},
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
@@ -4434,6 +4502,11 @@
 	},
 /turf/open/floor/iron/dark/textured/airless,
 /area/station/science/lobby)
+"cwT" = (
+/obj/effect/spawner/random/trash,
+/obj/vehicle/ridden/secway,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "cwX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -4468,7 +4541,7 @@
 "cxM" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "cxU" = (
 /obj/machinery/light/small/directional/south,
@@ -4543,7 +4616,7 @@
 "cAT" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "cBe" = (
 /obj/structure/window/spawner/directional/south,
@@ -4803,12 +4876,15 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "cHF" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "cHK" = (
 /turf/open/floor/iron/dark/textured/airless,
@@ -5265,7 +5341,7 @@
 /obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/camera/autoname/directional/west,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "cTW" = (
 /obj/effect/turf_decal/stripes{
@@ -5301,10 +5377,12 @@
 /area/station/service/chapel)
 "cUp" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 6
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 6;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -5723,6 +5801,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 5
 	},
+/obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "dhy" = (
@@ -5930,9 +6009,18 @@
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/ce)
 "dls" = (
-/obj/structure/closet/crate/coffin/metalcoffin,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "dlI" = (
 /obj/structure/cable,
 /obj/machinery/duct/industrial/waste,
@@ -6132,11 +6220,13 @@
 /area/station/cargo/miningoffice)
 "dpV" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -6183,11 +6273,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/science/genetics)
 "dqy" = (
-/obj/effect/turf_decal/trimline/dark_blue/corner,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/trimline/brown/corner,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 9
 	},
-/obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "dqA" = (
@@ -6230,7 +6320,7 @@
 "drs" = (
 /obj/effect/turf_decal/bot,
 /obj/vehicle/ridden/cargo_train,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "drG" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
@@ -6326,6 +6416,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room)
 "dtc" = (
@@ -6346,10 +6440,13 @@
 "dtY" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "due" = (
@@ -7244,11 +7341,11 @@
 "dWi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/line{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "dWw" = (
@@ -7379,7 +7476,7 @@
 	pixel_x = -7;
 	pixel_y = 5
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "eap" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -7730,7 +7827,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "ekx" = (
 /obj/structure/disposalpipe/junction,
@@ -7771,6 +7868,10 @@
 "ell" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning,
 /obj/effect/turf_decal/trimline/brown/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
+/obj/effect/turf_decal/trimline/brown/mid_joiner{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/diagonal,
@@ -8002,10 +8103,13 @@
 "eso" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "esx" = (
@@ -8215,11 +8319,11 @@
 "eyu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/trimline/green/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -8263,7 +8367,7 @@
 /area/station/engineering/atmos)
 "ezO" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "eAr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -8317,7 +8421,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate,
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "eBt" = (
 /obj/effect/turf_decal/siding/blue{
@@ -8405,13 +8509,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "eDq" = (
@@ -8477,6 +8579,17 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/office)
+"eEZ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "eFa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9037,8 +9150,11 @@
 /area/station/engineering/main)
 "eSf" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning,
-/obj/effect/turf_decal/trimline/dark_blue/warning{
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -9331,16 +9447,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "faI" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/autolathe,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "fbb" = (
 /obj/machinery/shower/directional/south,
@@ -9541,13 +9657,13 @@
 /turf/open/floor/plating,
 /area/station/security/office)
 "ffP" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/red/corner{
 	dir = 1
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "ffQ" = (
@@ -9868,6 +9984,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"fpz" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "fpN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10169,11 +10292,13 @@
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "fBG" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -10226,10 +10351,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "fDX" = (
@@ -10249,11 +10377,15 @@
 /area/station/maintenance/starboard/upper)
 "fEP" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner,
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -10447,7 +10579,7 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "fKI" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "fKR" = (
 /obj/structure/disposalpipe/segment{
@@ -10527,7 +10659,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "fNw" = (
 /obj/structure/table/reinforced,
@@ -10543,12 +10675,21 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "fOf" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/service/library)
+"fOs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "fOt" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -10673,7 +10814,10 @@
 /area/station/engineering/atmos/office)
 "fRb" = (
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/west,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "fRj" = (
 /obj/machinery/button/ticket_machine{
@@ -10812,7 +10956,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "fVi" = (
 /obj/machinery/light/small/directional/south,
@@ -10959,10 +11103,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "fZG" = (
@@ -10990,7 +11137,7 @@
 "gae" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/cart,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "gak" = (
 /obj/structure/chair{
@@ -11012,12 +11159,17 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "gau" = (
-/obj/machinery/door/airlock{
-	id_tag = "Cabin7";
-	name = "Cabin 1"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "gaz" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -11103,6 +11255,12 @@
 	},
 /obj/effect/turf_decal/trimline/brown/corner,
 /obj/machinery/vending/coffee,
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "gco" = (
@@ -11593,12 +11751,12 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/aft)
 "gtk" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "gtl" = (
@@ -11655,10 +11813,13 @@
 "gun" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 9
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 9;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner,
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "guV" = (
@@ -11690,6 +11851,10 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
+"gvJ" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "gvP" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
@@ -11753,14 +11918,13 @@
 /turf/open/floor/iron,
 /area/mine/storage/public)
 "gym" = (
+/obj/machinery/medical_kiosk,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 8
 	},
-/obj/machinery/stasis,
-/obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
 "gyA" = (
@@ -11797,6 +11961,14 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"gzu" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/security/office)
 "gzx" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage/tech)
@@ -11925,13 +12097,17 @@
 "gCo" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "gCN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/warning,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "gCU" = (
@@ -11969,7 +12145,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/trimline/green/warning,
+/turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "gDC" = (
 /obj/machinery/duct/industrial/waste,
@@ -12308,14 +12485,16 @@
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
 "gPp" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "gPH" = (
@@ -12486,6 +12665,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/genetics)
 "gVR" = (
@@ -12514,7 +12696,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "gWh" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners{
@@ -12525,10 +12707,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"gWl" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "gWr" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera/autoname/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "gXb" = (
 /turf/closed/wall/r_wall,
@@ -12565,7 +12758,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "gXq" = (
 /obj/machinery/airalarm/directional/north,
@@ -12774,7 +12967,15 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 4;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics/garden)
 "hby" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
@@ -13144,8 +13345,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "hon" = (
-/obj/machinery/door/airlock/external,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "hoo" = (
@@ -13378,7 +13579,7 @@
 "hvE" = (
 /obj/machinery/light/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "hvJ" = (
 /obj/structure/disposalpipe/segment,
@@ -13606,7 +13807,10 @@
 /area/station/medical/surgery/theatre)
 "hBR" = (
 /obj/machinery/restaurant_portal/bar,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "hCk" = (
 /obj/structure/cable,
@@ -13621,6 +13825,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -13674,6 +13881,12 @@
 	},
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
@@ -13992,10 +14205,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/green/warning{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -14475,6 +14688,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/line,
+/obj/effect/turf_decal/trimline/brown/mid_joiner,
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "iax" = (
@@ -14747,6 +14964,18 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
+"ijx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "ijM" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -14878,13 +15107,13 @@
 /obj/structure/cable,
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/west,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/trimline/brown/line{
 	dir = 8
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "inf" = (
@@ -14950,7 +15179,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "ipq" = (
 /obj/effect/turf_decal/bot,
@@ -14960,7 +15189,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "iqc" = (
 /obj/structure/sign/poster/contraband/rebels_unite{
@@ -15137,14 +15366,14 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/robotics/lab)
 "iul" = (
-/obj/machinery/duct/industrial/waste,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/aft)
 "iut" = (
 /turf/open/floor/wood/parquet,
 /area/station/medical/medbay/central)
@@ -15217,14 +15446,14 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "iwW" = (
 /obj/machinery/duct/industrial/waste,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
 "ixt" = (
-/obj/machinery/door/airlock/external,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "ixz" = (
@@ -15615,6 +15844,22 @@
 /obj/machinery/requests_console/auto_name/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/office)
+"iJW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 10;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
+"iKt" = (
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "iKC" = (
 /obj/structure/cable,
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/east,
@@ -15625,7 +15870,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "iKF" = (
 /obj/structure/disposalpipe/segment{
@@ -15914,7 +16159,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/obj/structure/disposaloutlet{
+	name = "Prisoner Delivery"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "iRT" = (
 /obj/structure/lattice,
@@ -16002,12 +16250,14 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "iVc" = (
-/obj/machinery/door/airlock{
-	id_tag = "Cabin2";
-	name = "Cabin 4"
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured/airless,
+/area/station/science/lobby)
 "iVp" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/disposalpipe/segment{
@@ -16033,6 +16283,9 @@
 "iWI" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room)
 "iWL" = (
@@ -16068,6 +16321,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/hydroponics/upper)
+"iXZ" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "iYi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16315,6 +16574,9 @@
 "jeZ" = (
 /obj/structure/table/wood,
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room)
 "jfa" = (
@@ -16351,7 +16613,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "jgI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -16455,6 +16717,12 @@
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "jjd" = (
@@ -16463,6 +16731,13 @@
 	},
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "jjf" = (
@@ -16532,11 +16807,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
 "jkE" = (
-/obj/effect/turf_decal/trimline/dark_blue/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
+	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -16952,7 +17227,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "jys" = (
 /obj/machinery/duct/industrial/waste,
@@ -17032,7 +17307,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "jAI" = (
 /obj/machinery/light/directional/east,
@@ -17066,6 +17341,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
+"jAS" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "jAU" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
@@ -17122,6 +17408,10 @@
 "jBo" = (
 /turf/open/ballpit,
 /area/station/security/checkpoint/customs)
+"jBC" = (
+/obj/machinery/suit_storage_unit/security,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "jBM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced,
@@ -17195,10 +17485,10 @@
 /area/station/science/lab)
 "jEi" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/warning,
+/obj/effect/turf_decal/trimline/green/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "jEn" = (
@@ -17678,11 +17968,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -17898,10 +18190,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "jXL" = (
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/trimline/green/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -17952,7 +18244,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "jZb" = (
 /obj/machinery/door/airlock/security{
@@ -18132,11 +18424,13 @@
 "kdC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 6
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 6;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -18220,10 +18514,13 @@
 /area/station/engineering/storage/tech)
 "kfX" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/dark_blue/warning,
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "kgc" = (
@@ -18252,6 +18549,10 @@
 "kgA" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room)
 "kgC" = (
@@ -18789,10 +19090,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "kwc" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/green/corner{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -18889,6 +19190,10 @@
 	},
 /obj/effect/turf_decal/trimline/brown/line,
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/brown/mid_joiner,
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "kzg" = (
@@ -18936,7 +19241,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/trimline/green/warning,
+/turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "kAA" = (
 /obj/effect/spawner/structure/window,
@@ -18987,7 +19293,14 @@
 	name = "Central Access"
 	},
 /obj/machinery/duct/industrial/waste,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "kBz" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -19055,11 +19368,11 @@
 "kDC" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/green/warning{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -19244,15 +19557,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "kIu" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/end{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
+/turf/open/floor/iron/dark/textured/airless,
+/area/station/science/lobby)
 "kIM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19289,10 +19598,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/trimline/brown/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -19576,10 +19885,12 @@
 /area/station/command/heads_quarters/cmo)
 "kOZ" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -19954,11 +20265,13 @@
 /area/ocean/near_station_powered)
 "kZH" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -20221,10 +20534,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/warning,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "lhr" = (
@@ -20475,7 +20791,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "lpl" = (
 /mob/living/basic/mouse/rat,
@@ -20591,8 +20907,11 @@
 /area/station/maintenance/starboard/lesser)
 "ltK" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning,
-/obj/effect/turf_decal/trimline/dark_blue/warning{
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -20996,11 +21315,25 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"lDp" = (
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/service/hydroponics/garden)
 "lDr" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/robotics/lab)
+"lDs" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "lDH" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -21207,11 +21540,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "lHT" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -21315,10 +21650,10 @@
 "lLz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/green/corner{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -21350,6 +21685,12 @@
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/brown/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "lMo" = (
@@ -21368,7 +21709,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "lNA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -21376,9 +21717,12 @@
 /area/station/engineering/main)
 "lNF" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner,
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 9
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 9;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -21661,8 +22005,8 @@
 "lVC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/corner,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+/obj/effect/turf_decal/trimline/green/corner,
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 9
 	},
 /turf/open/floor/iron/dark/textured,
@@ -21688,7 +22032,8 @@
 "lWg" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 9
+	dir = 9;
+	color = "#009dc4"
 	},
 /obj/effect/turf_decal/trimline/neutral/corner,
 /turf/open/floor/plastic,
@@ -21696,6 +22041,10 @@
 "lWJ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Crew Quarters Access"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/dorms)
@@ -21746,7 +22095,7 @@
 /area/station/medical/virology)
 "lZa" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "lZe" = (
 /obj/machinery/atmospherics/components/binary/pump/off/supply/visible/layer4,
@@ -21949,10 +22298,13 @@
 "mhY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/warning,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "miu" = (
@@ -22079,10 +22431,6 @@
 	},
 /turf/open/floor/plating/ocean,
 /area/station/cargo/storage)
-"mmb" = (
-/obj/machinery/suit_storage_unit/security,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "mne" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22151,7 +22499,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "mnX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22206,6 +22558,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/storage/primary)
+"mpU" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "mqy" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 9
@@ -22710,6 +23075,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room)
 "mHK" = (
@@ -22743,6 +23112,16 @@
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 2
+	},
+/obj/structure/disposaloutlet{
+	dir = 1;
+	name = "Cargo Deliveries"
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/science/lobby)
@@ -22825,10 +23204,10 @@
 /area/station/engineering/atmos)
 "mKj" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/trimline/brown/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -22886,7 +23265,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "mMc" = (
 /obj/structure/disposalpipe/segment{
@@ -22967,7 +23346,13 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/qm)
 "mOh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23028,10 +23413,12 @@
 /area/station/commons/dorms)
 "mQx" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -23075,7 +23462,7 @@
 /area/station/cargo/warehouse)
 "mRO" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "mSd" = (
 /obj/structure/disposalpipe/segment{
@@ -23131,6 +23518,11 @@
 /obj/machinery/camera/directional/east,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"mTh" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "mTo" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -23169,7 +23561,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "mTC" = (
 /obj/structure/cable,
@@ -23231,7 +23623,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/obj/structure/disposaloutlet{
+	name = "Prisoner Delivery"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "mUJ" = (
 /obj/effect/turf_decal/stripes,
@@ -23251,7 +23646,7 @@
 /area/station/ai_monitored/turret_protected/ai)
 "mUV" = (
 /obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "mVu" = (
 /obj/effect/landmark/start/clown,
@@ -23262,11 +23657,9 @@
 /area/station/service/theater)
 "mVB" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -23279,11 +23672,14 @@
 /area/station/maintenance/port/central)
 "mWr" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "mWs" = (
@@ -23732,14 +24128,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
-"nhH" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/security/office)
 "nhJ" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -23791,7 +24179,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "nip" = (
 /obj/effect/turf_decal/trimline/brown/warning{
@@ -23955,10 +24343,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/primary/central)
-"nmL" = (
-/obj/vehicle/ridden/secway,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "nnv" = (
 /obj/structure/fireaxecabinet/mechremoval/directional/east,
 /turf/open/floor/noslip{
@@ -24058,10 +24442,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
 "nqk" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/green/corner{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -24243,11 +24627,13 @@
 "nvl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -24348,12 +24734,17 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/courtroom)
 "nxP" = (
-/obj/machinery/door/airlock{
-	id_tag = "Cabin4";
-	name = "Cabin 5"
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "nxY" = (
 /obj/machinery/light/directional/south,
 /obj/structure/table/reinforced/rglass,
@@ -24404,9 +24795,13 @@
 /obj/structure/sign/departments/botany,
 /turf/closed/wall,
 /area/station/service/hydroponics)
+"nyO" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "nyQ" = (
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "nzt" = (
 /obj/structure/table/reinforced,
@@ -24478,6 +24873,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"nBb" = (
+/obj/machinery/duct/industrial/waste,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "nBu" = (
 /obj/machinery/griddle,
 /turf/open/floor/iron/kitchen,
@@ -24546,8 +24954,11 @@
 /area/station/security/office)
 "nDl" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning,
-/obj/effect/turf_decal/trimline/dark_blue/warning{
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -24713,6 +25124,13 @@
 	name = "Hole Access"
 	},
 /obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "nIT" = (
@@ -24804,7 +25222,7 @@
 "nLm" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "nLr" = (
 /obj/effect/turf_decal/trimline/brown/warning{
@@ -24834,6 +25252,9 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/theatre)
@@ -25380,7 +25801,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "oft" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -25491,8 +25912,11 @@
 "oij" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -25502,6 +25926,10 @@
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "oiy" = (
@@ -25990,10 +26418,10 @@
 /area/station/science/lobby)
 "otV" = (
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/west,
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/trimline/green/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -26021,7 +26449,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "ouC" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
@@ -26080,10 +26508,15 @@
 /area/station/hallway/primary/central)
 "ovT" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -26163,6 +26596,19 @@
 /mob/living/basic/cockroach,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"oyi" = (
+/obj/machinery/duct/industrial/waste,
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "oyj" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/structure/reagent_dispensers/watertank,
@@ -26176,12 +26622,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "oyo" = (
-/obj/machinery/door/airlock{
-	id_tag = "Cabin6";
-	name = "Cabin 2"
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "oyB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -26363,10 +26809,6 @@
 /obj/structure/cable/industrial,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"oEi" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/red,
-/area/station/security/office)
 "oEo" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -26462,11 +26904,13 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 10;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 10
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -26488,7 +26932,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "oIg" = (
 /obj/structure/cable,
@@ -26511,7 +26955,11 @@
 /area/station/medical/medbay/lobby)
 "oII" = (
 /obj/structure/cable,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics/garden)
 "oIJ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -26659,11 +27107,13 @@
 "oQa" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 5
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 5;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -27081,13 +27531,15 @@
 /area/station/engineering/atmos)
 "pcB" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "pdS" = (
@@ -27294,12 +27746,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "piw" = (
-/obj/machinery/door/airlock{
-	id_tag = "Cabin5";
-	name = "Cabin 3"
+/obj/structure/chair{
+	dir = 8
 	},
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/courtroom)
 "piW" = (
 /obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/trunk{
@@ -27619,7 +28071,7 @@
 	},
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "prr" = (
 /obj/structure/cable,
@@ -27730,14 +28182,18 @@
 	},
 /area/station/science/lab)
 "pua" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/trimline/brown/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
+"puf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/server)
 "pug" = (
 /turf/closed/wall,
 /area/station/commons/fitness)
@@ -28144,8 +28600,8 @@
 /area/ocean)
 "pHV" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning,
-/obj/effect/turf_decal/trimline/dark_blue/warning{
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -28225,9 +28681,12 @@
 "pIW" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -28325,7 +28784,7 @@
 /obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "pLr" = (
 /obj/machinery/light/directional/south,
@@ -28450,7 +28909,7 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "pPh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28945,7 +29404,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "qbO" = (
 /obj/effect/landmark/start/station_engineer,
@@ -28966,10 +29425,10 @@
 "qbR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/green/corner{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -29199,9 +29658,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner,
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 9
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -29326,10 +29785,10 @@
 /area/station/command/heads_quarters/captain/private)
 "qmM" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+/obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/warning,
+/obj/effect/turf_decal/trimline/green/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "qmR" = (
@@ -29346,9 +29805,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "qnC" = (
-/obj/machinery/door/airlock/external,
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external/glass,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "qnD" = (
@@ -29370,7 +29829,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/service/cafeteria)
 "qnI" = (
 /turf/open/floor/carpet/orange,
@@ -29419,7 +29884,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "qpL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrous_output{
@@ -29560,13 +30025,11 @@
 	name = "Indoor Park"
 	},
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "qsc" = (
@@ -29584,7 +30047,7 @@
 	pixel_y = 3
 	},
 /obj/structure/table,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "qsh" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -29605,7 +30068,7 @@
 /obj/item/clothing/head/costume/mailman,
 /obj/item/clothing/under/misc/mailman,
 /obj/item/storage/bag/mail,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "qsG" = (
 /obj/structure/cable,
@@ -29624,10 +30087,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/trimline/brown/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -29702,11 +30165,11 @@
 "qvp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/green/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -29805,11 +30268,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "qyZ" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line,
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 1
-	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "qza" = (
@@ -29970,6 +30436,10 @@
 	name = "Central Access"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "qFt" = (
@@ -30012,7 +30482,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "qHw" = (
 /obj/structure/disposalpipe/segment,
@@ -30063,7 +30533,11 @@
 "qIf" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics/garden)
 "qIz" = (
 /obj/effect/spawner/structure/window,
@@ -30107,6 +30581,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/medical/storage)
 "qJM" = (
@@ -30140,6 +30617,13 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "qKp" = (
@@ -30196,6 +30680,10 @@
 /obj/effect/turf_decal/trimline/brown/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "qLF" = (
@@ -30295,11 +30783,11 @@
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den/gaming)
 "qNW" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/green/corner{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -30563,13 +31051,13 @@
 "qUe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/green/line{
 	dir = 4
 	},
-/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "qUv" = (
@@ -31017,10 +31505,10 @@
 "rhP" = (
 /obj/structure/cable,
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/west,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/trimline/brown/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -31372,6 +31860,11 @@
 /obj/item/gps,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
+"rrt" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "rrB" = (
 /turf/closed/wall/r_wall,
 /area/station/security/warden)
@@ -31451,11 +31944,13 @@
 "rtP" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -31559,10 +32054,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
-"rwD" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "rwX" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
@@ -31641,7 +32132,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "ryY" = (
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -31685,6 +32176,12 @@
 	},
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
@@ -32051,7 +32548,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "rJL" = (
 /obj/structure/cable,
@@ -32213,7 +32710,7 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "rOb" = (
 /obj/effect/turf_decal/stripes{
@@ -32337,6 +32834,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 5
+	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room)
 "rRy" = (
@@ -32389,13 +32890,17 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "rUa" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -32617,13 +33122,15 @@
 "saD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "saU" = (
@@ -32716,6 +33223,18 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/robotics/lab)
+"sed" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/vacant_room)
 "seR" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Toilet"
@@ -32765,11 +33284,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 10;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 10
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -32861,6 +33382,10 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room)
@@ -32979,7 +33504,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/warning{
-	dir = 8
+	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -33044,6 +33569,10 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/theatre)
+"spJ" = (
+/obj/vehicle/ridden/secway,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "sqk" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -33176,8 +33705,11 @@
 "sul" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/dark_blue/line,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -33252,6 +33784,10 @@
 /area/station/service/abandoned_gambling_den/gaming)
 "svS" = (
 /obj/structure/reagent_dispensers/water_cooler,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room)
 "swe" = (
@@ -33259,7 +33795,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "sws" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "swv" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -33282,10 +33818,12 @@
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation/entertainment)
 "sxq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -33423,9 +33961,8 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "sBe" = (
-/obj/structure/table,
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "sBo" = (
 /obj/machinery/camera/directional/north,
 /turf/open/floor/engine,
@@ -33490,6 +34027,12 @@
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "sCS" = (
@@ -33507,13 +34050,15 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
 "sDA" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 4
-	},
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "sDD" = (
@@ -33931,7 +34476,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "sPC" = (
 /obj/effect/spawner/random/trash,
@@ -34145,7 +34690,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "sVq" = (
 /obj/structure/table/glass,
@@ -34225,6 +34770,19 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"sYl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "sYn" = (
 /turf/open/floor/wood,
 /area/station/cargo/miningoffice)
@@ -34340,7 +34898,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "tdg" = (
 /obj/structure/window/spawner/directional/south,
@@ -34363,10 +34921,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -34802,7 +35362,7 @@
 "tso" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "tto" = (
 /obj/item/grown/bananapeel,
@@ -34940,7 +35500,7 @@
 /area/station/hallway/primary/central/fore)
 "txG" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "tyd" = (
 /obj/structure/disposalpipe/segment{
@@ -34992,7 +35552,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "tzD" = (
 /obj/structure/cable,
@@ -35121,13 +35684,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"tDm" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark/textured,
-/area/station/security/courtroom)
 "tDH" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/camera/autoname/directional/north,
@@ -35285,6 +35841,10 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/brown/mid_joiner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/mid_joiner,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "tGW" = (
@@ -35430,6 +35990,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "tJY" = (
@@ -35455,13 +36022,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "tLb" = (
@@ -35669,7 +36238,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "tRo" = (
 /obj/structure/fluff/broken_flooring,
@@ -35750,11 +36322,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/west,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner,
-/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "tUH" = (
@@ -35874,6 +36449,15 @@
 /obj/structure/fans/tiny/forcefield,
 /turf/open/floor/engine,
 /area/station/science/ordnance/office)
+"tWM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "tXg" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 10
@@ -35891,7 +36475,7 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/effect/turf_decal/trimline/brown/warning{
-	dir = 8
+	dir = 9
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
@@ -35910,10 +36494,13 @@
 /area/station/engineering/atmos)
 "tYl" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "tYt" = (
@@ -36046,11 +36633,13 @@
 "ubI" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -36204,7 +36793,7 @@
 /area/station/cargo/miningoffice)
 "uez" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "ueF" = (
 /obj/effect/turf_decal/stripes{
@@ -36309,6 +36898,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
 /turf/open/floor/iron/white/textured_large,
@@ -36435,10 +37027,13 @@
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "umh" = (
-/obj/structure/table,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/commons/dorms)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "umt" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Office Maintenance"
@@ -36528,8 +37123,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning,
+/obj/effect/turf_decal/trimline/dark_blue/tram{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -37035,10 +37630,13 @@
 /area/station/command/bridge)
 "uEb" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "uEz" = (
@@ -37090,6 +37688,10 @@
 "uFU" = (
 /obj/machinery/photocopier,
 /obj/structure/table/wood,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room)
 "uGg" = (
@@ -37111,6 +37713,13 @@
 "uGB" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -37148,6 +37757,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"uHM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "uHW" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -37523,11 +38145,13 @@
 /area/station/engineering/atmos)
 "uRZ" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -37603,6 +38227,13 @@
 "uTC" = (
 /turf/closed/wall/r_wall,
 /area/station/science/cytology)
+"uUl" = (
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 4;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/dorms)
 "uUo" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/red/filled/warning,
@@ -37815,7 +38446,9 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/corner,
-/obj/machinery/medical_kiosk,
+/obj/item/storage/medkit,
+/obj/structure/table/glass,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
 "vaZ" = (
@@ -38047,7 +38680,7 @@
 /area/station/maintenance/port/aft)
 "vfM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "vfX" = (
 /obj/machinery/modular_computer/console/preset/civilian{
@@ -38233,13 +38866,13 @@
 /area/station/science/cytology)
 "vkw" = (
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/west,
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/green/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 4
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "vkC" = (
@@ -38248,9 +38881,6 @@
 /obj/item/holosign_creator/robot_seat/bar,
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar/backroom)
-"vkJ" = (
-/turf/open/floor/carpet/red,
-/area/station/security/office)
 "vkU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 10
@@ -39094,7 +39724,14 @@
 	name = "Crew Quarters Access"
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/commons/dorms)
 "vMy" = (
 /turf/open/floor/iron/stairs,
@@ -39176,9 +39813,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/office)
+"vPa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "vPb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/iron/dark,
+/turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
 "vPp" = (
 /obj/structure/cable,
@@ -39275,10 +39920,13 @@
 "vSI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/dark_blue/warning,
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "vSN" = (
@@ -39296,10 +39944,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/trimline/green/line{
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
@@ -39512,7 +40157,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "vYU" = (
 /obj/structure/table,
@@ -39726,13 +40371,11 @@
 /area/station/command/heads_quarters/qm)
 "wfc" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/brown/corner,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "wfC" = (
@@ -39752,6 +40395,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"wgo" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/dorms)
 "wgE" = (
 /obj/structure/fans/tiny/forcefield{
 	dir = 8
@@ -39939,9 +40589,6 @@
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/warning{
-	dir = 8
-	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "wme" = (
@@ -39981,6 +40628,10 @@
 	name = "Central Access"
 	},
 /obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "wny" = (
@@ -40164,6 +40815,11 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
+"wtE" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "wtF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -40395,17 +41051,19 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
 "wAH" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 10
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 10;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "wAI" = (
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "wAP" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -40419,10 +41077,13 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "wBl" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/dark_blue/line{
-	dir = 1
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -40528,7 +41189,7 @@
 /area/station/maintenance/port/central)
 "wCO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "wCS" = (
 /obj/machinery/door/airlock/maintenance{
@@ -40688,6 +41349,17 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/command/bridge)
+"wIL" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "wJz" = (
 /obj/effect/spawner/liquids_spawner{
 	reagent_list = list(/datum/reagent/ammonia/urine=400)
@@ -40695,11 +41367,14 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/upper)
 "wJB" = (
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/warning,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "wJN" = (
@@ -40713,12 +41388,18 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 5
 	},
+/obj/effect/turf_decal/trimline/brown/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "wJX" = (
-/obj/structure/closet/crate/coffin,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/central)
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "wKB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -40769,7 +41450,14 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Crew Quarters Access"
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/commons/dorms)
 "wMh" = (
 /obj/machinery/duct/industrial/waste,
@@ -40818,7 +41506,7 @@
 /area/station/engineering/atmos)
 "wNT" = (
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "wOi" = (
 /obj/structure/disposalpipe/segment{
@@ -41088,6 +41776,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
 "wUz" = (
@@ -41244,11 +41935,11 @@
 /area/station/security/office)
 "wYV" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/trimline/brown/line,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line,
-/obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "wZC" = (
@@ -41443,11 +42134,6 @@
 "xdZ" = (
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
-"xed" = (
-/obj/effect/spawner/random/trash,
-/obj/vehicle/ridden/secway,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
 "xem" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -41501,10 +42187,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/dark_blue/line{
+/obj/effect/turf_decal/trimline/brown/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -41591,9 +42277,11 @@
 /turf/open/floor/iron,
 /area/mine/storage/public)
 "xjU" = (
-/obj/structure/closet/crate/coffin/securecoffin,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/central)
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/dorms)
 "xjX" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/closet/secure_closet/chemical,
@@ -41704,10 +42392,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "xmS" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner,
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "xmT" = (
@@ -42052,7 +42743,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "xvF" = (
 /obj/effect/turf_decal/stripes/full,
@@ -42150,13 +42844,15 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 5
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 5;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 8
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "xxX" = (
@@ -42369,7 +43065,7 @@
 	invisibility = 101
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "xEK" = (
 /obj/structure/table/reinforced,
@@ -42401,6 +43097,13 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
+"xFG" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "xGw" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
@@ -42603,7 +43306,7 @@
 	pixel_x = 4;
 	pixel_y = -2
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "xMv" = (
 /obj/structure/table/reinforced,
@@ -42739,9 +43442,6 @@
 "xQl" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	name = "Security Lockdown Shutters";
 	id = "securityshutter"
@@ -42922,10 +43622,10 @@
 "xUj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+/obj/effect/turf_decal/trimline/green/corner,
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/dark_blue/corner,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "xUv" = (
@@ -43064,6 +43764,17 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"xYk" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "xYm" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/trash,
@@ -43312,7 +44023,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "yge" = (
 /obj/structure/cable,
@@ -43421,6 +44132,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "yjR" = (
@@ -43519,7 +44231,7 @@
 "ylU" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/item/banner/cargo/mundane,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 
 (1,1,1) = {"
@@ -58266,15 +58978,15 @@ fdQ
 vwP
 wri
 lUz
-vwP
+rnM
 bOl
-vwP
+rnM
 qZZ
-vwP
+rnM
 rmF
-vwP
+rnM
 gAV
-vwP
+rnM
 eQp
 vwP
 xmS
@@ -58523,20 +59235,20 @@ vwP
 vwP
 bmW
 lUz
-vwP
-nxP
-vwP
-iVc
-vwP
-piw
-vwP
-oyo
-vwP
-gau
+rnM
+rnM
+rnM
+rnM
+rnM
+rnM
+rnM
+rnM
+rnM
+rnM
 vwP
 aMJ
 kwp
-scY
+xFG
 rdt
 cda
 jLV
@@ -58789,11 +59501,11 @@ rnM
 rnM
 rnM
 rnM
-rnM
+xjU
 wMb
 gCN
 rfc
-scY
+xFG
 nPn
 epv
 iDn
@@ -59046,7 +59758,7 @@ rnM
 rnM
 iPh
 iPh
-iPh
+wgo
 vMl
 wJB
 rfc
@@ -59297,17 +60009,17 @@ vwP
 rnM
 rnM
 rnM
-sBe
-sBe
 rnM
-sBe
-umh
+rnM
+rnM
+rnM
+iPh
 rnM
 amz
 vwP
 tYl
 rfc
-scY
+xFG
 rdt
 nKi
 kJF
@@ -59554,17 +60266,17 @@ vwP
 jCa
 rnM
 rnM
-sBe
-sBe
 rnM
-sBe
-umh
+rnM
+rnM
+rnM
+iPh
 rnM
 aWp
 vwP
 uEb
 kwp
-scY
+xFG
 rdt
 rdt
 rdt
@@ -59810,7 +60522,7 @@ bmW
 vwP
 pZJ
 rnM
-rnM
+uUl
 rnM
 rnM
 ksj
@@ -59825,13 +60537,13 @@ vTm
 lLz
 mnS
 lVC
-nvl
-nvl
-nvl
-nvl
+lrZ
+lrZ
+lrZ
+lrZ
 hMM
-nvl
-nvl
+sYl
+sYl
 tKO
 nvl
 nvl
@@ -59839,7 +60551,7 @@ nvl
 nvl
 nvl
 nvl
-lLz
+iJW
 tJW
 gun
 lrZ
@@ -60077,7 +60789,7 @@ vwP
 vwP
 vwP
 vwP
-scA
+gau
 rKc
 pIW
 lQS
@@ -60146,9 +60858,9 @@ vUV
 lwj
 byv
 fKI
-bZS
+nyO
 nyQ
-gCo
+rrt
 wAI
 mLC
 dqy
@@ -60323,7 +61035,7 @@ bmW
 bmW
 vwP
 xmS
-beP
+xYk
 sxq
 beP
 beP
@@ -60331,7 +61043,7 @@ sDA
 beP
 beP
 beP
-beP
+xYk
 wAH
 uGB
 vSI
@@ -60340,18 +61052,18 @@ nDl
 kBt
 oQa
 dpV
+oyi
+dpV
+dpV
+dpV
+dpV
+nBb
+dpV
 rtP
-dpV
-dpV
-dpV
-dpV
-ubI
-dpV
-rtP
-dpV
-dpV
-dpV
-dpV
+nxP
+nxP
+nxP
+nxP
 ubI
 cUp
 nIO
@@ -60589,11 +61301,11 @@ kZH
 sga
 wFP
 vAr
-wBl
+pIW
 lQS
 fDR
 qkH
-wki
+wBl
 xwm
 xwm
 xwm
@@ -60831,10 +61543,10 @@ uSV
 uSV
 wop
 jMP
-xjU
-wJX
-dls
-wJX
+uSV
+uSV
+uSV
+uSV
 pyU
 pyU
 pyU
@@ -60850,7 +61562,7 @@ bec
 uGB
 vSI
 tYL
-wki
+wBl
 xwm
 auY
 dcF
@@ -61105,9 +61817,9 @@ ort
 nGD
 nGD
 nGD
-aih
+bZH
 rfc
-wki
+wBl
 xwm
 oas
 agP
@@ -61172,7 +61884,7 @@ jfI
 tNT
 qhS
 eDo
-xgr
+mpU
 xgr
 imV
 kJB
@@ -61358,7 +62070,7 @@ uzZ
 ceK
 pyU
 dtb
-tTb
+sed
 uFU
 nGD
 eso
@@ -61393,13 +62105,13 @@ nyD
 cCg
 qbR
 pAj
-hrr
+umh
 tRg
 hrr
 hrr
 hrr
 hrr
-hrr
+umh
 tzl
 eco
 xUj
@@ -61618,10 +62330,10 @@ mHp
 sJd
 jeZ
 nGD
-scA
+ijx
 rfc
 kwp
-wki
+wBl
 xwm
 qeN
 oas
@@ -61649,15 +62361,15 @@ rfc
 wDZ
 jgV
 pHV
-qEO
-bTn
+gWl
+lDs
 kAd
 bTn
 auj
 bTn
 bTn
-bTn
-bTn
+fpz
+wtE
 qEO
 qmM
 sTn
@@ -61670,7 +62382,7 @@ sTn
 sTn
 ltK
 qJW
-qmM
+eEZ
 hzM
 sTn
 ngm
@@ -61684,7 +62396,7 @@ hzM
 sTn
 nTa
 gUe
-pHp
+bRX
 qaa
 uNE
 lap
@@ -61693,7 +62405,7 @@ kBn
 mue
 qaa
 cov
-cov
+lDp
 oII
 qIf
 bZJ
@@ -61905,16 +62617,16 @@ lck
 bMn
 kkW
 lca
-nDl
-wmV
-pXi
+akh
+wIL
+oyo
 gDA
 pXi
 hwW
 pXi
 pXi
-pXi
-pXi
+wJX
+mTh
 wmV
 jEi
 eLS
@@ -61928,7 +62640,7 @@ vIx
 eSf
 jjd
 fEP
-kIu
+iaP
 pam
 aMs
 whA
@@ -61941,7 +62653,7 @@ sJj
 iaP
 gxe
 ngm
-mLx
+iul
 qaa
 uDo
 bcQ
@@ -62132,9 +62844,9 @@ rQX
 kgA
 svS
 nGD
-aih
+bZH
 rfc
-wki
+wBl
 fue
 fue
 fue
@@ -62171,7 +62883,7 @@ hrr
 xVm
 xVm
 fRb
-xVm
+iXZ
 yhH
 qNW
 vkw
@@ -62198,7 +62910,7 @@ twN
 twN
 jfI
 ngm
-mLx
+iul
 qaa
 mtV
 afN
@@ -62389,9 +63101,9 @@ nGD
 nGD
 nGD
 nGD
-scA
+ijx
 kwp
-wki
+wBl
 fue
 qet
 gMt
@@ -62455,7 +63167,7 @@ lYm
 twN
 jfI
 gtt
-mLx
+iul
 qaa
 qry
 jJI
@@ -62648,7 +63360,7 @@ uRG
 ewl
 lhq
 rfc
-wki
+wBl
 ljv
 ewL
 gMt
@@ -62712,7 +63424,7 @@ xmK
 twN
 jfI
 ngm
-mLx
+iul
 qaa
 uAo
 dYT
@@ -62903,9 +63615,9 @@ lHt
 jSp
 lHt
 yke
-scA
+gau
 tYL
-dPe
+nDl
 ilm
 kOf
 kOf
@@ -62969,7 +63681,7 @@ cLN
 twN
 jfI
 ngm
-mLx
+iul
 qaa
 weQ
 uVd
@@ -63160,9 +63872,9 @@ wlx
 gIZ
 nVx
 ukf
-scA
+gau
 rfc
-iul
+mWr
 nMK
 svH
 svH
@@ -63417,9 +64129,9 @@ lHt
 jSp
 lHt
 yke
-scA
+gau
 kwp
-wki
+wBl
 ljv
 aTw
 uth
@@ -63676,7 +64388,7 @@ wlx
 nMG
 mhY
 rfc
-wki
+wBl
 fue
 qet
 ewL
@@ -63931,9 +64643,9 @@ gIZ
 jSp
 oUo
 nLV
-scA
+gau
 rfc
-wki
+wBl
 fue
 fue
 fue
@@ -64188,9 +64900,9 @@ wlx
 lHt
 wlx
 nLV
-scA
+gau
 rfc
-wki
+wBl
 pkw
 dMh
 vhM
@@ -64445,9 +65157,9 @@ lHt
 eBe
 pse
 nLV
-scA
+gau
 kwp
-wki
+wBl
 ahh
 adv
 adv
@@ -64702,9 +65414,9 @@ wlx
 ecM
 eBe
 nLV
-fZv
+dls
 rfc
-dPe
+jAS
 wZC
 adv
 adv
@@ -64959,9 +65671,9 @@ lHt
 wlx
 lHt
 nLV
-aih
+uHM
 rfc
-wki
+wBl
 ahh
 adv
 amw
@@ -65216,9 +65928,9 @@ bIJ
 lHt
 rOB
 nLV
-scA
+gau
 rfc
-wki
+wBl
 pkw
 xji
 tRB
@@ -65473,9 +66185,9 @@ nLV
 nLV
 nLV
 nLV
-scA
+gau
 rfc
-wki
+wBl
 pkw
 pkw
 orx
@@ -65730,9 +66442,9 @@ mFh
 mFh
 fgS
 gGL
-mhY
+vSI
 kwp
-wki
+wBl
 pkw
 gyj
 pqf
@@ -65987,9 +66699,9 @@ tXC
 tXC
 tXC
 tXC
-scA
+tWM
 rfc
-wki
+wBl
 pkw
 xji
 tRB
@@ -66244,9 +66956,9 @@ uUY
 eGO
 hHy
 tXC
-scA
+fOs
 tYL
-wki
+wBl
 pkw
 adv
 tRB
@@ -66501,7 +67213,7 @@ sRK
 tme
 keD
 mMl
-mhY
+vPa
 veZ
 oij
 lxM
@@ -66760,7 +67472,7 @@ tXC
 tXC
 faF
 cbq
-wki
+wBl
 pkw
 adv
 bJU
@@ -67015,9 +67727,9 @@ ftA
 uPO
 bhD
 rXT
-scA
+tWM
 wDZ
-wki
+wBl
 ahh
 uYW
 cPJ
@@ -67088,11 +67800,11 @@ rrB
 rrB
 rrB
 rrB
-xed
-rwD
-mmb
-mmb
-uvd
+cwT
+gvJ
+jBC
+jBC
+sBe
 udB
 llX
 kkp
@@ -67272,9 +67984,9 @@ gyG
 iip
 qza
 aES
-scA
+vPa
 wDZ
-wki
+wBl
 pkw
 pkw
 pkw
@@ -67345,11 +68057,11 @@ lKN
 ydD
 ofT
 rrB
-nmL
-uvd
-uvd
-uvd
-uvd
+spJ
+sBe
+sBe
+sBe
+sBe
 okD
 gvZ
 uPB
@@ -67529,9 +68241,9 @@ qHJ
 nya
 tfm
 rIM
-scA
+vPa
 wDZ
-wki
+wBl
 tYA
 nwZ
 iEa
@@ -67786,12 +68498,12 @@ iVp
 tfm
 qza
 vAD
-scA
+tWM
 cbq
-wki
+wBl
 tYA
 iEa
-hmX
+pKF
 cje
 mSq
 wXG
@@ -68305,7 +69017,7 @@ sSO
 xxK
 tYA
 cje
-pKF
+hmX
 fya
 mSq
 wXG
@@ -73003,9 +73715,9 @@ upz
 trt
 ehb
 naf
-nhH
+gzu
 voj
-oEi
+bKk
 rhn
 wCS
 rMy
@@ -73261,7 +73973,7 @@ aus
 eJj
 wfC
 oUp
-vkJ
+iKt
 xRW
 vWE
 ajQ
@@ -74795,7 +75507,7 @@ lkF
 nbU
 fXB
 gPZ
-tDm
+piw
 gPZ
 gPZ
 onf
@@ -79603,7 +80315,7 @@ rdb
 wdA
 wdA
 vPb
-vPb
+puf
 bYP
 wvm
 hwz
@@ -79860,7 +80572,7 @@ rdb
 wdA
 qQF
 adu
-vPb
+puf
 koq
 jcU
 jcU
@@ -80374,7 +81086,7 @@ gzZ
 wdA
 qQF
 adu
-vPb
+puf
 iLR
 cJw
 cJw
@@ -80631,7 +81343,7 @@ gzZ
 wdA
 wdA
 vPb
-vPb
+puf
 mrJ
 gIk
 wBt
@@ -83216,9 +83928,9 @@ mne
 cHK
 cHK
 cHK
-cHK
-cHK
-cHK
+kIu
+iVc
+iVc
 mHR
 cmR
 ezI

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -1556,6 +1556,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners{
 	color = "#009dc4"
 	},
+/obj/structure/mirror/directional/north,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "aSy" = (
@@ -2783,12 +2784,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "bvf" = (
-/obj/structure/disposaloutlet{
-	name = "Cargo Deliveries";
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/station/science/robotics)
+/obj/machinery/holopad/secure,
+/turf/open/floor/wood/large,
+/area/station/security/warden)
 "bvp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -6145,7 +6146,6 @@
 /area/station/security/detectives_office)
 "dji" = (
 /obj/machinery/cassette/dj_station,
-/obj/machinery/light/dim/directional/west,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/vaporwave,
 /area/station/service/library)
@@ -7733,7 +7733,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "dXv" = (
 /obj/machinery/duct/industrial/waste,
@@ -19262,7 +19262,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/interrogation)
 "jZd" = (
 /obj/effect/turf_decal/stripes{
@@ -20392,6 +20392,7 @@
 /obj/item/storage/backpack/duffelbag/sec,
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/machinery/light/floor/has_bulb,
+/obj/item/storage/medkit/regular,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "kDh" = (
@@ -21955,7 +21956,7 @@
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
-/turf/open/floor/iron/smooth,
+/turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "lrZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31985,12 +31986,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics)
 "qBI" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 6
-	},
-/turf/open/floor/plating/ocean,
-/area/ocean/generated_above)
+/obj/machinery/requests_console/directional/west,
+/turf/open/floor/pod/dark,
+/area/station/security/warden)
 "qBL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34872,6 +34870,13 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"sbd" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/line,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "sbg" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/green/warning{
@@ -41771,7 +41776,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "vMb" = (
 /obj/machinery/button/door/directional/south{
@@ -43798,7 +43803,7 @@
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/interrogation)
 "wQE" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -68849,7 +68854,7 @@ fjT
 xBV
 xzw
 xBV
-xSC
+sbd
 owJ
 mLx
 emN
@@ -70397,7 +70402,7 @@ mLx
 rrB
 qfA
 lKN
-ydD
+qBI
 ofT
 rrB
 lhf
@@ -71167,7 +71172,7 @@ iIe
 piv
 rrB
 dys
-tIq
+bvf
 vMF
 sqw
 fRn
@@ -84734,7 +84739,7 @@ noG
 mnj
 ovu
 uzj
-bvf
+uzj
 mxq
 uzj
 uzj
@@ -89930,7 +89935,7 @@ aah
 aah
 aah
 aah
-qBI
+aah
 aah
 aah
 aah
@@ -90188,7 +90193,7 @@ aah
 aah
 aah
 aah
-qBI
+aah
 aah
 aah
 aah

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -43960,6 +43960,11 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"xRb" = (
+/obj/machinery/computer/cargo/request,
+/obj/structure/window/spawner/directional/north,
+/turf/open/floor/plating,
+/area/station/cargo/sorting)
 "xRd" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock{
@@ -61826,7 +61831,7 @@ tPb
 afI
 vmz
 pGC
-qIz
+xRb
 iao
 jwO
 pFJ

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -1,4 +1,15 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aad" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 9;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "aah" = (
 /turf/open/floor/plating/ocean,
 /area/ocean/generated_above)
@@ -188,11 +199,7 @@
 "adv" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#00ff00";
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
-	color = "#00ff00"
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
@@ -526,13 +533,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
-"alg" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/purple,
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "alo" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/spawner/random/structure/grille,
@@ -1318,34 +1318,12 @@
 	dir = 4
 	},
 /area/station/engineering/atmos/hfr_room)
-"aLK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/white{
-	color = "#00ff00"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/mine/storage/public)
 "aLM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/station/cargo/sorting)
-"aLO" = (
-/obj/machinery/light_switch/directional/north,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#00ff00";
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/white/corner{
-	color = "#00ff00";
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/mine/storage/public)
 "aMo" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/reagent_containers/cup/soda_cans/monkestation/lemonade{
@@ -1491,12 +1469,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
-"aQU" = (
-/obj/structure/cable,
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/brown,
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "aRb" = (
 /obj/machinery/announcement_system,
 /turf/open/floor/circuit,
@@ -2846,12 +2818,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
-"bvZ" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#00ff00"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/mine/storage/public)
 "bwi" = (
 /obj/machinery/light_switch/directional/north{
 	pixel_y = -21;
@@ -3284,14 +3250,6 @@
 /obj/structure/flora/ocean/longseaweed,
 /turf/open/floor/holofloor/beach/water,
 /area/station/maintenance/starboard/aft)
-"bFB" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/stripes,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/main)
 "bFI" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4"
@@ -3716,6 +3674,12 @@
 /obj/item/paper/pamphlet,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/hop)
+"bQC" = (
+/obj/machinery/duct/industrial/waste,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/glass/reinforced,
+/area/station/engineering/main)
 "bQI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
@@ -6697,6 +6661,13 @@
 "dtE" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/aft)
+"dtG" = (
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "dtJ" = (
 /obj/machinery/light/floor/has_bulb,
 /obj/effect/turf_decal/trimline/blue,
@@ -6795,6 +6766,12 @@
 "dxq" = (
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"dxr" = (
+/obj/structure/cable,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/purple,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "dxs" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/sign/departments/evac,
@@ -7058,13 +7035,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/storage)
-"dFw" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#00ff00";
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/mine/storage/public)
 "dFW" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -9872,13 +9842,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
-"fbr" = (
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 10;
-	color = "#00ff00"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/mine/storage/public)
 "fbt" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
@@ -10293,13 +10256,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
-"flW" = (
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/white{
-	color = "#00ff00"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/mine/storage/public)
 "fmI" = (
 /obj/structure/spider/stickyweb/sealed,
 /turf/open/floor/plating,
@@ -10611,6 +10567,16 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
+"fvY" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/dark_blue,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "fxe" = (
 /turf/closed/wall/r_wall,
 /area/station/science/xenobiology)
@@ -10900,6 +10866,14 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"fFQ" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "fGs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13160,16 +13134,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/storage/emergency/starboard)
-"gSq" = (
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 5;
-	color = "#00ff00"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/mine/storage/public)
 "gSr" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/cable,
@@ -13244,7 +13208,7 @@
 	invisibility = 101
 	},
 /obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/dark_blue,
+/obj/effect/turf_decal/trimline/brown,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "gUq" = (
@@ -14296,16 +14260,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
-"hxr" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#00ff00";
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#00ff00"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/mine/storage/public)
 "hxC" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/white/filled/corner{
@@ -14826,16 +14780,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/security/warden)
-"hLm" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
-	},
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/brown,
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "hLn" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
@@ -15829,6 +15773,17 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"ins" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "int" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 8
@@ -17004,6 +16959,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"iVo" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/yellow,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central/fore)
 "iVp" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/disposalpipe/segment{
@@ -18582,20 +18544,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/executive,
 /area/station/command/bridge)
-"jNq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 4;
-	color = "#00ff00"
-	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#00ff00";
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/mine/storage/public)
 "jNs" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -19123,6 +19071,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/command/bridge)
+"jZR" = (
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 10;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "jZT" = (
 /obj/effect/turf_decal/tile/dark_red/fourcorners,
 /obj/structure/table/reinforced,
@@ -19300,14 +19255,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"keV" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 1;
-	color = "#00ff00"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/mine/storage/public)
 "kfc" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -19925,7 +19872,9 @@
 "kwp" = (
 /obj/structure/cable,
 /obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/purple,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "kwv" = (
@@ -20358,17 +20307,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
-"kHS" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#00ff00"
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 1;
-	color = "#00ff00"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "kHX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22186,6 +22124,16 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"lCm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "lCz" = (
 /obj/structure/sign/departments/chemistry/pharmacy,
 /turf/closed/wall/r_wall,
@@ -22240,6 +22188,13 @@
 /obj/effect/turf_decal/box/red,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/storage/emergency/starboard)
+"lDM" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/purple,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "lDV" = (
 /obj/effect/turf_decal/stripes/end,
 /obj/machinery/suit_storage_unit,
@@ -22776,19 +22731,6 @@
 /obj/item/phone,
 /turf/open/floor/carpet/blue,
 /area/station/security/checkpoint/customs)
-"lRz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#00ff00"
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 1;
-	color = "#00ff00"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/mine/storage/public)
 "lRA" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/item/storage/secure/briefcase,
@@ -24187,6 +24129,16 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/engine,
 /area/station/cargo/miningoffice)
+"mLp" = (
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "mLr" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -24214,6 +24166,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/commons/fitness/recreation/entertainment)
+"mLS" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "mLX" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/warning{
@@ -24837,6 +24800,20 @@
 /obj/structure/sign/departments/evac,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"nbn" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 6;
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 6;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "nbw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
@@ -25676,6 +25653,16 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation/entertainment)
+"nvx" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "nvL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -25903,15 +25890,17 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
+"nBU" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "nBV" = (
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/hop)
-"nBX" = (
-/obj/machinery/duct/industrial/waste,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/glass/reinforced,
-/area/station/engineering/main)
 "nCm" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Head of Personel's office"
@@ -29022,6 +29011,17 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
+"pmk" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central/fore)
 "pmv" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
@@ -31822,14 +31822,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"qIQ" = (
-/obj/structure/cable,
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/white{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "qJg" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access"
@@ -33942,9 +33934,7 @@
 	dir = 6
 	},
 /obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/white{
-	color = "#009dc4"
-	},
+/obj/effect/turf_decal/trimline/purple,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "rKi" = (
@@ -34262,6 +34252,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/red,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "rUa" = (
@@ -36027,15 +36018,6 @@
 /obj/item/electronics/apc,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"sTz" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/purple,
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "sTK" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/tile/blue/diagonal_centre,
@@ -36134,6 +36116,12 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"sVJ" = (
+/obj/structure/cable,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/brown,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "sVS" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners{
@@ -36889,6 +36877,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"tvB" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "tvC" = (
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 8
@@ -39076,6 +39070,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
+"uCj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "uCm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
@@ -39487,6 +39494,17 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"uMu" = (
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#00ff00"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "uMD" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
@@ -39993,11 +40011,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 6;
-	color = "#00ff00"
-	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 6;
+	dir = 5;
 	color = "#00ff00"
 	},
 /turf/open/floor/iron/dark/textured,
@@ -41534,6 +41548,18 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"vSq" = (
+/obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#00ff00";
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#00ff00";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "vSw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -42894,13 +42920,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"wCL" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/yellow,
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
 "wCO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
@@ -45247,17 +45266,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/commons/lounge)
-"xPJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#00ff00"
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 9;
-	color = "#00ff00"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/mine/storage/public)
 "xPK" = (
 /mob/living/basic/chicken/brown,
 /turf/open/misc/sandy_dirt,
@@ -45870,17 +45878,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"yfX" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/white{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
 "ygb" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -45969,16 +45966,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/commons/lounge)
-"yhN" = (
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 1;
-	color = "#00ff00"
-	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#00ff00"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/mine/storage/public)
 "yhQ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -46015,6 +46002,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/red,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "yjR" = (
@@ -46061,6 +46049,20 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics)
+"yle" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 4;
+	color = "#00ff00"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#00ff00";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/mine/storage/public)
 "ylf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -62681,7 +62683,7 @@ gCN
 fue
 fue
 umh
-rKc
+ins
 pIW
 lQS
 sul
@@ -64223,7 +64225,7 @@ jeZ
 vwP
 xEU
 rfc
-qIQ
+kwp
 nxP
 xwm
 qeN
@@ -64277,16 +64279,16 @@ wVt
 hzM
 sTn
 ngm
-aQU
+sVJ
 sTn
 tjR
-hLm
+gUe
 owJ
 sTn
-aQU
+sVJ
 sTn
 nTa
-hLm
+gUe
 epx
 qaa
 uNE
@@ -64993,7 +64995,7 @@ vwP
 vwP
 vwP
 xEU
-qIQ
+kwp
 nxP
 wJX
 qet
@@ -65828,7 +65830,7 @@ pEa
 sYn
 mIK
 jfI
-gUe
+fvY
 mLx
 emN
 emN
@@ -66021,7 +66023,7 @@ jSp
 lHt
 yke
 umh
-qIQ
+kwp
 nxP
 ljv
 aTw
@@ -66599,7 +66601,7 @@ pEa
 wsx
 twN
 jfI
-gUe
+fvY
 mLx
 emN
 xhY
@@ -66793,12 +66795,12 @@ wlx
 nLV
 umh
 rfc
-kHS
+mLS
 pkw
 dMh
 vhM
 dIo
-adv
+uMu
 gYV
 pkw
 bfN
@@ -67049,10 +67051,10 @@ eBe
 pse
 nLV
 umh
-qIQ
-kHS
+kwp
+mLS
 ahh
-hxr
+nvx
 lel
 lel
 lel
@@ -67309,11 +67311,11 @@ jQZ
 rfc
 iwy
 wZC
-yhN
-flW
+mLp
+dtG
 lel
 lel
-lRz
+uCj
 pkw
 xUe
 upR
@@ -67564,11 +67566,11 @@ lHt
 nLV
 tXk
 rfc
-kHS
+mLS
 ahh
-hxr
+nvx
 amw
-xPJ
+aad
 xdP
 ufr
 pkw
@@ -67821,10 +67823,10 @@ rOB
 nLV
 umh
 rfc
-kHS
+mLS
 pkw
-aLO
-jNq
+vSq
+yle
 xix
 pkw
 nbX
@@ -68078,7 +68080,7 @@ nLV
 nLV
 umh
 rfc
-kHS
+mLS
 pkw
 pkw
 orx
@@ -68334,12 +68336,12 @@ mFh
 fgS
 gGL
 vSI
-qIQ
-kHS
+kwp
+mLS
 pkw
 gyj
 pqf
-fbr
+jZR
 vrg
 ugV
 upR
@@ -68592,10 +68594,10 @@ tXC
 tXC
 gAV
 rfc
-kHS
+mLS
 pkw
 xji
-aLK
+lCm
 cGg
 pkw
 fGs
@@ -68849,11 +68851,11 @@ hHy
 tXC
 wgD
 tYL
-kHS
+mLS
 pkw
-dFw
+adv
 tRB
-bvZ
+tvB
 ahh
 wXG
 ske
@@ -69108,9 +69110,9 @@ iyS
 veZ
 oij
 lxM
-keV
+nBU
 jZX
-bvZ
+tvB
 ahh
 vxY
 ske
@@ -69363,9 +69365,9 @@ tXC
 tXC
 faF
 cbq
-kHS
+mLS
 pkw
-dFw
+adv
 bJU
 rOJ
 pkw
@@ -69620,11 +69622,11 @@ bhD
 rXT
 gAV
 wDZ
-kHS
+mLS
 ahh
-gSq
-cPJ
 uYW
+cPJ
+nbn
 pkw
 wXG
 ske
@@ -69877,7 +69879,7 @@ qza
 aES
 iyS
 wDZ
-kHS
+mLS
 pkw
 pkw
 pkw
@@ -79129,7 +79131,7 @@ bUu
 bUu
 bUu
 jXE
-qIQ
+kwp
 nxP
 tYA
 cXb
@@ -79706,7 +79708,7 @@ pPs
 pkw
 fIP
 hxC
-yfX
+pmk
 iFe
 gZg
 tPb
@@ -80157,7 +80159,7 @@ ahy
 bUu
 bUu
 jXE
-kwp
+dxr
 ePC
 sri
 qxz
@@ -81248,7 +81250,7 @@ qZP
 pxQ
 fBH
 ukS
-yfX
+pmk
 iFe
 gZg
 lpu
@@ -82019,7 +82021,7 @@ aIc
 jBo
 jMN
 vYQ
-yfX
+pmk
 iFe
 gZg
 tPb
@@ -82480,14 +82482,14 @@ jAU
 dUR
 kPm
 iMu
-sTz
+rKc
 cOB
 wFP
 wFP
 wSx
 wFP
 oaW
-alg
+lDM
 pIW
 lQS
 tzD
@@ -82790,7 +82792,7 @@ vjk
 dXN
 fvi
 glV
-yfX
+pmk
 iFe
 vUJ
 seY
@@ -84061,7 +84063,7 @@ jRC
 aVs
 szt
 klb
-wCL
+iVo
 yew
 ikz
 wws
@@ -86614,7 +86616,7 @@ kFZ
 xQn
 eMG
 tCB
-nBX
+bQC
 sgQ
 asg
 sli
@@ -87385,7 +87387,7 @@ aNi
 aNi
 aNi
 qay
-bFB
+fFQ
 jvI
 jRw
 auZ

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -302,9 +302,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "afY" = (
-/obj/structure/table/wood,
-/turf/open/floor/iron/dark/textured,
-/area/station/service/library)
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating/ocean,
+/area/ocean/generated_above)
 "agf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/computer/scan_consolenew{
@@ -383,6 +383,11 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
+"ahT" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating/ocean,
+/area/ocean/generated_above)
 "aih" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /obj/structure/chair/comfy,
@@ -555,7 +560,7 @@
 /area/station/construction/storage_wing)
 "anc" = (
 /obj/structure/dresser,
-/obj/machinery/light/directional/north,
+/obj/machinery/light/dim/directional/north,
 /turf/open/floor/eighties,
 /area/station/service/abandoned_gambling_den/gaming)
 "anf" = (
@@ -848,6 +853,10 @@
 	dir = 8
 	},
 /area/station/service/hydroponics)
+"axF" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "axQ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -968,6 +977,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"aBx" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean/generated_above)
 "aBy" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/ce)
@@ -2077,6 +2091,12 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"bfR" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/lattice,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "bgu" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/toggleable/riot{
@@ -3651,8 +3671,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "bSK" = (
-/obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/iron/dark/textured,
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/vaporwave,
 /area/station/service/library)
 "bST" = (
 /obj/structure/table,
@@ -4687,10 +4710,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "cBs" = (
-/obj/item/radio/radio_mic,
-/obj/structure/table/wood,
-/turf/open/floor/iron/dark/textured,
-/area/station/service/library)
+/obj/structure/closet/crate/bin,
+/obj/item/tape/random,
+/obj/item/gps/spaceruin,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "cBt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -7748,6 +7772,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
+"efb" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "efz" = (
 /obj/structure/table/wood,
 /obj/item/book/granter/action/spell/smoke/lesser{
@@ -8030,12 +8059,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"eoL" = (
-/obj/machinery/modular_computer/console/preset/id{
-	dir = 1
-	},
-/turf/open/floor/carpet/orange,
-/area/station/command/heads_quarters/ce)
 "epb" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/camera/autoname/directional/south,
@@ -8944,6 +8967,10 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/large,
 /area/station/security/checkpoint/customs)
+"eKS" = (
+/obj/structure/lattice,
+/turf/open/floor/plating/ocean/pit/wall,
+/area/ocean)
 "eLs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9133,29 +9160,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "ePE" = (
-/obj/structure/table/wood,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron/dark/textured,
-/area/station/service/library)
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "ePQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -10001,6 +10008,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
+"fnT" = (
+/mob/living/basic/butterfly,
+/obj/structure/cable,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "fnW" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -10250,6 +10262,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"fuD" = (
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "fuQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10410,6 +10425,7 @@
 	dir = 1
 	},
 /obj/machinery/holopad,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/library)
 "fAO" = (
@@ -10744,6 +10760,23 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"fLq" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/button/door/directional/north{
+	pixel_x = -23;
+	id = "radio";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = 23
+	},
+/obj/effect/landmark/start/librarian,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "fLN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -11185,6 +11218,10 @@
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"fXY" = (
+/obj/effect/overlay/palmtree_l,
+/turf/open/floor/holofloor/beach,
+/area/station/service/library)
 "fYq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -11339,8 +11376,8 @@
 /obj/structure/mirror{
 	pixel_y = -28
 	},
-/obj/machinery/light/small/directional/south{
-	pixel_x = 11
+/obj/machinery/light/small/maintenance/directional/south{
+	pixel_x = 9
 	},
 /turf/open/floor/iron/freezer,
 /area/station/service/abandoned_gambling_den/gaming)
@@ -11508,6 +11545,20 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
+"geB" = (
+/obj/structure/cassette_rack,
+/obj/item/device/cassette_tape/friday,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "geD" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Base"
@@ -12364,6 +12415,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
+"gEA" = (
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 1
+	},
+/turf/open/floor/carpet/orange,
+/area/station/command/heads_quarters/ce)
 "gEE" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor,
@@ -12588,6 +12645,10 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
+"gMr" = (
+/obj/structure/cable,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "gMt" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13801,6 +13862,11 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/server)
+"hwD" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "hwI" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -14481,6 +14547,22 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"hNI" = (
+/obj/structure/table/wood,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/structure/window/spawner/directional/west,
+/obj/item/device/cassette_tape/blank,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "hNS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -15316,6 +15398,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
+"imS" = (
+/obj/item/instrument/eguitar,
+/turf/open/floor/holofloor/beach,
+/area/station/service/library)
 "imU" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -15531,6 +15617,13 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
+"isz" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
+	},
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "itp" = (
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -17029,6 +17122,11 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
+"jjO" = (
+/obj/structure/window/spawner/directional/west,
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "jjP" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -19310,18 +19408,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
 "kuO" = (
-/obj/structure/table/wood,
-/obj/structure/cassette_rack,
-/obj/item/device/cassette_tape/friday,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/holofloor/beach/coast_b,
 /area/station/service/library)
 "kuQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21391,6 +21478,10 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"lyD" = (
+/obj/effect/overlay/palmtree_r,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "lyP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -22490,12 +22581,9 @@
 /turf/open/floor/engine,
 /area/station/commons/storage/emergency/port)
 "mcu" = (
-/obj/machinery/door/morgue{
-	name = "Private Study";
-	req_access = list("library")
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/service/library)
+/obj/structure/lattice,
+/turf/open/floor/plating/ocean/pit,
+/area/ocean)
 "mdc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -23665,6 +23753,11 @@
 	},
 /turf/open/floor/iron/dark/textured_corner,
 /area/station/hallway/primary/central)
+"mOK" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "mOU" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
@@ -25009,11 +25102,9 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "nvY" = (
-/obj/machinery/cassette/dj_station,
-/obj/structure/table/wood,
-/obj/machinery/light/dim/directional/west,
-/turf/open/floor/iron/dark/textured,
-/area/station/service/library)
+/obj/structure/lattice,
+/turf/open/floor/plating/ocean,
+/area/ocean/generated_above)
 "nwz" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -25223,6 +25314,11 @@
 "nBV" = (
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/hop)
+"nCf" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "nCm" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Head of Personel's office"
@@ -25336,6 +25432,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"nFN" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cassette/adv_cassette_deck,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "nFQ" = (
 /obj/effect/turf_decal/stripes{
 	dir = 9
@@ -26329,10 +26431,9 @@
 /turf/open/floor/iron/dark/textured_edge/airless,
 /area/station/science/lobby)
 "ojo" = (
-/obj/structure/table/wood,
-/obj/machinery/cassette/adv_cassette_deck,
-/turf/open/floor/iron/dark/textured,
-/area/station/service/library)
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "ojq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -27407,6 +27508,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"oOt" = (
+/obj/effect/spawner/random/structure/musician/piano/random_piano,
+/obj/structure/window/spawner/directional/west,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "oPd" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase{
@@ -27889,7 +27995,7 @@
 /area/station/commons/dorms)
 "pds" = (
 /obj/structure/chair/sofa/right,
-/obj/machinery/light/directional/north,
+/obj/machinery/light/dim/directional/north,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den/gaming)
 "pdS" = (
@@ -28574,6 +28680,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/main)
+"puM" = (
+/obj/structure/window/spawner/directional/east,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "puS" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/aft)
@@ -28693,6 +28803,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/commons/lounge)
+"pAO" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/public/glass{
+	name = "KRUM Radio";
+	id_tag = "radio"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/library,
+/obj/structure/cable,
+/turf/open/floor/pod/dark,
+/area/station/service/library)
 "pAS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/yjunction,
@@ -30852,6 +30972,11 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/science/robotics/lab)
+"qFS" = (
+/obj/structure/chair/stool/directional/west,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "qGa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/plating/ocean,
@@ -32273,6 +32398,13 @@
 "rrB" = (
 /turf/closed/wall/r_wall,
 /area/station/security/warden)
+"rrC" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "rrZ" = (
 /obj/effect/spawner/random/structure/crate_empty,
 /obj/effect/decal/cleanable/dirt,
@@ -34013,6 +34145,15 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
+"sqC" = (
+/obj/structure/statue/sandstone/venus{
+	anchored = 1;
+	desc = "Ugh, this is merely an ugly amateurish replica of the other statue! The letters RIPGOAT are scribbled onto the base.";
+	dir = 8
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "sqV" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash,
@@ -34159,6 +34300,10 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
 /area/ruin/space/ks13/engineering/secure_storage)
+"suQ" = (
+/obj/effect/overlay/palmtree_r,
+/turf/open/floor/holofloor/beach,
+/area/station/service/library)
 "svm" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/requests_console/directional/north{
@@ -35004,6 +35149,16 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/hop)
+"sSt" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/sunglasses/big{
+	name = "aesthetic sunglasses";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/item/radio/radio_mic,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "sSN" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35619,6 +35774,15 @@
 	dir = 4
 	},
 /area/station/science/lobby)
+"tmz" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/service/library)
 "tmA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/executive,
@@ -35780,6 +35944,14 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"tsk" = (
+/obj/structure/statue/sandstone/venus{
+	anchored = 1;
+	dir = 4
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "tso" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -36819,6 +36991,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/librarian,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/library)
 "tVX" = (
@@ -37654,7 +37827,7 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/office)
 "uqC" = (
-/turf/open/floor/iron/dark/textured,
+/turf/closed/wall/rust,
 /area/station/service/library)
 "urf" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -39492,6 +39665,9 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"vol" = (
+/turf/open/floor/holofloor/beach,
+/area/station/service/library)
 "voC" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -39782,6 +39958,12 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/science/genetics)
+"vxS" = (
+/obj/machinery/cassette/dj_station,
+/obj/machinery/light/dim/directional/west,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "vxY" = (
 /obj/machinery/conveyor/auto{
 	dir = 4
@@ -42191,6 +42373,15 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
+"wSb" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/table/wood,
+/obj/item/taperecorder{
+	pixel_y = 9;
+	pixel_x = -5
+	},
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "wSq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 5
@@ -42232,6 +42423,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"wTr" = (
+/obj/effect/overlay/palmtree_l,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "wTY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/circuit/telecomms,
@@ -42566,6 +42761,7 @@
 	name = "Private Study";
 	req_access = list("library")
 	},
+/obj/effect/mapping_helpers/airlock/access/all/service/library,
 /turf/open/floor/wood,
 /area/station/service/library)
 "xbZ" = (
@@ -43520,18 +43716,10 @@
 /turf/open/floor/iron,
 /area/station/construction/storage_wing)
 "xCE" = (
+/obj/structure/window/spawner/directional/west,
 /obj/structure/table/wood,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/turf/open/floor/iron/dark/textured,
+/obj/item/statuebust,
+/turf/open/floor/iron/vaporwave,
 /area/station/service/library)
 "xCP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -44335,6 +44523,9 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
+"xZy" = (
+/turf/open/floor/holofloor/beach/coast_t,
+/area/station/service/library)
 "xZC" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/cable,
@@ -44543,8 +44734,12 @@
 /turf/open/floor/plating,
 /area/station/security/office)
 "yfp" = (
-/obj/machinery/camera/autoname/directional/east,
-/turf/open/floor/iron/dark/textured,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/station/service/library)
 "yfT" = (
 /obj/machinery/duct/industrial/waste,
@@ -70103,11 +70298,11 @@ aah
 aah
 aah
 meJ
-meJ
-meJ
-meJ
-fKl
-aYY
+mdW
+mdW
+mdW
+eKS
+mcu
 aah
 aah
 aah
@@ -70360,11 +70555,11 @@ aah
 aah
 aah
 aah
-fKl
+eKS
 aYY
+mcu
 aYY
-aYY
-aYY
+mcu
 aYY
 aYY
 aah
@@ -70617,11 +70812,11 @@ aah
 aah
 fKl
 aYY
+mcu
 aYY
+mcu
 aYY
-aYY
-aYY
-aYY
+mcu
 aYY
 aYY
 aYY
@@ -70874,11 +71069,11 @@ aYY
 aYY
 aYY
 aYY
+mcu
 aYY
+mcu
 aYY
-aYY
-aYY
-aYY
+mcu
 aYY
 aYY
 aYY
@@ -71131,11 +71326,11 @@ aYY
 aYY
 aYY
 aYY
-aYY
+mcu
 fAs
 fAs
 fAs
-aYY
+mcu
 aYY
 aYY
 aYY
@@ -71893,10 +72088,10 @@ aah
 aah
 aah
 aah
-aah
-aah
-fKl
-aYY
+nvY
+nvY
+eKS
+mcu
 fAs
 oGC
 fAs
@@ -72150,7 +72345,7 @@ aah
 aah
 aah
 aah
-aah
+nvY
 aah
 fKl
 aYY
@@ -72407,10 +72602,10 @@ aah
 aah
 aah
 aah
-aah
-aah
-fKl
-aYY
+nvY
+nvY
+eKS
+mcu
 fAs
 fAs
 nbY
@@ -72664,7 +72859,7 @@ aah
 aah
 aah
 aah
-aah
+nvY
 aah
 fKl
 aYY
@@ -72921,10 +73116,10 @@ aah
 aah
 aah
 aah
-aah
-aah
-fKl
-aYY
+nvY
+nvY
+eKS
+mcu
 fAs
 fAs
 fAs
@@ -73701,11 +73896,11 @@ aYY
 aYY
 aYY
 aYY
-aYY
+mcu
 fAs
 fAs
 fAs
-aYY
+mcu
 aYY
 aYY
 aYY
@@ -73958,11 +74153,11 @@ aYY
 aYY
 aYY
 aYY
+mcu
 aYY
+mcu
 aYY
-aYY
-aYY
-aYY
+mcu
 aYY
 aYY
 aYY
@@ -74215,11 +74410,11 @@ aah
 fKl
 aYY
 aYY
+mcu
 aYY
+mcu
 aYY
-aYY
-aYY
-aYY
+mcu
 aYY
 aYY
 aYY
@@ -74472,11 +74667,11 @@ aah
 aah
 aah
 aah
-fKl
+eKS
 aYY
+mcu
 aYY
-aYY
-aYY
+mcu
 aYY
 aYY
 aYY
@@ -74729,11 +74924,11 @@ aah
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
+nvY
+nvY
+nvY
+nvY
+nvY
 aah
 aah
 aah
@@ -83262,14 +83457,14 @@ pEh
 pEh
 uVL
 uVL
+rZh
 rly
 mLr
 uVL
-meJ
-meJ
+mdW
 meJ
 aah
-aah
+nvY
 aah
 aah
 aah
@@ -83519,14 +83714,14 @@ gKb
 rZh
 xbU
 qzb
+rZh
 lFB
 wQf
 uVL
-meJ
-meJ
+mdW
 aah
 aah
-aah
+nvY
 aah
 aah
 aah
@@ -83779,12 +83974,12 @@ uVL
 uVL
 uVL
 uVL
+uVL
+mdW
+mdW
 meJ
-aah
-aah
-aah
-aah
-aah
+mdW
+meJ
 aah
 aah
 aah
@@ -84034,17 +84229,17 @@ bTl
 ezG
 hmV
 sVS
-uVL
+uUD
+vol
+xQD
+xQD
+xQD
+xQD
+uqC
+mOK
 meJ
-meJ
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+nvY
 aah
 aah
 aah
@@ -84291,17 +84486,17 @@ tMt
 bTl
 bTl
 jNL
-uVL
-meJ
-meJ
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+uUD
+suQ
+vol
+suQ
+xZy
+kuO
+uUD
+bfR
+mdW
+nvY
+nvY
 aah
 aah
 aah
@@ -84548,15 +84743,15 @@ icW
 bTl
 gsK
 bTl
-uVL
-meJ
-meJ
-meJ
-meJ
-aah
-aah
-aah
-aah
+uqC
+oOt
+wSb
+xCE
+hNI
+jjO
+uUD
+ojo
+wTr
 aah
 aah
 aah
@@ -84805,16 +85000,16 @@ dzW
 bTl
 qfa
 hby
-uVL
-meJ
-meJ
-meJ
-meJ
-meJ
-aah
-aah
-aah
-aah
+uUD
+qFS
+fuD
+fuD
+fuD
+axF
+uUD
+sqC
+hwD
+aBx
 aah
 aah
 aah
@@ -85062,16 +85257,16 @@ rMU
 qLF
 kmc
 uRv
+uUD
+fuD
+fuD
+fuD
+fuD
+fuD
 xQD
-xQD
-xQD
-xQD
-meJ
-meJ
-aah
-aah
-aah
-aah
+ePE
+ePE
+ahT
 aah
 aah
 aah
@@ -85315,20 +85510,20 @@ wjK
 dEa
 les
 les
-gky
+tmz
 tVS
 fAx
-bTl
-xQD
+yfp
+pAO
 bSK
-xCE
+bSK
+gMr
+gMr
+fuD
 xQD
-meJ
-meJ
-aah
-aah
-aah
-aah
+ePE
+ePE
+afY
 aah
 aah
 aah
@@ -85575,17 +85770,17 @@ ixz
 uzR
 drG
 cyd
-xQD
-xQD
+bTl
 uqC
-uqC
+nFN
+sSt
+vxS
+gMr
+fuD
 xQD
-meJ
-meJ
-meJ
-aah
-aah
-aah
+ePE
+ePE
+afY
 aah
 aah
 aah
@@ -85830,19 +86025,19 @@ uVL
 uVL
 uVL
 uVL
-mcu
+uVL
 xQD
 xQD
 uqC
+fLq
+rrC
+geB
+fnT
+axF
 uqC
-uqC
-xQD
-meJ
-meJ
-meJ
-aah
-aah
-aah
+tsk
+hwD
+aBx
 aah
 aah
 aah
@@ -86085,20 +86280,20 @@ meJ
 meJ
 meJ
 meJ
-uVL
-nvY
-uqC
-uqC
-uqC
-uqC
-uqC
-uqC
-xQD
 meJ
 meJ
 meJ
-aah
-aah
+mdW
+meJ
+uUD
+isz
+nCf
+nCf
+nCf
+puM
+uUD
+efb
+lyD
 aah
 aah
 aah
@@ -86342,21 +86537,21 @@ meJ
 meJ
 meJ
 meJ
-uVL
+meJ
+meJ
+meJ
+mdW
+mdW
+uqC
+fXY
+imS
+fXY
+xZy
 kuO
 uqC
-uqC
-uqC
-uqC
-uqC
-uqC
-xQD
-meJ
-meJ
-aah
-aah
-aah
-aah
+bfR
+mdW
+nvY
 aah
 aah
 aah
@@ -86599,22 +86794,22 @@ aah
 aah
 meJ
 meJ
-uVL
-cBs
+meJ
+meJ
+meJ
+meJ
+mdW
+uUD
+xQD
+xQD
+xQD
+xQD
+xQD
 uqC
-yfp
-ojo
-ePE
-afY
-xQD
-xQD
+mOK
 meJ
-meJ
-aah
-aah
-aah
-aah
-aah
+nvY
+nvY
 aah
 aah
 aah
@@ -86856,20 +87051,20 @@ aah
 aah
 meJ
 meJ
-uVL
-uVL
-uVL
-uVL
-uVL
-uVL
-uVL
-xQD
 meJ
 meJ
 meJ
-aah
-aah
-aah
+meJ
+meJ
+meJ
+meJ
+mdW
+mdW
+cBs
+mdW
+meJ
+meJ
+meJ
 aah
 aah
 aah
@@ -87079,7 +87274,7 @@ gly
 bwi
 tan
 rdE
-eoL
+gEA
 lXt
 hUd
 oDZ
@@ -87120,10 +87315,10 @@ meJ
 meJ
 meJ
 meJ
+mdW
 meJ
 meJ
-meJ
-aah
+nvY
 aah
 aah
 aah
@@ -87377,7 +87572,7 @@ aah
 aah
 aah
 meJ
-meJ
+mdW
 aah
 aah
 aah
@@ -87394,7 +87589,7 @@ aah
 aah
 aah
 aah
-aah
+afY
 aah
 aah
 aah
@@ -87651,7 +87846,7 @@ aah
 aah
 aah
 aah
-aah
+afY
 aah
 aah
 aah
@@ -87908,7 +88103,7 @@ aah
 aah
 aah
 aah
-aah
+afY
 aah
 aah
 aah
@@ -89699,7 +89894,7 @@ aah
 aah
 aah
 aah
-aah
+nvY
 aah
 aah
 aah

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -503,6 +503,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
+"akJ" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "alb" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -595,6 +606,17 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
+"apa" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm2";
+	name = "Cabin 2"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "apc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -999,12 +1021,6 @@
 /obj/structure/sign/warning/no_smoking,
 /turf/open/floor/plating,
 /area/station/science/genetics)
-"aDS" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/shower/directional/south,
-/obj/structure/drain,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
 "aEw" = (
 /obj/structure/sign/poster/official/high_class_martini,
 /turf/closed/wall,
@@ -1303,10 +1319,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "aMJ" = (
-/obj/machinery/shower/directional/south,
-/obj/structure/drain,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured/airless,
+/area/station/science/lobby)
 "aNi" = (
 /turf/open/floor/engine,
 /area/station/engineering/main)
@@ -1395,8 +1415,11 @@
 /area/station/ai_monitored/command/storage/eva)
 "aQx" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -1892,11 +1915,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -2032,14 +2057,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "beP" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 8;
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
 	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4";
-	dir = 4
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/dorms)
@@ -2050,19 +2074,6 @@
 "bfx" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/virology)
-"bfA" = (
-/obj/machinery/duct/industrial/waste,
-/obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "bfN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2226,18 +2237,16 @@
 	},
 /area/station/engineering/main)
 "bkB" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 5
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/brown/corner{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
+/area/station/hallway/primary/central)
 "bkC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -2384,11 +2393,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"bnm" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
 "bnB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/camera/autoname/directional/south,
@@ -2527,8 +2531,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning,
+/obj/effect/turf_decal/trimline/dark_blue/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -2900,6 +2904,23 @@
 /obj/effect/landmark/start/captain,
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/captain/private)
+"bAj" = (
+/obj/machinery/button/door/directional/west{
+	id = "Dorm1";
+	name = "Dormitory Door Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/obj/structure/chair/comfy{
+	dir = 4
+	},
+/obj/item/clothing/head/fedora,
+/obj/item/toy/katana{
+	desc = "As seen in your favourite Japanese cartoon.";
+	name = "anime katana"
+	},
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "bAM" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/light_switch/directional/north,
@@ -3468,18 +3489,15 @@
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "bOl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
+/obj/structure/bed/double,
+/obj/item/bedsheet/clown/double,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/katana{
+	desc = "As seen in your favourite Japanese cartoon.";
+	name = "anime katana"
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "bOH" = (
 /obj/machinery/teleport/station,
 /turf/open/floor/mineral/titanium/purple,
@@ -3489,12 +3507,6 @@
 /obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
-"bOL" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/commons/dorms)
 "bOM" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -3577,6 +3589,9 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/ks13/engineering/secure_storage)
+"bRQ" = (
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "bRT" = (
 /obj/structure/table/optable,
 /obj/structure/window/spawner/directional/east,
@@ -3862,6 +3877,12 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"cbD" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "cbM" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/cable/industrial,
@@ -3902,10 +3923,13 @@
 /area/mine/storage/public)
 "ccx" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "cda" = (
@@ -3945,11 +3969,13 @@
 /area/station/medical/medbay/lobby)
 "cdv" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 5;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -4025,13 +4051,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar)
-"cfp" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "cfu" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/brown/filled/corner{
@@ -4148,11 +4167,12 @@
 	name = "Departure Lounge"
 	},
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -4298,6 +4318,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"cot" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/dorms)
 "cov" = (
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
@@ -4332,6 +4356,18 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"cpG" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/arcade/orion_trail{
+	desc = "For gamers only. Casuals need not apply.";
+	icon_screen = "library";
+	icon_state = "oldcomp";
+	name = "Gamer Computer";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "cpK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -4386,10 +4422,10 @@
 	name = "Central Access"
 	},
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "crT" = (
@@ -4717,7 +4753,15 @@
 	},
 /area/station/ai_monitored/turret_protected/ai)
 "cDa" = (
-/obj/machinery/light/directional/south,
+/obj/machinery/light/no_nightlight/directional/south,
+/obj/machinery/button/door/directional/west{
+	id = "Recept1";
+	name = "Reception Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_x = -7;
+	pixel_y = -23
+	},
 /turf/open/floor/carpet/executive,
 /area/station/commons/vacant_room/commissary)
 "cDd" = (
@@ -4819,19 +4863,6 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"cFt" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm1";
-	name = "Cabin 1"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
 "cFC" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/kitchen,
@@ -4937,13 +4968,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/purple,
 /area/station/science/server)
-"cJz" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark/textured,
-/area/station/security/courtroom)
 "cKa" = (
 /obj/machinery/atmospherics/components/binary/crystallizer{
 	dir = 4
@@ -5227,16 +5251,6 @@
 /obj/effect/turf_decal/trimline/blue/corner,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/theatre)
-"cRy" = (
-/obj/structure/curtain/cloth,
-/obj/structure/drain,
-/obj/machinery/shower/directional/north,
-/obj/machinery/door/window/brigdoor{
-	name = "Shower";
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/station/commons/dorms)
 "cRO" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -6035,18 +6049,16 @@
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/ce)
 "dls" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
-	dir = 8
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/central/fore)
 "dlI" = (
 /obj/structure/cable,
 /obj/machinery/duct/industrial/waste,
@@ -6063,13 +6075,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "dmj" = (
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 4;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 8
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "dmm" = (
@@ -6348,6 +6362,11 @@
 /obj/vehicle/ridden/cargo_train,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
+"drw" = (
+/obj/machinery/shower/directional/south,
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "drG" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners{
@@ -6785,9 +6804,12 @@
 "dFp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 9
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 9;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -6809,10 +6831,13 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
 "dGd" = (
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/warning,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "dGk" = (
@@ -6941,20 +6966,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/robotics)
-"dJu" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_y = 7
-	},
-/obj/structure/sink/directional/north,
-/obj/structure/mirror{
-	pixel_y = -28
-	},
-/obj/machinery/light/small/directional/south{
-	pixel_x = 11
-	},
-/turf/open/floor/iron/freezer,
-/area/station/commons/dorms)
 "dJB" = (
 /mob/living/basic/chicken,
 /turf/open/misc/sandy_dirt,
@@ -7061,11 +7072,13 @@
 /area/station/cargo/storage)
 "dMk" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 5
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 5;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -7435,9 +7448,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "dYf" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -8410,10 +8426,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "eAr" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/neutral/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -8435,14 +8453,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"eAK" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Bedroom"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/eighties,
-/area/station/service/abandoned_gambling_den/gaming)
 "eAY" = (
 /obj/effect/turf_decal/stripes{
 	dir = 6
@@ -8713,8 +8723,11 @@
 "eGV" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -9130,10 +9143,17 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "eQp" = (
-/obj/structure/window/reinforced/tinted,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/eighties,
-/area/station/service/abandoned_gambling_den/gaming)
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 6;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central/fore)
 "eQt" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/vending/imported/yangyu,
@@ -9145,13 +9165,6 @@
 /obj/structure/sign/warning/electric_shock,
 /turf/open/floor/plating,
 /area/station/engineering/main)
-"eQO" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "eRl" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -9162,6 +9175,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"eRn" = (
+/obj/machinery/door/airlock/bathroom{
+	name = "Showers"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "eRt" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/painting/library{
@@ -9258,6 +9277,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/storage/emergency/starboard)
 "eTM" = (
@@ -9318,16 +9340,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"eVE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/south,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "eWH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -9465,11 +9477,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
-"eZT" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "eZW" = (
 /obj/structure/table,
 /obj/machinery/plantgenes,
@@ -9740,12 +9747,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
-"fgt" = (
-/obj/machinery/door/airlock{
-	name = "Bedroom"
-	},
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
 "fgA" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -9849,6 +9850,14 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/mineral/titanium/yellow,
 /area/station/maintenance/starboard/aft)
+"fja" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "fjx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/camera/autoname/directional/south,
@@ -9856,11 +9865,14 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/storage/emergency/starboard)
-"fjN" = (
-/obj/structure/dresser,
-/obj/machinery/light/directional/north,
-/turf/open/floor/eighties,
-/area/station/service/abandoned_gambling_den/gaming)
+"fjP" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/security/office)
 "fjQ" = (
 /obj/structure/grille,
 /obj/effect/spawner/structure/window/plasma,
@@ -9881,10 +9893,10 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "fkl" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "fkr" = (
@@ -10044,13 +10056,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"fpL" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "fpN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10152,6 +10157,15 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
+"fua" = (
+/obj/machinery/door/airlock{
+	name = "Bedroom"
+	},
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "fue" = (
 /turf/closed/wall,
 /area/station/service/abandoned_gambling_den/gaming)
@@ -10203,9 +10217,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "fvi" = (
-/obj/effect/turf_decal/trimline/neutral/corner,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 9
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -10284,11 +10301,6 @@
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
-"fze" = (
-/obj/structure/chair/sofa/right,
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
 "fzi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/flora/bush/jungle/b/style_random,
@@ -10385,14 +10397,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
-"fCa" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/security/office)
 "fCx" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor/auto{
@@ -10479,9 +10483,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/command/bridge)
-"fFE" = (
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
 "fFI" = (
 /turf/open/floor/carpet/executive,
 /area/station/commons/vacant_room/commissary)
@@ -10538,10 +10539,10 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "fHa" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/obj/effect/turf_decal/trimline/neutral/corner,
+/obj/effect/turf_decal/trimline/yellow/corner,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "fHe" = (
@@ -10607,11 +10608,13 @@
 	},
 /area/station/engineering/main)
 "fIP" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -10880,14 +10883,6 @@
 "fQG" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/office)
-"fQY" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/turf/open/floor/wood,
-/area/station/commons/dorms)
 "fRb" = (
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/west,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -11179,12 +11174,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -11235,9 +11230,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "gau" = (
-/obj/machinery/suit_storage_unit/security,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
+/obj/structure/window/reinforced/tinted,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "gaz" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
@@ -11585,11 +11581,6 @@
 "giY" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/fore)
-"gjB" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "gks" = (
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/plating,
@@ -12048,11 +12039,13 @@
 /area/station/medical/treatment_center)
 "gzE" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 6;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -12119,10 +12112,13 @@
 "gAV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/warning,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "gBb" = (
@@ -12156,11 +12152,16 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
+"gCF" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "gCN" = (
-/obj/machinery/shower/directional/north,
-/obj/structure/drain,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "gCU" = (
 /obj/machinery/button/ticket_machine{
 	pixel_y = 22;
@@ -12483,7 +12484,8 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/machinery/door/airlock/public/glass{
-	name = "Reception"
+	name = "Reception";
+	id_tag = "Recept1"
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark/textured,
@@ -12524,10 +12526,13 @@
 /area/station/security/office)
 "gPk" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "gPn" = (
@@ -12610,11 +12615,13 @@
 /area/station/commons/storage/emergency/starboard)
 "gSr" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -12649,12 +12656,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/warning,
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
-"gSX" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/commons/dorms)
 "gTr" = (
 /turf/closed/wall,
 /area/station/medical/storage)
@@ -13148,9 +13149,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"heS" = (
-/turf/open/floor/eighties,
-/area/station/service/abandoned_gambling_den/gaming)
 "hfr" = (
 /obj/structure/table/wood/poker,
 /obj/item/reagent_containers/cup/glass/drinkingglass{
@@ -13274,6 +13272,17 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"hip" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central/fore)
 "hiv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -13708,11 +13717,13 @@
 /area/station/hallway/secondary/entry)
 "hxC" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 10;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -13727,11 +13738,12 @@
 	},
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 4;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -13807,14 +13819,16 @@
 /area/station/tcommsat/server)
 "hAc" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "hAw" = (
@@ -14014,11 +14028,13 @@
 	listening = 0;
 	name = "Common Channel"
 	},
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 10
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -14172,17 +14188,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/main)
-"hLc" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 1;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "hLd" = (
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
@@ -14397,6 +14402,13 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"hPG" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/courtroom)
 "hPI" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -14482,11 +14494,9 @@
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 10;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -14561,6 +14571,20 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
+"hVa" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/sink/directional/north,
+/obj/structure/mirror{
+	pixel_y = -28
+	},
+/obj/machinery/light/small/directional/south{
+	pixel_x = 11
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/abandoned_gambling_den/gaming)
 "hVe" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab"
@@ -14599,6 +14623,11 @@
 	},
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar)
+"hWg" = (
+/obj/machinery/shower/directional/north,
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "hWk" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
@@ -14743,6 +14772,14 @@
 "hZV" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"iah" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "iao" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -14763,20 +14800,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/executive,
 /area/station/commons/vacant_room/commissary)
-"iaH" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_y = 7
-	},
-/obj/structure/sink/directional/north,
-/obj/structure/mirror{
-	pixel_y = -28
-	},
-/obj/machinery/light/small/directional/south{
-	pixel_x = 11
-	},
-/turf/open/floor/iron/freezer,
-/area/station/service/abandoned_gambling_den/gaming)
 "iaP" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -14870,11 +14893,6 @@
 	},
 /turf/open/floor/plating/ocean,
 /area/ocean)
-"ids" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/dark/textured,
-/area/station/cargo/storage)
 "idx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
@@ -14954,12 +14972,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
-"ifP" = (
-/obj/effect/turf_decal/trimline/brown/end{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured/airless,
-/area/station/science/lobby)
 "ige" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -15049,6 +15061,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
+"iji" = (
+/obj/machinery/duct/industrial/waste,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "ijM" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -15439,28 +15464,14 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/robotics/lab)
 "iul" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/structure/sign/poster/contraband/lusty_xenomorph{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
+/obj/machinery/light/directional/north,
+/obj/machinery/shower/directional/south,
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "iut" = (
 /turf/open/floor/wood/parquet,
 /area/station/medical/medbay/central)
-"iuC" = (
-/obj/machinery/door/airlock{
-	name = "Bedroom"
-	},
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
-/area/station/commons/dorms)
 "iuY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -15554,8 +15565,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning,
+/obj/effect/turf_decal/trimline/dark_blue/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -15596,9 +15607,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
-"iAq" = (
-/turf/closed/wall/r_wall,
-/area/station/service/abandoned_gambling_den/gaming)
 "iAr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15725,12 +15733,27 @@
 "iFe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
+"iFq" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/dorms)
 "iFB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -16150,7 +16173,11 @@
 /area/station/tcommsat/server)
 "iPh" = (
 /obj/structure/cable,
-/turf/closed/wall,
+/obj/machinery/door/airlock{
+	name = "Bedroom"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/eighties,
 /area/station/service/abandoned_gambling_den/gaming)
 "iPl" = (
 /obj/effect/turf_decal/trimline/red/filled/warning,
@@ -16219,6 +16246,13 @@
 /obj/effect/base_turf_modifier/pit,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
+"iRs" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "iRw" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/trunk{
@@ -16246,7 +16280,8 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
 /obj/machinery/door/airlock/public/glass{
-	name = "Reception"
+	name = "Reception";
+	id_tag = "Recept1"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/machinery/door/firedoor/border_only,
@@ -16321,11 +16356,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "iVc" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/clown/double,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/eighties,
-/area/station/service/abandoned_gambling_den/gaming)
+/obj/structure/dresser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "iVp" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/disposalpipe/segment{
@@ -16653,18 +16687,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/central)
-"jft" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/arcade/orion_trail{
-	desc = "For gamers only. Casuals need not apply.";
-	icon_screen = "library";
-	icon_state = "oldcomp";
-	name = "Gamer Computer";
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
 "jfu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -17064,17 +17086,6 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
-"jpW" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "jpZ" = (
 /obj/machinery/computer/security{
 	dir = 8
@@ -17136,18 +17147,6 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
-"jsP" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "jsU" = (
 /obj/structure/displaycase/captain{
 	pixel_y = 5
@@ -17566,6 +17565,10 @@
 	dir = 1
 	},
 /area/station/science/lab)
+"jEf" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "jEi" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -17609,10 +17612,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "jFx" = (
@@ -17681,6 +17684,18 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
+"jHZ" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "Dorm3";
+	name = "Dormitory Door Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "jIt" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -17858,6 +17873,17 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/theatre)
+"jMk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "jME" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/structure/crate_loot,
@@ -18137,6 +18163,10 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/storage)
+"jTS" = (
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "jTU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -18541,13 +18571,6 @@
 /obj/machinery/meter,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
-"keu" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#009dc4";
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/service/hydroponics/garden)
 "keB" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/ai/directional/west,
@@ -18636,6 +18659,13 @@
 /obj/machinery/light/no_nightlight/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
+"kgu" = (
+/obj/machinery/door/window/brigdoor{
+	name = "Toilet";
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/abandoned_gambling_den/gaming)
 "kgA" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants/random,
@@ -18680,8 +18710,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/turf_decal/trimline/neutral/line{
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning,
+/obj/effect/turf_decal/trimline/dark_blue/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -19049,11 +19079,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "ksj" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
+/turf/open/floor/wood,
 /area/station/commons/dorms)
 "ksq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -19277,19 +19303,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"kys" = (
-/obj/machinery/duct/industrial/waste,
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "kyM" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -19584,6 +19597,12 @@
 /area/station/service/theater)
 "kGj" = (
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/machinery/button/door/directional/east{
+	id = "service_reception_priv";
+	name = "Privacy control";
+	pixel_y = 11;
+	pixel_x = 22
+	},
 /turf/open/floor/carpet/executive,
 /area/station/commons/vacant_room/commissary)
 "kGz" = (
@@ -19663,8 +19682,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "kIu" = (
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "kIM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19951,12 +19972,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
-"kOE" = (
-/obj/machinery/door/airlock/bathroom{
-	name = "Showers"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
 "kOH" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -19993,17 +20008,19 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/cmo)
 "kOZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
+/obj/structure/toilet{
+	dir = 4;
+	pixel_y = 7
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
+/obj/structure/sink/directional/north,
+/obj/structure/mirror{
+	pixel_y = -28
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/obj/machinery/light/small/directional/south{
+	pixel_x = 11
+	},
+/turf/open/floor/iron/freezer,
+/area/station/commons/dorms)
 "kPd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20278,10 +20295,12 @@
 "kVT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 6
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 6;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -20290,12 +20309,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
-"kWb" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "kWz" = (
 /obj/machinery/camera/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -20784,14 +20797,17 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "lln" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
-/obj/effect/turf_decal/trimline/neutral/warning{
-	dir = 1
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central)
 "llt" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -20799,11 +20815,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 4;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -20815,10 +20832,11 @@
 	pixel_y = 8
 	},
 /obj/item/key/security,
-/obj/item/key/security,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
 	},
+/obj/item/storage/medkit,
+/obj/item/key/security,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "llX" = (
@@ -20915,6 +20933,11 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"lpr" = (
+/obj/effect/spawner/random/trash,
+/obj/vehicle/ridden/secway,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "lpu" = (
 /obj/effect/spawner/random/trash,
 /obj/structure/cable,
@@ -20999,6 +21022,14 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/command/bridge)
+"lsz" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/clown/double,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "lsW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -21315,11 +21346,13 @@
 "lAh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -21692,6 +21725,10 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"lIX" = (
+/obj/vehicle/ridden/secway,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "lJE" = (
 /obj/structure/table/glass/plasmaglass,
 /obj/item/electronics/airlock,
@@ -21724,6 +21761,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"lKw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "lKD" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -21751,16 +21798,20 @@
 "lLz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 10;
-	color = "#009dc4"
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 10
 	},
-/obj/effect/turf_decal/trimline/white/corner{
-	color = "#009dc4";
+/obj/effect/turf_decal/trimline/green/corner{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"lLC" = (
+/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/shower/directional/north,
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "lLE" = (
 /obj/structure/sink/directional/east,
 /turf/open/floor/iron/showroomfloor,
@@ -22105,6 +22156,17 @@
 /obj/machinery/modular_computer/console/preset/id,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
+"lVw" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "lVC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22266,15 +22328,15 @@
 /area/station/medical/surgery/aft)
 "mbz" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	id = "service_reception_shutters";
-	name = "Reception Shutters"
-	},
 /obj/structure/desk_bell{
 	pixel_x = -7
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Reception Shutters";
+	id = "service_reception_shutters"
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
@@ -22385,11 +22447,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/commons/storage/emergency/starboard)
-"mhD" = (
-/obj/effect/spawner/random/trash,
-/obj/vehicle/ridden/secway,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "mhX" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -22400,13 +22457,10 @@
 "mhY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4"
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 1;
-	color = "#009dc4"
-	},
+/obj/effect/turf_decal/trimline/blue/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "miu" = (
@@ -22533,14 +22587,19 @@
 	},
 /turf/open/floor/plating/ocean,
 /area/station/cargo/storage)
-"mma" = (
-/obj/structure/dresser,
-/obj/machinery/light/directional/north,
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
+"mmN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
 	},
-/area/station/commons/dorms)
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "mne" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22668,6 +22727,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/storage/primary)
+"mpo" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "mqy" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 9
@@ -22740,6 +22810,15 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/purple/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"msj" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/station/commons/dorms)
+"mst" = (
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "msv" = (
 /obj/structure/fans/tiny/forcefield,
 /obj/machinery/door/poddoor/shutters{
@@ -22913,6 +22992,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
+"mwl" = (
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/service/hydroponics/garden)
 "mwr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23106,10 +23192,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"mEX" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark/textured,
-/area/station/cargo/storage)
 "mFh" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -23411,10 +23493,12 @@
 /area/station/medical/storage)
 "mMM" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 5
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 5;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -23534,11 +23618,13 @@
 "mRf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 10;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 10
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -23816,11 +23902,13 @@
 /turf/open/floor/plating,
 /area/station/service/hydroponics)
 "mXx" = (
-/obj/effect/turf_decal/trimline/neutral/corner{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 10;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 10
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -23844,6 +23932,9 @@
 	},
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar)
+"mXH" = (
+/turf/closed/wall/r_wall,
+/area/station/service/abandoned_gambling_den/gaming)
 "mYo" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/blue/diagonal_centre,
@@ -24927,17 +25018,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
-"nAk" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "nAn" = (
 /mob/living/carbon/human/species/monkey,
 /obj/machinery/door/window/right/directional/south{
@@ -25571,11 +25651,13 @@
 	},
 /area/station/engineering/main)
 "nUk" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -25663,17 +25745,6 @@
 "nWK" = (
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
-"nWL" = (
-/obj/structure/toilet/secret{
-	dir = 4
-	},
-/obj/item/bikehorn/rubberducky{
-	pixel_x = -9;
-	pixel_y = 12;
-	name = "The Watcher"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
 "nXd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -25732,11 +25803,6 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"nZl" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/eighties,
-/area/station/service/abandoned_gambling_den/gaming)
 "nZx" = (
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron/dark,
@@ -25812,6 +25878,9 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"ocx" = (
+/turf/open/floor/circuit/telecomms/server,
+/area/station/science/server)
 "ocM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -26151,10 +26220,12 @@
 /area/station/medical/virology)
 "okT" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -26202,6 +26273,19 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/chapel)
+"oms" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "omy" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -26447,6 +26531,9 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/iron,
 /area/mine/storage/public)
+"orK" = (
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "orQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -26530,10 +26617,12 @@
 /area/station/hallway/primary/aft)
 "oub" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 10
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 10;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
@@ -26711,16 +26800,18 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "oyo" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4";
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/aft)
 "oyB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -26843,6 +26934,13 @@
 "oBr" = (
 /turf/closed/wall,
 /area/station/service/lawoffice)
+"oBw" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "oBz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26953,6 +27051,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"oFT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "oGC" = (
 /obj/effect/base_turf_modifier/pit,
 /turf/closed/wall/r_wall/rust,
@@ -26997,13 +27104,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 10;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
-	dir = 4
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -27046,19 +27152,6 @@
 /obj/effect/turf_decal/tile/blue/diagonal_centre,
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/medbay/lobby)
-"oID" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "oII" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/white/filled/warning{
@@ -27153,15 +27246,6 @@
 /obj/item/storage/secure/safe/caps_spare/directional/west,
 /turf/open/floor/carpet/executive,
 /area/station/command/bridge)
-"oMU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "oNt" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/executive,
@@ -27257,6 +27341,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"oQr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "oRe" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor/auto,
@@ -27446,8 +27542,20 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
+/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/storage/emergency/starboard)
+"oWd" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "oWq" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /obj/machinery/door/poddoor/shutters/window/preopen{
@@ -27553,10 +27661,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
-"oYP" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "oZR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -27853,10 +27957,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
-"pis" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/dorms)
 "piv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28356,15 +28456,26 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/kitchen/kitchen_backroom)
+"pvE" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central/fore)
 "pwa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
-"pww" = (
-/turf/open/floor/carpet/red,
-/area/station/security/office)
+"pwH" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "pwU" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/stripes/line{
@@ -28450,11 +28561,6 @@
 /obj/structure/disposalpipe/junction/yjunction,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/primary/central)
-"pBs" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/patriot/double,
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
 "pBO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -28719,6 +28825,19 @@
 /obj/structure/showcase/machinery/tv,
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation/entertainment)
+"pHM" = (
+/obj/machinery/duct/industrial/waste,
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "pHU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28824,10 +28943,13 @@
 /area/station/hallway/secondary/service)
 "pJh" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "pJi" = (
@@ -28992,6 +29114,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/security/courtroom)
+"pOa" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "pOc" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -29281,13 +29407,6 @@
 	color = "#999999"
 	},
 /area/station/science/robotics)
-"pVJ" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "pWA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -29393,13 +29512,15 @@
 "pYC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 4
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 4;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "pYG" = (
@@ -29600,6 +29721,19 @@
 	dir = 8
 	},
 /area/station/engineering/break_room)
+"qcn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm1";
+	name = "Cabin 1"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "qco" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -29637,17 +29771,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/office)
-"qdA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/green/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "qdG" = (
 /obj/machinery/duct/industrial/waste,
 /turf/open/floor/plating,
@@ -29679,10 +29802,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "qeK" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "qeN" = (
@@ -29841,11 +29964,14 @@
 "qjb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "qjI" = (
@@ -29864,6 +29990,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"qkl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "qkz" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/wood,
@@ -29931,10 +30069,13 @@
 /area/station/command/heads_quarters/captain/private)
 "qmM" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/green/warning,
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "qmR" = (
@@ -30374,6 +30515,18 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/science/robotics/lab)
+"qxA" = (
+/obj/machinery/duct/industrial/waste,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central/fore)
 "qxC" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
@@ -30582,10 +30735,10 @@
 	name = "Central Access"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning,
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "qFt" = (
@@ -30855,18 +31008,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/commons/fitness/recreation/entertainment)
-"qMo" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/machinery/button/door/directional/west{
-	id = "Dorm3";
-	name = "Dormitory Door Lock";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/turf/open/floor/wood,
-/area/station/commons/dorms)
 "qMB" = (
 /obj/structure/bed,
 /obj/item/bedsheet,
@@ -31327,6 +31468,13 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
+/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/storage/emergency/starboard)
 "qYD" = (
@@ -31563,18 +31711,6 @@
 	dir = 4
 	},
 /area/station/security/office)
-"rfU" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#009dc4";
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#009dc4";
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
 "rfV" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -31589,11 +31725,13 @@
 /area/station/engineering/atmos)
 "rgW" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -31848,9 +31986,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "rmF" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "rmK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/corner{
@@ -31896,7 +32039,9 @@
 /turf/open/floor/plating/ocean,
 /area/ocean)
 "rnM" = (
-/turf/open/floor/wood,
+/obj/structure/bed/double,
+/obj/item/bedsheet/patriot/double,
+/turf/open/floor/carpet/orange,
 /area/station/commons/dorms)
 "rob" = (
 /obj/effect/landmark/start/assistant,
@@ -32052,6 +32197,9 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/security/checkpoint/customs)
+"rsJ" = (
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "rsL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -32369,6 +32517,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"rBs" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "rBv" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -32984,6 +33139,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room)
+"rRs" = (
+/obj/machinery/door/airlock{
+	name = "Bedroom"
+	},
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "rRy" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33711,6 +33872,18 @@
 	},
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
+"sqv" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/vacant_room)
 "sqw" = (
 /obj/machinery/computer/records/security{
 	dir = 1
@@ -33852,6 +34025,19 @@
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"suu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "suv" = (
 /obj/effect/base_turf_modifier/pit,
 /turf/closed/wall,
@@ -34059,6 +34245,19 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"szY" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
+/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
+/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
+/obj/item/reagent_containers/cup/soda_cans/pwr_game,
+/obj/item/reagent_containers/cup/soda_cans/pwr_game,
+/obj/item/reagent_containers/cup/soda_cans/pwr_game,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "sAw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -34186,6 +34385,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
+"sDi" = (
+/obj/structure/dresser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "sDA" = (
 /obj/effect/turf_decal/trimline/white/filled/warning{
 	dir = 8;
@@ -34275,12 +34482,6 @@
 /obj/item/hand_tele,
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/captain/private)
-"sFJ" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/dorms)
 "sFK" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -34771,11 +34972,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -35023,6 +35226,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"tcA" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "tde" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35092,9 +35300,12 @@
 /turf/open/floor/engine,
 /area/station/security/office)
 "tfe" = (
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -35623,8 +35834,11 @@
 /area/station/security/warden)
 "txw" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -35951,6 +36165,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/lobby)
+"tGL" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = -32
+	},
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "tGQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -36096,11 +36321,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"tJw" = (
-/obj/structure/dresser,
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
 "tJx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -36424,9 +36644,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/storage)
-"tSM" = (
-/turf/open/floor/circuit/telecomms/server,
-/area/station/science/server)
 "tSW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36576,13 +36793,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "tWp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
+/obj/structure/cable,
+/turf/closed/wall,
+/area/station/service/abandoned_gambling_den/gaming)
 "tWr" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark/textured,
@@ -36626,14 +36839,11 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "tYl" = (
-/obj/structure/chair/sofa/left,
-/obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/obj/structure/sign/poster/contraband/pwr_game{
-	pixel_y = 36
+/obj/effect/turf_decal/trimline/brown/end{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
+/turf/open/floor/iron/dark/textured/airless,
+/area/station/science/lobby)
 "tYt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -36764,26 +36974,13 @@
 "ubI" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
 	dir = 4
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
-"ubL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
 	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -36910,7 +37107,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "uea" = (
-/obj/machinery/light/directional/north,
+/obj/machinery/light/no_nightlight/directional/north,
 /obj/structure/table/reinforced,
 /obj/machinery/button/door/directional/east{
 	id = "service_reception_shutters";
@@ -37171,14 +37368,11 @@
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "umh" = (
-/obj/effect/turf_decal/trimline/brown/warning{
-	dir = 8
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
 	},
-/obj/effect/turf_decal/trimline/brown/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured/airless,
-/area/station/science/lobby)
+/area/station/commons/dorms)
 "umt" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Office Maintenance"
@@ -37256,10 +37450,12 @@
 /area/station/ai_monitored/security/armory)
 "unH" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 5
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 5;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -37416,18 +37612,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/mid_joiner,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/server)
-"usO" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/machinery/button/door/directional/west{
-	id = "Dorm1";
-	name = "Dormitory Door Lock";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
 "ute" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -37786,16 +37970,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/command/bridge)
 "uEb" = (
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
-	color = "#009dc4"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8;
-	color = "#009dc4"
-	},
+/obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/dark/textured,
-/area/station/commons/dorms)
+/area/station/hallway/primary/central)
 "uEz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37867,10 +38049,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/genetics,
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
-"uGq" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/red,
-/area/station/security/office)
 "uGB" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -38295,10 +38473,9 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
-	dir = 8
+	dir = 9
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
+/obj/effect/turf_decal/trimline/white/corner{
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
@@ -38869,6 +39046,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/command/bridge)
+"vhy" = (
+/obj/structure/dresser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "vhM" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
@@ -38995,15 +39177,6 @@
 /mob/living/basic/chicken,
 /turf/open/misc/sandy_dirt,
 /area/station/service/hydroponics/upper)
-"vkb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "vkl" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 8
@@ -39227,6 +39400,13 @@
 	},
 /turf/open/floor/iron/sepia,
 /area/station/commons/fitness/recreation)
+"vqR" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "vrg" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
@@ -39376,6 +39556,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/storage/emergency/starboard)
 "vvj" = (
@@ -39486,10 +39669,10 @@
 "vyz" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "vyU" = (
@@ -39688,17 +39871,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"vFf" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm2";
-	name = "Cabin 2"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/station/commons/dorms)
 "vFg" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 6
@@ -39762,6 +39934,17 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/storage/primary)
+"vHR" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "vHZ" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor/auto{
@@ -39790,11 +39973,13 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "vJm" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 10
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 10;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -39881,12 +40066,12 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
 "vMl" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/green/line{
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/lounge)
 "vMy" = (
 /turf/open/floor/iron/stairs,
 /area/station/service/chapel)
@@ -40292,11 +40477,14 @@
 /area/station/security/courtroom)
 "vYQ" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/warning,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "vYR" = (
@@ -40515,6 +40703,18 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
+"wfb" = (
+/obj/structure/cable,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "wfc" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/firealarm/directional/west,
@@ -40649,6 +40849,15 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
+"wjh" = (
+/obj/structure/chair/sofa/left,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/structure/sign/poster/contraband/pwr_game{
+	pixel_y = 36
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "wjK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40767,10 +40976,10 @@
 	name = "Central Access"
 	},
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning,
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "wny" = (
@@ -40795,6 +41004,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Reception Shutters";
+	id = "service_reception_priv"
+	},
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/commissary)
 "woW" = (
@@ -40813,6 +41026,16 @@
 /obj/machinery/ticket_machine/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"wpT" = (
+/obj/structure/curtain/cloth,
+/obj/structure/drain,
+/obj/machinery/shower/directional/north,
+/obj/machinery/door/window/brigdoor{
+	name = "Shower";
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/station/commons/dorms)
 "wqs" = (
 /turf/open/floor/holofloor/beach/water,
 /area/station/maintenance/starboard/aft)
@@ -40828,6 +41051,19 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
+"wqJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "wqL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -41066,10 +41302,13 @@
 "wws" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/line,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "wwy" = (
@@ -41151,12 +41390,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"wyZ" = (
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
-/area/station/commons/dorms)
 "wzb" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible/layer2{
@@ -41497,13 +41730,15 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/upper)
 "wJB" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/filled/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 10;
 	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 1;
-	color = "#009dc4"
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -41514,13 +41749,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"wJP" = (
-/obj/machinery/door/window/brigdoor{
-	name = "Toilet";
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/station/service/abandoned_gambling_den/gaming)
 "wJR" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 5
@@ -41531,20 +41759,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "wJX" = (
-/obj/machinery/camera/autoname/directional/south,
-/obj/machinery/shower/directional/north,
-/obj/structure/drain,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
-"wKb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line,
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/obj/structure/chair/sofa/right,
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "wKB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -42094,11 +42312,14 @@
 "wZN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
-	},
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "wZR" = (
@@ -42283,6 +42504,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/science/robotics/mechbay)
+"xeu" = (
+/obj/machinery/suit_storage_unit/security,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "xev" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/chair/sofa/left{
@@ -42323,10 +42548,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 5
 	},
-/obj/effect/turf_decal/trimline/brown/line{
+/obj/effect/turf_decal/trimline/brown/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -42396,19 +42621,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/science/genetics)
-"xiH" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
-/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
-/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
-/obj/item/reagent_containers/cup/soda_cans/pwr_game,
-/obj/item/reagent_containers/cup/soda_cans/pwr_game,
-/obj/item/reagent_containers/cup/soda_cans/pwr_game,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
 "xiT" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
@@ -42426,16 +42638,11 @@
 /turf/open/floor/iron,
 /area/mine/storage/public)
 "xjU" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4";
-	dir = 1
+/obj/structure/chair/wood{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "xjX" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/closet/secure_closet/chemical,
@@ -42630,17 +42837,24 @@
 /obj/effect/base_turf_modifier/pit,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
+"xpB" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/dorms)
 "xpZ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Departure Lounge"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -42737,10 +42951,12 @@
 "xst" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 5
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 5;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
@@ -42844,10 +43060,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"xue" = (
-/obj/vehicle/ridden/secway,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "xur" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42956,6 +43168,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"xwl" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "xwm" = (
 /turf/closed/wall,
 /area/station/commons/fitness/recreation)
@@ -43133,6 +43350,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Reception Shutters";
+	id = "service_reception_priv"
+	},
 /turf/open/floor/plating,
 /area/station/commons/vacant_room/commissary)
 "xCp" = (
@@ -43227,12 +43448,12 @@
 /area/station/cargo/sorting)
 "xEK" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/window/preopen{
-	id = "service_reception_shutters";
-	name = "Reception Shutters"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Reception Shutters";
+	id = "service_reception_shutters"
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
@@ -43548,18 +43769,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"xOB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
+"xOI" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/commons/lounge)
 "xOR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 10
@@ -43867,14 +44083,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
-"xWA" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/clown/double,
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
-/area/station/commons/dorms)
 "xWF" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Station Reception"
@@ -44045,6 +44253,17 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
+"ybQ" = (
+/obj/structure/toilet/secret{
+	dir = 4
+	},
+/obj/item/bikehorn/rubberducky{
+	pixel_x = -9;
+	pixel_y = 12;
+	name = "The Watcher"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "yca" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -44140,9 +44359,12 @@
 "yew" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -58888,11 +59110,11 @@ lUz
 lUz
 lUz
 lUz
-iAq
-iAq
-iAq
-iAq
-iAq
+mXH
+mXH
+mXH
+mXH
+mXH
 kJb
 kJb
 rdt
@@ -59138,17 +59360,17 @@ fdQ
 weo
 uSV
 lUz
-rmF
+pwH
 nxP
-dJu
+kOZ
 qZZ
-ksj
+oBw
 piw
-dJu
+kOZ
 fue
-nZl
-eQp
-iaH
+gCF
+gau
+hVa
 fue
 uRZ
 kwc
@@ -59395,20 +59617,20 @@ vwP
 vwP
 vwP
 lUz
-tJw
+iVc
 nxP
-cRy
+wpT
 vwP
-mma
+sDi
 piw
-cRy
+wpT
 fue
-fjN
-eQp
-wJP
+vhy
+gau
+kgu
 fue
-kwp
-vMl
+wfb
+rBs
 rdt
 cda
 jLV
@@ -59650,22 +59872,22 @@ uSV
 vwP
 vwP
 bmW
-nWL
+ybQ
 lUz
-pBs
-fFE
-fFE
+rnM
+bRQ
+bRQ
 vwP
-xWA
-wyZ
-wyZ
+lsz
+umh
+umh
 fue
-iVc
-heS
+bOl
+mst
 wMb
 fue
-rfc
-vMl
+jMk
+rBs
 nPn
 epv
 iDn
@@ -59910,18 +60132,18 @@ bmW
 fvS
 vwP
 vwP
-fgt
+rRs
 vwP
 vwP
 vwP
-iuC
+fua
 vwP
+tWp
+tWp
 iPh
-iPh
-eAK
-iPh
-iPh
-rfc
+tWp
+tWp
+jMk
 gtk
 rdt
 vaZ
@@ -60166,20 +60388,20 @@ bmW
 bmW
 uRq
 vwP
-fQY
-rnM
-qMo
+fja
+ksj
+jHZ
 vwP
-fQY
-rnM
+fja
+ksj
 sBe
-iPh
-iul
+tWp
+tGL
 amz
-usO
+bAj
 fue
-rfc
-vMl
+jMk
+rBs
 rdt
 nKi
 kJF
@@ -60424,19 +60646,19 @@ miY
 vwP
 vwP
 jCa
-rnM
+ksj
 lWJ
 vwP
 jCa
-rnM
+ksj
 lWJ
-iPh
-fze
+tWp
+wJX
 aWp
-jft
+cpG
 fue
-kwp
-vMl
+wfb
+rBs
 rdt
 rdt
 rdt
@@ -60676,25 +60898,25 @@ xHH
 wop
 weo
 vwP
-aMJ
+drw
 bmW
-gCN
+hWg
 vwP
 pZJ
-rnM
-bOL
+ksj
+xjU
 vwP
 pZJ
-rnM
-bOL
-iPh
-tYl
-bnm
-xiH
+ksj
+xjU
+tWp
+wjh
+kIu
+szY
 fue
 oHD
 vTm
-qdA
+lLz
 mnS
 lVC
 lrZ
@@ -60705,13 +60927,13 @@ hMM
 nvl
 nvl
 tKO
-dls
-dls
-dls
-dls
-dls
-dls
-lLz
+oms
+oms
+oms
+oms
+oms
+oms
+wJB
 tJW
 gun
 lrZ
@@ -60933,23 +61155,23 @@ xHH
 wop
 pVn
 vwP
-aDS
+iul
 bmW
-wJX
+lLC
 vwP
 vwP
 nKk
 vwP
 vwP
 vwP
-vFf
+apa
 vwP
 fue
 fue
-cFt
+qcn
 fue
 fue
-kOZ
+gAV
 rKc
 pIW
 lQS
@@ -61018,9 +61240,9 @@ vUV
 lwj
 byv
 fKI
-mEX
+pOa
 nyQ
-ids
+gCN
 wAI
 mLC
 dqy
@@ -61193,38 +61415,38 @@ wri
 bmW
 bmW
 bmW
-kOE
+eRn
 xmS
 sDA
 sxq
-uEb
-uEb
-sDA
-uEb
-uEb
-uEb
 beP
+beP
+sDA
+beP
+beP
+beP
+iFq
 wAH
 uGB
 vSI
 bBP
-oyo
+mpo
 kBt
 oQa
 dpV
-bfA
+pHM
 dpV
 dpV
 dpV
 dpV
-kys
+ubI
 dpV
 rtP
-jsP
-jsP
-jsP
-jsP
-ubI
+lln
+lln
+lln
+lln
+iji
 cUp
 nIO
 kfX
@@ -61459,13 +61681,13 @@ kZH
 kZH
 kZH
 sga
-pis
-sFJ
+cot
+xpB
 wBl
-gSX
+msj
 fDR
 qkH
-wJB
+bkB
 xwm
 xwm
 xwm
@@ -61722,7 +61944,7 @@ bec
 uGB
 vSI
 tYL
-wJB
+bkB
 xwm
 auY
 dcF
@@ -61977,9 +62199,9 @@ ort
 nGD
 nGD
 nGD
-ubL
+wqJ
 rfc
-wJB
+bkB
 xwm
 oas
 agP
@@ -62044,8 +62266,8 @@ jfI
 tNT
 qhS
 eDo
-bkB
 xgr
+oyo
 imV
 kJB
 mkz
@@ -62230,7 +62452,7 @@ uzZ
 ceK
 pyU
 dtb
-rfU
+sqv
 uFU
 nGD
 eso
@@ -62265,13 +62487,13 @@ nyD
 cCg
 qbR
 pAj
-tWp
+iah
 tRg
 hrr
 hrr
 hrr
 hrr
-tWp
+iah
 tzl
 eco
 xUj
@@ -62490,10 +62712,10 @@ mHp
 sJd
 jeZ
 nGD
-xOB
+qkl
 rfc
 kwp
-wJB
+bkB
 xwm
 qeN
 oas
@@ -62521,17 +62743,17 @@ rfc
 wDZ
 jgV
 pHV
-nAk
-pVJ
+qEO
+iRs
 kAd
 bTn
 auj
 bTn
 bTn
-eQO
-eZT
-qEO
-qmM
+xOI
+xwl
+vHR
+oWd
 sTn
 sTn
 sTn
@@ -62542,7 +62764,7 @@ sTn
 sTn
 ltK
 qJW
-hLc
+qmM
 hzM
 sTn
 ngm
@@ -62556,7 +62778,7 @@ hzM
 sTn
 nTa
 gUe
-eVE
+lKw
 qaa
 uNE
 lap
@@ -62565,7 +62787,7 @@ kBn
 mue
 qaa
 cov
-keu
+mwl
 oII
 qIf
 bZJ
@@ -62747,7 +62969,7 @@ shX
 tTb
 iWI
 nGD
-fZv
+mmN
 rfc
 lNF
 mQx
@@ -62778,16 +63000,16 @@ bMn
 kkW
 lca
 nDl
-wmV
-cfp
+lVw
+vqR
 gDA
 pXi
 hwW
 pXi
 pXi
-fpL
-gjB
-jpW
+vMl
+tcA
+wmV
 jEi
 eLS
 eLS
@@ -62813,7 +63035,7 @@ sJj
 iaP
 gxe
 ngm
-vkb
+rmF
 qaa
 uDo
 bcQ
@@ -63004,9 +63226,9 @@ rQX
 kgA
 svS
 nGD
-ubL
+wqJ
 rfc
-wJB
+bkB
 fue
 fue
 fue
@@ -63043,7 +63265,7 @@ hrr
 xVm
 xVm
 fRb
-kWb
+cbD
 yhH
 qNW
 vkw
@@ -63070,7 +63292,7 @@ twN
 twN
 jfI
 ngm
-vkb
+rmF
 qaa
 mtV
 afN
@@ -63261,9 +63483,9 @@ nGD
 nGD
 nGD
 nGD
-xOB
+qkl
 kwp
-wJB
+bkB
 fue
 qet
 gMt
@@ -63327,7 +63549,7 @@ lYm
 twN
 jfI
 gtt
-vkb
+rmF
 qaa
 qry
 jJI
@@ -63520,7 +63742,7 @@ uRG
 ewl
 lhq
 rfc
-wJB
+bkB
 ljv
 ewL
 gMt
@@ -63584,7 +63806,7 @@ xmK
 twN
 jfI
 ngm
-vkb
+rmF
 qaa
 uAo
 dYT
@@ -63775,9 +63997,9 @@ lHt
 jSp
 lHt
 yke
-kOZ
+gAV
 tYL
-oyo
+mpo
 ilm
 kOf
 kOf
@@ -63841,7 +64063,7 @@ cLN
 twN
 jfI
 ngm
-vkb
+rmF
 qaa
 weQ
 uVd
@@ -64032,7 +64254,7 @@ wlx
 gIZ
 nVx
 ukf
-kOZ
+gAV
 rfc
 mWr
 nMK
@@ -64289,9 +64511,9 @@ lHt
 jSp
 lHt
 yke
-kOZ
+gAV
 kwp
-wJB
+bkB
 ljv
 aTw
 uth
@@ -64546,9 +64768,9 @@ wlx
 gIZ
 wlx
 nMG
-mhY
+oQr
 rfc
-wJB
+bkB
 fue
 qet
 ewL
@@ -64803,9 +65025,9 @@ gIZ
 jSp
 oUo
 nLV
-kOZ
+gAV
 rfc
-wJB
+bkB
 fue
 fue
 fue
@@ -65060,9 +65282,9 @@ wlx
 lHt
 wlx
 nLV
-kOZ
+gAV
 rfc
-wJB
+bkB
 pkw
 dMh
 vhM
@@ -65317,9 +65539,9 @@ lHt
 eBe
 pse
 nLV
-kOZ
+gAV
 kwp
-wJB
+bkB
 ahh
 adv
 adv
@@ -65574,9 +65796,9 @@ wlx
 ecM
 eBe
 nLV
-bOl
+fZv
 rfc
-xjU
+akJ
 wZC
 adv
 adv
@@ -65831,9 +66053,9 @@ lHt
 wlx
 lHt
 nLV
-oID
+suu
 rfc
-wJB
+bkB
 ahh
 adv
 amw
@@ -66088,9 +66310,9 @@ bIJ
 lHt
 rOB
 nLV
-kOZ
+gAV
 rfc
-wJB
+bkB
 pkw
 xji
 tRB
@@ -66345,9 +66567,9 @@ nLV
 nLV
 nLV
 nLV
-kOZ
+gAV
 rfc
-wJB
+bkB
 pkw
 pkw
 orx
@@ -66604,7 +66826,7 @@ fgS
 gGL
 vSI
 kwp
-wJB
+bkB
 pkw
 gyj
 pqf
@@ -66859,9 +67081,9 @@ tXC
 tXC
 tXC
 tXC
-wKb
+uEb
 rfc
-wJB
+bkB
 pkw
 xji
 tRB
@@ -67116,9 +67338,9 @@ uUY
 eGO
 hHy
 tXC
-oMU
+oFT
 tYL
-wJB
+bkB
 pkw
 adv
 tRB
@@ -67373,7 +67595,7 @@ sRK
 tme
 keD
 mMl
-gAV
+mhY
 veZ
 oij
 lxM
@@ -67632,7 +67854,7 @@ tXC
 tXC
 faF
 cbq
-wJB
+bkB
 pkw
 adv
 bJU
@@ -67887,9 +68109,9 @@ ftA
 uPO
 bhD
 rXT
-wKb
+uEb
 wDZ
-wJB
+bkB
 ahh
 uYW
 cPJ
@@ -67960,11 +68182,11 @@ rrB
 rrB
 rrB
 rrB
-mhD
-oYP
-gau
-gau
-kIu
+lpr
+jEf
+xeu
+xeu
+orK
 udB
 llX
 kkp
@@ -68144,9 +68366,9 @@ gyG
 iip
 qza
 aES
-gAV
+mhY
 wDZ
-wJB
+bkB
 pkw
 pkw
 pkw
@@ -68217,11 +68439,11 @@ lKN
 ydD
 ofT
 rrB
-xue
-kIu
-kIu
-kIu
-kIu
+lIX
+orK
+orK
+orK
+orK
 okD
 gvZ
 uPB
@@ -68401,9 +68623,9 @@ qHJ
 nya
 tfm
 rIM
-gAV
+mhY
 wDZ
-wJB
+bkB
 tYA
 nwZ
 iEa
@@ -68658,9 +68880,9 @@ iVp
 tfm
 qza
 vAD
-wKb
+uEb
 cbq
-wJB
+bkB
 tYA
 iEa
 pKF
@@ -73875,9 +74097,9 @@ upz
 trt
 ehb
 naf
-fCa
+fjP
 voj
-uGq
+jTS
 rhn
 wCS
 rMy
@@ -74133,7 +74355,7 @@ aus
 eJj
 wfC
 oUp
-pww
+rsJ
 xRW
 vWE
 ajQ
@@ -75667,7 +75889,7 @@ lkF
 nbU
 fXB
 gPZ
-cJz
+hPG
 gPZ
 gPZ
 onf
@@ -78231,7 +78453,7 @@ xpc
 pkw
 pkw
 qRJ
-txw
+dls
 ydb
 iFe
 gqY
@@ -78488,7 +78710,7 @@ kAb
 kAb
 voJ
 qRJ
-eGV
+qxA
 ydb
 iFe
 gqY
@@ -78745,7 +78967,7 @@ rUJ
 eKC
 hmK
 qRJ
-txw
+dls
 vPp
 iFe
 gqY
@@ -79002,7 +79224,7 @@ pOm
 kAb
 voJ
 qRJ
-txw
+dls
 ydb
 iFe
 gZg
@@ -79259,7 +79481,7 @@ hUM
 oiP
 qRJ
 qRJ
-txw
+dls
 ydb
 iFe
 gZg
@@ -80474,7 +80696,7 @@ fgS
 rdb
 wdA
 wdA
-tSM
+ocx
 vPb
 bYP
 wvm
@@ -81314,7 +81536,7 @@ okT
 gSr
 okT
 rgW
-gzE
+eQp
 tKo
 ryL
 ixB
@@ -81502,7 +81724,7 @@ nRM
 gzZ
 wdA
 wdA
-tSM
+ocx
 vPb
 mrJ
 gIk
@@ -81831,7 +82053,7 @@ dLe
 dLe
 dLe
 dBk
-lln
+rhw
 uKT
 pFe
 fHe
@@ -82073,10 +82295,10 @@ aWQ
 xHL
 lXn
 dck
-rgW
+pvE
 oub
 cri
-gPk
+hip
 tKo
 tKo
 lul
@@ -84088,9 +84310,9 @@ mne
 cHK
 cHK
 cHK
-ifP
-umh
-umh
+tYl
+aMJ
+aMJ
 mHR
 cmR
 ezI

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -9605,6 +9605,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
+/obj/structure/cable/industrial,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "eXv" = (
@@ -14057,6 +14058,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
 	dir = 8
 	},
+/obj/structure/cable/industrial,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "hvv" = (
@@ -16387,6 +16389,7 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/effect/spawner/random/aimodule/harmful,
 /obj/effect/spawner/random/aimodule/syndicate,
+/obj/item/ai_module/zeroth/coderedmartiallaw,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "iIS" = (
@@ -18508,6 +18511,7 @@
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/industrial,
 /turf/open/floor/glass/reinforced,
 /area/station/engineering/main)
 "jQc" = (
@@ -27331,13 +27335,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"ouV" = (
-/obj/machinery/duct/industrial/waste,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/industrial,
-/turf/open/floor/glass/reinforced,
-/area/station/engineering/main)
 "ovi" = (
 /obj/effect/turf_decal/trimline/blue/filled/end,
 /obj/machinery/disposal/bin,
@@ -36835,7 +36832,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "tCC" = (
@@ -37236,6 +37232,8 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/end{
 	dir = 4
 	},
+/obj/machinery/porta_turret/ai,
+/obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "tLQ" = (
@@ -43129,6 +43127,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/cable/industrial,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "wUi" = (
@@ -85705,7 +85704,7 @@ eRI
 rvE
 pFm
 qRD
-ouV
+jPC
 qRD
 pYh
 nTi

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -394,22 +394,33 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "aiQ" = (
-/obj/structure/rack,
 /obj/item/grenade/barrier{
 	pixel_x = -3;
 	pixel_y = 1
 	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = 3;
-	pixel_y = -1
-	},
-/obj/item/grenade/barrier{
-	pixel_x = 6;
-	pixel_y = -2
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
+	},
+/obj/structure/closet/secure_closet/armory1,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -3;
+	pixel_y = 2
 	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
@@ -691,7 +702,7 @@
 /area/station/security/warden)
 "asq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/carpet/red,
 /area/station/security/office)
 "asA" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -720,7 +731,6 @@
 	},
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
-	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #6";
 	req_access = list("xenobiology")
@@ -2308,7 +2318,8 @@
 	},
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	name = "Prison Lockdown Shutters";
-	id = "prisonshutters"
+	id = "prisonshutters";
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/security/warden)
@@ -4177,7 +4188,7 @@
 	},
 /obj/structure/sign/departments/security,
 /turf/open/floor/plating,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "cmI" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -4709,7 +4720,6 @@
 	icon_state = "pink2_1"
 	},
 /obj/machinery/light/neon_lining{
-	dir = 2;
 	icon_state = "pink2_1"
 	},
 /turf/open/floor/wood,
@@ -5493,7 +5503,6 @@
 /area/station/science/cytology)
 "daT" = (
 /obj/machinery/door/window/left/directional/north{
-	dir = 1;
 	name = "Containment Pen #4";
 	req_access = list("xenobiology")
 	},
@@ -5573,7 +5582,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "ddU" = (
 /obj/machinery/vending/hydronutrients,
 /obj/effect/turf_decal/trimline/green/corner{
@@ -6183,9 +6192,7 @@
 /area/station/hallway/primary/aft)
 "dqA" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 2
-	},
+/obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar)
 "dqB" = (
@@ -7096,7 +7103,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "dSi" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
@@ -7452,7 +7459,7 @@
 "ecF" = (
 /obj/machinery/button/door{
 	desc = "Controls the shutters over the brig windows.";
-	id = "securityshutters";
+	id = "securityshutter";
 	name = "Security Lockdown Button";
 	pixel_x = -21;
 	pixel_y = 9;
@@ -8165,7 +8172,7 @@
 	name = "Brig"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "exF" = (
 /obj/structure/table/wood,
 /obj/item/clipboard{
@@ -8185,7 +8192,6 @@
 	pixel_y = -2
 	},
 /obj/machinery/light/neon_lining{
-	dir = 2;
 	icon_state = "pink2_1"
 	},
 /turf/open/floor/wood,
@@ -8507,7 +8513,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/carpet/red,
 /area/station/security/office)
 "eFQ" = (
 /obj/structure/disposalpipe/segment{
@@ -8595,9 +8601,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 6
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "eHM" = (
@@ -8769,7 +8773,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "eLS" = (
 /obj/machinery/duct/industrial/waste,
 /turf/open/floor/iron/dark/textured,
@@ -8866,6 +8870,7 @@
 	pixel_y = -2;
 	pixel_x = 4
 	},
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "eOu" = (
@@ -8957,7 +8962,6 @@
 	dir = 5
 	},
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -9356,9 +9360,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
 "fbv" = (
-/obj/machinery/computer/records/medical{
-	dir = 2
-	},
+/obj/machinery/computer/records/medical,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
@@ -9549,9 +9551,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "ffQ" = (
-/obj/machinery/computer/records/security{
-	dir = 2
-	},
+/obj/machinery/computer/records/security,
 /obj/machinery/button/door/directional/north{
 	id = "detective_shutters";
 	name = "detective's office shutters control";
@@ -10214,22 +10214,8 @@
 /area/ruin/space/ks13/engineering/secure_storage)
 "fCU" = (
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
-/obj/machinery/door/airlock/security{
-	name = "Security Lounge"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/warning{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -10602,7 +10588,8 @@
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	name = "Court Shutters";
 	id = "courtems";
-	desc = "Oh god fucking damn it someone brought a bomb."
+	desc = "Oh god fucking damn it someone brought a bomb.";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/courtroom)
@@ -10814,7 +10801,6 @@
 /obj/item/computer_disk/quartermaster,
 /obj/item/computer_disk/quartermaster,
 /obj/machinery/light/neon_lining{
-	dir = 2;
 	icon_state = "pink2_1"
 	},
 /turf/open/floor/wood,
@@ -11035,7 +11021,6 @@
 "gaz" = (
 /obj/machinery/door/window/left/directional/north{
 	base_state = "right";
-	dir = 1;
 	icon_state = "right";
 	name = "Containment Pen #6";
 	req_access = list("xenobiology")
@@ -11064,7 +11049,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "gbk" = (
 /obj/structure/table/glass/plasmaglass,
 /obj/item/electronics/tracker,
@@ -11224,8 +11209,11 @@
 /area/station/cargo/miningoffice)
 "geH" = (
 /obj/item/storage/secure/safe/directional/north,
-/obj/vehicle/ridden/secway,
 /obj/machinery/light/small/directional/west,
+/obj/machinery/suit_storage_unit/hos{
+	name = "Warden's suit storage unit";
+	desc = "An industrial unit made to hold and decontaminate irradiated equipment. This one seems to be earmarked for the warden"
+	},
 /turf/open/floor/pod/dark,
 /area/station/security/warden)
 "geU" = (
@@ -11994,7 +11982,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gDK" = (
-/obj/structure/closet/secure_closet/armory3,
 /obj/item/storage/secure/safe/directional/north{
 	name = "armory safe B"
 	},
@@ -12002,6 +11989,16 @@
 	dir = 5
 	},
 /obj/structure/cable,
+/obj/item/grenade/barrier{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/grenade/barrier{
+	pixel_x = 3;
+	pixel_y = -1
+	},
+/obj/item/grenade/barrier,
+/obj/structure/rack,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "gEb" = (
@@ -12296,7 +12293,7 @@
 	},
 /obj/structure/sign/departments/security,
 /turf/open/floor/plating,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "gPk" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
@@ -12700,7 +12697,8 @@
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	name = "Prison Lockdown Shutters";
-	id = "prisonshutters"
+	id = "prisonshutters";
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/security/warden)
@@ -12756,9 +12754,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "hbh" = (
-/obj/machinery/computer/department_orders/service{
-	dir = 2
-	},
+/obj/machinery/computer/department_orders/service,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
@@ -12923,10 +12919,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "hfR" = (
-/obj/structure/weightmachine/stacklifter,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "hgp" = (
@@ -13145,6 +13138,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "hon" = (
@@ -13300,7 +13296,6 @@
 /turf/open/floor/engine,
 /area/station/cargo/miningoffice)
 "htr" = (
-/obj/machinery/porta_turret,
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 9
 	},
@@ -13314,6 +13309,7 @@
 	dir = 9
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/porta_turret/ai,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "htx" = (
@@ -14576,7 +14572,6 @@
 /area/station/engineering/main)
 "idm" = (
 /obj/structure/disposaloutlet{
-	dir = 2;
 	name = "Prisoner Delivery"
 	},
 /obj/structure/disposalpipe/trunk{
@@ -14636,8 +14631,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "ifv" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
@@ -16157,11 +16152,15 @@
 	},
 /obj/machinery/button/door{
 	desc = "Controls the shutters over the brig windows.";
-	id = "securityshutters";
+	id = "securityshutter";
 	name = "Security Lockdown Button";
 	pixel_y = 34;
 	req_access = list("security")
 	},
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/obj/effect/landmark/start/warden,
 /turf/open/floor/wood/large,
 /area/station/security/warden)
 "jbU" = (
@@ -16198,7 +16197,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jcs" = (
-/obj/machinery/porta_turret,
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 9
 	},
@@ -16212,6 +16210,7 @@
 	dir = 9
 	},
 /obj/machinery/light/directional/south,
+/obj/machinery/porta_turret/ai,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "jcw" = (
@@ -16567,9 +16566,7 @@
 /turf/open/floor/engine,
 /area/station/maintenance/port/central)
 "jle" = (
-/obj/machinery/computer/order_console/cook{
-	dir = 2
-	},
+/obj/machinery/computer/order_console/cook,
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
@@ -16810,7 +16807,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "jtJ" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
@@ -18783,7 +18780,6 @@
 /area/station/science/robotics/lab)
 "kvA" = (
 /obj/structure/chair/comfy/carp{
-	pixel_y = 0;
 	dir = 8
 	},
 /obj/structure/cable,
@@ -19043,6 +19039,7 @@
 	},
 /obj/item/storage/backpack/duffelbag/sec,
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "kDh" = (
@@ -19519,18 +19516,11 @@
 /turf/open/floor/eighties/red,
 /area/station/service/abandoned_gambling_den/gaming)
 "kOp" = (
-/obj/structure/rack,
-/obj/item/storage/box/flashes{
-	pixel_x = 3
-	},
-/obj/item/storage/box/teargas{
-	pixel_x = 1;
-	pixel_y = -2
-	},
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
 	},
+/obj/structure/closet/secure_closet/armory3,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "kOt" = (
@@ -19671,7 +19661,8 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	name = "Security Lockdown Shutters";
-	id = "securityshutter"
+	id = "securityshutter";
+	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/door/window/brigdoor{
@@ -21309,9 +21300,8 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "lKN" = (
-/obj/machinery/computer/arcade{
-	dir = 4;
-	pixel_x = -6
+/obj/machinery/computer/arcade/orion_trail{
+	dir = 4
 	},
 /turf/open/floor/pod/dark,
 /area/station/security/warden)
@@ -22089,6 +22079,10 @@
 	},
 /turf/open/floor/plating/ocean,
 /area/station/cargo/storage)
+"mmb" = (
+/obj/machinery/suit_storage_unit/security,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "mne" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22349,9 +22343,7 @@
 	},
 /area/station/engineering/main)
 "mtV" = (
-/obj/machinery/computer/cargo{
-	dir = 2
-	},
+/obj/machinery/computer/cargo,
 /obj/machinery/light/neon_lining{
 	dir = 1;
 	icon_state = "pink2_1"
@@ -22371,7 +22363,6 @@
 	pixel_x = 8
 	},
 /obj/machinery/light/neon_lining{
-	dir = 2;
 	icon_state = "pink2_1"
 	},
 /turf/open/floor/iron/stairs{
@@ -22668,7 +22659,8 @@
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	name = "Court Shutters";
 	id = "courtems";
-	desc = "Oh god fucking damn it someone brought a bomb."
+	desc = "Oh god fucking damn it someone brought a bomb.";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/courtroom)
@@ -22787,7 +22779,8 @@
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	name = "Court Shutters";
 	id = "courtems";
-	desc = "Oh god fucking damn it someone brought a bomb."
+	desc = "Oh god fucking damn it someone brought a bomb.";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/courtroom)
@@ -22900,7 +22893,6 @@
 	dir = 4
 	},
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -23214,9 +23206,6 @@
 	name = "Brig"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23616,7 +23605,7 @@
 	},
 /obj/effect/turf_decal/trimline/red/warning,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "neN" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/disposalpipe/segment{
@@ -23743,6 +23732,14 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
+"nhH" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/security/office)
 "nhJ" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -23958,6 +23955,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/primary/central)
+"nmL" = (
+/obj/vehicle/ridden/secway,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "nnv" = (
 /obj/structure/fireaxecabinet/mechremoval/directional/east,
 /turf/open/floor/noslip{
@@ -24341,7 +24342,8 @@
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	name = "Court Shutters";
 	id = "courtems";
-	desc = "Oh god fucking damn it someone brought a bomb."
+	desc = "Oh god fucking damn it someone brought a bomb.";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/courtroom)
@@ -24729,7 +24731,7 @@
 	},
 /obj/effect/turf_decal/trimline/red/corner,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "nJU" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -24878,7 +24880,6 @@
 	name = "Quartermaster's Fax Machine"
 	},
 /obj/machinery/light/neon_lining{
-	dir = 2;
 	icon_state = "pink2_1"
 	},
 /obj/machinery/firealarm/directional/south,
@@ -25411,8 +25412,11 @@
 "ofT" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/structure/bed/dogbed/mcgriff,
 /mob/living/basic/pet/dog/pug/mcgriff,
+/obj/structure/bed/dogbed{
+	name = "pet bed";
+	desc = "A comfy-looking pet bed. You can even strap your pet in, in case the gravity turns off."
+	},
 /turf/open/floor/pod/dark,
 /area/station/security/warden)
 "ogd" = (
@@ -25824,7 +25828,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "opQ" = (
 /turf/open/misc/sandy_dirt,
 /area/station/service/hydroponics/upper)
@@ -26204,6 +26208,7 @@
 	pixel_y = 13
 	},
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "ozj" = (
@@ -26244,9 +26249,7 @@
 /area/station/maintenance/starboard/aft)
 "ozW" = (
 /obj/machinery/seed_extractor,
-/obj/effect/turf_decal/trimline/green/corner{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/green/corner,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 9
 	},
@@ -26360,6 +26363,10 @@
 /obj/structure/cable/industrial,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"oEi" = (
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "oEo" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -26814,7 +26821,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/carpet/red,
 /area/station/security/office)
 "oUx" = (
 /obj/effect/turf_decal/stripes{
@@ -27044,7 +27051,8 @@
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	name = "Court Shutters";
 	id = "courtems";
-	desc = "Oh god fucking damn it someone brought a bomb."
+	desc = "Oh god fucking damn it someone brought a bomb.";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/courtroom)
@@ -27181,7 +27189,7 @@
 	},
 /obj/effect/turf_decal/trimline/red/warning,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "pgI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -28121,6 +28129,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red/opposingcorners,
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "pHK" = (
@@ -28581,11 +28590,10 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "pTF" = (
-/obj/structure/rack,
-/obj/item/storage/box/stingbangs,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/armory2,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "pTL" = (
@@ -29200,7 +29208,7 @@
 "qic" = (
 /obj/effect/turf_decal/trimline/red/corner,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "qiN" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
@@ -30392,9 +30400,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
-	dir = 4
-	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "qRt" = (
@@ -31495,7 +31500,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "rvE" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/dark/textured,
@@ -31554,6 +31559,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
+"rwD" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "rwX" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
@@ -32380,9 +32389,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/warning{
-	dir = 8
-	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "rUa" = (
@@ -32607,7 +32613,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "saD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33357,6 +33363,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/pod/dark,
 /area/station/security/warden)
 "syJ" = (
@@ -34918,7 +34925,6 @@
 /turf/open/floor/plating,
 /area/station/hallway/primary/aft)
 "txs" = (
-/obj/effect/landmark/start/warden,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -34974,9 +34980,7 @@
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation/entertainment)
 "tzi" = (
-/obj/machinery/power/terminal{
-	dir = 2
-	},
+/obj/machinery/power/terminal,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 10
@@ -35039,7 +35043,8 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	name = "Security Lockdown Shutters";
-	id = "securityshutter"
+	id = "securityshutter";
+	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35112,11 +35117,17 @@
 "tDi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"tDm" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/courtroom)
 "tDH" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/camera/autoname/directional/north,
@@ -36125,7 +36136,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "udB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance"
@@ -36675,7 +36686,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "utg" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/spawner/random/structure/grille,
@@ -37300,7 +37311,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 5
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
@@ -37739,9 +37750,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
 "uXY" = (
-/obj/machinery/modular_computer/console/preset/cargochat/service{
-	dir = 2
-	},
+/obj/machinery/modular_computer/console/preset/cargochat/service,
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "uYy" = (
@@ -37898,7 +37907,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light/neon_lining{
-	dir = 2;
 	icon_state = "pink2_1"
 	},
 /turf/open/floor/wood,
@@ -37934,7 +37942,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/carpet/red,
 /area/station/security/office)
 "vdv" = (
 /obj/structure/disposalpipe/segment{
@@ -38240,6 +38248,9 @@
 /obj/item/holosign_creator/robot_seat/bar,
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar/backroom)
+"vkJ" = (
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "vkU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 10
@@ -38380,6 +38391,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "voC" = (
@@ -38447,7 +38461,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "vrp" = (
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen/empty,
@@ -39093,7 +39107,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "vMF" = (
-/obj/structure/chair/office,
+/obj/structure/chair/comfy/teal,
+/obj/effect/landmark/start/warden,
 /turf/open/floor/carpet/executive,
 /area/station/security/warden)
 "vMM" = (
@@ -39295,6 +39310,10 @@
 	pixel_x = -9
 	},
 /obj/structure/table,
+/obj/machinery/recharger{
+	pixel_y = 3;
+	pixel_x = 9
+	},
 /turf/open/floor/carpet/executive,
 /area/station/security/warden)
 "vTM" = (
@@ -39306,7 +39325,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "vUg" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/bamboo,
@@ -39383,34 +39402,18 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "vWi" = (
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_y = -2
-	},
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = -2
-	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/armory1,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/mob/living/simple_animal/bot/secbot/beepsky/armsky,
+/obj/effect/spawner/random/contraband/armory,
+/obj/structure/closet/secure_closet{
+	name = "contraband locker";
+	req_access = list("armory")
+	},
+/obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "vWn" = (
@@ -39473,7 +39476,8 @@
 /obj/machinery/door/poddoor/shutters/window/preopen{
 	name = "Court Shutters";
 	id = "courtems";
-	desc = "Oh god fucking damn it someone brought a bomb."
+	desc = "Oh god fucking damn it someone brought a bomb.";
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/courtroom)
@@ -39520,7 +39524,6 @@
 /turf/open/floor/carpet/neon/simple/orange/nodots,
 /area/station/cargo/miningoffice)
 "vZk" = (
-/obj/structure/closet/secure_closet/armory2,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -39528,6 +39531,12 @@
 	name = "armory safe A"
 	},
 /obj/structure/cable,
+/obj/structure/rack,
+/obj/item/storage/box/stingbangs,
+/obj/item/storage/box/teargas{
+	pixel_x = 1;
+	pixel_y = -2
+	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "vZG" = (
@@ -39730,7 +39739,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/carpet/red,
 /area/station/security/office)
 "wfN" = (
 /turf/closed/wall/r_wall,
@@ -40115,17 +40124,13 @@
 /turf/open/floor/wood,
 /area/station/cargo/miningoffice)
 "wsF" = (
-/obj/structure/closet/secure_closet{
-	name = "contraband locker";
-	req_access = list("armory")
-	},
-/obj/effect/spawner/random/maintenance/three,
-/obj/effect/spawner/random/contraband/armory,
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 5
 	},
-/obj/item/grenade/clusterbuster/random,
-/mob/living/simple_animal/bot/secbot/beepsky/armsky,
+/obj/structure/rack,
+/obj/item/storage/box/flashes{
+	pixel_x = 3
+	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
 "wsG" = (
@@ -40656,7 +40661,6 @@
 	name = "Xenobio Pen 4 Blast Door"
 	},
 /obj/machinery/door/window/left/directional/north{
-	dir = 1;
 	name = "Containment Pen #4";
 	req_access = list("xenobiology")
 	},
@@ -40668,7 +40672,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/security/office)
 "wIz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41439,6 +41443,11 @@
 "xdZ" = (
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
+"xed" = (
+/obj/effect/spawner/random/trash,
+/obj/vehicle/ridden/secway,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "xem" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -41512,6 +41521,7 @@
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "xhu" = (
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/courtroom)
 "xhD" = (
@@ -42748,7 +42758,7 @@
 	id_tag = "innerbrig";
 	name = "Brig"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "xQn" = (
 /obj/structure/rack,
@@ -42801,7 +42811,7 @@
 "xRW" = (
 /obj/structure/table,
 /obj/machinery/coffeemaker,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/carpet/red,
 /area/station/security/office)
 "xRZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -66826,7 +66836,7 @@ okD
 okD
 okD
 okD
-uvd
+okD
 llX
 wOn
 wOn
@@ -67078,12 +67088,12 @@ rrB
 rrB
 rrB
 rrB
-lju
-uvd
-uvd
+xed
+rwD
+mmb
+mmb
 uvd
 udB
-uvd
 llX
 kkp
 uLQ
@@ -67335,12 +67345,12 @@ lKN
 ydD
 ofT
 rrB
+nmL
 uvd
 uvd
 uvd
 uvd
 okD
-uvd
 gvZ
 uPB
 uPB
@@ -70419,9 +70429,9 @@ kRz
 tAV
 ajQ
 ajQ
-atY
+gap
 fCU
-ajQ
+hfR
 tPP
 gDK
 xvP
@@ -72993,9 +73003,9 @@ upz
 trt
 ehb
 naf
-oFP
+nhH
 voj
-mal
+oEi
 rhn
 wCS
 rMy
@@ -73251,7 +73261,7 @@ aus
 eJj
 wfC
 oUp
-lEA
+vkJ
 xRW
 vWE
 ajQ
@@ -74785,7 +74795,7 @@ lkF
 nbU
 fXB
 gPZ
-gPZ
+tDm
 gPZ
 gPZ
 onf

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -302,8 +302,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "afY" = (
-/turf/open/floor/holofloor/beach/coast_b,
-/area/station/service/library)
+/obj/structure/lattice,
+/turf/open/floor/plating/ocean/pit,
+/area/ocean)
 "agf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/computer/scan_consolenew{
@@ -666,23 +667,6 @@
 	color = "#D381C9"
 	},
 /area/station/science/robotics)
-"arG" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/north,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/machinery/button/door/directional/north{
-	pixel_x = -23;
-	id = "radio";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_y = 23
-	},
-/obj/effect/landmark/start/librarian,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "arQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -995,6 +979,11 @@
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
+"aCp" = (
+/mob/living/basic/butterfly,
+/obj/structure/cable,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "aDe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -1453,6 +1442,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/storage/emergency/port)
+"aRr" = (
+/obj/item/instrument/eguitar,
+/turf/open/floor/holofloor/beach,
+/area/station/service/library)
 "aRF" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor/auto{
@@ -2189,6 +2182,11 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation/entertainment)
+"bin" = (
+/obj/effect/spawner/random/structure/musician/piano/random_piano,
+/obj/structure/window/spawner/directional/west,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "biq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2508,6 +2506,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
+"bpn" = (
+/obj/structure/chair/stool/directional/west,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "bpu" = (
 /obj/structure/cable,
 /obj/machinery/duct/industrial/waste,
@@ -2990,11 +2993,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"bBN" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/ocean,
-/area/ocean/generated_above)
 "bBP" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -3296,12 +3294,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
-"bHV" = (
-/obj/machinery/cassette/dj_station,
-/obj/machinery/light/dim/directional/west,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "bIa" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 1
@@ -3995,10 +3987,6 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
-"cdn" = (
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "cdv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/white/filled/corner{
@@ -4133,6 +4121,11 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/medical/virology)
+"chA" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "chG" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -4275,11 +4268,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
-"clx" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "cly" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -4726,17 +4714,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "cBs" = (
-/obj/structure/cassette_rack,
-/obj/item/device/cassette_tape/friday,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/structure/table/reinforced,
+/obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/vaporwave,
 /area/station/service/library)
 "cBt" = (
@@ -5205,22 +5183,6 @@
 /obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"cPz" = (
-/obj/structure/table/wood,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/structure/window/spawner/directional/west,
-/obj/item/device/cassette_tape/blank,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "cPD" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -5649,19 +5611,6 @@
 	},
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
-"cYO" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/table/wood,
-/obj/item/taperecorder{
-	pixel_y = 9;
-	pixel_x = -5
-	},
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
-"cYX" = (
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plating/ocean,
-/area/ocean/generated_above)
 "cZg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 8
@@ -6020,6 +5969,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"dji" = (
+/obj/machinery/cassette/dj_station,
+/obj/machinery/light/dim/directional/west,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "djt" = (
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/engine,
@@ -6459,6 +6414,12 @@
 /obj/vehicle/ridden/cargo_train,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
+"drz" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cassette/adv_cassette_deck,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "drG" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners{
@@ -6737,15 +6698,6 @@
 	dir = 1
 	},
 /obj/structure/bookcase/random/nonfiction,
-/turf/open/floor/iron,
-/area/station/service/library)
-"dAB" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/library)
 "dAF" = (
@@ -7465,6 +7417,14 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
+"dUn" = (
+/obj/structure/statue/sandstone/venus{
+	anchored = 1;
+	dir = 4
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "dUJ" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/supply)
@@ -7504,6 +7464,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
+"dWC" = (
+/obj/structure/cable,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "dWT" = (
 /obj/machinery/computer/robotics{
 	dir = 4
@@ -7519,15 +7483,14 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/hos)
+"dXf" = (
+/obj/structure/window/spawner/directional/east,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "dXk" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/security/office)
-"dXq" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plating/ocean,
-/area/ocean/generated_above)
 "dXv" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -8338,12 +8301,6 @@
 /obj/structure/spider/stickyweb/sealed,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"etI" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/lattice,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "etN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -8512,6 +8469,15 @@
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"exS" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/service/library)
 "exZ" = (
 /obj/machinery/food_cart,
 /turf/open/floor/iron/kitchen,
@@ -8786,6 +8752,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/office)
+"eEZ" = (
+/obj/machinery/light/floor/has_bulb,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/secondary/exit/departure_lounge)
 "eFa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9225,8 +9196,13 @@
 /area/station/hallway/primary/central)
 "ePE" = (
 /obj/structure/lattice,
-/turf/open/floor/plating/ocean/pit,
+/turf/open/floor/plating/ocean/pit/wall,
 /area/ocean)
+"ePK" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating/ocean,
+/area/ocean/generated_above)
 "ePQ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -10528,6 +10504,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
+"fCq" = (
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/service/library)
 "fCx" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor/auto{
@@ -10979,6 +10963,14 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"fQb" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/cassette/mailbox,
+/turf/open/floor/iron,
+/area/station/service/library)
 "fQi" = (
 /obj/structure/toilet{
 	dir = 8
@@ -11297,6 +11289,12 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"fZc" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/table/wood,
+/obj/item/statuebust,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "fZe" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -11599,6 +11597,13 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/security/warden)
+"geR" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "geU" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -11764,10 +11769,6 @@
 	},
 /obj/structure/table/wood,
 /turf/open/floor/iron,
-/area/station/service/library)
-"gle" = (
-/obj/effect/overlay/palmtree_r,
-/turf/open/floor/holofloor/beach,
 /area/station/service/library)
 "glg" = (
 /obj/effect/spawner/random/structure/chair_maintenance,
@@ -12697,6 +12698,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/vacant_room/commissary)
+"gOb" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/lattice,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "gOc" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 8
@@ -13631,6 +13638,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
+"hqp" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "hrp" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/window/preopen{
@@ -14979,6 +14990,14 @@
 /obj/effect/turf_decal/stripes,
 /turf/open/floor/engine,
 /area/station/engineering/main)
+"hZB" = (
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/secondary/exit/departure_lounge)
 "hZJ" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/bot{
@@ -15687,12 +15706,6 @@
 "iut" = (
 /turf/open/floor/wood/parquet,
 /area/station/medical/medbay/central)
-"iuL" = (
-/obj/machinery/modular_computer/console/preset/id{
-	dir = 1
-	},
-/turf/open/floor/carpet/orange,
-/area/station/command/heads_quarters/ce)
 "iuY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -15736,13 +15749,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
-"ivJ" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "iwc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -16467,12 +16473,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
-"iQr" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cassette/adv_cassette_deck,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "iQE" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -16725,6 +16725,7 @@
 /obj/effect/spawner/random/special_lighter,
 /obj/effect/spawner/random/decoration/carpet,
 /obj/item/pen/screwdriver,
+/obj/machinery/light/very_dim/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "jaP" = (
@@ -16942,15 +16943,6 @@
 /obj/effect/turf_decal/trimline/brown/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
-"jgy" = (
-/obj/structure/statue/sandstone/venus{
-	anchored = 1;
-	desc = "Ugh, this is merely an ugly amateurish replica of the other statue! The letters RIPGOAT are scribbled onto the base.";
-	dir = 8
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "jgE" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment{
@@ -18484,6 +18476,22 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"jVs" = (
+/obj/structure/table/wood,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/structure/window/spawner/directional/west,
+/obj/item/device/cassette_tape/blank,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "jVF" = (
 /obj/effect/turf_decal/tile/green/opposingcorners{
 	dir = 1
@@ -18600,11 +18608,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"jYN" = (
-/mob/living/basic/butterfly,
-/obj/structure/cable,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "jYT" = (
 /obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -19086,8 +19089,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "klr" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /obj/structure/table/wood/fancy/royalblue,
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/door/window/brigdoor/left{
@@ -19284,16 +19285,9 @@
 /area/station/commons/lounge)
 "kqx" = (
 /obj/machinery/mecha_part_fabricator/maint,
+/obj/machinery/light/very_dim/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"kqN" = (
-/obj/structure/statue/sandstone/venus{
-	anchored = 1;
-	dir = 4
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "kqQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -19427,7 +19421,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
 "kuO" = (
-/turf/open/floor/holofloor/beach/coast_t,
+/turf/open/floor/iron/vaporwave,
 /area/station/service/library)
 "kuQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21368,14 +21362,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
-"luB" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
-	},
-/obj/machinery/cassette/mailbox,
-/turf/open/floor/iron,
-/area/station/service/library)
 "luH" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -22003,6 +21989,7 @@
 /obj/item/electronics/airlock{
 	pixel_x = 4
 	},
+/obj/machinery/light/very_dim/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "lJV" = (
@@ -22369,6 +22356,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/hydroponics)
+"lUo" = (
+/obj/effect/overlay/palmtree_l,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "lUz" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/dorms)
@@ -22579,6 +22570,10 @@
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/aft)
+"mbp" = (
+/obj/effect/overlay/palmtree_r,
+/turf/open/floor/holofloor/beach,
+/area/station/service/library)
 "mbz" = (
 /obj/structure/table/reinforced,
 /obj/structure/desk_bell{
@@ -22604,12 +22599,7 @@
 /turf/open/floor/engine,
 /area/station/commons/storage/emergency/port)
 "mcu" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/turf/closed/wall/rust,
 /area/station/service/library)
 "mdc" = (
 /obj/structure/disposalpipe/segment{
@@ -22666,11 +22656,6 @@
 /obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"meR" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "mfc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22680,12 +22665,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"mfd" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/table/wood,
-/obj/item/statuebust,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "mfk" = (
 /obj/structure/closet/secure_closet/chief_medical,
 /obj/item/screwdriver,
@@ -23716,13 +23695,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
-"mMz" = (
-/obj/structure/window/spawner/directional/east,
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
-	},
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "mMH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23871,10 +23843,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
-"mRt" = (
-/obj/effect/overlay/palmtree_l,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "mRF" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/glass/waterbottle/large{
@@ -25146,9 +25114,9 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "nvY" = (
-/obj/structure/lattice,
+/obj/effect/turf_decal/sand,
 /turf/open/floor/plating/ocean,
-/area/ocean/generated_above)
+/area/ocean)
 "nwz" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -25568,6 +25536,11 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
+"nIm" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "nIO" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Hole Access"
@@ -25871,11 +25844,6 @@
 "nQI" = (
 /turf/closed/wall/r_wall,
 /area/station/science/lab)
-"nQV" = (
-/obj/structure/chair/stool/directional/west,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "nRr" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/disposalpipe/segment,
@@ -26469,9 +26437,9 @@
 /turf/open/floor/iron/dark/textured_edge/airless,
 /area/station/science/lobby)
 "ojo" = (
-/obj/effect/turf_decal/sand,
+/obj/structure/lattice,
 /turf/open/floor/plating/ocean,
-/area/ocean)
+/area/ocean/generated_above)
 "ojq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -27766,6 +27734,13 @@
 	color = "#D381C9"
 	},
 /area/station/science/robotics)
+"oVc" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
+	},
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "oVr" = (
 /obj/machinery/button/door{
 	desc = "Controls the shutters over the brig windows.";
@@ -27966,10 +27941,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"paT" = (
-/obj/structure/cable,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "pbh" = (
 /obj/structure/cable,
 /obj/structure/table/wood,
@@ -28457,6 +28428,11 @@
 /obj/structure/sign/poster/official/cleanliness,
 /turf/closed/wall,
 /area/station/service/kitchen)
+"pnO" = (
+/obj/structure/window/spawner/directional/west,
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "poE" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer"
@@ -28778,6 +28754,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/theatre)
+"pyr" = (
+/obj/structure/cassette_rack,
+/obj/item/device/cassette_tape/friday,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "pyE" = (
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/machinery/door/airlock/medical/glass{
@@ -28820,10 +28810,6 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"pzP" = (
-/obj/item/instrument/eguitar,
-/turf/open/floor/holofloor/beach,
-/area/station/service/library)
 "pzX" = (
 /obj/structure/closet/crate,
 /turf/open/floor/carpet/executive,
@@ -29864,6 +29850,15 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
+"pZQ" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/table/wood,
+/obj/item/taperecorder{
+	pixel_y = 9;
+	pixel_x = -5
+	},
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "pZV" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -29964,11 +29959,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"qch" = (
-/obj/structure/window/spawner/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "qck" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -30272,10 +30262,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"qkR" = (
-/obj/effect/overlay/palmtree_l,
-/turf/open/floor/holofloor/beach,
-/area/station/service/library)
 "qli" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/mineral/titanium/yellow,
@@ -30753,10 +30739,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
-"qwW" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "qxd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31094,6 +31076,10 @@
 /obj/machinery/grill,
 /turf/open/floor/plating,
 /area/station/service/kitchen/kitchen_backroom)
+"qIa" = (
+/obj/effect/overlay/palmtree_r,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "qIf" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -31432,9 +31418,6 @@
 	icon_state = "clown_carpet"
 	},
 /area/station/commons/dorms)
-"qQj" = (
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "qQx" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -31888,6 +31871,16 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/executive,
 /area/station/commons/vacant_room/commissary)
+"rcQ" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/public/glass{
+	name = "KRUM Radio";
+	id_tag = "radio"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/library,
+/obj/structure/cable,
+/turf/open/floor/pod/dark,
+/area/station/service/library)
 "rcT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32510,6 +32503,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"rtO" = (
+/obj/structure/statue/sandstone/venus{
+	anchored = 1;
+	desc = "Ugh, this is merely an ugly amateurish replica of the other statue! The letters RIPGOAT are scribbled onto the base.";
+	dir = 8
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "rtP" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/camera/autoname/directional/east,
@@ -33942,9 +33944,6 @@
 /obj/structure/fans/tiny/forcefield,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"shL" = (
-/turf/open/floor/holofloor/beach,
-/area/station/service/library)
 "shP" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/light/directional/south,
@@ -33972,10 +33971,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/robotics/lab)
-"sjJ" = (
-/obj/effect/overlay/palmtree_r,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "sjN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -34109,6 +34104,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/service/theater/abandoned)
+"smo" = (
+/turf/open/floor/holofloor/beach/coast_t,
+/area/station/service/library)
 "smC" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock"
@@ -34154,10 +34152,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/theatre)
-"sqc" = (
-/obj/structure/lattice,
-/turf/open/floor/plating/ocean/pit/wall,
-/area/ocean)
 "sqk" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -35473,6 +35467,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"tct" = (
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating/ocean,
+/area/ocean/generated_above)
 "tde" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35867,12 +35865,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
-"tpl" = (
-/obj/structure/closet/crate/bin,
-/obj/item/tape/random,
-/obj/item/gps/spaceruin,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "tpo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -36768,6 +36760,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
+"tOB" = (
+/obj/effect/overlay/palmtree_l,
+/turf/open/floor/holofloor/beach,
+/area/station/service/library)
 "tOO" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners{
@@ -37835,7 +37831,21 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/office)
 "uqC" = (
-/turf/closed/wall/rust,
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/button/door/directional/north{
+	pixel_x = -23;
+	id = "radio";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = 23
+	},
+/obj/effect/landmark/start/librarian,
+/turf/open/floor/iron/vaporwave,
 /area/station/service/library)
 "urf" = (
 /obj/machinery/rnd/production/circuit_imprinter,
@@ -38296,16 +38306,6 @@
 "uEF" = (
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation/entertainment)
-"uFb" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/public/glass{
-	name = "KRUM Radio";
-	id_tag = "radio"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/library,
-/obj/structure/cable,
-/turf/open/floor/pod/dark,
-/area/station/service/library)
 "uFh" = (
 /obj/machinery/computer/warrant{
 	dir = 1
@@ -38691,6 +38691,16 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
+"uPl" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/sunglasses/big{
+	name = "aesthetic sunglasses";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/item/radio/radio_mic,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "uPn" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -38723,16 +38733,6 @@
 /obj/structure/curtain/cloth,
 /turf/open/floor/plating,
 /area/station/medical/medbay/central)
-"uQm" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/sunglasses/big{
-	name = "aesthetic sunglasses";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/item/radio/radio_mic,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "uQJ" = (
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood,
@@ -38842,6 +38842,11 @@
 "uSv" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Art Gallery"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/library)
@@ -39336,6 +39341,12 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"vfe" = (
+/obj/structure/closet/crate/bin,
+/obj/item/tape/random,
+/obj/item/gps/spaceruin,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "vfE" = (
 /obj/structure/statue/bananium/clown,
 /turf/open/floor/mineral/bananium,
@@ -40574,11 +40585,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
-"vSg" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "vSw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -40698,6 +40704,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
+"vVi" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "vVW" = (
 /turf/open/floor/engine,
 /area/station/engineering/atmos/office)
@@ -41376,6 +41387,9 @@
 /obj/machinery/ticket_machine/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"wpG" = (
+/turf/open/floor/holofloor/beach,
+/area/station/service/library)
 "wqs" = (
 /turf/open/floor/holofloor/beach/water,
 /area/station/maintenance/starboard/aft)
@@ -41406,11 +41420,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"wqW" = (
-/obj/effect/spawner/random/structure/musician/piano/random_piano,
-/obj/structure/window/spawner/directional/west,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "wqZ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -41516,6 +41525,12 @@
 /obj/effect/base_turf_modifier/pit,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
+"wte" = (
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 1
+	},
+/turf/open/floor/carpet/orange,
+/area/station/command/heads_quarters/ce)
 "wtD" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/delivery,
@@ -42912,6 +42927,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
+"xfS" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean/generated_above)
 "xgr" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -43732,9 +43752,10 @@
 /turf/open/floor/iron,
 /area/station/construction/storage_wing)
 "xCE" = (
-/obj/structure/window/spawner/directional/east,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "xCP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -44745,9 +44766,7 @@
 /turf/open/floor/plating,
 /area/station/security/office)
 "yfp" = (
-/obj/structure/window/spawner/directional/west,
-/obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/iron/vaporwave,
+/turf/open/floor/holofloor/beach/coast_b,
 /area/station/service/library)
 "yfT" = (
 /obj/machinery/duct/industrial/waste,
@@ -70309,8 +70328,8 @@ meJ
 mdW
 mdW
 mdW
-sqc
 ePE
+afY
 aah
 aah
 aah
@@ -70563,11 +70582,11 @@ aah
 aah
 aah
 aah
-sqc
-aYY
 ePE
 aYY
-ePE
+afY
+aYY
+afY
 aYY
 aYY
 aah
@@ -70820,11 +70839,11 @@ aah
 aah
 fKl
 aYY
-ePE
+afY
 aYY
-ePE
+afY
 aYY
-ePE
+afY
 aYY
 aYY
 aYY
@@ -71077,11 +71096,11 @@ aYY
 aYY
 aYY
 aYY
-ePE
+afY
 aYY
-ePE
+afY
 aYY
-ePE
+afY
 aYY
 aYY
 aYY
@@ -71334,11 +71353,11 @@ aYY
 aYY
 aYY
 aYY
-ePE
+afY
 fAs
 fAs
 fAs
-ePE
+afY
 aYY
 aYY
 aYY
@@ -72096,10 +72115,10 @@ aah
 aah
 aah
 aah
-nvY
-nvY
-sqc
+ojo
+ojo
 ePE
+afY
 fAs
 oGC
 fAs
@@ -72353,7 +72372,7 @@ aah
 aah
 aah
 aah
-nvY
+ojo
 aah
 fKl
 aYY
@@ -72610,10 +72629,10 @@ aah
 aah
 aah
 aah
-nvY
-nvY
-sqc
+ojo
+ojo
 ePE
+afY
 fAs
 fAs
 nbY
@@ -72867,7 +72886,7 @@ aah
 aah
 aah
 aah
-nvY
+ojo
 aah
 fKl
 aYY
@@ -73124,10 +73143,10 @@ aah
 aah
 aah
 aah
-nvY
-nvY
-sqc
+ojo
+ojo
 ePE
+afY
 fAs
 fAs
 fAs
@@ -73904,11 +73923,11 @@ aYY
 aYY
 aYY
 aYY
-ePE
+afY
 fAs
 fAs
 fAs
-ePE
+afY
 aYY
 aYY
 aYY
@@ -74161,11 +74180,11 @@ aYY
 aYY
 aYY
 aYY
-ePE
+afY
 aYY
-ePE
+afY
 aYY
-ePE
+afY
 aYY
 aYY
 aYY
@@ -74418,11 +74437,11 @@ aah
 fKl
 aYY
 aYY
-ePE
+afY
 aYY
-ePE
+afY
 aYY
-ePE
+afY
 aYY
 aYY
 aYY
@@ -74675,11 +74694,11 @@ aah
 aah
 aah
 aah
-sqc
-aYY
 ePE
 aYY
-ePE
+afY
+aYY
+afY
 aYY
 aYY
 aYY
@@ -74932,11 +74951,11 @@ aah
 aah
 aah
 aah
-nvY
-nvY
-nvY
-nvY
-nvY
+ojo
+ojo
+ojo
+ojo
+ojo
 aah
 aah
 aah
@@ -83472,7 +83491,7 @@ uVL
 mdW
 meJ
 aah
-nvY
+ojo
 aah
 aah
 aah
@@ -83729,7 +83748,7 @@ uVL
 mdW
 aah
 aah
-nvY
+ojo
 aah
 aah
 aah
@@ -84238,16 +84257,16 @@ ezG
 hmV
 sVS
 uUD
-shL
+wpG
 xQD
 xQD
 xQD
 xQD
-uqC
-meR
+mcu
+vVi
 meJ
 aah
-nvY
+ojo
 aah
 aah
 aah
@@ -84495,16 +84514,16 @@ bTl
 bTl
 jNL
 uUD
-gle
-shL
-gle
-kuO
-afY
+mbp
+wpG
+mbp
+smo
+yfp
 uUD
-etI
+gOb
 mdW
-nvY
-nvY
+ojo
+ojo
 aah
 aah
 aah
@@ -84737,7 +84756,7 @@ ccr
 ccr
 wrG
 sWi
-sWi
+vBn
 xhD
 nSA
 kEj
@@ -84751,15 +84770,15 @@ icW
 bTl
 gsK
 bTl
-uqC
-wqW
-cYO
-mfd
-cPz
-yfp
+mcu
+bin
+pZQ
+fZc
+jVs
+pnO
 uUD
-cdn
-mRt
+hqp
+lUo
 aah
 aah
 aah
@@ -84994,7 +85013,7 @@ ukF
 ufI
 sMx
 nXC
-sWi
+vBn
 xhD
 oBr
 oBr
@@ -85009,15 +85028,15 @@ bTl
 qfa
 hby
 uUD
-nQV
-qQj
-qQj
-qQj
-qwW
+bpn
+kuO
+kuO
+kuO
+cBs
 uUD
-jgy
-vSg
-bBN
+rtO
+nIm
+xfS
 aah
 aah
 aah
@@ -85251,7 +85270,7 @@ ieG
 ieG
 ieG
 sWi
-sWi
+vBn
 ybO
 fOf
 klr
@@ -85266,15 +85285,15 @@ qLF
 kmc
 uRv
 uUD
-qQj
-qQj
-qQj
-qQj
-qQj
+kuO
+kuO
+kuO
+kuO
+kuO
 xQD
-ojo
-ojo
-dXq
+nvY
+nvY
+ePK
 aah
 aah
 aah
@@ -85508,8 +85527,8 @@ rio
 sWi
 sWi
 sWi
-rio
-ybO
+eEZ
+hZB
 uSv
 fGX
 fGX
@@ -85518,20 +85537,20 @@ wjK
 dEa
 les
 les
-dAB
+exS
 tVS
 fAx
-mcu
-uFb
+fCq
+rcQ
 bSK
 bSK
-paT
-paT
-qQj
+dWC
+dWC
+kuO
 xQD
-ojo
-ojo
-cYX
+nvY
+nvY
+tct
 aah
 aah
 aah
@@ -85773,22 +85792,22 @@ eRt
 tdI
 rFV
 uUD
-luB
+fQb
 ixz
 uzR
 drG
 cyd
 bTl
-uqC
-iQr
-uQm
-bHV
-paT
-qQj
+mcu
+drz
+uPl
+dji
+dWC
+kuO
 xQD
-ojo
-ojo
-cYX
+nvY
+nvY
+tct
 aah
 aah
 aah
@@ -86036,16 +86055,16 @@ uVL
 uVL
 xQD
 xQD
+mcu
 uqC
-arG
-ivJ
+geR
+pyr
+aCp
 cBs
-jYN
-qwW
-uqC
-kqN
-vSg
-bBN
+mcu
+dUn
+nIm
+xfS
 aah
 aah
 aah
@@ -86294,14 +86313,14 @@ meJ
 mdW
 meJ
 uUD
-mMz
-qch
-qch
-qch
-xCE
+oVc
+chA
+chA
+chA
+dXf
 uUD
-clx
-sjJ
+xCE
+qIa
 aah
 aah
 aah
@@ -86550,16 +86569,16 @@ meJ
 meJ
 mdW
 mdW
-uqC
-qkR
-pzP
-qkR
-kuO
-afY
-uqC
-etI
+mcu
+tOB
+aRr
+tOB
+smo
+yfp
+mcu
+gOb
 mdW
-nvY
+ojo
 aah
 aah
 aah
@@ -86813,11 +86832,11 @@ xQD
 xQD
 xQD
 xQD
-uqC
-meR
+mcu
+vVi
 meJ
-nvY
-nvY
+ojo
+ojo
 aah
 aah
 aah
@@ -87068,7 +87087,7 @@ meJ
 meJ
 mdW
 mdW
-tpl
+vfe
 mdW
 meJ
 meJ
@@ -87282,7 +87301,7 @@ gly
 bwi
 tan
 rdE
-iuL
+wte
 lXt
 hUd
 oDZ
@@ -87326,7 +87345,7 @@ meJ
 mdW
 meJ
 meJ
-nvY
+ojo
 aah
 aah
 aah
@@ -87597,7 +87616,7 @@ aah
 aah
 aah
 aah
-cYX
+tct
 aah
 aah
 aah
@@ -87854,7 +87873,7 @@ aah
 aah
 aah
 aah
-cYX
+tct
 aah
 aah
 aah
@@ -88111,7 +88130,7 @@ aah
 aah
 aah
 aah
-cYX
+tct
 aah
 aah
 aah
@@ -89902,7 +89921,7 @@ aah
 aah
 aah
 aah
-nvY
+ojo
 aah
 aah
 aah

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -819,6 +819,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
+"avZ" = (
+/obj/machinery/door/airlock/command/glass{
+	name = "Bridge"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/command/bridge)
 "awg" = (
 /obj/machinery/computer/department_orders/science{
 	dir = 4
@@ -1066,6 +1078,10 @@
 /obj/item/stock_parts/cell,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
+"aGw" = (
+/obj/machinery/vending/boozeomat,
+/turf/closed/wall,
+/area/station/service/bar)
 "aGz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -3127,12 +3143,16 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "bER" = (
-/obj/structure/bed/double/pod{
-	name = "Air Matress"
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning,
+/obj/effect/turf_decal/trimline/dark_blue/warning{
+	dir = 1
 	},
-/obj/item/bedsheet/hos/double,
-/turf/open/floor/pod/dark,
-/area/station/security/warden)
+/obj/effect/turf_decal/trimline/dark_blue/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/command/bridge)
 "bFq" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth (Chaplain)";
@@ -6314,7 +6334,11 @@
 /area/station/hallway/primary/aft)
 "dqA" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 8;
+	pixel_y = 5;
+	pixel_x = 4
+	},
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar)
 "dqB" = (
@@ -6349,6 +6373,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"drl" = (
+/obj/machinery/vending/boozeomat,
+/turf/closed/wall/r_wall,
+/area/station/security/warden)
 "drs" = (
 /obj/effect/turf_decal/bot,
 /obj/vehicle/ridden/cargo_train,
@@ -7316,6 +7344,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
 	dir = 1
 	},
+/obj/machinery/vending/medical,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "dTU" = (
@@ -14614,6 +14643,10 @@
 	dir = 10;
 	color = "#009dc4"
 	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "hSR" = (
@@ -21190,7 +21223,6 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 4
 	},
-/obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
@@ -22854,6 +22886,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured_edge,
 /area/station/command/bridge)
 "mrJ" = (
@@ -26338,6 +26371,7 @@
 "okC" = (
 /obj/effect/turf_decal/trimline/yellow/line,
 /obj/effect/turf_decal/trimline/yellow/line,
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 1
 	},
@@ -26900,7 +26934,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /mob/living/basic/cockroach,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/port/aft)
 "oyj" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
@@ -29898,6 +29932,10 @@
 	},
 /turf/open/floor/plating/ocean,
 /area/ocean)
+"qfA" = (
+/obj/structure/reagent_dispensers/wall/peppertank/directional/north,
+/turf/open/floor/pod/dark,
+/area/station/security/warden)
 "qfE" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -31639,9 +31677,14 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/bar/backroom)
 "rbK" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/carpet/neon/simple/green/nodots,
-/area/station/service/bar)
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_blue/warning,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central/fore)
 "rbQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31796,7 +31839,10 @@
 /area/station/hallway/primary/central/fore)
 "rgY" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 8;
+	pixel_x = 4
+	},
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar)
 "rhi" = (
@@ -32232,6 +32278,7 @@
 "rsk" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/cell_10k,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "rsl" = (
@@ -33989,7 +34036,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/port/aft)
 "srJ" = (
 /obj/structure/table/reinforced,
@@ -34573,7 +34620,12 @@
 	},
 /area/station/science/robotics)
 "sHI" = (
-/obj/item/storage/secure/safe/directional/north,
+/obj/machinery/button/door/directional/north{
+	pixel_x = 7;
+	id = "wardbed";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
 /turf/open/floor/pod/dark,
 /area/station/security/warden)
 "sHS" = (
@@ -35599,7 +35651,8 @@
 /area/station/commons/fitness/recreation/entertainment)
 "toq" = (
 /obj/machinery/door/airlock/security{
-	name = "Evidence Storage"
+	name = "Evidence Storage";
+	id_tag = "wardbed"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /obj/machinery/door/firedoor,
@@ -36060,6 +36113,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname/directional/north,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar)
 "tDP" = (
@@ -37325,6 +37379,10 @@
 	color = "#D381C9"
 	},
 /area/station/science/robotics)
+"uij" = (
+/obj/structure/reagent_dispensers/wall/virusfood/directional/west,
+/turf/open/floor/iron/white,
+/area/station/medical/virology)
 "uiQ" = (
 /obj/machinery/light/small/directional/east{
 	dir = 1
@@ -38434,9 +38492,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
 "uPn" = (
-/obj/structure/reagent_dispensers/wall/peppertank/directional/east,
-/turf/open/floor/pod/dark,
-/area/station/security/warden)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/port/aft)
 "uPB" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -38890,7 +38949,7 @@
 	dir = 5
 	},
 /obj/effect/spawner/random/trash,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/port/aft)
 "vbW" = (
 /obj/machinery/telecomms/bus/preset_one,
@@ -39659,6 +39718,13 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
+"vvw" = (
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/port/aft)
 "vvB" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -43606,9 +43672,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "xIv" = (
-/obj/machinery/vending/medical,
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue/full,
+/obj/machinery/vending/wardrobe/medi_wardrobe,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
 "xID" = (
@@ -44672,7 +44738,13 @@
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation/entertainment)
 "ylE" = (
-/obj/machinery/vending/boozeomat/all_access,
+/obj/structure/bed/double/pod{
+	name = "Air Matress";
+	dir = 4
+	},
+/obj/item/bedsheet/hos/double{
+	dir = 4
+	},
 /turf/open/floor/pod/dark,
 /area/station/security/warden)
 "ylI" = (
@@ -65148,8 +65220,8 @@ ojS
 ojS
 aSq
 ojS
-rbK
-lzc
+ojS
+aGw
 jdl
 lwx
 jdl
@@ -67232,11 +67304,11 @@ xBV
 fey
 brz
 qNe
-ejd
+vvw
 srI
 oyc
-wtN
-wtN
+uPn
+uPn
 srI
 vbV
 wKX
@@ -68005,8 +68077,8 @@ owJ
 mLx
 rrB
 sHI
-uPn
-bER
+ydD
+ydD
 rrB
 okD
 okD
@@ -68262,7 +68334,7 @@ uSB
 mLx
 rrB
 toq
-rrB
+drl
 rrB
 rrB
 rrB
@@ -68518,7 +68590,7 @@ fey
 owJ
 mLx
 rrB
-ydD
+qfA
 lKN
 ydD
 ofT
@@ -73138,9 +73210,9 @@ tVq
 tAq
 okC
 mrF
-xhJ
-ogi
-kjE
+bER
+avZ
+rbK
 ydb
 fZn
 bDd
@@ -96705,7 +96777,7 @@ aaK
 bfx
 lNZ
 xwH
-dXQ
+uij
 dXQ
 pUe
 bfx

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -14303,7 +14303,6 @@
 "hLg" = (
 /obj/structure/table,
 /obj/machinery/coffeemaker/impressa,
-/obj/item/coffee_cartridge/fancy,
 /obj/item/reagent_containers/cup/bottle/syrup_bottle/laughsyrup{
 	pixel_y = 19;
 	pixel_x = 13

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -2004,6 +2004,12 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
+"bcF" = (
+/obj/machinery/duct/industrial/waste,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/glass/reinforced,
+/area/station/engineering/main)
 "bcL" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -4865,6 +4871,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"cDf" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
+/obj/structure/cable,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "cDm" = (
 /obj/item/pen,
 /obj/structure/table/reinforced,
@@ -9605,7 +9619,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
-/obj/structure/cable/industrial,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "eXv" = (
@@ -14058,7 +14071,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
 	dir = 8
 	},
-/obj/structure/cable/industrial,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "hvv" = (
@@ -36835,6 +36847,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "tCC" = (
@@ -43130,7 +43143,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/structure/cable/industrial,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "wUi" = (
@@ -86221,7 +86233,7 @@ kFZ
 xQn
 eMG
 tCB
-jPC
+bcF
 sgQ
 asg
 sli
@@ -86992,7 +87004,7 @@ aNi
 aNi
 aNi
 qay
-dnr
+cDf
 jvI
 jRw
 auZ

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -349,7 +349,7 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "ahh" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -503,17 +503,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
-"akJ" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4";
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "alb" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -569,6 +558,11 @@
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
+"anc" = (
+/obj/structure/dresser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "anf" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -606,17 +600,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
-"apa" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm2";
-	name = "Cabin 2"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/wood,
-/area/station/commons/dorms)
 "apc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -1319,11 +1302,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "aMJ" = (
-/obj/effect/turf_decal/trimline/brown/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/brown/warning{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/end{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured/airless,
 /area/station/science/lobby)
@@ -1554,7 +1534,7 @@
 /area/station/maintenance/starboard/aft)
 "aTw" = (
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "aTy" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Security's Office"
@@ -1570,6 +1550,9 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/hos)
+"aTD" = (
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "aTV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2237,16 +2220,16 @@
 	},
 /area/station/engineering/main)
 "bkB" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4"
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = 5
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 1;
-	color = "#009dc4"
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = -32
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "bkC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -2397,7 +2380,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/plating,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "bnI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -2904,23 +2887,6 @@
 /obj/effect/landmark/start/captain,
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/captain/private)
-"bAj" = (
-/obj/machinery/button/door/directional/west{
-	id = "Dorm1";
-	name = "Dormitory Door Lock";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/obj/structure/chair/comfy{
-	dir = 4
-	},
-/obj/item/clothing/head/fedora,
-/obj/item/toy/katana{
-	desc = "As seen in your favourite Japanese cartoon.";
-	name = "anime katana"
-	},
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
 "bAM" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/light_switch/directional/north,
@@ -3466,6 +3432,15 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"bMR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "bMU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -3474,6 +3449,15 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"bNb" = (
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured/airless,
+/area/station/science/lobby)
 "bNx" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/mineral/titanium/purple,
@@ -3489,15 +3473,9 @@
 /turf/open/floor/circuit,
 /area/station/tcommsat/server)
 "bOl" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/clown/double,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/toy/katana{
-	desc = "As seen in your favourite Japanese cartoon.";
-	name = "anime katana"
-	},
-/turf/open/floor/eighties,
-/area/station/service/abandoned_gambling_den/gaming)
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "bOH" = (
 /obj/machinery/teleport/station,
 /turf/open/floor/mineral/titanium/purple,
@@ -3543,6 +3521,18 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/engineering/main)
+"bPh" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "Dorm1";
+	name = "Dormitory Door Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "bPl" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -3589,9 +3579,6 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/ks13/engineering/secure_storage)
-"bRQ" = (
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
 "bRT" = (
 /obj/structure/table/optable,
 /obj/structure/window/spawner/directional/east,
@@ -3790,7 +3777,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "bYt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3877,12 +3864,6 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"cbD" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "cbM" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/structure/cable/industrial,
@@ -4312,16 +4293,12 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "coj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"cot" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/dorms)
 "cov" = (
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
@@ -4356,18 +4333,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"cpG" = (
-/obj/structure/table/wood,
-/obj/machinery/computer/arcade/orion_trail{
-	desc = "For gamers only. Casuals need not apply.";
-	icon_screen = "library";
-	icon_state = "oldcomp";
-	name = "Gamer Computer";
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
 "cpK" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -4497,6 +4462,23 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/rd)
+"cuI" = (
+/obj/machinery/button/door/directional/west{
+	id = "Dorm1";
+	name = "Dormitory Door Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/obj/structure/chair/comfy{
+	dir = 4
+	},
+/obj/item/clothing/head/fedora,
+/obj/item/toy/katana{
+	desc = "As seen in your favourite Japanese cartoon.";
+	name = "anime katana"
+	},
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "cvg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -4899,6 +4881,12 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
+"cHm" = (
+/obj/machinery/door/airlock/bathroom{
+	name = "Showers"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "cHp" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /obj/effect/turf_decal/trimline/dark_blue/line{
@@ -5024,6 +5012,13 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/service/library)
+"cLu" = (
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/service/hydroponics/garden)
 "cLv" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/red/filled/corner,
@@ -6049,16 +6044,16 @@
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/ce)
 "dls" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 10
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
+/obj/effect/turf_decal/trimline/green/corner{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central)
 "dlI" = (
 /obj/structure/cable,
 /obj/machinery/duct/industrial/waste,
@@ -6362,11 +6357,6 @@
 /obj/vehicle/ridden/cargo_train,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
-"drw" = (
-/obj/machinery/shower/directional/south,
-/obj/structure/drain,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
 "drG" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners{
@@ -7579,6 +7569,14 @@
 	},
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/science/lobby)
+"eaU" = (
+/obj/structure/dresser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "ebe" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/machinery/airalarm/directional/west,
@@ -7818,6 +7816,18 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"eip" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/west{
+	id = "Dorm3";
+	name = "Dormitory Door Lock";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "eiI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8021,6 +8031,16 @@
 /obj/machinery/coffeemaker/impressa,
 /turf/open/floor/iron/dark,
 /area/station/service/cafeteria)
+"epx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "epC" = (
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
@@ -8312,7 +8332,7 @@
 "ewL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "ewQ" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/purple,
@@ -8330,6 +8350,9 @@
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
 	name = "Brig"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
@@ -9143,17 +9166,17 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "eQp" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 6;
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
 	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
+/obj/effect/turf_decal/trimline/white/warning{
 	color = "#009dc4";
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
+/area/station/commons/dorms)
 "eQt" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/vending/imported/yangyu,
@@ -9175,12 +9198,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"eRn" = (
-/obj/machinery/door/airlock/bathroom{
-	name = "Showers"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
 "eRt" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/painting/library{
@@ -9340,6 +9357,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"eVV" = (
+/obj/machinery/door/window/brigdoor{
+	name = "Toilet";
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/abandoned_gambling_den/gaming)
 "eWH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -9637,6 +9661,12 @@
 /obj/effect/decal/cleanable/plasma,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
+"fdq" = (
+/obj/machinery/camera/autoname/directional/south,
+/obj/machinery/shower/directional/north,
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "fdr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
@@ -9850,14 +9880,6 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/mineral/titanium/yellow,
 /area/station/maintenance/starboard/aft)
-"fja" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/turf/open/floor/wood,
-/area/station/commons/dorms)
 "fjx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/camera/autoname/directional/south,
@@ -9865,14 +9887,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/storage/emergency/starboard)
-"fjP" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/security/office)
 "fjQ" = (
 /obj/structure/grille,
 /obj/effect/spawner/structure/window/plasma,
@@ -9922,6 +9936,10 @@
 "fla" = (
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
+"flc" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/dorms)
 "flp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
@@ -10157,15 +10175,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
-"fua" = (
-/obj/machinery/door/airlock{
-	name = "Bedroom"
-	},
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
-/area/station/commons/dorms)
 "fue" = (
 /turf/closed/wall,
 /area/station/service/abandoned_gambling_den/gaming)
@@ -10301,6 +10310,9 @@
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
+"fyP" = (
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "fzi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/flora/bush/jungle/b/style_random,
@@ -10341,6 +10353,18 @@
 /obj/structure/sign/departments/evac,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"fAn" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/arcade/orion_trail{
+	desc = "For gamers only. Casuals need not apply.";
+	icon_screen = "library";
+	icon_state = "oldcomp";
+	name = "Gamer Computer";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "fAs" = (
 /obj/effect/base_turf_modifier/pit,
 /turf/closed/wall/r_wall,
@@ -10719,7 +10743,7 @@
 /obj/machinery/disposal/bin,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "fMw" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/modular_computer/console/preset/civilian,
@@ -10872,6 +10896,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
+"fQp" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "fQw" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -11130,6 +11158,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"fYs" = (
+/obj/structure/cable,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "fYz" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plating,
@@ -11174,12 +11214,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
 	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -11255,6 +11295,20 @@
 /obj/effect/turf_decal/trimline/dark_blue/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
+"gaM" = (
+/obj/structure/toilet{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/structure/sink/directional/north,
+/obj/structure/mirror{
+	pixel_y = -28
+	},
+/obj/machinery/light/small/directional/south{
+	pixel_x = 11
+	},
+/turf/open/floor/iron/freezer,
+/area/station/service/abandoned_gambling_den/gaming)
 "gaP" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/reagent_dispensers/foamtank,
@@ -11490,6 +11544,17 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood/parquet,
 /area/station/medical/medbay/central)
+"ggj" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central/fore)
 "ggD" = (
 /obj/machinery/door/airlock/research{
 	name = "Ordnance Lab"
@@ -11620,6 +11685,18 @@
 /obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"glV" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 6;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central/fore)
 "gmj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11776,7 +11853,7 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "grB" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -12039,13 +12116,13 @@
 /area/station/medical/treatment_center)
 "gzE" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#009dc4";
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 6;
 	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -12112,13 +12189,10 @@
 "gAV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
+/obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "gBb" = (
@@ -12149,19 +12223,21 @@
 "gCo" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
-/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
-"gCF" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/eighties,
-/area/station/service/abandoned_gambling_den/gaming)
 "gCN" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/dark/textured,
-/area/station/cargo/storage)
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm1";
+	name = "Cabin 1"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "gCU" = (
 /obj/machinery/button/ticket_machine{
 	pixel_y = 22;
@@ -12330,6 +12406,18 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/bamboo,
 /area/station/commons/fitness)
+"gIh" = (
+/obj/machinery/duct/industrial/waste,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central/fore)
 "gIk" = (
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -12381,6 +12469,11 @@
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"gKa" = (
+/obj/structure/dresser,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "gKb" = (
 /obj/structure/table/wood,
 /obj/machinery/cassette/adv_cassette_deck,
@@ -12461,7 +12554,7 @@
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "gMA" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -12770,6 +12863,12 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
+"gWA" = (
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "gXb" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/central)
@@ -13272,17 +13371,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"hip" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 1;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
 "hiv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -13914,6 +14002,19 @@
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"hCR" = (
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/structure/closet/crate/freezer,
+/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
+/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
+/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
+/obj/item/reagent_containers/cup/soda_cans/pwr_game,
+/obj/item/reagent_containers/cup/soda_cans/pwr_game,
+/obj/item/reagent_containers/cup/soda_cans/pwr_game,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "hCY" = (
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/ce)
@@ -14167,6 +14268,17 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
+"hJv" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "hJI" = (
 /obj/structure/flora/bush/jungle/b/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
@@ -14402,13 +14514,6 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"hPG" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark/textured,
-/area/station/security/courtroom)
 "hPI" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -14438,6 +14543,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/theater/abandoned)
+"hPT" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "hQm" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -14571,20 +14687,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
-"hVa" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_y = 7
-	},
-/obj/structure/sink/directional/north,
-/obj/structure/mirror{
-	pixel_y = -28
-	},
-/obj/machinery/light/small/directional/south{
-	pixel_x = 11
-	},
-/turf/open/floor/iron/freezer,
-/area/station/service/abandoned_gambling_den/gaming)
 "hVe" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab"
@@ -14623,11 +14725,6 @@
 	},
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar)
-"hWg" = (
-/obj/machinery/shower/directional/north,
-/obj/structure/drain,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
 "hWk" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
@@ -14772,14 +14869,6 @@
 "hZV" = (
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"iah" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "iao" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -14986,7 +15075,7 @@
 	},
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "igC" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood,
@@ -15061,19 +15150,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
-"iji" = (
-/obj/machinery/duct/industrial/waste,
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "ijM" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -15107,7 +15183,7 @@
 	},
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "ilC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -15464,11 +15540,16 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/robotics/lab)
 "iul" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/shower/directional/south,
-/obj/structure/drain,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
+/obj/machinery/door/airlock/public/glass{
+	name = "Central Access"
+	},
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "iut" = (
 /turf/open/floor/wood/parquet,
 /area/station/medical/medbay/central)
@@ -15528,6 +15609,17 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/cafeteria)
+"iwy" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "iwF" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -15576,6 +15668,10 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"iyv" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "iyx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15598,6 +15694,15 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
+"iyS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "izd" = (
 /turf/open/floor/iron/stairs{
 	dir = 8
@@ -15607,6 +15712,11 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"iAd" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/patriot/double,
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "iAr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15742,18 +15852,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
-"iFq" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 8;
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4";
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/dorms)
 "iFB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -16173,11 +16271,7 @@
 /area/station/tcommsat/server)
 "iPh" = (
 /obj/structure/cable,
-/obj/machinery/door/airlock{
-	name = "Bedroom"
-	},
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/eighties,
+/turf/closed/wall,
 /area/station/service/abandoned_gambling_den/gaming)
 "iPl" = (
 /obj/effect/turf_decal/trimline/red/filled/warning,
@@ -16246,13 +16340,6 @@
 /obj/effect/base_turf_modifier/pit,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
-"iRs" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "iRw" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/trunk{
@@ -16356,9 +16443,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "iVc" = (
-/obj/structure/dresser,
-/obj/machinery/light/directional/north,
-/turf/open/floor/carpet/orange,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/station/commons/dorms)
 "iVp" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
@@ -17565,10 +17653,6 @@
 	dir = 1
 	},
 /area/station/science/lab)
-"jEf" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "jEi" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/green/filled/warning{
@@ -17684,18 +17768,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/cmo)
-"jHZ" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/machinery/button/door/directional/west{
-	id = "Dorm3";
-	name = "Dormitory Door Lock";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
-/turf/open/floor/wood,
-/area/station/commons/dorms)
 "jIt" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -17707,7 +17779,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "jIC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -17740,6 +17812,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
+"jJy" = (
+/obj/machinery/shower/directional/south,
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "jJD" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron,
@@ -17873,13 +17950,15 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/theatre)
-"jMk" = (
-/obj/structure/cable,
+"jMq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
@@ -18054,6 +18133,19 @@
 /obj/item/flashlight,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"jQZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "jRw" = (
 /obj/structure/cable/industrial,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -18163,10 +18255,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/storage)
-"jTS" = (
-/obj/structure/cable,
-/turf/open/floor/carpet/red,
-/area/station/security/office)
 "jTU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -18659,13 +18747,6 @@
 /obj/machinery/light/no_nightlight/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
-"kgu" = (
-/obj/machinery/door/window/brigdoor{
-	name = "Toilet";
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/station/service/abandoned_gambling_den/gaming)
 "kgA" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants/random,
@@ -19682,10 +19763,18 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "kIu" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
+/obj/machinery/duct/industrial/waste,
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "kIM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19947,7 +20036,7 @@
 "kOf" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "kOp" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -20008,19 +20097,17 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/cmo)
 "kOZ" = (
-/obj/structure/toilet{
-	dir = 4;
-	pixel_y = 7
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
-/obj/structure/sink/directional/north,
-/obj/structure/mirror{
-	pixel_y = -28
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
 	},
-/obj/machinery/light/small/directional/south{
-	pixel_x = 11
-	},
-/turf/open/floor/iron/freezer,
-/area/station/commons/dorms)
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "kPd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20658,6 +20745,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"lhf" = (
+/obj/vehicle/ridden/secway,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "lhq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20761,7 +20852,7 @@
 /obj/effect/spawner/structure/window,
 /obj/structure/barricade/wooden/crude,
 /turf/open/floor/plating,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "ljE" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -20797,17 +20888,19 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "lln" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
+/obj/structure/toilet{
+	dir = 4;
+	pixel_y = 7
 	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
+/obj/structure/sink/directional/north,
+/obj/structure/mirror{
+	pixel_y = -28
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/obj/machinery/light/small/directional/south{
+	pixel_x = 11
+	},
+/turf/open/floor/iron/freezer,
+/area/station/commons/dorms)
 "llt" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -20862,6 +20955,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
+"lms" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "lmt" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/food/spaghetti/security,
@@ -20893,6 +20991,11 @@
 /obj/machinery/computer/old,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"lmO" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "lmX" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 4
@@ -20933,11 +21036,6 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"lpr" = (
-/obj/effect/spawner/random/trash,
-/obj/vehicle/ridden/secway,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "lpu" = (
 /obj/effect/spawner/random/trash,
 /obj/structure/cable,
@@ -21022,14 +21120,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/command/bridge)
-"lsz" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/clown/double,
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
-/area/station/commons/dorms)
 "lsW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -21220,6 +21310,13 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/rd)
+"lxJ" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/textured,
+/area/station/security/courtroom)
 "lxM" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Conveyor Access"
@@ -21725,10 +21822,6 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"lIX" = (
-/obj/vehicle/ridden/secway,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "lJE" = (
 /obj/structure/table/glass/plasmaglass,
 /obj/item/electronics/airlock,
@@ -21761,16 +21854,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"lKw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/south,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "lKD" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -21798,20 +21881,16 @@
 "lLz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 10
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 10;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/green/corner{
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"lLC" = (
-/obj/machinery/camera/autoname/directional/south,
-/obj/machinery/shower/directional/north,
-/obj/structure/drain,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
 "lLE" = (
 /obj/structure/sink/directional/east,
 /turf/open/floor/iron/showroomfloor,
@@ -21880,6 +21959,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"lNO" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "lNZ" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -22156,17 +22242,6 @@
 /obj/machinery/modular_computer/console/preset/id,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
-"lVw" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "lVC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22204,9 +22279,16 @@
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "lWJ" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/station/commons/dorms)
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "lXc" = (
 /obj/structure/cable,
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/south,
@@ -22457,10 +22539,13 @@
 "mhY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/blue/warning,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "miu" = (
@@ -22587,19 +22672,6 @@
 	},
 /turf/open/floor/plating/ocean,
 /area/station/cargo/storage)
-"mmN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/autoname/directional/north,
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "mne" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22632,6 +22704,13 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/plating/ocean,
 /area/ocean/near_station_powered)
+"mnD" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "mnI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
@@ -22727,17 +22806,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/storage/primary)
-"mpo" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4";
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "mqy" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 9
@@ -22810,15 +22878,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/purple/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"msj" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/station/commons/dorms)
-"mst" = (
-/turf/open/floor/eighties,
-/area/station/service/abandoned_gambling_den/gaming)
 "msv" = (
 /obj/structure/fans/tiny/forcefield,
 /obj/machinery/door/poddoor/shutters{
@@ -22992,13 +23051,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
-"mwl" = (
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#009dc4";
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/service/hydroponics/garden)
 "mwr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23932,9 +23984,6 @@
 	},
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar)
-"mXH" = (
-/turf/closed/wall/r_wall,
-/area/station/service/abandoned_gambling_den/gaming)
 "mYo" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/tile/blue/diagonal_centre,
@@ -24416,6 +24465,16 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/engineering/main)
+"njC" = (
+/obj/structure/curtain/cloth,
+/obj/structure/drain,
+/obj/machinery/shower/directional/north,
+/obj/machinery/door/window/brigdoor{
+	name = "Shower";
+	dir = 4
+	},
+/turf/open/floor/iron/freezer,
+/area/station/commons/dorms)
 "njU" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -24524,7 +24583,7 @@
 	dir = 4
 	},
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "nmx" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -24921,9 +24980,16 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/courtroom)
 "nxP" = (
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "nxY" = (
 /obj/machinery/light/directional/south,
 /obj/structure/table/reinforced/rglass,
@@ -25455,11 +25521,11 @@
 /obj/structure/barricade/wooden/crude,
 /obj/structure/cable,
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "nMN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "nMV" = (
 /obj/structure/table/wood,
 /obj/machinery/fax{
@@ -25661,6 +25727,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
+"nUv" = (
+/obj/effect/spawner/random/trash,
+/obj/vehicle/ridden/secway,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "nUw" = (
 /obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
@@ -25742,6 +25813,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/storage)
+"nWw" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "nWK" = (
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
@@ -25751,7 +25835,7 @@
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "nXC" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
@@ -25878,9 +25962,6 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
-"ocx" = (
-/turf/open/floor/circuit/telecomms/server,
-/area/station/science/server)
 "ocM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -26273,19 +26354,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/chapel)
-"oms" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "omy" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -26531,9 +26599,6 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/iron,
 /area/mine/storage/public)
-"orK" = (
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "orQ" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -26800,18 +26865,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/mechbay)
 "oyo" = (
+/obj/effect/spawner/structure/window,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/station/commons/dorms)
 "oyB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -26934,13 +26992,6 @@
 "oBr" = (
 /turf/closed/wall,
 /area/station/service/lawoffice)
-"oBw" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
-/area/station/commons/dorms)
 "oBz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27051,15 +27102,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
-"oFT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/line,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "oGC" = (
 /obj/effect/base_turf_modifier/pit,
 /turf/closed/wall/r_wall/rust,
@@ -27169,6 +27211,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
+"oIY" = (
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "oJo" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
@@ -27341,18 +27387,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
-"oQr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 1;
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "oRe" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor/auto,
@@ -27548,14 +27582,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/storage/emergency/starboard)
-"oWd" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/warning,
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
 "oWq" = (
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
 /obj/machinery/door/poddoor/shutters/window/preopen{
@@ -27569,6 +27595,9 @@
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
 	name = "Brig"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
@@ -27765,6 +27794,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/dorms)
+"pds" = (
+/obj/structure/chair/sofa/right,
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "pdS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -27916,6 +27950,10 @@
 	dir = 4
 	},
 /area/station/service/chapel)
+"phv" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "phA" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -27969,12 +28007,17 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "piw" = (
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 8
 	},
-/area/station/commons/dorms)
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/commons/vacant_room)
 "piW" = (
 /obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/trunk{
@@ -27994,6 +28037,12 @@
 "pkw" = (
 /turf/closed/wall,
 /area/mine/storage/public)
+"pkH" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/dorms)
 "pkS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack,
@@ -28456,26 +28505,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/kitchen/kitchen_backroom)
-"pvE" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
 "pwa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
-"pwH" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
 "pwU" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/stripes/line{
@@ -28526,10 +28561,16 @@
 /area/station/engineering/main)
 "pyJ" = (
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "pyU" = (
 /turf/closed/wall,
 /area/station/service/chapel/office)
+"pzo" = (
+/obj/machinery/door/airlock{
+	name = "Bedroom"
+	},
+/turf/open/floor/carpet/orange,
+/area/station/commons/dorms)
 "pzs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -28825,19 +28866,6 @@
 /obj/structure/showcase/machinery/tv,
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation/entertainment)
-"pHM" = (
-/obj/machinery/duct/industrial/waste,
-/obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "pHU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29114,10 +29142,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/security/courtroom)
-"pOa" = (
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark/textured,
-/area/station/cargo/storage)
 "pOc" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -29646,6 +29670,13 @@
 	dir = 1
 	},
 /area/station/engineering/main)
+"qbg" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "qbp" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -29721,19 +29752,6 @@
 	dir = 8
 	},
 /area/station/engineering/break_room)
-"qcn" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/machinery/door/airlock{
-	id_tag = "Dorm1";
-	name = "Cabin 1"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
 "qco" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -29796,7 +29814,7 @@
 "qet" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "qeF" = (
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron,
@@ -29990,18 +30008,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"qkl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "qkz" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/wood,
@@ -30069,13 +30075,10 @@
 /area/station/command/heads_quarters/captain/private)
 "qmM" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 1;
-	color = "#009dc4"
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/white/warning{
-	color = "#009dc4"
-	},
+/obj/effect/turf_decal/trimline/green/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "qmR" = (
@@ -30411,6 +30414,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
+"qtW" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/shower/directional/south,
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "quh" = (
 /obj/structure/table/wood/poker,
 /obj/item/reagent_containers/cup/glass/drinkingglass{
@@ -30493,7 +30502,7 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "qxw" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/rack,
@@ -30515,18 +30524,6 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/science/robotics/lab)
-"qxA" = (
-/obj/machinery/duct/industrial/waste,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central/fore)
 "qxC" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/disposalpipe/segment{
@@ -30632,6 +30629,13 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/carpet/lone/star,
 /area/station/service/chapel/office)
+"qBk" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/green/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "qBs" = (
 /obj/effect/turf_decal/stripes{
 	dir = 6
@@ -30735,10 +30739,10 @@
 	name = "Central Access"
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning,
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "qFt" = (
@@ -31080,7 +31084,7 @@
 "qNT" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "qNW" = (
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 8
@@ -31159,6 +31163,14 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"qPO" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/clown/double,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "qQx" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -31725,13 +31737,11 @@
 /area/station/engineering/atmos)
 "rgW" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
-	color = "#009dc4"
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -31986,14 +31996,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/break_room)
 "rmF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/trimline/brown/line{
-	dir = 1
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
 	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
+/area/station/commons/dorms)
 "rmK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/purple/corner{
@@ -32039,10 +32047,14 @@
 /turf/open/floor/plating/ocean,
 /area/ocean)
 "rnM" = (
-/obj/structure/bed/double,
-/obj/item/bedsheet/patriot/double,
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
+/obj/structure/chair/sofa/left,
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/structure/sign/poster/contraband/pwr_game{
+	pixel_y = 36
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "rob" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair,
@@ -32197,9 +32209,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/security/checkpoint/customs)
-"rsJ" = (
-/turf/open/floor/carpet/red,
-/area/station/security/office)
 "rsL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -32236,13 +32245,13 @@
 "rtP" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/camera/autoname/directional/east,
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8;
-	color = "#009dc4"
-	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -32273,6 +32282,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
+"rve" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "rvq" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/ocean,
@@ -32349,7 +32364,7 @@
 "rwX" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /turf/open/floor/plating,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "rxa" = (
 /obj/structure/fans/tiny/forcefield,
 /turf/open/floor/engine,
@@ -32517,13 +32532,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"rBs" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "rBv" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -33139,12 +33147,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room)
-"rRs" = (
-/obj/machinery/door/airlock{
-	name = "Bedroom"
-	},
-/turf/open/floor/carpet/orange,
-/area/station/commons/dorms)
 "rRy" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33446,6 +33448,13 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"sbg" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "sbh" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/delivery,
@@ -33770,6 +33779,14 @@
 /obj/structure/rack,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
+"sln" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/security/office)
 "slt" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -33872,18 +33889,6 @@
 	},
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
-"sqv" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#009dc4";
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner{
-	color = "#009dc4";
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
 "sqw" = (
 /obj/machinery/computer/records/security{
 	dir = 1
@@ -34025,19 +34030,6 @@
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
-"suu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "suv" = (
 /obj/effect/base_turf_modifier/pit,
 /turf/closed/wall,
@@ -34095,7 +34087,7 @@
 "svH" = (
 /obj/structure/cable,
 /turf/open/floor/eighties/red,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "svS" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/trimline/white/filled/line{
@@ -34245,19 +34237,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
-"szY" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/structure/closet/crate/freezer,
-/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
-/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
-/obj/item/reagent_containers/cup/soda_cans/monkey_energy,
-/obj/item/reagent_containers/cup/soda_cans/pwr_game,
-/obj/item/reagent_containers/cup/soda_cans/pwr_game,
-/obj/item/reagent_containers/cup/soda_cans/pwr_game,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
 "sAw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -34288,15 +34267,7 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "sBe" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/obj/machinery/button/door/directional/west{
-	id = "Dorm1";
-	name = "Dormitory Door Lock";
-	normaldoorcontrol = 1;
-	specialfunctions = 4
-	},
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "sBo" = (
@@ -34385,14 +34356,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
-"sDi" = (
-/obj/structure/dresser,
-/obj/machinery/light/directional/north,
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
-	},
-/area/station/commons/dorms)
 "sDA" = (
 /obj/effect/turf_decal/trimline/white/filled/warning{
 	dir = 8;
@@ -35226,11 +35189,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"tcA" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "tde" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35509,6 +35467,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
+"tlN" = (
+/obj/structure/bed/double,
+/obj/item/bedsheet/clown/double,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/katana{
+	desc = "As seen in your favourite Japanese cartoon.";
+	name = "anime katana"
+	},
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "tme" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -35834,12 +35802,12 @@
 /area/station/security/warden)
 "txw" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4";
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
@@ -36165,17 +36133,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/lobby)
-"tGL" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/structure/sign/poster/contraband/lusty_xenomorph{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
 "tGQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -36793,8 +36750,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "tWp" = (
-/obj/structure/cable,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/station/service/abandoned_gambling_den/gaming)
 "tWr" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
@@ -36813,6 +36769,19 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
+"tXk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "tXl" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/disposalpipe/segment{
@@ -36839,11 +36808,8 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "tYl" = (
-/obj/effect/turf_decal/trimline/brown/end{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured/airless,
-/area/station/science/lobby)
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "tYt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37065,6 +37031,9 @@
 	name = "Brig"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "udB" = (
@@ -37368,11 +37337,17 @@
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "umh" = (
-/turf/open/floor/eighties/red{
-	icon = 'goon/icons/turf/floors.dmi';
-	icon_state = "clown_carpet"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
 	},
-/area/station/commons/dorms)
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "umt" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chapel Office Maintenance"
@@ -37630,7 +37605,7 @@
 /area/station/maintenance/starboard/central)
 "uth" = (
 /turf/open/floor/plating,
-/area/station/service/abandoned_gambling_den/gaming)
+/area/station/service/electronic_marketing_den)
 "utm" = (
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
@@ -37730,6 +37705,19 @@
 "uxK" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/fitness/recreation/entertainment)
+"uxR" = (
+/obj/machinery/duct/industrial/waste,
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "uyh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37970,14 +37958,16 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/command/bridge)
 "uEb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/central/fore)
 "uEz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38020,6 +38010,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/courtroom)
+"uFj" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "uFS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -38239,6 +38237,17 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
+"uLC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/door/airlock{
+	id_tag = "Dorm2";
+	name = "Cabin 2"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "uLQ" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash/graffiti,
@@ -38769,6 +38778,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
+"uZx" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "vaZ" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table/wood,
@@ -39046,11 +39060,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/command/bridge)
-"vhy" = (
-/obj/structure/dresser,
-/obj/machinery/light/directional/north,
-/turf/open/floor/eighties,
-/area/station/service/abandoned_gambling_den/gaming)
 "vhM" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
@@ -39400,13 +39409,6 @@
 	},
 /turf/open/floor/iron/sepia,
 /area/station/commons/fitness/recreation)
-"vqR" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "vrg" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
@@ -39658,6 +39660,14 @@
 /obj/effect/turf_decal/trimline/dark_blue/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
+"vyi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "vyk" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -39752,6 +39762,13 @@
 /obj/item/assembly/igniter,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
+"vAN" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "vBn" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
@@ -39934,17 +39951,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/storage/primary)
-"vHR" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Central Access"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "vHZ" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor/auto{
@@ -40066,12 +40072,8 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
 "vMl" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
 /turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
+/area/station/maintenance/port/aft)
 "vMy" = (
 /turf/open/floor/iron/stairs,
 /area/station/service/chapel)
@@ -40153,8 +40155,7 @@
 /turf/open/floor/plating,
 /area/station/security/office)
 "vPb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
 "vPp" = (
 /obj/structure/cable,
@@ -40430,6 +40431,11 @@
 "vXa" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/storage/primary)
+"vXi" = (
+/obj/machinery/shower/directional/north,
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "vXo" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor/auto{
@@ -40641,6 +40647,17 @@
 "wdT" = (
 /turf/open/floor/engine,
 /area/station/maintenance/port/central)
+"wed" = (
+/obj/structure/toilet/secret{
+	dir = 4
+	},
+/obj/item/bikehorn/rubberducky{
+	pixel_x = -9;
+	pixel_y = 12;
+	name = "The Watcher"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "weo" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
@@ -40703,18 +40720,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
-"wfb" = (
-/obj/structure/cable,
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "wfc" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/firealarm/directional/west,
@@ -40741,6 +40746,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
+"wgD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "wgE" = (
 /obj/structure/fans/tiny/forcefield{
 	dir = 8
@@ -40849,15 +40863,6 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/station/science/ordnance/storage)
-"wjh" = (
-/obj/structure/chair/sofa/left,
-/obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/obj/structure/sign/poster/contraband/pwr_game{
-	pixel_y = 36
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
 "wjK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40976,10 +40981,10 @@
 	name = "Central Access"
 	},
 /obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/green/filled/warning,
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/lounge)
 "wny" = (
@@ -41026,16 +41031,6 @@
 /obj/machinery/ticket_machine/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"wpT" = (
-/obj/structure/curtain/cloth,
-/obj/structure/drain,
-/obj/machinery/shower/directional/north,
-/obj/machinery/door/window/brigdoor{
-	name = "Shower";
-	dir = 4
-	},
-/turf/open/floor/iron/freezer,
-/area/station/commons/dorms)
 "wqs" = (
 /turf/open/floor/holofloor/beach/water,
 /area/station/maintenance/starboard/aft)
@@ -41051,19 +41046,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
-"wqJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/extinguisher_cabinet/directional/north,
-/obj/effect/turf_decal/trimline/white/line{
-	color = "#009dc4"
-	},
-/obj/effect/turf_decal/trimline/white/filled/line{
-	color = "#009dc4";
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
 "wqL" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -41407,6 +41389,15 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/wood/large,
 /area/station/security/checkpoint/customs)
+"wzI" = (
+/obj/machinery/door/airlock{
+	name = "Bedroom"
+	},
+/turf/open/floor/eighties/red{
+	icon = 'goon/icons/turf/floors.dmi';
+	icon_state = "clown_carpet"
+	},
+/area/station/commons/dorms)
 "wAk" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -41730,18 +41721,17 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/upper)
 "wJB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/white/filled/warning{
-	dir = 10;
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
 	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/white/corner{
-	color = "#009dc4";
-	dir = 4
-	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/central/fore)
 "wJN" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/disposalpipe/segment{
@@ -41759,10 +41749,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "wJX" = (
-/obj/structure/chair/sofa/right,
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood,
-/area/station/service/abandoned_gambling_den/gaming)
+/turf/closed/wall,
+/area/station/service/electronic_marketing_den)
 "wKB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -42173,6 +42161,17 @@
 	color = "#D381C9"
 	},
 /area/station/science/robotics)
+"wVt" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "wVu" = (
 /obj/structure/cable,
 /obj/structure/closet/secure_closet/security/sec,
@@ -42330,6 +42329,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
+"wZY" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/lounge)
 "xae" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/duct/industrial/waste,
@@ -42484,6 +42489,19 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/science/robotics/lab)
+"xdL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "xdP" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -42504,10 +42522,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/station/science/robotics/mechbay)
-"xeu" = (
-/obj/machinery/suit_storage_unit/security,
-/turf/open/floor/iron/dark/textured,
-/area/station/maintenance/port/aft)
 "xev" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/structure/chair/sofa/left{
@@ -42638,11 +42652,9 @@
 /turf/open/floor/iron,
 /area/mine/storage/public)
 "xjU" = (
-/obj/structure/chair/wood{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/commons/dorms)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/server)
 "xjX" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/closet/secure_closet/chemical,
@@ -42837,12 +42849,6 @@
 /obj/effect/base_turf_modifier/pit,
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
-"xpB" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/dorms)
 "xpZ" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Departure Lounge"
@@ -43168,11 +43174,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"xwl" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/warning,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "xwm" = (
 /turf/closed/wall,
 /area/station/commons/fitness/recreation)
@@ -43298,6 +43299,11 @@
 "xzr" = (
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
+"xzv" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den/gaming)
 "xzw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43457,6 +43463,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"xEU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "xFc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -43769,13 +43787,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"xOI" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/lounge)
 "xOR" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 10
@@ -43837,6 +43848,9 @@
 	id_tag = "innerbrig";
 	name = "Brig"
 	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "xQn" = (
@@ -43876,6 +43890,14 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"xRd" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock{
+	name = "Bedroom"
+	},
+/obj/effect/mapping_helpers/airlock/abandoned,
+/turf/open/floor/eighties,
+/area/station/service/abandoned_gambling_den/gaming)
 "xRl" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/grimy,
@@ -43887,6 +43909,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"xRF" = (
+/obj/machinery/suit_storage_unit/security,
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "xRW" = (
 /obj/structure/table,
 /obj/machinery/coffeemaker,
@@ -44253,17 +44279,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
-"ybQ" = (
-/obj/structure/toilet/secret{
-	dir = 4
-	},
-/obj/item/bikehorn/rubberducky{
-	pixel_x = -9;
-	pixel_y = 12;
-	name = "The Watcher"
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms)
 "yca" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -59110,11 +59125,11 @@ lUz
 lUz
 lUz
 lUz
-mXH
-mXH
-mXH
-mXH
-mXH
+tWp
+tWp
+tWp
+tWp
+tWp
 kJb
 kJb
 rdt
@@ -59360,17 +59375,17 @@ fdQ
 weo
 uSV
 lUz
-pwH
-nxP
-kOZ
+phv
+bOl
+lln
 qZZ
-oBw
-piw
-kOZ
+qbg
+rmF
+lln
 fue
-gCF
+uZx
 gau
-hVa
+gaM
 fue
 uRZ
 kwc
@@ -59617,20 +59632,20 @@ vwP
 vwP
 vwP
 lUz
-iVc
-nxP
-wpT
+gKa
+bOl
+njC
 vwP
-sDi
-piw
-wpT
+eaU
+rmF
+njC
 fue
-vhy
+anc
 gau
-kgu
+eVV
 fue
-wfb
-rBs
+fYs
+qBk
 rdt
 cda
 jLV
@@ -59701,7 +59716,7 @@ afn
 vfM
 vfM
 fKI
-gCo
+rve
 rkn
 pII
 aej
@@ -59872,22 +59887,22 @@ uSV
 vwP
 vwP
 bmW
-ybQ
+wed
 lUz
-rnM
-bRQ
-bRQ
+iAd
+aTD
+aTD
 vwP
-lsz
-umh
-umh
+qPO
+gWA
+gWA
 fue
-bOl
-mst
+tlN
+tYl
 wMb
 fue
-jMk
-rBs
+lWJ
+qBk
 nPn
 epv
 iDn
@@ -60132,18 +60147,18 @@ bmW
 fvS
 vwP
 vwP
-rRs
+pzo
 vwP
 vwP
 vwP
-fua
+wzI
 vwP
-tWp
-tWp
 iPh
-tWp
-tWp
-jMk
+iPh
+xRd
+iPh
+iPh
+lWJ
 gtk
 rdt
 vaZ
@@ -60388,20 +60403,20 @@ bmW
 bmW
 uRq
 vwP
-fja
+uFj
 ksj
-jHZ
+eip
 vwP
-fja
+uFj
 ksj
-sBe
-tWp
-tGL
+bPh
+iPh
+bkB
 amz
-bAj
+cuI
 fue
-jMk
-rBs
+lWJ
+qBk
 rdt
 nKi
 kJF
@@ -60647,18 +60662,18 @@ vwP
 vwP
 jCa
 ksj
-lWJ
+sBe
 vwP
 jCa
 ksj
-lWJ
-tWp
-wJX
+sBe
+iPh
+pds
 aWp
-cpG
+fAn
 fue
-wfb
-rBs
+fYs
+qBk
 rdt
 rdt
 rdt
@@ -60898,25 +60913,25 @@ xHH
 wop
 weo
 vwP
-drw
+jJy
 bmW
-hWg
+vXi
 vwP
 pZJ
 ksj
-xjU
+iVc
 vwP
 pZJ
 ksj
-xjU
-tWp
-wjh
-kIu
-szY
+iVc
+iPh
+rnM
+xzv
+hCR
 fue
 oHD
 vTm
-lLz
+dls
 mnS
 lVC
 lrZ
@@ -60927,13 +60942,13 @@ hMM
 nvl
 nvl
 tKO
-oms
-oms
-oms
-oms
-oms
-oms
-wJB
+jMq
+jMq
+jMq
+jMq
+jMq
+jMq
+lLz
 tJW
 gun
 lrZ
@@ -61155,23 +61170,23 @@ xHH
 wop
 pVn
 vwP
-iul
+qtW
 bmW
-lLC
+fdq
 vwP
 vwP
 nKk
 vwP
 vwP
 vwP
-apa
+uLC
 vwP
 fue
 fue
-qcn
+gCN
 fue
 fue
-gAV
+umh
 rKc
 pIW
 lQS
@@ -61240,9 +61255,9 @@ vUV
 lwj
 byv
 fKI
-pOa
+iyv
 nyQ
-gCN
+gCo
 wAI
 mLC
 dqy
@@ -61415,7 +61430,7 @@ wri
 bmW
 bmW
 bmW
-eRn
+cHm
 xmS
 sDA
 sxq
@@ -61425,28 +61440,28 @@ sDA
 beP
 beP
 beP
-iFq
+eQp
 wAH
 uGB
 vSI
 bBP
-mpo
+hJv
 kBt
 oQa
 dpV
-pHM
+rtP
 dpV
 dpV
 dpV
 dpV
 ubI
 dpV
-rtP
-lln
-lln
-lln
-lln
-iji
+kIu
+kOZ
+kOZ
+kOZ
+kOZ
+uxR
 cUp
 nIO
 kfX
@@ -61681,13 +61696,13 @@ kZH
 kZH
 kZH
 sga
-cot
-xpB
+flc
+pkH
 wBl
-msj
+oyo
 fDR
 qkH
-bkB
+nxP
 xwm
 xwm
 xwm
@@ -61944,7 +61959,7 @@ bec
 uGB
 vSI
 tYL
-bkB
+nxP
 xwm
 auY
 dcF
@@ -62199,9 +62214,9 @@ ort
 nGD
 nGD
 nGD
-wqJ
+xdL
 rfc
-bkB
+nxP
 xwm
 oas
 agP
@@ -62267,7 +62282,7 @@ tNT
 qhS
 eDo
 xgr
-oyo
+nWw
 imV
 kJB
 mkz
@@ -62452,7 +62467,7 @@ uzZ
 ceK
 pyU
 dtb
-sqv
+piw
 uFU
 nGD
 eso
@@ -62487,13 +62502,13 @@ nyD
 cCg
 qbR
 pAj
-iah
+vyi
 tRg
 hrr
 hrr
 hrr
 hrr
-iah
+vyi
 tzl
 eco
 xUj
@@ -62712,10 +62727,10 @@ mHp
 sJd
 jeZ
 nGD
-qkl
+xEU
 rfc
 kwp
-bkB
+nxP
 xwm
 qeN
 oas
@@ -62743,17 +62758,17 @@ rfc
 wDZ
 jgV
 pHV
-qEO
-iRs
+hPT
+vAN
 kAd
 bTn
 auj
 bTn
 bTn
-xOI
-xwl
-vHR
-oWd
+sbg
+lms
+qEO
+qmM
 sTn
 sTn
 sTn
@@ -62764,7 +62779,7 @@ sTn
 sTn
 ltK
 qJW
-qmM
+wVt
 hzM
 sTn
 ngm
@@ -62778,7 +62793,7 @@ hzM
 sTn
 nTa
 gUe
-lKw
+epx
 qaa
 uNE
 lap
@@ -62787,7 +62802,7 @@ kBn
 mue
 qaa
 cov
-mwl
+cLu
 oII
 qIf
 bZJ
@@ -62969,7 +62984,7 @@ shX
 tTb
 iWI
 nGD
-mmN
+fZv
 rfc
 lNF
 mQx
@@ -63000,16 +63015,16 @@ bMn
 kkW
 lca
 nDl
-lVw
-vqR
+wmV
+lNO
 gDA
 pXi
 hwW
 pXi
 pXi
-vMl
-tcA
-wmV
+mnD
+lmO
+iul
 jEi
 eLS
 eLS
@@ -63035,7 +63050,7 @@ sJj
 iaP
 gxe
 ngm
-rmF
+bMR
 qaa
 uDo
 bcQ
@@ -63226,19 +63241,19 @@ rQX
 kgA
 svS
 nGD
-wqJ
+xdL
 rfc
-bkB
-fue
-fue
-fue
-fue
-fue
+nxP
+wJX
+wJX
+wJX
+wJX
+wJX
 ljv
 qNT
 ljv
 ljv
-fue
+wJX
 ucK
 gPH
 kPd
@@ -63265,7 +63280,7 @@ hrr
 xVm
 xVm
 fRb
-cbD
+wZY
 yhH
 qNW
 vkw
@@ -63292,7 +63307,7 @@ twN
 twN
 jfI
 ngm
-rmF
+bMR
 qaa
 mtV
 afN
@@ -63483,10 +63498,10 @@ nGD
 nGD
 nGD
 nGD
-qkl
+xEU
 kwp
-bkB
-fue
+nxP
+wJX
 qet
 gMt
 ewL
@@ -63495,7 +63510,7 @@ nMN
 pyJ
 nXd
 fMu
-fue
+wJX
 xmh
 xCU
 csW
@@ -63549,7 +63564,7 @@ lYm
 twN
 jfI
 gtt
-rmF
+bMR
 qaa
 qry
 jJI
@@ -63742,7 +63757,7 @@ uRG
 ewl
 lhq
 rfc
-bkB
+nxP
 ljv
 ewL
 gMt
@@ -63752,7 +63767,7 @@ pyJ
 kOf
 grw
 ewL
-fue
+wJX
 bfN
 csW
 ttR
@@ -63806,7 +63821,7 @@ xmK
 twN
 jfI
 ngm
-rmF
+bMR
 qaa
 uAo
 dYT
@@ -63997,9 +64012,9 @@ lHt
 jSp
 lHt
 yke
-gAV
+umh
 tYL
-mpo
+hJv
 ilm
 kOf
 kOf
@@ -64009,7 +64024,7 @@ kOf
 aTw
 nmp
 bnB
-fue
+wJX
 xmh
 csW
 lGH
@@ -64063,7 +64078,7 @@ cLN
 twN
 jfI
 ngm
-rmF
+bMR
 qaa
 weQ
 uVd
@@ -64254,7 +64269,7 @@ wlx
 gIZ
 nVx
 ukf
-gAV
+umh
 rfc
 mWr
 nMK
@@ -64266,7 +64281,7 @@ kOf
 uth
 qxd
 qet
-fue
+wJX
 xmh
 xCU
 ttR
@@ -64511,9 +64526,9 @@ lHt
 jSp
 lHt
 yke
-gAV
+umh
 kwp
-bkB
+nxP
 ljv
 aTw
 uth
@@ -64523,7 +64538,7 @@ kOf
 aTw
 nmp
 qet
-fue
+wJX
 xmh
 ttR
 ttR
@@ -64768,10 +64783,10 @@ wlx
 gIZ
 wlx
 nMG
-oQr
+mhY
 rfc
-bkB
-fue
+nxP
+wJX
 qet
 ewL
 ewL
@@ -64780,7 +64795,7 @@ kOf
 aTw
 coa
 ewL
-fue
+wJX
 bfN
 mSq
 sun
@@ -65025,19 +65040,19 @@ gIZ
 jSp
 oUo
 nLV
-gAV
+umh
 rfc
-bkB
-fue
-fue
-fue
-fue
-fue
-fue
-fue
+nxP
+wJX
+wJX
+wJX
+wJX
+wJX
+wJX
+wJX
 igp
-fue
-fue
+wJX
+wJX
 bfN
 mSq
 vbk
@@ -65282,9 +65297,9 @@ wlx
 lHt
 wlx
 nLV
-gAV
+umh
 rfc
-bkB
+nxP
 pkw
 dMh
 vhM
@@ -65539,9 +65554,9 @@ lHt
 eBe
 pse
 nLV
-gAV
+umh
 kwp
-bkB
+nxP
 ahh
 adv
 adv
@@ -65796,9 +65811,9 @@ wlx
 ecM
 eBe
 nLV
-fZv
+jQZ
 rfc
-akJ
+iwy
 wZC
 adv
 adv
@@ -66053,9 +66068,9 @@ lHt
 wlx
 lHt
 nLV
-suu
+tXk
 rfc
-bkB
+nxP
 ahh
 adv
 amw
@@ -66310,9 +66325,9 @@ bIJ
 lHt
 rOB
 nLV
-gAV
+umh
 rfc
-bkB
+nxP
 pkw
 xji
 tRB
@@ -66567,9 +66582,9 @@ nLV
 nLV
 nLV
 nLV
-gAV
+umh
 rfc
-bkB
+nxP
 pkw
 pkw
 orx
@@ -66826,7 +66841,7 @@ fgS
 gGL
 vSI
 kwp
-bkB
+nxP
 pkw
 gyj
 pqf
@@ -67081,9 +67096,9 @@ tXC
 tXC
 tXC
 tXC
-uEb
+gAV
 rfc
-bkB
+nxP
 pkw
 xji
 tRB
@@ -67338,9 +67353,9 @@ uUY
 eGO
 hHy
 tXC
-oFT
+wgD
 tYL
-bkB
+nxP
 pkw
 adv
 tRB
@@ -67595,7 +67610,7 @@ sRK
 tme
 keD
 mMl
-mhY
+iyS
 veZ
 oij
 lxM
@@ -67854,7 +67869,7 @@ tXC
 tXC
 faF
 cbq
-bkB
+nxP
 pkw
 adv
 bJU
@@ -68109,9 +68124,9 @@ ftA
 uPO
 bhD
 rXT
-uEb
+gAV
 wDZ
-bkB
+nxP
 ahh
 uYW
 cPJ
@@ -68182,11 +68197,11 @@ rrB
 rrB
 rrB
 rrB
-lpr
-jEf
-xeu
-xeu
-orK
+nUv
+fQp
+xRF
+xRF
+vMl
 udB
 llX
 kkp
@@ -68366,9 +68381,9 @@ gyG
 iip
 qza
 aES
-mhY
+iyS
 wDZ
-bkB
+nxP
 pkw
 pkw
 pkw
@@ -68439,11 +68454,11 @@ lKN
 ydD
 ofT
 rrB
-lIX
-orK
-orK
-orK
-orK
+lhf
+vMl
+vMl
+vMl
+vMl
 okD
 gvZ
 uPB
@@ -68623,9 +68638,9 @@ qHJ
 nya
 tfm
 rIM
-mhY
+iyS
 wDZ
-bkB
+nxP
 tYA
 nwZ
 iEa
@@ -68880,9 +68895,9 @@ iVp
 tfm
 qza
 vAD
-uEb
+gAV
 cbq
-bkB
+nxP
 tYA
 iEa
 pKF
@@ -74097,9 +74112,9 @@ upz
 trt
 ehb
 naf
-fjP
+sln
 voj
-jTS
+oIY
 rhn
 wCS
 rMy
@@ -74355,7 +74370,7 @@ aus
 eJj
 wfC
 oUp
-rsJ
+fyP
 xRW
 vWE
 ajQ
@@ -75889,7 +75904,7 @@ lkF
 nbU
 fXB
 gPZ
-hPG
+lxJ
 gPZ
 gPZ
 onf
@@ -78453,7 +78468,7 @@ xpc
 pkw
 pkw
 qRJ
-dls
+txw
 ydb
 iFe
 gqY
@@ -78710,7 +78725,7 @@ kAb
 kAb
 voJ
 qRJ
-qxA
+gIh
 ydb
 iFe
 gqY
@@ -78967,7 +78982,7 @@ rUJ
 eKC
 hmK
 qRJ
-dls
+txw
 vPp
 iFe
 gqY
@@ -79224,7 +79239,7 @@ pOm
 kAb
 voJ
 qRJ
-dls
+txw
 ydb
 iFe
 gZg
@@ -79481,7 +79496,7 @@ hUM
 oiP
 qRJ
 qRJ
-dls
+txw
 ydb
 iFe
 gZg
@@ -79995,7 +80010,7 @@ jBo
 aNn
 qRJ
 qRJ
-txw
+uEb
 ydb
 wZN
 gZg
@@ -80696,8 +80711,8 @@ fgS
 rdb
 wdA
 wdA
-ocx
 vPb
+xjU
 bYP
 wvm
 hwz
@@ -80954,7 +80969,7 @@ rdb
 wdA
 qQF
 adu
-vPb
+xjU
 koq
 jcU
 jcU
@@ -81280,7 +81295,7 @@ vjk
 vjk
 dXN
 fvi
-gzE
+glV
 diH
 iFe
 vUJ
@@ -81468,7 +81483,7 @@ gzZ
 wdA
 qQF
 adu
-vPb
+xjU
 iLR
 cJw
 cJw
@@ -81531,12 +81546,12 @@ qeK
 rEC
 mFJ
 dMk
-rgW
+wJB
 okT
 gSr
 okT
-rgW
-eQp
+wJB
+gzE
 tKo
 ryL
 ixB
@@ -81724,8 +81739,8 @@ nRM
 gzZ
 wdA
 wdA
-ocx
 vPb
+xjU
 mrJ
 gIk
 wBt
@@ -82295,10 +82310,10 @@ aWQ
 xHL
 lXn
 dck
-pvE
+rgW
 oub
 cri
-hip
+ggj
 tKo
 tKo
 lul
@@ -84310,9 +84325,9 @@ mne
 cHK
 cHK
 cHK
-tYl
 aMJ
-aMJ
+bNb
+bNb
 mHR
 cmR
 ezI

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -19047,6 +19047,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
 	dir = 4
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "kdC" = (
@@ -30353,13 +30354,8 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "qay" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/structure/cable/industrial,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 1
-	},
+/obj/structure/cable,
+/turf/open/floor/engine,
 /area/station/engineering/main)
 "qbg" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
@@ -33553,6 +33549,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "rHF" = (
@@ -41900,8 +41897,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
 "wky" = (
-/obj/structure/cable/industrial,
-/turf/open/floor/iron/stairs,
+/obj/structure/cable,
+/turf/closed/wall,
 /area/station/engineering/main)
 "wkS" = (
 /obj/machinery/computer/station_alert{
@@ -85970,7 +85967,7 @@ ohC
 nZR
 ohC
 ohC
-nTi
+wky
 jvI
 jvI
 jvI
@@ -86994,15 +86991,15 @@ jWO
 aNi
 aNi
 aNi
-aNi
+qay
 dnr
 jvI
 jRw
 auZ
-auZ
-xKz
-wky
-qay
+rvE
+lSE
+eIg
+qqf
 ghz
 ghz
 ghz
@@ -87251,7 +87248,7 @@ fdi
 aNi
 pGN
 urf
-aNi
+qay
 dnr
 jvI
 cME

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -10671,6 +10671,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners{
 	color = "#009dc4"
 	},
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/engineering_hacking,
+/obj/item/reagent_containers/cup/glass/coffee{
+	pixel_y = 16;
+	pixel_x = 12
+	},
+/obj/item/food/burger{
+	pixel_y = -5;
+	pixel_x = 10
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "fvY" = (
@@ -22701,7 +22711,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "lLE" = (
-/obj/structure/sink/directional/east,
+/obj/structure/sink/directional/east{
+	name = "Urinal";
+	desc = "Oh god I washed my hands in it..."
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
 "lMa" = (
@@ -24543,6 +24556,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners{
 	color = "#009dc4"
 	},
+/obj/structure/bookcase/random/fiction,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "mQx" = (

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -1217,7 +1217,9 @@
 	network = list("aiupload");
 	pixel_x = -29
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/trimline/dark_blue/filled/end{
@@ -1239,7 +1241,9 @@
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
 "aJi" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/iron/sepia,
 /area/station/commons/fitness/recreation)
@@ -1554,6 +1558,12 @@
 	id = "poopoofart"
 	},
 /obj/structure/sink/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "aSy" = (
@@ -2116,12 +2126,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "beP" = (
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
-	color = "#00ff00"
-	},
 /obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
@@ -2453,6 +2463,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "bmW" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "bmY" = (
@@ -2596,7 +2613,9 @@
 /area/station/hallway/primary/central)
 "bqD" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/dark/textured,
@@ -2946,9 +2965,15 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -3124,7 +3149,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
 "bCW" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/structure/table/glass/plasmaglass,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 9
@@ -3162,14 +3189,12 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "bDw" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/junction/flip{
+/obj/machinery/light/very_dim/directional/east,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/aft)
+/area/station/maintenance/port/aft)
 "bDK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4152,6 +4177,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/carpet/cyan,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "ceV" = (
@@ -4262,7 +4290,9 @@
 "ckb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
 	},
@@ -4271,6 +4301,9 @@
 	},
 /obj/machinery/ai_slipper{
 	uses = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -4858,7 +4891,22 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "cCF" = (
-/turf/open/floor/carpet/cyan,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Secure Network Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning,
+/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "cCH" = (
 /obj/effect/landmark/start/scientist,
@@ -4891,10 +4939,15 @@
 "cDd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/red/corner,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -5037,6 +5090,13 @@
 "cHm" = (
 /obj/machinery/door/airlock/bathroom{
 	name = "Showers"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
@@ -5286,7 +5346,9 @@
 /turf/open/floor/grass,
 /area/station/medical/virology)
 "cOV" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/machinery/computer/upload/borg{
 	dir = 1
 	},
@@ -5551,6 +5613,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/iron/dark/textured_corner,
 /area/station/engineering/main)
 "cUa" = (
@@ -6408,7 +6471,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 1
 	},
@@ -6418,6 +6483,9 @@
 	},
 /obj/machinery/ai_slipper{
 	uses = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -6596,7 +6664,9 @@
 /area/station/command/bridge)
 "dsA" = (
 /obj/machinery/camera/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 4
 	},
@@ -6920,7 +6990,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/storage/emergency/starboard)
 "dCH" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/structure/table/glass/plasmaglass,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -8592,7 +8664,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -8955,8 +9029,14 @@
 "eFa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/red/warning,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "eFd" = (
@@ -9455,7 +9535,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/dorms)
 "eQt" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/machinery/vending/imported/yangyu,
 /turf/open/floor/iron/sepia,
 /area/station/commons/fitness/recreation)
@@ -9765,6 +9847,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"eZq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/docking_port/stationary/escape_pod{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/cargo/miningoffice)
 "eZx" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/rack,
@@ -9960,6 +10052,9 @@
 /obj/structure/drain,
 /obj/structure/window/reinforced/tinted{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/end{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
@@ -10198,7 +10293,9 @@
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/upper)
 "fjT" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/machinery/vending/boozeomat{
 	pixel_y = -32
 	},
@@ -10340,6 +10437,7 @@
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 1
 	},
+/obj/structure/table/glass,
 /turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics)
 "foQ" = (
@@ -10459,7 +10557,9 @@
 "ftk" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/bot_red,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 5
 	},
@@ -10565,6 +10665,12 @@
 /area/station/hallway/primary/central)
 "fvS" = (
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "fvY" = (
@@ -11208,7 +11314,9 @@
 /turf/open/floor/plating/ocean,
 /area/ocean/generated_above)
 "fPu" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/structure/table/glass/plasmaglass,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -11271,6 +11379,9 @@
 /area/station/medical/surgery/theatre)
 "fQp" = (
 /obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/port/aft)
 "fQw" = (
@@ -11803,7 +11914,9 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "gcz" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/structure/table/glass/plasmaglass,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -11932,6 +12045,17 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/science/genetics)
+"gfJ" = (
+/obj/structure/cable,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/dark_blue,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/aft)
 "gfL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -12620,7 +12744,9 @@
 /turf/open/floor/plating/ocean,
 /area/ocean/near_station_powered)
 "gBc" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
@@ -12943,7 +13069,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "gMh" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 6
 	},
@@ -13363,7 +13491,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
 "gXL" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/machinery/vending/mechcomp,
 /turf/open/floor/iron/sepia,
 /area/station/commons/fitness/recreation)
@@ -14313,7 +14443,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "hyQ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/machinery/vending/clothing,
 /obj/structure/cable,
 /turf/open/floor/iron/sepia,
@@ -14658,6 +14790,17 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
+"hHd" = (
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 6;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 10;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms)
 "hHy" = (
 /obj/structure/table/glass,
 /obj/item/radio/intercom/directional/west{
@@ -14792,8 +14935,14 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/red/warning,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "hLY" = (
@@ -15096,6 +15245,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "hTB" = (
@@ -16053,7 +16203,9 @@
 /turf/open/floor/wood/parquet,
 /area/station/medical/medbay/central)
 "iuY" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
 	},
@@ -16503,7 +16655,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "iIl" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/structure/table/glass/plasmaglass,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -16625,6 +16779,9 @@
 /obj/structure/fans/tiny/forcefield,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/docking_port/stationary/escape_pod{
+	dir = 2
+	},
 /turf/open/floor/engine,
 /area/station/commons/fitness/recreation/entertainment)
 "iLH" = (
@@ -16950,7 +17107,9 @@
 "iUK" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/bot_red,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "iVc" = (
@@ -18347,10 +18506,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "jJy" = (
-/obj/machinery/shower/directional/south,
-/obj/structure/drain,
-/obj/structure/window/reinforced/tinted{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
@@ -18655,12 +18815,17 @@
 	network = list("aiupload")
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "jQW" = (
@@ -19055,11 +19220,16 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "jZH" = (
@@ -21123,7 +21293,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
 "lbq" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/machinery/vending/cart,
 /turf/open/floor/iron/sepia,
 /area/station/commons/fitness/recreation)
@@ -21342,6 +21514,9 @@
 /area/station/engineering/atmos)
 "lhf" = (
 /obj/vehicle/ridden/secway,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/port/aft)
 "lhq" = (
@@ -21833,7 +22008,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lvU" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/structure/table/glass/plasmaglass,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -21858,7 +22035,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "lwg" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 8
 	},
@@ -21891,7 +22070,9 @@
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/station/service/bar/backroom)
 "lxi" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 4
 	},
@@ -22223,10 +22404,16 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/red/corner,
 /obj/structure/sign/plaques/kiddie{
 	pixel_y = 16
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -22611,7 +22798,9 @@
 "lOc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -23192,6 +23381,12 @@
 	name = "Toilets";
 	desc = "A professional 'Ranked Competitive Shitting' arena.";
 	id_tag = "poopoofart"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
@@ -24342,6 +24537,12 @@
 /area/station/engineering/atmos)
 "mQt" = (
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "mQx" = (
@@ -26522,6 +26723,9 @@
 "nUv" = (
 /obj/effect/spawner/random/trash,
 /obj/vehicle/ridden/secway,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/port/aft)
 "nUw" = (
@@ -26621,6 +26825,12 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
+"nWE" = (
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "nWK" = (
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
@@ -29629,7 +29839,9 @@
 "pEl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 8
 	},
@@ -29962,7 +30174,9 @@
 /area/station/command/heads_quarters/hop)
 "pLg" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/structure/table/glass/plasmaglass,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -30077,7 +30291,9 @@
 	name = "\improper A Simpleton's Guide to Safe-cracking with Stethoscopes"
 	},
 /obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /turf/open/floor/wood,
 /area/station/command/bridge)
 "pOm" = (
@@ -30325,6 +30541,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner{
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 8
 	},
@@ -31162,7 +31379,7 @@
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "qqB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
@@ -31370,11 +31587,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
 "qtW" = (
-/obj/machinery/light/directional/north,
 /obj/machinery/shower/directional/south,
 /obj/structure/drain,
 /obj/structure/window/reinforced/tinted{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/end{
+	color = "#009dc4";
+	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
@@ -33862,7 +34082,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured,
+/turf/closed/wall,
 /area/station/medical/pharmacy)
 "rIW" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -34079,13 +34299,18 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line,
 /obj/machinery/flasher/directional/north{
 	id = "AI"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -34544,9 +34769,11 @@
 /turf/open/floor/engine,
 /area/station/cargo/miningoffice)
 "scA" = (
-/obj/docking_port/stationary/escape_pod,
-/turf/open/floor/engine,
-/area/station/cargo/miningoffice)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/maintenance/port/aft)
 "scY" = (
 /obj/effect/turf_decal/trimline/white/filled/line{
 	color = "#009dc4"
@@ -34754,7 +34981,9 @@
 /area/station/science/robotics/lab)
 "sjN" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
@@ -35196,15 +35425,15 @@
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation/entertainment)
 "sxq" = (
-/obj/effect/turf_decal/trimline/white/filled/line{
-	dir = 8;
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 5;
 	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4;
-	color = "#00ff00"
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 9;
+	color = "#009dc4"
 	},
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "sxv" = (
 /obj/structure/chair/comfy/black{
@@ -36404,7 +36633,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "tfT" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
@@ -36524,8 +36755,11 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "tjQ" = (
@@ -36652,7 +36886,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "tnM" = (
 /obj/machinery/light/directional/south,
@@ -37328,19 +37565,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "tIm" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Secure Network Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning,
-/obj/effect/turf_decal/trimline/dark_blue/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/carpet/cyan,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "tIn" = (
 /obj/structure/table,
@@ -37512,7 +37739,9 @@
 /area/station/commons/fitness/recreation/entertainment)
 "tLD" = (
 /obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/end{
 	dir = 4
 	},
@@ -38184,6 +38413,10 @@
 	name = "Security Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/turf_decal/trimline/red/filled/warning,
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "udH" = (
@@ -38697,7 +38930,7 @@
 	name = "disposals chute";
 	pixel_x = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "uqC" = (
 /obj/structure/chair/comfy/black{
@@ -38960,7 +39193,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "uyx" = (
@@ -39127,7 +39365,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "uDt" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/machinery/computer/upload/ai{
 	dir = 1
 	},
@@ -39686,6 +39926,12 @@
 "uRq" = (
 /obj/structure/toilet/secret{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
@@ -40545,7 +40791,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/turf/open/floor/iron,
 /area/station/commons/fitness/recreation/entertainment)
 "vlw" = (
 /obj/machinery/camera/directional/east{
@@ -41127,13 +41376,6 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -41272,7 +41514,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "vIU" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 4
 	},
@@ -41378,6 +41622,9 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
 "vMl" = (
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 10
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/port/aft)
 "vMy" = (
@@ -41771,6 +42018,9 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/white/filled/end{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "vXo" = (
@@ -42005,6 +42255,12 @@
 	pixel_x = -9;
 	pixel_y = 12;
 	name = "The Watcher"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
@@ -42434,6 +42690,13 @@
 /area/station/engineering/main)
 "wri" = (
 /obj/machinery/door/airlock/maintenance,
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 1;
+	color = "#009dc4"
+	},
 /turf/open/floor/plating,
 /area/station/commons/dorms)
 "wro" = (
@@ -44444,7 +44707,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/station/science/server)
 "xtr" = (
 /obj/structure/chair/wood{
@@ -44749,13 +45012,18 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning,
 /obj/machinery/ai_slipper{
 	uses = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -45362,6 +45630,9 @@
 /area/station/maintenance/starboard/central)
 "xRF" = (
 /obj/machinery/suit_storage_unit/security,
+/obj/effect/turf_decal/trimline/red/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/port/aft)
 "xRW" = (
@@ -45403,7 +45674,9 @@
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
 "xTe" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/tile/neutral/fourcorners{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
 "xTm" = (
@@ -61382,7 +61655,7 @@ wop
 uSV
 vwP
 vwP
-bmW
+jJy
 wed
 lUz
 iAd
@@ -61639,7 +61912,7 @@ wop
 weo
 vwP
 mQt
-bmW
+jJy
 fvS
 vwP
 vwP
@@ -61896,7 +62169,7 @@ wop
 pVn
 vwP
 aSx
-bmW
+jJy
 uRq
 vwP
 dPe
@@ -62409,8 +62682,8 @@ xHH
 wop
 weo
 vwP
+qtW
 jJy
-bmW
 vXi
 vwP
 aih
@@ -62667,7 +62940,7 @@ wop
 pVn
 vwP
 qtW
-bmW
+jJy
 fdq
 vwP
 vwP
@@ -62923,13 +63196,13 @@ xHH
 nOV
 uSV
 wri
+sxq
 bmW
-bmW
-bmW
+hHd
 cHm
 xmS
 sDA
-sxq
+beP
 beP
 beP
 sDA
@@ -66847,7 +67120,7 @@ iLH
 ont
 dGk
 hcx
-hcx
+eZq
 dGk
 nip
 qRY
@@ -67105,7 +67378,7 @@ ont
 dGk
 hcx
 hcx
-scA
+dGk
 nip
 qRY
 fUp
@@ -67616,10 +67889,10 @@ wdT
 koQ
 jkJ
 twN
-twN
-wgE
-wgE
-weC
+dGk
+hcx
+hcx
+dGk
 xBV
 xBV
 xBV
@@ -67873,13 +68146,13 @@ kND
 fQw
 qTc
 kND
-meJ
-etN
-etN
-meJ
+dGk
+hcx
+hcx
+dGk
 vSD
 iUK
-cCF
+xUS
 tfk
 uOT
 xBV
@@ -68130,20 +68403,20 @@ kND
 sHe
 wdT
 kND
-meJ
-etN
-etN
-meJ
+twN
+wgE
+wgE
+weC
 vSD
-xUS
+tIm
 ceU
 jgI
 ckX
 xBV
 jQc
-xBV
-fey
-uSB
+cCF
+gaJ
+gfJ
 mLx
 emN
 hCB
@@ -68153,7 +68426,7 @@ xbQ
 dHU
 iNX
 xgE
-emN
+hCB
 fcd
 fEU
 miu
@@ -68398,9 +68671,9 @@ cDd
 fjT
 xBV
 xzw
-tIm
-gaJ
-bDw
+xBV
+xSC
+owJ
 mLx
 emN
 emN
@@ -68409,8 +68682,8 @@ qDE
 qDE
 qDE
 jUk
-emN
-emN
+hCB
+hCB
 ugj
 abD
 lZM
@@ -69951,10 +70224,10 @@ ydD
 ofT
 rrB
 lhf
-vMl
-vMl
-vMl
-vMl
+bDw
+nWE
+bDw
+scA
 okD
 gvZ
 uPB

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -302,9 +302,8 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "afY" = (
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plating/ocean,
-/area/ocean/generated_above)
+/turf/open/floor/holofloor/beach/coast_b,
+/area/station/service/library)
 "agf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/computer/scan_consolenew{
@@ -383,11 +382,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
-"ahT" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plating/ocean,
-/area/ocean/generated_above)
 "aih" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /obj/structure/chair/comfy,
@@ -672,6 +666,23 @@
 	color = "#D381C9"
 	},
 /area/station/science/robotics)
+"arG" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
+/obj/machinery/button/door/directional/north{
+	pixel_x = -23;
+	id = "radio";
+	normaldoorcontrol = 1;
+	specialfunctions = 4;
+	pixel_y = 23
+	},
+/obj/effect/landmark/start/librarian,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "arQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -853,10 +864,6 @@
 	dir = 8
 	},
 /area/station/service/hydroponics)
-"axF" = (
-/obj/machinery/light/small/directional/south,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "axQ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -977,11 +984,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"aBx" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/ocean,
-/area/ocean/generated_above)
 "aBy" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/ce)
@@ -2091,12 +2093,6 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"bfR" = (
-/obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/sand/plating,
-/obj/structure/lattice,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "bgu" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/toggleable/riot{
@@ -2994,6 +2990,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"bBN" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean/generated_above)
 "bBP" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -3295,6 +3296,12 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
+"bHV" = (
+/obj/machinery/cassette/dj_station,
+/obj/machinery/light/dim/directional/west,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "bIa" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 1
@@ -3988,6 +3995,10 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
+"cdn" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "cdv" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/white/filled/corner{
@@ -4264,6 +4275,11 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
+"clx" = (
+/obj/effect/turf_decal/stripes/asteroid/line,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "cly" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -4710,11 +4726,19 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "cBs" = (
-/obj/structure/closet/crate/bin,
-/obj/item/tape/random,
-/obj/item/gps/spaceruin,
-/turf/open/floor/plating/ocean,
-/area/ocean)
+/obj/structure/cassette_rack,
+/obj/item/device/cassette_tape/friday,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/item/device/cassette_tape/random,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "cBt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -5181,6 +5205,22 @@
 /obj/effect/turf_decal/trimline/red/filled/warning,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"cPz" = (
+/obj/structure/table/wood,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/item/device/walkman,
+/obj/structure/window/spawner/directional/west,
+/obj/item/device/cassette_tape/blank,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "cPD" = (
 /obj/structure/cable,
 /obj/machinery/holopad,
@@ -5609,6 +5649,19 @@
 	},
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
+"cYO" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/table/wood,
+/obj/item/taperecorder{
+	pixel_y = 9;
+	pixel_x = -5
+	},
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
+"cYX" = (
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating/ocean,
+/area/ocean/generated_above)
 "cZg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
 	dir = 8
@@ -6686,6 +6739,15 @@
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/iron,
 /area/station/service/library)
+"dAB" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/obj/structure/table/wood,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/service/library)
 "dAF" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light_switch/directional/north{
@@ -7461,6 +7523,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/security/office)
+"dXq" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating/ocean,
+/area/ocean/generated_above)
 "dXv" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -7772,11 +7839,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
-"efb" = (
-/obj/effect/turf_decal/stripes/asteroid/line,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "efz" = (
 /obj/structure/table/wood,
 /obj/item/book/granter/action/spell/smoke/lesser{
@@ -8276,6 +8338,12 @@
 /obj/structure/spider/stickyweb/sealed,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"etI" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/turf_decal/sand/plating,
+/obj/structure/lattice,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "etN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -8967,10 +9035,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/large,
 /area/station/security/checkpoint/customs)
-"eKS" = (
-/obj/structure/lattice,
-/turf/open/floor/plating/ocean/pit/wall,
-/area/ocean)
 "eLs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9160,8 +9224,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "ePE" = (
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plating/ocean,
+/obj/structure/lattice,
+/turf/open/floor/plating/ocean/pit,
 /area/ocean)
 "ePQ" = (
 /obj/structure/table/reinforced,
@@ -10008,11 +10072,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/virology)
-"fnT" = (
-/mob/living/basic/butterfly,
-/obj/structure/cable,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "fnW" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -10262,9 +10321,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"fuD" = (
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "fuQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10760,23 +10816,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"fLq" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/machinery/light/small/directional/north,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/machinery/button/door/directional/north{
-	pixel_x = -23;
-	id = "radio";
-	normaldoorcontrol = 1;
-	specialfunctions = 4;
-	pixel_y = 23
-	},
-/obj/effect/landmark/start/librarian,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "fLN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -11218,10 +11257,6 @@
 /obj/effect/spawner/random/structure/barricade,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"fXY" = (
-/obj/effect/overlay/palmtree_l,
-/turf/open/floor/holofloor/beach,
-/area/station/service/library)
 "fYq" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
@@ -11545,20 +11580,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured,
 /area/mine/storage/public)
-"geB" = (
-/obj/structure/cassette_rack,
-/obj/item/device/cassette_tape/friday,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/item/device/cassette_tape/random,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "geD" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Base"
@@ -11743,6 +11764,10 @@
 	},
 /obj/structure/table/wood,
 /turf/open/floor/iron,
+/area/station/service/library)
+"gle" = (
+/obj/effect/overlay/palmtree_r,
+/turf/open/floor/holofloor/beach,
 /area/station/service/library)
 "glg" = (
 /obj/effect/spawner/random/structure/chair_maintenance,
@@ -12415,12 +12440,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
-"gEA" = (
-/obj/machinery/modular_computer/console/preset/id{
-	dir = 1
-	},
-/turf/open/floor/carpet/orange,
-/area/station/command/heads_quarters/ce)
 "gEE" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor,
@@ -12645,10 +12664,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/ai_monitored/security/armory)
-"gMr" = (
-/obj/structure/cable,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "gMt" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -13862,11 +13877,6 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/science/server)
-"hwD" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "hwI" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment{
@@ -14547,22 +14557,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"hNI" = (
-/obj/structure/table/wood,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/item/device/walkman,
-/obj/structure/window/spawner/directional/west,
-/obj/item/device/cassette_tape/blank,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "hNS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -15398,10 +15392,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
-"imS" = (
-/obj/item/instrument/eguitar,
-/turf/open/floor/holofloor/beach,
-/area/station/service/library)
 "imU" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -15617,13 +15607,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/service/janitor)
-"isz" = (
-/obj/structure/window/spawner/directional/east,
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
-	},
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "itp" = (
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -15704,6 +15687,12 @@
 "iut" = (
 /turf/open/floor/wood/parquet,
 /area/station/medical/medbay/central)
+"iuL" = (
+/obj/machinery/modular_computer/console/preset/id{
+	dir = 1
+	},
+/turf/open/floor/carpet/orange,
+/area/station/command/heads_quarters/ce)
 "iuY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -15747,6 +15736,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
+"ivJ" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "iwc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -16471,6 +16467,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
+"iQr" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cassette/adv_cassette_deck,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "iQE" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -16940,6 +16942,15 @@
 /obj/effect/turf_decal/trimline/brown/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
+"jgy" = (
+/obj/structure/statue/sandstone/venus{
+	anchored = 1;
+	desc = "Ugh, this is merely an ugly amateurish replica of the other statue! The letters RIPGOAT are scribbled onto the base.";
+	dir = 8
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "jgE" = (
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment{
@@ -17122,11 +17133,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
-"jjO" = (
-/obj/structure/window/spawner/directional/west,
-/obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "jjP" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/yellow/line{
@@ -18594,6 +18600,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"jYN" = (
+/mob/living/basic/butterfly,
+/obj/structure/cable,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "jYT" = (
 /obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -19275,6 +19286,14 @@
 /obj/machinery/mecha_part_fabricator/maint,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"kqN" = (
+/obj/structure/statue/sandstone/venus{
+	anchored = 1;
+	dir = 4
+	},
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "kqQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -19408,7 +19427,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
 "kuO" = (
-/turf/open/floor/holofloor/beach/coast_b,
+/turf/open/floor/holofloor/beach/coast_t,
 /area/station/service/library)
 "kuQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -21349,6 +21368,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
+"luB" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/cassette/mailbox,
+/turf/open/floor/iron,
+/area/station/service/library)
 "luH" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -21478,10 +21505,6 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"lyD" = (
-/obj/effect/overlay/palmtree_r,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "lyP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -22581,9 +22604,13 @@
 /turf/open/floor/engine,
 /area/station/commons/storage/emergency/port)
 "mcu" = (
-/obj/structure/lattice,
-/turf/open/floor/plating/ocean/pit,
-/area/ocean)
+/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/service/library)
 "mdc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -22639,6 +22666,11 @@
 /obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"meR" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "mfc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22648,6 +22680,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"mfd" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/table/wood,
+/obj/item/statuebust,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "mfk" = (
 /obj/structure/closet/secure_closet/chief_medical,
 /obj/item/screwdriver,
@@ -23678,6 +23716,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"mMz" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
+	},
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "mMH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23753,11 +23798,6 @@
 	},
 /turf/open/floor/iron/dark/textured_corner,
 /area/station/hallway/primary/central)
-"mOK" = (
-/obj/effect/turf_decal/sand,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "mOU" = (
 /obj/structure/table/reinforced,
 /obj/item/wrench,
@@ -23831,6 +23871,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
+"mRt" = (
+/obj/effect/overlay/palmtree_l,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "mRF" = (
 /obj/structure/table,
 /obj/item/reagent_containers/cup/glass/waterbottle/large{
@@ -25314,11 +25358,6 @@
 "nBV" = (
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/hop)
-"nCf" = (
-/obj/structure/window/spawner/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "nCm" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Head of Personel's office"
@@ -25432,12 +25471,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"nFN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cassette/adv_cassette_deck,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "nFQ" = (
 /obj/effect/turf_decal/stripes{
 	dir = 9
@@ -25838,6 +25871,11 @@
 "nQI" = (
 /turf/closed/wall/r_wall,
 /area/station/science/lab)
+"nQV" = (
+/obj/structure/chair/stool/directional/west,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "nRr" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/structure/disposalpipe/segment,
@@ -26431,7 +26469,7 @@
 /turf/open/floor/iron/dark/textured_edge/airless,
 /area/station/science/lobby)
 "ojo" = (
-/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/sand,
 /turf/open/floor/plating/ocean,
 /area/ocean)
 "ojq" = (
@@ -27508,11 +27546,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
-"oOt" = (
-/obj/effect/spawner/random/structure/musician/piano/random_piano,
-/obj/structure/window/spawner/directional/west,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "oPd" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase{
@@ -27933,6 +27966,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"paT" = (
+/obj/structure/cable,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "pbh" = (
 /obj/structure/cable,
 /obj/structure/table/wood,
@@ -28680,10 +28717,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/main)
-"puM" = (
-/obj/structure/window/spawner/directional/east,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "puS" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/aft)
@@ -28787,6 +28820,10 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"pzP" = (
+/obj/item/instrument/eguitar,
+/turf/open/floor/holofloor/beach,
+/area/station/service/library)
 "pzX" = (
 /obj/structure/closet/crate,
 /turf/open/floor/carpet/executive,
@@ -28803,16 +28840,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/commons/lounge)
-"pAO" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/airlock/public/glass{
-	name = "KRUM Radio";
-	id_tag = "radio"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/library,
-/obj/structure/cable,
-/turf/open/floor/pod/dark,
-/area/station/service/library)
 "pAS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction/yjunction,
@@ -29937,6 +29964,11 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"qch" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "qck" = (
 /obj/structure/chair/comfy/teal{
 	dir = 8
@@ -30240,6 +30272,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
+"qkR" = (
+/obj/effect/overlay/palmtree_l,
+/turf/open/floor/holofloor/beach,
+/area/station/service/library)
 "qli" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/mineral/titanium/yellow,
@@ -30717,6 +30753,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"qwW" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "qxd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30972,11 +31012,6 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/science/robotics/lab)
-"qFS" = (
-/obj/structure/chair/stool/directional/west,
-/obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "qGa" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/plating/ocean,
@@ -31397,6 +31432,9 @@
 	icon_state = "clown_carpet"
 	},
 /area/station/commons/dorms)
+"qQj" = (
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "qQx" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -32398,13 +32436,6 @@
 "rrB" = (
 /turf/closed/wall/r_wall,
 /area/station/security/warden)
-"rrC" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "rrZ" = (
 /obj/effect/spawner/random/structure/crate_empty,
 /obj/effect/decal/cleanable/dirt,
@@ -33911,6 +33942,9 @@
 /obj/structure/fans/tiny/forcefield,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"shL" = (
+/turf/open/floor/holofloor/beach,
+/area/station/service/library)
 "shP" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/light/directional/south,
@@ -33938,6 +33972,10 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/robotics/lab)
+"sjJ" = (
+/obj/effect/overlay/palmtree_r,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "sjN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -34116,6 +34154,10 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery/theatre)
+"sqc" = (
+/obj/structure/lattice,
+/turf/open/floor/plating/ocean/pit/wall,
+/area/ocean)
 "sqk" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -34145,15 +34187,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/brig)
-"sqC" = (
-/obj/structure/statue/sandstone/venus{
-	anchored = 1;
-	desc = "Ugh, this is merely an ugly amateurish replica of the other statue! The letters RIPGOAT are scribbled onto the base.";
-	dir = 8
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "sqV" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/trash,
@@ -34300,10 +34333,6 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/iron,
 /area/ruin/space/ks13/engineering/secure_storage)
-"suQ" = (
-/obj/effect/overlay/palmtree_r,
-/turf/open/floor/holofloor/beach,
-/area/station/service/library)
 "svm" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/requests_console/directional/north{
@@ -35149,16 +35178,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/hop)
-"sSt" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/sunglasses/big{
-	name = "aesthetic sunglasses";
-	dir = 1;
-	layer = 3.1
-	},
-/obj/item/radio/radio_mic,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "sSN" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -35774,15 +35793,6 @@
 	dir = 4
 	},
 /area/station/science/lobby)
-"tmz" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/service/library)
 "tmA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/executive,
@@ -35857,6 +35867,12 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"tpl" = (
+/obj/structure/closet/crate/bin,
+/obj/item/tape/random,
+/obj/item/gps/spaceruin,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "tpo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -35944,14 +35960,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
-"tsk" = (
-/obj/structure/statue/sandstone/venus{
-	anchored = 1;
-	dir = 4
-	},
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "tso" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -38288,6 +38296,16 @@
 "uEF" = (
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation/entertainment)
+"uFb" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/airlock/public/glass{
+	name = "KRUM Radio";
+	id_tag = "radio"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/library,
+/obj/structure/cable,
+/turf/open/floor/pod/dark,
+/area/station/service/library)
 "uFh" = (
 /obj/machinery/computer/warrant{
 	dir = 1
@@ -38705,6 +38723,16 @@
 /obj/structure/curtain/cloth,
 /turf/open/floor/plating,
 /area/station/medical/medbay/central)
+"uQm" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/sunglasses/big{
+	name = "aesthetic sunglasses";
+	dir = 1;
+	layer = 3.1
+	},
+/obj/item/radio/radio_mic,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "uQJ" = (
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood,
@@ -39665,9 +39693,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
-"vol" = (
-/turf/open/floor/holofloor/beach,
-/area/station/service/library)
 "voC" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -39958,12 +39983,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/science/genetics)
-"vxS" = (
-/obj/machinery/cassette/dj_station,
-/obj/machinery/light/dim/directional/west,
-/obj/structure/table/reinforced,
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "vxY" = (
 /obj/machinery/conveyor/auto{
 	dir = 4
@@ -40555,6 +40574,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
+"vSg" = (
+/obj/effect/turf_decal/sand,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plating/ocean,
+/area/ocean)
 "vSw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -41382,6 +41406,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
+"wqW" = (
+/obj/effect/spawner/random/structure/musician/piano/random_piano,
+/obj/structure/window/spawner/directional/west,
+/turf/open/floor/iron/vaporwave,
+/area/station/service/library)
 "wqZ" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -42373,15 +42402,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
-"wSb" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/table/wood,
-/obj/item/taperecorder{
-	pixel_y = 9;
-	pixel_x = -5
-	},
-/turf/open/floor/iron/vaporwave,
-/area/station/service/library)
 "wSq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 5
@@ -42423,10 +42443,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"wTr" = (
-/obj/effect/overlay/palmtree_l,
-/turf/open/floor/plating/ocean,
-/area/ocean)
 "wTY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/circuit/telecomms,
@@ -43716,9 +43732,7 @@
 /turf/open/floor/iron,
 /area/station/construction/storage_wing)
 "xCE" = (
-/obj/structure/window/spawner/directional/west,
-/obj/structure/table/wood,
-/obj/item/statuebust,
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron/vaporwave,
 /area/station/service/library)
 "xCP" = (
@@ -44523,9 +44537,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
-"xZy" = (
-/turf/open/floor/holofloor/beach/coast_t,
-/area/station/service/library)
 "xZC" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/cable,
@@ -44734,12 +44745,9 @@
 /turf/open/floor/plating,
 /area/station/security/office)
 "yfp" = (
-/obj/effect/turf_decal/tile/dark_blue/opposingcorners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/structure/window/spawner/directional/west,
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/iron/vaporwave,
 /area/station/service/library)
 "yfT" = (
 /obj/machinery/duct/industrial/waste,
@@ -70301,8 +70309,8 @@ meJ
 mdW
 mdW
 mdW
-eKS
-mcu
+sqc
+ePE
 aah
 aah
 aah
@@ -70555,11 +70563,11 @@ aah
 aah
 aah
 aah
-eKS
+sqc
 aYY
-mcu
+ePE
 aYY
-mcu
+ePE
 aYY
 aYY
 aah
@@ -70812,11 +70820,11 @@ aah
 aah
 fKl
 aYY
-mcu
+ePE
 aYY
-mcu
+ePE
 aYY
-mcu
+ePE
 aYY
 aYY
 aYY
@@ -71069,11 +71077,11 @@ aYY
 aYY
 aYY
 aYY
-mcu
+ePE
 aYY
-mcu
+ePE
 aYY
-mcu
+ePE
 aYY
 aYY
 aYY
@@ -71326,11 +71334,11 @@ aYY
 aYY
 aYY
 aYY
-mcu
+ePE
 fAs
 fAs
 fAs
-mcu
+ePE
 aYY
 aYY
 aYY
@@ -72090,8 +72098,8 @@ aah
 aah
 nvY
 nvY
-eKS
-mcu
+sqc
+ePE
 fAs
 oGC
 fAs
@@ -72604,8 +72612,8 @@ aah
 aah
 nvY
 nvY
-eKS
-mcu
+sqc
+ePE
 fAs
 fAs
 nbY
@@ -73118,8 +73126,8 @@ aah
 aah
 nvY
 nvY
-eKS
-mcu
+sqc
+ePE
 fAs
 fAs
 fAs
@@ -73896,11 +73904,11 @@ aYY
 aYY
 aYY
 aYY
-mcu
+ePE
 fAs
 fAs
 fAs
-mcu
+ePE
 aYY
 aYY
 aYY
@@ -74153,11 +74161,11 @@ aYY
 aYY
 aYY
 aYY
-mcu
+ePE
 aYY
-mcu
+ePE
 aYY
-mcu
+ePE
 aYY
 aYY
 aYY
@@ -74410,11 +74418,11 @@ aah
 fKl
 aYY
 aYY
-mcu
+ePE
 aYY
-mcu
+ePE
 aYY
-mcu
+ePE
 aYY
 aYY
 aYY
@@ -74667,11 +74675,11 @@ aah
 aah
 aah
 aah
-eKS
+sqc
 aYY
-mcu
+ePE
 aYY
-mcu
+ePE
 aYY
 aYY
 aYY
@@ -84230,13 +84238,13 @@ ezG
 hmV
 sVS
 uUD
-vol
+shL
 xQD
 xQD
 xQD
 xQD
 uqC
-mOK
+meR
 meJ
 aah
 nvY
@@ -84487,13 +84495,13 @@ bTl
 bTl
 jNL
 uUD
-suQ
-vol
-suQ
-xZy
+gle
+shL
+gle
 kuO
+afY
 uUD
-bfR
+etI
 mdW
 nvY
 nvY
@@ -84744,14 +84752,14 @@ bTl
 gsK
 bTl
 uqC
-oOt
-wSb
-xCE
-hNI
-jjO
+wqW
+cYO
+mfd
+cPz
+yfp
 uUD
-ojo
-wTr
+cdn
+mRt
 aah
 aah
 aah
@@ -85001,15 +85009,15 @@ bTl
 qfa
 hby
 uUD
-qFS
-fuD
-fuD
-fuD
-axF
+nQV
+qQj
+qQj
+qQj
+qwW
 uUD
-sqC
-hwD
-aBx
+jgy
+vSg
+bBN
 aah
 aah
 aah
@@ -85258,15 +85266,15 @@ qLF
 kmc
 uRv
 uUD
-fuD
-fuD
-fuD
-fuD
-fuD
+qQj
+qQj
+qQj
+qQj
+qQj
 xQD
-ePE
-ePE
-ahT
+ojo
+ojo
+dXq
 aah
 aah
 aah
@@ -85510,20 +85518,20 @@ wjK
 dEa
 les
 les
-tmz
+dAB
 tVS
 fAx
-yfp
-pAO
+mcu
+uFb
 bSK
 bSK
-gMr
-gMr
-fuD
+paT
+paT
+qQj
 xQD
-ePE
-ePE
-afY
+ojo
+ojo
+cYX
 aah
 aah
 aah
@@ -85765,22 +85773,22 @@ eRt
 tdI
 rFV
 uUD
-bTl
+luB
 ixz
 uzR
 drG
 cyd
 bTl
 uqC
-nFN
-sSt
-vxS
-gMr
-fuD
+iQr
+uQm
+bHV
+paT
+qQj
 xQD
-ePE
-ePE
-afY
+ojo
+ojo
+cYX
 aah
 aah
 aah
@@ -86029,15 +86037,15 @@ uVL
 xQD
 xQD
 uqC
-fLq
-rrC
-geB
-fnT
-axF
+arG
+ivJ
+cBs
+jYN
+qwW
 uqC
-tsk
-hwD
-aBx
+kqN
+vSg
+bBN
 aah
 aah
 aah
@@ -86286,14 +86294,14 @@ meJ
 mdW
 meJ
 uUD
-isz
-nCf
-nCf
-nCf
-puM
+mMz
+qch
+qch
+qch
+xCE
 uUD
-efb
-lyD
+clx
+sjJ
 aah
 aah
 aah
@@ -86543,13 +86551,13 @@ meJ
 mdW
 mdW
 uqC
-fXY
-imS
-fXY
-xZy
+qkR
+pzP
+qkR
 kuO
+afY
 uqC
-bfR
+etI
 mdW
 nvY
 aah
@@ -86806,7 +86814,7 @@ xQD
 xQD
 xQD
 uqC
-mOK
+meR
 meJ
 nvY
 nvY
@@ -87060,7 +87068,7 @@ meJ
 meJ
 mdW
 mdW
-cBs
+tpl
 mdW
 meJ
 meJ
@@ -87274,7 +87282,7 @@ gly
 bwi
 tan
 rdE
-gEA
+iuL
 lXt
 hUd
 oDZ
@@ -87589,7 +87597,7 @@ aah
 aah
 aah
 aah
-afY
+cYX
 aah
 aah
 aah
@@ -87846,7 +87854,7 @@ aah
 aah
 aah
 aah
-afY
+cYX
 aah
 aah
 aah
@@ -88103,7 +88111,7 @@ aah
 aah
 aah
 aah
-afY
+cYX
 aah
 aah
 aah

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -8004,13 +8004,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "eeS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9781,6 +9775,11 @@
 /area/station/medical/surgery/theatre)
 "eXH" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Medical Closure Shutters";
+	desc = "Fuck off we're closed.";
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/medical/treatment_center)
 "eXV" = (
@@ -11274,6 +11273,10 @@
 	name = "Medical Reception Desk";
 	req_access = list("medical")
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Medical Closure Shutters";
+	desc = "Fuck off we're closed."
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "fNz" = (
@@ -11450,6 +11453,16 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname/directional/east,
+/obj/machinery/button/door/directional/east{
+	pixel_x = 22;
+	id = "medclosed";
+	desc = "Fuck off we're closed";
+	name = "Medical Desk Closure Shutters"
+	},
+/obj/item/radio/intercom/directional/east{
+	pixel_x = 32;
+	pixel_y = -13
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "fRn" = (
@@ -13115,7 +13128,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "gMi" = (
-/obj/machinery/medical_kiosk,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
@@ -15563,6 +15575,16 @@
 /obj/item/book/manual/wiki,
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
+"iaI" = (
+/obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/treatment_center)
 "iaP" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -17949,6 +17971,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
 "jsj" = (
@@ -21373,11 +21398,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "lca" = (
 /obj/machinery/duct/industrial/waste,
@@ -22014,10 +22035,10 @@
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/hallway/primary/central)
 "ltZ" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/siding/white{
+	dir = 6
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
 "luc" = (
@@ -22387,6 +22408,7 @@
 /area/mine/storage/public)
 "lCz" = (
 /obj/structure/sign/departments/chemistry/pharmacy,
+/obj/machinery/vending/drugs,
 /turf/closed/wall/r_wall,
 /area/station/medical/medbay/central)
 "lCD" = (
@@ -23685,6 +23707,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/mid_joiner,
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 8
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "moq" = (
@@ -24154,6 +24182,26 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"mCO" = (
+/obj/structure/table/reinforced,
+/obj/item/wrench/medical,
+/obj/item/wrench/medical{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/clothing/gloves/latex/nitrile,
+/obj/item/clothing/gloves/latex/nitrile{
+	pixel_y = 4;
+	pixel_x = 2
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Medical Closure Shutters";
+	desc = "Fuck off we're closed."
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/medbay/central)
 "mCV" = (
 /obj/structure/cable,
 /obj/structure/sign/painting/library{
@@ -24226,7 +24274,8 @@
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Engineering Services Desk";
-	id = "engiedesk"
+	id = "engiedesk";
+	dir = 8
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "elock";
@@ -24303,10 +24352,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "mHY" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -26406,10 +26452,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "nIg" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/vending/drugs,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
 "nIm" = (
@@ -26718,7 +26765,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/blue,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "nQI" = (
 /turf/closed/wall/r_wall,
@@ -28192,19 +28239,19 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "oEo" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 8
+	},
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
-	dir = 8
-	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "oEs" = (
@@ -36255,7 +36302,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/siding/blue,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "sQL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -38715,6 +38762,12 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/mid_joiner{
+	dir = 4
+	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/treatment_center)
 "uhr" = (
@@ -39245,7 +39298,7 @@
 /obj/effect/turf_decal/siding/blue,
 /obj/structure/window/spawner/directional/west,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "uxK" = (
 /turf/closed/wall/r_wall,
@@ -39334,13 +39387,13 @@
 /area/station/science/genetics)
 "uzC" = (
 /obj/item/kirbyplants/random,
+/obj/machinery/camera/autoname/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "uzR" = (
@@ -41126,6 +41179,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
+"vsL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Medical Closure Shutters";
+	desc = "Fuck off we're closed.";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/science/genetics)
 "vsU" = (
 /obj/machinery/duct/industrial/waste,
 /turf/open/floor/plating,
@@ -41220,7 +41282,8 @@
 	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Engineering Services Desk";
-	id = "engiedesk"
+	id = "engiedesk";
+	dir = 8
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "elock";
@@ -41571,6 +41634,10 @@
 "vGh" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/door/poddoor/shutters/preopen{
+	name = "Medical Closure Shutters";
+	desc = "Fuck off we're closed."
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "vGu" = (
@@ -44680,7 +44747,8 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	name = "Engineering Services Desk";
-	id = "engiedesk"
+	id = "engiedesk";
+	dir = 8
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "elock";
@@ -45360,6 +45428,7 @@
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/blue/full,
 /obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
 "xID" = (
@@ -45518,9 +45587,11 @@
 /obj/item/clothing/gloves/latex/nitrile,
 /obj/item/clothing/gloves/latex/nitrile,
 /obj/item/clothing/gloves/latex/nitrile,
-/obj/item/clothing/gloves/latex/nitrile,
-/obj/item/wrench/medical,
 /obj/effect/turf_decal/tile/blue/full,
+/obj/effect/turf_decal/siding/white{
+	dir = 5
+	},
+/obj/machinery/cell_charger,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/medbay/central)
 "xMG" = (
@@ -73592,7 +73663,7 @@ jKo
 jKo
 jKo
 gVL
-aDe
+vsL
 xxZ
 xxZ
 eJv
@@ -75138,7 +75209,7 @@ wGM
 wGM
 oEo
 fRj
-vGh
+mCO
 hsi
 xeP
 kAH
@@ -75392,7 +75463,7 @@ tBQ
 xXa
 uhh
 eXH
-eXH
+uOF
 uOF
 eJv
 eJv
@@ -75648,7 +75719,7 @@ dLY
 nsM
 avv
 wYe
-dLY
+iaI
 uzC
 hpU
 gMi

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -12653,6 +12653,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/item/book/manual/wiki/grenades,
+/obj/item/book/manual/wiki/chemistry,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
 "gyH" = (
@@ -16992,19 +16994,8 @@
 "iPp" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/machinery/light/directional/east,
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = 2
-	},
-/obj/item/reagent_containers/cup/beaker/large{
-	pixel_x = 2
-	},
 /obj/effect/turf_decal/stripes/line,
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/book/manual/wiki/grenades,
+/obj/machinery/vending/drugs,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
 "iPw" = (
@@ -26056,6 +26047,15 @@
 /obj/item/toy/figure/chemist{
 	pixel_y = 13;
 	pixel_x = 8
+	},
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 2
+	},
+/obj/item/reagent_containers/cup/beaker/large{
+	pixel_x = 2
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -76,6 +76,12 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "abL" = (
@@ -260,7 +266,7 @@
 /obj/effect/turf_decal/trimline/purple/warning{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured_edge/airless,
+/turf/open/floor/iron/dark/textured_edge,
 /area/station/science/lobby)
 "afh" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
@@ -271,6 +277,12 @@
 "afn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "aft" = (
@@ -471,6 +483,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ake" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "akj" = (
@@ -491,11 +506,11 @@
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
 "akF" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	invisibility = 101
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "alb" = (
@@ -521,6 +536,9 @@
 "amg" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/crate_empty,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "amw" = (
@@ -679,7 +697,6 @@
 	name = "Primary Tool Storage"
 	},
 /obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
@@ -977,6 +994,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "aCp" = (
@@ -1059,9 +1077,9 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
 "aFE" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/camera/autoname/directional/north,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "aFP" = (
@@ -1081,6 +1099,9 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
 /obj/item/stock_parts/cell,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "aGw" = (
@@ -1427,6 +1448,10 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "aRb" = (
@@ -1459,9 +1484,6 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
 "aRZ" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
@@ -1473,6 +1495,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "aSf" = (
@@ -2133,11 +2158,11 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
 "bgA" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -2216,9 +2241,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
 "bjQ" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
@@ -2227,6 +2249,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "bkh" = (
@@ -2324,6 +2349,9 @@
 /area/station/medical/surgery/aft)
 "blk" = (
 /obj/machinery/rnd/bepis,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "blt" = (
@@ -2661,6 +2689,9 @@
 /area/station/science/genetics)
 "btg" = (
 /obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "btu" = (
@@ -2696,11 +2727,11 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/central)
 "bul" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 1
-	},
 /obj/machinery/suit_storage_unit/mining,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "buu" = (
@@ -2875,6 +2906,9 @@
 /area/station/medical/surgery/theatre)
 "byv" = (
 /obj/machinery/conveyor/auto{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -3536,6 +3570,9 @@
 "bOK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/suit_storage_unit/industrial/loader,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "bOM" = (
@@ -4154,11 +4191,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "chP" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "chZ" = (
@@ -4452,6 +4489,9 @@
 	dir = 1;
 	color = "#009dc4"
 	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "crT" = (
@@ -4593,9 +4633,12 @@
 	name = "Central Access"
 	},
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 1
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 1;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -4616,6 +4659,9 @@
 "cxM" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "cxU" = (
@@ -4691,6 +4737,9 @@
 "cAT" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "cBe" = (
@@ -4916,6 +4965,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"cGa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "cGg" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
@@ -4970,8 +5027,8 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "cHF" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "cHK" = (
@@ -5122,11 +5179,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
@@ -5437,8 +5494,8 @@
 /area/mine/storage/public)
 "cTT" = (
 /obj/effect/turf_decal/stripes,
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/camera/autoname/directional/west,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "cTW" = (
@@ -5545,6 +5602,9 @@
 	invisibility = 101
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "cWn" = (
@@ -5573,7 +5633,11 @@
 /area/station/maintenance/port/central)
 "cXc" = (
 /obj/structure/table,
-/turf/open/floor/iron,
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "cXm" = (
 /obj/structure/disposalpipe/segment{
@@ -5725,11 +5789,11 @@
 /turf/closed/wall/r_wall,
 /area/station/command/bridge)
 "dds" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
 /obj/machinery/rnd/production/techfab/department/cargo,
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "ddv" = (
@@ -5804,6 +5868,7 @@
 /obj/item/gps,
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/gps,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/storage/primary)
 "dez" = (
@@ -6126,6 +6191,7 @@
 /obj/structure/cable,
 /obj/machinery/duct/industrial/waste,
 /obj/structure/disposalpipe/junction/flip,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "dma" = (
@@ -6315,10 +6381,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "dpI" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "dpV" = (
@@ -6542,7 +6608,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "dtc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/blood/old,
@@ -6635,7 +6701,10 @@
 /obj/machinery/microwave{
 	pixel_y = 6
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "dxd" = (
 /obj/structure/cable,
@@ -6746,7 +6815,10 @@
 /area/station/commons/storage/primary)
 "dAY" = (
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "dBe" = (
 /obj/machinery/computer/teleporter{
@@ -7617,7 +7689,6 @@
 	},
 /area/station/science/robotics)
 "dZG" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -7639,6 +7710,7 @@
 	pixel_x = -7;
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "eap" = (
@@ -7763,6 +7835,9 @@
 /obj/effect/spawner/random/maintenance,
 /obj/item/airlock_painter/decal,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "edA" = (
@@ -8270,10 +8345,9 @@
 /turf/open/floor/engine,
 /area/station/ai_monitored/turret_protected/ai)
 "erU" = (
-/obj/structure/cable,
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron/dark/textured,
-/area/station/commons/storage/primary)
+/obj/structure/window/reinforced/tinted/fulltile,
+/turf/open/floor/plating,
+/area/station/cargo/sorting)
 "esa" = (
 /obj/structure/cable,
 /obj/machinery/defibrillator_mount/directional/south,
@@ -8432,13 +8506,13 @@
 	},
 /area/station/service/chapel)
 "ewC" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
 /obj/machinery/suit_storage_unit/mining,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	invisibility = 101
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -8545,6 +8619,10 @@
 /obj/machinery/computer/pandemic,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"ezr" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "ezE" = (
 /obj/structure/falsewall,
 /turf/open/floor/iron/dark,
@@ -8637,6 +8715,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate,
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "eBt" = (
@@ -9404,12 +9483,18 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"eTz" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
+"eSW" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
 	},
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
+"eTz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
@@ -9659,8 +9744,8 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "faI" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/autolathe,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "fbb" = (
@@ -9866,6 +9951,9 @@
 	pixel_y = 28
 	},
 /obj/structure/chair/wood,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "ffD" = (
@@ -10319,6 +10407,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pharmacy)
+"ftM" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "fue" = (
 /turf/closed/wall,
 /area/station/service/abandoned_gambling_den/gaming)
@@ -10494,11 +10586,11 @@
 /turf/open/floor/engine,
 /area/station/engineering/main)
 "fAd" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/chair/office/light,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "fAl" = (
@@ -10602,6 +10694,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/ks13/engineering/secure_storage)
+"fCM" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "fCU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10891,6 +10990,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "fMs" = (
@@ -10918,6 +11020,12 @@
 /obj/effect/spawner/random/structure/table_or_rack,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"fMM" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "fNr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate_empty,
@@ -10938,10 +11046,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/central)
 "fNz" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "fOf" = (
@@ -11182,11 +11290,11 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/lobby)
 "fUp" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
 /obj/machinery/light/directional/north,
 /obj/effect/landmark/start/shaft_miner,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "fUy" = (
@@ -11226,6 +11334,9 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "fVi" = (
@@ -11243,6 +11354,11 @@
 /obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
+"fVM" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/sorting)
 "fWk" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -11946,7 +12062,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
 "gop" = (
 /obj/machinery/light/directional/east,
@@ -11963,11 +12079,13 @@
 /area/ocean)
 "gpl" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -12811,6 +12929,9 @@
 /obj/machinery/stasis{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 9
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
 "gPf" = (
@@ -13008,6 +13129,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/plasticflaps,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
 /turf/open/floor/plating,
 /area/ruin/space/ks13/engineering/secure_storage)
 "gVf" = (
@@ -13043,9 +13167,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "gVX" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 8
 	},
@@ -13058,6 +13179,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "gWh" = (
@@ -13102,9 +13226,6 @@
 	},
 /area/station/science/robotics)
 "gXm" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
@@ -13114,6 +13235,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
@@ -13402,10 +13526,10 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "hdI" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "hdM" = (
@@ -13809,7 +13933,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "hsi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13904,6 +14029,9 @@
 /area/station/engineering/atmos/office)
 "htZ" = (
 /obj/machinery/stasis,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 6
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
 "huL" = (
@@ -13943,6 +14071,9 @@
 "hvE" = (
 /obj/machinery/light/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "hvJ" = (
@@ -14204,10 +14335,10 @@
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/server)
 "hCG" = (
+/obj/machinery/light/no_nightlight/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
-/obj/machinery/light/no_nightlight/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/storage/primary)
 "hCN" = (
@@ -15594,11 +15725,11 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "ipf" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "ipq" = (
@@ -15879,6 +16010,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "iwW" = (
@@ -16154,6 +16288,7 @@
 /obj/structure/railing/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 8
 	},
@@ -16305,9 +16440,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "iKE" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "iKF" = (
@@ -16333,10 +16468,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
 "iLj" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "iLp" = (
@@ -16673,6 +16810,9 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "iUI" = (
@@ -16723,7 +16863,7 @@
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "iWL" = (
 /obj/machinery/mineral/ore_redemption{
 	dir = 4;
@@ -17015,7 +17155,7 @@
 	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "jfa" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
@@ -17043,13 +17183,13 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "jgE" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	invisibility = 101
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "jgI" = (
@@ -17399,10 +17539,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "jpe" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "jpm" = (
@@ -17642,14 +17782,11 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "jwY" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/cargo/storage)
 "jwZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -17664,15 +17801,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "jys" = (
-/obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
 	},
-/turf/open/floor/plastic,
-/area/station/hallway/primary/central)
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "jyv" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
@@ -17740,10 +17880,10 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "jAH" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "jAI" = (
@@ -17953,6 +18093,9 @@
 	dir = 1;
 	color = "#009dc4"
 	},
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "jFx" = (
@@ -18113,9 +18256,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/exit/departure_lounge)
 "jLj" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	invisibility = 101
@@ -18127,6 +18267,9 @@
 	id = "ticket_machine_cargo"
 	},
 /obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "jLk" = (
@@ -18491,15 +18634,15 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "jSQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
 	color = "#52B4E9"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
@@ -18528,15 +18671,15 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
 "jUd" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	invisibility = 101
 	},
 /obj/machinery/light/directional/north,
 /obj/machinery/ore_silo,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "jUk" = (
@@ -18713,12 +18856,12 @@
 /area/station/hallway/primary/central)
 "jYT" = (
 /obj/effect/turf_decal/stripes,
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "jZb" = (
@@ -18953,6 +19096,18 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/pharmacy)
+"keE" = (
+/obj/machinery/duct/industrial/waste,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1;
+	color = "#009dc4"
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "kfc" = (
 /obj/structure/table/reinforced,
 /obj/structure/disposalpipe/segment{
@@ -19029,7 +19184,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "kgC" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Atmospherics Tank - N2O"
@@ -19076,6 +19231,9 @@
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/trash/janitor_supplies,
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "khS" = (
@@ -19454,6 +19612,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
 "ksz" = (
@@ -19662,11 +19821,11 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/construction/storage_wing)
 "kzg" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "kzi" = (
@@ -19830,6 +19989,12 @@
 	luminosity = 2
 	},
 /area/station/ai_monitored/turret_protected/ai)
+"kDr" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/plastic,
+/area/station/hallway/primary/central)
 "kDC" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/cable,
@@ -20474,6 +20639,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/office)
+"kRV" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 5
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "kRY" = (
 /obj/structure/chair/sofa/right/brown,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -20771,6 +20942,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "lap" = (
@@ -20795,7 +20967,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
@@ -20956,6 +21128,13 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
+"lgp" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/sorting)
 "lgB" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -21289,10 +21468,10 @@
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/hop)
 "lpi" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/cargo_technician,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "lpl" = (
@@ -21542,6 +21721,10 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "lwu" = (
@@ -22204,7 +22387,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "lMA" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -22545,7 +22728,9 @@
 	dir = 9;
 	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/corner,
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4"
+	},
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "lWJ" = (
@@ -22596,8 +22781,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "lYm" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "lYV" = (
@@ -22606,6 +22791,9 @@
 /area/station/medical/virology)
 "lZa" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "lZe" = (
@@ -22918,6 +23106,7 @@
 /obj/effect/turf_decal/trimline/dark_red/filled/warning{
 	dir = 1
 	},
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "mlu" = (
@@ -23102,6 +23291,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
+"mqX" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/dark/textured,
+/area/station/commons/storage/primary)
 "mrC" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/flasher/directional/east{
@@ -23169,7 +23362,10 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured_edge/airless,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_edge,
 /area/station/science/lobby)
 "mrQ" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/purple/visible,
@@ -23360,10 +23556,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "mwD" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "mxp" = (
@@ -23615,7 +23811,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "mHK" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -23786,9 +23982,6 @@
 /turf/open/floor/engine,
 /area/station/commons/fitness/recreation/entertainment)
 "mLX" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
@@ -23800,6 +23993,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "mMc" = (
@@ -24000,11 +24196,17 @@
 	pixel_x = -9;
 	pixel_y = 3
 	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "mRO" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "mSd" = (
@@ -24099,6 +24301,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "mTC" = (
@@ -24443,9 +24648,9 @@
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai)
 "nca" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/computer/order_console/mining,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "ncg" = (
@@ -24714,11 +24919,11 @@
 	},
 /area/station/engineering/break_room)
 "nij" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "nip" = (
@@ -25007,6 +25212,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "nqf" = (
@@ -25621,8 +25827,12 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "nGD" = (
-/turf/closed/wall,
-/area/station/commons/vacant_room)
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plastic,
+/area/station/hallway/primary/central)
 "nGM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -25659,14 +25869,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/office)
 "nHO" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "nHZ" = (
@@ -25799,6 +26009,9 @@
 "nLm" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "nLr" = (
@@ -26003,6 +26216,10 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"nRQ" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/station/medical/surgery/theatre)
 "nSA" = (
 /obj/structure/sign/departments/lawyer,
 /turf/closed/wall,
@@ -26395,12 +26612,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/storage/tech)
 "ofl" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "oft" = (
@@ -26423,7 +26640,6 @@
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
@@ -26596,7 +26812,7 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured_edge/airless,
+/turf/open/floor/iron/dark/textured_edge,
 /area/station/science/lobby)
 "ojo" = (
 /obj/structure/lattice,
@@ -26812,6 +27028,10 @@
 	req_access = list("shipping")
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ooi" = (
@@ -26841,6 +27061,10 @@
 "ope" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "opl" = (
@@ -26953,7 +27177,7 @@
 /turf/open/floor/iron/stairs{
 	dir = 4
 	},
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "orx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27030,7 +27254,7 @@
 /obj/effect/turf_decal/trimline/purple/warning{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured_edge/airless,
+/turf/open/floor/iron/dark/textured_edge,
 /area/station/science/lobby)
 "otV" = (
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/west,
@@ -27067,6 +27291,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "ouC" = (
@@ -27101,6 +27331,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"ouV" = (
+/obj/machinery/duct/industrial/waste,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/industrial,
+/turf/open/floor/glass/reinforced,
+/area/station/engineering/main)
 "ovi" = (
 /obj/effect/turf_decal/trimline/blue/filled/end,
 /obj/machinery/disposal/bin,
@@ -27180,8 +27417,8 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/storage/primary)
 "oxu" = (
@@ -27536,10 +27773,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "oHT" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "oIg" = (
@@ -27551,6 +27788,7 @@
 	dir = 5
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "oIu" = (
@@ -28102,7 +28340,7 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured_edge/airless,
+/turf/open/floor/iron/dark/textured_edge,
 /area/station/science/lobby)
 "pam" = (
 /obj/machinery/duct/industrial/waste,
@@ -28202,15 +28440,15 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/lobby)
 "pdU" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	invisibility = 101
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/filingcabinet/filingcabinet,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "pfg" = (
@@ -28400,7 +28638,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central/fore)
 "piw" = (
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/white/filled/corner{
 	color = "#009dc4";
 	dir = 8
@@ -28410,7 +28647,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "piW" = (
 /obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/trunk{
@@ -28427,6 +28664,11 @@
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
 /area/station/medical/medbay/central)
+"pkl" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/theatre)
 "pkw" = (
 /turf/closed/wall,
 /area/mine/storage/public)
@@ -28737,13 +28979,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "prq" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	invisibility = 101
 	},
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "prr" = (
@@ -29218,7 +29460,7 @@
 /turf/closed/wall/r_wall,
 /area/station/science/lobby)
 "pGC" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
+/obj/effect/turf_decal/tile/brown/opposingcorners{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -29351,6 +29593,9 @@
 "pII" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "pIL" = (
@@ -29476,8 +29721,8 @@
 /area/station/ai_monitored/turret_protected/ai_upload)
 "pLj" = (
 /obj/effect/turf_decal/stripes,
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/cable,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "pLr" = (
@@ -29596,13 +29841,13 @@
 /turf/open/floor/grass,
 /area/station/maintenance/starboard/upper)
 "pOW" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/light/directional/north,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "pPh" = (
@@ -29636,6 +29881,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
+"pPk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "pPs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 6
@@ -29706,6 +29961,12 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
+"pQD" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/storage)
 "pQE" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/warning{
@@ -30105,9 +30366,6 @@
 	},
 /area/station/commons/dorms)
 "qbp" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
@@ -30117,6 +30375,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
@@ -30608,6 +30869,12 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "qpL" = (
@@ -30771,10 +31038,12 @@
 	pixel_y = 3
 	},
 /obj/structure/table,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "qsh" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/table,
 /obj/item/stack/package_wrap{
 	pixel_x = 2;
@@ -30792,7 +31061,8 @@
 /obj/item/clothing/head/costume/mailman,
 /obj/item/clothing/under/misc/mailman,
 /obj/item/storage/bag/mail,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/brown/fourcorners,
+/turf/open/space/basic,
 /area/station/cargo/sorting)
 "qsG" = (
 /obj/structure/cable,
@@ -31226,11 +31496,11 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/treatment_center)
 "qGV" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "qHw" = (
@@ -31325,6 +31595,9 @@
 "qJu" = (
 /obj/machinery/stasis,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 5
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
 "qJD" = (
@@ -31492,10 +31765,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/turf_decal/trimline/neutral/warning{
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/aft)
 "qNi" = (
@@ -31903,7 +32179,7 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "qXu" = (
 /obj/structure/reflector/box{
 	dir = 4
@@ -32442,13 +32718,11 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "rlM" = (
-/obj/structure/cable,
-/obj/machinery/duct/industrial/waste,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
-/area/station/commons/storage/primary)
+/area/station/cargo/warehouse)
 "rlW" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
@@ -32549,7 +32823,7 @@
 /obj/effect/turf_decal/trimline/purple/line{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured_edge/airless,
+/turf/open/floor/iron/dark/textured_edge,
 /area/station/science/lobby)
 "rou" = (
 /turf/closed/wall/r_wall,
@@ -32594,6 +32868,7 @@
 "rps" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "rpP" = (
@@ -32608,12 +32883,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "rqh" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/closet/wardrobe/miner,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	invisibility = 101
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "rqG" = (
@@ -32649,6 +32924,9 @@
 "rrZ" = (
 /obj/effect/spawner/random/structure/crate_empty,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "rse" = (
@@ -32694,8 +32972,13 @@
 "rsO" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
 	},
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
@@ -32777,6 +33060,9 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/maintenance,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 10
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "rvq" = (
@@ -32931,6 +33217,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
 "ryY" = (
@@ -33113,6 +33405,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate_empty,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "rDc" = (
@@ -33347,6 +33640,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "rJL" = (
@@ -33501,7 +33797,6 @@
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "rNY" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33509,6 +33804,7 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "rOb" = (
@@ -33640,7 +33936,7 @@
 	dir = 5
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "rRy" = (
 /obj/machinery/duct/industrial/waste,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33755,6 +34051,7 @@
 /obj/structure/cable,
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "rUH" = (
@@ -34171,8 +34468,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "shX" = (
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -34181,7 +34476,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "sjq" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -34289,14 +34584,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/medbay/lobby)
 "slx" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	invisibility = 101
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "slD" = (
@@ -34501,6 +34796,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
 /area/station/service/lawoffice)
+"ssU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/science/lobby)
 "sth" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -34598,12 +34899,15 @@
 	dir = 6
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "swe" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "sws" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "swv" = (
@@ -35060,9 +35364,8 @@
 /area/station/maintenance/starboard/aft)
 "sJd" = (
 /obj/effect/landmark/start/assistant,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "sJj" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -35255,14 +35558,14 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/lobby)
 "sNP" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "sNV" = (
@@ -35303,6 +35606,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "sPC" = (
@@ -35514,11 +35820,11 @@
 /turf/closed/wall,
 /area/station/service/kitchen)
 "sUW" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "sVq" = (
@@ -35700,6 +36006,13 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"tbT" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/tile/purple/opposingcorners,
+/turf/open/floor/plastic,
+/area/station/hallway/primary/central)
 "tcf" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -35715,9 +36028,9 @@
 /turf/open/floor/plating/ocean,
 /area/ocean/generated_above)
 "tde" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "tdg" = (
@@ -35876,6 +36189,9 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
 	},
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
@@ -36198,6 +36514,12 @@
 "tso" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 10
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "tto" = (
@@ -36399,10 +36721,13 @@
 "tzD" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/line{
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/line,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "tzU" = (
@@ -36565,6 +36890,7 @@
 	dir = 10
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "tEG" = (
@@ -37144,9 +37470,8 @@
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "tTb" = (
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "tTe" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -37229,7 +37554,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "sci"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
 "tVQ" = (
 /obj/effect/turf_decal/trimline/red/filled/warning,
@@ -37637,7 +37962,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "uez" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "ueF" = (
@@ -38180,6 +38505,21 @@
 "uth" = (
 /turf/open/floor/plating,
 /area/station/service/electronic_marketing_den)
+"utj" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/mid_joiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 8
+	},
+/area/station/science/lobby)
 "utm" = (
 /turf/open/floor/grass,
 /area/station/service/hydroponics)
@@ -38605,7 +38945,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/station/commons/vacant_room)
+/area/station/commons/dorms)
 "uGg" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/nitrogen_input{
 	dir = 1
@@ -38838,7 +39178,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "uMq" = (
 /obj/structure/disposalpipe/segment{
@@ -38941,10 +39281,10 @@
 /turf/open/floor/carpet/cyan,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "uPb" = (
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
+/obj/structure/closet/secure_closet/miner,
+/obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "uPg" = (
@@ -39009,7 +39349,6 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Primary Tool Storage"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
@@ -39416,6 +39755,9 @@
 /area/station/hallway/primary/central/fore)
 "vbA" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
 "vbD" = (
@@ -39573,11 +39915,13 @@
 /area/station/service/hydroponics)
 "ves" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
 	},
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
@@ -39623,6 +39967,9 @@
 /area/station/maintenance/port/aft)
 "vfM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "vfX" = (
@@ -39902,15 +40249,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "vmz" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	invisibility = 101
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
@@ -40535,6 +40882,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
 "vGh" = (
@@ -40555,10 +40903,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/surgery/theatre)
 "vHe" = (
+/obj/machinery/light/no_nightlight/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
-/obj/machinery/light/no_nightlight/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/storage/primary)
 "vHs" = (
@@ -41007,11 +41355,11 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/station/maintenance/starboard/aft)
 "vWf" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/effect/turf_decal/tile/brown/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -41046,8 +41394,8 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
 "vWE" = (
@@ -41216,6 +41564,19 @@
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/auxiliary)
+"wbl" = (
+/obj/machinery/duct/industrial/waste,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/trimline/white/filled/line{
+	color = "#009dc4";
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/central)
 "wbr" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/structure/furniture_parts,
@@ -42078,6 +42439,7 @@
 /area/station/commons/dorms)
 "wAI" = (
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "wAP" = (
@@ -42454,13 +42816,15 @@
 /area/station/service/abandoned_gambling_den/gaming)
 "wMh" = (
 /obj/machinery/duct/industrial/waste,
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/neutral/corner{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/white/corner{
+	color = "#009dc4";
 	dir = 4
 	},
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/neutral/filled/warning{
+	dir = 10;
+	color = "#009dc4"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "wMH" = (
@@ -42499,6 +42863,9 @@
 /area/station/engineering/atmos)
 "wNT" = (
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
 "wOi" = (
@@ -42602,6 +42969,15 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
+"wPX" = (
+/obj/machinery/stasis{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/surgery/theatre)
 "wQa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42875,12 +43251,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
 "wXn" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
 /obj/machinery/suit_storage_unit/mining,
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
@@ -43032,6 +43408,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"xbh" = (
+/obj/machinery/suit_storage_unit/mining,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "xbj" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -43127,6 +43514,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/grass,
 /area/station/medical/virology)
+"xdw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/station/cargo/warehouse)
 "xdE" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -43415,7 +43809,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
 "xmK" = (
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
+/obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -44105,13 +44499,13 @@
 /turf/open/floor/holofloor/dark,
 /area/station/science/cytology)
 "xDY" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	invisibility = 101
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "xEK" = (
@@ -44329,7 +44723,6 @@
 /turf/open/floor/circuit/telecomms,
 /area/station/science/xenobiology)
 "xMk" = (
-/obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -44361,6 +44754,7 @@
 	pixel_x = 4;
 	pixel_y = -2
 	},
+/obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "xMv" = (
@@ -44557,8 +44951,13 @@
 /area/station/maintenance/starboard/central)
 "xRb" = (
 /obj/machinery/computer/cargo/request,
-/obj/structure/window/spawner/directional/north,
-/turf/open/floor/plating,
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/station/cargo/sorting)
 "xRd" = (
 /obj/structure/cable,
@@ -44752,8 +45151,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/warning{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/filled/warning{
+	dir = 8;
+	color = "#009dc4"
+	},
+/obj/effect/turf_decal/trimline/white/warning{
+	color = "#009dc4";
+	dir = 4
 	},
 /turf/open/floor/plastic,
 /area/station/hallway/primary/central)
@@ -45021,9 +45425,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "ydl" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	invisibility = 101
@@ -45032,6 +45433,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/brown/opposingcorners{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/sorting)
 "ydB" = (
@@ -45082,11 +45486,13 @@
 "yfT" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4;
+	color = "#009dc4"
 	},
-/obj/effect/turf_decal/trimline/neutral/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 8;
+	color = "#009dc4"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
@@ -45100,6 +45506,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
@@ -45315,6 +45724,9 @@
 "ylU" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/item/banner/cargo/mundane,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 
@@ -60136,10 +60548,10 @@ qbp
 gXm
 fNz
 pLj
+lgp
 ezO
 ezO
-ezO
-ezO
+fVM
 aQS
 mRO
 nWb
@@ -60399,15 +60811,15 @@ sON
 uMj
 kAA
 afn
-afn
+cGa
 vfM
 vfM
-fKI
+jwY
 rve
 rkn
 pII
 aej
-txG
+xdw
 ake
 iUE
 ucv
@@ -61174,9 +61586,9 @@ fKI
 gae
 fKI
 gae
-fKI
+ftM
 hrY
-ake
+rlM
 jkc
 txG
 bEQ
@@ -61416,11 +61828,11 @@ ope
 ydl
 sNP
 afI
-qIz
+erU
 kfc
 kmp
-qIz
-qIz
+erU
+erU
 afI
 yba
 aOq
@@ -61431,7 +61843,7 @@ mUV
 drs
 fKI
 drs
-fKI
+ezr
 rkn
 bOK
 lZa
@@ -61672,7 +62084,7 @@ bSj
 afI
 pdU
 hdI
-qIz
+erU
 gce
 csw
 sCM
@@ -61688,7 +62100,7 @@ fKI
 fKI
 fKI
 fKI
-fKI
+ezr
 rkn
 rkn
 ryM
@@ -61929,7 +62341,7 @@ oTE
 afI
 pdU
 eTz
-qIz
+erU
 kyM
 jwO
 vNp
@@ -62197,12 +62609,12 @@ yba
 aOq
 icx
 ooa
-fKI
-fKI
+kRV
+pQD
 cxM
-nyQ
+fCM
 amg
-fKI
+eSW
 mLC
 aOZ
 clo
@@ -62646,7 +63058,7 @@ bec
 uGB
 vSI
 tYL
-nxP
+keE
 xwm
 auY
 dcF
@@ -62898,9 +63310,9 @@ oDX
 pyU
 qXr
 ort
-nGD
-nGD
-nGD
+vwP
+vwP
+vwP
 xdL
 rfc
 nxP
@@ -63156,7 +63568,7 @@ pyU
 dtb
 piw
 uFU
-nGD
+vwP
 eso
 kdC
 rfc
@@ -63413,7 +63825,7 @@ pyU
 mHp
 sJd
 jeZ
-nGD
+vwP
 xEU
 rfc
 kwp
@@ -63670,7 +64082,7 @@ pyU
 shX
 tTb
 iWI
-nGD
+vwP
 fZv
 rfc
 lNF
@@ -63927,7 +64339,7 @@ pyU
 rQX
 kgA
 svS
-nGD
+vwP
 xdL
 rfc
 nxP
@@ -64181,10 +64593,10 @@ pyU
 fGQ
 pyU
 pyU
-nGD
-nGD
-nGD
-nGD
+vwP
+vwP
+vwP
+vwP
 xEU
 kwp
 nxP
@@ -65266,11 +65678,11 @@ kGi
 frv
 omy
 kCz
-ewC
+xbh
 cWe
-cDw
-eYv
-itp
+pPk
+jys
+fMM
 fMn
 jce
 fZG
@@ -74445,7 +74857,7 @@ bMU
 fgS
 nhC
 gPc
-gPc
+wPX
 pbq
 rwu
 ord
@@ -74702,7 +75114,7 @@ iqh
 djZ
 oft
 vbA
-vbA
+pkl
 qrS
 nrd
 ubZ
@@ -75220,8 +75632,8 @@ jpS
 imy
 ksZ
 kge
-oft
-oft
+nRQ
+nRQ
 aCo
 ipa
 vcR
@@ -81423,15 +81835,15 @@ gpl
 gpl
 gpl
 gpl
-yfT
+wbl
 wMh
 cxg
 lWg
 ves
 xVN
 rsO
-jys
-jys
+sqk
+sqk
 tgT
 vVY
 vXa
@@ -81681,21 +82093,21 @@ wSx
 wFP
 oaW
 vAr
-jwY
+pIW
 lQS
 tzD
-cev
+tbT
 rps
-cUM
-cUM
+kDr
+kDr
 npl
 oIg
 iiq
 ofO
 kqT
 moB
-rlM
-erU
+moB
+tSt
 tSt
 vHN
 fLN
@@ -81953,7 +82365,7 @@ dAF
 tSt
 dev
 tgW
-tSt
+mqX
 vHN
 aDh
 syJ
@@ -82975,11 +83387,11 @@ bkF
 lqw
 xcy
 tEr
-cUM
-cUM
-cUM
-cev
-cUM
+fet
+fet
+fet
+nGD
+fet
 rUu
 dlI
 iwF
@@ -84745,7 +85157,7 @@ vKu
 pXk
 hcz
 bSw
-tGQ
+utj
 tGQ
 tGQ
 tGQ
@@ -85011,7 +85423,7 @@ mne
 mne
 cHK
 cHK
-cHK
+ssU
 aMJ
 bNb
 bNb
@@ -85293,7 +85705,7 @@ eRI
 rvE
 pFm
 qRD
-jPC
+ouV
 qRD
 pYh
 nTi


### PR DESCRIPTION

## About The Pull Request

This is a suite of random shit I fixed on OSHAN sec, more to come.

OK! Experimental OSHAN changes to sec, let's goooo

- Swapped instances of obj/machinery/porta_turret to obj/machinery/porta_turret to obj/machinery/porta_turret/ai because they weren't doing their job 
- Shuffled the bullshit in the armory around (again) to reduce the turret issues
- Adjusted shutter rotation, fixed a one-character typo 
- Removed a door
- Placed some missing floor decals 
- fixed 1 tile being the wrong type under a door 
- added more lights 
- Made the arcade machine the "Orion Trail" subtype because random arcade spawners are broken
- Placed one additional charger in security
- Added MODsuits to security, they are located in the room to the left of the holding cells. NOTE TO SELF: SOMEONE SHOULD MOVE THESE LATER., 
- Note: There is no BrigMed for Oshan, it's actually pretty damn cramped, 
- Re-adds the delivery chute at Sci, I don't know why it was removed. 
- Fixes cycle linkage for security doors

## Why It's Good For The Game

Let me cook...

## Changelog

:cl:

qol: Sec fixes
qol: Innumerable OSHAN fixes
/:cl:
