### PR TITLE
Various Timestop Guardian bug fixes

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
@@ -6,7 +6,7 @@
 		used = FALSE
 		return
 	if(IS_BLOODSUCKER(user))
-		var/mob/living/basic/guardian/standard/bloodsucker_guardian = new(user, GUARDIAN_THEME_MAGIC)
+		var/mob/living/basic/guardian/standard/timestop/bloodsucker_guardian = new(user, GUARDIAN_THEME_MAGIC)
 
 		bloodsucker_guardian.set_summoner(user, different_person = TRUE)
 		bloodsucker_guardian.key = candidate.key
@@ -22,7 +22,7 @@
 /**
  * The Guardian itself
  */
-/mob/living/basic/guardian/standard
+/mob/living/basic/guardian/standard/timestop
 	// Like Bloodsuckers do, you will take more damage to Burn and less to Brute
 	damage_coeff = list(BRUTE = 0.5, BURN = 2.5, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 
@@ -30,7 +30,7 @@
 	creator_desc = "Devastating close combat attacks and high damage resistance. Can smash through weak walls and stop time."
 	creator_icon = "standard"
 
-/mob/living/basic/guardian/standard/Initialize(mapload, theme)
+/mob/living/basic/guardian/standard/timestop/Initialize(mapload, theme)
 	//Wizard Holoparasite theme, just to be more visibly stronger than regular ones
 	theme = GLOB.guardian_themes[GUARDIAN_THEME_TECH]
 	. = ..()

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
@@ -40,8 +40,9 @@
 ///Guardian Timestop ability
 /datum/action/cooldown/spell/timestop/guardian
 	name = "Guardian Timestop"
-	desc = "This spell stops time for everyone except for you and your master, \
-		allowing you to move freely while your enemies and even projectiles are frozen."
+	desc = "This spell stops time for everyone (including your master) in a \
+		small radius around you, allowing you to move freely while your \
+		enemies and even projectiles are frozen."
 	cooldown_time = 60 SECONDS
 	spell_requirements = NONE
 	invocation_type = INVOCATION_NONE

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
@@ -1,19 +1,47 @@
 ///Bloodsuckers spawning a Guardian will get the Bloodsucker one instead.
-/obj/item/guardian_creator/spawn_guardian(mob/living/user, mob/dead/candidate)
-	var/list/guardians = user.get_all_linked_holoparasites()
-	if(length(guardians))
-		to_chat(user, span_holoparasite("You already have a [mob_name]!"))
-		used = FALSE
-		return
-	if(IS_BLOODSUCKER(user))
-		var/mob/living/basic/guardian/standard/timestop/bloodsucker_guardian = new(user, GUARDIAN_THEME_MAGIC)
+/obj/item/guardian_creator/attack_self(mob/living/user)
+	// If this code looks odd, it's because I'm intentionally inserting a hack,
+	// as I'm trying to avoid touching `guardian_creator.dm` with this fix. A
+	// later refactor/modularization will make this code much less of a hack.
 
-		bloodsucker_guardian.set_summoner(user, different_person = TRUE)
-		bloodsucker_guardian.key = candidate.key
-		user.log_message("has summoned [key_name(bloodsucker_guardian)], a [bloodsucker_guardian.creator_name] holoparasite.", LOG_GAME)
-		bloodsucker_guardian.log_message("was summoned as a [bloodsucker_guardian.creator_name] holoparasite.", LOG_GAME)
-		to_chat(user, replacetext(success_message, "%GUARDIAN", mob_name))
-		bloodsucker_guardian.client?.init_verbs()
+	// START COPIED CODE FROM guardian_creator.dm
+	if(isguardian(user) && !allow_guardian)
+		balloon_alert(user, "can't do that!")
+		return
+	var/list/guardians = user.get_all_linked_holoparasites()
+	if(length(guardians) && !allow_multiple)
+		balloon_alert(user, "already have one!")
+		return
+	if(user.mind && user.mind.has_antag_datum(/datum/antagonist/changeling) && !allow_changeling)
+		to_chat(user, ling_failure)
+		return
+	if(used)
+		to_chat(user, used_message)
+		return
+	// END COPIED CODE FROM guardian_creator.dm
+
+	if (IS_BLOODSUCKER(user))
+		//var/mob/living/basic/guardian/standard/timestop/guardian_path = new(user, GUARDIAN_THEME_MAGIC)
+		var/mob/living/basic/guardian/guardian_path = /mob/living/basic/guardian/standard/timestop
+
+		// START COPIED CODE FROM guardian_creator.dm
+		used = TRUE
+		to_chat(user, use_message)
+		var/guardian_type_name = capitalize(initial(guardian_path.creator_name))
+		var/list/mob/dead/observer/candidates = poll_ghost_candidates(
+			"Do you want to play as [user.real_name]'s [guardian_type_name] [mob_name]?",
+			jobban_type = ROLE_PAI,
+			poll_time = 10 SECONDS,
+			ignore_category = POLL_IGNORE_HOLOPARASITE,
+		)
+		if(LAZYLEN(candidates))
+			var/mob/dead/observer/candidate = pick(candidates)
+			spawn_guardian(user, candidate, guardian_path)
+		else
+			to_chat(user, failure_message)
+			used = FALSE
+		// END COPIED CODE FROM guardian_creator.dm
+
 		return
 
 	// Call parent to deal with everyone else


### PR DESCRIPTION
## About The Pull Request
Timestop Guardian was originally intended to be locked to Bloodsuckers. However, due to a (presumably accidental) change made in the commit https://github.com/Monkestation/Monkestation2.0/commit/a767b9f896cae35aadc591f44f7f3fadb6e0a255, Timestop Guardian ended up overwriting Standard Guardian.

While players could still choose other guardian types, the Timestop Guardian has fairly overpowered abilities, making it a very easy choice compared to anything else.

In the process of fixing and testing this, I found a couple other errors; namely, the timestop's description is wrong; and that Bloodsuckers would be offered a useless Guardian Type selection - despite the guardian type then being overwritten if you were a Bloodsucker. These have been fixed.

I plan to work with Dexee to refactor/modularize Guardians as a whole, at a later date. However, these bug fixes are important now.

## Why It's Good For The Game
Fixes dat fuggin Timestop Guardian.

## Changelog

:cl: MichiRecRoom
fix: Timestop Guardian no longer overwrites the Standard Guardian, which additionally restricts Timestop Guardian to Bloodsuckers (as was intended)
fix: Guardian Timestop spell incorrectly stated that the master was exempt from the Timestop field
/:cl:
