### PR TITLE
Fixes bomber logging to log to LOG_ATTACK instead of LOG_GAME when there's no user attached

### DIFF
--- a/code/__HELPERS/~monkestation-helpers/logging/attack.dm
+++ b/code/__HELPERS/~monkestation-helpers/logging/attack.dm
@@ -15,7 +15,7 @@
 		user.log_message(bomb_message, LOG_ATTACK) //let it go to individual logs as well as the game log
 		bomb_message = "[key_name(user)] at [AREACOORD(user)] [bomb_message]."
 	else
-		log_game(bomb_message)
+		log_attack(bomb_message)
 
 	GLOB.bombers += bomb_message
 


### PR DESCRIPTION
## About The Pull Request
Title. It didn't occur to me before now that it would try to log this to two separate places.

## How It's Good For The Game
*No response entered.*
