### PR TITLE
Huge Simian Nerf (They will never recover)

### DIFF
--- a/monkestation/code/modules/mob/living/carbon/human/species_type/simian.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/simian.dm
@@ -19,10 +19,7 @@
 
 	use_skintones = FALSE
 
-	inherent_biotypes = list(
-		MOB_ORGANIC,
-		MOB_HUMANOID
-		)
+	inherent_biotypes = MOB_ORGANIC | MOB_HUMANOID
 
 	mutanttongue = /obj/item/organ/internal/tongue/monkey
 	changesource_flags = MIRROR_BADMIN | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN


### PR DESCRIPTION
## About The Pull Request
Fixes the inherent biotypes on simians so they actually are humanoid/organic.  

![image](https://github.com/Monkestation/Monkestation2.0/assets/85052537/f39bd4cc-b74c-47fa-9116-d99a29e92038)


## Why It's Good For The Game
As silly as the undead biotype was, its a bug,  I kill the bug

## Changelog

:cl:
fix: Simians now have their appropriate biotype (They're no longer undead)
/:cl:

