### PR TITLE
Storytellers fixes

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -333,7 +333,7 @@ Runs the event
 						return
 			message_admins("[key_name_admin(usr)] force scheduled event [src.name].")
 			log_admin_private("[key_name(usr)] force scheduled event [src.name].")
-			SSgamemode.forced_next_events[src.track] += src
+			SSgamemode.forced_next_events[src.track] = src
 
 //monkestation addition ends - STORYTELLERS
 

--- a/monkestation/code/modules/storytellers/converted_events/_base_event.dm
+++ b/monkestation/code/modules/storytellers/converted_events/_base_event.dm
@@ -229,11 +229,10 @@
 		if(!candidate.mind)
 			candidate.mind = new /datum/mind(candidate.key)
 
-		setup_minds += candidate.mind
 		var/mob/living/carbon/human/new_human = make_body(candidate)
-		candidate.mind.set_current(new_human)
-		candidate.mind.special_role = antag_flag
-		candidate.mind.restricted_roles = restricted_roles
+		new_human.mind.special_role = antag_flag
+		new_human.mind.restricted_roles = restricted_roles
+		setup_minds += new_human.mind
 	setup = TRUE
 
 


### PR DESCRIPTION

## About The Pull Request

Fixes wizard(and maybe some other things too) spawning without their antag datum by removing some redundancy with setting mind as well as adding the wrong mind instance to a list.
Removes an extra - that was breaking the entire forced events system.

## Why It's Good For The Game

AND THE BUGS GO CRUNCH CRUNCH CRUNCH

## Changelog
:cl:
fix: Admins can now actually force events
fix: fixed some midrounds spawning without their antag datum
/:cl:
