### PR TITLE
Chemistry-related fixes

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -124,7 +124,11 @@
 	new /obj/item/storage/box/medigels(src)
 	new /obj/item/ph_booklet(src)
 	new /obj/item/reagent_containers/dropper(src)
+	//MONKESTATION REMOVAL START - FermiChem/pH chem is disabled, so having buffer bottles in the chemist lockers is a complete waste of time, space and processing power.
+	/*
 	new /obj/item/reagent_containers/cup/bottle/acidic_buffer(src) //hopefully they get the hint
+	*/
+	//MONKESTATION REMOVAL END
 
 /obj/structure/closet/secure_closet/chemical/heisenberg //contains one of each beaker, syringe etc.
 	name = "advanced chemical closet"

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -49,7 +49,11 @@
 	ears = /obj/item/radio/headset/headset_med
 	glasses = /obj/item/clothing/glasses/science
 	shoes = /obj/item/clothing/shoes/sneakers/white
+	//MONKESTATION REMOVAL START - FermiChem/pH chem is disabled, so having buffer bottles in the chemists starting loadout is a complete waste of time, space and processing power.
+	/*
 	l_pocket = /obj/item/reagent_containers/cup/bottle/random_buffer
+	*/
+	//MONKESTATION REMOVAL END
 	r_pocket = /obj/item/reagent_containers/dropper
 
 	backpack = /obj/item/storage/backpack/chemistry


### PR DESCRIPTION

## About The Pull Request

Simple monkestation edits to remove Buffer Bottles from chemist starting loadout and the random bottle in chem lockers as it is irrelevent.
## Why It's Good For The Game

Irrelevent items not existing means less crap at roundstart. It's not much, but it's honest work.
## Changelog
:cl:
del: Removed buffer bottles from Chemist job starting gear and the Chemist lockers.
/:cl:
