### PR TITLE
Map QOLs Another Edition

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -3943,7 +3943,6 @@
 	layer = 4.1
 	},
 /obj/structure/railing{
-	dir = 10;
 	layer = 3.1
 	},
 /turf/open/space/basic,
@@ -56363,7 +56362,6 @@
 "nHf" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
-	dir = 10;
 	layer = 3.1
 	},
 /turf/open/space/basic,
@@ -98851,7 +98849,6 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	dir = 10;
 	layer = 3.1
 	},
 /turf/open/space/basic,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -5033,6 +5033,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/sign/directions/cryo/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "bEH" = (
@@ -12169,6 +12170,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
+"dNb" = (
+/obj/structure/sign/directions/cryo/directional/west,
+/turf/closed/wall,
+/area/station/commons/storage/mining)
 "dNi" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -21093,6 +21098,10 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"gJR" = (
+/obj/structure/sign/directions/cryo/directional/north,
+/turf/closed/wall,
+/area/station/maintenance/central/lesser)
 "gJT" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/white/side{
@@ -22889,6 +22898,11 @@
 /obj/item/shovel/spade,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"hrG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/directions/cryo/directional/west,
+/turf/open/floor/plating,
+/area/station/hallway/primary/central)
 "hrJ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -31264,6 +31278,7 @@
 /area/station/science/ordnance/testlab)
 "kdF" = (
 /obj/effect/spawner/random/vending/snackvend,
+/obj/structure/sign/directions/cryo/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "kdJ" = (
@@ -43064,12 +43079,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
-"nOy" = (
-/obj/structure/sign/directions/cryo/directional/south{
-	pixel_y = 1
-	},
-/turf/closed/wall,
-/area/station/service/hydroponics/garden)
 "nOB" = (
 /obj/structure/railing{
 	dir = 4
@@ -43541,6 +43550,10 @@
 	dir = 1
 	},
 /area/station/service/hydroponics)
+"nVA" = (
+/obj/structure/sign/directions/cryo/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "nVB" = (
 /obj/effect/turf_decal/trimline/dark/warning{
 	dir = 4
@@ -54010,6 +54023,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"roD" = (
+/obj/structure/sign/directions/cryo/directional/west,
+/turf/closed/wall,
+/area/station/commons/toilet)
 "roH" = (
 /obj/structure/chair/pew/right,
 /turf/open/floor/wood,
@@ -56489,6 +56506,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"seS" = (
+/obj/structure/sign/directions/cryo/directional/north,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/central/greater)
 "seX" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
@@ -221884,7 +221905,7 @@ kMu
 esB
 oCO
 xJv
-fsv
+nVA
 fsv
 nDk
 fsv
@@ -222141,7 +222162,7 @@ slv
 rEN
 oCO
 oCO
-nOy
+oCO
 aPI
 iKR
 aPI
@@ -231929,7 +231950,7 @@ gfb
 gfb
 pYB
 gfb
-gfb
+seS
 nqU
 rcE
 rcE
@@ -234220,7 +234241,7 @@ tgn
 itN
 nuX
 yfF
-pAZ
+hrG
 dnq
 kgD
 utR
@@ -236048,7 +236069,7 @@ qQC
 qQC
 kta
 kta
-kta
+dNb
 tqQ
 iuv
 vyb
@@ -239103,7 +239124,7 @@ uja
 uja
 uja
 hsB
-uja
+roD
 wJk
 iuv
 ezK
@@ -239125,7 +239146,7 @@ lpM
 lpM
 log
 sIt
-sIt
+gJR
 sIt
 log
 mhQ

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -18278,6 +18278,7 @@
 	},
 /area/station/engineering/engine_smes)
 "fNA" = (
+/obj/structure/sign/warning/bodysposal/directional/north,
 /turf/open/openspace,
 /area/station/medical/medbay/central)
 "fNK" = (
@@ -54668,6 +54669,7 @@
 /area/icemoon/surface/outdoors/nospawn)
 "rzS" = (
 /obj/structure/sign/departments/chemistry/pharmacy/directional/west,
+/obj/structure/sign/warning/bodysposal/directional/south,
 /turf/open/openspace,
 /area/station/medical/medbay/lobby)
 "rAr" = (
@@ -64363,10 +64365,6 @@
 "uJt" = (
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"uJO" = (
-/obj/machinery/porta_turret/aux_base,
-/turf/closed/wall/r_wall,
-/area/station/security/lockers)
 "uJX" = (
 /obj/structure/closet/firecloset,
 /obj/item/radio/intercom/directional/north,
@@ -231349,7 +231347,7 @@ tGr
 tGr
 tGr
 tGr
-uJO
+bDu
 bDu
 bDu
 bDu

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -15722,10 +15722,10 @@
 "fXj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/structure/railing/corner{
+/obj/structure/railing,
+/obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/railing/corner,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "fXm" = (
@@ -19052,7 +19052,6 @@
 /area/station/maintenance/starboard/aft)
 "hgE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing,
 /obj/machinery/atmospherics/pipe/bridge_pipe/orange/hidden,
 /turf/open/floor/iron/stairs/right{
 	dir = 8
@@ -30007,7 +30006,6 @@
 	dir = 4;
 	layer = 4.1
 	},
-/obj/structure/railing,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kRi" = (
@@ -30574,7 +30572,10 @@
 /area/station/engineering/atmos/pumproom)
 "laI" = (
 /obj/structure/railing{
-	dir = 5
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -47328,6 +47329,9 @@
 	req_access = list("atmospherics")
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "qZa" = (
@@ -58402,7 +58406,6 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
 	},
-/obj/structure/railing/corner,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
@@ -61173,10 +61176,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing,
 /obj/structure/railing{
 	dir = 8;
 	layer = 4.1
@@ -84329,7 +84328,7 @@ aaa
 aaa
 aaa
 aaa
-mWd
+aaa
 aaa
 aaa
 lMJ

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -531,14 +531,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
-"agt" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port/fore)
 "agv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -808,12 +800,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/aft)
-"akh" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/library)
 "aki" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -1125,12 +1111,6 @@
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/medical)
-"anW" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/library)
 "aof" = (
 /obj/machinery/suit_storage_unit/radsuit,
 /obj/machinery/light/small/directional/west,
@@ -1351,15 +1331,6 @@
 	dir = 1
 	},
 /area/station/cargo/sorting)
-"aqR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port/aft)
 "aqU" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -1368,9 +1339,6 @@
 "aqW" = (
 /obj/effect/turf_decal/trimline/green/filled/arrow_cw{
 	dir = 1
-	},
-/obj/structure/railing/corner{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1529,14 +1497,6 @@
 "asS" = (
 /turf/open/floor/bamboo/tatami/black,
 /area/station/commons/storage/art)
-"asU" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port)
 "asV" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
@@ -1547,19 +1507,7 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
-"ata" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/starboard/aft)
 "ate" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/corner{
 	dir = 4
 	},
@@ -2650,7 +2598,7 @@
 /area/station/maintenance/floor1/port/fore)
 "aGK" = (
 /obj/structure/railing{
-	dir = 9
+	dir = 1
 	},
 /obj/structure/chair/comfy/brown,
 /obj/machinery/door/firedoor/border_only{
@@ -3818,9 +3766,6 @@
 /area/station/hallway/floor2/aft)
 "aWd" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
@@ -3918,7 +3863,6 @@
 /obj/effect/turf_decal/trimline/green/filled/arrow_cw{
 	dir = 9
 	},
-/obj/structure/railing/corner,
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/virology/isolation)
@@ -4182,15 +4126,6 @@
 	},
 /turf/open/floor/bamboo/tatami/black,
 /area/station/commons/storage/art)
-"aZI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/starboard/aft)
 "aZN" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -4210,21 +4145,6 @@
 "aZW" = (
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor1/port/aft)
-"baa" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/wood/tile,
-/area/station/service/library)
 "bad" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4450,7 +4370,6 @@
 /turf/open/floor/iron/dark/side,
 /area/station/cargo/lobby)
 "bdx" = (
-/obj/structure/railing/corner,
 /obj/structure/chair/stool/bar/directional/east,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -4716,16 +4635,6 @@
 /obj/structure/reflector/double,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"bhb" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port/aft)
 "bhj" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -5157,12 +5066,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"blq" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/hedge,
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/grass,
-/area/station/service/chapel)
 "blt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/west,
@@ -5217,7 +5120,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "blO" = (
-/obj/structure/railing/corner,
 /obj/effect/turf_decal/trimline/green/corner,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -6253,6 +6155,12 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
+"bxc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/floor4/port/fore)
 "bxd" = (
 /obj/structure/table,
 /obj/machinery/airalarm/directional/north,
@@ -6585,9 +6493,6 @@
 /obj/effect/turf_decal/trimline/green/filled/arrow_cw{
 	dir = 5
 	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/virology/isolation)
 "bAu" = (
@@ -6772,9 +6677,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "bDr" = (
@@ -6961,6 +6863,16 @@
 	},
 /turf/open/openspace,
 /area/station/maintenance/floor4/port/aft)
+"bGM" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/pod,
+/area/station/maintenance/floor4/port/aft)
 "bGP" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/camera/autoname/directional/west,
@@ -7012,21 +6924,6 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/port)
-"bIk" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/wood/tile,
-/area/station/service/library)
 "bIl" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -7133,16 +7030,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
-"bJN" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor4/starboard/fore)
 "bJQ" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -7827,12 +7714,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
-"bSj" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/library)
 "bSq" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
 	dir = 6
@@ -11311,11 +11192,11 @@
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor2/aft)
 "cPQ" = (
-/obj/structure/railing{
-	dir = 5
-	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 5
+	},
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/open/water/jungle{
 	desc = "Filthy.";
@@ -11585,7 +11466,7 @@
 "cTs" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/cable,
-/turf/open/openspace,
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/port/aft)
 "cTw" = (
 /obj/structure/table/reinforced,
@@ -11606,9 +11487,6 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "cTJ" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 10
 	},
@@ -11914,9 +11792,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/structure/railing/corner{
 	dir = 8
 	},
@@ -12483,15 +12358,6 @@
 /obj/machinery/status_display/ai/directional/west,
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
-"dfA" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/starboard)
 "dfD" = (
 /obj/structure/disposalpipe/trunk/multiz/down,
 /turf/open/floor/plating/foam,
@@ -12503,9 +12369,6 @@
 /turf/open/floor/iron/checker,
 /area/station/commons/locker)
 "dfY" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -12751,15 +12614,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"djX" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/starboard/fore)
 "dke" = (
 /obj/machinery/door/window/left/directional/south,
 /obj/machinery/door/window/left/directional/north,
@@ -12791,12 +12645,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"dkn" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/space/openspace,
-/area/space)
 "dks" = (
 /obj/structure/girder,
 /obj/item/stack/sheet/iron,
@@ -13317,9 +13165,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "dso" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13845,9 +13690,6 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/port/fore)
 "dAk" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
@@ -14032,9 +13874,6 @@
 /area/station/command/bridge)
 "dDF" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -14303,12 +14142,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "dHd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/airalarm/directional/north,
 /obj/machinery/status_display/ai/directional/east,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/textured_large,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/engine_smes)
 "dHf" = (
 /turf/open/floor/catwalk_floor/iron,
@@ -14344,9 +14184,6 @@
 "dHS" = (
 /obj/effect/turf_decal/trimline/green/filled/arrow_cw{
 	dir = 10
-	},
-/obj/structure/railing/corner{
-	dir = 4
 	},
 /obj/machinery/light/cold/no_nightlight/directional/west,
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -14423,13 +14260,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/science/xenobiology/hallway)
-"dIO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/railing/corner,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port/fore)
 "dIQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -15337,7 +15167,6 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/aft)
 "dUU" = (
-/obj/structure/railing/corner,
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 9
 	},
@@ -16908,9 +16737,6 @@
 "eoo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -17145,9 +16971,6 @@
 /area/station/tcommsat/server)
 "esu" = (
 /obj/effect/turf_decal/trimline/green/filled/arrow_cw,
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/virology/isolation)
 "esw" = (
@@ -17249,9 +17072,6 @@
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor3/fore)
 "eud" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -17463,21 +17283,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/service/theater)
-"ewH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port)
 "ewM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/nitrogen_output,
 /obj/effect/turf_decal/trimline/red/line,
@@ -18006,9 +17811,6 @@
 /area/station/medical/psychology)
 "eGr" = (
 /obj/effect/turf_decal/tile/green/full,
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -18219,6 +18021,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port)
 "eJs" = (
@@ -18228,6 +18033,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor3/fore)
+"eJA" = (
+/obj/structure/cable,
+/obj/machinery/power/smes/engineering,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "eJF" = (
 /obj/machinery/airalarm/directional/south,
 /obj/item/kirbyplants/random,
@@ -19086,9 +18897,6 @@
 /turf/open/floor/engine/hull/reinforced,
 /area/space/nearstation)
 "eYp" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 6
 	},
@@ -19726,13 +19534,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor1/fore)
-"fio" = (
-/obj/structure/railing/corner,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/wood/tile,
-/area/station/service/library)
 "fiu" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/carpet/red,
@@ -20226,14 +20027,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard)
-"foB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/railing/corner,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/port/aft)
 "foF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20979,9 +20772,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "fzG" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 4
 	},
@@ -21000,9 +20790,6 @@
 /turf/open/floor/wood/tile,
 /area/station/command/heads_quarters/captain/private)
 "fzV" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/structure/chair{
 	dir = 8
 	},
@@ -21063,15 +20850,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/floor3/aft)
-"fAU" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port/fore)
 "fBa" = (
 /obj/structure/railing{
 	dir = 4
@@ -21904,13 +21682,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/starboard)
-"fLX" = (
-/obj/structure/railing/corner,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance/testlab)
 "fMa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23302,15 +23073,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"geL" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port)
 "geW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23765,7 +23527,7 @@
 "glN" = (
 /obj/effect/mapping_helpers/airlock/access/any/security/armory,
 /obj/machinery/door/airlock/security/glass{
-	name = "Armoury"
+	name = "Armory"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23818,12 +23580,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"gmA" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor4/starboard/fore)
 "gmC" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
 	dir = 4
@@ -23872,12 +23628,6 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage/tech)
-"gnj" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
 "gnm" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24618,9 +24368,6 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/aft)
 "gyp" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -24906,9 +24653,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/floor3/fore)
 "gCH" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -25484,16 +25228,6 @@
 /obj/effect/spawner/random/structure/crate_abandoned,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor1/port/aft)
-"gKO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port/aft)
 "gKQ" = (
 /obj/structure/window/plasma/spawner,
 /obj/machinery/rnd/server/master,
@@ -26460,15 +26194,6 @@
 "gZu" = (
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
-"gZG" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
 "gZJ" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/item/camera,
@@ -26856,9 +26581,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
 	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
@@ -26987,18 +26709,6 @@
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/plating,
 /area/station/maintenance/floor2/starboard/aft)
-"hfE" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/white/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance/testlab)
 "hge" = (
 /turf/open/floor/engine,
 /area/station/command/heads_quarters/rd)
@@ -27527,9 +27237,6 @@
 /obj/effect/turf_decal/stripes{
 	dir = 5
 	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
 "hnK" = (
@@ -27594,18 +27301,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/floor1/fore)
-"hoK" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/port/fore)
 "hoU" = (
 /obj/effect/spawner/random/contraband/landmine,
 /turf/open/floor/pod/dark,
@@ -27727,7 +27422,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/hfr_room)
 "hqR" = (
-/obj/structure/railing/corner,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28090,9 +27784,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
 	dir = 8
 	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -28208,9 +27899,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/storage)
 "hxN" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -30588,9 +30276,6 @@
 /obj/effect/turf_decal/arrows{
 	dir = 1
 	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /turf/open/floor/wood/tile,
 /area/station/service/library/lounge)
 "igS" = (
@@ -30710,10 +30395,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/structure/railing/corner,
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/port)
@@ -30769,13 +30450,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
-"ijJ" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/structure/railing/corner,
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
 "ijL" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/textured_large,
@@ -31351,13 +31025,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/eva)
-"isk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/railing/corner,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/starboard/aft)
 "isl" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Shelter"
@@ -32203,13 +31870,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/port/fore)
-"iEU" = (
-/obj/machinery/door/firedoor,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/pod/dark,
-/area/station/maintenance/floor3/starboard)
 "iFn" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -33003,9 +32663,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "iPV" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 1
 	},
@@ -33260,12 +32917,6 @@
 	},
 /turf/open/floor/grass,
 /area/station/service/library/garden)
-"iTJ" = (
-/obj/structure/railing/corner,
-/obj/effect/spawner/random/structure/crate_abandoned,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor1/port)
 "iTM" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/tile/red/half{
@@ -33299,9 +32950,6 @@
 "iUP" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/structure/railing/corner{
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/south,
@@ -33592,15 +33240,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/station/science/auxlab)
-"iYA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/starboard)
 "iYE" = (
 /obj/effect/turf_decal/trimline/brown/line{
 	dir = 4
@@ -33663,15 +33302,6 @@
 	dir = 8
 	},
 /area/station/security/prison)
-"iZi" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor4/port/aft)
 "iZA" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/remains/human{
@@ -35883,15 +35513,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor2/starboard/aft)
-"jDL" = (
-/obj/effect/turf_decal/trimline/red/warning{
-	dir = 4
-	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/pod/dark,
-/area/station/hallway/secondary/entry)
 "jEc" = (
 /obj/effect/mapping_helpers/airlock/access/any/supply/mining,
 /obj/structure/cable,
@@ -36105,7 +35726,6 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/port)
 "jFT" = (
-/obj/structure/railing/corner,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
 /turf/open/floor/pod/light,
@@ -36794,7 +36414,6 @@
 	name = "Starboard Quarter Solars"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
-/obj/structure/railing/corner,
 /turf/open/floor/pod/light,
 /area/station/maintenance/solars/starboard/aft)
 "jOX" = (
@@ -36866,9 +36485,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/cargo/office)
 "jPD" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/brown/filled/arrow_ccw{
 	dir = 4
 	},
@@ -36958,15 +36574,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
-"jQK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port)
 "jQP" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/bottle/syrup_bottle/korta_nectar{
@@ -37396,7 +37003,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "jWR" = (
-/obj/structure/railing/corner,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
@@ -37790,15 +37396,6 @@
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
-"kcy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/port)
 "kcA" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
@@ -38062,16 +37659,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"kgK" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/tile,
-/area/station/service/library)
 "kgT" = (
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/starboard)
@@ -39250,6 +38837,10 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/storage)
+"kwO" = (
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "kxf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39704,10 +39295,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/fore)
-"kCk" = (
-/obj/structure/railing/corner,
-/turf/open/floor/wood/tile,
-/area/station/service/library)
 "kCm" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /obj/machinery/holopad,
@@ -39801,7 +39388,6 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/port/fore)
 "kEv" = (
-/obj/structure/railing/corner,
 /obj/effect/turf_decal/arrows,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
@@ -40280,9 +39866,6 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "kKk" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
@@ -40327,15 +39910,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
-"kKG" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/starboard/aft)
 "kKJ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/space_heater,
@@ -40451,9 +40025,6 @@
 /turf/open/floor/plating,
 /area/station/hallway/floor1/fore)
 "kLM" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -40696,15 +40267,6 @@
 	dir = 4
 	},
 /area/station/hallway/floor4/aft)
-"kQo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/starboard)
 "kQp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41017,16 +40579,6 @@
 	dir = 8
 	},
 /area/station/service/chapel)
-"kUe" = (
-/obj/structure/holosign/barrier/engineering,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port/aft)
 "kUf" = (
 /obj/effect/turf_decal/tile/blue/full,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42666,6 +42218,9 @@
 	dir = 10
 	},
 /obj/structure/marker_beacon/burgundy,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/floor/plating/airless,
 /area/station/solars/starboard/aft)
 "lpe" = (
@@ -42893,9 +42448,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "lsm" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 10
 	},
@@ -43442,6 +42994,9 @@
 	dir = 6
 	},
 /obj/structure/marker_beacon/burgundy,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/station/solars/starboard/aft)
 "lzA" = (
@@ -44259,15 +43814,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"lKh" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port)
 "lKj" = (
 /obj/structure/closet/crate/solarpanel_small,
 /obj/structure/window/spawner/directional/west,
@@ -44395,15 +43941,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/commons/fitness/recreation)
-"lMx" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/starboard/fore)
 "lMz" = (
 /obj/effect/turf_decal/siding/thinplating_new{
 	dir = 8
@@ -44793,7 +44330,7 @@
 /area/station/maintenance/floor2/port/aft)
 "lQt" = (
 /obj/structure/railing{
-	dir = 5
+	dir = 1
 	},
 /obj/structure/chair/comfy/brown,
 /obj/machinery/door/firedoor/border_only{
@@ -44884,9 +44421,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/railing,
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/port)
@@ -45782,14 +45316,6 @@
 	icon_state = "snow7"
 	},
 /area/station/hallway/floor2/fore)
-"mdE" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/hallway/floor4/fore)
 "mdJ" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/tile/yellow{
@@ -46279,7 +45805,7 @@
 "mjP" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/cable,
-/turf/open/openspace,
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor3/port)
 "mjQ" = (
 /obj/effect/turf_decal/tile/yellow,
@@ -47574,7 +47100,7 @@
 /area/station/maintenance/floor2/starboard/aft)
 "mzT" = (
 /obj/structure/cable,
-/turf/open/openspace,
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/port/aft)
 "mzW" = (
 /obj/structure/cable,
@@ -47748,10 +47274,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/railing/corner,
-/obj/structure/railing/corner{
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor,
@@ -48412,9 +47934,6 @@
 /area/station/maintenance/floor1/port/aft)
 "mLk" = (
 /obj/machinery/door/firedoor,
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/starboard)
 "mLm" = (
@@ -49209,9 +48728,6 @@
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/exit/escape_pod)
 "mVp" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -49632,9 +49148,6 @@
 /area/station/maintenance/floor1/port/fore)
 "naz" = (
 /obj/effect/turf_decal/siding/wideplating_new/corner{
-	dir = 8
-	},
-/obj/structure/railing/corner{
 	dir = 8
 	},
 /turf/open/floor/iron/white/smooth_edge{
@@ -50198,9 +49711,6 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -50302,9 +49812,6 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor1/starboard/fore)
 "niA" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 4
 	},
@@ -50484,16 +49991,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/fore)
-"nko" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/railing/corner,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port/aft)
 "nkp" = (
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50793,12 +50290,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
-"nnU" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor2/port/fore)
 "nnV" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/pod/light,
@@ -51452,9 +50943,6 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/port/aft)
 "nvv" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 1
 	},
@@ -51516,12 +51004,6 @@
 "nwa" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
-	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/railing/corner{
-	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 8
@@ -51758,15 +51240,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"nzm" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port/fore)
 "nzq" = (
 /obj/machinery/door/airlock/wood{
 	name = "Bedroom"
@@ -51972,9 +51445,6 @@
 	},
 /area/station/security/brig)
 "nBV" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -51992,15 +51462,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/exit/departure_lounge)
-"nCd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/starboard)
 "nCg" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/reagent_containers/pill/happinesspsych{
@@ -52649,9 +52110,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/border_only,
@@ -53174,7 +52632,6 @@
 /obj/effect/turf_decal/trimline/yellow/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/railing/corner,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -53200,13 +52657,6 @@
 	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port)
-"nRn" = (
-/obj/structure/railing/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/starboard/fore)
 "nRo" = (
 /obj/machinery/vending/games,
 /turf/open/floor/bamboo/tatami/black,
@@ -53568,14 +53018,6 @@
 "nWe" = (
 /turf/closed/wall,
 /area/station/commons/fitness)
-"nWf" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port)
 "nWk" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -54047,9 +53489,6 @@
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/floor4/aft)
 "ocu" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 8
 	},
@@ -54673,15 +54112,6 @@
 	dir = 4
 	},
 /area/station/maintenance/floor1/starboard/aft)
-"olt" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port/fore)
 "olA" = (
 /obj/effect/turf_decal/trimline/green/warning{
 	dir = 9
@@ -55883,15 +55313,6 @@
 /obj/structure/table,
 /turf/open/floor/catwalk_floor/iron,
 /area/station/cargo/office)
-"oCe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port/aft)
 "oCf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56142,13 +55563,6 @@
 	dir = 1
 	},
 /area/station/hallway/floor3/aft)
-"oGc" = (
-/obj/effect/turf_decal/trimline/red/warning{
-	dir = 4
-	},
-/obj/structure/railing/corner,
-/turf/open/floor/pod/dark,
-/area/station/hallway/secondary/entry)
 "oGf" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -57357,14 +56771,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/station/service/chapel)
-"oXd" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/structure/railing/corner,
-/turf/open/space/openspace,
-/area/space/nearstation)
 "oXg" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -58968,10 +58374,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"pwH" = (
-/obj/structure/railing/corner,
-/turf/open/floor/engine/hull/reinforced,
-/area/space/nearstation)
 "pwL" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
@@ -59177,9 +58579,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "pze" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59509,14 +58908,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/checker,
 /area/station/service/bar/atrium)
-"pDX" = (
-/obj/structure/railing/corner,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/station/service/bar/atrium)
 "pEp" = (
 /turf/open/openspace,
 /area/station/maintenance/floor2/port/aft)
@@ -59612,14 +59003,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/command/gateway)
-"pFy" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/starboard/fore)
 "pFA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -59747,15 +59130,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
-"pHQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/port)
 "pHT" = (
 /obj/structure/table/wood,
 /obj/item/paper/fluff/gateway,
@@ -60097,7 +59471,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "pMW" = (
-/obj/structure/railing/corner,
 /obj/effect/turf_decal/trimline/purple/corner,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -61949,12 +61322,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/floor4/starboard/aft)
-"qng" = (
-/obj/structure/railing/corner,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port)
 "qnq" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
@@ -62415,7 +61782,6 @@
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/port/fore)
 "qtA" = (
-/obj/structure/railing/corner,
 /obj/structure/chair{
 	dir = 4
 	},
@@ -62487,14 +61853,6 @@
 "qun" = (
 /turf/closed/wall/r_wall,
 /area/station/science/genetics)
-"quA" = (
-/obj/structure/railing/corner,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood/tile,
-/area/station/service/library)
 "quB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63068,9 +62426,6 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor1/port/fore)
 "qAM" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -63465,9 +62820,6 @@
 	},
 /area/station/security/checkpoint)
 "qEB" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 8
 	},
@@ -64255,9 +63607,6 @@
 /obj/effect/turf_decal/tile/green/full,
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/vending/wallmed/directional/west,
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -64644,14 +63993,6 @@
 /obj/structure/sign/departments/psychology,
 /turf/closed/wall,
 /area/station/maintenance/floor1/port)
-"qUV" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/structure/railing/corner,
-/obj/structure/cable,
-/turf/open/floor/plating/airless,
-/area/station/solars/starboard/aft)
 "qVa" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -65300,9 +64641,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "rdK" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/wood,
 /area/station/service/bar/atrium)
@@ -65558,15 +64896,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/service/library/private)
-"rgE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/starboard/aft)
 "rgG" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -65788,9 +65117,6 @@
 	},
 /area/station/maintenance/floor1/starboard/aft)
 "rjp" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 8
 	},
@@ -66710,15 +66036,6 @@
 "ryx" = (
 /turf/open/floor/carpet/royalblue,
 /area/station/commons/dorms/room4)
-"ryz" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port/fore)
 "ryA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -66738,13 +66055,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plating,
 /area/station/maintenance/floor4/starboard)
-"ryX" = (
-/obj/structure/railing/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port)
 "rza" = (
 /obj/effect/turf_decal/trimline/brown/warning{
 	dir = 9
@@ -66990,6 +66300,9 @@
 "rCO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/engine_smes)
 "rCQ" = (
@@ -67284,15 +66597,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/service/chapel/office)
-"rHP" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/port)
 "rHX" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -67607,15 +66911,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor1/port)
-"rMc" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port/fore)
 "rMl" = (
 /obj/structure/chair/sofa/bench{
 	dir = 4
@@ -68003,12 +67298,6 @@
 	dir = 4
 	},
 /area/station/engineering/storage/tech)
-"rSu" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor3/port)
 "rSw" = (
 /turf/open/misc/asteroid/snow/standard_air{
 	icon_state = "snow1"
@@ -68042,9 +67331,6 @@
 "rSK" = (
 /obj/structure/railing/corner{
 	dir = 1
-	},
-/obj/structure/railing/corner{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68243,13 +67529,6 @@
 "rVk" = (
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"rVo" = (
-/obj/structure/railing/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/starboard/fore)
 "rVy" = (
 /turf/open/floor/plating,
 /area/station/maintenance/floor4/port/fore)
@@ -68369,6 +67648,12 @@
 	dir = 4
 	},
 /area/station/hallway/floor3/aft)
+"rXZ" = (
+/obj/effect/landmark/navigate_destination/dockaux,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/hallway/floor3/fore)
 "rYa" = (
 /obj/structure/window/reinforced/tinted/frosted{
 	dir = 8
@@ -68605,12 +67890,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/floor2/starboard/aft)
-"scu" = (
-/obj/structure/railing/corner,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/commons/vacant_room/commissary)
 "scv" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal)
@@ -69283,6 +68562,9 @@
 /obj/structure/railing{
 	dir = 6
 	},
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/space/openspace,
 /area/space/nearstation)
 "soI" = (
@@ -69318,13 +68600,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard/aft)
-"spa" = (
-/obj/structure/railing/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/starboard)
 "spb" = (
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/light_switch/directional/west,
@@ -69534,15 +68809,6 @@
 	},
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/fore)
-"ssz" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/starboard/aft)
 "ssL" = (
 /obj/machinery/door/airlock/science/glass{
 	name = "Research and Development"
@@ -70209,9 +69475,6 @@
 /turf/open/floor/wood,
 /area/station/maintenance/floor3/starboard/aft)
 "sBF" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 1
 	},
@@ -71177,9 +70440,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/arrows{
 	dir = 1
 	},
@@ -71856,9 +71116,6 @@
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "sYw" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/brown/filled/arrow_ccw{
 	dir = 4
 	},
@@ -71998,9 +71255,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
@@ -72060,15 +71314,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/tile,
 /area/station/service/library)
-"tbh" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/port/fore)
 "tbp" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -72255,13 +71500,6 @@
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/starboard)
-"tdB" = (
-/obj/structure/railing/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/starboard/aft)
 "tdF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73205,7 +72443,7 @@
 "trz" = (
 /obj/structure/cable/multilayer/multiz,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor2/port)
 "trB" = (
 /obj/machinery/ai_slipper{
@@ -74488,9 +73726,6 @@
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms/room1)
 "tKl" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark/side{
@@ -74904,9 +74139,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor4/aft)
 "tQJ" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -75565,9 +74797,6 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "ubi" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 1
@@ -75678,9 +74907,6 @@
 	},
 /area/station/cargo/lobby)
 "ucS" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/trash/graffiti,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -75751,13 +74977,6 @@
 	},
 /turf/open/floor/plating/foam,
 /area/station/maintenance/floor2/starboard/fore)
-"uep" = (
-/obj/structure/railing/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port/fore)
 "ueu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -75865,9 +75084,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "ufL" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 1
 	},
@@ -76242,9 +75458,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/port/aft)
 "ukK" = (
@@ -77026,17 +76239,6 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor4/starboard/fore)
-"uxD" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port)
 "uxF" = (
 /obj/machinery/status_display/ai/directional/west,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -77533,9 +76735,6 @@
 "uEY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/floor4/starboard/fore)
 "uFc" = (
@@ -77772,9 +76971,6 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -77948,23 +77144,6 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor3/port)
-"uLj" = (
-/obj/structure/railing/corner,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor1/port)
-"uLk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/port/aft)
 "uLA" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -79130,21 +78309,6 @@
 "uZF" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/floor2/starboard/aft)
-"uZG" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/duct,
-/obj/structure/railing,
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor4/port/aft)
 "uZV" = (
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/machinery/door/airlock/hatch{
@@ -79914,12 +79078,16 @@
 /obj/effect/turf_decal/trimline/brown/filled/mid_joiner{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
 /turf/open/floor/carpet/red,
 /area/station/service/theater)
 "vlQ" = (
@@ -80288,7 +79456,6 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/railing/corner,
 /turf/open/openspace,
 /area/station/maintenance/floor2/port/aft)
 "vqz" = (
@@ -81419,13 +80586,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/floor1/port/aft)
-"vFJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port)
 "vFS" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/maintenance,
@@ -81797,15 +80957,6 @@
 /obj/structure/rack,
 /turf/open/floor/iron/textured_large,
 /area/station/medical/chemistry)
-"vKw" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port)
 "vKD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/light/dim/directional/north,
@@ -82861,9 +82012,6 @@
 /area/station/command/gateway)
 "vZl" = (
 /obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/structure/railing/corner{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -82930,12 +82078,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/security/prison/safe)
-"waX" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/starboard)
 "wba" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -83254,9 +82396,6 @@
 /area/station/hallway/floor1/aft)
 "weg" = (
 /obj/structure/sign/poster/official/random/directional/east,
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/arrows,
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood/tile,
@@ -83383,12 +82522,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/engineering/storage/tech)
-"wgo" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/pod/light,
-/area/station/maintenance/floor1/starboard)
 "wgO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -84053,15 +83186,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/floor2/fore)
-"wpa" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/starboard/fore)
 "wpc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/bodycontainer/morgue{
@@ -84505,16 +83629,6 @@
 	dir = 4
 	},
 /area/station/hallway/floor4/aft)
-"wuS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/railing/corner,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/port/fore)
 "wuZ" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -85530,9 +84644,6 @@
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor4/starboard)
 "wHs" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -85628,9 +84739,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
 "wIC" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/side{
 	dir = 8
@@ -86337,9 +85445,6 @@
 	dir = 1
 	},
 /obj/machinery/duct,
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/structure/railing{
 	dir = 1
 	},
@@ -86760,15 +85865,6 @@
 /obj/structure/ladder,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/starboard/aft)
-"wWm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port/aft)
 "wWn" = (
 /obj/machinery/light/cold/no_nightlight/directional/east,
 /obj/item/radio/intercom/directional/east,
@@ -87064,14 +86160,6 @@
 /obj/item/shovel/spade,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"xbj" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port)
 "xbk" = (
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
@@ -87613,9 +86701,6 @@
 /turf/open/floor/grass,
 /area/station/service/bar/atrium)
 "xit" = (
-/obj/structure/railing/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -87801,7 +86886,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
 	},
-/obj/structure/railing/corner,
 /obj/machinery/light/directional/north,
 /turf/open/floor/carpet/red,
 /area/station/service/theater)
@@ -88080,7 +87164,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner,
 /obj/structure/railing{
 	dir = 1
 	},
@@ -88529,19 +87612,6 @@
 /obj/structure/grille,
 /turf/open/floor/pod/light,
 /area/station/maintenance/floor2/port/fore)
-"xvA" = (
-/obj/effect/turf_decal/tile/green/full,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/hallway/secondary/entry)
 "xvK" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/clothing/gloves/latex,
@@ -88787,15 +87857,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
-"xyC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/starboard)
 "xyD" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -88835,15 +87896,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark/textured,
 /area/station/commons/fitness)
-"xzr" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor1/port/aft)
 "xzA" = (
 /obj/machinery/light/cold/no_nightlight/directional/west,
 /turf/open/floor/iron,
@@ -89462,9 +88514,6 @@
 /turf/open/floor/iron/dark/side,
 /area/station/security/courtroom)
 "xHw" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/brown/filled/arrow_ccw{
 	dir = 4
 	},
@@ -89617,15 +88666,6 @@
 /obj/effect/spawner/random/engineering/canister,
 /turf/open/floor/pod/dark,
 /area/station/maintenance/floor2/port)
-"xJW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor3/port)
 "xKa" = (
 /obj/effect/turf_decal/stripes/white/corner,
 /turf/open/floor/iron/dark/corner,
@@ -89643,10 +88683,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
-"xKt" = (
-/obj/structure/railing/corner,
-/turf/open/space/openspace,
-/area/space)
 "xKy" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 8
@@ -89871,15 +88907,6 @@
 	dir = 1
 	},
 /area/station/engineering/lobby)
-"xNX" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor,
-/area/station/maintenance/floor2/starboard/fore)
 "xOd" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -90079,6 +89106,9 @@
 	dir = 10
 	},
 /obj/structure/marker_beacon/burgundy,
+/obj/structure/railing{
+	dir = 8
+	},
 /turf/open/space/openspace,
 /area/space/nearstation)
 "xRG" = (
@@ -90229,12 +89259,6 @@
 /obj/effect/turf_decal/tile/green/full,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"xUk" = (
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/space/openspace,
-/area/space)
 "xUI" = (
 /obj/structure/cable,
 /obj/structure/chair/sofa/bench/left,
@@ -90972,9 +89996,6 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -91339,12 +90360,6 @@
 "yjR" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
-	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/railing/corner{
-	dir = 1
 	},
 /turf/open/floor/iron/white/smooth_corner{
 	dir = 4
@@ -110097,7 +109112,7 @@ xob
 wnP
 nnV
 oic
-rVo
+rRf
 ala
 ala
 ala
@@ -110637,7 +109652,7 @@ hJy
 hJy
 sui
 sui
-olt
+hOV
 hJy
 uoP
 cnW
@@ -110868,7 +109883,7 @@ uzN
 aaC
 twL
 oic
-djX
+rRf
 jIW
 tNS
 ybF
@@ -111382,7 +110397,7 @@ laS
 btP
 bxf
 oic
-rVo
+rRf
 wsw
 tNS
 thq
@@ -111665,7 +110680,7 @@ hJy
 hJy
 vZl
 pxY
-agt
+omF
 hJy
 jMI
 eiM
@@ -112153,7 +111168,7 @@ oic
 oic
 sBT
 qLI
-djX
+rRf
 lIe
 lIe
 joP
@@ -112696,7 +111711,7 @@ kDQ
 sDT
 vZw
 hJy
-dIO
+iGt
 hJy
 hJy
 hJy
@@ -113981,11 +112996,11 @@ hJy
 eqK
 iGt
 udE
-fAU
+iGt
 fqg
 fqg
 fqg
-nzm
+iGt
 iGt
 iGt
 iGt
@@ -116296,8 +115311,8 @@ brj
 brj
 fmf
 jlx
-jDL
-oGc
+uzn
+uzn
 jlx
 cCR
 brj
@@ -116553,7 +115568,7 @@ bsu
 qPM
 ixQ
 ixQ
-xvA
+eGr
 eGr
 ixQ
 ixQ
@@ -119114,12 +118129,12 @@ tTU
 kyP
 pLe
 xgH
-qng
+dyS
 uya
 uya
 uya
 uya
-xbj
+dyS
 xgH
 twx
 dyS
@@ -119628,12 +118643,12 @@ oMV
 dyS
 dyS
 qLN
-nWf
+dyS
 ema
 ema
 ema
 ema
-asU
+dyS
 xgH
 pLe
 dyS
@@ -120137,9 +119152,9 @@ rpj
 ppf
 uOT
 xgH
-iTJ
+gbh
 xee
-xbj
+dyS
 xgH
 rTt
 trD
@@ -126798,10 +125813,10 @@ whV
 whV
 whV
 jJm
-wgo
+sKW
 nSv
 vWS
-xyC
+erU
 crj
 nLk
 efr
@@ -127052,7 +126067,7 @@ foI
 iGz
 nnN
 whV
-spa
+kSp
 bcK
 bcK
 kSp
@@ -127824,7 +126839,7 @@ jJm
 nQw
 jJm
 kSp
-waX
+jJm
 vwJ
 bMD
 aut
@@ -129663,7 +128678,7 @@ aIV
 xgH
 eKk
 hdA
-uLj
+eVk
 bQV
 bQV
 gaH
@@ -133760,7 +132775,7 @@ igQ
 wec
 fOq
 sQD
-iAS
+eJA
 uRS
 pSG
 sQD
@@ -134531,7 +133546,7 @@ hTS
 rBP
 nag
 rBP
-oSt
+kwO
 dHd
 tNC
 sQD
@@ -136336,12 +135351,12 @@ xYU
 fYg
 fvP
 dEc
-bhb
+ulU
 vcr
 eCr
 uhx
 vcr
-kUe
+xep
 wRM
 nJt
 nJt
@@ -137878,12 +136893,12 @@ unW
 dEc
 mSe
 uov
-wWm
+uov
 bwL
 bwL
 bwL
 bwL
-xzr
+uov
 nsX
 vcr
 cIW
@@ -174866,7 +173881,7 @@ bQv
 tEb
 rYw
 uUG
-wpa
+kEI
 wwu
 wwu
 wwu
@@ -175633,11 +174648,11 @@ ebA
 lXs
 gqP
 gqP
-nRn
+kEI
 lGh
 lGh
 lGh
-lMx
+kEI
 wwu
 mdC
 tTB
@@ -176404,11 +175419,11 @@ ebA
 lXs
 gqP
 gqP
-wpa
+kEI
 egD
 tqw
 ozn
-xNX
+kEI
 pgS
 wwu
 xXe
@@ -176918,7 +175933,7 @@ crd
 wwu
 wwu
 wwu
-nRn
+kEI
 eLK
 tqw
 cWF
@@ -177689,11 +176704,11 @@ wwu
 cNf
 bDr
 wwu
-wpa
+kEI
 roe
 roe
 roe
-pFy
+dAk
 gaf
 vlo
 qln
@@ -178232,7 +177247,7 @@ hLz
 uXA
 hLz
 jVu
-wuS
+hpW
 hLz
 hLz
 fGy
@@ -179517,11 +178532,11 @@ hLz
 uXA
 uXA
 uXA
-tbh
+uXA
 wNb
 wNb
 wNb
-hoK
+jly
 jJu
 kxh
 lvM
@@ -184655,7 +183670,7 @@ vXT
 vXT
 vXT
 vXT
-nnU
+vaF
 ssy
 xop
 mSZ
@@ -188265,7 +187280,7 @@ dWR
 aal
 cdH
 cda
-kcy
+ybG
 fzm
 aal
 aal
@@ -190065,7 +189080,7 @@ aal
 gzw
 gzw
 gzw
-rHP
+xit
 aal
 aal
 ucA
@@ -190787,7 +189802,7 @@ vnK
 vnK
 vnK
 uBW
-nCd
+kpt
 sHv
 kpt
 kRS
@@ -199828,7 +198843,7 @@ aal
 oVH
 oVH
 aal
-pHQ
+ybG
 iRN
 iRN
 aal
@@ -202101,9 +201116,9 @@ mPw
 mPw
 mPw
 uJs
-isk
+mPw
 syP
-rgE
+mPw
 mPw
 dEt
 lgO
@@ -202643,12 +201658,12 @@ rGL
 qjn
 wkw
 aXC
-foB
+qjn
 eCK
 qWN
 vqx
 jOj
-uLk
+xui
 xui
 xui
 xui
@@ -207779,7 +206794,7 @@ hQT
 oyh
 oyh
 hQT
-ilK
+oyh
 oyh
 oyh
 oyh
@@ -239898,7 +238913,7 @@ vpa
 gec
 qTD
 bks
-bks
+rXZ
 bks
 myU
 viZ
@@ -242443,7 +241458,7 @@ ucA
 ucA
 iTg
 aZN
-oXd
+pRs
 soz
 ucA
 xuh
@@ -242737,7 +241752,7 @@ gwL
 gwL
 xwI
 vuN
-rMc
+gyp
 oIj
 gwL
 jPd
@@ -244032,7 +243047,7 @@ gwL
 uQL
 niP
 lGK
-uep
+dso
 eZa
 eZa
 eZa
@@ -245321,7 +244336,7 @@ gwL
 gwL
 gwL
 vGT
-ryz
+dso
 gwL
 gwL
 ucA
@@ -245546,7 +244561,7 @@ upT
 lXW
 aYJ
 ccp
-pDX
+ccp
 upT
 sjX
 rdK
@@ -250459,7 +249474,7 @@ tGn
 tGn
 teV
 mUA
-ewH
+xpH
 eJl
 mUA
 tGn
@@ -250973,7 +249988,7 @@ tGn
 npO
 bGc
 qwy
-rSu
+ajs
 tDf
 mUA
 tGn
@@ -252773,7 +251788,7 @@ tGn
 tGn
 tGn
 tGn
-vFJ
+pSl
 mzA
 tGn
 tGn
@@ -253027,10 +252042,10 @@ dfp
 qfT
 ldq
 tGn
-vFJ
+pSl
 fvb
 fvb
-uxD
+tDf
 aGQ
 tGn
 tGn
@@ -253798,10 +252813,10 @@ lvs
 uZc
 tGn
 qCv
-jQK
+pSl
 kYC
 mex
-xJW
+pSl
 pSl
 cHT
 cHT
@@ -254569,11 +253584,11 @@ mms
 dYf
 tGn
 ajs
-ryX
+jPG
 fBa
 fBa
 fBa
-lKh
+jPG
 tGn
 tGn
 ucA
@@ -255597,11 +254612,11 @@ uwG
 kVM
 tGn
 mwg
-vKw
+jPG
 wNH
 oxJ
 wNH
-geL
+jPG
 tGn
 tGn
 ucA
@@ -257093,7 +256108,7 @@ qrd
 qrd
 qrd
 qrd
-iEU
+mLk
 qrd
 qrd
 sSB
@@ -257380,7 +256395,7 @@ wpI
 kNT
 ufN
 lFa
-scu
+ufN
 dDF
 eLw
 nVl
@@ -258127,7 +257142,7 @@ qrd
 hqR
 jmU
 jmU
-iYA
+sSB
 ejP
 qrd
 eoe
@@ -258638,7 +257653,7 @@ qrd
 xRM
 hVI
 eir
-dfA
+hqR
 aea
 aVs
 iGh
@@ -258898,7 +257913,7 @@ qrd
 sSB
 aaw
 lFw
-kQo
+sSB
 isU
 cdj
 eAi
@@ -263008,11 +262023,11 @@ cIM
 kRw
 fKd
 csM
-kgK
+blF
 knk
-bSj
+fzw
 rws
-akh
+fzw
 sXX
 kLM
 fzw
@@ -263522,13 +262537,13 @@ cIM
 kRw
 fKd
 ngr
-quA
+blF
 tjc
-anW
+fzw
 pdO
-kCk
+fzw
 ePH
-bIk
+wjm
 tXV
 iMN
 eIz
@@ -263822,7 +262837,7 @@ biO
 piR
 qeX
 cvf
-nko
+pOn
 rIY
 lRh
 piR
@@ -264807,14 +263822,14 @@ cIM
 kRw
 iMN
 kjp
-kgK
+blF
 mAJ
 fll
 hav
 mJy
 kKE
-baa
-fio
+wjm
+bTe
 dCW
 dCW
 dCW
@@ -265364,7 +264379,7 @@ pOn
 pOn
 pOn
 pOn
-oCe
+pOn
 uKD
 rTv
 piR
@@ -265830,10 +264845,10 @@ ucA
 ucA
 kRw
 kRw
-tdB
+cIM
 oxP
 xhC
-kKG
+cIM
 kRw
 aNz
 ciM
@@ -266601,10 +265616,10 @@ ucA
 ucA
 kRw
 kRw
-ssz
+cIM
 cWY
 veA
-ata
+cIM
 kRw
 qgh
 ciM
@@ -267639,7 +266654,7 @@ qjq
 eJc
 jOT
 nHf
-aZI
+cIM
 kRw
 kRw
 kRw
@@ -268433,12 +267448,12 @@ sjH
 uqi
 uqi
 uqi
-gKO
+uqi
 kRO
 aYq
 aYq
 aYq
-aqR
+pOn
 pOn
 pOn
 pOn
@@ -273308,11 +272323,11 @@ ucA
 ucA
 ucA
 ucA
-xKt
+ucA
 djc
 djc
 djc
-dkn
+ucA
 ucA
 ucA
 ucA
@@ -305938,7 +304953,7 @@ yjN
 uxw
 aLb
 eGK
-bJN
+bNb
 gEB
 cmw
 cHz
@@ -307245,7 +306260,7 @@ uIx
 rhJ
 rhJ
 rhJ
-pTI
+bxc
 rao
 iES
 voT
@@ -309802,7 +308817,7 @@ wjj
 oKq
 bJV
 hWp
-mdE
+gxn
 uPX
 ogl
 czp
@@ -310294,7 +309309,7 @@ xHe
 kqp
 dIQ
 dIQ
-gmA
+hto
 uxw
 jBa
 xHe
@@ -313123,7 +312138,7 @@ bYl
 kiw
 exv
 wMU
-fLX
+fPd
 ixd
 bDn
 gwe
@@ -313894,7 +312909,7 @@ sab
 vuB
 vuB
 vuB
-hfE
+vuB
 bep
 hnG
 pNa
@@ -318309,7 +317324,7 @@ duZ
 vEa
 fXs
 fXs
-uZG
+tPS
 sOU
 ncB
 ncB
@@ -319592,8 +318607,8 @@ sWo
 jvz
 wyv
 ycM
-nXQ
-nXQ
+bGM
+bGM
 ukr
 bzM
 ncB
@@ -321137,7 +320152,7 @@ ycM
 noA
 noA
 noA
-iZi
+pze
 ncB
 ncB
 ucA
@@ -325206,7 +324221,7 @@ wiu
 rem
 rNo
 wOt
-blq
+rNo
 rNo
 oHC
 oHC
@@ -332688,11 +331703,11 @@ vyR
 vyR
 vyR
 oyh
-pwH
-hQT
-ijJ
+oyh
 hQT
 ilK
+hQT
+oyh
 oyh
 oyh
 oyh
@@ -333716,11 +332731,11 @@ vyR
 vyR
 vyR
 vyR
+oyh
+itT
 qWn
 itT
-gZG
-itT
-gnj
+oyh
 oyh
 oyh
 oyh
@@ -335006,7 +334021,7 @@ oyh
 oyh
 acl
 acl
-xUk
+ucA
 ucA
 ucA
 ucA
@@ -336774,7 +335789,7 @@ ucA
 ucA
 eEE
 cUq
-qUV
+bjb
 lzq
 ucA
 ucA
@@ -338844,11 +337859,11 @@ ucA
 ucA
 ucA
 ucA
-xKt
+ucA
 djc
 djc
 djc
-dkn
+ucA
 ucA
 ucA
 ucA

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1424,6 +1424,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
+"dY" = (
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/landmark/navigate_destination/centcom/borbop,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/borbop)
 "dZ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -2689,6 +2695,10 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/mineral/titanium/tiled,
 /area/centcom/syndicate_mothership/control)
+"hV" = (
+/obj/effect/landmark/navigate_destination/centcom/boxing,
+/turf/open/floor/carpet,
+/area/centcom/central_command_areas/hall)
 "hX" = (
 /obj/machinery/light/floor/has_bulb,
 /obj/item/kirbyplants{
@@ -3995,6 +4005,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation/ship)
+"mg" = (
+/obj/effect/landmark/navigate_destination/centcom/hydro,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/botany)
 "mh" = (
 /obj/structure/bed,
 /obj/item/bedsheet/centcom,
@@ -4671,6 +4685,7 @@
 "ok" = (
 /obj/structure/fight_button,
 /obj/machinery/light/floor/has_bulb,
+/obj/effect/landmark/navigate_destination/centcom/duelbutton,
 /turf/open/floor/wood/large,
 /area/centcom/tdome/observation)
 "ol" = (
@@ -8972,6 +8987,10 @@
 /obj/machinery/vending/hydroseeds,
 /turf/open/floor/iron/dark/small,
 /area/centcom/central_command_areas/botany)
+"Bj" = (
+/obj/effect/landmark/navigate_destination/centcom/dresser,
+/turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/hall)
 "Bk" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/turf_decal/siding/wood{
@@ -15380,6 +15399,10 @@
 "Uz" = (
 /turf/closed/indestructible/fakeglass,
 /area/centcom/central_command_areas/hall)
+"UA" = (
+/obj/effect/landmark/navigate_destination/centcom/medical,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/medical)
 "UB" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
@@ -16872,6 +16895,11 @@
 /obj/item/kirbyplants/fullysynthetic,
 /turf/open/floor/mineral/titanium/white,
 /area/centcom/central_command_areas/admin)
+"Zj" = (
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/effect/landmark/navigate_destination/centcom/kitchen,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/kitchen)
 "Zk" = (
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/plating,
@@ -56661,7 +56689,7 @@ LK
 kM
 cc
 XE
-XE
+mg
 Zp
 PO
 YZ
@@ -60313,7 +60341,7 @@ wf
 wf
 wf
 wf
-wf
+hV
 vh
 sb
 sb
@@ -60515,7 +60543,7 @@ IV
 GX
 tK
 gr
-ao
+Zj
 ao
 cE
 qT
@@ -60544,7 +60572,7 @@ fD
 Lh
 Jm
 Jm
-uq
+dY
 Iy
 ui
 Jm
@@ -62369,7 +62397,7 @@ GJ
 aA
 qK
 qK
-qK
+Bj
 qK
 qK
 OA
@@ -64367,7 +64395,7 @@ cu
 Nb
 XW
 Cx
-Nb
+UA
 Ca
 Re
 vS

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -9408,9 +9408,6 @@
 /area/station/cargo/miningdock)
 "bKe" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
@@ -16508,7 +16505,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/ladder,
 /obj/structure/railing{
-	dir = 9;
 	layer = 3.1
 	},
 /turf/open/openspace,
@@ -20777,7 +20773,6 @@
 	dir = 1
 	},
 /obj/structure/railing{
-	dir = 10;
 	layer = 3.1
 	},
 /turf/open/openspace,
@@ -26553,7 +26548,6 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	dir = 9;
 	layer = 3.1
 	},
 /turf/open/floor/plating,
@@ -43294,14 +43288,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"mQi" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "mQk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -44880,16 +44866,6 @@
 /obj/machinery/door/airlock/public/glass,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/central/greater)
-"nqB" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "nqG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46345,9 +46321,6 @@
 /area/station/bitrunning/den)
 "nPp" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 8
-	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "nPv" = (
@@ -52421,7 +52394,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/structure/railing{
-	dir = 9;
 	layer = 3.1
 	},
 /obj/structure/railing{
@@ -53543,9 +53515,14 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "qir" = (
-/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/plastic,
+/obj/structure/railing{
+	dir = 4
+	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/medical)
 "qit" = (
@@ -53776,7 +53753,6 @@
 	dir = 4
 	},
 /obj/structure/railing{
-	dir = 9;
 	layer = 3.1
 	},
 /turf/open/floor/plating,
@@ -68350,9 +68326,14 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "uQP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
+	},
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 5
+	},
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/lesser)
@@ -115437,7 +115418,7 @@ hZr
 pHM
 hZr
 djX
-mQi
+hYn
 ixc
 ixc
 bNz
@@ -117241,7 +117222,7 @@ nPp
 gTl
 bKe
 eno
-nqB
+qud
 vXM
 vXM
 mzx

--- a/monkestation/_maps/RandomBars/Icebox/junglebar.dmm
+++ b/monkestation/_maps/RandomBars/Icebox/junglebar.dmm
@@ -103,6 +103,7 @@
 /area/station/commons/lounge)
 "hi" = (
 /obj/machinery/firealarm/directional/east,
+/obj/structure/chair/sofa/left/brown,
 /turf/open/misc/grass/jungle,
 /area/station/commons/lounge)
 "ho" = (
@@ -297,6 +298,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/dim/directional/north,
+/obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "Es" = (
@@ -356,12 +358,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"JV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "Ke" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -371,9 +367,6 @@
 /area/station/commons/lounge)
 "Km" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/restaurant_portal/bar,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
@@ -431,7 +424,9 @@
 /area/station/service/bar)
 "QV" = (
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "Rp" = (
@@ -448,6 +443,12 @@
 /obj/machinery/light/dim/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"Tg" = (
+/obj/machinery/holopad,
+/turf/open/misc/dirt/jungle/wasteland{
+	slowdown = 0
+	},
+/area/station/commons/lounge)
 "TK" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -455,6 +456,14 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
+"Vc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "Vd" = (
@@ -489,7 +498,6 @@
 /obj/structure/cable,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "YU" = (
@@ -509,7 +517,7 @@ EK
 tV
 xY
 OC
-Ke
+Vc
 TK
 YA
 pl
@@ -548,7 +556,7 @@ de
 EK
 EK
 EK
-ac
+xY
 Xr
 Xr
 dB
@@ -587,7 +595,7 @@ EK
 EK
 "}
 (7,1,1) = {"
-JV
+HP
 Xr
 mL
 LG
@@ -620,7 +628,7 @@ tx
 GX
 Mt
 qR
-qR
+Tg
 qR
 Xr
 Xr

--- a/monkestation/code/game/objects/effects/landmark.dm
+++ b/monkestation/code/game/objects/effects/landmark.dm
@@ -5,34 +5,49 @@
 
 /obj/effect/landmark/navigate_destination/common/portbowsolar
 	location = "Port Bow Solar Array"
+
 /obj/effect/landmark/navigate_destination/common/portquartersolar
 	location = "Port Quarter Solar Array"
+
 /obj/effect/landmark/navigate_destination/common/starboardbowsolar
 	location = "Starboard Bow Solar Array"
+
 /obj/effect/landmark/navigate_destination/common/starboardquartersolar
 	location = "Starboard Quarter Solar Array"
+
 /obj/effect/landmark/navigate_destination/common/fitness
 	location = "Fitness"
+
 /obj/effect/landmark/navigate_destination/common/cryogenics
 	location = "Cryogenics"
+
 /obj/effect/landmark/navigate_destination/common/vaccommissary
 	location = "Vacant Commissary"
+
 /obj/effect/landmark/navigate_destination/common/artstorage
 	location = "Art Storage"
+
 /obj/effect/landmark/navigate_destination/common/barber
 	location = "Barber"
+
 /obj/effect/landmark/navigate_destination/common/auxbaseconst
 	location = "Aux Base Construction"
+
 /obj/effect/landmark/navigate_destination/common/holodeck
 	location = "Holodeck"
+
 /obj/effect/landmark/navigate_destination/common/construction
 	location = "Construction Site"
+
 /obj/effect/landmark/navigate_destination/common/shitter
 	location = "Toilet"
+
 /obj/effect/landmark/navigate_destination/common/bitrunner
 	location = "Bitrunner Den"
+
 /obj/effect/landmark/navigate_destination/common/theatrebackstage
 	location = "Theatre Backstage"
+
 /obj/effect/landmark/navigate_destination/common/dorms
 	location = "Dormitories"
 
@@ -65,24 +80,56 @@
 
 
 // Deltastation specific
+
 /obj/effect/landmark/navigate_destination/delta/abandsci
 	location = "Abandoned Science Labs"
+
 /obj/effect/landmark/navigate_destination/delta/abandgambling
 	location = "Abandoned Gambling Den"
+
 /obj/effect/landmark/navigate_destination/delta/abandlibrary
 	location = "Abandoned Library"
+
 /obj/effect/landmark/navigate_destination/delta/evamaint
 	location = "EVA Maintenance"
+
 /obj/effect/landmark/navigate_destination/delta/pioffice
 	location = "Private Investigator's Office"
+
 /obj/effect/landmark/navigate_destination/delta/abandtheatre
 	location = "Abandoned Theatre"
+
 /obj/effect/landmark/navigate_destination/delta/abandkitchen
 	location = "Abandoned Kitchen"
+
 /obj/effect/landmark/navigate_destination/delta/abandgameroom
 	location = "Abandoned Game Den"
+
 /obj/effect/landmark/navigate_destination/delta/abandmedbay
 	location = "Abandoned Medbay"
+
 /obj/effect/landmark/navigate_destination/delta/abandmarketbay
 	location = "Abandoned Market Bay"
+
+// Centcom Areas
+/obj/effect/landmark/navigate_destination/centcom/medical
+	location = "CentCom Medical"
+
+/obj/effect/landmark/navigate_destination/centcom/hydro
+	location = "CentCom Hydroponics"
+
+/obj/effect/landmark/navigate_destination/centcom/borbop
+	location = "Borbop's Bar"
+
+/obj/effect/landmark/navigate_destination/centcom/kitchen
+	location = "CentCom Kitchen"
+
+/obj/effect/landmark/navigate_destination/centcom/duelbutton
+	location = "Thunderdome"
+
+/obj/effect/landmark/navigate_destination/centcom/boxing
+	location = "Boxing Ring"
+
+/obj/effect/landmark/navigate_destination/centcom/dresser
+	location = "Dressing Room"
 

--- a/monkestation/code/game/objects/effects/landmark.dm
+++ b/monkestation/code/game/objects/effects/landmark.dm
@@ -70,14 +70,7 @@
 /obj/effect/landmark/navigate_destination/oshan/miningelevator
 	location = "Miners' Elevator"
 
-
-// Northstar Specific
-
-
-
 // Metastation Specific
-
-
 
 // Deltastation specific
 


### PR DESCRIPTION

## About The Pull Request

More map QOL mostly. Added nav functions to CentCom for Intern Ghosts.

As a note, this is my final PR that will touch Northstar as it has been discussed and Northstar shall be removed from rotation due to its LONG list of problems that it has. It is very unfortunate but understandable that Northstar just has to go away. Not just because of a lack of population on average days, but because it runs exceptionally poorly.
## Why It's Good For The Game

People like fixes and progress.
## Changelog
:cl:
add: Centcom map now has nav support
add: Icebox now has cryo signs in spots to point towards the room, because its on lower Z level.
fix: Fixed railings on Delta, Meta, Icebox.
del: Lots of railings on Northstar
add: Icebox now has signs next to the stairs to the morgue to help indicate where the Morgue is (z level problems and navigate)
/:cl:
