### PR TITLE
[BOUNTY] Restrict romerol from maint pills

### DIFF
--- a/monkestation/code/modules/reagents/misc.dm
+++ b/monkestation/code/modules/reagents/misc.dm
@@ -1,0 +1,2 @@
+/datum/reagent/romerol
+	restricted = TRUE // romerol maintpills were funny the first few times. not anymore.

--- a/monkestation/code/modules/reagents/misc.dm
+++ b/monkestation/code/modules/reagents/misc.dm
@@ -1,2 +1,2 @@
 /datum/reagent/romerol
-	restricted = TRUE // romerol maintpills were funny the first few times. not anymore.
+	restricted = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6486,6 +6486,7 @@
 #include "monkestation\code\modules\random_rooms\bars\tram_bar_modules.dm"
 #include "monkestation\code\modules\reagents\_reagents.dm"
 #include "monkestation\code\modules\reagents\containers.dm"
+#include "monkestation\code\modules\reagents\misc.dm"
 #include "monkestation\code\modules\reagents\reagent_containers.dm"
 #include "monkestation\code\modules\reagents\reagents.dm"
 #include "monkestation\code\modules\reagents\fun\austrialium.dm"


### PR DESCRIPTION

## About The Pull Request

Makes it so romerol can't appear in maint pills. Simple as. For this bounty: https://discord.com/channels/748354466335686736/1202131743243776091

## Why It's Good For The Game

> I am (and i know at least some of the admin team is) sick of random ass romerol from 'funny lizard pill consumer'

(from bidlink)

## Changelog
:cl:
del; Romerol can no longer generate in maint pills.
/:cl:
