### PR TITLE
Makes adjusted uniforms that cover the chest respect body type.

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -344,6 +344,8 @@
 		return
 	adjusted = !adjusted
 	if(adjusted)
+		if(alt_covers_chest) //For snowflake suits that do NOT expose the chest. //MONKESTATION EDIT
+			return
 		if(!(female_sprite_flags & FEMALE_UNIFORM_TOP_ONLY))
 			female_sprite_flags = NO_FEMALE_UNIFORM
 		if(!alt_covers_chest) // for the special snowflake suits that expose the chest when adjusted (and also the arms, realistically)


### PR DESCRIPTION

## About The Pull Request
Adds a bit of code to the jumpsuit toggling proc that makes it recognize if a jumpsuit covers the chest before it removes the feminine bodytype's sprite filters for the chest on adjustment (alt_click). This should make things that roll up the sleeves not lose their differences when you adjust it
## Why It's Good For The Game
Consistancy. If it changes depending on body type it should stay that way in both iterations.
## Changelog
:cl:
fix: Fixed adjusted uniforms that covered the chest not using feminine version on feminine bodytype.
/:cl:
