### PR TITLE
It is now possible to splash liquid containers while using Intents

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -146,7 +146,7 @@
 /obj/item/reagent_containers/pre_attack_secondary(atom/target, mob/living/user, params)
 	if(HAS_TRAIT(target, TRAIT_DO_NOT_SPLASH))
 		return ..()
-	if(!(user.istate & ISTATE_HARM))
+	if(!(user.istate & ISTATE_HARM) && istype(user.client?.imode, /datum/interaction_mode/combat_mode))
 		return ..()
 	if (try_splash(user, target))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN


### PR DESCRIPTION

## About The Pull Request

Closes #570.
What it says on the tin. Splashing containers can now be achieved by using the liquid container while in disarm intent.
The way it works for combat mode users is unchanged.
## Why It's Good For The Game

Who doesn't like a bugfix?
## Changelog
:cl:
fix: reagent containers can now be splashed while using Intents (click while on disarm intent).
/:cl:
