### PR TITLE
Rebalance to "Throwing Arm" Quirk

### DIFF
--- a/code/datums/quirks/positive_quirks.dm
+++ b/code/datums/quirks/positive_quirks.dm
@@ -301,7 +301,7 @@
 
 /datum/quirk/throwingarm
 	name = "Throwing Arm"
-	desc = "Your arms have a lot of heft to them! Objects that you throw just always seem to fly further than everyone elses, and you never miss a toss."
+	desc = "Your arms have a lot of heft to them! You throw objects a bit further than other people, and you never miss a toss into a disposal bin." //monkestation edit
 	icon = "baseball"
 	value = 5 //monkestation edit
 	mob_trait = TRAIT_THROWINGARM

--- a/code/datums/quirks/positive_quirks.dm
+++ b/code/datums/quirks/positive_quirks.dm
@@ -303,7 +303,7 @@
 	name = "Throwing Arm"
 	desc = "Your arms have a lot of heft to them! Objects that you throw just always seem to fly further than everyone elses, and you never miss a toss."
 	icon = "baseball"
-	value = 7
+	value = 5 //monkestation edit
 	mob_trait = TRAIT_THROWINGARM
 	gain_text = span_notice("Your arms are full of energy!")
 	lose_text = span_danger("Your arms ache a bit.")


### PR DESCRIPTION

## About The Pull Request
In looking at the code, the throwing arm perk does exactly 2 things:

- Throwing an item into a trash can normally has a 25% chance to bounce out. With the perk, you'll never miss.
- With the perk, you can throw items 2 squares further normal. The default throw distance differs from item to item.

After speaking with Dexee, we feel like its more of a 5 point perk. I also updated the text so it clarifies "you'll never miss" means for trash cans.
## Why It's Good For The Game

- Clarifies description to make effect more apparent
- Rebalances perk that is relatively niche yet is 2nd most expensive perk available
## Changelog

- Updated code\datums\quirks\positive_quirks.dm
- Throwing Arm quirk cost changed from 7 to 5
- Throwing Arm quirk description updated
:cl: Senri
balance: rebalanced Throwing Arm quirk
/:cl:
