### PR TITLE
Allows emptying nutrients from botany trays, fixes a couple minor bugs

### DIFF
--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -181,7 +181,7 @@
 	returned_message += "\nPest level: [span_notice("[scanned_tray.pestlevel] / [MAX_TRAY_PESTS]")]"
 	returned_message += "\nToxicity level: [span_notice("[scanned_tray.toxic] / [MAX_TRAY_TOXINS]")]"
 	returned_message += "\nWater level: [span_notice("[scanned_tray.waterlevel] / [scanned_tray.maxwater]")]"
-	returned_message += "\nNutrition level: [span_notice("[round(scanned_tray.reagents.total_volume)] / [scanned_tray.maxnutri]")]"
+	returned_message += "\nNutrition level: [span_notice("[round(scanned_tray.reagents.total_volume)] / [scanned_tray.maxnutri]")] Right-click to empty."
 	if(scanned_tray.yieldmod != 1)
 		returned_message += "\nYield modifier on harvest: [span_notice("[scanned_tray.yieldmod]x")]"
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1029,12 +1029,13 @@
 		return
 	if(issilicon(user)) //How does AI know what plant is?
 		return
-	var/growth_mult = (1.01 ** -myseed.maturation)
-	if(growth >= myseed.harvest_age * growth_mult)
-		//if(myseed.harvest_age < age * max(myseed.production * 0.044, 0.5) && (myseed.harvest_age) < (age - lastproduce) * max(myseed.production * 0.044, 0.5) && (!harvest && !dead))
-		nutrimentMutation()
-		if(myseed && myseed.yield != -1) // Unharvestable shouldn't be harvested
-			set_plant_status(HYDROTRAY_PLANT_HARVESTABLE)
+	if(myseed)
+		var/growth_mult = (1.01 ** -myseed.maturation)
+		if(growth >= myseed.harvest_age * growth_mult)
+			//if(myseed.harvest_age < age * max(myseed.production * 0.044, 0.5) && (myseed.harvest_age) < (age - lastproduce) * max(myseed.production * 0.044, 0.5) && (!harvest && !dead))
+			nutrimentMutation()
+			if(myseed && myseed.yield != -1) // Unharvestable shouldn't be harvested
+				set_plant_status(HYDROTRAY_PLANT_HARVESTABLE)
 
 	if(plant_status == HYDROTRAY_PLANT_HARVESTABLE)
 		return myseed.harvest(user)
@@ -1047,6 +1048,30 @@
 	else
 		if(user)
 			user.examinate(src)
+
+/obj/machinery/hydroponics/attack_hand_secondary(mob/user, list/modifiers)
+	. = ..()
+	if(. == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return
+	if(issilicon(user))
+		return
+
+	if(reagents.total_volume)
+		to_chat(user, span_notice("You begin to dump out the tray's nutrient mix."))
+		if(do_after(user, 4 SECONDS, target = src))
+			playsound(user.loc, 'sound/effects/slosh.ogg', 50, TRUE, -1)
+			//dump everything on the floor
+			var/turf/user_loc = user.loc
+			if(istype(user_loc, /turf/open))
+				user_loc.add_liquid_from_reagents(reagents)
+			else
+				user_loc = get_step_towards(user_loc, src)
+				user_loc.add_liquid_from_reagents(reagents)
+			adjust_plant_nutriments(100) //PURGE
+	else
+		to_chat(user, span_warning("The tray's nutrient mix is already empty!"))
+
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /**
  * Update Tray Proc
@@ -1179,7 +1204,7 @@
 ///The usb port circuit
 
 /obj/item/circuit_component/hydroponics
-	display_name = "Hydropnics Tray"
+	display_name = "Hydroponics Tray"
 	desc = "Automate the means of botanical production. Trigger to toggle auto-grow."
 	circuit_flags = CIRCUIT_FLAG_INPUT_SIGNAL
 

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -614,7 +614,7 @@
 		. += span_info("It's empty.")
 
 	. += span_info("Water: [waterlevel]/[maxwater].")
-	. += span_info("Nutrient: [round(reagents.total_volume)]/[maxnutri].")
+	. += span_info("Nutrient: [round(reagents.total_volume)]/[maxnutri]. Right-click to empty.")
 	if(self_sustaining)
 		. += span_info("The tray's self-sustenance is active, protecting it from species mutations, weeds, and pests.")
 	if(self_growing)


### PR DESCRIPTION

## About The Pull Request

When you right click a botany tray, you now empty its nutrient mix onto the floor.
This also fixes a runtime with left-clicking a tray with no seed.
This also fixes a spelling error with the hydro tray circuit.

![image](https://github.com/Monkestation/Monkestation2.0/assets/31165061/78ee4ddc-8d49-4015-8af0-ea96b923f5b4)

## Why It's Good For The Game

Right now build-up of nutrient is an issue.  It messes with stats, which you need to micromanage for some mutations, and only depletes slowly as plants use it.  So if all your trays have nutrient mixes you're forced to grow trash plants just to use it up.  Worse, if science upgrades your trays it massively reduces nutrient usage making this process take even longer!  We shouldn't ever be hoping that science DOESN'T bring us upgrades.

## Changelog
:cl:
add: You can now right-click botany trays to dump their nutrients onto the floor!
fix: a couple minor botany tray bugs
/:cl:
