### PR TITLE
Fixes saltpetre for Monke botany

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2319,7 +2319,7 @@
 		var/salt = chems.get_reagent_amount(src.type)
 		mytray.adjust_plant_health(round(salt * 0.18))
 		if(myseed)
-			myseed.adjust_production(-round(salt * 0.1)-prob(salt%10))
+			myseed.adjust_production(round(salt * 0.1)+prob(salt%10)) // Monke edit: Inverted since Monke's use of production speed is inverted
 			myseed.adjust_potency(round(salt*0.2))
 
 /datum/reagent/lye


### PR DESCRIPTION
## About The Pull Request

On TG, saltpetre reduces production speed and this is a buffing effect; lower production speed is faster there. But on Monke this stat has been inverted: higher production speed is faster. This makes saltpetre something to avoid.

This PR inverts the effect of saltpetre on production speed so that, as originally intended, it makes plants produce faster.

## Why It's Good For The Game

Saltpetre is intended to be a buffing, not debuffing, fertilizer. When it causes negative effects, most will avoid it to stay on the lower tier fertilizers. By fixing this bug, there's now a reason to use the more expensive option.

Also, botany occurs in a lot of places outside of hydroponics:
* The garden
* Maintenance
* Space ruins and lavaland ruins
* Even the lavaland outpost
* And of course, the prison

None of these places get a biocube machine, so having plants take 3~4x longer to grow compared with TG and with short rounds really limits and cripples such a widely used system. Ammonia can speed it, of course, but that becomes its own project before one can then work on potency and yield and there just isn't enough time in a round to do much.

I think this PR stands on its own, but it's also important to #919 .

## Changelog

:cl:
fix: saltpetre now correctly buffs instead of debuffs plants' production time.
/:cl:
