### PR TITLE
Remove some ocky icky messages from Tourettes

### DIFF
--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -161,7 +161,7 @@
 			if(1)
 				owner.emote("twitch")
 			if(2 to 3)
-				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "VALID", "AHELP", "ANIMES", "ICKY", "OCKY", "LIZZZARD", "HELP")]", forced=name)
+				owner.say("[prob(50) ? ";" : ""][pick("SHIT", "PISS", "FUCK", "MROW", "ANIMES", "LIZZZARD", "HELP")]", forced=name)
 		var/x_offset_old = owner.pixel_x
 		var/y_offset_old = owner.pixel_y
 		var/x_offset = owner.pixel_x + rand(-2,2)


### PR DESCRIPTION

## About The Pull Request

This removes "VALID", "AHELP", "ICKY", and "OCKY" from the possible tourettes phrases. "MROW" has been added, as I didn't want to _just_ remove stuff.

## Why It's Good For The Game

Due to Monke trying to become more RP-focused, it's better to remove some of the less RP-ish terms from Tourettes.

## Changelog
:cl:
del: Removed "VALID", "AHELP", "ICKY", and "OCKY" from the possible Tourettes phrases.
add: Added "MROW" to the possible possible Tourettes phrases.
/:cl:
