### PR TITLE
Area restrictions placed on CentCom ghost players can no longer be bypassed by being in a container

### DIFF
--- a/monkestation/code/modules/ghost_players/area_changes.dm
+++ b/monkestation/code/modules/ghost_players/area_changes.dm
@@ -62,12 +62,31 @@
 /area/centcom/central_command_areas/firing_range_checkpoint_control
 	area_flags = UNIQUE_AREA | NOTELEPORT | NO_EXPLOSIONS_DURING
 
-/area/Entered(mob/M)
+// Override that handles teleporting ghost player's mobs back to Centcom ghostspawn, if they try to
+// move out of it during the round.
+/area/Entered(atom/movable/thing)
 	. = ..()
-	if(!(area_flags & GHOST_AREA) && istype(M, /mob/living/carbon/human/ghost))
-		var/mob/living/carbon/human/ghost/mob = M
-		mob.move_to_ghostspawn()
 
-	if((area_flags & NO_GHOSTS_DURING_ROUND) && istype(M, /mob/living/carbon/human/ghost) && SSticker.current_state != GAME_STATE_FINISHED)
-		var/mob/living/carbon/human/ghost/mob = M
-		mob.move_to_ghostspawn()
+	if(istype(thing, /mob/living/carbon/human/ghost))
+		// If this is a ghost, run the teleport checks
+		teleport_ghost_mob_if_needed(thing)
+	else
+		// Else, loop through this thing's contents...
+		for(var/atom/movable/atom_inside in thing.get_all_contents())
+			if(istype(atom_inside, /mob/living/carbon/human/ghost))
+				// ...and for any ghosts, run the checks
+				teleport_ghost_mob_if_needed(atom_inside)
+
+// Teleports a ghost's mob to ghostspawn, if this area does not meet certain requirements.
+/area/proc/teleport_ghost_mob_if_needed(mob/living/carbon/human/ghost/ghost)
+	// We should teleport, if...
+	var/should_teleport = FALSE
+	// ...this is not an area allowed to be inhabited by ghost characters
+	should_teleport |= (!(area_flags & GHOST_AREA))
+	// ...this is an area ghosts are prohibited to inhabit during a round, and the round is ongoing
+	should_teleport |= ((area_flags & NO_GHOSTS_DURING_ROUND) && SSticker.current_state != GAME_STATE_FINISHED)
+	// Note: I realize the above bits seem sort of like the same thing. But in refactoring this, I
+	// decided to leave both checks in.
+
+	if(should_teleport)
+		ghost.move_to_ghostspawn()


### PR DESCRIPTION
## About The Pull Request
See the title. Also, did a little bit of refactoring while I was at it.

We may wish to extend the space a CentCom ghost player can enter, because I don't know of much that can be abused in the CentCom Administrative Offices. However, for now, it's no longer possible for a CentCom ghost player to get into areas they shouldn't be.

## Why It's Good For The Game
Fixes #793.

## Changelog
:cl: MichiRecRoom
fix: CentCom ghost players can no longer bypass the area restrictions placed on them by being in a container. Sorry, but while there is some fun to be had, it appears that some exploits were also to be had too.
/:cl: