### PR TITLE
Increases the stock of traitor discounts from 1 to 20

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -96,7 +96,7 @@
 				if((uplink_handler.assigned_role in item.restricted_roles) || (uplink_handler.assigned_species in item.restricted_species))
 					uplink_items += item
 					continue
-		uplink_handler.extra_purchasable += create_uplink_sales(uplink_sale_count, /datum/uplink_category/discounts, 1, uplink_items)
+		uplink_handler.extra_purchasable += create_uplink_sales(uplink_sale_count, /datum/uplink_category/discounts, 20, uplink_items) //monkestation edit: from 1 stock to 20
 
 	if(give_objectives)
 		forge_traitor_objectives()


### PR DESCRIPTION

## About The Pull Request

Read tin. Note this is the amount of times a discounted item can be bought not the amount of discounts you get.

## Why It's Good For The Game

I asked about it in the discord and people seemed pretty receptive.

## Changelog
:cl:
balance: traitors can now buy their discounts up to 20 times, instead of just 1
/:cl:
