### PR TITLE
Quick corndog fix

### DIFF
--- a/monkestation/code/game/objects/items/food/corndog.dm
+++ b/monkestation/code/game/objects/items/food/corndog.dm
@@ -81,7 +81,7 @@
 	food_flags = FOOD_FINGER_FOOD
 	eatverbs = list("bite", "chew", "nibble", "gobble", "chomp")
 	w_class = WEIGHT_CLASS_SMALL
-	burns_on_grill = TRUE
+	burns_in_oven = TRUE
 	venue_value = FOOD_PRICE_NORMAL
 
 /obj/item/food/corndog/rod


### PR DESCRIPTION
Fugg

## About The Pull Request

Corndogs don't instantly burn in ovens after being cooked anymore.

## Why It's Good For The Game

Corndogs are a holy foodstuff, and don't deserve this treatment.

## Changelog

:cl:
fix: Corndogs are no longer condemned to Hell upon being born
/:cl:
