### PR TITLE
Completely removes the changeling tranformation sting

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -63,6 +63,7 @@
 	return 1
 
 
+/* MONKE EDIT: remove transformation sting. do not re-add this. it is never going to be used properly. it is solely used for soft-grief.
 /datum/action/changeling/sting/transformation
 	name = "Transformation Sting"
 	desc = "We silently sting a human, injecting a retrovirus that forces them to transform. Costs 50 chemicals."
@@ -105,7 +106,7 @@
 		C.real_name = NewDNA.real_name
 		NewDNA.transfer_identity(C)
 		C.updateappearance(mutcolor_update=1)
-
+*/
 
 /datum/action/changeling/sting/false_armblade
 	name = "False Armblade Sting"


### PR DESCRIPTION

## About The Pull Request

Exactly what it says on the tin.

![3yrzdf](https://github.com/Monkestation/Monkestation2.0/assets/65794972/f43382f0-0cbf-437c-847c-851edd66e3a2)

## Why It's Good For The Game

This is _solely_ used as a way to fuck people up and basically soft-grief half the station by turning them into the most undesirable person you can get DNA from. Whatever tactical where's waldo bullshit that the original author had planned is certainly never going to happen here, and has probably never happened on _any_ server where this is a thing.

## Changelog
:cl:
del: Completely removed the changeling tranformation sting. Good riddance. No more turning half the crew into an goblin or lizard.
/:cl:
