### PR TITLE
Exclude plastic cards from being inserted as paper into computers

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -749,6 +749,11 @@ GLOBAL_LIST_EMPTY(TabletMessengers) // a list of all active messengers, similar 
 			return
 
 	if(istype(attacking_item, /obj/item/paper))
+		//MONKESTATION EDIT START
+		// Don't allow plastic cards (including the spare ID safe code biscuits!) to be inserted
+		if(istype(attacking_item, /obj/item/paper/paperslip/corporate))
+			return
+		//MONKESTATION EDIT END
 		if(stored_paper >= max_paper)
 			balloon_alert(user, "no more room!")
 			return


### PR DESCRIPTION
## About The Pull Request
This PR excludes plastic cards (that is, anything that is of type `/obj/item/paper/paperslip/corporate` or one of its subtypes, including the spare ID code cards) from being inserted into computers.

## Why It's Good For The Game
This change protects players from losing the spare ID code cards, and protects admins from having to send the emergency biscuit in response.

## Changelog

:cl: MichiRecRoom
fix: Corporate plastic cards, as well as spare ID code cards, are no longer considered paper by computers that take paper (such as PDAs or the identification consoles)
/:cl:
