### PR TITLE
Rotten Tomatoes

### DIFF
--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -432,7 +432,7 @@
 
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
 	var/mob/living/spawned_mob = new killer_plant(our_plant.drop_location())
-	spawned_mob.maxHealth += round(our_seed.endurance * mob_health_multiplier)
+	spawned_mob.maxHealth += round(min(our_seed.endurance, 90) * mob_health_multiplier)
 	spawned_mob.health = spawned_mob.maxHealth
 	if(ishostile(spawned_mob))
 		var/mob/living/simple_animal/hostile/spawned_simplemob = spawned_mob

--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -442,10 +442,10 @@
 
 	if(isbasicmob(spawned_mob))
 		var/mob/living/basic/spawned_basicmob = spawned_mob
-		spawned_basicmob.melee_damage_lower += round(our_seed.potency * mob_melee_multiplier)
-		spawned_basicmob.melee_damage_upper += round(our_seed.potency * mob_melee_multiplier)
+		spawned_basicmob.melee_damage_lower += round(min(our_seed.potency, 100) * mob_melee_multiplier)
+		spawned_basicmob.melee_damage_upper += round(min(our_seed.potency, 100) * mob_melee_multiplier)
 		// basic mob speeds aren't exactly equivalent to simple animal's "move to delay" but this seems balanced enough.
-		var/calculated_speed = initial(spawned_basicmob.speed) - round((our_seed.production * mob_speed_multiplier), 0.01)
+		var/calculated_speed = initial(spawned_basicmob.speed) - round((min(our_seed.production, 25) * mob_speed_multiplier), 0.01)
 		spawned_basicmob.set_varspeed(calculated_speed)
 
 	our_plant.forceMove(our_plant.drop_location())


### PR DESCRIPTION

## About The Pull Request

Despite multiple areas of botany being updated from our botany prior to the rebase last year, killer tomatoes and their scaling off of potency/speed stats were not brought up to par. This PR fixes the resulting near-zero delay movement that made it impossible for people to avoid them. The infinite scaling also applied to melee and health modifiers, which have also been capped to roughly double in the best circumstances. A further overview of the repercussions of our infinite stat cap on hard-coded TG botany is in order.

## Why It's Good For The Game

People abusing overlooked exploits is bad, mkay? The past events on the station have left me VERY disappointed.

## Changelog

:cl:
balance: Hard-capped killer tomatoes from having near-instant speed and potentially infinite health/damage
/:cl:

