### PR TITLE
Fixes cargo borg reset invisibility

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -358,6 +358,7 @@
 	cut_overlays()
 	SSvis_overlays.remove_vis_overlay(src, managed_vis_overlays)
 	icon_state = model.cyborg_base_icon
+	icon = model.cyborg_base_icon_file
 	if(stat != DEAD && !(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || IsStun() || IsParalyzed() || low_power_mode)) //Not dead, not stunned.
 		if(!eye_lights)
 			eye_lights = new()

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -21,6 +21,8 @@
 	var/model_select_icon = "nomod"
 	///Produces the icon for the borg and, if no special_light_key is set, the lights
 	var/cyborg_base_icon = "robot"
+	///Keeps track of alternate icon files for the borg
+	var/cyborg_base_icon_file = 'icons/mob/silicon/robots.dmi'
 	///If we want specific lights, use this instead of copying lights in the dmi
 	var/special_light_key
 	///Holds all the usable modules (tools)
@@ -238,6 +240,7 @@
 	cyborg.diag_hud_set_status()
 	cyborg.diag_hud_set_borgcell()
 	cyborg.diag_hud_set_aishell()
+	cyborg.update_icons()
 	log_silicon("CYBORG: [key_name(cyborg)] has transformed into the [new_model] model.")
 
 	INVOKE_ASYNC(new_model, PROC_REF(do_transform_animation))

--- a/monkestation/code/modules/cargoborg/code/cargo_module.dm
+++ b/monkestation/code/modules/cargoborg/code/cargo_module.dm
@@ -29,6 +29,7 @@
 	)
 	hat_offset = 0
 	cyborg_base_icon = "cargo"
+	cyborg_base_icon_file = 'monkestation/code/modules/cargoborg/icons/robots_cargo.dmi'
 	model_select_icon = "cargo"
 	canDispose = TRUE
 	borg_skins = list(


### PR DESCRIPTION

## About The Pull Request

There is an issue where a borg reset from one of the modular-file icons (such as the cargo borgs) would become invisible.  This fixes that.

https://github.com/Monkestation/Monkestation2.0/issues/321

Basically, nothing kept track of the icon file for the borg, so it never got reset from the modular file to the base file.  This adds a variable to /obj/item/robot_model that keeps track of custom files, and an update_icon to ensure it gets applied properly.  It should work for any future models as long as the file is defined for them.

## Why It's Good For The Game

INVISIBLE BORGS AAAAAAAAAAAAAA

## Changelog

:cl:
fix: cargo, zoomba and kerfus borgs should no longer go invisible when reset
/:cl:
