### PR TITLE
Update build script to ensure that modular code is checked for changes

### DIFF
--- a/tools/build/build.js
+++ b/tools/build/build.js
@@ -75,6 +75,8 @@ export const DmTarget = new Juke.Target({
     'html/**',
     'icons/**',
     'interface/**',
+    'monkestation/code/**', // monke edit: ensure it also checks for updates in modular code
+    'monkestation/icons/**',
     `${DME_NAME}.dme`,
     NamedVersionFile,
   ],


### PR DESCRIPTION
This makes it so build.bat checks modular code for changing when building, preventing you to have to re-save tgstation.dme or something to make it stop thinking that nothing's been changed.

Closes https://github.com/Monkestation/Monkestation2.0/pull/564

PR only affects development workflow, no actual changes to the game itself

**proof I didn't break the build script at least:**
![image](https://github.com/Monkestation/Monkestation2.0/assets/65794972/0bb69d5a-ddc3-40c9-8ff1-1f4d57da53c1)

