### PR TITLE
Herald Shotgun Removal

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -138,9 +138,7 @@
 	if(target)
 		H.original = target
 	H.fire(set_angle)
-	if(is_trishot)
-		shoot_projectile(marker, set_angle + 15, FALSE, FALSE)
-		shoot_projectile(marker, set_angle - 15, FALSE, FALSE)
+	//monke edit - removed heralds shotgun BS from his tri shot
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/proc/herald_trishot(target)
 	ranged_cooldown = world.time + 30


### PR DESCRIPTION

## About The Pull Request

Heralds biggest issue is that when sentient, people opt to place his mirror, and spam his tri shot which fires a burst of three sets of three projectiles, which totals 18 PROJECTILES EVERY TWO SECONDS IN YOUR GENERAL DIRECTION making it nigh instant win, and god forbid your standing at point blank. Herald is supposed to be WEAKER than collosus. This changes it so he just fires a burst of three projectiles, without the fucking kunai fan ass shit.

## Why It's Good For The Game

Herald shouldnt be stronger than its boss counterpart.

## Changelog

:cl:
balance: Herald triple shot no longer shotgun fans. Its just three projectiles.
/:cl:

