### PR TITLE
Fixes job page constantly making itself bigger

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/JobsPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/JobsPage.tsx
@@ -237,9 +237,10 @@ const JobRow = (
       style={{
         'margin-top': 0,
       }}>
-      <Stack align="center">
+      <Stack>
         <Tooltip content={job.description} position="right">
           <Stack.Item
+            align="center"
             className="job-name"
             width="50%"
             style={{


### PR DESCRIPTION
## About The Pull Request

This dumbass codebase i can't fork it because i 'already have a fork of tgstation' i fucking hate git so fucking much god fuck

pictured: fuck this world
![image](https://github.com/Monkestation/Monkestation2.0/assets/53777086/223eab54-9a44-400a-b7f0-be21a91f276c)


After and before

https://github.com/Monkestation/Monkestation2.0/assets/53777086/7a6d0af3-a434-45cd-bc29-7c10efb64be5

Fixes every time you click on it, the job page getting bigger.

## Why It's Good For The Game

I haven't seen a single issue report here or on skyrat about this but it is annoying and it sucks. die.

## Changelog

:cl:
fix: The jobs page will no longer constantly get bigger when picking a new job title (or not).
/:cl: