### PR TITLE
Clarify that H.A.U.L. Gauntlets make your hands considered chunky

### DIFF
--- a/code/modules/clothing/gloves/special.dm
+++ b/code/modules/clothing/gloves/special.dm
@@ -1,7 +1,10 @@
 
 /obj/item/clothing/gloves/cargo_gauntlet
 	name = "\improper H.A.U.L. gauntlets"
-	desc = "These clunky gauntlets allow you to drag things with more confidence on them not getting nabbed from you."
+	//MONKESTATION EDIT START
+	//desc = "These clunky gauntlets allow you to drag things with more confidence on them not getting nabbed from you." //MONKESTATION EDIT ORIGINAL
+	desc = "These clunky gauntlets allow you to drag things with more confidence on them not getting nabbed from you. However, they make your fingers too chunky to use most firearms, stun batons, and some computers flexibly."
+	//MONKESTATION EDIT END
 	icon_state = "haul_gauntlet"
 	greyscale_colors = "#2f2e31"
 	equip_delay_self = 3 SECONDS


### PR DESCRIPTION
## About The Pull Request
Changes the description of H.A.U.L. Gauntlets to mention that they cause your fingers to be considered chunky - making gun usage (and other things) harder.

## Why It's Good For The Game
The user won't need to learn on their own that HAUL Gauntlets are why their IPC's fingers are considered chunky.

## Changelog

:cl: MichiRecRoom
add: The description of H.A.U.L. Gauntlets now denotes that they cause your fingers to be considered chunky.
/:cl:
