### PR TITLE
Update /proc/log_bomber() to mention if the bomber is a pacifist

### DIFF
--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -76,6 +76,10 @@
 	var/bomb_message = "[details][bomb ? " [bomb.name] at [AREACOORD(bomb)]": ""][additional_details ? " [additional_details]" : ""]."
 
 	if(user)
+		//MONKESTATION ADDITION START - Mark if the bomber was a pacifist
+		if(HAS_TRAIT(user, TRAIT_PACIFISM))
+			bomb_message = "(while pacifist) [bomb_message]"
+		//MONKESTATION ADDITION END
 		user.log_message(bomb_message, LOG_ATTACK) //let it go to individual logs as well as the game log
 		bomb_message = "[key_name(user)] at [AREACOORD(user)] [bomb_message]."
 	else
@@ -85,4 +89,9 @@
 
 	add_event_to_buffer(user, data = bomb_message, log_key = "BOMB")
 	if(message_admins)
+		//MONKESTATION EDIT START - Mark if the bomber was a pacifist
+		/*
 		message_admins("[user ? "[ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(user)] " : ""][details][bomb ? " [bomb.name] at [ADMIN_VERBOSEJMP(bomb)]": ""][additional_details ? " [additional_details]" : ""].")
+		*/ //MONKESTATION EDIT ORIGINAL
+		message_admins("[user ? "[ADMIN_LOOKUPFLW(user)][HAS_TRAIT(user, TRAIT_PACIFISM) ? " (pacifist)" : ""] at [ADMIN_VERBOSEJMP(user)] " : ""][details][bomb ? " [bomb.name] at [ADMIN_VERBOSEJMP(bomb)]": ""][additional_details ? " [additional_details]" : ""].")
+		//MONKESTATION EDIT END

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -117,8 +117,13 @@
 		target = bomb_target
 		active = TRUE
 
+		//MONKESTATION EDIT START - Why is this not just a call to log_bomber...?
+		/*
 		message_admins("[ADMIN_LOOKUPFLW(user)] planted [name] on [target.name] at [ADMIN_VERBOSEJMP(target)] with [det_time] second fuse")
 		user.log_message("planted [name] on [target.name] with a [det_time] second fuse.", LOG_ATTACK)
+		*/ //MONKESTATION EDIT ORIGINAL
+		log_bomber(user, "planted", src, "on [target] at [ADMIN_VERBOSEJMP(target)] with [det_time] second fuse")
+		//MONKESTATION EDIT END
 		notify_ghosts("[user] has planted \a [src] on [target] with a [det_time] second fuse!", source = bomb_target, action = (isturf(target) ? NOTIFY_JUMP : NOTIFY_ORBIT), flashwindow = FALSE, header = "Explosive Planted")
 
 		moveToNullspace() //Yep

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -122,7 +122,7 @@
 		message_admins("[ADMIN_LOOKUPFLW(user)] planted [name] on [target.name] at [ADMIN_VERBOSEJMP(target)] with [det_time] second fuse")
 		user.log_message("planted [name] on [target.name] with a [det_time] second fuse.", LOG_ATTACK)
 		*/ //MONKESTATION EDIT ORIGINAL
-		log_bomber(user, "planted", src, "on [target] at [ADMIN_VERBOSEJMP(target)] with [det_time] second fuse")
+		log_bomber(user, "planted", src, "on [target] with [det_time] second fuse")
 		//MONKESTATION EDIT END
 		notify_ghosts("[user] has planted \a [src] on [target] with a [det_time] second fuse!", source = bomb_target, action = (isturf(target) ? NOTIFY_JUMP : NOTIFY_ORBIT), flashwindow = FALSE, header = "Explosive Planted")
 


### PR DESCRIPTION
## About The Pull Request
The Pacifist quirk is supposed to prevent you from harming creatures. In most cases, it works - the character will refuse to attack with lethal objects or lethally-loaded guns, as well as silly stuff like not stomping cockroaches.

However, it's possible for the player to bypass this pacifism. One way is through grenade-type items.

This PR doesn't block players from using grenades if they're pacifist, but it DOES cause logs to mark if they were a pacifist at the time of priming the grenade.

![image](https://github.com/Monkestation/Monkestation2.0/assets/1008889/06550b5b-913d-4919-b736-18c859b82211)
![image](https://github.com/Monkestation/Monkestation2.0/assets/1008889/3de38dd1-8d48-4d4f-8d94-a98516e033ee)
Note the `(pacifist)` and `(while pacifist)` added near the beginning of these logs. These appear if the user has the Pacifist trait. Users without the Pacifist trait have the same logs as before.

P.S. I plan to perform a much wider-reaching PR in the future, aimed at actually blocking Pacifists from bypassing their pacifism. For now, I wanted to get this out.

## Why It's Good For The Game
Pacifist characters shouldn't be using dangerous items! While this doesn't block them from using them, it makes it much easier for admins to spot whether a player was pacifist at the time of priming a grenade.

## Changelog

:cl:
admin: Bomb-priming-type logs now mark the relevant mob as pacifist, if they indeed are pacifist.
/:cl:
