### PR TITLE
Adds indicative coloring to the blood and surplus limb crates

### DIFF
--- a/monkestation/code/game/objects/structures/crates_lockers/crates.dm
+++ b/monkestation/code/game/objects/structures/crates_lockers/crates.dm
@@ -1,0 +1,14 @@
+#define CRATE_COLOR_BLOOD_FREEZER		"#fe3435"
+// should be a darker, metallic gray
+#define CRATE_COLOR_SURPLUS_LIMBS		"#3c3c3c"
+
+/obj/structure/closet/crate/freezer/blood/Initialize(mapload)
+	. = ..()
+	add_atom_colour(CRATE_COLOR_BLOOD_FREEZER, FIXED_COLOUR_PRIORITY)
+
+/obj/structure/closet/crate/freezer/surplus_limbs/Initialize(mapload)
+	. = ..()
+	add_atom_colour(CRATE_COLOR_SURPLUS_LIMBS, FIXED_COLOUR_PRIORITY)
+
+#undef CRATE_COLOR_SURPLUS_LIMBS
+#undef CRATE_COLOR_BLOOD_FREEZER

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5716,6 +5716,7 @@
 #include "monkestation\code\game\objects\items\storage\boxes.dm"
 #include "monkestation\code\game\objects\items\storage\crate.dm"
 #include "monkestation\code\game\objects\items\storage\uplink_kits.dm"
+#include "monkestation\code\game\objects\structures\crates_lockers\crates.dm"
 #include "monkestation\code\game\turfs\open\water.dm"
 #include "monkestation\code\modules\_paperwork\paper_premade.dm"
 #include "monkestation\code\modules\admin\antag_tokens.dm"


### PR DESCRIPTION

## About The Pull Request

This makes the blood freezer red, and the surplus prosthetics crate a dark metallic gray.

![2024-02-07 (1707343310) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/68aaadaf-4c0f-4b3f-af97-42481767d3d2)


## Why It's Good For The Game

Makes it easier to see which crate is why by visuals alone.

## Changelog
:cl:
image: Made the blood freezer crate red, and the surplus prosthetics crate a dark metallic gray.
/:cl:
