### PR TITLE
Many Map QOLs!

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -375,8 +375,8 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/splicer,
 /obj/item/food/grown/poppy/lily,
+/obj/machinery/plantgenes,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/powered/seedvault)
 "bb" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -16184,7 +16184,6 @@
 /area/station/hallway/primary/fore)
 "dRK" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "dRO" = (
@@ -24675,6 +24674,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
+"fXc" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "fXi" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sign/plaques/kiddie/badger{
@@ -25828,8 +25836,6 @@
 /area/station/security/courtroom)
 "glb" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
@@ -37227,11 +37233,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
-"jcg" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "jcl" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /obj/structure/sink/directional/east,
@@ -75182,14 +75183,12 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "sst" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "ssy" = (
@@ -87523,10 +87522,6 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/library/lounge)
 "vrs" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
@@ -119399,8 +119394,8 @@ tqa
 gnw
 lFQ
 mWF
-jcg
-jcg
+mWF
+mWF
 sst
 pgY
 gAw
@@ -119658,7 +119653,7 @@ sHT
 glb
 dRK
 wcP
-yeO
+fXc
 nbZ
 gAw
 ifw

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -7051,7 +7051,6 @@
 "cks" = (
 /obj/item/wrench,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
@@ -14683,9 +14682,7 @@
 /area/station/commons/fitness)
 "eDC" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "eDM" = (
@@ -43622,10 +43619,6 @@
 /area/station/security/prison/safe)
 "nXl" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "nXn" = (
@@ -58183,10 +58176,6 @@
 /area/mine/living_quarters)
 "sGJ" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
@@ -64304,9 +64293,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "uIV" = (
-/obj/machinery/meter,
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "uJn" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -53307,6 +53307,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/sink/directional/west,
 /obj/structure/sign/poster/random/directional/south,
+/obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "tck" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4982,6 +4982,7 @@
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/mail_sorting/supply/disposals,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "bMY" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -6790,11 +6790,9 @@
 /turf/closed/wall/r_wall,
 /area/station/security/checkpoint)
 "bDO" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 4
-	},
 /obj/machinery/status_display/evac/directional/north,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "bDU" = (
@@ -47245,10 +47243,6 @@
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningoffice)
 "mvg" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/machinery/camera{
 	c_tag = "Supermatter Foyer Cam #4";
 	network = list("ss13","engine")
@@ -83315,13 +83309,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"wfl" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "wfx" = (
 /obj/machinery/door/window/brigdoor/left/directional/west,
 /obj/structure/cable,
@@ -138400,8 +138387,8 @@ vap
 lQD
 juf
 klY
-kfo
-wfl
+xgW
+xgW
 dEc
 uhx
 uov
@@ -138657,7 +138644,7 @@ uyD
 uyD
 uyD
 bDO
-kfo
+xgW
 mvg
 dEc
 ggX

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -605,7 +605,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/carpet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "anP" = (
 /obj/effect/turf_decal/trimline/yellow,
 /turf/open/floor/iron/dark/textured,
@@ -865,7 +865,7 @@
 	},
 /obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "avO" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
@@ -1024,7 +1024,7 @@
 /obj/effect/turf_decal/trimline/blue/line,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "aCp" = (
 /mob/living/basic/butterfly,
 /obj/structure/cable,
@@ -1335,7 +1335,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "aKV" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/gambling,
@@ -1919,7 +1919,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "aZB" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/engine,
@@ -2776,6 +2776,9 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/captain/private)
+"bxs" = (
+/turf/closed/wall/r_wall,
+/area/station/medical/psychology)
 "bxM" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -4357,7 +4360,7 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "clC" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/egg_incubator,
@@ -4600,7 +4603,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "cvu" = (
 /obj/structure/sink/kitchen/directional/east,
 /turf/open/floor/iron/kitchen,
@@ -5320,7 +5323,7 @@
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "cQM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5911,7 +5914,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/cmo,
 /turf/open/floor/plating,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "dgu" = (
 /obj/structure/chair/sofa/right{
 	dir = 1
@@ -5968,7 +5971,7 @@
 	},
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "dhA" = (
 /obj/machinery/modular_computer/console/preset/id,
 /obj/machinery/light/directional/north,
@@ -7022,7 +7025,7 @@
 "dHt" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/stairs,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "dHJ" = (
 /obj/structure/cable,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
@@ -7155,7 +7158,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "dMc" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -7291,7 +7294,7 @@
 	dir = 6
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "dPe" = (
 /obj/machinery/grill,
 /obj/item/stack/sheet/mineral/coal/ten,
@@ -7322,7 +7325,7 @@
 	dir = 1
 	},
 /turf/closed/wall,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "dQd" = (
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
@@ -7361,7 +7364,7 @@
 	name = "Mender Moff"
 	},
 /turf/open/floor/carpet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "dRJ" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
@@ -7588,7 +7591,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "dXN" = (
 /obj/machinery/status_display/ai,
 /obj/structure/table/glass,
@@ -7643,7 +7646,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "dZk" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/mineral/titanium,
@@ -7804,7 +7807,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/warning,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "ecC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -8287,7 +8290,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "eqO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -8356,7 +8359,7 @@
 	},
 /obj/machinery/stasis,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "esh" = (
 /obj/structure/toilet{
 	dir = 4
@@ -8836,7 +8839,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "eDZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct/industrial/waste,
@@ -9078,7 +9081,7 @@
 /area/station/security/office)
 "eJv" = (
 /turf/closed/wall/r_wall,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "eJV" = (
 /obj/structure/cable/industrial,
 /turf/open/floor/plating,
@@ -9633,7 +9636,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "eXV" = (
 /obj/effect/turf_decal/stripes{
 	dir = 10
@@ -10506,7 +10509,7 @@
 "fvF" = (
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "fvN" = (
 /obj/machinery/duct/industrial/waste,
 /obj/structure/disposalpipe/segment{
@@ -11883,7 +11886,7 @@
 	},
 /obj/item/bedsheet/medical,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "gcz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners{
 	color = "#009dc4"
@@ -12005,7 +12008,7 @@
 "gfV" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "ggj" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/white/filled/warning{
@@ -12604,7 +12607,7 @@
 /obj/structure/drain,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/noslip,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "gzE" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/white/line{
@@ -12981,7 +12984,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "gJV" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/barricade/wooden/crude,
@@ -13166,7 +13169,7 @@
 	name = "Psychology Office Fax Machine"
 	},
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "gQC" = (
 /obj/effect/gibspawner/xeno/bodypartless,
 /obj/structure/spider/stickyweb,
@@ -14879,7 +14882,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "hJu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15467,7 +15470,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "hXz" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -15509,6 +15512,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"hYO" = (
+/turf/closed/wall,
+/area/station/medical/medbay/aft)
 "hZe" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -15803,7 +15809,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "ihB" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -15879,7 +15885,7 @@
 	cycle_id = "medbay_lobby"
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "ijM" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
@@ -15970,7 +15976,7 @@
 	},
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "imq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -16073,7 +16079,7 @@
 "ipa" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "ipf" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -16319,7 +16325,7 @@
 /area/station/commons/lounge)
 "iut" = (
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "iuY" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners{
 	color = "#009dc4"
@@ -17713,7 +17719,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "jiZ" = (
 /obj/machinery/air_sensor/nitrogen_tank,
 /turf/open/floor/engine/n2,
@@ -17738,7 +17744,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "jjp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -18055,7 +18061,7 @@
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/camera/directional/west,
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "jtn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -19002,7 +19008,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "jPB" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
@@ -21781,7 +21787,7 @@
 	dir = 2
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "lgp" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -22023,7 +22029,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "lms" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -22578,7 +22584,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "lAP" = (
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/north,
 /obj/machinery/light/floor/has_bulb,
@@ -22653,7 +22659,7 @@
 /obj/structure/sign/departments/chemistry/pharmacy,
 /obj/machinery/vending/drugs,
 /turf/closed/wall/r_wall,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "lCD" = (
 /obj/structure/cable,
 /obj/machinery/plumbing/floor_pump/input/on/waste/directional/west,
@@ -23003,7 +23009,7 @@
 	cycle_id = "medbay_lobby"
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "lJE" = (
 /obj/structure/table/glass/plasmaglass,
 /obj/item/electronics/airlock,
@@ -23106,7 +23112,7 @@
 /obj/effect/turf_decal/trimline/blue/corner,
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "lMo" = (
 /obj/structure/window/spawner/directional/south,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
@@ -23889,7 +23895,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/closed/wall,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "mkv" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -24582,7 +24588,7 @@
 /obj/structure/chair/sofa/left/brown,
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/carpet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "mBG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/south{
@@ -24707,7 +24713,7 @@
 /area/station/hallway/primary/central/fore)
 "mFK" = (
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "mFX" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/effect/spawner/random/entertainment/arcade,
@@ -24875,7 +24881,7 @@
 	},
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "mJW" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -25244,7 +25250,7 @@
 /obj/structure/drain,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/noslip,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "mTy" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/portable_atmospherics/scrubber,
@@ -25929,7 +25935,7 @@
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "niT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -26173,7 +26179,7 @@
 /area/station/cargo/storage)
 "noF" = (
 /turf/open/floor/carpet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "noG" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/purple/filled/warning{
@@ -26312,7 +26318,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "nsX" = (
 /obj/effect/turf_decal/stripes{
 	dir = 5
@@ -26395,7 +26401,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "nuD" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/effect/turf_decal/tile/green/half/contrasted,
@@ -26477,7 +26483,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "nwW" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -26897,7 +26903,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/line,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "nGD" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -28133,7 +28139,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "onJ" = (
 /obj/machinery/vending/mechcomp,
 /obj/effect/turf_decal/tile/purple/opposingcorners{
@@ -28374,7 +28380,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/medical/pharmacy,
 /obj/effect/mapping_helpers/airlock/access/any/medical/general,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "otz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -28685,7 +28691,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "ozV" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
@@ -28998,7 +29004,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "oKD" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -29027,7 +29033,7 @@
 "oMo" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "oMw" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -29642,7 +29648,7 @@
 "pfg" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "pfl" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/disposal/bin{
@@ -29827,7 +29833,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "pjg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -30248,7 +30254,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "pse" = (
 /obj/structure/table/wood,
 /obj/machinery/camera/autoname/directional/south,
@@ -30731,7 +30737,7 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "pHe" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -30859,7 +30865,7 @@
 	invisibility = 101
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "pIW" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -31055,7 +31061,7 @@
 /obj/effect/landmark/start/psychologist,
 /obj/structure/chair/office/light,
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "pNB" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
@@ -31910,7 +31916,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "qhu" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
@@ -32503,7 +32509,7 @@
 	dir = 2
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "qvJ" = (
 /obj/machinery/computer/rdconsole{
 	dir = 8
@@ -32829,7 +32835,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "qGV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33305,7 +33311,7 @@
 	},
 /obj/item/storage/belt/medical,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "qRY" = (
 /turf/closed/wall,
 /area/station/cargo/miningoffice)
@@ -34367,7 +34373,7 @@
 	invisibility = 101
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "rtr" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/portable_atmospherics/pump,
@@ -34574,7 +34580,7 @@
 	},
 /obj/machinery/stasis,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "rzB" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/light/floor/has_bulb,
@@ -34794,7 +34800,7 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/curtain,
 /turf/open/floor/noslip,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "rEC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34895,7 +34901,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "rHY" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -34907,7 +34913,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "rIh" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
@@ -35071,7 +35077,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/stairs,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "rLb" = (
 /obj/machinery/duct/industrial/waste,
 /obj/effect/turf_decal/trimline/blue/filled/warning,
@@ -35151,7 +35157,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "rNz" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office"
@@ -35600,7 +35606,7 @@
 	},
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "rZw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct/industrial/waste,
@@ -36535,7 +36541,7 @@
 	},
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "sAA" = (
 /obj/structure/cable/industrial,
 /turf/open/floor/iron/stairs,
@@ -36554,7 +36560,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "sBe" = (
 /obj/structure/table/wood,
 /obj/item/food/ready_donk/mac_n_cheese,
@@ -37354,7 +37360,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "sVF" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -38101,6 +38107,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/effect/mapping_helpers/airlock/access/any/medical,
 /obj/effect/mapping_helpers/airlock/access/any/science/genetics,
+/obj/effect/mapping_helpers/airlock/access/any/medical,
 /turf/open/floor/iron/white/textured,
 /area/station/science/genetics)
 "tuT" = (
@@ -38137,7 +38144,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "tvt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -38399,7 +38406,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "tCm" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 9
@@ -39560,7 +39567,7 @@
 	invisibility = 101
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "ueN" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -39712,7 +39719,7 @@
 	invisibility = 101
 	},
 /turf/open/floor/iron/white/textured_large,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "uhr" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -39732,7 +39739,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "uhB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40444,7 +40451,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct/industrial/waste,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "uAJ" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -40891,7 +40898,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "uKT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41020,7 +41027,7 @@
 	dir = 8
 	},
 /turf/closed/wall,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "uNu" = (
 /obj/effect/turf_decal/stripes,
 /obj/structure/disposalpipe/segment,
@@ -41053,7 +41060,7 @@
 "uOF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "uOL" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -41135,7 +41142,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/curtain/cloth,
 /turf/open/floor/plating,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "uQJ" = (
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood,
@@ -41651,7 +41658,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "vcU" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -42705,7 +42712,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "vCo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -43044,7 +43051,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/warning/no_smoking,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "vOg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43286,7 +43293,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "vUu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43916,7 +43923,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "wiA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43932,7 +43939,7 @@
 /obj/machinery/duct/industrial/waste,
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "wiK" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -44309,7 +44316,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/medical/psychology)
 "wtT" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -44321,7 +44328,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/medical_kiosk,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "wuf" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -44660,7 +44667,7 @@
 	},
 /obj/machinery/light/directional/east,
 /turf/closed/wall,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "wCJ" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable,
@@ -45005,7 +45012,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "wOu" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/vending/wardrobe/jani_wardrobe,
@@ -45416,7 +45423,7 @@
 	invisibility = 101
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "wYo" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/item/restraints/legcuffs/beartrap,
@@ -45484,7 +45491,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "wZW" = (
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /obj/machinery/door/firedoor,
@@ -46099,7 +46106,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "xoP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -46869,7 +46876,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/medbay/aft)
 "xGf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -46895,7 +46902,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "xGC" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/open/floor/engine,
@@ -47286,7 +47293,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "xPG" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -47625,9 +47632,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
-"xXa" = (
-/turf/closed/wall,
-/area/station/medical/treatment_center)
 "xXz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
@@ -47681,7 +47685,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "xZC" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/cable,
@@ -47985,7 +47989,7 @@
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/treatment_center)
+/area/station/medical/medbay/central)
 "yhu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -72420,11 +72424,11 @@ nRM
 fiw
 mFh
 fgS
-eJv
-eJv
-eJv
+bxs
+bxs
+bxs
 dgc
-eJv
+bxs
 hoz
 mbj
 qlJ
@@ -72676,8 +72680,8 @@ obQ
 ykG
 kLL
 fgS
-eJv
-eJv
+bxs
+bxs
 rZp
 jth
 iut
@@ -72939,7 +72943,7 @@ noF
 nuB
 pNw
 pHc
-ols
+hYO
 mJm
 jiC
 rNm
@@ -73190,7 +73194,7 @@ fiw
 fgS
 tAk
 fgS
-eJv
+bxs
 mBv
 noF
 uKC
@@ -73447,7 +73451,7 @@ fiw
 fgS
 mFh
 tAk
-eJv
+bxs
 anf
 lmd
 gJS
@@ -73704,7 +73708,7 @@ hrC
 mFh
 fgS
 mFh
-eJv
+bxs
 gQq
 pjd
 nwz
@@ -77058,11 +77062,11 @@ dvQ
 nhC
 nhC
 tBQ
-xXa
+ols
 uhh
 eXH
-xXa
-xXa
+ols
+ols
 nqU
 bKh
 xoE
@@ -78860,8 +78864,8 @@ gct
 rzA
 vUo
 esa
-xXa
-xXa
+ols
+ols
 vSw
 pqz
 adf

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -17808,9 +17808,6 @@
 	pixel_x = 5;
 	pixel_y = 7
 	},
-/obj/item/assembly/flash,
-/obj/item/assembly/flash,
-/obj/item/assembly/flash,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -17819,6 +17816,18 @@
 	},
 /obj/item/book/manual/wiki/experimentor,
 /obj/item/book/manual/wiki/robotics_cyborgs,
+/obj/item/assembly/flash/handheld{
+	pixel_x = 6;
+	pixel_y = 13
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 6;
+	pixel_y = 13
+	},
+/obj/item/assembly/flash/handheld{
+	pixel_x = 6;
+	pixel_y = 13
+	},
 /turf/open/floor/noslip{
 	icon_state = "textured_white";
 	color = "#D381C9"

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2135,10 +2135,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
-"iV" = (
-/obj/machinery/chem_heater/debug,
-/turf/closed/indestructible/riveted,
-/area/centcom/central_command_areas/medical)
 "iW" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
@@ -3724,9 +3720,6 @@
 "qz" = (
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/storage/backpack/duffelbag/med/surgery,
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
@@ -4966,6 +4959,7 @@
 /area/centcom/central_command_areas/medical)
 "vT" = (
 /obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/chem_heater/debug,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "vW" = (
@@ -6722,6 +6716,7 @@
 /area/centcom/central_command_areas/admin_hangout)
 "Dr" = (
 /obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "Dt" = (
@@ -10965,6 +10960,12 @@
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin_hangout)
+"UH" = (
+/obj/structure/railing/wood,
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/medical)
 "UI" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 4
@@ -58849,7 +58850,7 @@ YL
 uw
 vS
 zp
-iV
+we
 we
 aU
 lZ
@@ -59616,7 +59617,7 @@ Nb
 FV
 dl
 Nb
-Ca
+UH
 ux
 vS
 vT

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2135,6 +2135,10 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"iV" = (
+/obj/machinery/chem_heater/debug,
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/medical)
 "iW" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
@@ -2588,6 +2592,10 @@
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"ls" = (
+/obj/machinery/telecomms/allinone/nuclear,
+/turf/open/floor/circuit/red/telecomms,
+/area/centcom/central_command_areas/admin)
 "lu" = (
 /obj/structure/railing/wood{
 	dir = 1
@@ -3714,7 +3722,6 @@
 /area/centcom/central_command_areas/medical)
 "qD" = (
 /obj/structure/table/reinforced,
-/obj/machinery/infuser,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/botany)
 "qE" = (
@@ -6359,6 +6366,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
+"Bq" = (
+/obj/machinery/vending/medical,
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/medical)
 "Br" = (
 /obj/structure/railing/wood{
 	dir = 8
@@ -6699,6 +6710,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin_hangout)
+"Dp" = (
+/obj/machinery/vending/dinnerware,
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/kitchen)
 "Dr" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
@@ -11914,6 +11929,7 @@
 /obj/structure/table/reinforced,
 /obj/item/knife,
 /obj/item/knife,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/kitchen)
 "Zb" = (
@@ -43169,7 +43185,7 @@ oJ
 lo
 oM
 iF
-aa
+ls
 On
 On
 GZ
@@ -54711,7 +54727,7 @@ IV
 IV
 IV
 Vx
-mQ
+Dp
 MO
 IO
 SK
@@ -58827,7 +58843,7 @@ YL
 uw
 vS
 zp
-we
+iV
 we
 aU
 lZ
@@ -59849,7 +59865,7 @@ fE
 AO
 fE
 we
-we
+Bq
 Nb
 YL
 Wv

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2756,6 +2756,16 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"mj" = (
+/obj/effect/turf_decal/siding/dark{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/dark{
+	dir = 8
+	},
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/iron/white/herringbone,
+/area/centcom/central_command_areas/kitchen)
 "mk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -6710,10 +6720,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin_hangout)
-"Dp" = (
-/obj/machinery/vending/dinnerware,
-/turf/closed/indestructible/riveted,
-/area/centcom/central_command_areas/kitchen)
 "Dr" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
@@ -54210,7 +54216,7 @@ mQ
 mQ
 Rm
 Ac
-RN
+mj
 Nx
 ZX
 mQ
@@ -54727,7 +54733,7 @@ IV
 IV
 IV
 Vx
-Dp
+mQ
 MO
 IO
 SK

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -149,7 +149,7 @@
 /area/station/security/prison/safe)
 "aaA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/ballpit,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "aaB" = (
 /obj/structure/table,
@@ -2165,14 +2165,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal)
 "agt" = (
-/obj/structure/table/glass,
-/obj/item/radio/intercom/directional/east{
-	freerange = 1;
-	listening = 0;
-	name = "Common Channel";
-	pixel_x = 0
+/obj/machinery/computer/old{
+	dir = 8
 	},
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/small,
 /area/ruin/powered/clownplanet)
 "agu" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -2198,7 +2194,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/ruin/powered/clownplanet)
 "agw" = (
@@ -2224,20 +2219,13 @@
 /obj/item/clothing/under/syndicate,
 /obj/item/clothing/under/syndicate,
 /obj/item/clothing/under/misc/syndicate_souvenir,
-/obj/item/nullrod/clown,
-/obj/item/clothing/mask/gas/clown_hat,
-/obj/item/clothing/shoes/clown_shoes,
-/obj/item/clothing/under/rank/civilian/clown/magic{
-	name = "clown suit"
-	},
-/obj/item/storage/secure/safe/directional/north,
-/turf/open/floor/carpet/neon/simple/yellow,
+/turf/open/floor/iron/grimy,
 /area/ruin/powered/clownplanet)
 "agx" = (
 /obj/structure/filingcabinet,
 /obj/structure/window/spawner/directional/north,
 /obj/item/paper/crumpled,
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/small,
 /area/ruin/powered/clownplanet)
 "agy" = (
 /obj/structure/alien/weeds,
@@ -2248,7 +2236,7 @@
 /obj/structure/chair/comfy/carp{
 	dir = 1
 	},
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "agA" = (
 /obj/effect/turf_decal/sand/plating,
@@ -2299,12 +2287,12 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "agG" = (
 /obj/structure/dresser,
 /obj/item/clothing/mask/cigarette/cigar/havana,
-/turf/open/floor/carpet/neon/simple/yellow,
+/turf/open/floor/iron/grimy,
 /area/ruin/powered/clownplanet)
 "agH" = (
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -3770,7 +3758,7 @@
 /area/station/cargo/miningdock/cafeteria)
 "atl" = (
 /obj/structure/hoop,
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "atC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4713,18 +4701,7 @@
 /turf/open/floor/plating,
 /area/station/command/teleporter)
 "aBI" = (
-/obj/structure/table/glass,
-/obj/item/radio/intercom/directional/east{
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_x = 0
-	},
-/obj/item/toy/figure/clown{
-	pixel_x = 8;
-	pixel_y = 16
-	},
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/small,
 /area/ruin/powered/clownplanet)
 "aBK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6672,7 +6649,7 @@
 /area/station/command/heads_quarters/cmo)
 "aQh" = (
 /obj/machinery/light/directional/east,
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "aQj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -7732,7 +7709,7 @@
 /area/station/medical/medbay/central)
 "bhG" = (
 /obj/machinery/door/airlock/bananium,
-/turf/open/floor/carpet/neon/simple/yellow,
+/turf/open/floor/iron/grimy,
 /area/ruin/powered/clownplanet)
 "bhK" = (
 /obj/structure/curtain,
@@ -7981,9 +7958,6 @@
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/structure/window/spawner/directional/west,
 /obj/item/toy/plush/goatplushie,
-/obj/item/storage/box/donkpockets/donkpockethonk,
-/obj/item/storage/box/donkpockets/donkpockethonk,
-/obj/item/food/grown/banana,
 /turf/open/floor/iron/white,
 /area/ruin/powered/clownplanet)
 "bmb" = (
@@ -8602,10 +8576,14 @@
 /area/station/science/lower)
 "bxd" = (
 /obj/structure/sign/calendar/directional/south,
-/obj/machinery/computer/old{
-	dir = 1
+/obj/structure/table/glass,
+/obj/item/radio/intercom/directional/east{
+	freerange = 1;
+	listening = 0;
+	name = "Common Channel";
+	pixel_x = 0
 	},
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/small,
 /area/ruin/powered/clownplanet)
 "bxr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9917,7 +9895,7 @@
 "bSM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/light_switch/directional/south,
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "bSS" = (
 /obj/effect/spawner/structure/window,
@@ -11260,13 +11238,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "cmx" = (
-/obj/effect/decal/cleanable/confetti,
 /obj/machinery/button/door/directional/south{
 	req_access = "theatre";
 	id_tag = "honkbunker";
 	name = "Deadbolt"
 	},
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "cmH" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -12110,7 +12087,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/ballpit,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "cBo" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -13644,7 +13621,7 @@
 /obj/machinery/door/airlock/external/glass{
 	name = "The Noise's Jam-Tastic Radical Listening Post"
 	},
-/turf/open/ballpit,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "dbu" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -15645,7 +15622,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "dLI" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -17945,7 +17922,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "exx" = (
 /obj/effect/turf_decal/stripes/line{
@@ -18370,10 +18347,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
-"eES" = (
-/obj/structure/statue/bananium/clown,
-/turf/open/indestructible/dark,
-/area/ruin/powered/clownplanet)
 "eFd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/plasticflaps/opaque{
@@ -18568,7 +18541,7 @@
 /area/station/service/library)
 "eJA" = (
 /obj/machinery/light/very_dim/directional/south,
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "eJQ" = (
 /turf/open/floor/glass/reinforced,
@@ -22215,7 +22188,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "fTP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22622,6 +22595,10 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
+"gcJ" = (
+/obj/item/storage/toolbox/syndicate,
+/turf/closed/mineral/random/stationside/asteroid/porus,
+/area/ruin/powered/clownplanet)
 "gcN" = (
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -23676,8 +23653,7 @@
 "gxi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/plastic,
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/ruin/powered/clownplanet)
 "gxk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -24734,9 +24710,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/eva)
-"gNy" = (
-/turf/open/floor/mineral/bananium,
-/area/ruin/powered/clownplanet)
 "gNz" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/engine,
@@ -25249,11 +25222,7 @@
 /area/station/medical/break_room)
 "gWk" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/spawner/random/engineering/tool,
-/obj/effect/spawner/random/mod,
-/obj/item/storage/toolbox/emergency/old,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/ruin/powered/clownplanet)
 "gWo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30641,7 +30610,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "iOi" = (
 /turf/open/floor/wood/large,
@@ -30670,7 +30639,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/turf/open/ballpit,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "iOG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -30877,10 +30846,6 @@
 /area/station/command/heads_quarters/hos)
 "iSw" = (
 /obj/machinery/griddle,
-/obj/structure/sign/poster/contraband/clown{
-	pixel_y = 4;
-	pixel_x = 32
-	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/white,
 /area/ruin/powered/clownplanet)
@@ -31418,7 +31383,7 @@
 /area/station/maintenance/department/crew_quarters/dorms)
 "jap" = (
 /obj/structure/chair/office,
-/turf/open/floor/carpet/neon/simple/yellow,
+/turf/open/floor/iron/dark/small,
 /area/ruin/powered/clownplanet)
 "jav" = (
 /obj/structure/alien/weeds/node,
@@ -32028,12 +31993,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
-"jjY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/spawner/random/engineering/flashlight,
-/turf/open/floor/plating,
-/area/ruin/powered/clownplanet)
 "jkc" = (
 /obj/machinery/status_display/ai/directional/west,
 /obj/structure/chair/office{
@@ -33340,8 +33299,8 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/mineral/bananium,
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "jFu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
@@ -33426,7 +33385,7 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/north,
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "jGX" = (
 /obj/effect/landmark/event_spawn,
@@ -35307,7 +35266,7 @@
 /area/station/science/genetics)
 "knr" = (
 /obj/machinery/light/directional/west,
-/turf/open/floor/carpet/neon/simple/yellow,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "knC" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -36245,14 +36204,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/tram/mid)
 "kFs" = (
-/obj/item/bedsheet/clown/double{
-	dir = 4
+/obj/structure/bed{
+	dir = 1
 	},
-/obj/structure/bed/double{
-	dir = 4
+/obj/item/bedsheet/syndie{
+	dir = 1
 	},
-/obj/item/pillow/clown,
-/turf/open/floor/carpet/neon/simple/yellow,
+/turf/open/floor/iron/grimy,
 /area/ruin/powered/clownplanet)
 "kFu" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -41188,15 +41146,6 @@
 	},
 /turf/open/floor/engine/cult,
 /area/station/service/library)
-"mfL" = (
-/obj/structure/reagent_dispensers/foamtank{
-	tank_volume = 1000;
-	reagent_id = /datum/reagent/lube/superlube;
-	desc = "A wheeled lubricant tank designed for clowns on interstellar voyages. There is a Donk Co logo on the front.";
-	name = "Lubricant Reservoir"
-	},
-/turf/open/floor/plating,
-/area/ruin/powered/clownplanet)
 "mfT" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -43752,7 +43701,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/indestructible/honk,
+/turf/open/misc/asteroid,
 /area/ruin/powered/clownplanet)
 "nag" = (
 /obj/effect/decal/cleanable/dirt,
@@ -43823,7 +43772,7 @@
 	pixel_x = 8;
 	pixel_y = 14
 	},
-/turf/open/floor/carpet/neon/simple/yellow,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "naN" = (
 /obj/machinery/door/firedoor,
@@ -45910,7 +45859,7 @@
 	req_access = "theatre";
 	name = "Shoe Storage Annex"
 	},
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "nHW" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -49001,14 +48950,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"oMX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/effect/spawner/random/decoration/ornament,
-/obj/item/reagent_containers/cup/beaker,
-/obj/item/grown/bananapeel/bluespace,
-/turf/open/floor/plating,
-/area/ruin/powered/clownplanet)
 "oMZ" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
@@ -50209,11 +50150,8 @@
 "piT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/turretid{
-	pixel_y = -24;
-	req_access = "theatre"
-	},
-/turf/open/floor/mineral/bananium,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "piX" = (
 /turf/open/floor/engine/n2o,
@@ -52769,10 +52707,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
-"pVy" = (
-/obj/machinery/light/directional/west,
-/turf/open/floor/mineral/bananium,
-/area/ruin/powered/clownplanet)
 "pVD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/warning,
@@ -53871,9 +53805,6 @@
 "qoD" = (
 /obj/structure/table,
 /obj/machinery/microwave,
-/obj/structure/sign/poster/contraband/tipper_cream_soda{
-	pixel_y = 35
-	},
 /turf/open/floor/iron/white,
 /area/ruin/powered/clownplanet)
 "qoE" = (
@@ -55242,7 +55173,7 @@
 	},
 /obj/item/kitchen/fork,
 /obj/item/plate,
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "qIL" = (
 /obj/structure/chair/comfy/shuttle,
@@ -59955,7 +59886,6 @@
 	pixel_x = 3
 	},
 /obj/item/reagent_containers/cup/beaker/large,
-/obj/item/reagent_containers/cup/beaker/large,
 /turf/open/floor/iron/white,
 /area/ruin/powered/clownplanet)
 "slx" = (
@@ -60635,16 +60565,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/central)
-"swV" = (
-/obj/machinery/porta_turret/syndicate/teleport{
-	desc = "A ballistic banana gun auto-turret that fires banana bullets. What the fuck?";
-	name = "Banana Turret";
-	req_access = "theatre";
-	lethal_projectile = /obj/projectile/bullet/honker;
-	stun_projectile = /obj/projectile/bullet/honker
-	},
-/turf/open/indestructible/dark,
-/area/ruin/powered/clownplanet)
 "swZ" = (
 /obj/structure/ladder,
 /turf/open/floor/catwalk_floor/iron_smooth,
@@ -61408,10 +61328,14 @@
 "sJp" = (
 /obj/structure/sign/clock/directional/south,
 /obj/item/paper/crumpled/bloody,
-/obj/structure/frame/computer{
-	dir = 1
+/obj/item/radio/intercom/directional/east{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_x = 0
 	},
-/turf/open/floor/mineral/bananium,
+/obj/structure/table/glass,
+/turf/open/floor/iron/dark/small,
 /area/ruin/powered/clownplanet)
 "sJx" = (
 /obj/structure/chair{
@@ -63115,7 +63039,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "tkp" = (
-/turf/open/floor/carpet/neon/simple/yellow,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "tkv" = (
 /obj/structure/ladder,
@@ -63693,10 +63617,8 @@
 	dir = 1;
 	req_access = list("syndicate")
 	},
-/obj/structure/sign/poster/contraband/clown{
-	pixel_y = -27
-	},
-/turf/open/floor/mineral/bananium,
+/obj/machinery/newscaster/directional/south,
+/turf/open/floor/iron/dark/small,
 /area/ruin/powered/clownplanet)
 "tsY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -63802,10 +63724,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"tun" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/open/floor/mineral/bananium,
-/area/ruin/powered/clownplanet)
 "tur" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer"
@@ -64554,7 +64472,7 @@
 	dir = 8
 	},
 /obj/structure/window/spawner/directional/north,
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/small,
 /area/ruin/powered/clownplanet)
 "tIA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -70778,7 +70696,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/ruin/powered/clownplanet)
 "vBG" = (
@@ -71020,7 +70937,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/airalarm/directional/west,
-/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/ruin/powered/clownplanet)
 "vDG" = (
@@ -72548,7 +72464,7 @@
 	name = "Old TV";
 	desc = "An old TV, at some point, a clown watched too much TV on this."
 	},
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "wdU" = (
 /obj/machinery/door/firedoor,
@@ -73098,13 +73014,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
-"wnM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/decoration/material,
-/obj/structure/table,
-/obj/effect/spawner/random/engineering/material_cheap,
-/turf/open/floor/plating,
-/area/ruin/powered/clownplanet)
 "wnN" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
@@ -73466,8 +73375,7 @@
 /area/station/medical/morgue)
 "wtK" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/mineral/bananium,
+/turf/open/floor/iron/dark/herringbone,
 /area/ruin/powered/clownplanet)
 "wtQ" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
@@ -75594,7 +75502,7 @@
 "xgi" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/light_switch/directional/north,
-/turf/open/floor/carpet/neon/simple/yellow,
+/turf/open/floor/iron/grimy,
 /area/ruin/powered/clownplanet)
 "xgp" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -76442,10 +76350,6 @@
 "xwf" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/central/greater)
-"xwi" = (
-/obj/effect/spawner/random/trash/garbage,
-/turf/open/floor/plating,
-/area/ruin/powered/clownplanet)
 "xwz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -76866,9 +76770,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
-"xDf" = (
-/turf/open/indestructible/honk,
-/area/ruin/powered/clownplanet)
 "xDn" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -77643,9 +77544,7 @@
 	pixel_x = 0;
 	pixel_y = 32
 	},
-/obj/structure/rack,
-/obj/item/clothing/shoes/sneakers,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/ruin/powered/clownplanet)
 "xSr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -81255,8 +81154,8 @@ nPb
 pkp
 pjA
 mZV
-xDf
-xDf
+pkp
+pkp
 pkp
 nPb
 vXM
@@ -83559,7 +83458,7 @@ nPb
 oVB
 nPb
 gcp
-gNy
+tkp
 knr
 tkp
 tkp
@@ -83820,7 +83719,7 @@ atl
 naI
 tkp
 tkp
-tun
+aaA
 iOC
 aaA
 dbr
@@ -84333,13 +84232,13 @@ gcp
 qQm
 fTI
 agz
-tun
+aaA
 nHV
 piT
 gcp
-eES
 coN
-swV
+coN
+coN
 nPb
 nPb
 uww
@@ -84589,7 +84488,7 @@ nPb
 gcp
 cKm
 agF
-tun
+aaA
 eJA
 gcp
 xAc
@@ -85620,10 +85519,10 @@ gcp
 gcp
 gcp
 gcp
-mfL
-xwi
-wnM
-gcp
+nPb
+nPb
+nPb
+nPb
 nPb
 nPb
 pkp
@@ -85876,11 +85775,11 @@ nPb
 nPb
 nPb
 nPb
-gcp
-gcp
-oMX
-jjY
-gcp
+nPb
+nPb
+nPb
+nPb
+nPb
 nPb
 pkp
 pkp
@@ -86134,10 +86033,10 @@ nPb
 nPb
 nPb
 nPb
-gcp
-gcp
-gcp
-gcp
+nPb
+nPb
+nPb
+nPb
 nPb
 pkp
 nPb
@@ -86390,7 +86289,7 @@ pkp
 nPb
 nPb
 oVB
-nPb
+gcJ
 nPb
 nPb
 nPb
@@ -149610,7 +149509,7 @@ cdf
 nPb
 gcp
 jFt
-pVy
+knr
 wtK
 gcp
 gcp
@@ -149868,7 +149767,7 @@ nPb
 gcp
 qBq
 exv
-gNy
+tkp
 agx
 aBI
 sJp
@@ -150125,8 +150024,8 @@ nPb
 gcp
 qBq
 exv
-gNy
 tkp
+aBI
 jap
 tsR
 gcp
@@ -150382,7 +150281,7 @@ nPb
 gcp
 iOh
 aQh
-gNy
+tkp
 tIw
 agt
 bxd

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -12046,6 +12046,12 @@
 	c_tag = "Service - Hydroponics"
 	},
 /obj/effect/turf_decal/tile/green/fourcorners,
+/obj/machinery/plantgenes,
+/obj/item/botanical_lexicon,
+/obj/item/botanical_lexicon,
+/obj/item/botanical_lexicon,
+/obj/item/botanical_lexicon,
+/obj/item/botanical_lexicon,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "cAd" = (
@@ -52525,12 +52531,6 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/botanical_lexicon,
-/obj/item/botanical_lexicon,
-/obj/item/botanical_lexicon,
-/obj/item/botanical_lexicon,
-/obj/item/botanical_lexicon,
-/obj/machinery/plantgenes,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "pQY" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -848,8 +848,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/escapepodbay)
@@ -945,12 +945,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/white/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/escapepodbay)
 "acP" = (
@@ -9752,6 +9752,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness)
+"bPp" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/escapepodbay)
 "bPq" = (
 /obj/effect/turf_decal/trimline/neutral/warning,
 /turf/open/floor/iron/dark,
@@ -10059,6 +10071,13 @@
 	dir = 8
 	},
 /area/station/command/bridge)
+"bVn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/station/escapepodbay)
 "bVs" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -11616,6 +11635,18 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"ctg" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/central/greater)
 "ctW" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -38336,6 +38367,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/auxlab/firing_range)
+"ljK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/escapepodbay)
 "ljU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39433,6 +39470,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock/cafeteria)
 "lDM" = (
@@ -71114,6 +71152,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/central)
 "vGI" = (
@@ -71537,13 +71578,12 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/crew_quarters/dorms)
 "vNV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/port/central)
 "vOx" = (
@@ -71991,6 +72031,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/central/greater)
 "vUW" = (
@@ -72890,6 +72931,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/central/greater)
 "wlK" = (
@@ -92369,8 +92411,8 @@ abm
 abm
 abf
 abf
-abf
-acA
+ljK
+bVn
 acN
 acT
 acA
@@ -92626,7 +92668,7 @@ abf
 abX
 acf
 acp
-acp
+bPp
 acB
 acO
 acU
@@ -105959,7 +106001,7 @@ qxf
 qxf
 jIN
 ldD
-vUP
+ctg
 vUP
 wlo
 hSy

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -52507,6 +52507,8 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/item/reagent_containers/cup/watering_can,
+/obj/item/reagent_containers/cup/watering_can,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "pQY" = (

--- a/monkestation/_maps/RandomEngines/KiloStation/supermatter.dmm
+++ b/monkestation/_maps/RandomEngines/KiloStation/supermatter.dmm
@@ -488,10 +488,8 @@
 /turf/open/floor/circuit/red,
 /area/station/engineering/supermatter/room)
 "sz" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "sF" = (
@@ -508,7 +506,6 @@
 /area/station/engineering/supermatter/room)
 "sY" = (
 /obj/effect/turf_decal/loading_area,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "th" = (
@@ -1446,10 +1443,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "Wo" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
@@ -1493,10 +1486,6 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
 "Yu" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)

--- a/monkestation/_maps/RandomEngines/MetaStation/supermatter.dmm
+++ b/monkestation/_maps/RandomEngines/MetaStation/supermatter.dmm
@@ -172,6 +172,10 @@
 "je" = (
 /turf/template_noop,
 /area/space)
+"jw" = (
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/station/engineering/supermatter/room)
 "kf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -226,10 +230,6 @@
 "nu" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
@@ -693,10 +693,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 1
-	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "HO" = (
@@ -1194,8 +1192,8 @@ eg
 ZC
 yT
 Qn
-ck
-ck
+jw
+jw
 UI
 Yf
 MT

--- a/monkestation/_maps/RandomEngines/TramStation/supermatter.dmm
+++ b/monkestation/_maps/RandomEngines/TramStation/supermatter.dmm
@@ -13,8 +13,6 @@
 /area/station/engineering/supermatter)
 "bw" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "bG" = (
@@ -31,14 +29,12 @@
 /area/station/engineering/supermatter/room)
 "cL" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "dt" = (
@@ -309,12 +305,6 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
-"ln" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "lr" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -446,10 +436,6 @@
 /area/station/engineering/supermatter)
 "oe" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
@@ -825,10 +811,6 @@
 /area/station/engineering/supermatter/room)
 "Fs" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "FF" = (
@@ -1591,7 +1573,7 @@ ft
 XW
 Rq
 ix
-ln
+TD
 oe
 Qg
 TU


### PR DESCRIPTION
## About The Pull Request

Mass number of little fixes to many maps. Includes things like readding things removed, removing things that really just need to be gone due to a long standing list of recent events, and otherwise small tweaks to fix things.

Big takeaways:
- All SM configurations are losing the gas filter and cans for said filters because of the recent LONG sting of sudden SM delams. This is to help newer players that are trying to learn safe SM operation while still leaving space available for people to add the filter to do gas synthesis ops on the SM.
- Adding missing features of some places, such as a high cap water tank for Botany on Metastation, readding the missing disposals marker for Metastation (no more infinite trash loops!), and moving machines around on Tram's Botany so things are in better starting positions.
## Why It's Good For The Game

Let's be honest, there's little nitpicks that needed fixed.

Plus, there's some big things that needed to just be fixed.
## Changelog
:cl:
add: Readded missing water tank for Botany on Metastation
add: Readded a missing helper for the disposals system on Metastation
add: plantgenes machine in the seed vaults!
del: ALL SM gas filters for gas synthesis are removed, but the space is still there if folk want to setup such filters for their operations.
qol: moved the plantgenes machine and all the botany lexicons on Tram to a different table so its not stacked.
del: reverted the "clown asteroid" on Tramstation down to 99% stock. It should still play clown.wmv when over there, because you still are a clown if you wanna use the place.
add: dinnerware, nanomed vendors added to Centcom
add: readded the missing tcomm server so syndie comms work again. it was on centcom, its now back on centcom.
qol: fixed some of the busted disposals.
qol: zones for rooms in Oshan Medical are redone. Medbay Central is now a "common sense" location so cargo crates can be opened properly.
/:cl:
