### PR TITLE
NTSS Independence - a little less free

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -440,7 +440,8 @@
 	With the NTSS Independence at your side, you can face any crisis head-on, knowing that the lives of your crew and survivors are in the hands of a vessel built on the principles of strength, bravery, and American ideals. \
 	Please note, In the face of a catastrophic event, the NTSS Independence shines as a true hero. Engineered to withstand extreme conditions, this shuttle fearlessly crashes into the space station, carving out a beachhead to facilitate the rescue and evacuation of survivors."
 	admin_notes = "This motherfucker is BIG. You might need to force dock it."
-	credit_cost = CARGO_CRATE_VALUE * 125
+	credit_cost = EMAG_LOCKED_SHUTTLE_COST * 5
+	emag_only = TRUE
 
 /datum/map_template/shuttle/emergency/monkey
 	suffix = "nature"

--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -440,7 +440,7 @@
 	With the NTSS Independence at your side, you can face any crisis head-on, knowing that the lives of your crew and survivors are in the hands of a vessel built on the principles of strength, bravery, and American ideals. \
 	Please note, In the face of a catastrophic event, the NTSS Independence shines as a true hero. Engineered to withstand extreme conditions, this shuttle fearlessly crashes into the space station, carving out a beachhead to facilitate the rescue and evacuation of survivors."
 	admin_notes = "This motherfucker is BIG. You might need to force dock it."
-	credit_cost = EMAG_LOCKED_SHUTTLE_COST * 5
+	credit_cost = EMAG_LOCKED_SHUTTLE_COST * 3.5
 	emag_only = TRUE
 
 /datum/map_template/shuttle/emergency/monkey


### PR DESCRIPTION

## About The Pull Request

Simply adjusts the cost for the NTSS Independence, as well as requiring a comms console to be emagged in order to purchase, given its ability to kill AND give crew weapons.

## Why It's Good For The Game

Some players have made thematic arguments for a shuttle that screams patriotism on our server. However, with its ability to crush players inside departures AND distribute weapons to the crew that don't die to the landing procedure, it seems more intuitive that it should fall under the "silly emag shuttle" category.

## Changelog

:cl:
balance: forced NTSS Independence to require emagging to purchase
balance: increased the cost to purchase the NTSS Independence
/:cl:

