### PR TITLE
Examining a clothing piece now tells you whether it makes your fingers considered chunky.

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -376,6 +376,13 @@
 	if(get_armor().has_any_armor() || (flags_cover & (HEADCOVERSMOUTH|PEPPERPROOF)))
 		. += span_notice("It has a <a href='?src=[REF(src)];list_armor=1'>tag</a> listing its protection classes.")
 
+	//MONKESTATION ADDITION START - Denotes some clothing traits when examining a clothing piece.
+	if(clothing_traits)
+		if(TRAIT_CHUNKYFINGERS in clothing_traits)
+			// Denotes that wearing makes your fingers chunky.
+			. += span_notice("Wearing [src] makes your fingers chunky, preventing use of most firearms, stun batons, and some computers.")
+	//MONKESTATION ADDITION
+
 /obj/item/clothing/Topic(href, href_list)
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request
Adds a bit to `/obj/item/clothing/examine`, which will add additional text based on whether the clothing piece will make your fingers considered chunky.

## Why It's Good For The Game
Now the player no longer needs to guess whether a clothing piece will make their fingers chunky.

Also, the way I structured this, it makes it easy to add similar examine text for other clothing traits.

## Changelog

:cl: MichiRecRoom
qol: Clothing pieces that make your fingers chunky (currently, only the H.A.U.L. Gauntlets and the Boxing Gloves) will now denote themselves as such upon examining them.
/:cl:
