### PR TITLE
Makes wizard mirrors properly change your characters bodytype.

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -243,7 +243,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 				else
 					return TRUE
 			amazed_human.dna.update_ui_block(DNA_GENDER_BLOCK)
-			amazed_human.update_body()
+			amazed_human.update_body(is_creating = TRUE) //MONKESTATION EDIT
 			amazed_human.update_mutations_overlay() //(hulk male/female)
 
 		if("hair")


### PR DESCRIPTION

## About The Pull Request
Adds a monkestation edit to the mirror file to allow swapping bodytypes to work properly.
## Why It's Good For The Game
While rare, this is a bit annoying.
## Changelog
:cl:
fix: Fixed bodytype swapping in magic mirrors.
/:cl:
