### PR TITLE
Changes Dragon Blood Skeleton

### DIFF
--- a/code/__DEFINES/~monkestation/mobs.dm
+++ b/code/__DEFINES/~monkestation/mobs.dm
@@ -1,4 +1,5 @@
 #define SPECIES_ARACHNIDS "arachnid"
+#define SPECIES_DRACONIC_SKELETON "draconic skeleton"
 
 GLOBAL_REAL_VAR(list/voice_type2sound) = list(
 	"1" = list(

--- a/code/__DEFINES/~monkestation/mobs.dm
+++ b/code/__DEFINES/~monkestation/mobs.dm
@@ -1,5 +1,5 @@
 #define SPECIES_ARACHNIDS "arachnid"
-#define SPECIES_DRACONIC_SKELETON "draconic skeleton"
+#define SPECIES_DRACONIC_SKELETON "draconic_skeleton"
 
 GLOBAL_REAL_VAR(list/voice_type2sound) = list(
 	"1" = list(

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -740,7 +740,7 @@
 			consumer.set_species(/datum/species/lizard)
 		if(2)
 			to_chat(user, span_danger("Your flesh begins to melt! Miraculously, you seem fine otherwise."))
-			consumer.set_species(/datum/species/skeleton)
+			consumer.set_species(/datum/species/skeleton/draconic)
 		if(3)
 			to_chat(user, span_danger("Power courses through you! You can now shift your form at will."))
 			var/datum/action/cooldown/spell/shapeshift/dragon/dragon_shapeshift = new(user.mind || user)

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -740,7 +740,7 @@
 			consumer.set_species(/datum/species/lizard)
 		if(2)
 			to_chat(user, span_danger("Your flesh begins to melt! Miraculously, you seem fine otherwise."))
-			consumer.set_species(/datum/species/skeleton/draconic)
+			consumer.set_species(/datum/species/skeleton/draconic) //monke edit
 		if(3)
 			to_chat(user, span_danger("Power courses through you! You can now shift your form at will."))
 			var/datum/action/cooldown/spell/shapeshift/dragon/dragon_shapeshift = new(user.mind || user)

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/skeletons.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/skeletons.dm
@@ -7,7 +7,6 @@
 /datum/species/skeleton/draconic
 	// Alternate skeleton for drake blood that can process chems!
 	name = "Draconic Skeleton"
-	id = SPECIES_SKELETON
 	sexes = 0
 	meat = /obj/item/food/meat/slab/human/mutant/skeleton
 	species_traits = list(

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/skeletons.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/skeletons.dm
@@ -7,6 +7,7 @@
 /datum/species/skeleton/draconic
 	// Alternate skeleton for drake blood that can process chems!
 	name = "Draconic Skeleton"
+	id = SPECIES_DRACONIC_SKELETON
 	sexes = 0
 	meat = /obj/item/food/meat/slab/human/mutant/skeleton
 	species_traits = list(

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/skeletons.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/skeletons.dm
@@ -3,3 +3,36 @@
 
 /datum/species/skeleton/get_laugh_sound(mob/living/carbon/human/human)
 	return 'monkestation/sound/voice/laugh/skeleton/skeleton_laugh.ogg'
+
+/datum/species/skeleton/draconic
+	// Alternate skeleton for drake blood that can process chems!
+	name = "Draconic Skeleton"
+	id = SPECIES_SKELETON
+	sexes = 0
+	meat = /obj/item/food/meat/slab/human/mutant/skeleton
+	species_traits = list(
+		NOTRANSSTING,
+		NOEYESPRITES,
+		NO_DNA_COPY,
+		NO_UNDERWEAR,
+		NOHUSK,
+	)
+	inherent_traits = list(
+		TRAIT_CAN_USE_FLIGHT_POTION,
+		TRAIT_EASYDISMEMBER,
+		TRAIT_FAKEDEATH,
+		TRAIT_GENELESS,
+		TRAIT_LIMBATTACHMENT,
+		TRAIT_NOBREATH,
+		TRAIT_NOCLONELOSS,
+		TRAIT_RADIMMUNE,
+		TRAIT_PIERCEIMMUNE,
+		TRAIT_RESISTCOLD,
+		TRAIT_RESISTHEAT,
+		TRAIT_RESISTHIGHPRESSURE,
+		TRAIT_RESISTLOWPRESSURE,
+		TRAIT_TOXIMMUNE,
+		TRAIT_XENO_IMMUNE,
+		TRAIT_NOBLOOD,
+	)
+	mutantliver = /obj/item/organ/internal/liver


### PR DESCRIPTION

## About The Pull Request

One of the worst possible rolls for dragons blood is skeleton, as it removes your ability to use medipens, which absolutely sucks for miners. This seeks to change that by adding a new skeleton varient, the Draconic Skeleton, which is the exact same but it has a liver and can process chems.
## Why It's Good For The Game

Regular skeleton roll for dragons blood fucking sucks, so now you can process chems, enjoy

## Changelog

:cl:
balance: Skeleton roll from dragons blood can now process chems! Rejoice!

/:cl:

