### PR TITLE
[Port from /tg/] Fixes Ranged Guardians from Shooting while Incorporeal

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_basic.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_basic.dm
@@ -4,6 +4,10 @@
 #define COMSIG_BASICMOB_LOOK_ALIVE "basicmob_look_alive"
 
 ///from the ranged_attacks component for basic mobs: (mob/living/basic/firer, atom/target, modifiers)
+#define COMSIG_BASICMOB_PRE_ATTACK_RANGED "basicmob_pre_attack_ranged"
+	#define COMPONENT_CANCEL_RANGED_ATTACK COMPONENT_CANCEL_ATTACK_CHAIN //! Cancel to prevent the attack from happening
+
+///from the ranged_attacks component for basic mobs: (mob/living/basic/firer, atom/target, modifiers)
 #define COMSIG_BASICMOB_POST_ATTACK_RANGED "basicmob_post_attack_ranged"
 
 /// Sent from /datum/ai_planning_subtree/parrot_as_in_repeat() : ()

--- a/code/datums/components/ranged_attacks.dm
+++ b/code/datums/components/ranged_attacks.dm
@@ -55,7 +55,9 @@
 
 /datum/component/ranged_attacks/proc/fire_ranged_attack(mob/living/basic/firer, atom/target, modifiers)
 	SIGNAL_HANDLER
-	if (!COOLDOWN_FINISHED(src, fire_cooldown))
+	if(!COOLDOWN_FINISHED(src, fire_cooldown))
+		return
+	if(SEND_SIGNAL(firer, COMSIG_BASICMOB_PRE_ATTACK_RANGED, target, modifiers) & COMPONENT_CANCEL_RANGED_ATTACK)
 		return
 	COOLDOWN_START(src, fire_cooldown, cooldown_time)
 	INVOKE_ASYNC(src, PROC_REF(async_fire_ranged_attack), firer, target, modifiers)

--- a/code/modules/mob/living/basic/guardian/guardian_types/ranged.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/ranged.dm
@@ -71,6 +71,7 @@
 	RegisterSignal(owner, COMSIG_GUARDIAN_MANIFESTED, PROC_REF(on_manifest))
 	RegisterSignal(owner, COMSIG_GUARDIAN_RECALLED, PROC_REF(on_recall))
 	RegisterSignal(owner, COMSIG_MOB_CLICKON, PROC_REF(on_click))
+	RegisterSignal(owner, COMSIG_BASICMOB_PRE_ATTACK_RANGED, PROC_REF(on_ranged_attack))
 
 	var/mob/living/basic/guardian/guardian_mob = owner
 	guardian_mob.unleash()
@@ -79,7 +80,12 @@
 
 /datum/status_effect/guardian_scout_mode/on_remove()
 	animate(owner, alpha = initial(owner.alpha), time = 0.5 SECONDS)
-	UnregisterSignal(owner, list(COMSIG_GUARDIAN_MANIFESTED, COMSIG_GUARDIAN_RECALLED, COMSIG_MOB_CLICKON))
+	UnregisterSignal(owner, list(
+		COMSIG_BASICMOB_PRE_ATTACK_RANGED,
+		COMSIG_GUARDIAN_MANIFESTED,
+		COMSIG_GUARDIAN_RECALLED,
+		COMSIG_MOB_CLICKON,
+	))
 	to_chat(owner, span_bolddanger("You return to your normal mode."))
 	var/mob/living/basic/guardian/guardian_mob = owner
 	guardian_mob.leash_to(owner, guardian_mob.summoner)
@@ -99,6 +105,11 @@
 	SIGNAL_HANDLER
 	return COMSIG_MOB_CANCEL_CLICKON
 
+/// We can't do any ranged attacks while in scout mode.
+/datum/status_effect/guardian_scout_mode/proc/on_ranged_attack()
+	SIGNAL_HANDLER
+	owner.balloon_alert(owner, "need to be in ranged mode!")
+	return COMPONENT_CANCEL_RANGED_ATTACK
 
 /// Place an invisible trap which alerts the guardian when it is crossed
 /datum/action/cooldown/mob_cooldown/guardian_alarm_snare


### PR DESCRIPTION
## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/79925. Fixes #715.

Original tgstation PR text follows, bar a couple of small edits.

----

Fixes https://github.com/tgstation/tgstation/pull/79921

Otherwise, on the tin. Attack mode is for attacking, scouting mode is for scouting. We were listening for clicking and stuff like that but it was still failing somehow so this is le fix
## Why It's Good For The Game

You aren't supposed to shoot in this mode, only scout.

## Changelog
:cl: san7890
fix: Ranged Guardians (Holoparasites/Power Miners/etc.) can no longer use ranged attacks in scouting (incorporeal) mode.
/:cl: