### PR TITLE
Fixes HoS's spaghetti setting you on infinite blaze

### DIFF
--- a/monkestation/code/modules/reagents/fun/liquid_justice.dm
+++ b/monkestation/code/modules/reagents/fun/liquid_justice.dm
@@ -5,12 +5,9 @@
 	metabolization_rate = 1.5 * REAGENTS_METABOLISM
 	ph = 0
 
-/*
-Liquid justce - Metabolizes 50% quicker than phlogiston, gives double the firestacks but dosent deal direct fire damage
-*/
-
+// Metabolizes 50% quicker than phlogiston, gives double firestacks. Also does not deal direct fire damage (very rare for fire reagents)
 /datum/reagent/liquid_justice/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
-	// if you don't have a liver, or your liver isn't an officer's liver
+	. = ..()
 	var/obj/item/organ/internal/liver/liver = affected_mob.get_organ_slot(ORGAN_SLOT_LIVER)
 	if(!liver || !HAS_TRAIT(liver, TRAIT_LAW_ENFORCEMENT_METABOLISM))
 		affected_mob.adjust_fire_stacks(2 * REM * seconds_per_tick)


### PR DESCRIPTION

## About The Pull Request

Makes the liquid justice reagent actually process, just shows how often people eat the spaghetti that no one found this until now huh?

fixes https://github.com/Monkestation/Monkestation2.0/issues/1004

## Why It's Good For The Game

because infinite fire was un-intended

## Changelog

:cl:
fix: HoS's spaghetti no longer sets you eternally on fire for the sins of eating it as an assistant
/:cl:
