### PR TITLE
Makes metastation be considered a low-pop station

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -15,8 +15,7 @@ endmap
 
 map metastation
 	#default
-	minplayers 25
-	#voteweight 0.5
+	minplayers 5
 	votable
 endmap
 


### PR DESCRIPTION

## About The Pull Request

Adjusts the minimum pop requirement from 25 to 5
Makes its vote multiplier 1 from 0.5

## Why It's Good For The Game

Shifts often get stuck on icebox, and i dont think its healthy for the game
We really just need more low-pop voteable stations, but metastation is fairly perfect in that regard for now

## Changelog

:cl:
balance: Metastation is now able to be voted with 5 players on the server instead of 25, and has normal vote weight
/:cl:
