### PR TITLE
Morphs can't eat pipes, air alarms or apcs

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/morph.dm
+++ b/code/modules/mob/living/basic/space_fauna/morph.dm
@@ -58,6 +58,7 @@
 
 	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/content_barfer)
+	AddElement(/datum/element/prevent_attacking_of_types, GLOB.typecache_general_bad_hostile_attack_targets, "this tastes awful!") // Monkestation edit
 
 	disguise_ability = new(src)
 	disguise_ability.Grant(src)

--- a/code/modules/mob/living/basic/space_fauna/morph.dm
+++ b/code/modules/mob/living/basic/space_fauna/morph.dm
@@ -58,7 +58,7 @@
 
 	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/content_barfer)
-	AddElement(/datum/element/prevent_attacking_of_types, GLOB.typecache_general_bad_hostile_attack_targets, "this tastes awful!") // Monkestation edit
+	AddElement(/datum/element/prevent_attacking_of_types, GLOB.typecache_general_bad_hostile_attack_targets, "this tastes awful!") // MONKESTATION ADDITION
 
 	disguise_ability = new(src)
 	disguise_ability.Grant(src)


### PR DESCRIPTION

## About The Pull Request
Does what the title says, simple as that.
## Why It's Good For The Game
Morphs shouldn't just be able to go and easily delam the supermatter, nor easily flood. Morphs can be round ending but they shouldn't have the ability to automatically do so. 
## Changelog
:cl:

balance: Morphs can no longer eat pipes, air alarms or apcs
/:cl:
