### PR TITLE
Labeler can now be used on living creatures, updated description

### DIFF
--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -1,6 +1,6 @@
 /obj/item/hand_labeler
 	name = "hand labeler"
-	desc = "A combined label printer, applicator, and remover, all in a single portable device. Designed to be easy to operate and use."
+	desc = "A combined label printer, applicator, and remover, all in a single portable device. Designed to be easy to operate and use.\nUse while powered off to remove existing labels."
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler0"
 	inhand_icon_state = null
@@ -54,9 +54,6 @@
 		return
 	if(length(A.name) + length(label) > 64)
 		to_chat(user, span_warning("Label too big!"))
-		return
-	if(ismob(A))
-		to_chat(user, span_warning("You can't label creatures!")) // use a collar
 		return
 
 	user.visible_message(span_notice("[user] labels [A] with \"[label]\"."), \


### PR DESCRIPTION

## About The Pull Request

This lets you use the hand labeler on living creatures.  I can't find or think of any real reason this was prohibited.
It also updates the description with information about how to remove a label.

## Why It's Good For The Game

Funny.

And descriptions that have use instructions are great to have.

## Changelog
:cl:
add: Hand labelers can now label living things!
add: Hand labelers now tell you how to remove labels in their description
/:cl:
