### PR TITLE
[BOUNTY] Cassette Crates + More!

### DIFF
--- a/monkestation/code/modules/cargo/crates/goodies.dm
+++ b/monkestation/code/modules/cargo/crates/goodies.dm
@@ -1,0 +1,17 @@
+/datum/supply_pack/goody/walkman
+	name = "Walkman Single-pack"
+	desc = "5 Walkmen is too much for the average man on the average occasion. Solution: 1 Singular Walkman. Contains 1 Walkman."
+	cost = PAYCHECK_CREW * 3
+	contains = list(/obj/item/device/walkman)
+
+/datum/supply_pack/goody/cassette
+	name = "Cassette Mini-Pack"
+	desc = "Alright, we'll admit it, 10 cassettes are too much for the majority of our users. Contains 3 Approved Cassettes."
+	cost = PAYCHECK_CREW * 5
+	contains = list(/obj/item/device/cassette_tape/random = 3)
+
+/datum/supply_pack/goody/blankcassette
+	name = "Blank Cassette Mini-Pack"
+	desc = "NO! We wont admit defeat! You will march yourself down to the Service section and purchase the 10 Blank Cassette pack instead of this Weak 3 Blank Cassette Pack!"
+	cost = PAYCHECK_CREW * 3
+	contains = list(/obj/item/device/cassette_tape/blank = 3)

--- a/monkestation/code/modules/cargo/crates/service.dm
+++ b/monkestation/code/modules/cargo/crates/service.dm
@@ -35,3 +35,33 @@
 	cost = CARGO_CRATE_VALUE * 20 //the crew shouldnt be able to just buy 15 jukeboxes all playing among us at the same time
 	contains = list(/obj/item/choice_beacon/jukebox)
 	crate_name = "jukebox beacon crate"
+
+/datum/supply_pack/service/cassettes
+	name = "Bulk Cassette Crate"
+	desc = "In the unlikely event all your cassettes are the same, or the likely event youve run out of songs to play, this crate is here to help you, contains 10 Approved Cassettes for use in the DJ Station."
+	cost = CARGO_CRATE_VALUE * 4
+	contains = list(/obj/item/device/cassette_tape/random = 10)
+	crate_name = "cassette crate"
+
+/datum/supply_pack/service/blankcassettes
+	name = "Blank Cassettes Crate"
+	desc = "in the VERY unlikely event you have run out of blank cassettes, you can get 10 blank ones here. Contains 10 blank cassettes for use in Walkmans."
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/device/cassette_tape/blank = 10)
+	crate_name = "cassette crate"
+
+/datum/supply_pack/service/walkmen
+	name = "Walkman Crate"
+	desc = "In the EXTREMELY unlikely event you have run out of walkmans in the library, this crate has 5 walkman devices for listening to cassettes personally. Cassettes Sold Seperately."
+	cost = CARGO_CRATE_VALUE * 3
+	contains = list(/obj/item/device/walkman = 5)
+	crate_name = "walkman crate"
+
+/datum/supply_pack/service/cassettedeck
+	name = "Advanced Cassette Deck Crate"
+	desc = "In the event you simply refuse to interact with the Curator at all. Contains 1 Advanced Cassette Deck and a wrench for moving it."
+	cost = CARGO_CRATE_VALUE * 5
+	contains = list(/obj/machinery/cassette/adv_cassette_deck,
+					/obj/item/wrench)
+	crate_name = "cassette deck crate"
+	crate_type = /obj/structure/closet/crate/large

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6005,6 +6005,7 @@
 #include "monkestation\code\modules\cargo\crates\emergency.dm"
 #include "monkestation\code\modules\cargo\crates\engineering.dm"
 #include "monkestation\code\modules\cargo\crates\general.dm"
+#include "monkestation\code\modules\cargo\crates\goodies.dm"
 #include "monkestation\code\modules\cargo\crates\imports.dm"
 #include "monkestation\code\modules\cargo\crates\large.dm"
 #include "monkestation\code\modules\cargo\crates\livestock.dm"


### PR DESCRIPTION
## About The Pull Request
[completes this bounty](https://discord.com/channels/748354466335686736/1197311496015847485/1197311496015847485)
adds 4 crates + 3 goodies:
Crates:

1. Random Cassette Crate: contains 10 random, approved cassettes (presumably)
2. Blank Cassette Crate: contains 10 blank cassettes
3. Walkman Crate: contains 5 walkmans.
4. Cassette Deck Crate: Contains a cassette deck and a wrench.

Goodies:

1. Random Cassettes: 3 random cassettes
2. Blank Cassettes: 3 blank cassettes
3. Walkman: 1 walkman.

really they just wanted the first one but i wanted the other 3.
should probably be test-merged first as i couldnt really properly test if the random cassettes would work locally.
## Why It's Good For The Game
its good for my wallet, that is, if it wasnt 1 rounds worth of monkecoin.
## Changelog
:cl: Tractor Mann
add: Added 4 new crates concerning cassettes at cargo! (Most importantly the 10 Random Cassettes one, go wild with buying the cassettes, curators!)
add: 3 new cargo goodies! (if you need 3 cassettes instead of 10, or just 1 walkman.)
/:cl:
