### PR TITLE
PDA crew manifest app for all!

### DIFF
--- a/code/modules/modular_computers/computers/item/disks/role_disks.dm
+++ b/code/modules/modular_computers/computers/item/disks/role_disks.dm
@@ -6,7 +6,7 @@
 	max_capacity = 32
 	///Static list of programss ALL command tablets have.
 	var/static/list/datum/computer_file/command_programs = list(
-		/datum/computer_file/program/crew_manifest,
+		// /datum/computer_file/program/crew_manifest, monke edit: everyone has the crew manifest anyways now
 		/datum/computer_file/program/science,
 		/datum/computer_file/program/status,
 	)

--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -36,6 +36,7 @@
 		/datum/computer_file/program/messenger,
 		/datum/computer_file/program/nt_pay,
 		/datum/computer_file/program/notepad,
+		/datum/computer_file/program/crew_manifest // monke edit: install crew manifest by default
 	)
 	///List of items that can be stored in a PDA
 	var/static/list/contained_item = list(

--- a/monkestation/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/monkestation/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -7,8 +7,8 @@
 	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, PROC_REF(_update_ui_data))
 
 /datum/computer_file/program/crew_manifest/Destroy()
-	. = ..()
 	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
+	return ..()
 
 /datum/computer_file/program/crew_manifest/proc/_update_ui_data()
 	SIGNAL_HANDLER

--- a/monkestation/code/modules/modular_computers/file_system/programs/crewmanifest.dm
+++ b/monkestation/code/modules/modular_computers/file_system/programs/crewmanifest.dm
@@ -1,0 +1,15 @@
+/datum/computer_file/program/crew_manifest
+	transfer_access = list()
+	detomatix_resistance = NONE
+
+/datum/computer_file/program/crew_manifest/New()
+	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED, PROC_REF(_update_ui_data))
+
+/datum/computer_file/program/crew_manifest/Destroy()
+	. = ..()
+	UnregisterSignal(SSdcs, COMSIG_GLOB_CREWMEMBER_JOINED)
+
+/datum/computer_file/program/crew_manifest/proc/_update_ui_data()
+	SIGNAL_HANDLER
+	update_static_data_for_all_viewers()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6312,6 +6312,7 @@
 #include "monkestation\code\modules\modular_bartending\item_modifications\attack_additions.dm"
 #include "monkestation\code\modules\modular_bartending\item_modifications\reagent_modification.dm"
 #include "monkestation\code\modules\modular_bartending\reactions\food_reactions.dm"
+#include "monkestation\code\modules\modular_computers\file_system\programs\crewmanifest.dm"
 #include "monkestation\code\modules\ocean_content\department_consoles\engineering.dm"
 #include "monkestation\code\modules\ocean_content\fluff\barrier.dm"
 #include "monkestation\code\modules\ocean_content\fluff\base_turf_editor.dm"


### PR DESCRIPTION

## About The Pull Request

This makes it so all crew can use the crew manifest app, and it's installed on PDAs by default now. However, the crew manifest app no longer grants detomatix protection.

As a bonus, the manifest app will now automatically refresh whenever someone latejoins.

## Why It's Good For The Game

No reason why you shouldn't be able to view the manifest... you can view it _in the lobby_, and you can kinda figure out a rudimentary version of the manifest by looking at the PDA messenger list.

## Changelog

:cl:
add: All crew can use the crew manifest app, and it's installed on PDAs by default now. However, the crew manifest app no longer grants detomatix protection.
tweak: The manifest app will now automatically refresh whenever someone latejoins.
/:cl:
