### PR TITLE
medical holodeck gets proper pathology machines and vials

### DIFF
--- a/_maps/templates/holodeck_medicalsim.dmm
+++ b/_maps/templates/holodeck_medicalsim.dmm
@@ -321,8 +321,8 @@
 	},
 /area/template_noop)
 "BS" = (
-/obj/machinery/computer/pandemic,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/machinery/disease2/centrifuge,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},
@@ -385,12 +385,12 @@
 /area/template_noop)
 "Ea" = (
 /obj/structure/table,
-/obj/item/reagent_containers/cup/beaker,
-/obj/item/reagent_containers/cup/beaker,
-/obj/item/reagent_containers/cup/beaker,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
+/obj/item/reagent_containers/cup/beaker/vial,
+/obj/item/reagent_containers/cup/beaker/vial,
+/obj/item/reagent_containers/cup/beaker/vial,
 /turf/open/floor/holofloor{
 	icon_state = "white"
 	},


### PR DESCRIPTION
## About The Pull Request

swaps the PANDEMIC with a centrifuge. replaces the three beakers with three vials. this is the bare minimum setup needed to cure diseases.

it's also my second time messing with monkestation code, and this is for a mapping change. god i hope this works

## Changelog
:cl: SentientVoid
qol: replaced the emergency medical holodeck's PANDEMIC with a centrifuge. swapped out 3 beakers for 3 vials.
/:cl:

