### PR TITLE
Fixes the tram's fax machine being un-accessible round-start

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -24859,10 +24859,9 @@
 /area/station/engineering/storage/tech)
 "gSi" = (
 /obj/structure/table,
-/obj/item/folder/yellow,
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
+/obj/machinery/fax{
+	fax_name = "Quartermaster's Office";
+	name = "Quartermaster's Fax Machine"
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/qm)
@@ -52687,12 +52686,14 @@
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
 "pUV" = (
-/obj/structure/table,
-/obj/item/clipboard,
-/obj/item/computer_disk/quartermaster,
-/obj/item/computer_disk/quartermaster,
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/structure/table,
+/obj/item/folder/yellow,
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
 	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/qm)
@@ -53956,7 +53957,10 @@
 /turf/open/floor/engine,
 /area/station/science/explab)
 "qqw" = (
-/obj/machinery/pdapainter/supply,
+/obj/item/computer_disk/quartermaster,
+/obj/item/computer_disk/quartermaster,
+/obj/item/clipboard,
+/obj/structure/table,
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/qm)
 "qqx" = (
@@ -73490,15 +73494,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "wuC" = (
-/obj/structure/table,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /obj/structure/sign/calendar/directional/west,
-/obj/machinery/fax{
-	fax_name = "Quartermaster's Office";
-	name = "Quartermaster's Fax Machine"
-	},
+/obj/machinery/pdapainter/supply,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "wuF" = (


### PR DESCRIPTION

## About The Pull Request

The fax machine on tram is unable to be used without opening the locker currently, this moves around some machinery to make it possible

## Why It's Good For The Game

Its neat to be able to access the fax machine round-start without opening your locker

## Changelog

:cl:
fix: The fax machine on tram is once again usable without opening QM's locker
/:cl:
