### PR TITLE
Fix broken Codex Cicatrix ritual

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/starting_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/starting_lore.dm
@@ -250,12 +250,20 @@ GLOBAL_LIST_INIT(heretic_start_knowledge, initialize_starting_knowledge())
 	if(!.)
 		return FALSE
 
-	for(var/mob/living/body in atoms)
-		if(body.stat != DEAD)
-			continue
+	// monke edit start: fix for codex cicatrix ritual
+	var/static/list/non_body_items = typecacheof(list(/obj/item/stack/sheet/leather, /obj/item/stack/sheet/animalhide))
 
-		selected_atoms += body
-		return TRUE
+	for(var/thingy in atoms)
+		if(is_type_in_typecache(thingy, non_body_items))
+			selected_atoms += thingy
+			return TRUE
+		else if(isliving(thingy))
+			var/mob/living/body = thingy
+			if(body.stat != DEAD)
+				continue
+			selected_atoms += body
+			return TRUE
+	// monke end
 	return FALSE
 
 /datum/heretic_knowledge/codex_cicatrix/cleanup_atoms(list/selected_atoms)


### PR DESCRIPTION

## About The Pull Request

Codex ritual _always_ required a dead body, despite the fact that the description said leather or a hide worked too, due to broken logic in `recipe_snowflake_check`. This fixes that, and was likely the originally intended behavior to begin with according to https://github.com/tgstation/tgstation/pull/77939:

> Codex Cicatrix is now a roundstart knowledge, works as an amber focus when held in-hand and opened, and has had its recipe changed to: 1 of any non-standard pen (literally anything that isn't the base pen), any book, and **either animal hide OR a corpse, any kind**.

## Changelog
:cl:
fix: Fixed the Codex Cicatrix always requiring a dead body, despite the description saying leather or a hide would work too.
/:cl:
