### PR TITLE
Adds a small list of blocked items to the anything-gift item

### DIFF
--- a/code/game/objects/items/gift.dm
+++ b/code/game/objects/items/gift.dm
@@ -127,7 +127,7 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 			// Per Biddi's suggestion; plus doesn't seem to do much anyways?
 			/obj/item/research,
 		)
-		for(var/blocked_item in blocked_items)
+		for(var/blocked_item as anything in blocked_items)
 			// Block the item listed, and any subtypes too.
 			gift_types_list -= typesof(blocked_item)
 		//MONKESTATION EDIT END

--- a/code/game/objects/items/gift.dm
+++ b/code/game/objects/items/gift.dm
@@ -110,6 +110,27 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 			var/obj/item/I = V
 			if((!initial(I.icon_state)) || (!initial(I.inhand_icon_state)) || (initial(I.item_flags) & ABSTRACT))
 				gift_types_list -= V
+		//MONKESTATION EDIT START
+		// List of items we want to block the anything-gift from spawning. Reasons for blocking
+		// these vary, but usually come down to keeping the server (and game clients) stable.
+		//
+		// Subtypes of these items will also be blocked.
+		var/list/blocked_items = list(
+			// Can crash people if too many are spawned.
+			// NOTE: Not likely to be an issue if the amount is kept low - perhaps a limited variant
+			// of this (i.e. can only spawn up to 25 humans) could be added for players to use?
+			/obj/item/debug/human_spawner,
+			// Just leaves the coordinates everywhere
+			/obj/item/gps/visible_debug,
+			// Can lag the hell out of the server
+			/obj/item/gun/energy/recharge/kinetic_accelerator/meme,
+			// Per Biddi's suggestion; plus doesn't seem to do much anyways?
+			/obj/item/research,
+		)
+		for(var/blocked_item in blocked_items)
+			// Block the item listed, and any subtypes too.
+			gift_types_list -= typesof(blocked_item)
+		//MONKESTATION EDIT END
 		GLOB.possible_gifts = gift_types_list
 	var/gift_type = pick(GLOB.possible_gifts)
 


### PR DESCRIPTION
## About The Pull Request
Adds a small list of blocked items to the anything-gift item.

This list of items consists primarily of items that can majorly affect the server and game client stability. The current list includes:
* `/obj/item/debug/human_spawner` (the debug human spawner) - Fun in small amounts, but it's easy for this to drop framerates to single digits, or even crash someone's game.
* `/obj/item/gps/visible_debug` (visible GPS) - Not dangerous, just spews text everywhere. So there's not really a point to it.
* `/obj/item/gun/energy/recharge/kinetic_accelerator/meme` (The adminium reaper) and `/obj/item/gun/energy/recharge/kinetic_accelerator/meme/nonlethal` (The adminium stunner; blocked by being a subtype) - There was a reason these things were removed from the CentCom spawners.
* `/obj/item/research` (research debug item) - Removed per Biddi's request. Plus I couldn't see anywhere it was used anyways.

I originally included `/obj/item/debug/omnitool/item_spawner` (an item that spawns one of a specified type, plus one of every one of its subtypes), but upon rereading the item's code, I decided to exclude this from the list. As far as I can tell, this item actually checks if the user is an admin - and if they aren't, gibs them after a few foreboding prompts, which can make for a funny scene when a non-admin tries to use it.

## Why It's Good For The Game
Server and client stability good. BYOND is already terrible enough.

## Changelog

:cl: MichiRecRoom
fix: The anything-gift now has a very small list of items that it will never spawn. The list consists primarily of items which could majorly endanger game-server/game-client stability - so you still have a chance to get that funny debug uplink!
/:cl:
