### PR TITLE
removes fungal TB from random maint pills

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1415,6 +1415,7 @@
 	taste_description = "slime"
 	penetrates_skin = NONE
 	ph = 11
+	restricted = TRUE //so they cant roll on maint pills, if this has other sides effects then this can be reworked to a global blacklist
 
 /datum/reagent/fungalspores/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume, show_message = TRUE, touch_protection = 0)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Sets the restricted var on the fungal TB chem to TRUE so ti can no longer roll on maint pills.

## Why It's Good For The Game

Ook wants it and roundstart TB two rounds in a row is not fun.

## Changelog
:cl:
tweak: fungal TB can no longer roll from maint pills
/:cl:
