### PR TITLE
Add death/revival policy messages

### DIFF
--- a/code/__DEFINES/~monkestation/admin.dm
+++ b/code/__DEFINES/~monkestation/admin.dm
@@ -5,5 +5,6 @@
 ///Sends a message in adminchat with the chosen notfication sound
 #define SEND_NOTFIED_ADMIN_MESSAGE(sound, message) SEND_ADMINS_NOTFICATION_SOUND(sound); SEND_ADMINCHAT_MESSAGE(message)
 
-#define POLICY_DEATH	"Death"
-#define POLICY_REVIVAL	"Revival"
+#define POLICY_DEATH			"Death"
+#define POLICY_REVIVAL			"Revival"
+#define POLICY_REVIVAL_CLONER	"Revival via Cloning"

--- a/code/__DEFINES/~monkestation/admin.dm
+++ b/code/__DEFINES/~monkestation/admin.dm
@@ -4,3 +4,6 @@
 #define SEND_ADMINCHAT_MESSAGE(message) to_chat(GLOB.admins, type = MESSAGE_TYPE_ADMINCHAT, html = message, confidential = TRUE)
 ///Sends a message in adminchat with the chosen notfication sound
 #define SEND_NOTFIED_ADMIN_MESSAGE(sound, message) SEND_ADMINS_NOTFICATION_SOUND(sound); SEND_ADMINCHAT_MESSAGE(message)
+
+#define POLICY_DEATH	"Death"
+#define POLICY_REVIVAL	"Revival"

--- a/config/policy.json
+++ b/config/policy.json
@@ -1,5 +1,7 @@
 {
 	"How do I set policy?": "Policy is set in this file. It's simply setting the key to the text to show up.",
 	"Where is policy shown?": "Most, but not all policy text, is displayed when releveant, such as on gaining a role.",
-	"What can I all set policy of?": "Antagonist typepaths, mob typepaths, species typepaths, special roles, and some extra special policy keys are all valid. Consult the code."
+	"What can I all set policy of?": "Antagonist typepaths, mob typepaths, species typepaths, special roles, and some extra special policy keys are all valid. Consult the code.",
+	"Death": "<span class='death_message'><span class='big bold'>You have died!</span><br/>Barring complete bodyloss, you can in most cases be revived by other players. If you do not wish to be brought back, use the \"Do Not Resuscitate\" verb in the ghost tab.<br/><span class='bold red'>You do not remember the details of circumstances leading up to your death, including who killed you!</span></span>",
+	"Revival": "<span class='death_message'><span class='big bold'>You have been revived!</span><br/>Welcome back to the living! Remember, your recollection of events leading up to your death should still be foggy. If you were revived through conventional means, you do not remember the circumstances of your death or who was responsible.<br/>However, if you were brought back through supernatural or antagonist methods (such as wands of healing, changeling stasis, blood cult revive rune, etc), <span class='bold purple'>you might retain memories from before your death.</span> Use this knowledge wisely and remember to adhere to the server's policies.<br/>It's good to have a second chance - make the most out of it!</span>"
 }

--- a/monkestation/code/game/machinery/cloning.dm
+++ b/monkestation/code/game/machinery/cloning.dm
@@ -398,7 +398,7 @@
 
 	var/policy = get_policy(POLICY_REVIVAL_CLONER) || get_policy(POLICY_REVIVAL)
 	if(policy)
-		to_chat(src, policy)
+		to_chat(occupant, policy)
 
 	mob_occupant.adjustOrganLoss(ORGAN_SLOT_BRAIN, mob_occupant.getCloneLoss())
 

--- a/monkestation/code/game/machinery/cloning.dm
+++ b/monkestation/code/game/machinery/cloning.dm
@@ -396,6 +396,10 @@
 		to_chat(occupant, "<span class='notice'><b>There is a bright flash!</b><br><i>You feel like a new being.</i></span>")
 		mob_occupant.flash_act()
 
+	var/policy = get_policy(POLICY_REVIVAL_CLONER) || get_policy(POLICY_REVIVAL)
+	if(policy)
+		to_chat(src, policy)
+
 	mob_occupant.adjustOrganLoss(ORGAN_SLOT_BRAIN, mob_occupant.getCloneLoss())
 
 	occupant.forceMove(T)

--- a/monkestation/code/modules/mob/living/carbon/carbon_death.dm
+++ b/monkestation/code/modules/mob/living/carbon/carbon_death.dm
@@ -1,0 +1,11 @@
+/mob/living/carbon/death(gibbed)
+	var/policy = get_policy(POLICY_DEATH)
+	if(policy)
+		to_chat(src, policy)
+	return ..()
+
+/mob/living/carbon/revive(full_heal_flags, excess_healing, force_grab_ghost)
+	. = ..()
+	var/policy = get_policy(POLICY_REVIVAL)
+	if(policy)
+		to_chat(src, policy)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6307,6 +6307,7 @@
 #include "monkestation\code\modules\mob\living\basic\ggg\susflash.dm"
 #include "monkestation\code\modules\mob\living\basic\space_fauna\fugu_gland.dm"
 #include "monkestation\code\modules\mob\living\basic\vermin\mouse.dm"
+#include "monkestation\code\modules\mob\living\carbon\carbon_death.dm"
 #include "monkestation\code\modules\mob\living\carbon\carbon_defense.dm"
 #include "monkestation\code\modules\mob\living\carbon\carbon_defines.dm"
 #include "monkestation\code\modules\mob\living\carbon\carbon_update_icons.dm"

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1189,3 +1189,14 @@ $border-width-px: $border-width * 1px;
   color: #ffde5c;
   font-weight: bold;
 }
+
+.death_message {
+  display: block;
+  color: white;
+  text-align: center;
+  background-color: black;
+  border: 2px solid rgb(240, 62, 225);
+  border-radius: 10px;
+  padding: 10px;
+  margin: 10px 20px;
+}

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1226,3 +1226,14 @@ $border-width-px: $border-width * 1px;
   color: #2e57d1;
   font-weight: bold;
 }
+
+.death_message {
+  display: block;
+  color: white;
+  text-align: center;
+  background-color: black;
+  border: 2px solid rgb(240, 62, 225);
+  border-radius: 10px;
+  padding: 10px;
+  margin: 10px 20px;
+}


### PR DESCRIPTION

## About The Pull Request

Partial port of https://github.com/BeeStation/BeeStation-Hornet/pull/10109

[Fullfills this bounty](https://discord.com/channels/748354466335686736/1202151375530901514)

Fully configurable server-side via `policy.json`

## Why It's Good For The Game

Helps remind players of the rules, reducing accidental rule-breaks, which can ruin someone's round.

## Changelog
:cl: Absolucy, PowerfulBacon
add: Added messages that are displayed on death and revival, reminding players of the policy.
config: Added the `Death` and `Revival` keys to policy.json.
/:cl:
