### PR TITLE
Botany TLC - Unused/unobtainable plants and mutations

### DIFF
--- a/code/modules/hydroponics/grown/beans.dm
+++ b/code/modules/hydroponics/grown/beans.dm
@@ -65,7 +65,7 @@
 	icon_dead = "bean-dead"
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	genes = list(/datum/plant_gene/trait/never_mutate, /datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/greenbean/jump)
+	possible_mutations = list(/datum/hydroponics/plant_mutation/greenbean_jump)
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/medicine/c2/multiver = 0.04) //They're good for you!
 	graft_gene = /datum/plant_gene/trait/never_mutate
 

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -272,9 +272,8 @@
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	icon_grow = "rose-grow"
 	icon_dead = "rose-dead"
-	mutatelist = list(/obj/item/seeds/carbon_rose)
-	//Roses are commonly used as herbal medicines (diarrhodons) and for their 'rose oil'.
-	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05, /datum/reagent/medicine/granibitaluri = 0.1, /datum/reagent/fuel/oil = 0.05)
+	possible_mutations = list(/datum/hydroponics/plant_mutation/rose_carbon)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.05, /datum/reagent/medicine/granibitaluri = 0.1)
 
 /obj/item/food/grown/rose
 	seed = /obj/item/seeds/rose

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -306,7 +306,7 @@
 	icon_state = "seed-carbonrose"
 	species = "carbonrose"
 	plantname = "Carbon Rose Flower"
-	product = /obj/item/grown/carbon_rose
+	product = /obj/item/food/grown/carbon_rose
 	endurance = 12
 	yield = 6
 	potency = 15
@@ -319,16 +319,14 @@
 	rarity = 10
 	graft_gene = /datum/plant_gene/reagent/preset/carbon
 
-/obj/item/grown/carbon_rose
+/obj/item/food/grown/carbon_rose
 	seed = /obj/item/seeds/carbon_rose
 	name = "carbon rose"
 	desc = "The all new fleur d'amour gris - the flower of love, modernized, with no harsh thorns."
 	icon_state = "carbonrose"
 	lefthand_file = 'icons/mob/inhands/weapons/plants_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/plants_righthand.dmi'
-	force = 0
-	throwforce = 0
 	slot_flags = ITEM_SLOT_HEAD
 	alternate_worn_layer = ABOVE_BODY_FRONT_HEAD_LAYER
-	throw_speed = 1
-	throw_range = 3
+	bite_consumption_mod = 2
+	foodtypes = VEGETABLES | GROSS

--- a/code/modules/hydroponics/grown/hedges.dm
+++ b/code/modules/hydroponics/grown/hedges.dm
@@ -12,6 +12,7 @@
 	yield = 2
 	growthstages = 3
 	reagents_add = list()
+	possible_mutations = list(/datum/hydroponics/plant_mutation/kudzu_vines)
 
 /obj/item/grown/shrub
 	seed = /obj/item/seeds/shrub

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -11,7 +11,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	icon_dead = "watermelon-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/watermelon/holy, /obj/item/seeds/watermelon/barrel)
+	possible_mutations = list(/datum/hydroponics/plant_mutation/melon_barrel, /datum/hydroponics/plant_mutation/holy_melon)
 	reagents_add = list(/datum/reagent/water = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.2)
 
 /obj/item/seeds/watermelon/suicide_act(mob/living/user)

--- a/code/modules/hydroponics/grown/peas.dm
+++ b/code/modules/hydroponics/grown/peas.dm
@@ -13,7 +13,7 @@
 	icon_grow = "peas-grow"
 	icon_dead = "peas-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = list(/obj/item/seeds/peas/laugh)
+	possible_mutations = list(/datum/hydroponics/plant_mutation/peas_laughin)
 	reagents_add = list (/datum/reagent/consumable/nutriment/vitamin = 0.1, /datum/reagent/consumable/nutriment = 0.05, /datum/reagent/water = 0.05)
 
 /obj/item/food/grown/peas
@@ -42,7 +42,7 @@
 	icon_grow = "laughpeas-grow"
 	icon_dead = "laughpeas-dead"
 	genes = list (/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/glow/purple, /datum/plant_gene/trait/plant_laughter)
-	mutatelist = list (/obj/item/seeds/peas/laugh/peace)
+	possible_mutations = list(/datum/hydroponics/plant_mutation/peas_world)
 	reagents_add = list (/datum/reagent/consumable/laughter = 0.05, /datum/reagent/consumable/sugar = 0.05, /datum/reagent/consumable/nutriment = 0.07)
 	rarity = 25 //It actually might make Central Command Officials loosen up a smidge, eh?
 	graft_gene = /datum/plant_gene/trait/plant_laughter
@@ -77,7 +77,7 @@
 	reagents_add = list (/datum/reagent/pax = 0.1, /datum/reagent/drug/happiness = 0.1, /datum/reagent/consumable/nutriment = 0.15)
 	rarity = 50 // This absolutely will make even the most hardened Syndicate Operators relax.
 	graft_gene = /datum/plant_gene/trait/glow/blue
-	mutatelist = null
+	possible_mutations = list()
 
 /obj/item/food/grown/peace
 	seed = /obj/item/seeds/peas/laugh/peace

--- a/code/modules/hydroponics/grown/pineapple.dm
+++ b/code/modules/hydroponics/grown/pineapple.dm
@@ -11,7 +11,6 @@
 	growthstages = 3
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/juicing)
-	mutatelist = list(/obj/item/seeds/apple)
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.02, /datum/reagent/consumable/nutriment = 0.2, /datum/reagent/water = 0.04)
 	graft_gene = /datum/plant_gene/trait/juicing
 

--- a/code/modules/hydroponics/grown/plum.dm
+++ b/code/modules/hydroponics/grown/plum.dm
@@ -13,7 +13,7 @@
 	icon_grow = "plum-grow"
 	icon_dead = "plum-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest, /datum/plant_gene/trait/one_bite)
-	mutatelist = list(/obj/item/seeds/plum/plumb)
+	possible_mutations = list(/datum/hydroponics/plant_mutation/plumb)
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/impurity/rosenol = 0.04)
 
 /obj/item/food/grown/plum
@@ -35,7 +35,7 @@
 	plantname = "Plumb Tree"
 	product = /obj/item/food/grown/plum/plumb
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
-	mutatelist = null
+	possible_mutations = list()
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1, /datum/reagent/lead = 0.04)
 	rarity = 30
 

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -251,7 +251,7 @@
 	species = "cactus"
 	plantname = "Fruiting Cactus"
 	product = /obj/item/food/grown/ash_flora/cactus_fruit
-	mutatelist = list(/obj/item/seeds/star_cactus)
+	possible_mutations = list(/datum/hydroponics/plant_mutation/star_cactus)
 	genes = list(/datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	growthstages = 2

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -18,6 +18,7 @@
 				/obj/item/seeds/cherry = 3,
 				/obj/item/seeds/chili = 3,
 				/obj/item/seeds/cocoapod = 3,
+				/obj/item/seeds/coconut = 3,
 				/obj/item/seeds/eggplant = 3,
 				/obj/item/seeds/grape = 3,
 				/obj/item/seeds/lemon = 3,

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -18,7 +18,6 @@
 				/obj/item/seeds/cherry = 3,
 				/obj/item/seeds/chili = 3,
 				/obj/item/seeds/cocoapod = 3,
-				/obj/item/seeds/coconut = 3,
 				/obj/item/seeds/eggplant = 3,
 				/obj/item/seeds/grape = 3,
 				/obj/item/seeds/lemon = 3,
@@ -95,6 +94,7 @@
 		/obj/item/seeds/cannabis = 3,
 		/obj/item/seeds/starthistle = 2,
 		/obj/item/seeds/cocaleaf = 2, // MONKESTATION ADDITION
+		/obj/item/seeds/coconut = 3, // MONKESTATION ADDITION
 		/obj/item/seeds/random = 2,
 	)
 

--- a/monkestation/code/game/objects/items/drugs/cocaine_item.dm
+++ b/monkestation/code/game/objects/items/drugs/cocaine_item.dm
@@ -143,7 +143,7 @@
 	potency = 20
 	growthstages = 1
 	product = /obj/item/food/grown/cocaleaf
-	mutatelist = list()
+	possible_mutations = list()
 	reagents_add = list(/datum/reagent/drug/cocaine = 0.3, /datum/reagent/consumable/nutriment = 0.15)
 
 /obj/item/food/grown/cocaleaf

--- a/monkestation/code/modules/hydroponics/mutations/base.dm
+++ b/monkestation/code/modules/hydroponics/mutations/base.dm
@@ -398,3 +398,8 @@
 	mutates_from = list(/obj/item/seeds/lavaland/cactus)
 	created_product = /obj/item/food/grown/star_cactus
 	created_seed = /obj/item/seeds/star_cactus
+
+/datum/hydroponics/plant_mutation/kudzu_vines
+	mutates_from = list(/obj/item/seeds/shrub)
+	created_product = /obj/item/food/grown/kudzupod
+	created_seed = /obj/item/seeds/kudzu

--- a/monkestation/code/modules/hydroponics/mutations/base.dm
+++ b/monkestation/code/modules/hydroponics/mutations/base.dm
@@ -363,3 +363,38 @@
 	created_product = /obj/item/grown/log/steel
 	created_seed = /obj/item/seeds/tower/steel
 	required_endurance = list(80, INFINITY)
+
+/datum/hydroponics/plant_mutation/greenbean_jump
+	mutates_from = list(/obj/item/seeds/greenbean)
+	created_product = /obj/item/food/grown/jumpingbeans
+	created_seed = /obj/item/seeds/greenbean/jump
+
+/datum/hydroponics/plant_mutation/melon_barrel
+	mutates_from = list(/obj/item/seeds/watermelon)
+	created_product = /obj/item/food/grown/barrelmelon
+	created_seed = /obj/item/seeds/watermelon/barrel
+
+/datum/hydroponics/plant_mutation/rose_carbon
+	mutates_from = list(/obj/item/seeds/rose)
+	created_product = /obj/item/grown/carbon_rose
+	created_seed = /obj/item/seeds/carbon_rose
+
+/datum/hydroponics/plant_mutation/peas_laughin
+	mutates_from = list(/obj/item/seeds/peas)
+	created_product = /obj/item/food/grown/laugh
+	created_seed = /obj/item/seeds/peas/laugh
+
+/datum/hydroponics/plant_mutation/peas_world
+	mutates_from = list(/obj/item/seeds/peas/laugh)
+	created_product = /obj/item/food/grown/peace
+	created_seed = /obj/item/seeds/peas/laugh/peace
+
+/datum/hydroponics/plant_mutation/plumb
+	mutates_from = list(/obj/item/seeds/plum)
+	created_product = /obj/item/food/grown/plum/plumb
+	created_seed = /obj/item/seeds/plum/plumb
+
+/datum/hydroponics/plant_mutation/star_cactus
+	mutates_from = list(/obj/item/seeds/lavaland/cactus)
+	created_product = /obj/item/food/grown/star_cactus
+	created_seed = /obj/item/seeds/star_cactus

--- a/monkestation/code/modules/hydroponics/mutations/base.dm
+++ b/monkestation/code/modules/hydroponics/mutations/base.dm
@@ -368,38 +368,53 @@
 	mutates_from = list(/obj/item/seeds/greenbean)
 	created_product = /obj/item/food/grown/jumpingbeans
 	created_seed = /obj/item/seeds/greenbean/jump
+	required_potency = list(70, INFINITY)
 
 /datum/hydroponics/plant_mutation/melon_barrel
 	mutates_from = list(/obj/item/seeds/watermelon)
 	created_product = /obj/item/food/grown/barrelmelon
 	created_seed = /obj/item/seeds/watermelon/barrel
+	required_endurance = list(60, INFINITY)
+	required_lifespan = list(40, INFINITY)
 
 /datum/hydroponics/plant_mutation/rose_carbon
 	mutates_from = list(/obj/item/seeds/rose)
 	created_product = /obj/item/food/grown/carbon_rose
 	created_seed = /obj/item/seeds/carbon_rose
+	required_lifespan = list(30, 50)
 
 /datum/hydroponics/plant_mutation/peas_laughin
 	mutates_from = list(/obj/item/seeds/peas)
 	created_product = /obj/item/food/grown/laugh
 	created_seed = /obj/item/seeds/peas/laugh
+	required_endurance = list(-INFINITY, 25)
+	required_potency = list(40, 50)
 
 /datum/hydroponics/plant_mutation/peas_world
 	mutates_from = list(/obj/item/seeds/peas/laugh)
 	created_product = /obj/item/food/grown/peace
 	created_seed = /obj/item/seeds/peas/laugh/peace
+	required_production = list(100, INFINITY)
+	required_yield = list(100, INFINITY)
 
 /datum/hydroponics/plant_mutation/plumb
 	mutates_from = list(/obj/item/seeds/plum)
 	created_product = /obj/item/food/grown/plum/plumb
 	created_seed = /obj/item/seeds/plum/plumb
+	required_endurance = list(60, INFINITY)
 
 /datum/hydroponics/plant_mutation/star_cactus
 	mutates_from = list(/obj/item/seeds/lavaland/cactus)
 	created_product = /obj/item/food/grown/star_cactus
 	created_seed = /obj/item/seeds/star_cactus
+	required_endurance = list(-INFINITY, 20)
+	required_yield = list(-INFINITY, 20)
 
 /datum/hydroponics/plant_mutation/kudzu_vines
 	mutates_from = list(/obj/item/seeds/shrub)
 	created_product = /obj/item/food/grown/kudzupod
 	created_seed = /obj/item/seeds/kudzu
+	required_production = list(90, 100)
+	required_endurance = list(60, 70)
+	required_yield = list(5, 10)
+	required_lifespan = list(-INFINITY, 20)

--- a/monkestation/code/modules/hydroponics/mutations/base.dm
+++ b/monkestation/code/modules/hydroponics/mutations/base.dm
@@ -376,7 +376,7 @@
 
 /datum/hydroponics/plant_mutation/rose_carbon
 	mutates_from = list(/obj/item/seeds/rose)
-	created_product = /obj/item/grown/carbon_rose
+	created_product = /obj/item/food/grown/carbon_rose
 	created_seed = /obj/item/seeds/carbon_rose
 
 /datum/hydroponics/plant_mutation/peas_laughin

--- a/monkestation/code/modules/hydroponics/seeds/coconut.dm
+++ b/monkestation/code/modules/hydroponics/seeds/coconut.dm
@@ -1,6 +1,6 @@
 /obj/item/seeds/coconut
-	name = "coconut tree"
-	desc = "A coconut tree."
+	name = "pack of Coconut seeds"
+	desc = "These seeds grow into coconut trees."
 	seed_offset = -12
 	icon = 'monkestation/icons/obj/hydroponics/fruit.dmi'
 	icon_state = "coconut_seed"

--- a/monkestation/code/modules/loadouts/items/heads.dm
+++ b/monkestation/code/modules/loadouts/items/heads.dm
@@ -378,7 +378,7 @@ GLOBAL_LIST_INIT(loadout_helmets, generate_loadout_items(/datum/loadout_item/hea
 
 /datum/loadout_item/head/donator/carbon_rose
 	name = "Carbon Rose Flower"
-	item_path = /obj/item/grown/carbon_rose
+	item_path = /obj/item/food/grown/carbon_rose
 
 /datum/loadout_item/head/donator/sunflower
 	name = "Sunflower"


### PR DESCRIPTION

## About The Pull Request

This PR brings forth from the depths a number of niche, unused, or unobtainable plants and mutations. Of note, holymelons' mutation was previously unobtainable due to a missing datum, coconuts were missing from the MegaSeed servitor, and kudzu was unobtainable (for both antags and non-antags) outside of event-based spawns. A number of other TG-based crops such as Laughin' Peas, Jumping Beans, and others were also given proper mutations and brought up-to-date with the current mutation system.

## Why It's Good For The Game

Botany gameplay, beyond simple service provisions, thrives off of niche plants used for ~wanton murder and grief~ interesting interactions with the crew. A number of common plants like holymelons and kudzu were unobtainable outright, and several other plants that weren't given botany's update after the rebase have gone unused and/or unknown to both veteran and new botanist players. Most of the plants in question add a handful of genes/reagents to botany's ~arsenal~ disposal, and kudzu in the hands of antagonists can be a much more significant threat to unprepared crews. Kudzu has been given some requirements in both botany chem knowledge AND interaction with cargo to acquire, and should ideally take a considerable amount of time to obtain at first- possibly enough for potential discovery by security, the HoP, or other crew.

Note: I am more than willing to make balance changes to kudzu or any other crops as needed in the future, but I genuinely hold the opinion that the lack of kudzu as a threat has led to botany being more or less overlooked as potential vector for antags in general (killer tomatoes and combustible lemons don't seem to concern players much). Whether this should be subject to change is up for debate.

## Changelog

:cl:
add: Added mutations for unused plants
add: long-sought coconut seeds to the MegaSeed vendor
fix: fixed mutations/genes for unused/unobtainable plants
qol: reintroduced kudzu as an obtainable crop outside of events, with a time-consuming process to obtain
/:cl:

