### PR TITLE
Makes oshan tendrils make fissures instead of chasms, adds a fish tendril to ocean

### DIFF
--- a/code/game/objects/structures/lavaland/necropolis_tendril.dm
+++ b/code/game/objects/structures/lavaland/necropolis_tendril.dm
@@ -18,6 +18,7 @@
 	var/gps = null
 	var/obj/effect/light_emitter/tendril/emitted_light
 
+	var/deconstruct_override = FALSE // Monkestation addition: override for ocean tendrils
 
 /obj/structure/spawner/lavaland/goliath
 	mob_types = list(/mob/living/basic/mining/goliath)
@@ -40,6 +41,10 @@ GLOBAL_LIST_INIT(tendrils, list())
 	GLOB.tendrils += src
 
 /obj/structure/spawner/lavaland/deconstruct(disassembled)
+	// Monkestation addition start: override for ocean tendrils
+	if(deconstruct_override)
+		return ..()
+	// Monkestation addition end
 	new /obj/effect/collapse(loc)
 	return ..()
 

--- a/monkestation/code/modules/liquids/ocean_generator.dm
+++ b/monkestation/code/modules/liquids/ocean_generator.dm
@@ -98,9 +98,10 @@
 		/mob/living/basic/mining/lobstrosity/lava = 20,
 		/mob/living/simple_animal/hostile/asteroid/brimdemon = 20,
 		/mob/living/basic/mining/goldgrub = 10,
-		/obj/structure/spawner/lavaland = 2,
-		/obj/structure/spawner/lavaland/goliath = 3,
-		/obj/structure/spawner/lavaland/legion = 3,
+		/obj/structure/spawner/lavaland/ocean = 2,
+		/obj/structure/spawner/lavaland/ocean/goliath = 3,
+		/obj/structure/spawner/lavaland/ocean/legion = 3,
+		/obj/structure/spawner/lavaland/ocean/fish = 1, // a rare fish challenger approaches!
 	)
 
 	flora_spawn_list = null

--- a/monkestation/code/modules/ocean_content/fluff/ocean_tendril.dm
+++ b/monkestation/code/modules/ocean_content/fluff/ocean_tendril.dm
@@ -1,0 +1,45 @@
+//Oceanic Tendrils, which spawn lavaland monsters and DONT break into a chasm when killed (chasms cause puddles, so we cant have dat)
+/obj/structure/spawner/lavaland/ocean
+	name = "oceanic tendril"
+	desc = "A vile tendril of corruption, originating deep under the sea. Terrible monsters are pouring out of it."
+
+	deconstruct_override = TRUE
+
+/obj/structure/spawner/lavaland/ocean/deconstruct(disassembled)
+	new /obj/effect/collapse/ocean(loc)
+	return ..()
+
+
+/obj/effect/collapse/ocean
+	name = "collapsing oceanic tendril"
+	desc = "Get your loot and get clear, else you will be sleeping with the fishes!"
+
+	// a var used in terraformation, i could just type the turf into it but that would look ugly due to its lenght
+	var/transformation_turf = /turf/open/floor/plating/ocean/dark/rock/warm/fissure
+
+/obj/effect/collapse/ocean/collapse()
+	for(var/mob/M in range(7,src))
+		shake_camera(M, 15, 1)
+	playsound(get_turf(src),'sound/effects/explosionfar.ogg', 200, TRUE)
+	visible_message(span_boldannounce("The tendril falls inward, the ground around it filling with magma!"))
+	for(var/turf/T in RANGE_TURFS(2,src))
+		if(!T.density)
+			T.TerraformTurf(transformation_turf, transformation_turf, flags = CHANGETURF_INHERIT_AIR)
+	qdel(src)
+
+
+/obj/structure/spawner/lavaland/ocean/goliath
+	mob_types = list(/mob/living/basic/mining/goliath)
+
+/obj/structure/spawner/lavaland/ocean/legion
+	mob_types = list(/mob/living/simple_animal/hostile/asteroid/hivelord/legion/tendril)
+
+/obj/structure/spawner/lavaland/ocean/fish
+	max_mobs = 6
+	mob_types = list(
+		/mob/living/basic/aquatic/fish/cod,
+		/mob/living/basic/aquatic/fish/gupper,
+	)
+
+/obj/structure/spawner/lavaland/ocean/icewatcher
+	mob_types = list(/mob/living/basic/mining/watcher/icewing)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5967,6 +5967,7 @@
 #include "monkestation\code\modules\ocean_content\fluff\industrial_power_cables.dm"
 #include "monkestation\code\modules\ocean_content\fluff\launching.dm"
 #include "monkestation\code\modules\ocean_content\fluff\ocean_elevators.dm"
+#include "monkestation\code\modules\ocean_content\fluff\ocean_tendril.dm"
 #include "monkestation\code\modules\ocean_content\fluff\trench_ladder.dm"
 #include "monkestation\code\modules\ocean_content\hotspot\center.dm"
 #include "monkestation\code\modules\ocean_content\hotspot\hotspot.dm"


### PR DESCRIPTION

## About The Pull Request

adds an override var to lavaland tendrils, to choose custom effects on initialize

Adds a new subtype of the lavaland tendril that makes fissures instead of chasms (used in oshan's turf generator, due to chasms making puddles on themselfes)

adds the rare fish tendril, the rarest of them all

## Why It's Good For The Game

when a tendril is destroyed in oshan right now it makes puddles on chasms and that just does not look good, this replaces them with fissures.

## Changelog

:cl:
add: A new exotic tendril can now spawn on oshan
add: Oshan tendrils now cause fissures to appear instead of chasms (where's the tweak label for changelogs anyway?)
/:cl:
