### PR TITLE
Fix Human screams not varying in pitch when they should

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -102,7 +102,11 @@
 	var/tmp_sound = get_sound(user)
 	if(tmp_sound && should_play_sound(user, intentional) && !TIMER_COOLDOWN_CHECK(user, type))
 		TIMER_COOLDOWN_START(user, type, audio_cooldown)
-		playsound(user, tmp_sound, 50, vary, mixer_channel = CHANNEL_MOB_SOUNDS)
+		//MONKESTATION EDIT START - Allows sounds to vary based on their calling conditions.
+		//playsound(user, tmp_sound, 50, vary, mixer_channel = CHANNEL_MOB_SOUNDS) //MONKESTATION EDIT ORIGINAL
+		var/tmp_vary = should_vary(user)
+		playsound(user, tmp_sound, 50, tmp_vary, mixer_channel = CHANNEL_MOB_SOUNDS)
+		//MONKESTATION EDIT END
 
 	var/user_turf = get_turf(user)
 	if (user.client)

--- a/monkestation/code/datums/emotes.dm
+++ b/monkestation/code/datums/emotes.dm
@@ -3,3 +3,12 @@
 	var/message_ipc = ""
 	/// Message displayed if the user is an insect.
 	var/message_insect = ""
+
+// Whether this emote should vary in pitch every time it's played.
+//
+// By default, this returns the `vary` variable, so you should set that if it will always be TRUE or
+// FALSE. However, if your emote only varies under certain calling conditions (such as the user
+// being a human despite the emote applying to all living creatures), then you should override this
+// proc.
+/datum/emote/proc/should_vary(mob/living/user)
+	return vary

--- a/monkestation/code/modules/mob/living/emote.dm
+++ b/monkestation/code/modules/mob/living/emote.dm
@@ -92,6 +92,7 @@
 	message = "screams!"
 	message_mime = "acts out a scream!"
 	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
+	vary = FALSE
 
 /datum/emote/living/scream/get_sound(mob/living/user)
 	if(issilicon(user))
@@ -108,6 +109,11 @@
 		. = human_user.dna.species.get_scream_sound(user)
 	if(is_cat_enough(user))
 		return pick('monkestation/sound/voice/feline/scream1.ogg', 'monkestation/sound/voice/feline/scream2.ogg', 'monkestation/sound/voice/feline/scream3.ogg')
+
+/datum/emote/living/scream/should_vary(mob/living/user)
+	if(ishuman(user) && !is_cat_enough(user))
+		return TRUE
+	return ..()
 
 /datum/emote/living/scream/screech //If a human tries to screech it'll just scream.
 	key = "screech"


### PR DESCRIPTION
## About The Pull Request
A recent PR, #831, added some very delightful cat sounds. However, in the process, they inadvertently made it so that human-mob screams (such as IPC screams) don't vary in pitch.

This PR fixes that issue, by only varying the scream sound if the human *is not* cat enough. If the human is cat enough, the sound will not be varied in pitch, as before.

In the process, I introduced a new feature to `/datum/emote` - the `should_vary(mob/living/user)` proc. By default, this proc returns the value of emote's `vary` variable - and for most emotes, this is all you need. However, if the emote should vary only under certain conditions, then you should use this proc.

## Why It's Good For The Game
We want our funny high-pitched IPC voices back.

## Changelog

:cl: MichiRecRoom
fix: Human mobs (such as IPCs) should once again vary their scream's pitch - unless you're a cat.
code: "/datum/emote" now has a new proc: "should_vary(mob/living/user)". If your emote needs to vary in pitch, but only under certain conditions, override that proc.
/:cl:
