### PR TITLE
Update settings.json to no longer use the deprecated boolean value

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
 		"**/.pnp.*": true
 	},
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	},
 	"files.eol": "\n",
 	"files.insertFinalNewline": true,


### PR DESCRIPTION
## About The Pull Request
A recent VSCode update deprecated the boolean-style values under `editor.codeActionsOnSave` in favor of the string equivalents. From <https://code.visualstudio.com/updates/v1_85#_editor>:

> Editor: Code Actions On Save (editor.codeActionsOnSave) settings have been migrated over to corresponding enum values.
> [...]
> The setting value updates are as follows, with the previous boolean values to be deprecated in favor of the string equivalent.
> [...]
> `explicit` - Triggers Code Actions when explicitly saved. Same as `true`.

VSCode has been automatically updating `settings.json` to include this change, causing confusion to some coders.

Since the change makes no difference to the codebase, and because committing this change to `master` would remove coder's confusion, I'm making this PR.

## Why It's Good For The Game
SS13 is now deleted from existence, reducing strain on many developers who had to deal with BYOND in the past.

## Changelog

:cl: MichiRecRoom
config: Microsoft did a change to how VSCode handles `editor.codeActionsOnSave`, and so now VSCode will auto-update its contents to the string equivalents. This PR commits said string equivalents to the repository to prevent developer confusion. Nothing has changed about how you develop SS13.
/:cl: