### PR TITLE
Takes miner medipens on station back down to how they should be(still very very strong)

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -255,7 +255,7 @@
 		return
 
 	to_chat(user,span_notice("You start manually releasing the low-pressure gauge..."))
-	if(!do_after(user, 0.5 SECONDS, affected_mob, interaction_key = DOAFTER_SOURCE_SURVIVALPEN))
+	if(!do_after(user, 10 SECONDS, affected_mob, interaction_key = DOAFTER_SOURCE_SURVIVALPEN))
 		return
 
 	amount_per_transfer_from_this = initial(amount_per_transfer_from_this) * 0.5


### PR DESCRIPTION

## About The Pull Request

Reverts our change making miner medipens only take half a second to be used on station.

## Why It's Good For The Game

Might be a good idea not to buff miner gear based on what miner mains say.

## Changelog
:cl:
balance: Reverts our change making miner medipens take only half a second to use on station
/:cl:
