### PR TITLE
[Port from /tg/] Fixes Cell Message With Mulebots

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -156,8 +156,10 @@
 		user.put_in_hands(cell)
 	else
 		cell.forceMove(drop_location())
-	visible_message(span_notice("[user] crowbars [cell] out from [src]."),
-					span_notice("You pry [cell] out of [src]."))
+	user.visible_message(
+		span_notice("[user] crowbars [cell] out from [src]."),
+		span_notice("You pry [cell] out of [src]."),
+	)
 	cell = null
 	diag_hud_set_mulebotcell()
 	return TOOL_ACT_TOOLTYPE_SUCCESS
@@ -171,8 +173,10 @@
 			return TRUE
 		cell = I
 		diag_hud_set_mulebotcell()
-		visible_message(span_notice("[user] inserts \a [cell] into [src]."),
-						span_notice("You insert [cell] into [src]."))
+		user.visible_message(
+			span_notice("[user] inserts \a [cell] into [src]."),
+			span_notice("You insert [cell] into [src]."),
+		)
 		return TRUE
 	else if(is_wire_tool(I) && bot_cover_flags & BOT_COVER_OPEN)
 		return attack_hand(user)


### PR DESCRIPTION
(The following is pulled from https://github.com/tgstation/tgstation/pull/77374, which this is a port of.)

## About The Pull Request
Fixes the message when removing/adding a cell to mulebots using the mulebot as the user, resulting in sentient mulebots receiving the message "You add/pry out the cell in the mulebot" despite not being the one adding/removing the cell. First time making a pr for this codebase, so let me know if I fucked something up.

## Why It's Good For The Game
The mulebot isn't moving the cell, whoever IS moving it is. Also bug bad.

## Changelog
:cl: Wisemonster
fix: Fix mulebots receiving the wrong message when thier cell is added/removed.
/:cl: