### PR TITLE
More pathology stuff

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -263,8 +263,6 @@
 				continue
 			item.post_equip_item(humanc.client?.prefs, humanc)
 
-	DiseaseCarrierCheck(humanc)
-
 /mob/dead/new_player/proc/AddEmploymentContract(mob/living/carbon/human/employee)
 	//TODO:  figure out a way to exclude wizards/nukeops/demons from this.
 	for(var/C in GLOB.employmentCabinets)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -112,7 +112,7 @@
 				var/obj/loc_as_obj = loc
 				breath = loc_as_obj.handle_internal_lifeform(src, BREATH_VOLUME)
 			else if(isturf(loc)) //Breathe from loc as turf
-
+				breath_airborne_diseases() //monkestation edit - VIROLOGY
 				var/turf/our_turf = loc
 				if(our_turf.liquids && !HAS_TRAIT(src, TRAIT_NOBREATH) && ((body_position == LYING_DOWN && our_turf.liquids.liquid_state >= LIQUID_STATE_WAIST) || (body_position == STANDING_UP && our_turf.liquids.liquid_state >= LIQUID_STATE_FULLTILE)))
 					//Officially trying to breathe underwater
@@ -151,7 +151,6 @@
 				loc_as_obj.handle_internal_lifeform(src,0)
 
 	check_breath(breath)
-	breath_airborne_diseases() //monkestation edit - VIROLOGY
 
 	if(breath)
 		loc.assume_air(breath)

--- a/monkestation/code/modules/virology/disease/_disease.dm
+++ b/monkestation/code/modules/virology/disease/_disease.dm
@@ -509,7 +509,6 @@ GLOBAL_LIST_INIT(virusDB, list())
 
 	if (mob.immune_system)
 		var/immune_system = mob.immune_system.GetImmunity()
-		var/immune_str = immune_system[1]
 		var/list/antibodies = immune_system[2]
 		var/subdivision = (strength - ((robustness * strength) / 100)) / max_stages
 		//for each antigen, we measure the corresponding antibody concentration in the carrier's immune system

--- a/monkestation/code/modules/virology/disease/_disease.dm
+++ b/monkestation/code/modules/virology/disease/_disease.dm
@@ -33,8 +33,8 @@ GLOBAL_LIST_INIT(virusDB, list())
 
 	//When an opportunity for the disease to spread_flags to a mob arrives, runs this percentage through prob()
 	//Ignored if infected materials are ingested (injected with infected blood, eating infected meat)
-	var/infectionchance = 70
-	var/infectionchance_base = 70
+	var/infectionchance = 20
+	var/infectionchance_base = 20
 
 	//ticks increases by [speed] every time the disease activates. Drinking Virus Food also accelerates the process by 10.
 	var/ticks = 0
@@ -378,6 +378,10 @@ GLOBAL_LIST_INIT(virusDB, list())
 	if(!(infectable_biotypes & mob.mob_biotypes))
 		return
 
+	if(mob.immune_system)
+		if(prob(8))
+			mob.immune_system.NaturalImmune()
+
 	if(!mob.immune_system.CanInfect(src))
 		cure(mob)
 		return
@@ -511,7 +515,7 @@ GLOBAL_LIST_INIT(virusDB, list())
 		//for each antigen, we measure the corresponding antibody concentration in the carrier's immune system
 		//the less robust the pathogen, the more likely that further stages' effects won't activate at a given concentration
 		for (var/A in antigen)
-			var/concentration = immune_str * antibodies[A]
+			var/concentration = antibodies[A]
 			highest_concentration = max(highest_concentration,concentration)
 			var/i = lowest_stage
 			while (i > 0)
@@ -634,8 +638,8 @@ GLOBAL_LIST_INIT(virusDB, list())
 /datum/disease/advanced/virus
 	form = "Virus"
 	max_stages = 4
-	infectionchance = 70
-	infectionchance_base = 70
+	infectionchance = 20
+	infectionchance_base = 20
 	stageprob = 10
 	stage_variance = -1
 	can_kill = list("Bacteria")
@@ -643,24 +647,24 @@ GLOBAL_LIST_INIT(virusDB, list())
 /datum/disease/advanced/bacteria//faster spread_flags and progression, but only 3 stages max, and reset to stage 1 on every spread_flags
 	form = "Bacteria"
 	max_stages = 3
-	infectionchance = 90
-	infectionchance_base = 90
+	infectionchance = 30
+	infectionchance_base = 30
 	stageprob = 30
 	stage_variance = -4
 	can_kill = list("Parasite")
 
 /datum/disease/advanced/parasite//slower spread_flags. stage preserved on spread_flags
 	form = "Parasite"
-	infectionchance = 50
-	infectionchance_base = 50
+	infectionchance = 15
+	infectionchance_base = 15
 	stageprob = 10
 	stage_variance = 0
 	can_kill = list("Virus")
 
 /datum/disease/advanced/prion//very fast progression, but very slow spread_flags and resets to stage 1.
 	form = "Prion"
-	infectionchance = 10
-	infectionchance_base = 10
+	infectionchance = 3
+	infectionchance_base = 3
 	stageprob = 80
 	stage_variance = -10
 	can_kill = list()

--- a/monkestation/code/modules/virology/disease/symtoms/stage4.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/stage4.dm
@@ -229,7 +229,7 @@
 		for(var/i=0,i<iter,i++)
 			step_towards(S,mob)
 
-/datum/symptom/dnaspread
+/*/datum/symptom/dnaspread //commented out due to causing enough problems to turn random people into monkies apon curing.
 	name = "Retrotransposis"
 	desc = "This symptom transplants the genetic code of the intial vector into new hosts."
 	badness = EFFECT_DANGER_HARMFUL
@@ -293,7 +293,7 @@
 	name = "Mothification"
 	desc = "Turns you into a Moth."
 	new_species = /datum/species/moth
-
+*/
 /datum/symptom/retrovirus
 	name = "Retrovirus"
 	desc = "A DNA-altering retrovirus that scrambles the structural and unique enzymes of a host constantly."

--- a/monkestation/code/modules/virology/immune_systems/_immune_system.dm
+++ b/monkestation/code/modules/virology/immune_systems/_immune_system.dm
@@ -59,13 +59,7 @@
 	source.immune_system.antibodies = antibodies.Copy()
 
 /datum/immune_system/proc/GetImmunity()
-	var/effective_strength = strength
-
-	if(host)
-		if(HAS_TRAIT(host, TRAIT_HULK))
-			effective_strength *= 2
-
-	return list(effective_strength, antibodies.Copy())
+	return list(strength, antibodies.Copy())
 
 /datum/immune_system/proc/Overload()
 	host.adjustToxLoss(100)
@@ -88,7 +82,7 @@
 		return TRUE
 
 	for (var/antigen in disease.antigen)
-		if ((strength * antibodies[antigen]) >= disease.strength)
+		if ((antibodies[antigen]) >= disease.strength)
 			return FALSE
 	return TRUE
 
@@ -110,7 +104,7 @@
 					else
 						tally += 2//if we're sleeping in a bed, we get up to 4
 			else if(istype(host.loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
-				tally += 1.5
+				tally += 2.5
 
 			if (antibodies[A] < threshold)
 				antibodies[A] = min(antibodies[A] + tally, threshold)//no overshooting here
@@ -118,6 +112,42 @@
 				if (prob(threshold) && prob(tally * 10) && prob((100 - antibodies[A])*100/(100-threshold)))//smaller and smaller chance for further increase
 					antibodies[A] = min(antibodies[A] + 1, 100)
 
+/datum/immune_system/proc/NaturalImmune() //called with a 8% chance every time a virus activates
+	for (var/datum/disease/advanced/disease as anything in host.diseases)
+		for (var/A in disease.antigen)
+			var/tally = 1.5
+			if (isturf(host.loc) && (host.body_position == LYING_DOWN))
+				tally += 0.5
+				var/obj/structure/bed/B = locate() in host.loc
+				if (host.buckled == B)//fucking chairs n stuff
+					tally += 0.5
+				if (host.IsUnconscious())
+					if (tally < 3)
+						tally += 1
+					else
+						tally += 2//if we're sleeping in a bed, we get up to 5.5
+			else if(istype(host.loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
+				tally += 3.5
+
+			if (antibodies[A] < 60)
+				antibodies[A] = min(antibodies[A] + tally * strength, 60)
+			else
+				if(strength < 0.7) //stop trying at all once below 70%
+					return
+				if(prob(80)) //immune system begins gaining attrition over 60% antigen.
+					strength = max(strength - 0.05, 0)
+				antibodies[A] = min(antibodies[A] + tally * strength, 100)
+
+// fix immune system damage
+/datum/immune_system/proc/ImmuneRepair(level, threshold)
+	if(level < 0)
+		strength = max(strength + level, 0)
+		return
+	if(strength > threshold) //do not turn 500% into 100% because you drank a lower level immune healer
+		return
+	strength = min(strength + level, threshold)
+
+//instantly maxxes the antibodies for any disease in your body
 /datum/immune_system/proc/AntibodyCure()
 	if (overloaded)
 		return
@@ -137,4 +167,4 @@
 
 /datum/immune_system/proc/decay_vaccine(list/antigens, amount = 1)
 	for (var/A in antigens)
-		antibodies[A] = max(antibodies[A] - 8 * amount, 10)
+		antibodies[A] = max(antibodies[A] - 5 * amount, 10)

--- a/monkestation/code/modules/virology/immune_systems/_immune_system.dm
+++ b/monkestation/code/modules/virology/immune_systems/_immune_system.dm
@@ -129,12 +129,12 @@
 			else if(istype(host.loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
 				tally += 3.5
 
-			if (antibodies[A] < 60)
+			if (antibodies[A] < 70)
 				antibodies[A] = min(antibodies[A] + tally * strength, 60)
 			else
-				if(strength < 0.7) //stop trying at all once below 70%
+				if(strength < 0.7) //stop trying at all once below 70% strength and above 70% antibodies
 					return
-				if(prob(80)) //immune system begins gaining attrition over 60% antigen.
+				if(prob(80)) //immune system begins gaining attrition over 70% antigen.
 					strength = max(strength - 0.05, 0)
 				antibodies[A] = min(antibodies[A] + tally * strength, 100)
 

--- a/monkestation/code/modules/virology/immune_systems/_immune_system.dm
+++ b/monkestation/code/modules/virology/immune_systems/_immune_system.dm
@@ -122,7 +122,7 @@
 				if (host.buckled == B)//fucking chairs n stuff
 					tally += 0.5
 				if (host.IsUnconscious())
-					if (tally < 3)
+					if (tally < 2.5)
 						tally += 1
 					else
 						tally += 2//if we're sleeping in a bed, we get up to 5.5

--- a/monkestation/code/modules/virology/items/antibodyscanner.dm
+++ b/monkestation/code/modules/virology/items/antibodyscanner.dm
@@ -73,7 +73,7 @@
 				if ("C")
 					rgb = "#F54B4B"
 				//add colors for new special antigens here
-			scan.DrawBox(rgb,i*bar_spacing+bar_offset+x_adjustment,6,i*bar_spacing+bar_width+bar_offset+x_adjustment,6+antibodies[antibody]*3*immune_str)
+			scan.DrawBox(rgb,i*bar_spacing+bar_offset+x_adjustment,6,i*bar_spacing+bar_width+bar_offset+x_adjustment,6+antibodies[antibody]*3)
 			i++
 
 	if (length(L.diseases))
@@ -105,7 +105,7 @@
 	info += "<tr>"
 	if (L.immune_system)
 		for (var/antibody in antigens_that_matter)
-			info += "<td>[round(L.immune_system.antibodies[antibody]*L.immune_system.strength)]%</th>"
+			info += "<td>[round(L.immune_system.antibodies[antibody])]%</th>"
 	info += "</tr>"
 	info += "</table>"
 

--- a/monkestation/code/modules/virology/living/spread_disease.dm
+++ b/monkestation/code/modules/virology/living/spread_disease.dm
@@ -39,7 +39,7 @@
 	if(prob(disease.infectionchance) || forced)
 		var/datum/disease/advanced/D = disease.Copy()
 		if (D.infectionchance > 5)
-			D.infectionchance = max(5, D.infectionchance - 2)//The virus gets weaker as it jumps from people to people
+			D.infectionchance = max(5, D.infectionchance - 5)//The virus gets weaker as it jumps from people to people
 
 		D.stage = clamp(D.stage+D.stage_variance, 1, D.max_stages)
 		D.log += "<br />[ROUND_TIME()] Infected [key_name(src)] [notes]. Infection chance now [D.infectionchance]%"
@@ -55,3 +55,35 @@
 
 		D.AddToGoggleView(src)
 	return TRUE
+
+/mob/dead/new_player/proc/DiseaseCarrierCheck(mob/living/carbon/human/H)
+	if(world.time < SSautotransfer.starttime + 30 MINUTES)
+		return
+	// 10% of players are joining the station with some minor disease if latejoined
+	if(prob(10))
+		var/virus_choice = pick(subtypesof(/datum/disease/advanced)- typesof(/datum/disease/advanced/premade))
+		var/datum/disease/advanced/D = new virus_choice
+
+		var/list/anti = list(
+			ANTIGEN_BLOOD	= 1,
+			ANTIGEN_COMMON	= 1,
+			ANTIGEN_RARE	= 0,
+			ANTIGEN_ALIEN	= 0,
+			)
+		var/list/bad = list(
+			EFFECT_DANGER_HELPFUL	= 1,
+			EFFECT_DANGER_FLAVOR	= 4,
+			EFFECT_DANGER_ANNOYING	= 4,
+			EFFECT_DANGER_HINDRANCE	= 0,
+			EFFECT_DANGER_HARMFUL	= 0,
+			EFFECT_DANGER_DEADLY	= 0,
+			)
+
+		D.makerandom(list(30,55),list(0,50),anti,bad,null)
+
+		D.log += "<br />[ROUND_TIME()] Infected [key_name(H)]"
+		if(!length(H.diseases))
+			H.diseases = list()
+		H.diseases += D
+
+		D.AddToGoggleView(H)

--- a/monkestation/code/modules/virology/living/spread_disease.dm
+++ b/monkestation/code/modules/virology/living/spread_disease.dm
@@ -38,8 +38,8 @@
 
 	if(prob(disease.infectionchance) || forced)
 		var/datum/disease/advanced/D = disease.Copy()
-		if (D.infectionchance > 10)
-			D.infectionchance = max(10, D.infectionchance - 10)//The virus gets weaker as it jumps from people to people
+		if (D.infectionchance > 5)
+			D.infectionchance = max(5, D.infectionchance - 2)//The virus gets weaker as it jumps from people to people
 
 		D.stage = clamp(D.stage+D.stage_variance, 1, D.max_stages)
 		D.log += "<br />[ROUND_TIME()] Infected [key_name(src)] [notes]. Infection chance now [D.infectionchance]%"

--- a/monkestation/code/modules/virology/living/spread_disease.dm
+++ b/monkestation/code/modules/virology/living/spread_disease.dm
@@ -55,35 +55,3 @@
 
 		D.AddToGoggleView(src)
 	return TRUE
-
-/mob/dead/new_player/proc/DiseaseCarrierCheck(mob/living/carbon/human/H)
-	if(world.time < SSautotransfer.starttime + 30 MINUTES)
-		return
-	// 10% of players are joining the station with some minor disease if latejoined
-	if(prob(10))
-		var/virus_choice = pick(subtypesof(/datum/disease/advanced)- typesof(/datum/disease/advanced/premade))
-		var/datum/disease/advanced/D = new virus_choice
-
-		var/list/anti = list(
-			ANTIGEN_BLOOD	= 1,
-			ANTIGEN_COMMON	= 1,
-			ANTIGEN_RARE	= 0,
-			ANTIGEN_ALIEN	= 0,
-			)
-		var/list/bad = list(
-			EFFECT_DANGER_HELPFUL	= 1,
-			EFFECT_DANGER_FLAVOR	= 4,
-			EFFECT_DANGER_ANNOYING	= 4,
-			EFFECT_DANGER_HINDRANCE	= 0,
-			EFFECT_DANGER_HARMFUL	= 0,
-			EFFECT_DANGER_DEADLY	= 0,
-			)
-
-		D.makerandom(list(30,55),list(0,50),anti,bad,null)
-
-		D.log += "<br />[ROUND_TIME()] Infected [key_name(H)]"
-		if(!length(H.diseases))
-			H.diseases = list()
-		H.diseases += D
-
-		D.AddToGoggleView(H)

--- a/monkestation/code/modules/virology/reagents/immune_healers.dm
+++ b/monkestation/code/modules/virology/reagents/immune_healers.dm
@@ -1,0 +1,51 @@
+/datum/reagent/medicine/immune_healer
+	name = "Aluxive"
+	description = "A powerful immune enhancing drug, often used in small doses to counteract immunodeficiency."
+	color = "#667056"
+	ph = 7.4
+	metabolization_rate = 0.2 * REAGENTS_METABOLISM
+	data = list(
+		"level" = 0.05,
+		"threshold" = 1,
+		) //level is in precentage
+
+/datum/reagent/medicine/immune_healer/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	affected_mob.immune_system.ImmuneRepair(data["level"] ,data["threshold"])
+	return ..()
+
+/datum/reagent/medicine/immune_healer/immune_suppressant
+	name = "Radiohydrate"
+	description = "A potent immunosuppressant, can be used to prevent so-called benifical viruses from being naturally cured."
+	color = "#7ba813"
+	ph = 10.8
+	metabolization_rate = REAGENTS_METABOLISM
+	data = list(
+		"level" = -0.05,
+		"threshold" = 1,
+		) //level is in precentage
+
+/datum/reagent/medicine/immune_healer/immune_booster
+	name = "Aetericilide"
+	description = "An immune system enhancement drug, able to increase the power of a person's immune system up to 5 times its starting level."
+	color = "#16eedc"
+	ph = 6.3
+	metabolization_rate = REAGENTS_METABOLISM
+	data = list(
+		"level" = 0.05,
+		"threshold" = 5,
+		) //level is in precentage
+
+/datum/chemical_reaction/immune_healer
+	results = list(/datum/reagent/medicine/immune_healer = 3)
+	required_reagents = list(/datum/reagent/consumable/sugar = 1, /datum/reagent/medicine/c2/seiver = 1, /datum/reagent/cryptobiolin = 1)
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
+
+/datum/chemical_reaction/immune_suppressant
+	results = list(/datum/reagent/medicine/immune_healer/immune_suppressant = 4)
+	required_reagents = list(/datum/reagent/uranium/radium = 1, /datum/reagent/medicine/mine_salve = 1)
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER
+
+/datum/chemical_reaction/immune_booster
+	results = list(/datum/reagent/medicine/immune_healer/immune_booster = 2)
+	required_reagents = list(/datum/reagent/toxin/mutagen = 1, /datum/reagent/stable_plasma = 1, /datum/reagent/diethylamine = 1, /datum/reagent/copper = 1)
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER

--- a/monkestation/code/modules/virology/reagents/vaccine.dm
+++ b/monkestation/code/modules/virology/reagents/vaccine.dm
@@ -10,7 +10,7 @@
 
 /datum/reagent/vaccine/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
 	. = ..()
-	drinker.immune_system.ApplyVaccine(data["antigen"], 10, 30 MINUTES)
+	drinker.immune_system.ApplyVaccine(data["antigen"], 5, 30 MINUTES)
 
 /datum/reagent/vaccine/on_merge(list/mix_data)
 	if(data && mix_data)

--- a/monkestation/code/modules/virology/reagents/vaccine.dm
+++ b/monkestation/code/modules/virology/reagents/vaccine.dm
@@ -10,7 +10,7 @@
 
 /datum/reagent/vaccine/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
 	. = ..()
-	drinker.immune_system.ApplyVaccine(data["antigen"], 1, 30 MINUTES)
+	drinker.immune_system.ApplyVaccine(data["antigen"], 10, 30 MINUTES)
 
 /datum/reagent/vaccine/on_merge(list/mix_data)
 	if(data && mix_data)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6629,6 +6629,7 @@
 #include "monkestation\code\modules\virology\machines\isolator.dm"
 #include "monkestation\code\modules\virology\machines\splicer.dm"
 #include "monkestation\code\modules\virology\reagents\antipathenogenics.dm"
+#include "monkestation\code\modules\virology\reagents\immune_healers.dm"
 #include "monkestation\code\modules\virology\reagents\symptom_reagents.dm"
 #include "monkestation\code\modules\virology\reagents\vaccine.dm"
 #include "monkestation\code\modules\virology\research\circuitboards.dm"


### PR DESCRIPTION

## About The Pull Request
Adds immune strength mechanics, and natural immunity.

Three new chems that interact with this.

Removes the random 10% chance for latejoiners to be infected with something.

Massively decreases the exposure infection chance for all diseases.

People will no longer breathe out disease clouds while wearing internals

Vaccines work the same way at any volume. 0.1u pills are back!

All species changing/dna spreading symptoms have been disabled due to being extremely buggy on cure

Cryo cells now are better than sleeping in a bed for antipathogenics.

## Why It's Good For The Game
Bringing down the disease exposure infection chance will help greatly with our current absurd r-naught for literally every disease. 

Natural immunity moves us from a SI model to a full SIR model, meaning diseases can naturally fizzle out instead of staying endemic forever.

Nobody liked the latejoiners getting fucked by a disease gamble, it could quickly overwhelm medical with multiple diseases(like our old system that nobody liked)

Vaccines being easily distributable is critical to the job of the pathologist

When your in a cryo cell you have effectively sold your soul off to medical, you deserve a bit faster viral immunity gain

## Changelog
:cl:
add: Natural immunity.
add: Aluxive, an immune repair chem that is created with sugar, seiver and cryptobiolin.
add: Radiohydrate, an immune suppressor that is created with miner's salve and radium.
add: Aetericilide, an immune booster that is created with unstable mutagen, copper, diethylamine, and stable plasma.
del: Removed the buggy species change symptoms
del: Latejoiners no longer have a 10% chance of starting with a disease
balance: Reduced the exposure infection chance on all diseases.
balance: Vaccines now work in 0.1u pills again.
balance: Buffs cryo cell's effects on anti-pathogenics.
fix: Internals now actually stop you from emitting(and breathing) disease clouds.
/:cl:
