### PR TITLE
Unit Test Fixes [Needs TM]

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -12673,10 +12673,6 @@
 	dir = 8
 	},
 /area/station/science/research)
-"dWv" = (
-/obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
-/turf/open/genturf,
-/area/icemoon/underground/unexplored/rivers/deep)
 "dWK" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/shovel/spade,
@@ -46702,9 +46698,7 @@
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
 /obj/structure/cable,
-/obj/machinery/power/terminal{
-	dir = 2
-	},
+/obj/machinery/power/terminal,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "oXc" = (
@@ -60092,9 +60086,7 @@
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "tqb" = (
-/obj/machinery/siren/weather{
-	dir = 2
-	},
+/obj/machinery/siren/weather,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "tqk" = (
@@ -78049,7 +78041,7 @@ oSU
 oSU
 oSU
 oSU
-dWv
+oSU
 oSU
 oSU
 oSU

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -20121,7 +20121,9 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen/diner)
 "gtg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
+	dir = 8
+	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "gti" = (
@@ -20937,6 +20939,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gHm" = (
@@ -23133,11 +23138,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "huZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "hvl" = (
 /obj/effect/turf_decal/siding/white,
@@ -28276,9 +28282,8 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
 "jdA" = (
-/obj/machinery/atmospherics/components/trinary/mixer/flipped/layer4{
-	dir = 8;
-	name = "Turbine Mixer'"
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Turbine"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -29885,6 +29890,9 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jIg" = (
@@ -30024,12 +30032,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "jJH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1,
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "jJM" = (
 /turf/open/floor/glass,
 /area/station/security/lockers)
@@ -30969,7 +30975,6 @@
 	dir = 9
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "jYL" = (
@@ -31567,8 +31572,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "khf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kho" = (
@@ -31835,11 +31841,15 @@
 	},
 /area/station/medical/chemistry)
 "klr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "klv" = (
 /obj/structure/chair/sofa/corp/corner{
@@ -32165,10 +32175,6 @@
 	name = "O2 To Pure"
 	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	dir = 1;
-	name = "O2 to Turbine"
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kqV" = (
@@ -36724,7 +36730,9 @@
 /area/station/commons/dorms)
 "lOI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
+	dir = 5
+	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "lOU" = (
@@ -38495,7 +38503,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mvU" = (
@@ -52271,13 +52278,15 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "qMM" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
+	dir = 10
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "qMN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -54298,9 +54307,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/storage/gas)
 "ruw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 1;
+	name = "plasma mixer"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -54441,9 +54450,6 @@
 	piping_layer = 4
 	},
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -56601,7 +56607,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sht" = (
@@ -57257,7 +57262,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ssq" = (
@@ -59213,13 +59217,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "sYZ" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "sZa" = (
 /obj/effect/turf_decal/box/white{
 	color = "#9FED58"
@@ -62037,13 +62039,9 @@
 /turf/open/floor/plating/snowed/coldroom,
 /area/station/service/kitchen/coldroom)
 "tWI" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	dir = 8;
-	name = "Plasma to Turbine"
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/dark{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -64162,7 +64160,9 @@
 /turf/open/openspace,
 /area/station/security/brig/upper)
 "uGy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "uGz" = (
@@ -64288,6 +64288,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/trinary/mixer{
+	dir = 1;
+	name = "plasma mixer"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
@@ -240431,11 +240435,11 @@ lxU
 fcN
 fcN
 nBG
-hHN
-hHN
-jJH
+jdA
+khf
+rBQ
 ssh
-sYZ
+skx
 kqS
 mIk
 wMe
@@ -240689,7 +240693,7 @@ jBR
 fnA
 hHN
 lRR
-bpR
+tWI
 shj
 qnO
 lxu
@@ -240941,13 +240945,13 @@ fQc
 fQc
 noY
 ruw
-klr
-klr
-klr
+fQc
+fQc
+fQc
 mvG
 shj
 uGy
-jdA
+hHN
 cqO
 cfC
 fsQ
@@ -241197,14 +241201,14 @@ oyX
 xfB
 khe
 oSX
-tWI
+oyX
 xfB
 cHm
 xfB
 oyX
 xfB
 jHQ
-khf
+xfB
 gBx
 rkm
 sEX
@@ -241461,7 +241465,7 @@ hHN
 meT
 xGM
 gHl
-huZ
+flH
 bOY
 rPn
 kqq
@@ -241711,13 +241715,13 @@ eMr
 cnq
 nVe
 xMh
-qMM
+huZ
 cnq
 nVe
 cnq
-qMM
+huZ
 cnq
-nVe
+klr
 jYH
 kfs
 kfs
@@ -241974,8 +241978,8 @@ rwB
 swu
 mkG
 swu
-rwB
-lOI
+qMM
+jJH
 lOI
 pGQ
 wgG
@@ -242747,7 +242751,7 @@ aOX
 aRj
 aOX
 qwF
-gtg
+sYZ
 vuu
 xvj
 rCW

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -23138,13 +23138,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "huZ" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
+	dir = 10
+	},
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "hvl" = (
 /obj/effect/turf_decal/siding/white,
 /obj/effect/spawner/random/entertainment/arcade,
@@ -28282,11 +28284,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/commons/vacant_room/office)
 "jdA" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Turbine"
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
+	dir = 10
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/open/floor/plating/snowed/icemoon,
+/area/icemoon/surface/outdoors/nospawn)
 "jdB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted{
@@ -30032,10 +30034,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "jJH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1,
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "jJM" = (
 /turf/open/floor/glass,
 /area/station/security/lockers)
@@ -31572,8 +31577,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "khf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/dark{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -52278,15 +52284,11 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "qMM" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
-	dir = 10
-	},
-/turf/open/floor/plating/snowed/icemoon,
-/area/icemoon/surface/outdoors/nospawn)
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qMN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -59217,9 +59219,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "sYZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1,
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "sZa" = (
@@ -62039,9 +62040,8 @@
 /turf/open/floor/plating/snowed/coldroom,
 /area/station/service/kitchen/coldroom)
 "tWI" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/obj/machinery/atmospherics/pipe/layer_manifold/dark{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to Turbine"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -64285,14 +64285,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "uID" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 1;
-	name = "plasma mixer"
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
 "uII" = (
@@ -240435,8 +240431,8 @@ lxU
 fcN
 fcN
 nBG
-jdA
-khf
+tWI
+qMM
 rBQ
 ssh
 skx
@@ -240693,7 +240689,7 @@ jBR
 fnA
 hHN
 lRR
-tWI
+khf
 shj
 qnO
 lxu
@@ -241715,11 +241711,11 @@ eMr
 cnq
 nVe
 xMh
-huZ
+jJH
 cnq
 nVe
 cnq
-huZ
+jJH
 cnq
 klr
 jYH
@@ -241978,8 +241974,8 @@ rwB
 swu
 mkG
 swu
-qMM
-jJH
+huZ
+sYZ
 lOI
 pGQ
 wgG
@@ -242751,7 +242747,7 @@ aOX
 aRj
 aOX
 qwF
-sYZ
+jdA
 vuu
 xvj
 rCW

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -28080,6 +28080,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"jap" = (
+/obj/effect/turf_decal/trimline/dark_red/arrow_ccw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jaq" = (
 /obj/effect/landmark/start/head_of_personnel,
 /turf/open/floor/iron,
@@ -52257,6 +52270,20 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
+"qMM" = (
+/obj/effect/turf_decal/trimline/dark_red/arrow_ccw{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
+/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/off{
+	dir = 4;
+	name = "O2 To Pure"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "qMN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -62021,7 +62048,7 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer4{
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -242985,7 +243012,7 @@ aOX
 qwF
 sEB
 hpI
-loV
+qMM
 kfs
 kfs
 kfs
@@ -243242,7 +243269,7 @@ qwF
 qwF
 sEB
 hpI
-loV
+jap
 kfs
 bln
 sEB

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -54277,11 +54277,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/storage/gas)
 "ruw" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 1;
-	name = "plasma mixer"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ruC" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -52271,18 +52271,12 @@
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
 "qMM" = (
-/obj/effect/turf_decal/trimline/dark_red/arrow_ccw{
-	dir = 1
+/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 4;
-	name = "O2 To Pure"
-	},
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "qMN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -54449,9 +54443,8 @@
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	dir = 8;
-	name = "Plasma to Turbine"
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible/layer4{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -62045,11 +62038,12 @@
 /area/station/service/kitchen/coldroom)
 "tWI" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
+/obj/machinery/atmospherics/components/binary/pump/layer4{
+	dir = 8;
+	name = "Plasma to Turbine"
+	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible/layer4{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -241717,11 +241711,11 @@ eMr
 cnq
 nVe
 xMh
-eMr
+qMM
 cnq
 nVe
 cnq
-eMr
+qMM
 cnq
 nVe
 jYH
@@ -243012,7 +243006,7 @@ aOX
 qwF
 sEB
 hpI
-qMM
+jap
 kfs
 kfs
 kfs

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1198,6 +1198,9 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "aww" = (
@@ -20501,7 +20504,7 @@
 /area/station/maintenance/starboard/fore)
 "hHt" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2456,6 +2456,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
+"aSB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "aSD" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -5195,11 +5199,13 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "bQY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer4,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/layer_manifold/dark{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "bRG" = (
 /obj/machinery/shower/directional/west,
@@ -17221,12 +17227,7 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "gyg" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/dark{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "gyG" = (
@@ -28303,11 +28304,13 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "klg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Incinerator"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "klj" = (
 /obj/machinery/light/small/directional/north,
@@ -30710,6 +30713,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "lds" = (
@@ -32171,15 +32175,6 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
-"lDR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Incinerator"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/atmos)
 "lEr" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -40290,7 +40285,6 @@
 /obj/structure/sign/warning/fire/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -52387,16 +52381,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"sJj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/trinary/mixer/flipped/layer4{
-	dir = 4;
-	name = "Turbine Mixer'"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "sKf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -62608,10 +62592,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"wmz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "wmB" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark,
@@ -63135,8 +63115,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "wxe" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wxg" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -65543,10 +65526,6 @@
 	dir = 1;
 	name = "O2 To Pure"
 	},
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	dir = 1;
-	name = "O2 to Turbine"
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "xoK" = (
@@ -65581,6 +65560,7 @@
 "xpB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/machinery/meter/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "xpO" = (
@@ -108886,7 +108866,7 @@ qRM
 cGS
 kkf
 kLp
-wxe
+gyg
 uwQ
 cii
 niY
@@ -109653,11 +109633,11 @@ bLg
 prT
 prT
 fVA
-wmz
-wmz
-wmz
+aSB
+aSB
+aSB
 fEA
-wxe
+gyg
 lAh
 aaf
 gWn
@@ -109910,7 +109890,7 @@ ftd
 cAt
 gxb
 apg
-wmz
+aSB
 sBV
 mei
 awt
@@ -110167,7 +110147,7 @@ dKE
 mHT
 tJF
 nau
-wmz
+aSB
 jvj
 vmx
 mGl
@@ -110424,7 +110404,7 @@ aGS
 mHT
 gXW
 nau
-klg
+wxe
 jvj
 nnD
 hfZ
@@ -110681,7 +110661,7 @@ hQB
 mHT
 egP
 gMt
-wmz
+aSB
 jvj
 nnD
 jea
@@ -110938,7 +110918,7 @@ cyW
 iQB
 tds
 nzo
-wmz
+aSB
 lxm
 smt
 tDt
@@ -111196,8 +111176,8 @@ cyW
 cyW
 nzo
 mTI
-sJj
-bQY
+jvj
+qua
 xoB
 hGk
 tfs
@@ -111452,7 +111432,7 @@ cyW
 cyW
 lxt
 nzo
-wmz
+aSB
 iTC
 smt
 eNi
@@ -111709,7 +111689,7 @@ cyW
 cyW
 cyW
 nzo
-wmz
+aSB
 dwf
 nnD
 elW
@@ -111966,7 +111946,7 @@ cyW
 cyW
 dfS
 nzo
-wmz
+aSB
 cyW
 kEe
 fPg
@@ -112223,7 +112203,7 @@ kLi
 kLi
 kLi
 swy
-gyg
+bQY
 nbv
 sEI
 tuf
@@ -112480,7 +112460,7 @@ tBM
 jhn
 jaO
 hXn
-lDR
+klg
 jhn
 svj
 rhx

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1193,8 +1193,8 @@
 /obj/structure/window/spawner/directional/south,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -14746,14 +14746,14 @@
 /area/station/hallway/secondary/service)
 "fEA" = (
 /obj/structure/window/spawner/directional/south,
-/obj/machinery/computer/atmos_control/nitrogen_tank{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/obj/machinery/computer/atmos_control/nitrogen_tank{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fEK" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -555,10 +555,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "akZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /turf/closed/wall,
 /area/station/engineering/atmos)
 "alg" = (
@@ -2458,10 +2456,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"aSB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "aSD" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -5629,7 +5623,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "caC" = (
@@ -5673,7 +5666,6 @@
 /obj/machinery/atmospherics/components/trinary/mixer{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ccV" = (
@@ -6113,9 +6105,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 6
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "cnA" = (
@@ -8610,12 +8600,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
-"dkK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/atmos)
 "dkL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
@@ -9164,7 +9148,6 @@
 /area/station/hallway/primary/central)
 "dwf" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dwl" = (
@@ -14753,10 +14736,10 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
 /obj/machinery/computer/atmos_control/nitrogen_tank{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fEK" = (
@@ -17238,8 +17221,11 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "gyg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 9
+/obj/effect/turf_decal/tile/neutral/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/dark{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
@@ -20504,9 +20490,7 @@
 /area/station/maintenance/starboard/fore)
 "hHt" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "hHK" = (
@@ -24473,7 +24457,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "iTH" = (
@@ -28320,10 +28303,10 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "klg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "klj" = (
@@ -30205,7 +30188,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "kUm" = (
@@ -31538,10 +31520,6 @@
 	dir = 1;
 	name = "Plasma to Pure"
 	},
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	dir = 1;
-	name = "Plasma to Turbine"
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lqT" = (
@@ -31922,7 +31900,6 @@
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lxp" = (
@@ -32195,10 +32172,13 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/locker)
 "lDR" = (
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/door/firedoor/heavy,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Incinerator"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "lEr" = (
 /obj/effect/turf_decal/stripes/line,
@@ -35873,6 +35853,7 @@
 /area/station/maintenance/starboard/greater)
 "mTI" = (
 /obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mTR" = (
@@ -36375,7 +36356,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /obj/machinery/meter/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
@@ -39877,9 +39857,11 @@
 	pixel_x = 24
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Fuel Pipe to Incinerator"
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "ooz" = (
@@ -40308,9 +40290,8 @@
 /obj/structure/sign/warning/fire/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Fuel Pipe to Incinerator"
-	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "ouX" = (
@@ -43151,9 +43132,7 @@
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	name = "Waste Release"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "pxN" = (
@@ -46978,7 +46957,6 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qOZ" = (
@@ -52005,7 +51983,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sCh" = (
@@ -62632,9 +62609,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "wmz" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/dark{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wmB" = (
@@ -63160,9 +63135,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "wxe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "wxg" = (
@@ -65173,12 +65146,13 @@
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
 "xhb" = (
-/obj/machinery/meter,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold/dark{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -66607,17 +66581,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
-"xHw" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "xIx" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -109434,7 +109397,7 @@ gnT
 lgL
 lrK
 heV
-lDR
+cyW
 cyW
 ffk
 hHt
@@ -109690,11 +109653,11 @@ bLg
 prT
 prT
 fVA
-cyW
-aSB
+wmz
+wmz
 wmz
 fEA
-gyg
+wxe
 lAh
 aaf
 gWn
@@ -109947,7 +109910,7 @@ ftd
 cAt
 gxb
 apg
-cyW
+wmz
 sBV
 mei
 awt
@@ -110204,8 +110167,8 @@ dKE
 mHT
 tJF
 nau
-cyW
-klg
+wmz
+jvj
 vmx
 mGl
 hGk
@@ -110461,8 +110424,8 @@ aGS
 mHT
 gXW
 nau
-qwi
 klg
+jvj
 nnD
 hfZ
 sbl
@@ -110718,8 +110681,8 @@ hQB
 mHT
 egP
 gMt
-cyW
-klg
+wmz
+jvj
 nnD
 jea
 aTN
@@ -110975,7 +110938,7 @@ cyW
 iQB
 tds
 nzo
-cyW
+wmz
 lxm
 smt
 tDt
@@ -111489,7 +111452,7 @@ cyW
 cyW
 lxt
 nzo
-cyW
+wmz
 iTC
 smt
 eNi
@@ -111746,7 +111709,7 @@ cyW
 cyW
 cyW
 nzo
-cyW
+wmz
 dwf
 nnD
 elW
@@ -112003,8 +111966,8 @@ cyW
 cyW
 dfS
 nzo
+wmz
 cyW
-aSB
 kEe
 fPg
 jie
@@ -112260,7 +112223,7 @@ kLi
 kLi
 kLi
 swy
-kLi
+gyg
 nbv
 sEI
 tuf
@@ -112517,8 +112480,8 @@ tBM
 jhn
 jaO
 hXn
+lDR
 jhn
-dkK
 svj
 rhx
 tuo
@@ -113289,7 +113252,7 @@ nzo
 cQQ
 sCW
 lNY
-xHw
+sCW
 nnD
 uBg
 oIM
@@ -113546,7 +113509,7 @@ nzo
 jms
 rVJ
 fzM
-xHw
+sCW
 qua
 rZV
 kBh
@@ -113803,7 +113766,7 @@ nzo
 cQQ
 sCW
 fzM
-xHw
+sCW
 nnD
 nbx
 oIM
@@ -114060,7 +114023,7 @@ nzo
 fiE
 hur
 uel
-aSB
+cyW
 nnD
 lRA
 xXG
@@ -114317,7 +114280,7 @@ mDA
 jZz
 vlq
 gTC
-aSB
+cyW
 qzK
 vdf
 eSZ
@@ -114574,7 +114537,7 @@ nzo
 fzM
 rZt
 jZz
-aSB
+cyW
 ccK
 lqS
 kBh

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -30710,7 +30710,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "lds" = (
@@ -36344,13 +36343,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"nbv" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/meter/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "nbx" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -40282,7 +40274,9 @@
 /obj/structure/sign/warning/fire/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
+/obj/machinery/atmospherics/pipe/layer_manifold/dark{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "ouX" = (
@@ -65131,9 +65125,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/dark{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "xhh" = (
@@ -65557,7 +65550,6 @@
 "xpB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/obj/machinery/meter/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "xpO" = (
@@ -112201,7 +112193,7 @@ kLi
 kLi
 swy
 bQY
-nbv
+kLi
 sEI
 tuf
 oLV

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1193,9 +1193,6 @@
 /obj/structure/window/spawner/directional/south,
 /obj/effect/turf_decal/tile/red/fourcorners,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 4
 	},
@@ -14742,10 +14739,10 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /obj/machinery/computer/atmos_control/nitrogen_tank{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fEK" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -8157,9 +8157,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/window/right/directional/west,
+/obj/machinery/door/window/right/directional/west{
+	req_access = list("security")
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/plating,
 /area/station/security/office)
 "bwp" = (
@@ -34616,7 +34617,8 @@
 "kcT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/window/brigdoor/left/directional/east{
-	name = "Medical Delivery Chute"
+	name = "Medical Delivery Chute";
+	req_access = list("medical")
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -34626,7 +34628,6 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/plating,
 /area/station/medical/storage)
 "kcX" = (
@@ -73446,7 +73447,6 @@
 	location = "Security";
 	name = "navigation beacon (Security Delivery)"
 	},
-/obj/machinery/door/window/right/directional/west,
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -236,7 +236,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	QDEL_LIST_ASSOC_VAL(plane_master_controllers)
 	QDEL_LIST(always_visible_inventory)
 	mymob = null
-	hand_slots = null
+	hand_slots = null //Monkestation edit: Fixes a harddel
 
 	QDEL_NULL(screentip_text)
 

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -236,6 +236,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	QDEL_LIST_ASSOC_VAL(plane_master_controllers)
 	QDEL_LIST(always_visible_inventory)
 	mymob = null
+	hand_slots = null
 
 	QDEL_NULL(screentip_text)
 

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -443,10 +443,10 @@ SUBSYSTEM_DEF(air)
 			if(item.parent)
 				var/static/pipenetwarnings = 10
 				if(pipenetwarnings > 0)
-					log_mapping("build_pipeline(): [item.type] added to a pipenet while still having one. (pipes leading to the same spot stacking in one turf) around [AREACOORD(item)].")
-					pipenetwarnings--
+					log_mapping("expand_pipeline(): [item.type] added to a pipenet while still having one. (pipes leading to the same spot stacking in one turf) around [AREACOORD(item)].")
+					////DEBUG PURPOSES, UNCOMMENT WHEN DONE!!!!!  pipenetwarnings--
 					if(pipenetwarnings == 0)
-						log_mapping("build_pipeline(): further messages about pipenets will be suppressed")
+						log_mapping("expand_pipeline(): further messages about pipenets will be suppressed")
 
 			net.members += item
 			border += item

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -444,7 +444,7 @@ SUBSYSTEM_DEF(air)
 				var/static/pipenetwarnings = 10
 				if(pipenetwarnings > 0)
 					log_mapping("expand_pipeline(): [item.type] added to a pipenet while still having one. (pipes leading to the same spot stacking in one turf) around [AREACOORD(item)].")
-					////DEBUG PURPOSES, UNCOMMENT WHEN DONE!!!!!  pipenetwarnings--
+					pipenetwarnings--
 					if(pipenetwarnings == 0)
 						log_mapping("expand_pipeline(): further messages about pipenets will be suppressed")
 

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -92,6 +92,11 @@
 	icon_state = "eng"
 	icon_door = "eng_tool"
 
+/obj/structure/closet/toolcloset/populate_contents_immediate()
+	. = ..()
+	if(prob(5))
+		new /obj/item/clothing/gloves/color/yellow(src) //Monkestation edit: Moves this to immediate for unit tests.
+
 /obj/structure/closet/toolcloset/PopulateContents()
 	..()
 	if(prob(40))
@@ -120,8 +125,6 @@
 		new /obj/item/stack/cable_coil(src)
 	if(prob(20))
 		new /obj/item/multitool(src)
-	if(prob(5))
-		new /obj/item/clothing/gloves/color/yellow(src)
 	if(prob(40))
 		new /obj/item/clothing/head/utility/hardhat(src)
 

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -96,10 +96,10 @@
 				if(item.parent)
 					var/static/pipenetwarnings = 10
 					if(pipenetwarnings > 0)
-						log_mapping("build_pipeline(): [item.type] added to a pipenet while still having one. (pipes leading to the same spot stacking in one turf) around [AREACOORD(item)].")
-						pipenetwarnings--
+						log_mapping("build_pipeline_blocking(): [item.type] added to a pipenet while still having one. (pipes leading to the same spot stacking in one turf) around [AREACOORD(item)].")
+						////DEBUG PURPOSES, UNCOMMENT WHEN DONE!!!!! pipenetwarnings--
 						if(pipenetwarnings == 0)
-							log_mapping("build_pipeline(): further messages about pipenets will be suppressed")
+							log_mapping("build_pipeline_blocking(): further messages about pipenets will be suppressed")
 
 				members += item
 				possible_expansions += item

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -97,7 +97,7 @@
 					var/static/pipenetwarnings = 10
 					if(pipenetwarnings > 0)
 						log_mapping("build_pipeline_blocking(): [item.type] added to a pipenet while still having one. (pipes leading to the same spot stacking in one turf) around [AREACOORD(item)].")
-						////DEBUG PURPOSES, UNCOMMENT WHEN DONE!!!!! pipenetwarnings--
+						pipenetwarnings--
 						if(pipenetwarnings == 0)
 							log_mapping("build_pipeline_blocking(): further messages about pipenets will be suppressed")
 

--- a/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion_brood.dm
@@ -41,6 +41,7 @@
 	addtimer(CALLBACK(src, PROC_REF(death)), 10 SECONDS)
 
 /mob/living/basic/legion_brood/death(gibbed)
+	created_by = null
 	if (!gibbed)
 		new /obj/effect/temp_visual/hive_spawn_wither(get_turf(src), /* copy_from = */ src)
 	return ..()

--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
@@ -71,6 +71,8 @@
 	if(!isbasicmob(source))
 		return
 	var/mob/living/basic/basic_source = source
+	if(!ismob(target)) //Monkestation edit: Catches a runtime when the lobster charges into a wall.
+		return
 	var/mob/living/living_target = target
 	basic_source.melee_attack(living_target, ignore_cooldown = TRUE)
 	basic_source.ai_controller?.set_blackboard_key(BB_BASIC_MOB_STOP_FLEEING, TRUE)

--- a/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
+++ b/code/modules/mob/living/basic/lavaland/lobstrosity/lobstrosity.dm
@@ -17,7 +17,7 @@
 	attack_verb_continuous = "snips"
 	attack_verb_simple = "snip"
 	attack_sound = 'sound/weapons/bite.ogg'
-	attack_vis_effect = ATTACK_EFFECT_BITE // Closer than a scratch to a crustacean pinching effect
+	attack_vis_effect = ATTACK_EFFECT_BITE //  Closer than a scratch to a crustacean pinching effect
 	melee_attack_cooldown = 1 SECONDS
 	butcher_results = list(
 		/obj/item/food/meat/crab = 2,

--- a/code/modules/mob/living/basic/lavaland/mook/mook.dm
+++ b/code/modules/mob/living/basic/lavaland/mook/mook.dm
@@ -242,7 +242,7 @@
 /mob/living/basic/mining/mook/worker/bard/Destroy()
 	qdel(held_guitar)
 	held_guitar = null
-	..()
+	return ..()
 
 /mob/living/basic/mining/mook/worker/tribal_chief
 	name = "tribal chief"

--- a/code/modules/mob/living/basic/lavaland/mook/mook.dm
+++ b/code/modules/mob/living/basic/lavaland/mook/mook.dm
@@ -238,6 +238,11 @@
 	ai_controller.set_blackboard_key(BB_SONG_INSTRUMENT, held_guitar)
 	update_appearance()
 
+//Monkestation edit: Removes a harddel
+/mob/living/basic/mining/mook/worker/bard/Destroy()
+	held_guitar = null
+	..()
+
 /mob/living/basic/mining/mook/worker/tribal_chief
 	name = "tribal chief"
 	desc = "Acknowledge him!"

--- a/code/modules/mob/living/basic/lavaland/mook/mook.dm
+++ b/code/modules/mob/living/basic/lavaland/mook/mook.dm
@@ -240,8 +240,7 @@
 
 //Monkestation edit: Removes a harddel
 /mob/living/basic/mining/mook/worker/bard/Destroy()
-	qdel(held_guitar)
-	held_guitar = null
+	QDEL_NULL(held_guitar)
 	return ..()
 
 /mob/living/basic/mining/mook/worker/tribal_chief

--- a/code/modules/mob/living/basic/lavaland/mook/mook.dm
+++ b/code/modules/mob/living/basic/lavaland/mook/mook.dm
@@ -240,6 +240,7 @@
 
 //Monkestation edit: Removes a harddel
 /mob/living/basic/mining/mook/worker/bard/Destroy()
+	qdel(held_guitar)
 	held_guitar = null
 	..()
 

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -77,6 +77,7 @@
 	modules.Cut()
 	added_modules.Cut()
 	storages.Cut()
+	clock_modules.Cut() //MonkeStation Edit: Clears clock modules
 	return ..()
 
 /obj/item/robot_model/proc/get_usable_modules()

--- a/monkestation/code/modules/ocean_content/mobs/fish_base.dm
+++ b/monkestation/code/modules/ocean_content/mobs/fish_base.dm
@@ -19,7 +19,6 @@
 
 
 /mob/living/basic/aquatic/fish/Destroy()
-	. = ..()
 	var/datum/group_planning/attached = ai_controller?.blackboard[BB_GROUP_DATUM]
 	if(attached)
 		if(src in attached.group_mobs)
@@ -28,6 +27,7 @@
 			attached.in_progress_mobs -= src
 		if(src in attached.finished_mobs)
 			attached.finished_mobs -= src
+	return ..()
 
 /mob/living/basic/aquatic/fish/cod
 	name = "Cod"


### PR DESCRIPTION
## About The Pull Request

I was upset that my simple Florida Man fix had errors that weren't my fault, so I am fixing the errors that shouldn't be errors!

There should be no player-facing changes here, but I suggest testmerging to be safe anyway.

Utility Closets had their insul spawn chance moved to populate_contents_immediate() to prevent a unit test error.
Removes two mapping helpers from Tramstation that apply only to airlocks, not glass doors.
Fixes access to the two glass doors to follow the standards followed with other Tramstation glass doors.
Removes an unused mapping helper in the middle of Ice Box that would error out.
Properly nullifies a hard deletion upon removal of the "Bard Mook"
Cuts the list for Clock Modules on removal of cyborgs.
Removes a possible reference when destroying Legion Broods.
Moves a parent call in the 🐟 fish🐟 destroy proc to be after their references are removed.
Adds a check to lobster to prevent them from trying to grab turfs.
Changes the error messages for pipenet creation to directly say which proc has the error.
Reverts the majority of https://github.com/Monkestation/Monkestation2.0/pull/628/commits/cedc1d82d0d74c4dab29563f01d29e3d2798c401 as it was causing errors.
Removes the dedicated fuel line in Metastation's atmospherics as it was causing errors. There is certainly something weird going on with pipe layering, but I can't immediately fix that.

## Why It's Good For The Game

What's the point of unit tests if we get errors every time?

## Changelog
:cl:
/:cl:
