### PR TITLE
[Ports from /tg/] Fixes some airlock sleeps during explosions; Prevents MULEbots from being roundstart ghost-controllable; MULEbot trampling now requires hacking

### DIFF
--- a/code/__DEFINES/_helpers.dm
+++ b/code/__DEFINES/_helpers.dm
@@ -17,6 +17,14 @@
 /// Until a condition is true, sleep
 #define UNTIL(X) while(!(X)) stoplag()
 
+/// Sleep if we haven't been deleted
+/// Otherwise, return
+#define SLEEP_NOT_DEL(time) \
+	if(QDELETED(src)) { \
+		return; \
+	} \
+	sleep(time);
+
 #ifdef EXPERIMENT_515_DONT_CACHE_REF
 /// Takes a datum as input, returns its ref string
 #define text_ref(datum) ref(datum)

--- a/code/__DEFINES/robots.dm
+++ b/code/__DEFINES/robots.dm
@@ -88,6 +88,8 @@
 #define BOT_MODE_REMOTE_ENABLED (1<<2)
 ///The Bot is allowed to have a ghost placed in control of it.
 #define BOT_MODE_GHOST_CONTROLLABLE (1<<3)
+///The Bot is allowed to be possessed if it is present on mapload.
+#define BOT_MODE_ROUNDSTART_POSSESSION (1<<4)
 
 //Bot cover defines indicating the Bot's status
 ///The Bot's cover is open and can be modified/emagged by anyone.

--- a/code/__DEFINES/wires.dm
+++ b/code/__DEFINES/wires.dm
@@ -1,3 +1,7 @@
+/// from base of /datum/wires/proc/cut : (wire)
+#define COMSIG_CUT_WIRE(wire) "cut_wire [wire]"
+#define COMSIG_MEND_WIRE(wire) "mend_wire [wire]"
+
 //retvals for attempt_wires_interaction
 #define WIRE_INTERACTION_FAIL 0
 #define WIRE_INTERACTION_SUCCESSFUL 1

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -924,3 +924,25 @@
 
 /datum/status_effect/teleport_madness/tick()
 	dump_in_space(owner)
+
+/datum/status_effect/careful_driving
+	id = "careful_driving"
+	alert_type = /atom/movable/screen/alert/status_effect/careful_driving
+	duration = 5 SECONDS
+	status_type = STATUS_EFFECT_REPLACE
+
+/datum/status_effect/careful_driving/on_apply()
+	. = ..()
+	owner.add_movespeed_modifier(/datum/movespeed_modifier/careful_driving, update = TRUE)
+
+/datum/status_effect/careful_driving/on_remove()
+	. = ..()
+	owner.remove_movespeed_modifier(/datum/movespeed_modifier/careful_driving, update = TRUE)
+
+/atom/movable/screen/alert/status_effect/careful_driving
+	name = "Careful Driving"
+	desc = "That was close! You almost ran that one over!"
+	icon_state = "paralysis"
+
+/datum/movespeed_modifier/careful_driving
+	multiplicative_slowdown = 3

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -111,7 +111,8 @@
 	randomize()
 
 /datum/wires/proc/repair()
-	cut_wires.Cut()//a negative times a negative equals a positive
+	for(var/wire in cut_wires)
+		cut(wire) // I KNOW I KNOW OK
 
 /datum/wires/proc/get_wire(color)
 	return colors[color]
@@ -150,9 +151,11 @@
 /datum/wires/proc/cut(wire)
 	if(is_cut(wire))
 		cut_wires -= wire
+		SEND_SIGNAL(src, COMSIG_MEND_WIRE(wire), wire)
 		on_cut(wire, mend = TRUE)
 	else
 		cut_wires += wire
+		SEND_SIGNAL(src, COMSIG_CUT_WIRE(wire), wire)
 		on_cut(wire, mend = FALSE)
 
 /datum/wires/proc/cut_color(color)

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -148,25 +148,25 @@
 /datum/wires/proc/is_dud_color(color)
 	return is_dud(get_wire(color))
 
-/datum/wires/proc/cut(wire)
+/datum/wires/proc/cut(wire, source)
 	if(is_cut(wire))
 		cut_wires -= wire
 		SEND_SIGNAL(src, COMSIG_MEND_WIRE(wire), wire)
-		on_cut(wire, mend = TRUE)
+		on_cut(wire, mend = TRUE, source = source)
 	else
 		cut_wires += wire
 		SEND_SIGNAL(src, COMSIG_CUT_WIRE(wire), wire)
-		on_cut(wire, mend = FALSE)
+		on_cut(wire, mend = FALSE, source = source)
 
-/datum/wires/proc/cut_color(color)
-	cut(get_wire(color))
+/datum/wires/proc/cut_color(color, source)
+	cut(get_wire(color), source)
 
-/datum/wires/proc/cut_random()
-	cut(wires[rand(1, wires.len)])
+/datum/wires/proc/cut_random(source)
+	cut(wires[rand(1, wires.len)], source)
 
-/datum/wires/proc/cut_all()
+/datum/wires/proc/cut_all(source)
 	for(var/wire in wires)
-		cut(wire)
+		cut(wire, source)
 
 /datum/wires/proc/pulse(wire, user, force=FALSE)
 	if(!force && is_cut(wire))
@@ -220,7 +220,7 @@
 /datum/wires/proc/get_status()
 	return list()
 
-/datum/wires/proc/on_cut(wire, mend = FALSE)
+/datum/wires/proc/on_cut(wire, mend = FALSE, source = null)
 	return
 
 /datum/wires/proc/on_pulse(wire, user)
@@ -317,7 +317,7 @@
 			if(I || isAdminGhostAI(usr))
 				if(I && holder)
 					I.play_tool_sound(holder, 20)
-				cut_color(target_wire)
+				cut_color(target_wire, source = L)
 				. = TRUE
 			else
 				to_chat(L, span_warning("You need wirecutters!"))

--- a/code/datums/wires/airalarm.dm
+++ b/code/datums/wires/airalarm.dm
@@ -51,7 +51,7 @@
 				A.danger_level = AIR_ALARM_ALERT_NONE
 			A.update_appearance()
 
-/datum/wires/airalarm/on_cut(wire, mend)
+/datum/wires/airalarm/on_cut(wire, mend, source)
 	var/obj/machinery/airalarm/A = holder
 	switch(wire)
 		if(WIRE_POWER) // Short out forever.

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -157,7 +157,7 @@
 	else if(aiControlDisabled == AI_WIRE_HACKED)
 		aiControlDisabled = AI_WIRE_DISABLED_HACKED
 
-/datum/wires/airlock/on_cut(wire, mend)
+/datum/wires/airlock/on_cut(wire, mend, source)
 	var/obj/machinery/door/airlock/A = holder
 	switch(wire)
 		if(WIRE_POWER1, WIRE_POWER2) // Cut to lose power, repair all to gain power.
@@ -189,6 +189,8 @@
 				else if(A.aiControlDisabled == AI_WIRE_DISABLED_HACKED)
 					A.aiControlDisabled = AI_WIRE_HACKED
 		if(WIRE_SHOCK) // Cut to shock the door, mend to unshock.
+			if (!isnull(source))
+				log_combat(source, A, "[mend ? "disabled" : "enabled"] shocking for")
 			if(mend)
 				if(A.secondsElectrified)
 					A.set_electrified(MACHINE_NOT_ELECTRIFIED, usr)
@@ -198,6 +200,8 @@
 				A.shock(usr, 100)
 		if(WIRE_SAFETY) // Cut to disable safeties, mend to re-enable.
 			A.safe = mend
+			if (!isnull(source))
+				log_combat(source, A, "[mend ? "enabled" : "disabled"] door safeties for")
 		if(WIRE_TIMING) // Cut to disable auto-close, mend to re-enable.
 			A.autoclose = mend
 			if(A.autoclose && !A.density)

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -40,7 +40,7 @@
 				A.aidisabled = TRUE
 				addtimer(CALLBACK(A, TYPE_PROC_REF(/obj/machinery/power/apc, reset), wire), 1 SECONDS)
 
-/datum/wires/apc/on_cut(wire, mend)
+/datum/wires/apc/on_cut(wire, mend, source)
 	var/obj/machinery/power/apc/A = holder
 	switch(wire)
 		if(WIRE_POWER1, WIRE_POWER2) // Short out.

--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -37,7 +37,7 @@
 			A.disabled = !A.disabled
 			addtimer(CALLBACK(A, TYPE_PROC_REF(/obj/machinery/autolathe, reset), wire), 60)
 
-/datum/wires/autolathe/on_cut(wire, mend)
+/datum/wires/autolathe/on_cut(wire, mend, source)
 	var/obj/machinery/autolathe/A = holder
 	switch(wire)
 		if(WIRE_HACK)

--- a/code/datums/wires/ecto_sniffer.dm
+++ b/code/datums/wires/ecto_sniffer.dm
@@ -12,6 +12,6 @@
 	our_sniffer.activate()
 	..()
 
-/datum/wires/ecto_sniffer/on_cut(wire, mend)
+/datum/wires/ecto_sniffer/on_cut(wire, mend, source)
 	var/obj/machinery/ecto_sniffer/our_sniffer = holder
 	our_sniffer.sensor_enabled = mend

--- a/code/datums/wires/explosive.dm
+++ b/code/datums/wires/explosive.dm
@@ -10,7 +10,9 @@
 /datum/wires/explosive/on_pulse(index)
 	explode()
 
-/datum/wires/explosive/on_cut(index, mend)
+/datum/wires/explosive/on_cut(index, mend, source)
+	if (!isnull(source))
+		log_combat(source, holder, "cut the detonation wire for")
 	explode()
 
 /datum/wires/explosive/proc/explode()
@@ -34,7 +36,7 @@
 		return
 	. = ..()
 
-/datum/wires/explosive/chem_grenade/on_cut(index, mend)
+/datum/wires/explosive/chem_grenade/on_cut(index, mend, source)
 	var/obj/item/grenade/chem_grenade/grenade = holder
 	if(grenade.stage != GRENADE_READY)
 		return
@@ -127,7 +129,7 @@
 		else // Boom
 			explode()
 
-/datum/wires/explosive/pizza/on_cut(wire, mend)
+/datum/wires/explosive/pizza/on_cut(wire, mend, source)
 	var/obj/item/pizzabox/P = holder
 	switch(wire)
 		if(WIRE_DISARM) // Disarm and untrap the box.
@@ -135,6 +137,8 @@
 				P.bomb_defused = TRUE
 		else
 			if(!mend && !P.bomb_defused)
+				if (!isnull(source))
+					log_combat(source, holder, "cut the detonation wire for")
 				explode()
 
 /datum/wires/explosive/pizza/explode()

--- a/code/datums/wires/fax.dm
+++ b/code/datums/wires/fax.dm
@@ -38,7 +38,7 @@
 		if(WIRE_LOADCHECK)
 			machine.allow_exotic_faxes = !machine.allow_exotic_faxes
 
-/datum/wires/fax/on_cut(wire, mend)
+/datum/wires/fax/on_cut(wire, mend, source)
 	var/obj/machinery/fax/machine = holder
 	switch(wire)
 		if(WIRE_SHOCK)

--- a/code/datums/wires/microwave.dm
+++ b/code/datums/wires/microwave.dm
@@ -22,7 +22,7 @@
 		if(WIRE_ACTIVATE)
 			M.cook()
 
-/datum/wires/microwave/on_cut(wire, mend)
+/datum/wires/microwave/on_cut(wire, mend, source)
 	var/obj/machinery/microwave/M = holder
 	switch(wire)
 		if(WIRE_ACTIVATE)

--- a/code/datums/wires/mod.dm
+++ b/code/datums/wires/mod.dm
@@ -34,7 +34,7 @@
 		if(WIRE_INTERFACE)
 			mod.interface_break = !mod.interface_break
 
-/datum/wires/mod/on_cut(wire, mend)
+/datum/wires/mod/on_cut(wire, mend, source)
 	var/obj/item/mod/control/mod = holder
 	switch(wire)
 		if(WIRE_HACK)

--- a/code/datums/wires/mulebot.dm
+++ b/code/datums/wires/mulebot.dm
@@ -23,7 +23,7 @@
 	if(mule.bot_cover_flags & BOT_COVER_OPEN)
 		return TRUE
 
-/datum/wires/mulebot/on_cut(wire, mend)
+/datum/wires/mulebot/on_cut(wire, mend, source)
 	var/mob/living/simple_animal/bot/mulebot/mule = holder
 	switch(wire)
 		if(WIRE_MOTOR1, WIRE_MOTOR2)
@@ -38,6 +38,9 @@
 				mule.set_varspeed(AVERAGE_MOTOR_SPEED)
 			else
 				mule.set_varspeed(SLOW_MOTOR_SPEED)
+		if(WIRE_AVOIDANCE)
+			if (!isnull(source))
+				log_combat(source, mule, "[is_cut(WIRE_AVOIDANCE) ? "cut" : "mended"] the MULE safety wire of")
 
 /datum/wires/mulebot/on_pulse(wire)
 	var/mob/living/simple_animal/bot/mulebot/mule = holder

--- a/code/datums/wires/r_n_d.dm
+++ b/code/datums/wires/r_n_d.dm
@@ -33,7 +33,7 @@
 			R.hacked = !R.hacked
 		if(WIRE_DISABLE)
 			R.disabled = !R.disabled
-/datum/wires/rnd/on_cut(wire, mend)
+/datum/wires/rnd/on_cut(wire, mend, source)
 	var/obj/machinery/rnd/R = holder
 	switch(wire)
 		if(WIRE_HACK)

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -72,7 +72,7 @@
 			if(R.has_model())
 				R.visible_message(span_notice("[R]'s model servos twitch."), span_notice("Your model display flickers."))
 
-/datum/wires/robot/on_cut(wire, mend)
+/datum/wires/robot/on_cut(wire, mend, source)
 	var/mob/living/silicon/robot/R = holder
 	switch(wire)
 		if(WIRE_AI) // Cut the AI wire to reset AI control.

--- a/code/datums/wires/roulette.dm
+++ b/code/datums/wires/roulette.dm
@@ -51,7 +51,7 @@
 			R.audible_message(span_warning("Unauthorized prize vend detected! Locking down machine!"))
 			R.prize_theft(0.20)
 
-/datum/wires/roulette/on_cut(wire, mend)
+/datum/wires/roulette/on_cut(wire, mend, source)
 	var/obj/machinery/roulette/R = holder
 	switch(wire)
 		if(WIRE_SHOCK)

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -35,7 +35,7 @@
 			if(usr)
 				SSU.shock(usr)
 
-/datum/wires/suit_storage_unit/on_cut(wire, mend)
+/datum/wires/suit_storage_unit/on_cut(wire, mend, source)
 	var/obj/machinery/suit_storage_unit/SSU = holder
 	switch(wire)
 		if(WIRE_HACK)

--- a/code/datums/wires/syndicatebomb.dm
+++ b/code/datums/wires/syndicatebomb.dm
@@ -69,7 +69,7 @@
 				B.detonation_timer += 100
 				B.delayedlittle = TRUE
 
-/datum/wires/syndicatebomb/on_cut(wire, mend)
+/datum/wires/syndicatebomb/on_cut(wire, mend, source)
 	var/obj/machinery/syndicatebomb/B = holder
 	switch(wire)
 		if(WIRE_BOOM,WIRE_BOOM2)
@@ -78,9 +78,9 @@
 				B.explode_now = TRUE
 				if(!istype(B.payload, /obj/machinery/syndicatebomb/training))
 					tell_admins(B)
-					// Cursed usr use but no easy way to get the cutter
-					if(isliving(usr))
-						add_memory_in_range(B, 7, /datum/memory/bomb_defuse_failure, protagonist = usr, antagonist = B)
+					if(isliving(source))
+						log_combat(source, holder, "cut the detonation wire for")
+						add_memory_in_range(B, 7, /datum/memory/bomb_defuse_failure, protagonist = source, antagonist = B)
 
 		if(WIRE_UNBOLT)
 			if(!mend && B.anchored)

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -66,7 +66,7 @@
 		if(WIRE_AGELIMIT)
 			vending_machine.age_restrictions = !vending_machine.age_restrictions
 
-/datum/wires/vending/on_cut(wire, mend)
+/datum/wires/vending/on_cut(wire, mend, source)
 	var/obj/machinery/vending/vending_machine = holder
 	switch(wire)
 		if(WIRE_THROW)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -624,6 +624,10 @@
 /atom/proc/HasProximity(atom/movable/proximity_check_mob as mob|obj)
 	return
 
+/// Sets the wire datum of an atom
+/atom/proc/set_wires(datum/wires/new_wires)
+	wires = new_wires
+
 /**
  * React to an EMP of the given severity
  *

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -24,7 +24,7 @@
 /obj/machinery/autolathe/Initialize(mapload)
 	AddComponent(/datum/component/material_container, SSmaterials.materials_by_category[MAT_CATEGORY_ITEM_MATERIAL], 0, MATCONTAINER_EXAMINE, _after_insert = CALLBACK(src, PROC_REF(AfterMaterialInsert)))
 	. = ..()
-	wires = new /datum/wires/autolathe(src)
+	set_wires(new /datum/wires/autolathe(src))
 	if(!GLOB.autounlock_techwebs[/datum/techweb/autounlocking/autolathe])
 		GLOB.autounlock_techwebs[/datum/techweb/autounlocking/autolathe] = new /datum/techweb/autounlocking/autolathe
 	stored_research = GLOB.autounlock_techwebs[/datum/techweb/autounlocking/autolathe]

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -106,26 +106,37 @@
 
 	///The type of door frame to drop during deconstruction
 	var/assemblytype = /obj/structure/door_assembly
-	var/security_level = 0 //How much are wires secured
-	var/aiControlDisabled = AI_WIRE_NORMAL //If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
-	var/hackProof = FALSE // if true, this door can't be hacked by the AI
-	var/secondsMainPowerLost = 0 //The number of seconds until power is restored.
-	var/secondsBackupPowerLost = 0 //The number of seconds until power is restored.
-	var/spawnPowerRestoreRunning = FALSE
-	var/lights = TRUE // bolt lights show by default
+	/// How much are wires secured
+	var/security_level = 0
+	/// If 1, AI control is disabled until the AI hacks back in and disables the lock. If 2, the AI has bypassed the lock. If -1, the control is enabled but the AI had bypassed it earlier, so if it is disabled again the AI would have no trouble getting back in.
+	var/aiControlDisabled = AI_WIRE_NORMAL
+	/// If true, this door can't be hacked by the AI
+	var/hackProof = FALSE
+	/// Timer id, active when we are actively waiting for the main power to be restored
+	var/main_power_timer = 0
+	/// Paired with main_power_timer. Records its remaining time when something happens to interrupt power regen
+	var/main_power_time
+	/// Timer id, active when we are actively waiting for the backup power to be restored
+	var/backup_power_timer = 0
+	/// Paired with backup_power_timer. Records its remaining time when something happens to interrupt power regen
+	var/backup_power_time
+	/// Bolt lights show by default
+	var/lights = TRUE
 	var/aiDisabledIdScanner = FALSE
 	var/aiHacking = FALSE
-	var/closeOtherId //Cyclelinking for airlocks that aren't on the same x or y coord as the target.
+	/// Cyclelinking for airlocks that aren't on the same x or y coord as the target.
+	var/closeOtherId
 	var/obj/machinery/door/airlock/closeOther
 	var/list/obj/machinery/door/airlock/close_others = list()
 	var/obj/item/electronics/airlock/electronics
 	COOLDOWN_DECLARE(shockCooldown)
-	var/obj/item/note //Any papers pinned to the airlock
+	/// Any papers pinned to the airlock
+	var/obj/item/note
 	/// The seal on the airlock
 	var/obj/item/seal
 	var/detonated = FALSE
 	var/abandoned = FALSE
-	///Controls if the door closes quickly or not. FALSE = the door autocloses in 1.5 seconds, TRUE = 8 seconds - see autoclose_in()
+	/// Controls if the door closes quickly or not. FALSE = the door autocloses in 1.5 seconds, TRUE = 8 seconds - see autoclose_in()
 	var/normalspeed = TRUE
 	var/cutAiWire = FALSE
 	var/autoname = FALSE
@@ -135,20 +146,25 @@
 	var/boltUp = 'sound/machines/boltsup.ogg'
 	var/boltDown = 'sound/machines/boltsdown.ogg'
 	var/noPower = 'sound/machines/doorclick.ogg'
-	var/previous_airlock = /obj/structure/door_assembly //what airlock assembly mineral plating was applied to
-	var/airlock_material //material of inner filling; if its an airlock with glass, this should be set to "glass"
+	/// What airlock assembly mineral plating was applied to
+	var/previous_airlock = /obj/structure/door_assembly
+	/// Material of inner filling; if its an airlock with glass, this should be set to "glass"
+	var/airlock_material
 	var/overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
-	var/note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi' //Used for papers and photos pinned to the airlock
+	/// Used for papers and photos pinned to the airlock
+	var/note_overlay_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
 
 	var/cyclelinkeddir = 0
 	var/obj/machinery/door/airlock/cyclelinkedairlock
 	var/shuttledocked = 0
-	var/delayed_close_requested = FALSE // TRUE means the door will automatically close the next time it's opened.
-	var/air_tight = FALSE //TRUE means density will be set as soon as the door begins to close
+	/// TRUE means the door will automatically close the next time it's opened.
+	var/delayed_close_requested = FALSE
+	/// TRUE means density will be set as soon as the door begins to close
+	var/air_tight = FALSE
 	var/prying_so_hard = FALSE
-	///Logging for door electrification.
+	/// Logging for door electrification.
 	var/shockedby
-	///How many seconds remain until the door is no longer electrified. -1/MACHINE_ELECTRIFIED_PERMANENT = permanently electrified until someone fixes it.
+	/// How many seconds remain until the door is no longer electrified. -1/MACHINE_ELECTRIFIED_PERMANENT = permanently electrified until someone fixes it.
 	var/secondsElectrified = MACHINE_NOT_ELECTRIFIED
 
 	flags_1 = HTML_USE_INITAL_ICON_1
@@ -156,7 +172,7 @@
 
 /obj/machinery/door/airlock/Initialize(mapload)
 	. = ..()
-	wires = set_wires()
+	set_wires(get_wires())
 	if(glass)
 		airlock_material = "glass"
 	if(security_level > AIRLOCK_SECURITY_IRON)
@@ -326,7 +342,7 @@
 	return ((aiControlDisabled == AI_WIRE_DISABLED) && (!hackProof) && (!isAllPowerCut()));
 
 /obj/machinery/door/airlock/hasPower()
-	return ((!secondsMainPowerLost || !secondsBackupPowerLost) && !(machine_stat & NOPOWER))
+	return ((!remaining_main_outage() || !remaining_backup_outage()) && !(machine_stat & NOPOWER))
 
 /obj/machinery/door/airlock/requiresID()
 	return !(wires.is_cut(WIRE_IDSCAN) || aiDisabledIdScanner)
@@ -335,51 +351,127 @@
 	if((wires.is_cut(WIRE_POWER1) || wires.is_cut(WIRE_POWER2)) && (wires.is_cut(WIRE_BACKUP1) || wires.is_cut(WIRE_BACKUP2)))
 		return TRUE
 
-/obj/machinery/door/airlock/proc/regainMainPower()
-	if(secondsMainPowerLost > 0)
-		secondsMainPowerLost = 0
-	update_appearance()
+/// Returns the amount of time we have to wait before main power comes back
+/// Assuming it was actively regenerating
+/// Returns 0 if it is active
+/obj/machinery/door/airlock/proc/remaining_main_outage()
+	if(main_power_timer)
+		return timeleft(main_power_timer)
+	return main_power_time
 
-/obj/machinery/door/airlock/proc/handlePowerRestore()
-	var/cont = TRUE
-	while (cont)
-		sleep(1 SECONDS)
-		if(QDELETED(src))
-			return
-		cont = FALSE
-		if(secondsMainPowerLost>0)
-			if(!wires.is_cut(WIRE_POWER1) && !wires.is_cut(WIRE_POWER2))
-				secondsMainPowerLost -= 1
-			cont = TRUE
-		if(secondsBackupPowerLost>0)
-			if(!wires.is_cut(WIRE_BACKUP1) && !wires.is_cut(WIRE_BACKUP2))
-				secondsBackupPowerLost -= 1
-			cont = TRUE
-	spawnPowerRestoreRunning = FALSE
-	update_appearance()
+/// Returns the amount of time we have to wait before backup power comes back
+/// Assuming it was actively regenerating
+/// Returns 0 if it is active
+/obj/machinery/door/airlock/proc/remaining_backup_outage()
+	if(backup_power_timer)
+		return timeleft(backup_power_timer)
+	return backup_power_time
+
+/obj/machinery/door/airlock/proc/set_main_outage(delay)
+	// Clear out the timer so we don't accidentially take from it later
+	if(main_power_timer)
+		deltimer(main_power_timer)
+		main_power_timer = null
+	var/old_time = main_power_time
+	main_power_time = delay
+	handle_main_power()
+	if(!!old_time != !!delay)
+		update_appearance()
+
+/obj/machinery/door/airlock/proc/set_backup_outage(delay)
+	// Clear out the timer so we don't accidentially take from it later
+	if(backup_power_timer)
+		deltimer(backup_power_timer)
+		backup_power_timer = null
+	var/old_time = backup_power_time
+	backup_power_time = delay
+	handle_backup_power()
+	if(!!old_time != !!delay)
+		update_appearance()
+
+/// Call to update our main power outage timer
+/// Will trigger a proper timer if we're actively restoring power, if not we'll dump the remaining time in a var on the airlock
+/obj/machinery/door/airlock/proc/handle_main_power()
+	if(main_power_time <= 0)
+		deltimer(main_power_timer)
+		main_power_timer = null
+		return
+
+	// If we can, we'll start a timer that hits when we're done
+	if(!wires.is_cut(WIRE_POWER1) && !wires.is_cut(WIRE_POWER2))
+		if(!main_power_timer || timeleft(main_power_timer) != main_power_time)
+			main_power_timer = addtimer(CALLBACK(src, PROC_REF(regainMainPower)), main_power_time, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_DELETE_ME)
+	// Otherwise, we'll ensure the timer matches main_power_time
+	else if(main_power_timer)
+		main_power_time = timeleft(main_power_timer)
+		deltimer(main_power_timer)
+		main_power_timer = null
+
+/// Call to update our backup power outage timer
+/// Will trigger a proper timer if we're actively restoring power, if not we'll dump the remaining time in a var on the airlock
+/obj/machinery/door/airlock/proc/handle_backup_power()
+	if(backup_power_time <= 0)
+		deltimer(backup_power_timer)
+		backup_power_timer = null
+		return
+
+	// If we can, we'll start a timer that hits when we're done
+	if(!wires.is_cut(WIRE_BACKUP1) && !wires.is_cut(WIRE_BACKUP2))
+		if(!backup_power_timer || timeleft(backup_power_timer) != backup_power_time)
+			backup_power_timer = addtimer(CALLBACK(src, PROC_REF(regainBackupPower)), backup_power_time, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_STOPPABLE|TIMER_DELETE_ME)
+	// Otherwise, we'll ensure the timer matches backup_power_time
+	else if(backup_power_timer)
+		backup_power_time = timeleft(backup_power_timer)
+		deltimer(backup_power_timer)
+		backup_power_timer = null
+
+// Alright, we're gonna do a meme here
+/obj/machinery/door/airlock/set_wires(datum/wires/new_wires)
+	if(wires)
+		UnregisterSignal(wires, list(
+			COMSIG_CUT_WIRE(WIRE_POWER1),
+			COMSIG_CUT_WIRE(WIRE_POWER2),
+			COMSIG_CUT_WIRE(WIRE_BACKUP1),
+			COMSIG_CUT_WIRE(WIRE_BACKUP2),
+			COMSIG_MEND_WIRE(WIRE_POWER1),
+			COMSIG_MEND_WIRE(WIRE_POWER2),
+			COMSIG_MEND_WIRE(WIRE_BACKUP1),
+			COMSIG_MEND_WIRE(WIRE_BACKUP2),
+		))
+	. = ..()
+	if(new_wires)
+		RegisterSignals(new_wires, list(
+			COMSIG_CUT_WIRE(WIRE_POWER1),
+			COMSIG_CUT_WIRE(WIRE_POWER2),
+			COMSIG_CUT_WIRE(WIRE_BACKUP1),
+			COMSIG_CUT_WIRE(WIRE_BACKUP2),
+			COMSIG_MEND_WIRE(WIRE_POWER1),
+			COMSIG_MEND_WIRE(WIRE_POWER2),
+			COMSIG_MEND_WIRE(WIRE_BACKUP1),
+			COMSIG_MEND_WIRE(WIRE_BACKUP2),
+		), PROC_REF(power_wires_changed))
+
+/// If our power wires have changed, then our backup/main power regen may have failed, so let's just check in yeah?
+/obj/machinery/door/airlock/proc/power_wires_changed(datum/source, wire)
+	SIGNAL_HANDLER
+	handle_main_power()
+	handle_backup_power()
+
+/obj/machinery/door/airlock/proc/regainMainPower()
+	set_main_outage(0 SECONDS)
 
 /obj/machinery/door/airlock/proc/loseMainPower()
-	if(secondsMainPowerLost <= 0)
-		secondsMainPowerLost = 60
-		if(secondsBackupPowerLost < 10)
-			secondsBackupPowerLost = 10
-	if(!spawnPowerRestoreRunning)
-		spawnPowerRestoreRunning = TRUE
-	INVOKE_ASYNC(src, PROC_REF(handlePowerRestore))
-	update_appearance()
+	if(!remaining_main_outage())
+		set_main_outage(60 SECONDS)
+		if(remaining_backup_outage() < 10 SECONDS)
+			set_backup_outage(10 SECONDS)
 
 /obj/machinery/door/airlock/proc/loseBackupPower()
-	if(secondsBackupPowerLost < 60)
-		secondsBackupPowerLost = 60
-	if(!spawnPowerRestoreRunning)
-		spawnPowerRestoreRunning = TRUE
-	INVOKE_ASYNC(src, PROC_REF(handlePowerRestore))
-	update_appearance()
+	if(remaining_backup_outage() < 60 SECONDS)
+		set_backup_outage(60 SECONDS)
 
 /obj/machinery/door/airlock/proc/regainBackupPower()
-	if(secondsBackupPowerLost > 0)
-		secondsBackupPowerLost = 0
-	update_appearance()
+	set_backup_outage(0 SECONDS)
 
 // shock user with probability prb (if all connections & power are working)
 // returns TRUE if shocked, FALSE otherwise
@@ -1529,10 +1621,10 @@
 	var/list/data = list()
 
 	var/list/power = list()
-	power["main"] = secondsMainPowerLost ? 0 : 2 // boolean
-	power["main_timeleft"] = secondsMainPowerLost
-	power["backup"] = secondsBackupPowerLost ? 0 : 2 // boolean
-	power["backup_timeleft"] = secondsBackupPowerLost
+	power["main"] = remaining_main_outage() ? 0 : 2 // boolean
+	power["main_timeleft"] = remaining_main_outage()
+	power["backup"] = remaining_backup_outage() ? 0 : 2 // boolean
+	power["backup_timeleft"] = remaining_backup_outage()
 	data["power"] = power
 
 	data["shock"] = secondsElectrified == MACHINE_NOT_ELECTRIFIED ? 2 : 0
@@ -1570,14 +1662,14 @@
 		return
 	switch(action)
 		if("disrupt-main")
-			if(!secondsMainPowerLost)
+			if(remaining_main_outage())
 				loseMainPower()
 				update_appearance()
 			else
 				to_chat(usr, span_warning("Main power is already offline."))
 			. = TRUE
 		if("disrupt-backup")
-			if(!secondsBackupPowerLost)
+			if(remaining_backup_outage())
 				loseBackupPower()
 				update_appearance()
 			else
@@ -1682,7 +1774,7 @@
  * Returns a new /datum/wires/ with the appropriate wire layout based on the airlock_wires
  * of the area the airlock is in.
  */
-/obj/machinery/door/airlock/proc/set_wires()
+/obj/machinery/door/airlock/proc/get_wires()
 	var/area/source_area = get_area(src)
 	return source_area?.airlock_wires ? new source_area.airlock_wires(src) : new /datum/wires/airlock(src)
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -387,10 +387,10 @@
 	use_power(active_power_usage)
 	do_animate("opening")
 	set_opacity(0)
-	sleep(0.5 SECONDS)
+	SLEEP_NOT_DEL(0.5 SECONDS)
 	set_density(FALSE)
 	flags_1 &= ~PREVENT_CLICK_UNDER_1
-	sleep(0.5 SECONDS)
+	SLEEP_NOT_DEL(0.5 SECONDS)
 	layer = initial(layer)
 	update_appearance()
 	set_opacity(0)
@@ -438,10 +438,10 @@
 			turfs_group.check_edges(direction_turf)
 
 	layer = closingLayer
-	sleep(0.5 SECONDS)
+	SLEEP_NOT_DEL(0.5 SECONDS)
 	set_density(TRUE)
 	flags_1 |= PREVENT_CLICK_UNDER_1
-	sleep(0.5 SECONDS)
+	SLEEP_NOT_DEL(0.5 SECONDS)
 	update_appearance()
 	if(visible && !glass)
 		set_opacity(1)

--- a/code/game/machinery/ecto_sniffer.dm
+++ b/code/game/machinery/ecto_sniffer.dm
@@ -16,7 +16,7 @@
 
 /obj/machinery/ecto_sniffer/Initialize(mapload)
 	. = ..()
-	wires = new/datum/wires/ecto_sniffer(src)
+	set_wires(new/datum/wires/ecto_sniffer(src))
 
 /obj/machinery/ecto_sniffer/attack_ghost(mob/user)
 	. = ..()

--- a/code/game/machinery/modular_shield.dm
+++ b/code/game/machinery/modular_shield.dm
@@ -109,7 +109,7 @@ the modular shield components(not generator) are climbable
 
 /obj/machinery/modular_shield_generator/Initialize(mapload)
 	. = ..()
-	wires = new /datum/wires/modular_shield_generator(src)
+	set_wires(new /datum/wires/modular_shield_generator(src))
 	if(mapload && active && anchored)
 		activate_shields()
 

--- a/code/game/machinery/roulette_machine.dm
+++ b/code/game/machinery/roulette_machine.dm
@@ -58,7 +58,7 @@
 /obj/machinery/roulette/Initialize(mapload)
 	. = ..()
 	jackpot_loop = new(src, FALSE)
-	wires = new /datum/wires/roulette(src)
+	set_wires(new /datum/wires/roulette(src))
 
 /obj/machinery/roulette/Destroy()
 	QDEL_NULL(jackpot_loop)

--- a/code/game/machinery/scan_gate.dm
+++ b/code/game/machinery/scan_gate.dm
@@ -51,7 +51,7 @@
 
 /obj/machinery/scanner_gate/Initialize(mapload)
 	. = ..()
-	wires = new /datum/wires/scanner_gate(src)
+	set_wires(new /datum/wires/scanner_gate(src))
 	set_scanline("passive")
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
@@ -60,7 +60,7 @@
 
 /obj/machinery/scanner_gate/Destroy()
 	qdel(wires)
-	wires = null
+	set_wires(null)
 	. = ..()
 
 /obj/machinery/scanner_gate/examine(mob/user)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -161,7 +161,7 @@
 
 /obj/machinery/suit_storage_unit/Initialize(mapload)
 	. = ..()
-	wires = new /datum/wires/suit_storage_unit(src)
+	set_wires(new /datum/wires/suit_storage_unit(src))
 	if(suit_type)
 		suit = new suit_type(src)
 	if(helmet_type)

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -99,7 +99,7 @@
 
 /obj/machinery/syndicatebomb/Initialize(mapload)
 	. = ..()
-	wires = new /datum/wires/syndicatebomb(src)
+	set_wires(new /datum/wires/syndicatebomb(src))
 	if(payload)
 		payload = new payload(src)
 	update_appearance()

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -97,7 +97,7 @@
 	var/radio_host = FALSE
 
 /obj/item/radio/Initialize(mapload)
-	wires = new /datum/wires/radio(src)
+	set_wires(new /datum/wires/radio(src))
 	secure_radio_connections = list()
 	. = ..()
 

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -32,7 +32,7 @@
 	AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES)
 	create_reagents(casing_holder_volume)
 	stage_change() // If no argument is set, it will change the stage to the current stage, useful for stock grenades that start READY.
-	wires = new /datum/wires/explosive/chem_grenade(src)
+	set_wires(new /datum/wires/explosive/chem_grenade(src))
 
 /obj/item/grenade/chem_grenade/apply_grenade_fantasy_bonuses(quality)
 	threatscale = modify_fantasy_variable("threatscale", threatscale, quality/10)

--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -40,11 +40,11 @@
 	. = ..()
 	AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES)
 	plastic_overlay = mutable_appearance(icon, "[inhand_icon_state]2", HIGH_OBJ_LAYER)
-	wires = new /datum/wires/explosive/c4(src)
+	set_wires(new /datum/wires/explosive/c4(src))
 
 /obj/item/grenade/c4/Destroy()
 	qdel(wires)
-	wires = null
+	set_wires(null)
 	target = null
 	return ..()
 

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -48,7 +48,7 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 
 /obj/machinery/airalarm/Initialize(mapload, ndir, nbuild)
 	. = ..()
-	wires = new /datum/wires/airalarm(src)
+	set_wires(new /datum/wires/airalarm(src))
 	if(ndir)
 		setDir(ndir)
 

--- a/code/modules/food_and_drinks/machinery/microwave.dm
+++ b/code/modules/food_and_drinks/machinery/microwave.dm
@@ -50,7 +50,7 @@
 /obj/machinery/microwave/Initialize(mapload)
 	. = ..()
 
-	wires = new /datum/wires/microwave(src)
+	set_wires(new /datum/wires/microwave(src))
 	create_reagents(100)
 	soundloop = new(src, FALSE)
 	set_on_table()

--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -208,7 +208,7 @@
 		if(open && !bomb)
 			if(!user.transferItemToLoc(I, src))
 				return
-			wires = new /datum/wires/explosive/pizza(src)
+			set_wires(new /datum/wires/explosive/pizza(src))
 			bomb = I
 			balloon_alert(user, "bomb placed")
 			update_appearance()
@@ -287,7 +287,7 @@
 /obj/item/pizzabox/proc/unprocess()
 	STOP_PROCESSING(SSobj, src)
 	qdel(wires)
-	wires = null
+	set_wires(null)
 	update_appearance()
 
 /obj/item/pizzabox/bomb/Initialize(mapload)
@@ -296,7 +296,7 @@
 		var/randompizza = pick(subtypesof(/obj/item/food/pizza))
 		pizza = new randompizza(src)
 	bomb = new(src)
-	wires = new /datum/wires/explosive/pizza(src)
+	set_wires(new /datum/wires/explosive/pizza(src))
 
 /obj/item/pizzabox/bomb/armed
 	bomb_timer = 5

--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -260,7 +260,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 
 /obj/item/radio/headset/headset_sec/alt/department/Initialize(mapload)
 	. = ..()
-	wires = new/datum/wires/radio(src)
+	set_wires(new/datum/wires/radio(src))
 	secure_radio_connections = list()
 	recalculateChannels()
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -240,13 +240,13 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 
 /obj/item/gibtonite/Destroy()
 	qdel(wires)
-	wires = null
+	set_wires(null)
 	return ..()
 
 /obj/item/gibtonite/attackby(obj/item/I, mob/user, params)
 	if(!wires && isigniter(I))
 		user.visible_message(span_notice("[user] attaches [I] to [src]."), span_notice("You attach [I] to [src]."))
-		wires = new /datum/wires/explosive/gibtonite(src)
+		set_wires(new /datum/wires/explosive/gibtonite(src))
 		attacher = key_name(user)
 		qdel(I)
 		add_overlay("Gibtonite_igniter")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -14,7 +14,7 @@
 		roleplay_emotes = list(/datum/emote/silicon/buzz, /datum/emote/silicon/buzz2, /datum/emote/living/beep), \
 		roleplay_callback = CALLBACK(src, PROC_REF(untip_roleplay)))
 
-	wires = new /datum/wires/robot(src)
+	set_wires(new /datum/wires/robot(src))
 	AddElement(/datum/element/empprotection, EMP_PROTECT_WIRES)
 	AddElement(/datum/element/ridable, /datum/component/riding/creature/cyborg)
 	RegisterSignal(src, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, PROC_REF(charge))

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -45,8 +45,8 @@
 	///All initial access this bot started with.
 	var/list/prev_access = list()
 
-	///Bot-related mode flags on the Bot indicating how they will act. BOT_MODE_ON | BOT_MODE_AUTOPATROL | BOT_MODE_REMOTE_ENABLED | BOT_MODE_GHOST_CONTROLLABLE
-	var/bot_mode_flags = BOT_MODE_ON | BOT_MODE_REMOTE_ENABLED | BOT_MODE_GHOST_CONTROLLABLE
+	///Bot-related mode flags on the Bot indicating how they will act. BOT_MODE_ON | BOT_MODE_AUTOPATROL | BOT_MODE_REMOTE_ENABLED | BOT_MODE_GHOST_CONTROLLABLE | BOT_MODE_ROUNDSTART_POSSESSION
+	var/bot_mode_flags = BOT_MODE_ON | BOT_MODE_REMOTE_ENABLED | BOT_MODE_GHOST_CONTROLLABLE | BOT_MODE_ROUNDSTART_POSSESSION
 
 	///Bot-related cover flags on the Bot to deal with what has been done to their cover, including emagging. BOT_COVER_OPEN | BOT_COVER_LOCKED | BOT_COVER_EMAGGED | BOT_COVER_HACKED
 	var/bot_cover_flags = BOT_COVER_LOCKED
@@ -190,7 +190,7 @@
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_BOTS_GLITCHED))
 		randomize_language_if_on_station()
 
-	if(mapload && is_station_level(z) && (bot_mode_flags & BOT_MODE_GHOST_CONTROLLABLE))
+	if(mapload && is_station_level(z) && bot_mode_flags & BOT_MODE_GHOST_CONTROLLABLE && bot_mode_flags & BOT_MODE_ROUNDSTART_POSSESSION)
 		enable_possession(mapload)
 
 /mob/living/simple_animal/bot/Destroy()
@@ -244,13 +244,16 @@
 
 /// Allows renaming the bot to something else
 /mob/living/simple_animal/bot/proc/rename(mob/user)
-	var/new_name = sanitize_name(reject_bad_text(tgui_input_text(
-		user = user,
-		message = "This machine is designated [real_name]. Would you like to update its registration?",
-		title = "Name change",
-		default = real_name,
-		max_length = MAX_NAME_LEN,
-	)))
+	var/new_name = sanitize_name(
+		reject_bad_text(tgui_input_text(
+			user = user,
+			message = "This machine is designated [real_name]. Would you like to update its registration?",
+			title = "Name change",
+			default = real_name,
+			max_length = MAX_NAME_LEN,
+		)),
+		allow_numbers = TRUE
+	)
 	if (isnull(new_name) || QDELETED(src))
 		return
 	if (key && user != src)

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -24,6 +24,7 @@
 	buckle_lying = 0
 	mob_size = MOB_SIZE_LARGE
 	buckle_prevents_pull = TRUE // No pulling loaded shit
+	bot_mode_flags = ~BOT_MODE_ROUNDSTART_POSSESSION
 
 	maints_access_required = list(ACCESS_ROBOTICS, ACCESS_CARGO)
 	radio_key = /obj/item/encryptionkey/headset_cargo
@@ -234,7 +235,7 @@
 			unload(0)
 		if(prob(25))
 			visible_message(span_danger("Something shorts out inside [src]!"))
-			wires.cut_random()
+			wires.cut_random(source = Proj.firer)
 
 /mob/living/simple_animal/bot/mulebot/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -672,6 +673,12 @@
 
 // when mulebot is in the same loc
 /mob/living/simple_animal/bot/mulebot/proc/run_over(mob/living/carbon/human/crushed)
+	if (!(bot_cover_flags & BOT_COVER_EMAGGED) && !wires.is_cut(WIRE_AVOIDANCE))
+		if (!has_status_effect(/datum/status_effect/careful_driving))
+			crushed.visible_message(span_notice("[src] slows down to avoid crushing [crushed]."))
+		apply_status_effect(/datum/status_effect/careful_driving)
+		return // Player mules must be emagged before they can trample
+
 	log_combat(src, crushed, "run over", addition = "(DAMTYPE: [uppertext(BRUTE)])")
 	crushed.visible_message(
 		span_danger("[src] drives over [crushed]!"),

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -69,7 +69,7 @@
 	if(prob(0.666) && mapload)
 		new /mob/living/simple_animal/bot/mulebot/paranormal(loc)
 		return INITIALIZE_HINT_QDEL
-	wires = new /datum/wires/mulebot(src)
+	set_wires(new /datum/wires/mulebot(src))
 
 	// Doing this hurts my soul, but simplebot access reworks are for another day.
 	var/datum/id_trim/job/cargo_trim = SSid_access.trim_singletons_by_path[/datum/id_trim/job/cargo_technician]

--- a/code/modules/mod/mod_control.dm
+++ b/code/modules/mod/mod_control.dm
@@ -105,7 +105,7 @@
 	complexity_max = theme.complexity_max
 	ui_theme = theme.ui_theme
 	charge_drain = theme.charge_drain
-	wires = new /datum/wires/mod(src)
+	set_wires(new /datum/wires/mod(src))
 	if(length(req_access))
 		locked = TRUE
 	new_core?.install(src)

--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -61,7 +61,7 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
 		fax_id = assign_random_name()
 	if (!fax_name)
 		fax_name = "Unregistered fax " + fax_id
-	wires = new /datum/wires/fax(src)
+	set_wires(new /datum/wires/fax(src))
 	register_context()
 	special_networks["nanotrasen"]["fax_name"] = GLOB.nt_fax_department
 

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -176,7 +176,7 @@
 		name = "\improper [get_area_name(area, TRUE)] APC"
 
 	//Initialize its electronics
-	wires = new /datum/wires/apc(src)
+	set_wires(new /datum/wires/apc(src))
 	alarm_manager = new(src)
 	AddElement(/datum/element/atmos_sensitive, mapload)
 	// for apcs created during map load make them fully functional

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -60,7 +60,7 @@
 /obj/machinery/power/emitter/Initialize(mapload)
 	. = ..()
 	RefreshParts()
-	wires = new /datum/wires/emitter(src)
+	set_wires(new /datum/wires/emitter(src))
 	if(welded)
 		if(!anchored)
 			set_anchored(TRUE)

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -36,7 +36,7 @@
 
 /obj/machinery/power/energy_accumulator/tesla_coil/Initialize(mapload)
 	. = ..()
-	wires = new /datum/wires/tesla_coil(src)
+	set_wires(new /datum/wires/tesla_coil(src))
 
 /obj/machinery/power/energy_accumulator/tesla_coil/RefreshParts()
 	. = ..()

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -338,7 +338,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 
 	update_appearance()
 	LAZYADD(GLOB.conveyors_by_id[id], src)
-	wires = new /datum/wires/conveyor(src)
+	set_wires(new /datum/wires/conveyor(src))
 	AddComponent(/datum/component/usb_port, list(
 		/obj/item/circuit_component/conveyor_switch,
 	))

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -22,7 +22,7 @@
 	. = ..()
 	if(!CONFIG_GET(flag/no_default_techweb_link) && !stored_research)
 		connect_techweb(SSresearch.science_tech)
-	wires = new /datum/wires/rnd(src)
+	set_wires(new /datum/wires/rnd(src))
 
 /obj/machinery/rnd/Destroy()
 	if(stored_research)

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -211,7 +211,7 @@
 		circuit = null
 		build_inv = TRUE
 	. = ..()
-	wires = new /datum/wires/vending(src)
+	set_wires(new /datum/wires/vending(src))
 
 	if(build_inv) //non-constructable vending machine
 		build_inventories()

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -35,7 +35,7 @@
 		return TRUE
 	return isAdminGhostAI(user)
 
-/obj/machinery/door/airlock/shell/set_wires()
+/obj/machinery/door/airlock/shell/get_wires()
 	return new /datum/wires/airlock/shell(src)
 
 /obj/item/circuit_component/airlock

--- a/code/modules/wiremod/shell/airlock.dm
+++ b/code/modules/wiremod/shell/airlock.dm
@@ -2,7 +2,7 @@
 	holder_type = /obj/machinery/door/airlock/shell
 	proper_name = "Circuit Airlock"
 
-/datum/wires/airlock/shell/on_cut(wire, mend)
+/datum/wires/airlock/shell/on_cut(wire, mend, source)
 	// Don't allow them to re-enable autoclose.
 	if(wire == WIRE_TIMING)
 		return

--- a/monkestation/code/datums/wires/particle_accelerator.dm
+++ b/monkestation/code/datums/wires/particle_accelerator.dm
@@ -28,7 +28,7 @@
 		if(WIRE_LIMIT)
 			C.visible_message("<span class='notice'>[icon2html(C, viewers(holder))]<b>[C]</b> makes a large whirring noise.</span>")
 
-/datum/wires/particle_accelerator/control_box/on_cut(wire, mend)
+/datum/wires/particle_accelerator/control_box/on_cut(wire, mend, source)
 	var/obj/machinery/particle_accelerator/control_box/C = holder
 	switch(wire)
 		if(WIRE_POWER)

--- a/monkestation/code/modules/power/singularity/particle_accelerator/particle_controller.dm
+++ b/monkestation/code/modules/power/singularity/particle_accelerator/particle_controller.dm
@@ -21,7 +21,7 @@
 
 /obj/machinery/particle_accelerator/control_box/Initialize()
 	. = ..()
-	wires = new /datum/wires/particle_accelerator/control_box(src)
+	set_wires(new /datum/wires/particle_accelerator/control_box(src))
 	connected_parts = list()
 
 /obj/machinery/particle_accelerator/control_box/Destroy()


### PR DESCRIPTION
## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/75961 and https://github.com/tgstation/tgstation/pull/76837.

The descriptions of these PRs follow, with changelogs cut and moved to the bottom of this PR:

<details><summary>Fixes some stupid airlock sleeps (https://github.com/tgstation/tgstation/pull/75961)</summary>

### About The Pull Request

[A common problem with explosions is an overabundance of sleeping](https://github.com/tgstation/tgstation/commit/6499077a09469ff401c224c0510bc184c663b118)

In an attempt to solve this issue, let's not continue to sleep and do work in door closing if the door is already deleted

(This is caused by firelocks activating due to other adjacent objects deleting, triggering an atmos update, and closing the firelocks before they get bombed. I don't have a elegant way of resolving that core problem, so let's just minimize the impact)

[Nukes a stupid sleep loop in airlock code](https://github.com/tgstation/tgstation/commit/5b16360520526d6f5aa3b511049456b74f33f430)

When an airlock was depowered, it would enter a sleep loop, decrementing its delay by 1 second every well, one second, so long as it had the right wires flipped This is very stupid

Instead, let's use signals off wire changes and a combo of timer and remaining time var to do this with JUST a timer

Most of the changes here are just swapping over wires to a setter to make signal registration work\
### Why It's Good For The Game

Less sleeping around explosions means less dropped ticks after a bomb goes off. Good just in general Also this excises dumb boomer code and adds some hooks for other devs to use (we should use wires more man)

</details>

<details><summary>No roundstart playable MULEs / Trampling requires hacking (https://github.com/tgstation/tgstation/pull/76837)</summary>

### About The Pull Request

Prevailing feedback has been:

    * The player base cannot be trusted to control MULEbots.

    * It should be clearer what bots can and can't do.


The former is easy to fix. The latter is sort of a matter for policy but I'm going to investigate giving bots a rudimentary laws system. Plus that sounds much more controversial than this so I am going to atomise this outside of that PR.

MULEbots can still be set to allow sentience by cargo technicians, but don't start that way.

ADDITIONALLY this PR just changes it so that MULEbots do not crush people unless:

    * They have been emagged.

    * Their safety wire has been cut.
      Either means works, so it's not too hard to access for nefarious purposes, but hard to do to yourself.
      Otherwise they just slow down for a few seconds instead.


Also fixed an unrelated name bug while I was there.

Closes https://github.com/tgstation/tgstation/issues/76926
### Why It's Good For The Game

Players would take them, not deliver any cargo, and repeatedly ask people to lie down in front of them. Plus Tram has 5 of the things which is frankly too many to be wandering around the bar.
### Changelog

🆑 balance: You can't possess a MULE as soon as the round starts, someone will have to give you permission. balance: MULEbots no longer crush prone characters unless they have been hacked (or emagged). fix: Bots can put numbers in their names, what with being robots. admin: Adds attack logging when certain wires are cut (for instance: MULEbot safeties) /:cl:

</details>

## Why It's Good For The Game
Fixes bugs. Also removes MULEbots from the roundstart mobs - something I was told was desired by some admins.

## Changelog

:cl: Jacquerel
balance: You can't possess a MULE as soon as the round starts, someone will have to give you permission.
balance: MULEbots no longer crush prone characters unless they have been hacked (or emagged).
fix: Bots can put numbers in their names, what with being robots.
admin: Adds attack logging when certain wires are cut (for instance: MULEbot safeties)
/:cl: