### PR TITLE
Removes ability for players to initiate vote on  storytellers

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -206,9 +206,7 @@ SUBSYSTEM_DEF(vote)
 		if(vote_initiator)
 			to_chat(vote_initiator, span_warning("Invalid voting choice."))
 		return FALSE
-		
-	if(!to_vote.player_startable)
-		return FALSE
+
 	// Vote can't be initiated in our circumstances? No vote
 	if(!to_vote.can_be_initiated(vote_initiator, unlimited_vote_power))
 		return FALSE

--- a/code/datums/votes/_vote_datum.dm
+++ b/code/datums/votes/_vote_datum.dm
@@ -80,7 +80,7 @@
  */
 /datum/vote/proc/can_be_initiated(mob/by_who, forced = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
-	if(!player_startable)
+	if(!player_startable && !forced)
 		return FALSE
 
 	if(started_time)

--- a/code/datums/votes/_vote_datum.dm
+++ b/code/datums/votes/_vote_datum.dm
@@ -80,8 +80,10 @@
  */
 /datum/vote/proc/can_be_initiated(mob/by_who, forced = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
+	//monkestation edit begin
 	if(!player_startable && !forced)
 		return FALSE
+	//monkestation edit end
 
 	if(started_time)
 		var/next_allowed_time = (started_time + CONFIG_GET(number/vote_delay))

--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -2,7 +2,6 @@
 	name = "Map"
 	message = "Vote for next round's map!"
 	count_method = VOTE_COUNT_METHOD_MULTI
-	player_startable = FALSE //monkestation edit
 	donator_multiplier = 3 //monkestation addition
 
 /datum/vote/map_vote/New()

--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -2,6 +2,7 @@
 	name = "Map"
 	message = "Vote for next round's map!"
 	count_method = VOTE_COUNT_METHOD_MULTI
+	player_startable = FALSE
 	donator_multiplier = 3 //monkestation addition
 
 /datum/vote/map_vote/New()

--- a/code/datums/votes/map_vote.dm
+++ b/code/datums/votes/map_vote.dm
@@ -2,7 +2,7 @@
 	name = "Map"
 	message = "Vote for next round's map!"
 	count_method = VOTE_COUNT_METHOD_MULTI
-	player_startable = FALSE
+	player_startable = FALSE //monkestation edit
 	donator_multiplier = 3 //monkestation addition
 
 /datum/vote/map_vote/New()

--- a/monkestation/code/modules/storytellers/storytellers/vote.dm
+++ b/monkestation/code/modules/storytellers/storytellers/vote.dm
@@ -7,6 +7,7 @@
 	name = "Storyteller"
 	message = "Vote for the storyteller!"
 	has_desc = TRUE
+	player_startable = FALSE
 
 
 /datum/vote/storyteller/New()


### PR DESCRIPTION
## About The Pull Request
Players can no longer initiate storyteller votes.  They can still participate in them.

## Why It's Good For The Game
stops spam

## Changelog

:cl:
del: Players can no longer initiate storyteller or map votes.
/:cl:

