### PR TITLE
Nav Makers Improvements

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1181,6 +1181,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_upload,
 /obj/structure/cable/layer3,
+/obj/effect/landmark/navigate_destination/minisat_access_ai,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "anF" = (
@@ -3530,7 +3531,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/door/airlock{
 	name = "Locker Room"
 	},
@@ -4430,6 +4430,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/landmark/navigate_destination/common/starboardquartersolar,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/aft)
 "bbx" = (
@@ -4641,11 +4642,11 @@
 	name = "Head of Personnel's Office"
 	},
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/command/hop,
+/obj/effect/landmark/navigate_destination/hop,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "beP" = (
@@ -7494,7 +7495,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "bLd" = (
@@ -11401,6 +11401,7 @@
 	name = "Turbine Generator Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/landmark/navigate_destination/incinerator,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "cGA" = (
@@ -11910,6 +11911,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
+/obj/effect/landmark/navigate_destination/teleporter,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "cNv" = (
@@ -12001,6 +12003,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination/delta/abandtheatre,
 /turf/open/floor/iron,
 /area/station/service/theater/abandoned)
 "cOD" = (
@@ -12336,6 +12339,7 @@
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/common/fitness,
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 4
 	},
@@ -15214,6 +15218,14 @@
 /obj/structure/table/glass,
 /turf/open/floor/iron,
 /area/station/medical/cryo)
+"dEq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/landmark/navigate_destination/library,
+/turf/open/floor/wood,
+/area/station/service/library)
 "dEv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/smooth_large,
@@ -15626,6 +15638,13 @@
 /obj/item/clothing/head/costume/cardborg,
 /turf/open/floor/wood,
 /area/station/service/theater/abandoned)
+"dJY" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination/court,
+/turf/open/floor/iron/dark,
+/area/station/security/courtroom)
 "dKg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20394,6 +20413,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/landmark/navigate_destination/common/starboardbowsolar,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/starboard/fore)
 "eUf" = (
@@ -21450,6 +21470,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/landmark/navigate_destination/common/shitter,
 /turf/open/floor/iron,
 /area/station/commons/toilet/restrooms)
 "ffo" = (
@@ -22312,6 +22333,7 @@
 "fqZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/plaque/static_plaque/golden/commission/delta,
+/obj/effect/landmark/navigate_destination/dockarrival,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "frq" = (
@@ -23145,6 +23167,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/landmark/navigate_destination/common/portbowsolar,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/fore)
 "fAT" = (
@@ -24318,10 +24341,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/landmark/navigate_destination,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/navigate_destination/common/vaccommissary,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "fRa" = (
@@ -26796,6 +26819,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/landmark/navigate_destination/lawyer,
 /turf/open/floor/iron,
 /area/station/service/lawoffice)
 "guI" = (
@@ -27101,6 +27125,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/gateway,
+/obj/effect/landmark/navigate_destination/gateway,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "gyn" = (
@@ -28342,6 +28367,23 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"gOA" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Access"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/navigate_destination/common/holodeck,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness/recreation)
 "gOH" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -28998,7 +29040,6 @@
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue"
 	},
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/medical/morgue)
@@ -30912,7 +30953,6 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Auxiliary Tool Storage"
 	},
-/obj/effect/landmark/navigate_destination,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -30921,6 +30961,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/effect/landmark/navigate_destination/tools,
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "hwK" = (
@@ -31731,7 +31772,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/navigate_destination,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -38648,6 +38688,21 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central/aft)
+"jrg" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/effect/mapping_helpers/airlock/access/any/medical/maintenance,
+/obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/landmark/navigate_destination/delta/abandmedbay,
+/turf/open/floor/iron,
+/area/station/medical/abandoned)
 "jrp" = (
 /turf/closed/wall,
 /area/station/cargo/storage)
@@ -39042,6 +39097,7 @@
 "jwy" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/effect/landmark/navigate_destination/research,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "jwA" = (
@@ -40734,7 +40790,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/medical/pharmacy)
 "jQq" = (
@@ -40821,6 +40876,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination/common/shitter,
 /turf/open/floor/iron,
 /area/station/commons/toilet/locker)
 "jQY" = (
@@ -43455,6 +43511,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/landmark/navigate_destination/common/portquartersolar,
 /turf/open/floor/iron,
 /area/station/maintenance/solars/port/aft)
 "kyD" = (
@@ -44266,6 +44323,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination/delta/evamaint,
 /turf/open/floor/iron,
 /area/station/maintenance/department/eva/abandoned)
 "kIM" = (
@@ -44590,6 +44648,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination/delta/pioffice,
 /turf/open/floor/iron,
 /area/station/security/detectives_office/private_investigators_office)
 "kNk" = (
@@ -47849,6 +47908,7 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination/delta/abandlibrary,
 /turf/open/floor/iron,
 /area/station/service/library/abandoned)
 "lCw" = (
@@ -49376,6 +49436,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/landmark/navigate_destination/aiupload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "lUI" = (
@@ -51511,7 +51572,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/cmo)
 "myI" = (
@@ -52020,7 +52080,6 @@
 	name = "Brig"
 	},
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "brig-entrance"
 	},
@@ -52034,6 +52093,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination/sec,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "mEH" = (
@@ -52172,13 +52232,13 @@
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office"
 	},
-/obj/effect/landmark/navigate_destination,
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/navigate_destination/det,
 /turf/open/floor/iron,
 /area/station/security/detectives_office)
 "mGw" = (
@@ -53776,6 +53836,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/landmark/navigate_destination/delta/abandgameroom,
 /turf/open/floor/iron,
 /area/station/service/abandoned_gambling_den/gaming)
 "mZr" = (
@@ -58834,6 +58895,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/access/all/service/janitor,
+/obj/effect/landmark/navigate_destination/janitor,
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
 "omW" = (
@@ -61900,6 +61962,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/effect/landmark/navigate_destination/atmos,
+/obj/effect/landmark/navigate_destination/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "peK" = (
@@ -65154,6 +65218,7 @@
 	name = "Auxiliary Construction Zone"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
+/obj/effect/landmark/navigate_destination/common/auxbaseconst,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "pSr" = (
@@ -65413,6 +65478,7 @@
 /obj/machinery/door/airlock/mining/glass{
 	name = "Bitrunning Den"
 	},
+/obj/effect/landmark/navigate_destination/common/bitrunner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/bitrunning/den)
 "pUw" = (
@@ -66651,6 +66717,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/unres,
+/obj/effect/landmark/navigate_destination/med,
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
 "qkf" = (
@@ -68131,7 +68198,6 @@
 	name = "Vault Door"
 	},
 /obj/structure/sign/warning/secure_area/directional/north,
-/obj/effect/landmark/navigate_destination,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -68532,6 +68598,21 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"qIc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Departures Lounge"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
+/obj/effect/landmark/navigate_destination/dockesc,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qIf" = (
 /obj/effect/spawner/random/trash/mess,
 /obj/effect/mapping_helpers/broken_floor,
@@ -72459,6 +72540,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/landmark/navigate_destination/delta/abandkitchen,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "rIn" = (
@@ -73188,6 +73270,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination/delta/abandsci,
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
 "rQp" = (
@@ -74330,6 +74413,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/landmark/navigate_destination/dockaux,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "seP" = (
@@ -75802,7 +75886,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/navigate_destination,
 /obj/structure/cable,
 /obj/machinery/duct,
 /turf/open/floor/iron,
@@ -76857,7 +76940,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/access/all/service/theatre,
-/obj/effect/landmark/navigate_destination,
+/obj/effect/landmark/navigate_destination/common/theatrebackstage,
 /turf/open/floor/iron,
 /area/station/service/theater)
 "sLc" = (
@@ -79717,7 +79800,6 @@
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge Access"
 	},
-/obj/effect/landmark/navigate_destination,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-right"
@@ -79729,6 +79811,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "tvG" = (
@@ -83025,13 +83108,13 @@
 	name = "E.V.A. Storage"
 	},
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination/eva,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "ukn" = (
@@ -83579,6 +83662,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
+/obj/effect/landmark/navigate_destination/delta/abandgambling,
 /turf/open/floor/iron,
 /area/station/service/abandoned_gambling_den)
 "urV" = (
@@ -90119,6 +90203,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "vXQ" = (
@@ -90841,6 +90926,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcoms,
+/obj/effect/landmark/navigate_destination/tcomms,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "wgc" = (
@@ -92750,7 +92836,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/medical/medbay)
 "wzT" = (
@@ -95232,6 +95317,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/landmark/navigate_destination/delta/abandmarketbay,
 /turf/open/floor/iron,
 /area/station/service/electronic_marketing_den)
 "xhV" = (
@@ -96594,7 +96680,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/landmark/navigate_destination,
+/obj/effect/landmark/navigate_destination/chemfactory,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
 "xzQ" = (
@@ -96952,6 +97038,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
+/obj/effect/landmark/navigate_destination/chapel,
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel)
 "xEE" = (
@@ -97844,6 +97931,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/vault,
+/obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
 "xPz" = (
@@ -143176,7 +143264,7 @@ arU
 dkL
 arU
 bDv
-dgJ
+qIc
 vaK
 vaK
 gFW
@@ -144406,7 +144494,7 @@ dra
 omj
 epc
 omj
-dra
+dJY
 vtn
 mDw
 vwO
@@ -145717,7 +145805,7 @@ wxv
 nHY
 nbd
 nHY
-nbd
+dEq
 lLJ
 nbd
 aBz
@@ -149837,7 +149925,7 @@ pCY
 iOX
 pWX
 fWr
-cbA
+jrg
 hPu
 dHq
 pbu
@@ -154963,7 +155051,7 @@ mfC
 lsG
 mfC
 mfC
-lsG
+gOA
 mfC
 mfC
 fIQ

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -4562,6 +4562,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/effect/landmark/navigate_destination/kitchen,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "bzB" = (
@@ -5852,6 +5853,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/dockescpod1,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "bRz" = (
@@ -7869,6 +7871,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"cyb" = (
+/obj/structure/chair/stool/directional/north,
+/obj/effect/landmark/navigate_destination/icebox/maintsbar,
+/turf/open/floor/wood,
+/area/station/maintenance/port/aft)
 "cyh" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -9057,7 +9064,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/navigate_destination,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/textured,
 /area/station/service/hydroponics/garden)
@@ -10446,6 +10452,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/landmark/navigate_destination/engineering,
+/obj/effect/landmark/navigate_destination/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "djT" = (
@@ -11444,6 +11452,10 @@
 	dir = 5
 	},
 /area/station/command/heads_quarters/rd)
+"dAJ" = (
+/obj/effect/landmark/navigate_destination/bar,
+/turf/open/openspace,
+/area/station/service/bar/atrium)
 "dAO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/siding/wood{
@@ -14772,6 +14784,7 @@
 	cycle_id = "brigoutpost"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/effect/landmark/navigate_destination/sec,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
@@ -18247,7 +18260,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/landmark/navigate_destination,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "fNp" = (
@@ -18901,7 +18913,6 @@
 	id_tag = "cargooffice";
 	name = "Cargo Office"
 	},
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -18909,6 +18920,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/general,
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
+/obj/effect/landmark/navigate_destination/cargo,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "gaq" = (
@@ -21580,6 +21592,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /obj/effect/turf_decal/tile/yellow/full,
+/obj/effect/landmark/navigate_destination/chemfactory,
 /turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
 "gTw" = (
@@ -22805,6 +22818,14 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"hpX" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/landmark/navigate_destination/chapel,
+/turf/open/floor/iron/sepia,
+/area/station/service/library)
 "hqi" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
@@ -25879,6 +25900,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
+/obj/effect/landmark/navigate_destination/det,
 /turf/open/floor/iron/grimy,
 /area/station/security/detectives_office)
 "iry" = (
@@ -28108,6 +28130,7 @@
 /obj/effect/turf_decal/trimline/dark_red/arrow_ccw{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/incinerator,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "jaS" = (
@@ -30317,8 +30340,8 @@
 	name = "Bridge"
 	},
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "jOj" = (
@@ -33483,6 +33506,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination/common/shitter,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "kMF" = (
@@ -34933,8 +34957,8 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Primary Tool Storage"
 	},
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination/tools,
 /turf/open/floor/iron/textured,
 /area/station/commons/storage/primary)
 "lka" = (
@@ -36412,13 +36436,13 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Telecommunications"
 	},
-/obj/effect/landmark/navigate_destination,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/landmark/navigate_destination/tcomms,
 /turf/open/floor/iron,
 /area/station/tcommsat/computer)
 "lIK" = (
@@ -37018,6 +37042,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/effect/turf_decal/tile/blue/full,
+/obj/effect/landmark/navigate_destination/med,
 /turf/open/floor/iron/large,
 /area/station/medical/medbay/lobby)
 "lUw" = (
@@ -37426,6 +37451,7 @@
 	name = "Escape Pod Four"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/landmark/navigate_destination/dockescpod3,
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "mcl" = (
@@ -39884,6 +39910,7 @@
 	name = "Hydroponics"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/effect/landmark/navigate_destination/hydro,
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
@@ -40899,6 +40926,7 @@
 	name = "Unisex Showers"
 	},
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination/common/shitter,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
 "nkO" = (
@@ -42330,7 +42358,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -44271,6 +44298,7 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/common/vaccommissary,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
 "oiO" = (
@@ -48134,6 +48162,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination/court,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "pvB" = (
@@ -48676,6 +48705,7 @@
 	name = "Escape Pod Three";
 	space_dir = 1
 	},
+/obj/effect/landmark/navigate_destination/dockescpod4,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/processing)
 "pDI" = (
@@ -50065,6 +50095,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple/half,
+/obj/effect/landmark/navigate_destination/research,
 /turf/open/floor/iron/half,
 /area/station/hallway/primary/starboard)
 "qaF" = (
@@ -51828,9 +51859,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/event_spawn,
-/obj/effect/landmark/navigate_destination,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/janitor,
+/obj/effect/landmark/navigate_destination/janitor,
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "qGe" = (
@@ -52080,6 +52111,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
+/obj/effect/landmark/navigate_destination/common/bitrunner,
 /turf/open/floor/iron,
 /area/station/bitrunning/den)
 "qKq" = (
@@ -55255,11 +55287,11 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Dormitory"
 	},
-/obj/effect/landmark/navigate_destination,
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/common/dorms,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "rKQ" = (
@@ -55765,6 +55797,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/dockescpod2,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "rTO" = (
@@ -58496,6 +58529,7 @@
 	id_tag = "FitnessShower";
 	name = "Cryogenic Storage"
 	},
+/obj/effect/landmark/navigate_destination/common/cryogenics,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
 "sMY" = (
@@ -58556,6 +58590,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
+/obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "sOl" = (
@@ -62266,6 +62301,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
+/obj/effect/landmark/navigate_destination/aiupload,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "uan" = (
@@ -65719,6 +65755,17 @@
 	dir = 6
 	},
 /area/station/science/research)
+"vij" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Chapel"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/landmark/navigate_destination/chapel,
+/turf/open/floor/iron/white/corner,
+/area/station/hallway/secondary/exit/departure_lounge)
 "vip" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67252,11 +67299,11 @@
 	name = "Vault"
 	},
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/supply/vault,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "vGJ" = (
@@ -69762,6 +69809,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/service/lawyer,
+/obj/effect/landmark/navigate_destination/lawyer,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "wxg" = (
@@ -71951,7 +71999,6 @@
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access"
 	},
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
@@ -72219,6 +72266,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination/disposals,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "xit" = (
@@ -72780,10 +72828,10 @@
 	name = "Tech Storage"
 	},
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tech_storage,
+/obj/effect/landmark/navigate_destination/techstorage,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "xsD" = (
@@ -74832,12 +74880,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/command/storage/eva)
-"yaG" = (
-/obj/effect/landmark/navigate_destination/chapel,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/hallway/primary/starboard)
 "yaJ" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 4
@@ -227030,7 +227072,7 @@ bln
 ptf
 qOl
 ace
-ybu
+cyb
 thW
 pRj
 uhP
@@ -242668,7 +242710,7 @@ mrF
 ptO
 jRA
 jRA
-jRA
+dAJ
 ixH
 fmD
 ptO
@@ -251922,7 +251964,7 @@ hUD
 qnm
 btQ
 hUD
-uum
+hpX
 uum
 hUD
 hUD
@@ -253468,7 +253510,7 @@ gEE
 fTX
 wjS
 bMY
-yaG
+emp
 cYE
 lso
 pHX
@@ -255006,7 +255048,7 @@ qPL
 pRG
 mtN
 dFt
-vHI
+vij
 vHI
 dFt
 dFt

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3105,6 +3105,7 @@
 	cycle_id = "bridge-right"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bdb" = (
@@ -3420,6 +3421,7 @@
 "biA" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/delivery,
+/obj/effect/landmark/navigate_destination/dockesc,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "biI" = (
@@ -4014,7 +4016,6 @@
 	name = "Dormitories"
 	},
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -6376,6 +6377,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/landmark/navigate_destination/atmos,
+/obj/effect/landmark/navigate_destination/engineering,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "csz" = (
@@ -6552,7 +6555,6 @@
 	name = "Locker Room"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "cvO" = (
@@ -6949,6 +6951,7 @@
 /area/station/engineering/supermatter/room)
 "cBw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination/common/shitter,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
 "cBy" = (
@@ -9487,7 +9490,6 @@
 /obj/machinery/door/airlock/external{
 	name = "Common Mining Dock"
 	},
-/obj/effect/landmark/navigate_destination,
 /turf/open/floor/plating,
 /area/station/hallway/primary/port)
 "dEp" = (
@@ -9594,6 +9596,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/command/gateway,
+/obj/effect/landmark/navigate_destination/gateway,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "dGv" = (
@@ -11683,16 +11686,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"erx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/security/brig)
 "erF" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/virology/glass{
@@ -13741,7 +13734,6 @@
 	name = "MiniSat Access"
 	},
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/poddoor/preopen{
 	id = "transitlockdown"
@@ -13749,6 +13741,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/effect/landmark/navigate_destination/minisat_access_tcomms_ai,
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
 "fip" = (
@@ -15142,6 +15135,7 @@
 	cycle_id = "brig-entrance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/entrance,
+/obj/effect/landmark/navigate_destination/sec,
 /turf/open/floor/iron,
 /area/station/security/brig)
 "fMb" = (
@@ -15434,6 +15428,7 @@
 /obj/structure/table,
 /obj/item/storage/crayons,
 /obj/effect/landmark/start/hangover,
+/obj/effect/landmark/navigate_destination/common/dorms,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "fRr" = (
@@ -16098,6 +16093,7 @@
 /area/station/command/bridge)
 "gev" = (
 /obj/effect/turf_decal/delivery,
+/obj/effect/landmark/navigate_destination/common/vaccommissary,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
 "gey" = (
@@ -16925,7 +16921,7 @@
 	name = "Medbay Clinic"
 	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/effect/landmark/navigate_destination,
+/obj/effect/landmark/navigate_destination/med,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gtb" = (
@@ -21524,6 +21520,7 @@
 	location = "15-Court"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination/court,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "ibc" = (
@@ -23189,15 +23186,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/main)
-"iBp" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Departure Lounge Airlock"
-	},
-/obj/effect/landmark/navigate_destination,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/exit/departure_lounge)
 "iBq" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/fore/lesser)
@@ -23244,7 +23232,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/supply/vault,
@@ -26788,6 +26775,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
+"jJh" = (
+/obj/effect/landmark/navigate_destination/common/holodeck,
+/turf/open/floor/engine{
+	name = "Holodeck Projector Floor"
+	},
+/area/station/holodeck/rec_center)
 "jJi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26849,6 +26842,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/landmark/navigate_destination/dockescpod4,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "jKz" = (
@@ -29759,6 +29753,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/landmark/navigate_destination/common/portquartersolar,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "kOf" = (
@@ -34626,6 +34621,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 10
 	},
+/obj/effect/landmark/navigate_destination/dockescpod3,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "mzD" = (
@@ -35171,6 +35167,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/landmark/navigate_destination/common/portbowsolar,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "mIi" = (
@@ -40405,6 +40402,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/landmark/navigate_destination/common/starboardbowsolar,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
 "ozB" = (
@@ -40966,6 +40964,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/landmark/navigate_destination/incinerator,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "oKc" = (
@@ -41006,13 +41005,13 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/tcoms,
+/obj/effect/landmark/navigate_destination/tcomms,
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/computer)
 "oKI" = (
@@ -41070,6 +41069,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
+"oMy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/landmark/navigate_destination/dockescpod1,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "oMA" = (
 /turf/closed/wall/r_wall,
 /area/station/science/cytology)
@@ -42263,6 +42269,7 @@
 /turf/open/floor/plating,
 /area/station/service/chapel/funeral)
 "pjd" = (
+/obj/effect/landmark/navigate_destination/dockescpod2,
 /turf/open/floor/plating,
 /area/station/commons/fitness/recreation)
 "pjh" = (
@@ -42549,11 +42556,11 @@
 	name = "Detective's Office"
 	},
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
+/obj/effect/landmark/navigate_destination/det,
 /turf/open/floor/iron,
 /area/station/security/detectives_office)
 "pqc" = (
@@ -43060,6 +43067,7 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/mapping_helpers/airlock/access/all/medical/chemistry,
 /obj/machinery/door/firedoor,
+/obj/effect/landmark/navigate_destination/chemfactory,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "pyP" = (
@@ -43573,8 +43581,8 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/effect/mapping_helpers/airlock/access/any/command/eva,
+/obj/effect/landmark/navigate_destination/eva,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "pIv" = (
@@ -44511,6 +44519,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"pZI" = (
+/obj/effect/landmark/navigate_destination/library,
+/turf/open/floor/carpet,
+/area/station/service/library)
 "pZQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45819,6 +45831,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/supply/vault,
+/obj/effect/landmark/navigate_destination/vault,
 /turf/open/floor/iron/dark,
 /area/station/construction/storage_wing)
 "qyr" = (
@@ -48848,6 +48861,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination/dockarrival,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/entry)
 "rCn" = (
@@ -49694,6 +49708,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
+/obj/effect/landmark/navigate_destination/aiupload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload_foyer)
 "rPF" = (
@@ -52004,8 +52019,8 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
 /obj/effect/mapping_helpers/airlock/access/any/command/hop,
+/obj/effect/landmark/navigate_destination/hop,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "sDS" = (
@@ -54826,14 +54841,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
-"tCG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/landmark/navigate_destination,
-/turf/open/floor/iron,
-/area/station/security/brig)
 "tCJ" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -56418,6 +56425,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/dockaux,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "ugE" = (
@@ -56928,6 +56936,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
+/obj/effect/landmark/navigate_destination/common/auxbaseconst,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
 "uqp" = (
@@ -59827,13 +59836,13 @@
 	name = "Bridge Access"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "bridge-left"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "vph" = (
@@ -60205,6 +60214,7 @@
 	id_tag = "FitnessShower";
 	name = "Cryogenic Storage"
 	},
+/obj/effect/landmark/navigate_destination/common/cryogenics,
 /turf/open/floor/iron/freezer,
 /area/station/commons/fitness/recreation)
 "vwP" = (
@@ -62365,6 +62375,12 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
+"wjV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination/chapel,
+/turf/open/floor/iron/dark,
+/area/station/service/chapel)
 "wjW" = (
 /obj/structure/table/wood,
 /obj/item/cigbutt/cigarbutt{
@@ -64539,6 +64555,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"wYy" = (
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
+/obj/effect/landmark/navigate_destination/research,
+/turf/open/floor/iron/white,
+/area/station/science/lobby)
 "wYB" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/service)
@@ -65512,7 +65535,6 @@
 	name = "Private Study";
 	req_access = list("library")
 	},
-/obj/effect/landmark/navigate_destination,
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "xrf" = (
@@ -66084,6 +66106,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/landmark/navigate_destination/common/starboardquartersolar,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "xBx" = (
@@ -77654,7 +77677,7 @@ edl
 cSk
 auJ
 jMZ
-sCZ
+oMy
 lGL
 qHs
 lMJ
@@ -88725,7 +88748,7 @@ rSk
 sVY
 bla
 cWr
-ecO
+pZI
 rFB
 tmB
 wcL
@@ -91613,7 +91636,7 @@ hsN
 jJi
 phR
 phR
-phR
+wjV
 phR
 pwq
 fkT
@@ -95214,7 +95237,7 @@ opk
 krc
 bVB
 ltx
-iBp
+sou
 hQu
 cSv
 qVo
@@ -96652,7 +96675,7 @@ ahj
 jwg
 wIr
 cJj
-erx
+klp
 lsP
 vYF
 eaP
@@ -97423,7 +97446,7 @@ lPl
 prY
 mLL
 jxV
-tCG
+pXC
 pHb
 qwh
 iQg
@@ -98250,7 +98273,7 @@ ylQ
 bGC
 wHu
 igr
-ibw
+wYy
 ibw
 nIP
 gFQ
@@ -107178,7 +107201,7 @@ pvY
 afD
 afD
 afD
-afD
+jJh
 afD
 afD
 afD

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -23004,7 +23004,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "lGn" = (
@@ -23961,6 +23960,14 @@
 /obj/item/stack/sheet/iron,
 /turf/open/floor/eighties/red,
 /area/station/service/electronic_marketing_den)
+"mgQ" = (
+/obj/machinery/door/airlock/external{
+	name = "Trench Elevator"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining,
+/obj/effect/landmark/navigate_destination/oshan/miningelevator,
+/turf/open/floor/iron,
+/area/station/cargo/miningoffice)
 "mgS" = (
 /obj/machinery/light/directional/east,
 /turf/closed/wall,
@@ -46209,6 +46216,7 @@
 "xkw" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/cytology)
 "xkQ" = (
@@ -71992,7 +72000,7 @@ gmy
 mXE
 dGk
 dGk
-jzj
+mgQ
 itp
 itp
 xMS

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -45920,7 +45920,6 @@
 	name = "Private Study";
 	req_access = list("library")
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/library,
 /turf/open/floor/wood,
 /area/station/service/library)
 "xcq" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -483,6 +483,7 @@
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
 	},
+/obj/effect/landmark/navigate_destination/dockescpod4,
 /turf/open/floor/iron,
 /area/station/escapepodbay)
 "abB" = (
@@ -1137,6 +1138,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination/hydro,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "adk" = (
@@ -2930,6 +2932,14 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison)
+"akd" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/landmark/navigate_destination/bar,
+/obj/effect/landmark/navigate_destination/kitchen,
+/turf/open/floor/iron,
+/area/station/hallway/primary/tram/center)
 "ake" = (
 /obj/machinery/airalarm/directional/east,
 /obj/structure/tank_dispenser{
@@ -9255,14 +9265,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
-"bHB" = (
-/obj/effect/landmark/navigate_destination/cargo,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/cargo/office)
 "bHE" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -11741,6 +11743,13 @@
 /obj/structure/cable,
 /turf/open/misc/asteroid/dug,
 /area/station/maintenance/department/cargo)
+"cvB" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/landmark/navigate_destination/common/fitness,
+/turf/open/floor/iron,
+/area/station/commons/fitness)
 "cvI" = (
 /obj/structure/table,
 /obj/item/airlock_painter,
@@ -18423,7 +18432,6 @@
 /obj/machinery/bluespace_beacon,
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/structure/cable,
-/obj/effect/landmark/navigate_destination/teleporter,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "eFo" = (
@@ -20227,14 +20235,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
-"flP" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/trimline/green/line{
-	dir = 1
-	},
-/obj/effect/landmark/navigate_destination/hydro,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics)
 "flQ" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access"
@@ -31246,6 +31246,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"iWy" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/landmark/navigate_destination/dockescpod1,
+/turf/open/floor/iron,
+/area/station/escapepodbay)
 "iWz" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Supply Door Airlock"
@@ -33201,6 +33208,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"jCy" = (
+/obj/effect/landmark/navigate_destination/common/holodeck,
+/turf/open/floor/engine{
+	name = "Holodeck Projector Floor"
+	},
+/area/station/holodeck/rec_center)
 "jCH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -38382,7 +38395,6 @@
 /area/station/security/office)
 "ljC" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/effect/landmark/navigate_destination/lawyer,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/station/service/lawoffice)
@@ -40536,6 +40548,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
+/obj/effect/landmark/navigate_destination/cargo,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "lUf" = (
@@ -41209,6 +41222,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/landmark/navigate_destination/bridge,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "mfB" = (
@@ -43224,7 +43238,6 @@
 /area/station/science/xenobiology)
 "mPf" = (
 /obj/machinery/holopad,
-/obj/effect/landmark/navigate_destination/bridge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -46749,6 +46762,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/landmark/navigate_destination/tram/radshelter,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/radshelter/civil)
 "nVm" = (
@@ -49145,6 +49159,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination/tram/abandonedmechbay,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/central)
 "oOJ" = (
@@ -51267,6 +51282,13 @@
 /obj/item/disk/nuclear,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
+"pyB" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/landmark/navigate_destination/dockescpod3,
+/turf/open/floor/iron,
+/area/station/escapepodbay)
 "pyF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/west{
@@ -58679,6 +58701,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/landmark/navigate_destination/lawyer,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "rOB" = (
@@ -60120,6 +60143,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/starboard/greater)
+"snU" = (
+/obj/effect/landmark/navigate_destination/common/shitter,
+/turf/open/floor/iron/freezer,
+/area/station/commons/toilet)
 "snZ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -63185,7 +63212,6 @@
 /area/station/command/meeting_room)
 "tld" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/landmark/navigate_destination/dockescpod1,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
@@ -72612,6 +72638,13 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
+"weG" = (
+/obj/effect/turf_decal/stripes/white/line{
+	dir = 8
+	},
+/obj/effect/landmark/navigate_destination/dockescpod2,
+/turf/open/floor/iron,
+/area/station/escapepodbay)
 "weS" = (
 /obj/structure/railing{
 	dir = 1
@@ -73118,6 +73151,7 @@
 	pixel_y = -32;
 	dir = 1
 	},
+/obj/effect/landmark/navigate_destination/common/cryogenics,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
 "woJ" = (
@@ -75302,6 +75336,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/landmark/navigate_destination/tram/bankofcargo,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/oresilo)
 "wYE" = (
@@ -75493,6 +75528,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"xdi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/landmark/navigate_destination/dockaux,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "xdw" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/iron/dark,
@@ -76625,6 +76667,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Barber Shop"
 	},
+/obj/effect/landmark/navigate_destination/common/barber,
 /turf/open/floor/wood/large,
 /area/station/service/barber)
 "xzq" = (
@@ -76644,6 +76687,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/eva,
 /obj/effect/mapping_helpers/airlock/access/any/command/gateway,
 /obj/effect/mapping_helpers/airlock/access/any/command/teleporter,
+/obj/effect/landmark/navigate_destination/teleporter,
 /turf/open/floor/iron,
 /area/station/command/teleporter)
 "xzI" = (
@@ -76902,6 +76946,7 @@
 	name = "Bitrunning Den"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/supply/bit_den,
+/obj/effect/landmark/navigate_destination/common/bitrunner,
 /turf/open/floor/iron,
 /area/station/bitrunning/den)
 "xEo" = (
@@ -77527,6 +77572,7 @@
 	dir = 4
 	},
 /obj/machinery/atm,
+/obj/effect/landmark/navigate_destination/common/dorms,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "xPQ" = (
@@ -91946,19 +91992,19 @@ aaV
 aaV
 dDk
 mXt
-abA
+iWy
 itN
 dDk
 dDk
 dDk
 mXt
-abA
+weG
 itN
 dDk
 dDk
 dDk
 mXt
-abA
+pyB
 itN
 dDk
 dDk
@@ -93777,7 +93823,7 @@ xkx
 lMw
 hAD
 hAD
-hAD
+snU
 hAD
 hAD
 hAD
@@ -96354,7 +96400,7 @@ mlI
 jsA
 wPE
 wPE
-wPE
+cvB
 wPE
 wPE
 wPE
@@ -110943,7 +110989,7 @@ wDw
 ale
 moV
 ptR
-flP
+tto
 feC
 sbv
 yka
@@ -155444,7 +155490,7 @@ etC
 jEu
 kqf
 dFP
-dFP
+xdi
 dFP
 ste
 jEu
@@ -167017,7 +167063,7 @@ tnu
 ndb
 ndb
 ndb
-ndb
+jCy
 ndb
 ndb
 ndb
@@ -176505,7 +176551,7 @@ vXM
 vXM
 vXM
 vXM
-aEj
+akd
 veL
 nOB
 fld
@@ -190119,7 +190165,7 @@ vYl
 oGF
 cwG
 kum
-bHB
+dPu
 vbA
 nrM
 nLe

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -49138,7 +49138,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/research/glass{
-	name = "Aseembly Lab"
+	name = "Assembly Lab"
 	},
 /obj/structure/barricade/wooden/crude,
 /obj/effect/decal/cleanable/dirt,

--- a/monkestation/_maps/RandomBars/Icebox/clockwork_icebox.dmm
+++ b/monkestation/_maps/RandomBars/Icebox/clockwork_icebox.dmm
@@ -648,6 +648,10 @@
 "IC" = (
 /turf/closed/wall/mineral/bronze,
 /area/station/commons/lounge)
+"IQ" = (
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/bronze/filled,
+/area/station/service/bar)
 "IT" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -1110,7 +1114,7 @@ dJ
 uw
 Ag
 PC
-zS
+IQ
 EK
 "}
 (15,1,1) = {"

--- a/monkestation/code/game/objects/effects/landmark.dm
+++ b/monkestation/code/game/objects/effects/landmark.dm
@@ -1,0 +1,88 @@
+// Monkestation Additional Navigation Markers for the Navigate Verb -Dexee
+// The code/markers here may be able to be used for a future expansion or completely new navigation/location system that both crew, antags, and pAIs alike will be able to use.
+
+// Non-station Specific Markers
+
+/obj/effect/landmark/navigate_destination/common/portbowsolar
+	location = "Port Bow Solar Array"
+/obj/effect/landmark/navigate_destination/common/portquartersolar
+	location = "Port Quarter Solar Array"
+/obj/effect/landmark/navigate_destination/common/starboardbowsolar
+	location = "Starboard Bow Solar Array"
+/obj/effect/landmark/navigate_destination/common/starboardquartersolar
+	location = "Starboard Quarter Solar Array"
+/obj/effect/landmark/navigate_destination/common/fitness
+	location = "Fitness"
+/obj/effect/landmark/navigate_destination/common/cryogenics
+	location = "Cryogenics"
+/obj/effect/landmark/navigate_destination/common/vaccommissary
+	location = "Vacant Commissary"
+/obj/effect/landmark/navigate_destination/common/artstorage
+	location = "Art Storage"
+/obj/effect/landmark/navigate_destination/common/barber
+	location = "Barber"
+/obj/effect/landmark/navigate_destination/common/auxbaseconst
+	location = "Aux Base Construction"
+/obj/effect/landmark/navigate_destination/common/holodeck
+	location = "Holodeck"
+/obj/effect/landmark/navigate_destination/common/construction
+	location = "Construction Site"
+/obj/effect/landmark/navigate_destination/common/shitter
+	location = "Toilet"
+/obj/effect/landmark/navigate_destination/common/bitrunner
+	location = "Bitrunner Den"
+/obj/effect/landmark/navigate_destination/common/theatrebackstage
+	location = "Theatre Backstage"
+/obj/effect/landmark/navigate_destination/common/dorms
+	location = "Dormitories"
+
+// Icebox Specific
+/obj/effect/landmark/navigate_destination/icebox/maintsbar
+	location = "Maintenance Bar"
+
+// Tramstation Specific
+
+/obj/effect/landmark/navigate_destination/tram/bankofcargo
+	location = "Bank of Cargo"
+
+/obj/effect/landmark/navigate_destination/tram/abandonedmechbay
+	location = "Abandoned Mechbay"
+
+/obj/effect/landmark/navigate_destination/tram/radshelter
+	location = "Radiation Shelter"
+
+// Oshan Specific
+/obj/effect/landmark/navigate_destination/oshan/miningelevator
+	location = "Miners' Elevator"
+
+
+// Northstar Specific
+
+
+
+// Metastation Specific
+
+
+
+// Deltastation specific
+/obj/effect/landmark/navigate_destination/delta/abandsci
+	location = "Abandoned Science Labs"
+/obj/effect/landmark/navigate_destination/delta/abandgambling
+	location = "Abandoned Gambling Den"
+/obj/effect/landmark/navigate_destination/delta/abandlibrary
+	location = "Abandoned Library"
+/obj/effect/landmark/navigate_destination/delta/evamaint
+	location = "EVA Maintenance"
+/obj/effect/landmark/navigate_destination/delta/pioffice
+	location = "Private Investigator's Office"
+/obj/effect/landmark/navigate_destination/delta/abandtheatre
+	location = "Abandoned Theatre"
+/obj/effect/landmark/navigate_destination/delta/abandkitchen
+	location = "Abandoned Kitchen"
+/obj/effect/landmark/navigate_destination/delta/abandgameroom
+	location = "Abandoned Game Den"
+/obj/effect/landmark/navigate_destination/delta/abandmedbay
+	location = "Abandoned Medbay"
+/obj/effect/landmark/navigate_destination/delta/abandmarketbay
+	location = "Abandoned Market Bay"
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5511,6 +5511,7 @@
 #include "monkestation\code\game\machinery\trains\train_head.dm"
 #include "monkestation\code\game\machinery\trains\train_network.dm"
 #include "monkestation\code\game\objects\effects\countdown.dm"
+#include "monkestation\code\game\objects\effects\landmark.dm"
 #include "monkestation\code\game\objects\effects\sprint_dust.dm"
 #include "monkestation\code\game\objects\effects\anomalies\anomalies_dimensional_themes.dm"
 #include "monkestation\code\game\objects\effects\random\ai_module.dm"


### PR DESCRIPTION

## About The Pull Request

This PR is primarily for setting up and improving the Navigation Verb. This adds a ton more direct descriptive markers to help with providing Navigate more places to go to while also supporting unique locations on some of our maps. These additions are being made via a modular landmark.dm located at monkestation/code/game/objects/effects. 

As this is a modular improvement, we do not have to worry about TG making a change to the base landmark file to cause us to have code clashes with anything they do in the future. This file can also be easily expanded to cover all the various maps we runn, both on and off rotation, to help ensure that it is kept up to date with changes as the station codebase evolves over time.

This PR also includes various map fixes alongside the major overhaul of all navmakers.
## Why It's Good For The Game

People have requested for improvements on ways they can look to get around the station. As such, the easiest solution is to add more things to Navigate. While this is still limited to ones' access on their IDs, markers have been adjusted such to help provide the most available locations to be able to navigate towards while also leaving room for improvement and a possible new system that takes advantage of these location markers to better provide the ability to look for places.
## Changelog
:cl: Dexee
All maps:

add: New navmakers for some lesser known places, as well as most station solar platforms
qol: Moved/replaced a ton of existing markers to better common sense spots.

Tram:
qol: Aseembly lab door renamed to Assembly Lab.

Ice Box Coggers Bar:
add: added the missing Booze-O-Mat. (thanks Skell Bones II)

/:cl:
