### PR TITLE
Composting at a distance fix

### DIFF
--- a/monkestation/code/modules/hydroponics/machines/composter.dm
+++ b/monkestation/code/modules/hydroponics/machines/composter.dm
@@ -97,7 +97,7 @@
 	// ensure user is next to what we're mouse dropping into
 	if (!Adjacent(usr, over))
 		return
-	// ensure the stuff we're mouse dropping
+	// ensure the stuff we're mouse dropping is ALSO adjacent
 	if(istype(over, /obj/machinery/composters) && Adjacent(src_location, over_location))
 		var/obj/machinery/composters/dropped = over
 		for(var/obj/item/seeds/seed in src_location)
@@ -108,7 +108,7 @@
 	// ensure user is next to what we're mouse dropping into
 	if (!Adjacent(usr, over))
 		return
-	// ensure the stuff we're mouse dropping
+	// ensure the stuff we're mouse dropping is ALSO adjacent
 	if(istype(over, /obj/machinery/composters) && Adjacent(src_location, over_location))
 		var/obj/machinery/composters/dropped = over
 		for(var/obj/item/food/food in src_location)

--- a/monkestation/code/modules/hydroponics/machines/composter.dm
+++ b/monkestation/code/modules/hydroponics/machines/composter.dm
@@ -94,14 +94,22 @@
 
 /obj/item/seeds/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
 	. = ..()
-	if(istype(over, /obj/machinery/composters))
+	// ensure user is next to what we're mouse dropping into
+	if (!Adjacent(usr, over))
+		return
+	// ensure the stuff we're mouse dropping
+	if(istype(over, /obj/machinery/composters) && Adjacent(src_location, over_location))
 		var/obj/machinery/composters/dropped = over
 		for(var/obj/item/seeds/seed in src_location)
 			dropped.compost(seed)
 
 /obj/item/food/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
 	. = ..()
-	if(istype(over, /obj/machinery/composters))
+	// ensure user is next to what we're mouse dropping into
+	if (!Adjacent(usr, over))
+		return
+	// ensure the stuff we're mouse dropping
+	if(istype(over, /obj/machinery/composters) && Adjacent(src_location, over_location))
 		var/obj/machinery/composters/dropped = over
 		for(var/obj/item/food/food in src_location)
 			dropped.compost(food)


### PR DESCRIPTION

## About The Pull Request

Fixes a reported bug where 1) players could compost food/seeds that were not adjacent to the composter, and 2) players could compost food/seeds in a composter without being adjacent to it.

## Why It's Good For The Game

Spooky at a distance is bad and inconsistent. Love or hate the composter, this is definitely better off removed.

## Changelog

:cl:
fix: Food/seed items can no longer be composted regardless of distance, must be adjacent.
/:cl:

