### PR TITLE
The great map proofreading

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -18024,7 +18024,9 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 4
 	},
-/obj/machinery/camera/directional/west,
+/obj/machinery/camera/directional/west{
+	c_tag = "Cargo - Bitrunning Den"
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/bitrunning/den)
 "eyy" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2245,11 +2245,7 @@
 "agx" = (
 /obj/structure/filingcabinet,
 /obj/structure/window/spawner/directional/north,
-/obj/item/paper/monitorkey,
-/obj/item/areaeditor/blueprints{
-	name = "Station Layout";
-	desc = "A crude mapping of the station layout based on leaked internal documents and orbital snapshots taken during construction. I'm not sure how up-to-date this is anymore..."
-	},
+/obj/item/paper/crumpled,
 /turf/open/floor/mineral/bananium,
 /area/ruin/powered/clownplanet)
 "agy" = (
@@ -8614,10 +8610,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/lower)
 "bxd" = (
-/obj/machinery/computer/message_monitor{
+/obj/structure/sign/calendar/directional/south,
+/obj/machinery/computer/old{
 	dir = 1
 	},
-/obj/structure/sign/calendar/directional/south,
 /turf/open/floor/mineral/bananium,
 /area/ruin/powered/clownplanet)
 "bxr" = (
@@ -9656,6 +9652,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "bNx" = (
@@ -10260,7 +10257,6 @@
 	pixel_x = 4;
 	pixel_y = -32
 	},
-/obj/item/stack/sheet/mineral/bananium/five,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "bXr" = (
@@ -18028,6 +18024,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 4
 	},
+/obj/machinery/camera/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/bitrunning/den)
 "eyy" = (
@@ -20096,7 +20093,7 @@
 /obj/item/ammo_box/a357,
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/gun/ballistic/revolver/mateba,
+/obj/item/gun/ballistic/revolver/russian,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "fkg" = (
@@ -25254,10 +25251,10 @@
 /area/station/medical/break_room)
 "gWk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/storage/toolbox/syndicate,
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tool,
 /obj/effect/spawner/random/mod,
+/obj/item/storage/toolbox/emergency/old,
 /turf/open/floor/plating,
 /area/ruin/powered/clownplanet)
 "gWo" = (
@@ -25514,6 +25511,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/art)
+"hbN" = (
+/obj/structure/cable,
+/obj/structure/cable/layer1,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/ai)
 "hbQ" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Civilian - Holodeck Controls"
@@ -29262,6 +29264,7 @@
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
 	},
+/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "iqZ" = (
@@ -31769,7 +31772,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/crew_quarters/dorms)
 "jfu" = (
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "jfD" = (
@@ -33339,9 +33342,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/industrial,
-/obj/item/mod/control/pre_equipped/cosmohonk,
-/obj/item/mod/module/insignia/clown,
+/obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/mineral/bananium,
 /area/ruin/powered/clownplanet)
 "jFu" = (
@@ -39125,7 +39126,6 @@
 "lwy" = (
 /obj/machinery/porta_turret/ai,
 /obj/machinery/light/directional/north,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "lwB" = (
@@ -49007,8 +49007,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/effect/spawner/random/decoration/ornament,
-/obj/item/stack/sheet/mineral/bananium/five,
 /obj/item/reagent_containers/cup/beaker,
+/obj/item/grown/bananapeel/bluespace,
 /turf/open/floor/plating,
 /area/ruin/powered/clownplanet)
 "oMZ" = (
@@ -61415,7 +61415,8 @@
 /area/station/commons/dorms)
 "sJp" = (
 /obj/structure/sign/clock/directional/south,
-/obj/machinery/computer/camera_advanced/syndie{
+/obj/item/paper/crumpled/bloody,
+/obj/structure/frame/computer{
 	dir = 1
 	},
 /turf/open/floor/mineral/bananium,
@@ -62181,6 +62182,7 @@
 	},
 /obj/machinery/holopad/secure,
 /obj/structure/cable,
+/obj/structure/cable/layer1,
 /turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "sVA" = (
@@ -63694,10 +63696,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tsR" = (
-/obj/item/paper{
-	default_raw_text = "Congradulations, agent 'INSERT NAME HERE'! You have been assigned reconnaissance duty among the orbiting rocks of Indecipheres! As this location was previously scouted as a potential build site for a Nanotrasen outpost, one of our benefactors has taken the oppertunity to pre-emptively construct a listening outpost within the region! You have been tasked with monitoring the potentially active future crew and logging all events onboard. If you are a Nanotrasen official who has stumbled upon this outpost before it could be properly established: Please ignore this entire paper.";
-	name = "initiation paperwork"
-	},
 /obj/machinery/computer/records/medical/syndie{
 	dir = 1;
 	req_access = list("syndicate")
@@ -63832,9 +63830,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "engi-entrance"
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "Engineering3"
 	},
@@ -64907,7 +64902,7 @@
 	c_tag = "Secure - AI Upper External North";
 	network = list("aicore")
 	},
-/obj/structure/cable,
+/obj/structure/cable/multilayer/connected,
 /turf/open/floor/engine/hull/reinforced,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "tNJ" = (
@@ -193311,7 +193306,7 @@ jfu
 lwy
 sVz
 bNr
-aoh
+hbN
 fyX
 ffe
 mgi

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -78037,19 +78037,19 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
-/mob/living/simple_animal/pet/cat/kitten{
-	name = "Blu";
-	gender = "female"
-	},
 /obj/structure/bed/dogbed{
 	desc = "A comfy-looking cat bed. You can even strap your pet in, in case the gravity turns off.";
-	name = "cat bed"
+	name = "slime bed"
 	},
 /obj/machinery/conveyor_switch/oneway{
 	id = "hydrodropoff";
 	name = "Shipment Delivery Chute Activator";
 	pixel_x = 10;
 	pixel_y = 20
+	},
+/mob/living/simple_animal/slime/pet{
+	colour = "orange";
+	name = "Happy Accident"
 	},
 /turf/open/floor/plastic,
 /area/station/engineering/break_room)

--- a/monkestation/_maps/RandomBars/Icebox/BarSM.dmm
+++ b/monkestation/_maps/RandomBars/Icebox/BarSM.dmm
@@ -24,17 +24,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/commons/lounge)
-"aZ" = (
-/obj/structure/bed/dogbed{
-	name = "pet bed";
-	desc = "A comfy-looking pet bed. You can even strap your pet in, in case the gravity turns off."
-	},
-/mob/living/simple_animal/pet/cat/kitten{
-	gender = "female";
-	name = "Blu"
-	},
-/turf/open/floor/carpet/neon/simple/yellow/nodots,
-/area/station/service/bar/backroom)
 "bo" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass/critical{
@@ -591,8 +580,6 @@
 /obj/item/reagent_containers/cup/beaker/large,
 /obj/item/vending_refill/cigarette,
 /obj/structure/table/reinforced,
-/obj/item/storage/box/lethalshot,
-/obj/item/storage/box/beanbag,
 /turf/open/floor/carpet/neon/simple/yellow/nodots,
 /area/station/service/bar/backroom)
 "uo" = (
@@ -905,18 +892,6 @@
 "Ec" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/autolathe,
-/obj/item/stack/sheet/iron/ten,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
 /turf/open/floor/pod/light,
 /area/station/service/bar)
 "Eu" = (
@@ -1212,11 +1187,9 @@
 	pixel_x = 4;
 	pixel_y = -4
 	},
-/obj/item/clothing/gloves/color/yellow,
 /obj/item/stack/cable_coil,
-/obj/item/mod/control/pre_equipped/engineering{
-	name = "Barkeeper MODsuit"
-	},
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/mod/control/pre_equipped/empty,
 /turf/open/floor/carpet/neon/simple/yellow/nodots,
 /area/station/service/bar/backroom)
 "KG" = (
@@ -1233,6 +1206,7 @@
 	pixel_y = 6
 	},
 /obj/item/reagent_containers/cup/rag,
+/obj/item/holosign_creator/robot_seat/bar,
 /turf/open/floor/pod/light,
 /area/station/service/bar)
 "KL" = (
@@ -1873,7 +1847,7 @@ EK
 "}
 (17,1,1) = {"
 Kf
-aZ
+Ix
 Ix
 qu
 wG

--- a/monkestation/_maps/RandomBars/Icebox/Drunkopsbar.dmm
+++ b/monkestation/_maps/RandomBars/Icebox/Drunkopsbar.dmm
@@ -592,7 +592,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
 "Gc" = (
-/obj/structure/closet/gimmick/tacticool,
 /obj/structure/cable,
 /obj/item/clothing/under/syndicate/tacticool,
 /obj/item/clothing/under/syndicate/tacticool/skirt,
@@ -600,6 +599,9 @@
 /obj/item/toy/sword,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/item/clothing/head/collectable/swat,
+/obj/structure/closet{
+	icon_state = "syndicate"
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/station/service/bar)
 "Gv" = (
@@ -726,12 +728,14 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /obj/effect/turf_decal/stripes/red/line,
 /obj/structure/railing,
-/obj/structure/closet/gimmick/tacticool,
 /obj/item/clothing/under/syndicate/tacticool,
 /obj/item/clothing/under/syndicate/tacticool/skirt,
 /obj/item/toy/gun,
 /obj/item/toy/sword,
 /obj/item/clothing/mask/gas,
+/obj/structure/closet{
+	icon_state = "syndicate"
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/station/service/bar)
 "Pk" = (
@@ -785,6 +789,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/bar/backroom)
 "Qe" = (
@@ -849,7 +854,9 @@
 /obj/item/toy/mecha/mauler,
 /obj/item/toy/sword,
 /obj/item/clothing/mask/gas,
-/obj/structure/closet,
+/obj/structure/closet{
+	icon_state = "syndicate"
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/station/service/bar)
 "RX" = (
@@ -924,7 +931,9 @@
 /obj/item/clothing/under/syndicate/tacticool/skirt,
 /obj/item/toy/gun,
 /obj/item/toy/sword,
-/obj/structure/closet,
+/obj/structure/closet{
+	icon_state = "syndicate"
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/station/service/bar)
 "TO" = (

--- a/monkestation/_maps/RandomBars/Icebox/MaidCafe.dmm
+++ b/monkestation/_maps/RandomBars/Icebox/MaidCafe.dmm
@@ -38,7 +38,7 @@
 /obj/structure/flora/bush/ferny/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/pale/style_random,
-/obj/structure/window/reinforced/fulltile,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/station/commons/lounge)
 "gO" = (
@@ -207,17 +207,14 @@
 /area/station/service/bar/backroom)
 "tc" = (
 /obj/machinery/duct,
-/mob/living/basic/carp/pet/cayenne{
-	desc = "It's Paprika! One of the Spider Clan's lovable Space Carp!";
-	faction = list("neutral");
-	name = "Paprika";
-	real_name = "Paprika"
-	},
-/obj/structure/bed/dogbed/cayenne{
-	name = "Paprika's bed"
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/mob/living/basic/carp/pet{
+	name = "Paprika"
+	},
+/obj/structure/bed/dogbed{
+	name = "fish bed"
+	},
 /turf/open/floor/carpet/black,
 /area/station/service/bar)
 "tg" = (
@@ -284,7 +281,7 @@
 /obj/structure/flora/bush/ferny/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/pale/style_random,
-/obj/structure/window/reinforced/fulltile,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/station/service/bar)
 "Ak" = (
@@ -568,9 +565,8 @@
 /obj/item/reagent_containers/cup/beaker/large,
 /obj/item/reagent_containers/cup/beaker/large,
 /obj/item/vending_refill/cigarette,
-/obj/item/storage/box/lethalshot,
-/obj/item/storage/box/beanbag,
-/obj/structure/table/wood,
+/obj/item/holosign_creator/robot_seat/bar,
+/obj/structure/closet/secure_closet/bar,
 /turf/open/floor/wood/tile,
 /area/station/service/bar/backroom)
 "Ou" = (
@@ -690,13 +686,6 @@
 /area/station/service/bar)
 "TT" = (
 /obj/structure/rack,
-/obj/item/melee/energy/sword/holographic/red,
-/obj/item/melee/energy/sword/holographic/red,
-/obj/item/melee/energy/sword/holographic/green,
-/obj/item/melee/energy/sword/holographic/green,
-/obj/item/melee/energy/sword/holographic,
-/obj/item/melee/energy/sword/holographic,
-/obj/item/melee/energy/sword/bananium,
 /obj/item/toy/katana{
 	desc = "As seen in your favourite Japanese cartoon.";
 	name = "anime katana"
@@ -710,6 +699,9 @@
 	name = "anime katana"
 	},
 /obj/machinery/light/directional/west,
+/obj/item/toy/sword,
+/obj/item/toy/sword,
+/obj/item/toy/sword,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
 "TY" = (
@@ -729,10 +721,10 @@
 /obj/structure/flora/bush/ferny/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/structure/flora/bush/pale/style_random,
-/obj/structure/window/reinforced/fulltile,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/grass,
 /area/station/service/bar)
 "UN" = (

--- a/monkestation/_maps/RandomBars/Icebox/clockwork_icebox.dmm
+++ b/monkestation/_maps/RandomBars/Icebox/clockwork_icebox.dmm
@@ -163,6 +163,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/bronze/filled,
 /area/station/service/bar/backroom)
 "hS" = (
@@ -576,6 +577,10 @@
 	},
 /turf/open/floor/bronze/filled,
 /area/station/service/bar)
+"Fm" = (
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/carpet/lone,
+/area/station/service/theater)
 "FS" = (
 /obj/machinery/restaurant_portal/bar,
 /turf/open/floor/bronze/filled,
@@ -654,6 +659,10 @@
 /obj/structure/closet/secure_closet/bar,
 /turf/open/floor/bronze/filled,
 /area/station/service/bar/backroom)
+"Ky" = (
+/obj/machinery/camera/autoname/directional/west,
+/turf/open/floor/bronze,
+/area/station/commons/lounge)
 "KP" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/bronze,
@@ -966,7 +975,7 @@ EK
 "}
 (5,1,1) = {"
 nZ
-YM
+Fm
 SW
 OY
 Pz
@@ -1016,7 +1025,7 @@ oC
 oC
 oC
 ux
-ZP
+Ky
 nl
 EK
 "}

--- a/monkestation/_maps/RandomBars/Icebox/cultbar_icebox.dmm
+++ b/monkestation/_maps/RandomBars/Icebox/cultbar_icebox.dmm
@@ -635,10 +635,6 @@
 /obj/item/toy/toy_dagger,
 /turf/open/floor/cult,
 /area/station/commons/lounge)
-"Ha" = (
-/obj/structure/constructshell,
-/turf/open/floor/cult,
-/area/station/service/bar/backroom)
 "HO" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/food/pie/cream{
@@ -1297,7 +1293,7 @@ EK
 HZ
 QV
 rf
-Ha
+rf
 TV
 xc
 zG

--- a/monkestation/_maps/RandomBars/Icebox/disco_icebox.dmm
+++ b/monkestation/_maps/RandomBars/Icebox/disco_icebox.dmm
@@ -99,6 +99,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/eighties/red,
 /area/station/commons/lounge)
 "jI" = (
@@ -277,6 +278,7 @@
 "BO" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/eighties,
 /area/station/commons/lounge)
 "BS" = (

--- a/monkestation/_maps/RandomBars/Icebox/junglebar.dmm
+++ b/monkestation/_maps/RandomBars/Icebox/junglebar.dmm
@@ -6,6 +6,15 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"az" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/floodlight,
+/obj/item/wrench,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bp" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -301,6 +310,7 @@
 /area/template_noop)
 "Fz" = (
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/wood,
 /area/station/service/bar)
 "FY" = (
@@ -344,6 +354,12 @@
 "HP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
+"JV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "Ke" = (
@@ -473,6 +489,7 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "YU" = (
@@ -481,6 +498,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/west,
 /obj/structure/cable,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 
@@ -543,7 +561,7 @@ EK
 (5,1,1) = {"
 ac
 xY
-VL
+az
 VL
 Mt
 Df
@@ -569,7 +587,7 @@ EK
 EK
 "}
 (7,1,1) = {"
-HP
+JV
 Xr
 mL
 LG

--- a/monkestation/_maps/RandomEngines/KiloStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/KiloStation/singularity.dmm
@@ -220,14 +220,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "oN" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Departures Lounge";
-	name = "shuttle camera"
-	},
 /obj/machinery/light/blacklight/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/camera/emp_proof/directional/west{
+	c_tag = "Singularity Engine #2"
+	},
 /turf/open/floor/iron,
 /turf/open/floor/iron,
 /turf/open/floor/iron,
@@ -298,9 +297,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "th" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Departures Lounge";
-	name = "shuttle camera"
+/obj/machinery/camera/emp_proof/directional/north{
+	c_tag = "Singularity Engine #3"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
@@ -471,6 +469,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"Ga" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable/layer1,
+/obj/structure/cable,
+/obj/machinery/camera/emp_proof/directional/west{
+	c_tag = "Singularity Engine #4"
+	},
+/turf/open/space/basic,
+/area/station/engineering/supermatter/room)
 "Hs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -535,13 +542,12 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "LD" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Departures Lounge";
-	name = "shuttle camera"
-	},
 /obj/machinery/light/blacklight/directional/north,
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/camera/emp_proof/directional/north{
+	c_tag = "Singularity Engine #1"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "LZ" = (
@@ -987,7 +993,7 @@ IJ
 cY
 cY
 cY
-vF
+Ga
 vF
 XV
 cY

--- a/monkestation/_maps/RandomEngines/MetaStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/MetaStation/singularity.dmm
@@ -376,9 +376,8 @@
 /area/station/engineering/supermatter/room)
 "AZ" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering - Engine Room North-West";
-	network = list("ss13","engine","engineering")
+/obj/machinery/camera/emp_proof/directional/north{
+	c_tag = "Singularity Engine #1"
 	},
 /turf/open/floor/carpet/black,
 /area/station/engineering/supermatter/room)
@@ -611,6 +610,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
+"Rw" = (
+/obj/structure/grille,
+/obj/machinery/camera/emp_proof/directional/west{
+	c_tag = "Singularity Engine #4"
+	},
+/turf/open/space/basic,
+/area/station/engineering/supermatter/room)
 "Sh" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -634,6 +640,12 @@
 "SS" = (
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"UU" = (
+/obj/machinery/camera/emp_proof/directional/east{
+	c_tag = "Singularity Engine #3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "Vk" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -644,9 +656,8 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "Vn" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering - Engine Room North-West";
-	network = list("ss13","engine","engineering")
+/obj/machinery/camera/emp_proof/directional/north{
+	c_tag = "Singularity Engine #2"
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
@@ -938,7 +949,7 @@ je
 je
 "}
 (10,1,1) = {"
-zC
+UU
 np
 gQ
 HO
@@ -1108,7 +1119,7 @@ An
 An
 ol
 An
-Bc
+Rw
 nM
 KS
 KS

--- a/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
+++ b/monkestation/_maps/RandomEngines/TramStation/singularity.dmm
@@ -156,9 +156,8 @@
 /area/station/engineering/supermatter/room)
 "qR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering - Engine Room North-West";
-	network = list("ss13","engine","engineering")
+/obj/machinery/camera/emp_proof/directional/north{
+	c_tag = "Singularity Engine #2"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
@@ -355,11 +354,10 @@
 /area/space/nearstation)
 "OY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering - Engine Room North-West";
-	network = list("ss13","engine","engineering")
-	},
 /obj/machinery/power/energy_accumulator/grounding_rod,
+/obj/machinery/camera/emp_proof/directional/north{
+	c_tag = "Singularity Engine #1"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "Pi" = (
@@ -491,6 +489,12 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"ZX" = (
+/obj/machinery/camera/emp_proof/directional/north{
+	c_tag = "Singularity Engine #3"
+	},
+/turf/open/space/basic,
+/area/station/engineering/supermatter/room)
 
 (1,1,1) = {"
 TZ
@@ -942,7 +946,7 @@ Gn
 Ho
 Ho
 Ho
-Zh
+ZX
 Zh
 jS
 zz


### PR DESCRIPTION
## About The Pull Request
I went through so many maps that we have edited and made a ton of small edits to remove some dead drops(a term i am using to refer to powergamer gear placed in hard-to-reach places for specific players to aquire). Adds some cameras where there weren't cameras before but really should have been.
THE LIST: 
- Removed blueprints from the clown sat
- Removed the comms agent stuff from clown sat
- Fixed the tramstation ai solars
- removed a lot of static bananium spawns in tramstation
- added cameras in the bitrunner dens in tram
- removed a dead drop from the tramstation vault
- tried to fix some of the cycle link errors
- removed references to banned players in maps
- added holosign emitters to some bars that were missing them
- removed the deathsquad modsuits from bars
- removed the construct shells from bars
- removed the holographic eswords from bars
- adds emp proofing to cameras near singulo engine
- adds an emp proof camera to the singulo engine.
- removes excess ammo from two bars
- replaces some windows in bars with proper window spawners

## Why It's Good For The Game
Fixes are good.
Most if not all the dead drops were made with malicious intent to add powerful gear in places that were out of reach for someone not looking for them, this should not be a thing in our maps.
The deathsquad modsuits seemed to be made in honest mistake, but were not fixed until now
Emp proofing cameras in the singulo engine area makes it so a singulo can actually be monitored by the ai.


## Changelog
:cl:
del: Lots of weirdly placed powerful gear is gone now.
qol: singularity engine cameras are now emp-proof
fix: tramstation ai solars have been remodeled to function.
fix: all bars now have the proper holosign emitters
/:cl:
