### PR TITLE
Malf AI minimum player count + lowered to 3 weight

### DIFF
--- a/monkestation/code/modules/storytellers/converted_events/solo/malf.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/malf.dm
@@ -15,7 +15,8 @@
 	maximum_antags = 1
 	exclusive_roles = list(JOB_AI)
 	required_enemies = 4
-	weight = 4
+	min_players = 35
+	weight = 3
 	max_occurrences = 1
 
 /datum/round_event_control/antagonist/solo/malf/trim_candidates(list/candidates)


### PR DESCRIPTION

## About The Pull Request
As title states, adds a minimum player count requirement to malf AI, as it's very destructive and with the frequency of Malf AI occuring, players are reasonably upset about it. Also lowers it from 4 weight to 3, to make it less common.
## Why your change is good for the game
I believe this is a healthy change for the server and community.
## Changelog
:cl:
balance: added a minimum player count of 35 to Malfunctioning AI, and lowered weight to 3 for storyteller.
/:cl:
