### PR TITLE
Reviver Implants will now actually revive people!

### DIFF
--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -53,42 +53,82 @@
 	var/revive_cost = 0
 	var/reviving = FALSE
 	COOLDOWN_DECLARE(reviver_cooldown)
+	COOLDOWN_DECLARE(defib_cooldown)
 
+/obj/item/organ/internal/cyberimp/chest/reviver/on_death(seconds_per_tick, times_fired)
+	if(isnull(owner)) // owner can be null, on_death() gets called by /obj/item/organ/internal/process() for decay
+		return
+	try_heal() // Allows implant to work even on dead people
 
 /obj/item/organ/internal/cyberimp/chest/reviver/on_life(seconds_per_tick, times_fired)
+	try_heal()
+
+/obj/item/organ/internal/cyberimp/chest/reviver/proc/try_heal()
 	if(reviving)
-		switch(owner.stat)
-			if(UNCONSCIOUS, HARD_CRIT)
-				addtimer(CALLBACK(src, PROC_REF(heal)), 3 SECONDS)
-			else
-				COOLDOWN_START(src, reviver_cooldown, revive_cost)
-				reviving = FALSE
-				to_chat(owner, span_notice("Your reviver implant shuts down and starts recharging. It will be ready again in [DisplayTimeText(revive_cost)]."))
+		if(owner.stat == CONSCIOUS)
+			COOLDOWN_START(src, reviver_cooldown, revive_cost)
+			reviving = FALSE
+			to_chat(owner, span_notice("Your reviver implant shuts down and starts recharging. It will be ready again in [DisplayTimeText(revive_cost)]."))
+		else
+			addtimer(CALLBACK(src, PROC_REF(heal)), 3 SECONDS)
 		return
 
 	if(!COOLDOWN_FINISHED(src, reviver_cooldown) || HAS_TRAIT(owner, TRAIT_SUICIDED))
 		return
 
-	switch(owner.stat)
-		if(UNCONSCIOUS, HARD_CRIT)
-			revive_cost = 0
-			reviving = TRUE
-			to_chat(owner, span_notice("You feel a faint buzzing as your reviver implant starts patching your wounds..."))
+	if(owner.stat != CONSCIOUS)
+		revive_cost = 0
+		reviving = TRUE
+		to_chat(owner, span_notice("You feel a faint buzzing as your reviver implant starts patching your wounds..."))
+		COOLDOWN_START(src, defib_cooldown, 8 SECONDS) // 5 seconds after heal proc delay
 
 
 /obj/item/organ/internal/cyberimp/chest/reviver/proc/heal()
+	if(COOLDOWN_FINISHED(src, defib_cooldown))
+		revive_dead()
+
+	/// boolean that stands for if PHYSICAL damage being patched
+	var/body_damage_patched = FALSE
+	var/need_mob_update = FALSE
 	if(owner.getOxyLoss())
-		owner.adjustOxyLoss(-5)
+		need_mob_update += owner.adjustOxyLoss(-5, updating_health = FALSE)
 		revive_cost += 5
 	if(owner.getBruteLoss())
-		owner.adjustBruteLoss(-2)
+		need_mob_update += owner.adjustBruteLoss(-2, updating_health = FALSE)
 		revive_cost += 40
+		body_damage_patched = TRUE
 	if(owner.getFireLoss())
-		owner.adjustFireLoss(-2)
+		need_mob_update += owner.adjustFireLoss(-2, updating_health = FALSE)
 		revive_cost += 40
+		body_damage_patched = TRUE
 	if(owner.getToxLoss())
-		owner.adjustToxLoss(-1)
+		need_mob_update += owner.adjustToxLoss(-1, updating_health = FALSE)
 		revive_cost += 40
+	if(need_mob_update)
+		owner.updatehealth()
+
+	if(body_damage_patched && prob(35)) // healing is called every few seconds, not every tick
+		owner.visible_message(span_warning("[owner]'s body twitches a bit."), span_notice("You feel like something is patching your injured body."))
+
+
+/obj/item/organ/internal/cyberimp/chest/reviver/proc/revive_dead()
+	if(!COOLDOWN_FINISHED(src, defib_cooldown) || owner.stat != DEAD || owner.can_defib() != DEFIB_POSSIBLE)
+		return
+	owner.notify_ghost_cloning("You are being revived by [src]!")
+	revive_cost += 10 MINUTES // Additional 10 minutes cooldown after revival.
+	owner.grab_ghost()
+
+	defib_cooldown += 16 SECONDS // delay so it doesn't spam
+
+	owner.visible_message(span_warning("[owner]'s body convulses a bit."))
+	playsound(owner, SFX_BODYFALL, 50, TRUE)
+	playsound(owner, 'sound/machines/defib_zap.ogg', 75, TRUE, -1)
+	owner.revive()
+	owner.emote("gasp")
+	owner.set_jitter_if_lower(200 SECONDS)
+	SEND_SIGNAL(owner, COMSIG_LIVING_MINOR_SHOCK)
+	log_game("[owner] been revived by [src]")
+
 
 /obj/item/organ/internal/cyberimp/chest/reviver/emp_act(severity)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/78377 and https://github.com/tgstation/tgstation/pull/80386

## Why It's Good For The Game

_stolen from original PR_

> Reviver implant been a mess for a long time. Only thing it had possible is slightly heal you in crit, doing that very slowly.
> 
> With this PR reviver implant will actually revive you.
> - You are not gonna be invincible, loosing a head or getting your organs decayed beyond functional state will make revival impossible.
> - This process will be slow, and even after revival you will have to wait until you are get out of crit state.
> - Being revived from dead will add an additional 10 minutes to implant cooldown.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: SSensum, Diamond-74, Absolucy
balance: Reviver Implants will now actually revive people, albeit slowly, with a 10 minute cooldown before the implant is ready again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
