### PR TITLE
Re-allowing bluespace syringes for the syringe gun

### DIFF
--- a/code/modules/projectiles/guns/special/syringe_gun.dm
+++ b/code/modules/projectiles/guns/special/syringe_gun.dm
@@ -78,9 +78,6 @@
 	return TRUE
 
 /obj/item/gun/syringe/attackby(obj/item/A, mob/user, params, show_msg = TRUE)
-	if(istype(A, /obj/item/reagent_containers/syringe/bluespace))
-		balloon_alert(user, "[A.name] is too big!")
-		return TRUE
 	if(istype(A, /obj/item/reagent_containers/syringe))
 		if(syringes.len < max_syringes)
 			if(!user.transferItemToLoc(A, src))


### PR DESCRIPTION

## About The Pull Request

It was brought to my attention that TG previously nerfed the ability to load syringe guns with bluespace syringes. I'm not familiar with the exact reasons (surely not just ided), but this was something we allowed on beecode prior to our rebase, with (anectdotally) minimal issue. Figured it was worth re-enabling, or at least promoting discussion for or against it.

## Why It's Good For The Game

Monkestation culture is largely driven by fixing player-sourced issues to problems, rather than coding out things we don't like that get abused by a select few (especially those that were breaking rules and/or not roleplaying to begin with). I think keeping the mechanic of the syringe gun consistent across all syringe types fits this standpoint.

## Changelog

:cl:
del: Removed a restriction that prevented syringe guns from being loaded with bluespace syringes
/:cl:

