### PR TITLE
Allow those with H.A.U.L. Gauntlets to open their pulled crate, without stopping their pull

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -266,7 +266,10 @@
 		return TRUE
 	if(welded || locked)
 		return FALSE
-	if(strong_grab)
+	//MONKESTATION EDIT START - Allow a strong grabber to open their own pulled closet
+	//if(strong_grab) //MONKESTATION EDIT ORIGINAL
+	if(strong_grab && pulledby != user)
+		//MONKESTATION EDIT END
 		to_chat(user, span_danger("[pulledby] has an incredibly strong grip on [src], preventing it from opening."))
 		return FALSE
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
## About The Pull Request
Currently, if someone has the H.A.U.L. Gauntlets on, and is dragging a crate/closet, that crate/closet can't be opened. It'll say `"[pulledby] has an incredibly strong grip on [src], preventing it from opening."`

However, this also affects the wearer of the H.A.U.L. Gauntlets - meaning that if you're wearing the gauntlets, you have to stop pulling before you can open the crate/closet you want to open.

This change allows the wearer of the H.A.U.L. Gauntlets to open the crate/closet they're pulling, *without* needing to stop their pull. Why would your own gauntlets prevent you from doing so anyways?

## Why It's Good For The Game
Makes the H.A.U.L. Gauntlets easier to use.

## Changelog

:cl: MichiRecRoom
qol: The H.A.U.L. Gauntlets will no longer prevent the wearer from opening the closet/crate that they're pulling.
/:cl:
