### PR TITLE
Ghost players now have their quirks and actual name applied to them

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -65,7 +65,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 
 /datum/controller/subsystem/processing/quirks/proc/AssignQuirks(mob/living/user, client/applied_client)
 	var/badquirk = FALSE
-	for(var/quirk_name in applied_client.prefs.all_quirks)
+	for(var/quirk_name in applied_client?.prefs?.all_quirks)
 		var/datum/quirk/quirk_type = quirks[quirk_name]
 		if(ispath(quirk_type))
 			if(user.add_quirk(quirk_type, override_client = applied_client))

--- a/monkestation/code/modules/ghost_players/ghost_player.dm
+++ b/monkestation/code/modules/ghost_players/ghost_player.dm
@@ -35,8 +35,6 @@ GLOBAL_VAR_INIT(disable_ghost_spawning, FALSE)
 	. = ..()
 	var/datum/action/cooldown/mob_cooldown/return_to_ghost/created_ability = new /datum/action/cooldown/mob_cooldown/return_to_ghost(src)
 	created_ability.Grant(src)
-	equipOutfit(/datum/outfit/job/assistant)
-	regenerate_icons()
 
 /mob/living/carbon/human/ghost/Destroy()
 	. = ..()
@@ -131,11 +129,14 @@ GLOBAL_VAR_INIT(disable_ghost_spawning, FALSE)
 		if(brain)
 			brain.temporary_sleep = TRUE
 
+	var/client/our_client = client || GLOB.directory[ckey]
 	var/mob/living/carbon/human/ghost/new_existance = new(key, mind, can_reenter_corpse, brain)
-	client?.prefs.safe_transfer_prefs_to(new_existance, TRUE, FALSE)
+	our_client?.prefs.safe_transfer_prefs_to(new_existance, TRUE, FALSE)
 	new_existance.move_to_ghostspawn()
 	new_existance.key = key
-	client?.init_verbs()
+	new_existance.equipOutfit(/datum/outfit/job/assistant)
+	SSquirks.AssignQuirks(new_existance, our_client)
+	our_client?.init_verbs()
 	qdel(src)
 	return TRUE
 


### PR DESCRIPTION

## About The Pull Request

This applies quirks to ghost players, and also changes it so their outfit is equipped _after_ their name is set, so they don't have an ID that differs from their actual name, i.e Shion Rosenthal (as Jane Doe)

![2024-01-14 (1705280169) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/9f24b914-ffcd-4998-ae08-faf713443ca0)


## Why It's Good For The Game

bug bad

## Changelog
:cl:
fix: Ghost players now have their quirks and actual name applied to them, including their ID.
/:cl:
