### PR TITLE
Fixes the DJing station cooldown timer

### DIFF
--- a/monkestation/code/modules/cassettes/machines/dj_station.dm
+++ b/monkestation/code/modules/cassettes/machines/dj_station.dm
@@ -52,8 +52,8 @@ GLOBAL_VAR(dj_booth)
 
 /obj/machinery/cassette/dj_station/examine(mob/user)
 	. = ..()
-	if(time_left > 0)
-		. += span_notice("It seems to be cooling down, you estimate it will take about [time_left] seconds.")
+	if(time_left > 0 || next_song_timer)
+		. += span_notice("It seems to be cooling down, you estimate it will take about [((time_left + next_song_timer) / 600)] minutes.")
 
 /obj/machinery/cassette/dj_station/process(seconds_per_tick)
 	if(waiting_for_yield)
@@ -71,7 +71,7 @@ GLOBAL_VAR(dj_booth)
 		return
 	if((!COOLDOWN_FINISHED(src, next_song_timer)) && !broadcasting)
 		to_chat(user, span_notice("The [src] feels hot to the touch and needs time to cooldown."))
-		to_chat(user, span_info("You estimate it will take about [time_left] seconds to cool down."))
+		to_chat(user, span_info("You estimate it will take about [((time_left + next_song_timer) / 600)] minutes to cool down."))
 		return
 	start_broadcast()
 


### PR DESCRIPTION

## About The Pull Request

The original PR only made it work while the song was playing, and only said the time in deciseconds... oops

also while at it, i adjusted it to tell minutes instead of seconds. Since i think its better for da situation with the DJ station

fixes #383 

## Why It's Good For The Game

working things = good

## Changelog

:cl:
fix: DJ station properly shows its cooldown time
/:cl:
