### PR TITLE
Adds upgraded blood filtering surgery

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -495,6 +495,7 @@
 	design_ids = list(
 		"surgery_heal_brute_upgrade",
 		"surgery_heal_burn_upgrade",
+		"surgery_filter_upgrade", // monke edit: improved blood filter surgery
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 
@@ -510,6 +511,7 @@
 		"surgery_heal_combo",
 		"surgery_lobotomy",
 		"surgery_wing_reconstruction",
+		"surgery_filter_upgrade_femto", // monke edit: advanced blood filter surgery
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
 

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -14,12 +14,14 @@
 		return FALSE
 	return ..()
 
+/* monke edit: replaced for toxin healing support
 /datum/surgery_step/filter_blood/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	if(!..())
 		return
 	while(has_filterable_chems(target, tool))
 		if(!..())
 			break
+monke end */
 
 /**
  * Checks if the mob contains chems we can filter
@@ -61,6 +63,7 @@
 	)
 	display_pain(target, "You feel a throbbing pain in your chest!")
 
+/* monke edit: replaced for toxin healing support
 /datum/surgery_step/filter_blood/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	var/obj/item/blood_filter/bloodfilter = tool
 	if(target.reagents?.total_volume)
@@ -79,6 +82,7 @@
 		chemscan(user, target)
 
 	return ..()
+monke end */
 
 /datum/surgery_step/filter_blood/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	display_results(

--- a/monkestation/code/modules/research/designs/medical_designs.dm
+++ b/monkestation/code/modules/research/designs/medical_designs.dm
@@ -22,3 +22,15 @@
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
+
+/datum/design/surgery/healing/filter_upgrade
+	name = "Filter Blood Upgrade"
+	desc = "Newfound knowledge allows us to remove the effect of toxins on the body whenever filtering someone's blood."
+	surgery = /datum/surgery/blood_filter/upgraded
+	id = "surgery_filter_upgrade"
+
+/datum/design/surgery/healing/filter_upgrade_2
+	name = "Filter Blood Upgrade"
+	surgery = /datum/surgery/blood_filter/femto
+	id = "surgery_filter_upgrade_femto"

--- a/monkestation/code/modules/surgery/blood_filter.dm
+++ b/monkestation/code/modules/surgery/blood_filter.dm
@@ -1,5 +1,6 @@
 /datum/surgery/blood_filter
 	replaced_by = /datum/surgery/blood_filter/upgraded
+	/// Path to the filtering step to replace the usual `/datum/surgery_step/filter_blood` with.
 	var/filtering_step_type
 
 /datum/surgery/blood_filter/New(atom/surgery_target, surgery_location, surgery_bodypart)
@@ -14,7 +15,9 @@
 		)
 
 /datum/surgery_step/filter_blood
+	/// The factor by which to purge the volume of reagents in the patient's blood.
 	var/chem_purge_factor = 0.2
+	/// The factor by which to heal the patient's toxin damage.
 	var/tox_heal_factor = 0
 
 /datum/surgery_step/filter_blood/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
@@ -47,9 +50,9 @@
 	display_results(
 		user,
 		target,
-		span_notice("\The [tool] pings as it finishes filtering [target]'s blood.[umsg]"),
-		span_notice("\The [tool] pings as it stops pumping [target]'s blood."),
-		span_notice("\The [tool] pings as it stops pumping."),
+		span_notice("[tool] pings as it finishes filtering [target]'s blood.[umsg]"),
+		span_notice("[tool] pings as it stops pumping [target]'s blood."),
+		span_notice("[tool] pings as it stops pumping."),
 	)
 
 	return ..()

--- a/monkestation/code/modules/surgery/blood_filter.dm
+++ b/monkestation/code/modules/surgery/blood_filter.dm
@@ -1,0 +1,76 @@
+/datum/surgery/blood_filter
+	replaced_by = /datum/surgery/blood_filter/upgraded
+	var/filtering_step_type
+
+/datum/surgery/blood_filter/New(atom/surgery_target, surgery_location, surgery_bodypart)
+	..()
+	if(filtering_step_type)
+		steps = list(
+			/datum/surgery_step/incise,
+			/datum/surgery_step/retract_skin,
+			/datum/surgery_step/incise,
+			filtering_step_type,
+			/datum/surgery_step/close,
+		)
+
+/datum/surgery_step/filter_blood
+	var/chem_purge_factor = 0.2
+	var/tox_heal_factor = 0
+
+/datum/surgery_step/filter_blood/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
+	if(!..())
+		return
+	while(has_filterable_chems(target, tool) || (tox_heal_factor && target.getToxLoss() > 0))
+		if(!..())
+			break
+
+/datum/surgery_step/filter_blood/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
+	var/obj/item/blood_filter/bloodfilter = tool
+	if(target.reagents?.total_volume)
+		for(var/datum/reagent/chem as anything in target.reagents.reagent_list)
+			if(!length(bloodfilter.whitelist) || (chem.type in bloodfilter.whitelist))
+				var/purge_amt = (chem.volume <= 2) ? chem.volume : min(chem.volume * chem_purge_factor, 10)
+				target.reagents.remove_reagent(chem.type, purge_amt)
+	var/tox_loss = target.getToxLoss()
+	if(tox_heal_factor > 0)
+		if(tox_loss <= 2)
+			target.setToxLoss(0, forced = TRUE)
+		else
+			target.adjustToxLoss(-(tox_loss * tox_heal_factor), forced = TRUE) //forced so this will actually heal oozelings too
+	var/list/remaining = list()
+	if(locate(/obj/item/healthanalyzer) in user.held_items)
+		if(tox_heal_factor > 0 && tox_loss > 0)
+			remaining += "<font color='[COLOR_GREEN]'>[round(tox_loss, 0.1)]</font> toxin"
+		if(target.reagents?.total_volume)
+			remaining += "<font color='[COLOR_MAGENTA]'>[round(target.reagents.total_volume, 0.1)]u</font> of reagents"
+	var/umsg = length(remaining) ? " [english_list(remaining)] remaining." : ""
+	display_results(
+		user,
+		target,
+		span_notice("\The [tool] pings as it finishes filtering [target]'s blood.[umsg]"),
+		span_notice("\The [tool] pings as it stops pumping [target]'s blood."),
+		span_notice("\The [tool] pings as it stops pumping."),
+	)
+
+	return ..()
+
+/datum/surgery/blood_filter/upgraded
+	name = "Filter Blood (Adv.)"
+	desc = "A surgical procedure that provides advanced toxin filtering to remove reagents from the patient's blood, in addition to undoing any damage the toxins done to the patient's system. Heals considerably more when the patient is severely injured."
+	requires_tech = TRUE
+	filtering_step_type = /datum/surgery_step/filter_blood/upgraded
+	replaced_by = /datum/surgery/blood_filter/femto
+
+/datum/surgery_step/filter_blood/upgraded
+	time = 1.85 SECONDS
+	tox_heal_factor = 0.075
+
+/datum/surgery/blood_filter/femto
+	name = "Filter Blood (Exp.)"
+	desc = "A surgical procedure that provides experimental toxin filtering to remove reagents from the patient's blood, in addition to undoing any damage the toxins done to the patient's system. Heals considerably more when the patient is severely injured."
+	requires_tech = TRUE
+	filtering_step_type = /datum/surgery_step/filter_blood/upgraded/femto
+	replaced_by = null
+
+/datum/surgery_step/filter_blood/upgraded/femto
+	time = 1 SECONDS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6602,6 +6602,7 @@
 #include "monkestation\code\modules\storytellers\storytellers\sleeper.dm"
 #include "monkestation\code\modules\storytellers\storytellers\vote.dm"
 #include "monkestation\code\modules\storytellers\storytellers\warrior.dm"
+#include "monkestation\code\modules\surgery\blood_filter.dm"
 #include "monkestation\code\modules\surgery\bodyparts\arachnid_bodyparts.dm"
 #include "monkestation\code\modules\surgery\bodyparts\clockwork_bodyparts.dm"
 #include "monkestation\code\modules\surgery\bodyparts\floran_bodyparts.dm"


### PR DESCRIPTION

## About The Pull Request

This adds upgraded blood filtering surgeries - similar to the advanced wound tending surgery. 
Upgraded blood filtering surgeries are faster and also are capable of purging toxin damage! They purge a _percentage_ of toxin damage, similar to how it purges reagents, so large amounts of tox will be lowered quickly, while it may take a bit to reduce lower amounts of tox.

Port of https://github.com/BeeStation/BeeStation-Hornet/pull/8903

## Screenshot

(i removed the chemical scan spam after taking the screenshot)
![2024-02-08 (1707445314) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/33da6204-63cc-4ee8-8a15-265156d1e65f)

## Why It's Good For The Game

Good for consistency with the other surgeries.

Plus, blood filtering is _always_ slow, even later in the game with advanced research, even though wound tending gets faster!

## Changelog
:cl:
add: Added upgraded blood filtering surgeries! These are obtained through the same research as its wound-tending counterparts, and work faster while also removing toxin damage.
balance: Very slightly reduced the amount of reagents that blood filtering purges (by around 2%), to compensate for the increased speed offered by the upgraded surgeries.
/:cl:
