### PR TITLE
Refactor Guardian Creator item code; Fix Timestop Guardian to not overwrite Standard Guardian

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
@@ -1,19 +1,7 @@
 ///Bloodsuckers spawning a Guardian will get the Bloodsucker one instead.
-/obj/item/guardian_creator/spawn_guardian(mob/living/user, mob/dead/candidate)
-	var/list/guardians = user.get_all_linked_holoparasites()
-	if(length(guardians))
-		to_chat(user, span_holoparasite("You already have a [mob_name]!"))
-		used = FALSE
-		return
-	if(IS_BLOODSUCKER(user))
-		var/mob/living/basic/guardian/standard/timestop/bloodsucker_guardian = new(user, GUARDIAN_THEME_MAGIC)
-
-		bloodsucker_guardian.set_summoner(user, different_person = TRUE)
-		bloodsucker_guardian.key = candidate.key
-		user.log_message("has summoned [key_name(bloodsucker_guardian)], a [bloodsucker_guardian.creator_name] holoparasite.", LOG_GAME)
-		bloodsucker_guardian.log_message("was summoned as a [bloodsucker_guardian.creator_name] holoparasite.", LOG_GAME)
-		to_chat(user, replacetext(success_message, "%GUARDIAN", mob_name))
-		bloodsucker_guardian.client?.init_verbs()
+/obj/item/guardian_creator/attack_self(mob/living/user)
+	if(allowed_to_get_new_guardian(user) && IS_BLOODSUCKER(user))
+		poll_for_guardian_player(user, /mob/living/basic/guardian/standard/timestop)
 		return
 
 	// Call parent to deal with everyone else

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
@@ -6,7 +6,7 @@
 		used = FALSE
 		return
 	if(IS_BLOODSUCKER(user))
-		var/mob/living/basic/guardian/standard/bloodsucker_guardian = new(user, GUARDIAN_THEME_MAGIC)
+		var/mob/living/basic/guardian/standard/timestop/bloodsucker_guardian = new(user, GUARDIAN_THEME_MAGIC)
 
 		bloodsucker_guardian.set_summoner(user, different_person = TRUE)
 		bloodsucker_guardian.key = candidate.key
@@ -22,7 +22,7 @@
 /**
  * The Guardian itself
  */
-/mob/living/basic/guardian/standard
+/mob/living/basic/guardian/standard/timestop
 	// Like Bloodsuckers do, you will take more damage to Burn and less to Brute
 	damage_coeff = list(BRUTE = 0.5, BURN = 2.5, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 
@@ -30,7 +30,7 @@
 	creator_desc = "Devastating close combat attacks and high damage resistance. Can smash through weak walls and stop time."
 	creator_icon = "standard"
 
-/mob/living/basic/guardian/standard/Initialize(mapload, theme)
+/mob/living/basic/guardian/standard/timestop/Initialize(mapload, theme)
 	//Wizard Holoparasite theme, just to be more visibly stronger than regular ones
 	theme = GLOB.guardian_themes[GUARDIAN_THEME_TECH]
 	. = ..()

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
@@ -40,8 +40,9 @@
 ///Guardian Timestop ability
 /datum/action/cooldown/spell/timestop/guardian
 	name = "Guardian Timestop"
-	desc = "This spell stops time for everyone except for you and your master, \
-		allowing you to move freely while your enemies and even projectiles are frozen."
+	desc = "This spell stops time for everyone (including your master) in a \
+		small radius around you, allowing you to move freely while your \
+		enemies and even projectiles are frozen."
 	cooldown_time = 60 SECONDS
 	spell_requirements = NONE
 	invocation_type = INVOCATION_NONE


### PR DESCRIPTION
## About The Pull Request

This PR was originally started as a means of fixing Timestop Guardian so that it doesn't overwrite the Standard Guardian. Due to Timestop Guardian's abilities, it is very overpowered compared to Standard Guardian - making it an easy choice since everything else was just worse.

In the process of fixing and testing this, I found that Bloodsuckers would be offered a useless Guardian Type selection - despite the guardian type then being overwritten if you were a Bloodsucker. So I went about refactoring the code to ensure we could skip the type selection if need be.

**Please do not merge this yet. It is not finished.**

## Why It's Good For The Game

1. Guardian Creator item code is not organized well.
2. The Timestop Guardian shouldn't be overwriting the Standard Guardian.
3. The Guardian Timestop spell description is wrong. (see https://github.com/Monkestation/Monkestation2.0/issues/648) This fixes the description (subject to reverting if we figure out the spell is *supposed* to allow the master to move).

## Changelog

:cl: MichiRecRoom
fix: Timestop Guardian no longer overwrites the Standard Guardian, which additionally restricts Timestop Guardian to Bloodsuckers (as was intended)
fix: Guardian Timestop spell incorrectly stated that the master was exempt from the Timestop field
refactor: refactor Guardian Creator item code (and the Bloodsucker code along with it)
/:cl:
