### PR TITLE
Makes cargo autolathes public like on old monkestation

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -13538,7 +13538,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
 "djt" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -28506,6 +28505,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
+"gQS" = (
+/obj/machinery/autolathe,
+/obj/machinery/door/window/left/directional/south{
+	dir = 1;
+	req_access = list("cargo")
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "gQV" = (
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
@@ -74109,7 +74117,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
 "sac" = (
-/obj/machinery/autolathe,
 /obj/machinery/light/directional/west,
 /obj/machinery/light_switch/directional/south{
 	pixel_x = -20
@@ -74119,6 +74126,7 @@
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 8
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "sao" = (
@@ -140157,7 +140165,7 @@ hqK
 jPk
 rve
 djt
-pas
+gQS
 kUn
 djq
 qQE

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -2466,6 +2466,16 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"aRf" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/autolathe,
+/obj/machinery/door/window/left/directional/west{
+	name = "Cargo Desk";
+	req_access = list("cargo")
+	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/cargo/office)
 "aRj" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
@@ -4328,7 +4338,6 @@
 /area/mine/laborcamp/security)
 "bvr" = (
 /obj/machinery/light_switch/directional/west,
-/obj/machinery/autolathe,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bvs" = (
@@ -229645,7 +229654,7 @@ uuP
 aGF
 uuP
 gam
-qQo
+aRf
 lmv
 uuP
 tue

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2540,16 +2540,6 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/ai)
 "aUj" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/stack/package_wrap,
-/obj/item/stack/package_wrap{
-	pixel_y = 2
-	},
-/obj/item/stack/package_wrap{
-	pixel_y = 5
-	},
 /obj/structure/sign/map/left{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
 	icon_state = "map-left-MS";
@@ -2558,7 +2548,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/effect/spawner/random/bureaucracy/birthday_wrap,
 /turf/open/floor/iron,
 /area/station/construction/storage_wing)
 "aUk" = (
@@ -5732,7 +5721,6 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/autolathe,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "cem" = (
@@ -6819,6 +6807,17 @@
 	},
 /obj/item/chair,
 /obj/machinery/firealarm/directional/north,
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/random/bureaucracy/birthday_wrap,
+/obj/item/stack/package_wrap{
+	pixel_y = 5
+	},
+/obj/item/stack/package_wrap{
+	pixel_y = 2
+	},
+/obj/item/stack/package_wrap,
 /turf/open/floor/iron,
 /area/station/construction/storage_wing)
 "cyS" = (
@@ -62119,8 +62118,17 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
 "wdM" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
+/obj/machinery/door/window/left/directional/west{
+	name = "Cargo Desk";
+	req_access = list("cargo")
+	},
+/obj/machinery/door/window/left/directional/north{
+	dir = 4;
+	name = "Reception Window"
+	},
+/obj/machinery/autolathe,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
 /area/station/construction/storage_wing)
 "wdQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -21962,7 +21962,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
 	},
-/obj/item/kirbyplants/random,
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/office)
@@ -29432,6 +29431,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "ivC" = (
@@ -35055,7 +35055,6 @@
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "kkq" = (
-/obj/machinery/autolathe,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
@@ -71327,6 +71326,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
+"vHd" = (
+/obj/machinery/autolathe,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/cargo/office)
 "vHi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -189502,7 +189506,7 @@ uWi
 rpY
 ivy
 fSM
-vYl
+vHd
 pDa
 tZP
 oNJ


### PR DESCRIPTION

## About The Pull Request
Makes cargo autolathes as accessible as the Ore redemption machines on delta, icebox, meta, and tramstation
## Why It's Good For The Game
Makes autolathe items and iron/glass recycling more available
## Changelog
:cl:
qol: made autolathes in cargo publicly accesible on Delta Station, IceBox Station, Meta Station and Tramstation
/:cl:
