### PR TITLE
Fixes invisible cyborgs and expand module

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -567,8 +567,9 @@
 		robot.SetLockdown(FALSE)
 	robot.set_anchored(FALSE)
 	REMOVE_TRAIT(robot, TRAIT_NO_TRANSFORM, REF(src))
+	robot.resize = 2
 	robot.hasExpanded = TRUE
-	robot.update_transform(2)
+	robot.update_transform()
 
 /obj/item/borg/upgrade/expand/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -358,7 +358,6 @@
 	cut_overlays()
 	SSvis_overlays.remove_vis_overlay(src, managed_vis_overlays)
 	icon_state = model.cyborg_base_icon
-	icon = model.cyborg_base_icon_file
 	if(stat != DEAD && !(HAS_TRAIT(src, TRAIT_KNOCKEDOUT) || IsStun() || IsParalyzed() || low_power_mode)) //Not dead, not stunned.
 		if(!eye_lights)
 			eye_lights = new()

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -21,8 +21,6 @@
 	var/model_select_icon = "nomod"
 	///Produces the icon for the borg and, if no special_light_key is set, the lights
 	var/cyborg_base_icon = "robot"
-	///Keeps track of alternate icon files for the borg
-	var/cyborg_base_icon_file = 'icons/mob/silicon/robots.dmi'
 	///If we want specific lights, use this instead of copying lights in the dmi
 	var/special_light_key
 	///Holds all the usable modules (tools)
@@ -228,6 +226,7 @@
 	var/mob/living/silicon/robot/cyborg = loc
 	var/obj/item/robot_model/new_model = new new_config_type(cyborg)
 	new_model.robot = cyborg
+	cyborg.icon = 'icons/mob/silicon/robots.dmi' //reset our icon to default, but before a new custom icon may be applied by be_transformed_to
 	if(!new_model.be_transformed_to(src, forced))
 		qdel(new_model)
 		return

--- a/monkestation/code/modules/cargoborg/code/cargo_module.dm
+++ b/monkestation/code/modules/cargoborg/code/cargo_module.dm
@@ -29,7 +29,6 @@
 	)
 	hat_offset = 0
 	cyborg_base_icon = "cargo"
-	cyborg_base_icon_file = 'monkestation/code/modules/cargoborg/icons/robots_cargo.dmi'
 	model_select_icon = "cargo"
 	canDispose = TRUE
 	borg_skins = list(


### PR DESCRIPTION

## About The Pull Request

Fixes
https://github.com/Monkestation/Monkestation2.0/issues/592
https://github.com/Monkestation/Monkestation2.0/issues/595
https://github.com/Monkestation/Monkestation2.0/issues/616

This makes custom cyborg icons work properly (again), so cyborgs using the sprites from the modular file should no longer go invisible.  It also makes the expand module function properly.

## Why It's Good For The Game

INVISIBLE CYBORGS AAAAAAA
TINY CYBORGS AAAAAA

## Changelog

:cl:
fix: cyborgs should no longer go invisible upon changing model
fix: the expand module for cyborgs should once again work properly
/:cl:
