### PR TITLE
Ever More QOL Editing

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2213,6 +2213,7 @@
 /area/station/maintenance/disposal)
 "axz" = (
 /obj/machinery/light/directional/south,
+/obj/machinery/egg_incubator,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "axH" = (

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -12498,6 +12498,15 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"guf" = (
+/obj/machinery/plumbing/disposer{
+	dir = 1;
+	name = "Oshan Upgraded Water Disposal Unit";
+	buffer = 500;
+	disposal_rate = 50
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/central)
 "gul" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor/auto{
@@ -28341,6 +28350,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"ooe" = (
+/obj/machinery/plumbing/layer_manifold{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "ooi" = (
 /obj/structure/cable,
 /turf/open/floor/noslip{
@@ -30731,7 +30746,7 @@
 /turf/open/floor/carpet/executive,
 /area/station/command/bridge)
 "pAa" = (
-/obj/machinery/plumbing/disposer,
+/obj/machinery/plumbing/layer_manifold,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
 "pAg" = (
@@ -45076,6 +45091,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
+"wHW" = (
+/obj/machinery/plumbing/disposer{
+	name = "Oshan Upgraded Water Disposal Unit";
+	buffer = 500;
+	disposal_rate = 50
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/upper)
 "wId" = (
 /obj/machinery/light_switch/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -64287,7 +64310,7 @@ rdt
 pVn
 qZT
 pAa
-jMP
+guf
 uSV
 fXU
 fXU
@@ -84307,8 +84330,8 @@ qSI
 nRM
 tAk
 ksI
-fgS
-fgS
+wHW
+ooe
 rdb
 fgS
 wdA

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -4510,6 +4510,7 @@
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
 "cpK" = (

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -13021,6 +13021,7 @@
 /area/station/service/chapel/office)
 "gHM" = (
 /obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/bamboo,
 /area/station/commons/fitness)
 "gIh" = (
@@ -13050,6 +13051,7 @@
 /area/station/maintenance/starboard/aft)
 "gIB" = (
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/bamboo,
 /area/station/commons/fitness)
 "gIV" = (
@@ -33434,6 +33436,10 @@
 	icon_state = "clown_carpet"
 	},
 /area/station/commons/dorms)
+"qQg" = (
+/obj/structure/cable,
+/turf/open/floor/bamboo,
+/area/station/commons/fitness)
 "qQx" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -65341,7 +65347,7 @@ sFP
 sFP
 sFP
 egP
-rYQ
+qQg
 dPH
 oHO
 afI
@@ -65594,11 +65600,11 @@ hdv
 oWO
 vtb
 aYq
-rYQ
-rYQ
-rYQ
-rYQ
-rYQ
+qQg
+qQg
+qQg
+qQg
+qQg
 dPH
 tPb
 afI

--- a/_maps/map_files/Oshan/oshan.dmm
+++ b/_maps/map_files/Oshan/oshan.dmm
@@ -3710,6 +3710,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/ruin/space/ks13/engineering/secure_storage)
 "bRT" = (
@@ -7196,6 +7197,7 @@
 "dMc" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/locker)
 "dMe" = (
@@ -21551,6 +21553,7 @@
 /obj/structure/table/wood,
 /obj/item/gun/ballistic/shotgun/doublebarrel,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/bar/backroom)
 "kUG" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -11636,6 +11636,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
+/obj/machinery/smartfridge/drying_rack,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/kitchen)
 "Jx" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -53156,7 +53156,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Security Maintenance Hatch"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/eva)
 "qcY" = (
@@ -77682,10 +77682,10 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Security Maintenance Hatch"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/security/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/eva)
 "xSD" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -5016,6 +5016,7 @@
 /obj/machinery/cassette/adv_cassette_deck,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/vaporwave,
 /area/station/service/library/upper)
 "aDR" = (
@@ -6160,6 +6161,7 @@
 	c_tag = "Civilian - Library East"
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/vaporwave,
 /area/station/service/library/upper)
 "aMz" = (
@@ -67511,6 +67513,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/vaporwave,
 /area/station/service/library/upper)
 "uFD" = (


### PR DESCRIPTION
## About The Pull Request
More map fixes! Such joy! Two exceptionally minor ones this time. Delta station's egg incubator has been found. A drying rack is being built in CentCom for people to make more varieties of cheese at the kitchen. Fixed more doors in more stations.

Big change: OSHAN'S FLOOD PROTECTION NOW WORKS... better at least, each drain is a 3x3 centered on itself, and it ain't perfect. But both the "left" and "right" sides of the station now have a varedited chem disposer that works at TEN TIMES the base deletion speed and TEN TIMES the buffer. IT JUST WORKS.

## Why It's Good For The Game

Missing gear added. Added drying rack for cheese. Plus, slowly trying to make Oshan something thats more wanted by people.

## Changelog
:cl:
add: Deltastation now has an incubator
add: Centcom now has a drying rack for CHEESE!
fix: Oshan's fitness room didn't get wired. Now it is!
fix: Sec's maints door into the brig medical room is now fixed on tram. Other related doors now marked correctly.
add: Oshan chem disposers, var edited for efficient flood protection until they're inevitably bombed.
fix: power to DJ booth on Tram fixed
/:cl:
