### PR TITLE
Lowered Anti-Meteor Shielding Prices

### DIFF
--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -187,7 +187,7 @@
 	name = "Shield Generator Satellite"
 	desc = "Protect the very existence of this station with these Anti-Meteor defenses. \
 		Contains three Shield Generator Satellites."
-	cost = CARGO_CRATE_VALUE * 6
+	cost = CARGO_CRATE_VALUE * 3 //Monkestation Edit: Anti-Meteor Shielding Prices Lowered
 	special = TRUE
 	access_view = ACCESS_COMMAND
 	contains = list(/obj/machinery/satellite/meteor_shield = 3)
@@ -197,7 +197,7 @@
 /datum/supply_pack/engineering/shield_sat_control
 	name = "Shield System Control Board"
 	desc = "A control system for the Shield Generator Satellite system."
-	cost = CARGO_CRATE_VALUE * 10
+	cost = CARGO_CRATE_VALUE * 3 //Monkestation Edit: Anti-Meteor Shielding Prices Lowered
 	special = TRUE
 	access_view = ACCESS_COMMAND
 	contains = list(/obj/item/circuitboard/computer/sat_control)


### PR DESCRIPTION
## About The Pull Request

Basically lowers the prices of Shield Generator Satelites, and Shield System Control Boards to 600 credits each, to help encourage the captain of the station to buy shielding for the station to help protect the crew to meteors, (and because I myself feel that the anti-meteor shielding the captain or HOP can buy on their Bridge Supply Request Console is a little too unnecessarily expensive)

## Why It's Good For The Game

Encourages station crews to use station shielding against meteors more, I barely (or to be more specific, have never seen) a single crew on a ss13 server that used station shielding against meteors

## Changelog
:cl:
code: small change to prices on Anti-Meteor Shield Generator Satelites, makes the prices lowered down to 600 each for satelites and control boards!
/:cl:
