### PR TITLE
Remove BOT_MODE_GHOST_CONTROLABLE from /mob/living/simple_animal/bot/mulebot

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -29,6 +29,11 @@
 	radio_key = /obj/item/encryptionkey/headset_cargo
 	radio_channel = RADIO_CHANNEL_SUPPLY
 	bot_type = MULE_BOT
+	//MONKESTATION ADDITION START - By request of admins, disable roundstart MULEbots by redefining
+	//their starting flags to not include BOT_MODE_GHOST_CONTROLLABLE. Reason: They end up griefing
+	//more than they end up doing their job.
+	bot_mode_flags = BOT_MODE_ON | BOT_MODE_REMOTE_ENABLED
+	//MONKESTATION ADDITION END
 	path_image_color = "#7F5200"
 	possessed_message = "You are a MULEbot! Do your best to make sure that packages get to their destination!"
 


### PR DESCRIPTION
## About The Pull Request
Done by request of the admins, as ghost-controlled MULEbots have a tendency to grief - blocking doorways, running over people, and so on; basically anything that isn't their job of taking packages to a destination.

## Why It's Good For The Game
Removes grief. :)

## Why It's Terrible For The Game
Muh grief role! :(

## Changelog

:cl: MichiRecRoom
config: MULEbots are no longer part of the roundstart ghost spawns. Players with proper access to the MULEbot's panel can still enable the "Download Personality" option to allow ghosts to take control.
/:cl: