### PR TITLE
Always Compile On Build

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -79,13 +79,14 @@ export const DmTarget = new Juke.Target({
     NamedVersionFile,
   ],
   outputs: ({ get }) => {
-    if (get(DmVersionParameter)) {
-      return []; // Always rebuild when dm version is provided
-    }
-    return [
-      `${DME_NAME}.dmb`,
-      `${DME_NAME}.rsc`,
-    ]
+    return []; //Always Rebuild
+	//if (get(DmVersionParameter)) {
+    //  return []; // Always rebuild when dm version is provided
+    //}
+    //return [
+    //  `${DME_NAME}.dmb`,
+    //  `${DME_NAME}.rsc`,
+    //]
   },
   executes: async ({ get }) => {
     await DreamMaker(`${DME_NAME}.dme`, {


### PR DESCRIPTION

## About The Pull Request
Always compile when you build (f5) rather than the random mess we have now.

## Changelog


:cl: Senri
qol: for developers - build should always compile now, no more fake compiling
/:cl:

