### PR TITLE
Fuck you, unaoes your mindswap

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/mobility.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/mobility.dm
@@ -1,9 +1,9 @@
 // Wizard spells that aid mobiilty(or stealth?)
-/*/datum/spellbook_entry/mindswap //monkestation edit: replaced with an aoe version
+/datum/spellbook_entry/mindswap
 	name = "Mindswap"
 	desc = "Allows you to switch bodies with a target next to you. You will both fall asleep when this happens, and it will be quite obvious that you are the target's body if someone watches you do it."
 	spell_type = /datum/action/cooldown/spell/pointed/mind_transfer
-	category = "Mobility"*/
+	category = "Mobility"
 
 /datum/spellbook_entry/knock
 	name = "Knock"

--- a/monkestation/code/modules/antagonists/wizard/equipment/spellbook_entries/mobility.dm
+++ b/monkestation/code/modules/antagonists/wizard/equipment/spellbook_entries/mobility.dm
@@ -1,5 +1,5 @@
-/datum/spellbook_entry/mindswap
+/*/datum/spellbook_entry/mindswap
 	name = "Mindswap"
 	desc = "This spell will randomly swap the minds of everyone around you, yourself included."
 	spell_type = /datum/action/cooldown/spell/aoe/mind_swap
-	category = "Mobility"
+	category = "Mobility"*/


### PR DESCRIPTION
## About The Pull Request
Reverts aoe mindswap to its original state

## Why It's Good For The Game
AOE mindswap is just not fun for anyone, and also literally worse than the regular mindswap because you can't choose your target. I, and most other players, are yet to have any actual fun with aoe mindswap that wouldn't also be had with regular mindswap.
## Changelog
:cl:
balance: Returns mindswap to its original, targeted form
/:cl:
