### PR TITLE
Remove bio cube scaling effects

### DIFF
--- a/monkestation/code/modules/hydroponics/machines/composter.dm
+++ b/monkestation/code/modules/hydroponics/machines/composter.dm
@@ -112,22 +112,17 @@
 	desc = "A cube made of pure biomatter does wonders on plant trays"
 	icon = 'monkestation/icons/obj/misc.dmi'
 	icon_state = "bio_cube"
-
-	var/total_duration = 60 SECONDS
-	var/scale_multiplier = 0.6
-
+	var/total_duration = 1 MINUTES
 
 /obj/item/bio_cube/update_desc()
 	. = ..()
-	desc = "A cube made of pure biomatter, it seems to be bigger than normal making it last [total_duration / 600] minutes. Does wonders on plant trays."
+	desc = "A cube made of pure biomatter, it seems to be denser than normal making it last [DisplayTimeText(total_duration)]. Does wonders on plant trays."
 
 /obj/item/bio_cube/attackby(obj/item/attacking_item, mob/living/user)
 	. = ..()
 	if(istype(attacking_item, /obj/item/bio_cube))
 		var/obj/item/bio_cube/attacking_cube = attacking_item
-		scale_multiplier += (attacking_cube.scale_multiplier - 0.5)
 		total_duration += attacking_cube.total_duration
-		to_chat(user, span_notice("You smash the two bio cubes together making a bigger bio cube that lasts longer."))
+		to_chat(user, span_notice("You smash the two bio cubes together, making a denser bio cube that lasts longer."))
 		update_desc()
-		transform = transform.Scale(scale_multiplier, scale_multiplier)
 		qdel(attacking_cube)


### PR DESCRIPTION

## About The Pull Request

This makes it so bio cubes no longer visually resize. They still function the exact same, the sprite just doesn't grow anymore.

References to making the cubes bigger have been changed to instead making it _denser_.

## Why It's Good For The Game

Because this is actively making the play experience worse for some players, reducing playability just because "haha funny beeeeg cube".

## Changelog
:cl:
del: Bio cubes no longer visually grow when combining. They still function the exact same, the sprite just doesn't grow.
qol: The bio cube's description now uses a proper method of displaying time length.
/:cl:
