### PR TITLE
Fix Support Guardian Healing

### DIFF
--- a/code/datums/components/healing_touch.dm
+++ b/code/datums/components/healing_touch.dm
@@ -202,7 +202,16 @@
 	)
 	healed += target.adjustOxyLoss(-heal_oxy, updating_health = FALSE, required_biotype = valid_biotypes)
 	healed += target.adjustToxLoss(-heal_tox, updating_health = FALSE, required_biotype = valid_biotypes)
-	//MONKESTATION REMOVAL START - While removing this could cause some issues, keeping it seems to cause more than it would solve. In particular, the above procs are somewhat bugged and don't return the values we expect - meaning this could cause a return even if the target was actually healed. Due to this, and because the UI update is behind this check, I've opted to remove it for now. Maybe later when the above procs are fixed, we can revisit this removal. (As an aside: If we ever undo this removal, we should probably include a balloon alert saying "nothing to heal!")
+	//MONKESTATION REMOVAL START
+	// While removing this could cause some issues, keeping it seems to cause more than it would
+	// solve. In particular, the above procs are somewhat bugged and don't return the values we
+	// expect - meaning this could cause a return even if the target was actually healed.
+	//
+	// Because of this, and because the UI update is behind this check, I've opted to remove it for
+	// now. Maybe later when the above procs are fixed, we can revisit this removal.
+	//
+	// (As an aside: If we ever undo this removal, we should probably include a balloon alert
+	// saying "nothing to heal!")
 	/*
 	if (healed <= 0)
 		return

--- a/code/datums/components/healing_touch.dm
+++ b/code/datums/components/healing_touch.dm
@@ -120,7 +120,10 @@
 		return // Fall back to attacking it
 
 	if (extra_checks && !extra_checks.Invoke(healer, target))
-		return COMPONENT_CANCEL_ATTACK_CHAIN
+		//MONKESTATION EDIT START - why would failing the extra checks cancel our attack chain?
+		//return COMPONENT_CANCEL_ATTACK_CHAIN //MONKESTATION EDIT ORIGINAL
+		return
+		//MONKESTATION EDIT END
 
 	if (DOING_INTERACTION(healer, interaction_key))
 		healer.balloon_alert(healer, "busy!")
@@ -199,8 +202,12 @@
 	)
 	healed += target.adjustOxyLoss(-heal_oxy, updating_health = FALSE, required_biotype = valid_biotypes)
 	healed += target.adjustToxLoss(-heal_tox, updating_health = FALSE, required_biotype = valid_biotypes)
+	//MONKESTATION REMOVAL START - While removing this could cause some issues, keeping it seems to cause more than it would solve. In particular, the above procs are somewhat bugged and don't return the values we expect - meaning this could cause a return even if the target was actually healed. Due to this, and because the UI update is behind this check, I've opted to remove it for now. Maybe later when the above procs are fixed, we can revisit this removal. (As an aside: If we ever undo this removal, we should probably include a balloon alert saying "nothing to heal!")
+	/*
 	if (healed <= 0)
 		return
+	*/
+	//MONKESTATION REMOVAL END
 
 	target.updatehealth()
 	new /obj/effect/temp_visual/heal(get_turf(target), heal_color)

--- a/code/modules/mob/living/basic/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_creator.dm
@@ -216,14 +216,7 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 		/mob/living/basic/guardian/protector, // Bodyblocks projectiles for you
 		/mob/living/basic/guardian/ranged, // Shoots the bad guys
 		/mob/living/basic/guardian/standard, // Can mine walls
-		//MONKESTATION REMOVAL START
-		/// The Support Power Miner is being made temporarily unavailable to the
-		/// Power Miner shard to limit frustration (and the number of ahelps),
-		/// as Support's heal is currently bugged, severely limiting its
-		/// usefulness. This removal will be undone when we figure out how to
-		/// fix such an issue.
-		// /mob/living/basic/guardian/support, // Heals and teleports you
-		//MONKESTATION REMOVAL END
+		/mob/living/basic/guardian/support, // Heals and teleports you
 		//MONKESTATION EDIT START
 		/mob/living/basic/guardian/standard/timestop,
 		//MONKESTATION EDIT END

--- a/code/modules/mob/living/basic/guardian/guardian_types/support.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/support.dm
@@ -14,8 +14,16 @@
 
 /mob/living/basic/guardian/support/Initialize(mapload, datum/guardian_fluff/theme)
 	. = ..()
-	//MONKESTATION EDIT START - Fixes support guardian not being able to heal. The original `required_modifier` check is bugged due to our codebase having both Combat Mode and Intents. We instead use the `extra_checks` feature here, to check if the user is right-clicking, by checking to see if they're performing a secondary action.
-	// Note: You may notice the original AddComponent macro is entirely commented out, instead of just the relevant part. I tried to only comment out the relevant part, but no matter what I do, it just kept returning errors about the macro syntax. So instead of trying to fix it, I opted for... this.
+	//MONKESTATION EDIT START
+	// Fixes support guardian not being able to heal. The original `required_modifier` check is
+	// bugged due to our codebase having both Combat Mode and Intents. We instead use the
+	// `extra_checks` feature here, to check if the user is right-clicking, by checking to see if
+	// they're performing a secondary action.
+	//
+	// Note: You may notice the original AddComponent macro is entirely commented out, instead of
+	// just the relevant part. I tried to only comment out the relevant part, but no matter what I
+	// do, it just kept returning errors about the macro syntax. So instead of trying to fix it, I
+	// opted for... this.
 	/*
 	AddComponent(\
 		/datum/component/healing_touch,\

--- a/code/modules/mob/living/basic/guardian/guardian_types/support.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/support.dm
@@ -14,6 +14,9 @@
 
 /mob/living/basic/guardian/support/Initialize(mapload, datum/guardian_fluff/theme)
 	. = ..()
+	//MONKESTATION EDIT START - Fixes support guardian not being able to heal. The original `required_modifier` check is bugged due to our codebase having both Combat Mode and Intents. We instead use the `extra_checks` feature here, to check if the user is right-clicking, by checking to see if they're performing a secondary action.
+	// Note: You may notice the original AddComponent macro is entirely commented out, instead of just the relevant part. I tried to only comment out the relevant part, but no matter what I do, it just kept returning errors about the macro syntax. So instead of trying to fix it, I opted for... this.
+	/*
 	AddComponent(\
 		/datum/component/healing_touch,\
 		heal_brute = healing_amount,\
@@ -25,7 +28,21 @@
 		complete_text = "",\
 		required_modifier = RIGHT_CLICK,\
 		after_healed = CALLBACK(src, PROC_REF(after_healed)),\
+	) //MONKESTATION EDIT ORIGINAL
+	*/
+	AddComponent(\
+		/datum/component/healing_touch,\
+		heal_brute = healing_amount,\
+		heal_burn = healing_amount,\
+		heal_tox = healing_amount,\
+		heal_oxy = healing_amount,\
+		heal_time = 0,\
+		action_text = "",\
+		complete_text = "",\
+		extra_checks = CALLBACK(src, PROC_REF(wants_to_heal)),\
+		after_healed = CALLBACK(src, PROC_REF(after_healed)),\
 	)
+	//MONKESTATION EDIT END
 
 	var/datum/atom_hud/medsensor = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
 	medsensor.show_to(src)
@@ -36,6 +53,15 @@
 /mob/living/basic/guardian/support/set_guardian_colour(colour)
 	. = ..()
 	AddComponent(/datum/component/healing_touch, heal_color = guardian_colour)
+
+//MONKESTATION ADDITION START
+/// Called by the healing_touch component to check if we want this attack to heal
+/mob/living/basic/guardian/support/proc/wants_to_heal(mob/living/source, mob/living/target)
+	var/is_right_clicking = (istate & ISTATE_SECONDARY)
+	if(is_right_clicking)
+		return TRUE
+	return FALSE
+//MONKESTATION ADDITION END
 
 /// Called after we heal someone, show some visuals
 /mob/living/basic/guardian/support/proc/after_healed(mob/living/healed)


### PR DESCRIPTION
## About The Pull Request
This PR fixes the Support Guardian's healing ability, allowing it to function once more.

Since its healing ability is now fixed, this PR also re-enables the ability for the Power Miner shard to randomly spawn a Support Guardian.

## Why It's Good For The Game
Bugs bad. Cool gameplay good.

Fixes #714.

## Changelog

:cl: MichiRecRoom
fix: Support Guardian's heal works once more!
fix: Due to how the Support Guardian heal fix was implemented, this also fixes Spider's health display not updating when another spider heals you.
fix: Previously, the Power Miner shard was temporarily blocked from spawning Support Guardians due to its healing being nonfunctional. Since its healing works once more, Power Miner shards can once again spawn Support Guardians.
/:cl:
