### PR TITLE
Un-fries your boiled spagetti

### DIFF
--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -36,6 +36,7 @@
 	mix_message = "You smell something good coming from the steaming pot of soup."
 	reaction_tags = REACTION_TAG_FOOD | REACTION_TAG_EASY
 	reaction_flags = REACTION_NON_INSTANT
+	var/Nonsouprecipe = FALSE
 
 	// General soup guideline:
 	// - Soups should produce 60-90 units (3-4 servings)
@@ -188,14 +189,14 @@
 			continue
 
 		// Things that had reagents or ingredients in the soup will get deleted
-		if((!isnull(ingredient.reagents) || is_type_in_list(ingredient, required_ingredients)) && !is_type_in_list(ingredient, outputted_ingredients))
+		if((!isnull(ingredient.reagents) || is_type_in_list(ingredient, required_ingredients)) && !is_type_in_list(ingredient, outputted_ingredients) && !Nonsouprecipe) //monkeedit
 			// Send everything left behind
 			transfer_ingredient_reagents(ingredient, holder)
 			// Delete, it's done
 			qdel(ingredient)
 
 		// Everything else will just get fried
-		else
+		if (!Nonsouprecipe) //monkeedit
 			ingredient.AddElement(/datum/element/fried_item, 30)
 
 	//LAZYNULL(pot.added_ingredients)

--- a/monkestation/code/modules/food_and_drinks/recipes/boiling.dm
+++ b/monkestation/code/modules/food_and_drinks/recipes/boiling.dm
@@ -4,3 +4,4 @@
 	outputted_ingredients = list(/obj/item/food/spaghetti/boiledspaghetti = 1)
 	results = list(/datum/reagent/water = 5)
 	max_outputs = 10
+	Nonsouprecipe = TRUE


### PR DESCRIPTION

## About The Pull Request

Boiled spagetti recipe had an error where due to a series of procs, soup recipe would fry your boiled spagetti. Fixes this and adds a variable that disables frying ingredients for recipes when enabled.

## Why It's Good For The Game

Un-fries your spagetti so you can use it now

## Changelog

:cl:
fix: Un-fries your boiled spagetti
/:cl:

