### PR TITLE
Add logging for wirehacking-related events, such as cuts/mends, pulses, etc.

### DIFF
--- a/code/__HELPERS/~monkestation-helpers/logging/wirehack.dm
+++ b/code/__HELPERS/~monkestation-helpers/logging/wirehack.dm
@@ -1,0 +1,70 @@
+//! Procs for logging wirehack actions, including pulses, cuts and mends, as well as assemblies
+//! being attached and detached.
+
+/// Logs a single wirehack event.
+///
+/// Because messing with wires can have side effects, make sure to call this at an appropriate time,
+/// such that the resulting logs make sense when put in order. For example, if you're logging that
+/// an assembly is attempting to pulse a wire, make sure that log comes before the logs about the
+/// wire being pulsed.
+///
+/// Parameters:
+/// * `user`: Required; The user that caused this event
+/// * `action`: Required; Text detailing the action that took place ("mended", "pulsed", etc.)
+/// * `target`: Required; The target of the action
+/// * `wire`: Required; The relevant wire, by its function (WIRE_TX, WIRE_AI, etc. - this should be
+///   something that translates to a string)
+/// * `action_additional`: Optional; a string that comes after the wire is named
+/// * `message_admins`: Optional; Whether this event should be sent to admins' chat window
+///   immediately. Wirehack events are usually not important, so this is FALSE by default to avoid
+///   spamming admins.
+/proc/log_wirehack(atom/user, action, atom/target, wire, additional = "", message_admins = FALSE)
+	// NOTE: Though `user` is required, we cannot count on it being non-null, as in some cases (such
+	// as with prefabs which perform wire actions, or with assemblies) user may be null. In
+	// particular, the following cases are known where `user` can be `null`:
+	//
+	// * Timers pulsing a wire
+	//
+	// However, we can make an effort to patch these holes, and where we haven't, still provide as
+	// much data as we can. Hence, I'll put a stack trace here to track down any such instances.
+	if(!user || !action || !target || !wire)
+		stack_trace("A wirehack event failed to specify a required parameter. This should not prevent logging, but is considered an error regardless. Parameters values: (user: [user]) (action: [action]) (target: [target]) (wire: [wire])")
+
+	var/event_text = "[action] the [wire] wire of [target ? "[target.name] at [AREACOORD(target)]" : "an unknown target (please report this)"][(additional != "") ? " [additional]" : ""]"
+
+	// TODO: It would be nice to take the data provided to this function, pass it to a proc on
+	// `target`, and get back some data on what happened. For example, if they pulsed the "Open"
+	// wire on an airlock, we could use such a proc to get details on what the pulse did - such as
+	// "Opening it", "Closing it", "Doing nothing due to bolts", and so on.
+
+	if(user)
+		// TODO: Replace with LOG_WIREHACK
+		user.log_message(event_text, LOG_GAME)
+	else
+		// TODO: Replace with LOG_WIREHACK
+		log_game(event_text)
+
+	add_event_to_buffer(
+		source = user,
+		target = target,
+		data = event_text,
+		log_key = "WIRE",
+	)
+
+	// Allow notifying the admins, for example if we consider this wire to be a particularly
+	// important wire to be notified of.
+	if(message_admins)
+		message_admins("[user ? "[ADMIN_LOOKUPFLW(user)] at [ADMIN_VERBOSEJMP(user)]" : "An unspecified user (please report this)"] [action ? action : "performed an unspecified action (please report this) on"] the [wire ? wire : "Unspecified (please report this)"] wire of [target ? "[target.name] at [ADMIN_VERBOSEJMP(target)]" : "an unspecified target (please report this)"][(additional != "") ? " [additional]" : ""]")
+
+/// Logs a single wirehack event related to assemblies.
+///
+/// The parameters are the same as with `/proc/log_wirehack()`, with a couple additions:
+/// * `assembly`: Required; The assembly which is related to this event, such as a Remote Signaling
+///   Device or Timer.
+/proc/log_wirehack_with_assembly(atom/user, action, atom/assembly, atom/target, wire, message_admins = FALSE)
+	if(!assembly)
+		stack_trace("An assembly-related wirehack event failed to specify the assembly related to the event. This should not prevent logging, but is considered an error regardless.")
+
+	// TODO: Make sure we log what the assembly is made of, and its settings (such as the timer on a
+	// Timer)
+	log_wirehack(user, action, target, wire, "using an assembly ([assembly ? assembly : "An unspecified assembly (please report this)"])", message_admins)

--- a/code/__HELPERS/~monkestation-helpers/logging/wirehack.dm
+++ b/code/__HELPERS/~monkestation-helpers/logging/wirehack.dm
@@ -28,7 +28,7 @@
 	// However, we can make an effort to patch these holes, and where we haven't, still provide as
 	// much data as we can. Hence, I'll put a stack trace here to track down any such instances.
 	if(!user || !action || !target || !wire)
-		stack_trace("A wirehack event failed to specify a required parameter. This should not prevent logging, but is considered an error regardless. Parameters values: (user: [user]) (action: [action]) (target: [target]) (wire: [wire])")
+		stack_trace("A wirehack event failed to specify a required parameter. This should not prevent logging, but is considered an error regardless.")
 
 	var/event_text = "[action] the [wire] wire of [target ? "[target.name] at [AREACOORD(target)]" : "an unknown target (please report this)"][(additional != "") ? " [additional]" : ""]"
 

--- a/code/__HELPERS/~monkestation-helpers/logging/wirehack.dm
+++ b/code/__HELPERS/~monkestation-helpers/logging/wirehack.dm
@@ -48,7 +48,7 @@
 		source = user,
 		target = target,
 		data = event_text,
-		log_key = "WIRE",
+		log_key = "WIREHACK",
 	)
 
 	// Allow notifying the admins, for example if we consider this wire to be a particularly

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -147,19 +147,15 @@
 /datum/wires/proc/is_dud_color(color)
 	return is_dud(get_wire(color))
 
+/* //MONKESTATION EDIT START - Moved to `monkestation/code/datums/wires/_wires.dm`
 /datum/wires/proc/cut(wire)
 	if(is_cut(wire))
-		//MONKESTATION ADDITION START - Wirehack logging
-		log_wirehack(usr, "mended", holder, wire)
-		//MONKESTATION ADDITION END
 		cut_wires -= wire
 		on_cut(wire, mend = TRUE)
 	else
-		//MONKESTATION ADDITION START - Wirehack logging
-		log_wirehack(usr, "cut", holder, wire)
-		//MONKESTATION ADDITION END
 		cut_wires += wire
 		on_cut(wire, mend = FALSE)
+*/ //MONKESTATION REMOVAL END
 
 /datum/wires/proc/cut_color(color)
 	cut(get_wire(color))

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -149,9 +149,15 @@
 
 /datum/wires/proc/cut(wire)
 	if(is_cut(wire))
+		//MONKESTATION ADDITION START - Wirehack logging
+		log_wirehack(usr, "mended", holder, wire)
+		//MONKESTATION ADDITION END
 		cut_wires -= wire
 		on_cut(wire, mend = TRUE)
 	else
+		//MONKESTATION ADDITION START - Wirehack logging
+		log_wirehack(usr, "cut", holder, wire)
+		//MONKESTATION ADDITION END
 		cut_wires += wire
 		on_cut(wire, mend = FALSE)
 
@@ -168,6 +174,9 @@
 /datum/wires/proc/pulse(wire, user, force=FALSE)
 	if(!force && is_cut(wire))
 		return
+	//MONKESTATION ADDITION START - Wirehack logging
+	log_wirehack(user, "[force ? "force-" : ""]pulsed", holder, wire)
+	//MONKESTATION ADDITION END
 	on_pulse(wire, user)
 
 /datum/wires/proc/pulse_color(color, mob/living/user, force=FALSE)
@@ -176,11 +185,17 @@
 /datum/wires/proc/pulse_assembly(obj/item/assembly/S)
 	for(var/color in assemblies)
 		if(S == assemblies[color])
+			//MONKESTATION ADDITION START - Wirehack logging
+			log_wirehack_with_assembly(usr, "used an assembly to attempt to pulse", holder, color, S)
+			//MONKESTATION ADDITION END
 			pulse_color(color, force=TRUE)
 			return TRUE
 
 /datum/wires/proc/attach_assembly(color, obj/item/assembly/S)
 	if(S && istype(S) && S.attachable && !is_attached(color))
+		//MONKESTATION ADDITION START - Wirehack logging
+		log_wirehack_with_assembly(usr, "attached an assembly to", holder, color, S)
+		//MONKESTATION ADDITION END
 		assemblies[color] = S
 		S.forceMove(holder)
 		S.connected = src
@@ -190,6 +205,9 @@
 /datum/wires/proc/detach_assembly(color)
 	var/obj/item/assembly/S = get_attached(color)
 	if(S && istype(S))
+		//MONKESTATION ADDITION START - Wirehack logging
+		log_wirehack_with_assembly(usr, "detached an assembly from", holder, color, S)
+		//MONKESTATION ADDITION END
 		assemblies -= color
 		S.on_detach()		// Notify the assembly.  This should remove the reference to our holder
 		S.forceMove(holder.drop_location())

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -24,7 +24,10 @@
 
 /obj/item/radio/intercom/prison/Initialize(mapload, ndir, building)
 	. = ..()
-	wires?.cut(WIRE_TX)
+	//MONKESTATION EDIT START - Use set_wire_state to avoid generating a log
+	//wires?.cut(WIRE_TX) //MONKESTATION EDIT ORIGINAL
+	wires?.set_wire_state(WIRE_TX, FALSE)
+	//MONKESTATION EDIT END
 
 /obj/item/radio/intercom/Initialize(mapload, ndir, building)
 	. = ..()

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -156,7 +156,10 @@
 			if(24 to 30)
 				airlock.set_panel_open(TRUE)
 	if(airlock.cutAiWire)
-		airlock.wires.cut(WIRE_AI)
+		//MONKESTATION EDIT START - Use set_wire_state to avoid generating a log
+		//airlock.wires.cut(WIRE_AI) //MONKESTATION EDIT ORIGINAL
+		airlock.wires.set_wire_state(WIRE_AI, FALSE)
+		//MONKESTATION EDIT END
 	if(airlock.autoname)
 		airlock.name = get_area_name(src, TRUE)
 	airlock.update_appearance()
@@ -274,7 +277,10 @@
 		qdel(src)
 		return
 	if(target.cut_AI_wire)
-		target.wires.cut(WIRE_AI)
+		//MONKESTATION EDIT START - Use set_wire_state to avoid generating a log
+		//target.wires.cut(WIRE_AI) //MONKESTATION EDIT ORIGINAL
+		target.wires.set_wire_state(WIRE_AI, FALSE)
+		//MONKESTATION EDIT END
 	if(target.cell_5k)
 		target.install_cell_5k()
 	if(target.cell_10k)

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -408,7 +408,10 @@
 		can_transmit = !can_transmit
 	else //receiving
 		can_receive = !can_receive
-	radio.wires.cut(transmit_holder)//wires.cut toggles cut and uncut states
+	//MONKESTATION EDIT START - Use set_wire_state to avoid generating a log
+	//radio.wires.cut(transmit_holder)//wires.cut toggles cut and uncut states //MONKESTATION EDIT ORIGINAL
+	radio.wires.set_wire_state(transmit_holder, radio.wires.is_cut(transmit_holder))
+	//MONKESTATION EDIT END
 	transmit_holder = (transmitting ? can_transmit : can_receive) //recycling can be fun!
 	balloon_alert(src, "[transmitting ? "outgoing" : "incoming"] radio [transmit_holder ? "enabled" : "disabled"]")
 	return TRUE

--- a/monkestation/code/datums/wires/_wires.dm
+++ b/monkestation/code/datums/wires/_wires.dm
@@ -1,0 +1,24 @@
+
+/// Sets whether a wire is now cut.
+///
+/// This avoids
+///
+/// Parameters:
+/// * `wire`: The wire we want to cut, by its constant. (WIRE_TX, WIRE_AI, etc.)
+/// * `mended`: If this wire is currently mended together. TRUE means it's mended, and FALSE means
+///   it's cut.
+/datum/wires/proc/set_wire_state(wire, mended)
+	if(mended)
+		cut_wires -= wire
+	else
+		cut_wires |= wire
+
+	on_cut(wire, mend = mended)
+
+// Moved from the original `cut` proc, located at `code/datums/wires/_wires.dm`, this is a refactor
+// of the original. The logic to modify the `cut_wires` list and call `on_cut` has been moved to the
+// above `set_wire_state` proc, and wirehack logging has been added to this proc.
+/datum/wires/proc/cut(wire)
+	var/is_currently_cut = is_cut(wire)
+	log_wirehack(usr, is_currently_cut ? "mended" : "cut", holder, wire)
+	set_wire_state(wire, !is_currently_cut)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5633,6 +5633,7 @@
 #include "monkestation\code\datums\station_traits\neutral_traits.dm"
 #include "monkestation\code\datums\status_effects\disorient.dm"
 #include "monkestation\code\datums\status_effects\food_buffs.dm"
+#include "monkestation\code\datums\wires\_wires.dm"
 #include "monkestation\code\datums\wires\particle_accelerator.dm"
 #include "monkestation\code\game\atom.dm"
 #include "monkestation\code\game\sound.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -524,6 +524,7 @@
 #include "code\__HELPERS\sorts\TimSort.dm"
 #include "code\__HELPERS\~monkestation-helpers\icon_smoothing.dm"
 #include "code\__HELPERS\~monkestation-helpers\virology.dm"
+#include "code\__HELPERS\~monkestation-helpers\logging\wirehack.dm"
 #include "code\_globalvars\_regexes.dm"
 #include "code\_globalvars\admin.dm"
 #include "code\_globalvars\bitfields.dm"


### PR DESCRIPTION
## About The Pull Request
Wire-hacking is not currently logged. This PR attempts to fix that.

I do not feel this is ready for a full merge. Among other things, there are still some instances where the user is not tracked properly - and thus, not logged properly. I intend to fix these issues soon enough.

However, I feel there may be a desire to testmerge this before it's complete - not to mention, others may wish to test it out locally. Thus, I will try to keep this PR in a state where it can be built successfully at all times.

## Why It's Good For The Game
Helps admins find griefers.

## Changelog

:cl: MichiRecRoom
admin: Wirehack logging is now available.
/:cl: