### PR TITLE
Fixes Brim Demons and Legion Skulls

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/brimdemon.dm
@@ -15,7 +15,7 @@
 	istate = ISTATE_HARM|ISTATE_BLOCKING
 	stat_attack = HARD_CRIT
 	ranged_cooldown_time = 5 SECONDS
-	vision_range = 9
+	vision_range = 6
 	retreat_distance = 2
 	speed = 3
 	move_to_delay = 5

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -86,7 +86,7 @@
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	pass_flags = PASSTABLE | PASSMOB
-	density = FALSE
+	density = TRUE
 	del_on_death = 1
 	var/clickbox_state = "hivelord"
 	var/clickbox_max_scale = INFINITY


### PR DESCRIPTION

## About The Pull Request

Reduces brim demon's sight range so that he dosnt spot you from across the map

Legions are now dense so you dont get legion stacked by 9 of them and instant killed by their combined attack power

## Why It's Good For The Game

Brim demons have often been discussed as having a far too long sight range, people even go to claim they can see through walls and from offscreen. While not true, they have a 9 tile sight range, meaning that if they arnt on the edge of your screen, they can see you, so that will be changed as to make them much less of a instant threat the moment you see them

Legion stacking is another issue that makes legions FAR more dangerous than they should be. Legion stacking is where legion skulls pile up on one tile, then hit you all at once for 30-50+ damage instantly, basically killing you, not to mention how they already perfectly pursue you once they chase. Setting them to dense means you cant fire past them or move past them without crawling, but it also means legion stacking will almost never occur (you can get surrounded but never hit by more than 9) This will make legion tendrils much easier, and multiple leagions easier for newer players to take on, while still remaining as a challenge.

:cl:
balance: Reduced brim demon sight range, and made legion skulls dense so they cant stack
/:cl:

