### PR TITLE
 The "Guide to Advanced Mimery" series now make but the faintest noise when turning their pages

### DIFF
--- a/code/game/objects/items/granters/magic/mime.dm
+++ b/code/game/objects/items/granters/magic/mime.dm
@@ -3,6 +3,7 @@
 	desc = "The missing entry into the legendary saga. Unfortunately it doesn't teach you anything."
 	icon_state ="bookmime"
 	remarks = list("...")
+	book_sounds = list('sound/effects/space_wind.ogg')
 
 /obj/item/book/granter/action/spell/mime/attack_self(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

What it says on the tin, brought from upstream https://github.com/tgstation/tgstation/pull/81068.
## Why It's Good For The Game

Closes #584, makes the item's behaviour match their description.
## Changelog
:cl:
sound: The Guide to Advanced Mimery book series now only make a very faint noise when turning their pages, in order to match their description
/:cl:
