### PR TITLE
Fix the titles of the "Toys" and "Other" store tabs

### DIFF
--- a/monkestation/code/modules/store/store_items/__store.dm
+++ b/monkestation/code/modules/store/store_items/__store.dm
@@ -154,8 +154,8 @@ GLOBAL_LIST_EMPTY(all_store_datums)
 	loadout_tabs += list(list("name" = "Misc. Under", "title" = "Uniform Slot Items (cont)", "contents" = list_to_data(GLOB.store_miscunders)))
 	loadout_tabs += list(list("name" = "Accessory", "title" = "Uniform Accessory Slot Items", "contents" = list_to_data(GLOB.store_accessory)))
 	loadout_tabs += list(list("name" = "Inhand", "title" = "In-hand Items", "contents" = list_to_data(GLOB.store_inhand_items)))
-	loadout_tabs += list(list("name" = "Toys", "title" = "Toys!)", "contents" = list_to_data(GLOB.store_toys)))
-	loadout_tabs += list(list("name" = "Other", "title" = "Backpack Items)", "contents" = list_to_data(GLOB.store_pockets)))
+	loadout_tabs += list(list("name" = "Toys", "title" = "Toys!", "contents" = list_to_data(GLOB.store_toys)))
+	loadout_tabs += list(list("name" = "Other", "title" = "Backpack Items", "contents" = list_to_data(GLOB.store_pockets)))
 
 	data["loadout_tabs"] = loadout_tabs
 


### PR DESCRIPTION
## About The Pull Request
Removes the errant `)` from the titles of the "Toys" and "Other" store tabs.

## Why It's Terrible For The Game
The game is now playable.

## Changelog
:cl: MichiRecRoom
spellcheck: Two store tabs had errant right parenthesis, which are now removed.
/:cl:
