### PR TITLE
Sorts radio host messages under the 'radio' tab in the fancy chat

### DIFF
--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -60,7 +60,8 @@ export const MESSAGE_TYPES = [
     name: 'Radio',
     description: 'All departments of radio messages',
     selector:
-      '.alert, .minorannounce, .syndradio, .centcomradio, .aiprivradio, .comradio, .secradio, .gangradio, .engradio, .medradio, .sciradio, .suppradio, .servradio, .radio, .deptradio, .binarysay, .newscaster, .resonate, .abductor, .alien, .changeling',
+      //      '.alert, .minorannounce, .syndradio, .centcomradio, .aiprivradio, .comradio, .secradio, .gangradio, .engradio, .medradio, .sciradio, .suppradio, .servradio, .radio, .deptradio, .binarysay, .newscaster, .resonate, .abductor, .alien, .changeling', MONKESTATION EDIT CHANGE OLD
+      '.alert, .minorannounce, .syndradio, .centcomradio, .aiprivradio, .comradio, .secradio, .gangradio, .engradio, .medradio, .sciradio, .suppradio, .servradio, .radio, .deptradio, .binarysay, .newscaster, .resonate, .abductor, .alien, .changeling, .radioradio', // MONKESTATION EDIT CHANGE NEW
   },
   {
     type: MESSAGE_TYPE_INFO,


### PR DESCRIPTION

## About The Pull Request

Makes radio host messages in the 'radio' category instead of 'uncategorized'

## Why It's Good For The Game

So people can sort their channels better

## Changelog

:cl:
fix: radio host messages are properly sorted in fancychat
/:cl:
