### PR TITLE
Expansion of cooking & botany for Tram Station's prison

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -1323,6 +1323,7 @@
 "adN" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
+/obj/structure/sink/kitchen/directional/east,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
 "adO" = (
@@ -1382,11 +1383,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/escapepodbay)
-"adX" = (
-/obj/structure/cable,
-/obj/structure/sink/kitchen/directional/east,
-/turf/open/floor/iron/cafeteria,
-/area/station/security/prison/mess)
 "adY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -3378,18 +3374,6 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/lesser)
 "arI" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/item/seeds/onion,
-/obj/item/seeds/garlic,
-/obj/item/seeds/potato,
-/obj/item/seeds/tomato,
-/obj/item/seeds/carrot,
-/obj/item/seeds/grass,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/wheat,
-/obj/item/seeds/pumpkin,
-/obj/effect/spawner/random/contraband/prison,
 /obj/machinery/light/directional/east,
 /obj/item/radio/intercom/prison/directional/east,
 /obj/machinery/camera{
@@ -3397,7 +3381,10 @@
 	dir = 6;
 	network = list("ss13","Security","prison")
 	},
-/obj/item/seeds/tower,
+/obj/structure/rack,
+/obj/effect/spawner/random/food_or_drink/seed_tools_prison{
+	spawn_all_loot = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
 "asc" = (
@@ -5328,6 +5315,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical)
+"aJg" = (
+/obj/machinery/oven/range,
+/turf/open/floor/iron/cafeteria,
+/area/station/security/prison/mess)
 "aJi" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
@@ -9098,6 +9089,9 @@
 /area/station/service/library)
 "bLk" = (
 /obj/structure/table,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 1
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
 "bLp" = (
@@ -10999,8 +10993,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cpy" = (
-/obj/structure/table,
-/obj/machinery/microwave,
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo"
+	},
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
 "cpG" = (
@@ -12075,6 +12070,10 @@
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
+	},
+/obj/effect/spawner/random/food_or_drink/seed{
+	spawn_all_loot = 1;
+	spawn_random_offset = 1
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
@@ -21461,6 +21460,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/station/service/library)
+"fJG" = (
+/obj/machinery/griddle,
+/turf/open/floor/iron/cafeteria,
+/area/station/security/prison/mess)
 "fJN" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -30477,6 +30480,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
+"iNl" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/security/prison/mess)
 "iNo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -32183,8 +32193,16 @@
 /area/station/command/meeting_room)
 "joG" = (
 /obj/structure/table,
-/obj/item/book/manual/chef_recipes,
 /obj/structure/sign/clock/directional/south,
+/obj/machinery/reagentgrinder{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/condiment/enzyme{
+	layer = 5
+	},
+/obj/item/book/manual/chef_recipes,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
 "joI" = (
@@ -32486,7 +32504,6 @@
 /obj/item/storage/bag/tray/cafeteria,
 /obj/item/storage/bag/tray/cafeteria,
 /obj/item/storage/box/drinkingglasses,
-/obj/machinery/light/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
 "jsW" = (
@@ -33825,7 +33842,8 @@
 /area/station/command/gateway)
 "jPP" = (
 /obj/machinery/duct,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/table,
+/obj/item/storage/bag/tray,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
 "jQa" = (
@@ -35908,6 +35926,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_upload,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
+"kzS" = (
+/obj/machinery/light/directional/south,
+/obj/structure/table,
+/obj/machinery/processor{
+	pixel_y = 12
+	},
+/turf/open/floor/iron/cafeteria,
+/area/station/security/prison/mess)
 "kzT" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -38389,6 +38415,7 @@
 /area/station/science/ordnance/bomb)
 "llf" = (
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/duct,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
 "llk" = (
@@ -40171,7 +40198,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
-/obj/item/cultivator,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
 "lQC" = (
@@ -42423,6 +42449,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
+"mBo" = (
+/obj/structure/closet/secure_closet/freezer/meat{
+	req_access = null
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/cafeteria,
+/area/station/security/prison/mess)
 "mBq" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/crew_quarters/dorms)
@@ -53624,7 +53657,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
 	},
-/obj/item/plant_analyzer,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
 "qjJ" = (
@@ -59323,7 +59355,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/item/shovel/spade,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
 "rZU" = (
@@ -61972,6 +62003,10 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"sQz" = (
+/obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
+/turf/open/floor/iron/cafeteria,
+/area/station/security/prison/mess)
 "sQG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -63834,7 +63869,13 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
-/obj/item/cultivator,
+/obj/structure/closet/crate/hydroponics,
+/obj/effect/spawner/random/contraband/prison,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/effect/spawner/random/food_or_drink/seed_prison{
+	spawn_all_loot = 1;
+	spawn_random_offset = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
 "tsE" = (
@@ -65505,6 +65546,12 @@
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
+	},
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 8;
+	pixel_y = 2
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/prison/garden)
@@ -94652,10 +94699,10 @@ rau
 cnD
 kRI
 jWs
-aaa
-aaa
-aaa
-aaa
+oVM
+oVM
+oVM
+oVM
 aaa
 aaa
 aaa
@@ -94909,10 +94956,10 @@ kYr
 trx
 wro
 jWs
-aaa
-aaa
-aaa
-aaa
+sQz
+mBo
+sQz
+oVM
 aaa
 pZW
 pZW
@@ -95166,9 +95213,9 @@ ggX
 jWs
 oVM
 oVM
-oVM
-oVM
-oVM
+mgS
+mgS
+mgS
 oVM
 aaa
 pZW
@@ -95423,8 +95470,8 @@ xcj
 oEN
 oVM
 adN
-adX
 dRJ
+iNl
 pWp
 oVM
 aaa
@@ -95937,7 +95984,7 @@ rBz
 ung
 cQD
 mgS
-bLk
+fJG
 edg
 smV
 oVM
@@ -96194,9 +96241,9 @@ rBz
 ung
 fZm
 mgS
-bLk
+aJg
 edg
-jsN
+kzS
 oVM
 aaa
 aaa
@@ -96451,8 +96498,8 @@ rBz
 ung
 fZm
 mgS
-afL
-jBD
+jsN
+edg
 cpy
 oVM
 aaa
@@ -96708,7 +96755,7 @@ rBz
 ung
 cQD
 adO
-mgS
+afL
 jBD
 bLk
 rUR

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -9968,6 +9968,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/composters,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
 "bZR" = (

--- a/code/game/objects/effects/spawners/random/food_or_drink.dm
+++ b/code/game/objects/effects/spawners/random/food_or_drink.dm
@@ -48,6 +48,53 @@
 		/obj/item/seeds/cucumber,
 	)
 
+// Template inspired by icebox, void raptor, and blue shift to give prisoners more to do
+// Meant to be used in tandem with the basic seed spawner, as this list removes duplicates but
+// the basic seed spawner has some pretty important ones.
+/obj/effect/spawner/random/food_or_drink/seed_prison
+	name = "prison seed spawner"
+	icon_state = "seed"
+	loot = list(
+		/obj/item/seeds/tower,
+		/obj/item/seeds/onion,
+		/obj/item/seeds/garlic,
+		/obj/item/seeds/grass,
+		/obj/item/seeds/pumpkin,
+		/obj/item/seeds/ambrosia,
+		/obj/item/seeds/banana, // Inspiration from Void Raptor and Blueshift (primary crate) from here. Not including seeds from secondary crate (those are maybe a bit OP).
+		/obj/item/seeds/carrot/parsnip,
+		/obj/item/seeds/chili,
+		/obj/item/seeds/lemon,
+		/obj/item/seeds/lime,
+		/obj/item/seeds/orange,
+		/obj/item/seeds/watermelon,
+		/obj/item/seeds/wheat/oat,
+		/obj/item/seeds/eggplant,
+		/obj/item/seeds/cherry/blue,
+		/obj/item/seeds/cherry,
+		/obj/item/seeds/grape,
+		/obj/item/seeds/grape/green,
+	)
+
+// This might not be strictly the best place but there doesn't really seem to be a random tools spawner.
+// Excludes wirecutters from the inspiration source.
+/obj/effect/spawner/random/food_or_drink/seed_tools_prison
+	name = "prison botany tools spawner"
+	icon_state = "seed"
+	loot = list( 
+		/obj/item/secateurs,
+		/obj/item/secateurs,
+		/obj/item/cultivator,
+		/obj/item/cultivator,
+		/obj/item/plant_analyzer,
+		/obj/item/plant_analyzer,
+		/obj/item/storage/bag/plants,
+		/obj/item/storage/bag/plants,
+		/obj/item/reagent_containers/cup/bucket,
+		/obj/item/reagent_containers/cup/bucket,
+	)
+
+
 /obj/effect/spawner/random/food_or_drink/seed_rare
 	spawn_loot_count = 5
 	icon_state = "seed"


### PR DESCRIPTION
## About The Pull Request

This expands the Tram Station prison's kitchen and botany gameplay with the intent of allowing cooking projects. The main inspiration for this comes from the Ice Box, Void Raptor, and BlueShift maps.

## Why It's Good For The Game

With only a microwave, very little can be cooked. Onion rings, eggs, and... that's mostly it, especially considering the limited ingredients available.
<details>
<summary>Screenshot</summary>

![image](https://github.com/Monkestation/Monkestation2.0/assets/86855173/ae6295c7-26c2-4f5e-ab3f-8a6610437798)

</details>

Playing on other servers, I've felt it can be pretty neat when facilities are good enough that you can actually get cooking projects going, and it means someone could take the role to learn and experiment (still to a limited degree, though) without the pressure of keeping a crew fed that comes with taking the formal job. It's something that I'd like to see on Monke, too.

Add to that, most wardens that care about the perma side of the job will tell you that giving things to do tends to help a lot with disincentivizing breaking out.

If this is received favorably, I'd like to work on Meta Station next. And then after that, there's a very good PR for Delta station that's already been done I'd like to try porting.

## Changelog

:cl:
add: Tram Station's prison kitchen and botany have more content.
/:cl:
