### PR TITLE
Adds "*weh" as a lizard emote

### DIFF
--- a/monkestation/code/modules/mob/living/emote.dm
+++ b/monkestation/code/modules/mob/living/emote.dm
@@ -162,3 +162,24 @@
 	else
 		return pick('monkestation/sound/voice/feline/bark.ogg','monkestation/sound/voice/feline/bark2.ogg') // Yes, bark trait in feline folder [Bad To The Bone]
 
+/datum/emote/living/weh
+	key = "weh"
+	key_third_person = "wehs"
+	message = "wehs!"
+	message_param = "wehs at %t!"
+	message_mime = "wehs silently!"
+	emote_type = EMOTE_VISIBLE | EMOTE_AUDIBLE
+
+/datum/emote/living/weh/get_sound(mob/living/user)
+	if(islizard(user))
+		return 'monkestation/sound/voice/weh.ogg'
+	else
+		return FALSE
+
+/datum/emote/living/weh/can_run_emote(mob/user, status_check, intentional)
+	. = ..()
+	if(islizard(user))
+		return TRUE
+	else
+		return FALSE
+

--- a/monkestation/code/modules/mob/living/emote.dm
+++ b/monkestation/code/modules/mob/living/emote.dm
@@ -177,7 +177,6 @@
 		return FALSE
 
 /datum/emote/living/weh/can_run_emote(mob/user, status_check, intentional)
-	. = ..()
 	if(islizard(user))
 		return TRUE
 	else


### PR DESCRIPTION

## About The Pull Request

You can use the lizard plushie sound as a lizard now.
## Why It's Good For The Game

Gives lizards a cool new emote, not sure what else to say lol
## Testing Video


https://github.com/Monkestation/Monkestation2.0/assets/152086196/1ac21311-5c17-465b-82cc-7ca1fc163ba1



## Changelog
:cl: KnigTheThrasher
add: You can "*weh" as a lizard now
/:cl:
