### PR TITLE
Minor Biogenerator UI touch-up

### DIFF
--- a/tgui/packages/tgui/interfaces/Biogenerator.tsx
+++ b/tgui/packages/tgui/interfaces/Biogenerator.tsx
@@ -56,11 +56,11 @@ export const Biogenerator = (props, context) => {
     categories.find((category) => category.name === selectedCategory)?.items ||
     [];
   return (
-    <Window width={400} height={500}>
+    <Window width={400} height={525}>
       <Window.Content>
         <Stack vertical fill>
           <Stack.Item>
-            <Section fill>
+            <Section fill minHeight="80px">
               <LabeledList>
                 <LabeledList.Item
                   label="Biomass"

--- a/tgui/packages/tgui/interfaces/BotanySplicer.js
+++ b/tgui/packages/tgui/interfaces/BotanySplicer.js
@@ -154,30 +154,6 @@ export const InsertedSeedTwo = (props, context) => {
   );
 };
 
-export const InsertedBeaker = (props, context) => {
-  const { act, data } = useBackend(context);
-  const { held_beaker, working } = data;
-  const beaker_data = data.beaker || [];
-  if (!held_beaker) {
-    return !working && <NoticeBox info>Please insert a beaker.</NoticeBox>;
-  }
-  return (
-    <Section
-      title="Inserted Beaker"
-      buttons={
-        <Button
-          icon="eject"
-          disabled={!!working}
-          onClick={() => act('eject_beaker')}
-          content="Eject Beaker"
-        />
-      }>
-      {!held_beaker && 'No Beaker detected.'}
-      {!!held_beaker && 'Beaker detected.'}
-    </Section>
-  );
-};
-
 export const SpliceButton = (props, context) => {
   const { act, data } = useBackend(context);
   const { working, seedone, seedtwo } = data;
@@ -214,7 +190,6 @@ export const BotanySplicer = (props, context) => {
         )}
         <InsertedSeedOne />
         <InsertedSeedTwo />
-        <InsertedBeaker />
         <SpliceButton />
       </Window.Content>
     </Window>

--- a/tgui/packages/tgui/interfaces/BotanySplicer.js
+++ b/tgui/packages/tgui/interfaces/BotanySplicer.js
@@ -154,6 +154,30 @@ export const InsertedSeedTwo = (props, context) => {
   );
 };
 
+export const InsertedBeaker = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { held_beaker, working } = data;
+  const beaker_data = data.beaker || [];
+  if (!held_beaker) {
+    return !working && <NoticeBox info>Please insert a beaker.</NoticeBox>;
+  }
+  return (
+    <Section
+      title="Inserted Beaker"
+      buttons={
+        <Button
+          icon="eject"
+          disabled={!!working}
+          onClick={() => act('eject_beaker')}
+          content="Eject Beaker"
+        />
+      }>
+      {!held_beaker && 'No Beaker detected.'}
+      {!!held_beaker && 'Beaker detected.'}
+    </Section>
+  );
+};
+
 export const SpliceButton = (props, context) => {
   const { act, data } = useBackend(context);
   const { working, seedone, seedtwo } = data;
@@ -190,6 +214,7 @@ export const BotanySplicer = (props, context) => {
         )}
         <InsertedSeedOne />
         <InsertedSeedTwo />
+        <InsertedBeaker />
         <SpliceButton />
       </Window.Content>
     </Window>


### PR DESCRIPTION

## About The Pull Request

The Biogenerator UI had a couple of those little things that are objectively minor but irk you SO MUCH.

![image](https://github.com/Monkestation/Monkestation2.0/assets/31165061/daa70e6a-adf1-4735-b49d-d234308bb859)

When you click a button to dispense a chem for instance the whole bottom half of the UI would shift.

Also, the window was vertically sized such that only diethylamine just BARELY needed you to scroll down for it.

This fixes both of those annoyances.

## Why It's Good For The Game

Smoother UI = happier players

## Changelog
:cl:
fix: fixed a couple small annoyances with the Biogenerator UI
/:cl:
