### PR TITLE
Prevent certain antagonists from being fucked over by associated phobias

### DIFF
--- a/monkestation/code/datums/brain_damage/phobia.dm
+++ b/monkestation/code/datums/brain_damage/phobia.dm
@@ -4,12 +4,12 @@
 	/// Whether this phobia is automatically suppressed by the presence of certain antags.
 	var/static/list/suppressed_antags = list(
 		"heresy" = list(
-			list(/datum/antagonist/heretic, /datum/antagonist/heretic_monster),
-			"Due to your connection to the Mansus, you are able to overcome and ignore your mind's fear of it.",
-			"You feel the fear of heresy return to your mind, as you lose your connection to the Mansus."
+			"antags" = list(/datum/antagonist/heretic, /datum/antagonist/heretic_monster),
+			"suppression_message" = "Due to your connection to the Mansus, you are able to overcome and ignore your mind's fear of it.",
+			"unsuppression_message" = "You feel the fear of heresy return to your mind, as you lose your connection to the Mansus."
 		),
 		"supernatural" = list(
-			list(
+			"antags" = list(
 				/datum/antagonist/bloodsucker,
 				/datum/antagonist/clock_cultist,
 				/datum/antagonist/cult,
@@ -20,34 +20,33 @@
 				/datum/antagonist/wizard,
 				/datum/antagonist/wizard_minion
 			),
-			"Due to your connection to the supernatural, you are able to overcome and ignore your mind's fear of it.",
-			"You feel the fear of the supernatural return to your mind, as you lose your connection to it."
+			"suppression_message" = "Due to your connection to the supernatural, you are able to overcome and ignore your mind's fear of it.",
+			"unsuppression_message" = "You feel the fear of the supernatural return to your mind, as you lose your connection to it."
 		),
 		"blood" = list(
-			list(/datum/antagonist/bloodsucker, /datum/antagonist/vassal),
-			"Due to your existence's reliance on blood, you are able to overcome and ignore your mind's fear of it.",
-			"You feel the fear of blood return to your mind, as you lose your reliance on it."
+			"antags" = list(/datum/antagonist/cult, /datum/antagonist/bloodsucker, /datum/antagonist/vassal),
+			"suppression_message" = "Due to your existence's reliance on blood, you are able to overcome and ignore your mind's fear of it.",
+			"unsuppression_message" = "You feel the fear of blood return to your mind, as you lose your reliance on it."
 		)
 	)
 
 /datum/brain_trauma/mild/phobia/proc/update_suppression()
 	SIGNAL_HANDLER
 	var/list/suppression_info = src.suppressed_antags[phobia_type]
-	if(length(suppression_info) != 3 || QDELETED(owner?.mind))
+	if(!suppression_info || QDELETED(owner?.mind))
 		return
-	var/list/suppressed_antags = suppression_info[1]
-	var/suppression_message = suppression_info[2]
-	var/unsuppression_message = suppression_info[3]
+
 	var/previous_suppressed = suppressed
 	suppressed = FALSE
-	for(var/antag_type in suppressed_antags)
+	for(var/antag_type in suppression_info["antags"])
 		if(owner.mind.has_antag_datum(antag_type))
 			suppressed = TRUE
 			break
+
 	if(suppressed && !previous_suppressed)
-		to_chat(owner, span_boldnotice(suppression_message))
+		to_chat(owner, span_boldnotice("[suppression_info["suppression_message"]]"))
 	else if(!suppressed && previous_suppressed)
-		to_chat(owner, span_bolddanger(unsuppression_message))
+		to_chat(owner, span_bolddanger("[suppression_info["unsuppression_message"]]"))
 
 /datum/brain_trauma/mild/phobia/on_gain()
 	. = ..()
@@ -66,9 +65,9 @@
 		return ..()
 
 /datum/brain_trauma/mild/phobia/is_scary_item(obj/checked)
-	. = ..()
 	if(suppressed)
 		return FALSE
+	return ..()
 
 /datum/brain_trauma/mild/phobia/handle_hearing(datum/source, list/hearing_args)
 	if(!suppressed)

--- a/monkestation/code/datums/brain_damage/phobia.dm
+++ b/monkestation/code/datums/brain_damage/phobia.dm
@@ -1,0 +1,83 @@
+/datum/brain_trauma/mild/phobia
+	/// Whether this phobia is "inactive" or not.
+	var/suppressed = FALSE
+	/// Whether this phobia is automatically suppressed by the presence of certain antags.
+	var/static/list/suppressed_antags = list(
+		"heresy" = list(
+			list(/datum/antagonist/heretic, /datum/antagonist/heretic_monster),
+			"Due to your connection to the Mansus, you are able to overcome and ignore your mind's fear of it.",
+			"You feel the fear of heresy return to your mind, as you lose your connection to the Mansus."
+		),
+		"supernatural" = list(
+			list(
+				/datum/antagonist/bloodsucker,
+				/datum/antagonist/clock_cultist,
+				/datum/antagonist/cult,
+				/datum/antagonist/heretic,
+				/datum/antagonist/heretic_monster,
+				/datum/antagonist/monsterhunter,
+				/datum/antagonist/vassal,
+				/datum/antagonist/wizard,
+				/datum/antagonist/wizard_minion
+			),
+			"Due to your connection to the supernatural, you are able to overcome and ignore your mind's fear of it.",
+			"You feel the fear of the supernatural return to your mind, as you lose your connection to it."
+		),
+		"blood" = list(
+			list(/datum/antagonist/bloodsucker, /datum/antagonist/vassal),
+			"Due to your existence's reliance on blood, you are able to overcome and ignore your mind's fear of it.",
+			"You feel the fear of blood return to your mind, as you lose your reliance on it."
+		)
+	)
+
+/datum/brain_trauma/mild/phobia/proc/update_suppression()
+	SIGNAL_HANDLER
+	var/list/suppression_info = src.suppressed_antags[phobia_type]
+	if(length(suppression_info) != 3 || QDELETED(owner?.mind))
+		return
+	var/list/suppressed_antags = suppression_info[1]
+	var/suppression_message = suppression_info[2]
+	var/unsuppression_message = suppression_info[3]
+	var/previous_suppressed = suppressed
+	suppressed = FALSE
+	for(var/antag_type in suppressed_antags)
+		if(owner.mind.has_antag_datum(antag_type))
+			suppressed = TRUE
+			break
+	if(suppressed && !previous_suppressed)
+		to_chat(owner, span_boldnotice(suppression_message))
+	else if(!suppressed && previous_suppressed)
+		to_chat(owner, span_bolddanger(unsuppression_message))
+
+/datum/brain_trauma/mild/phobia/on_gain()
+	. = ..()
+	if(!QDELETED(owner?.mind))
+		update_suppression()
+		RegisterSignals(owner.mind, list(COMSIG_ANTAGONIST_GAINED, COMSIG_ANTAGONIST_REMOVED), PROC_REF(update_suppression))
+
+/datum/brain_trauma/mild/phobia/on_lose(silent)
+	. = ..()
+	if(!QDELETED(owner?.mind))
+		update_suppression()
+		UnregisterSignal(owner.mind, list(COMSIG_ANTAGONIST_GAINED, COMSIG_ANTAGONIST_REMOVED))
+
+/datum/brain_trauma/mild/phobia/on_life(seconds_per_tick, times_fired)
+	if(!suppressed)
+		return ..()
+
+/datum/brain_trauma/mild/phobia/is_scary_item(obj/checked)
+	. = ..()
+	if(suppressed)
+		return FALSE
+
+/datum/brain_trauma/mild/phobia/handle_hearing(datum/source, list/hearing_args)
+	if(!suppressed)
+		return ..()
+
+/datum/brain_trauma/mild/phobia/handle_speech(datum/source, list/speech_args)
+	if(!suppressed)
+		return ..()
+
+/datum/brain_trauma/mild/phobia/freak_out(atom/reason, trigger_word)
+	if(!suppressed)
+		return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5642,6 +5642,7 @@
 #include "monkestation\code\datums\announcers\dagoth.dm"
 #include "monkestation\code\datums\announcers\duke.dm"
 #include "monkestation\code\datums\brain_damage\magic.dm"
+#include "monkestation\code\datums\brain_damage\phobia.dm"
 #include "monkestation\code\datums\components\carbon_sprint.dm"
 #include "monkestation\code\datums\components\multi_hit.dm"
 #include "monkestation\code\datums\components\throw_bounce.dm"


### PR DESCRIPTION
## About The Pull Request

This makes it so certain antags will "suppress" certain phobias, allowing them to just completely ignore it. The trauma is still there, tho, it's just dormant as long as they meet the criteria.

![image](https://github.com/Monkestation/Monkestation2.0/assets/65794972/e14c0493-ed86-4729-9b50-d881cb649621)

## Why It's Good For The Game

Prevents heretics from being fucked over due to being sacrificed, magical antags from being fucked over by a fear of the supernatural, and bloodsuckers from being fucked over by a fear of blood.

## Changelog
:cl:
qol: Prevent certain antagonists from being fucked over by associated phobias. Heretics (+minions) will ignore fear of heresy, magical antags will ignore fear of the supernatural,, bloodsuckers (+vassals) and blood cultists will ignore fear of blood.
/:cl:
