### PR TITLE
Make hypercharged slime battery EMP-proof

### DIFF
--- a/code/modules/cargo/exports/xenobio.dm
+++ b/code/modules/cargo/exports/xenobio.dm
@@ -28,7 +28,7 @@
 /datum/export/slime/hypercharged
 	cost = CARGO_CRATE_VALUE * 1.2
 	unit_name = "hypercharged slime core"
-	export_types = list(/obj/item/stock_parts/cell/high/slime_hypercharged)
+	export_types = list(/obj/item/stock_parts/cell/emproof/slime/hypercharged) // monke edit: make hypercharged slime cells EMP-proof, by changing their parent from cell/high to cell/emproof
 
 /datum/export/slime/epic //EPIIIIIIC
 	cost = CARGO_CRATE_VALUE * 0.44

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -86,17 +86,12 @@ Slimecrossing Items
 	return . | ..()
 
 //Hypercharged slime cell - Charged Yellow
-/obj/item/stock_parts/cell/high/slime_hypercharged
+/obj/item/stock_parts/cell/emproof/slime/hypercharged // monke edit: make hypercharged slime cells EMP-proof, by changing their parent from cell/high to cell/emproof
 	name = "hypercharged slime core"
-	desc = "A charged yellow slime extract, infused with plasma. It almost hurts to touch."
-	icon = 'icons/mob/simple/slimes.dmi'
-	icon_state = "yellow slime extract"
+	desc = "A charged yellow slime extract, infused with plasma. It almost hurts to touch. Its organic nature makes it immune to EMPs."
 	rating = 7
-	custom_materials = null
 	maxcharge = 50000
 	chargerate = 2500
-	charge_light_type = null
-	connector_type = "slimecore"
 
 //Barrier cube - Chilling Grey
 /obj/item/barriercube

--- a/code/modules/research/xenobiology/crossbreeding/charged.dm
+++ b/code/modules/research/xenobiology/crossbreeding/charged.dm
@@ -81,7 +81,7 @@ Charged extracts:
 	effect_desc = "Creates a hypercharged slime cell battery, which has high capacity but takes longer to recharge."
 
 /obj/item/slimecross/charged/yellow/do_effect(mob/user)
-	new /obj/item/stock_parts/cell/high/slime_hypercharged(get_turf(user))
+	new /obj/item/stock_parts/cell/emproof/slime/hypercharged(user.drop_location()) // monke edit: make hypercharged slime cells EMP-proof, by changing their parent from cell/high to cell/emproof
 	user.visible_message(span_notice("[src] sparks violently, and swells with electric power!"))
 	..()
 

--- a/monkestation/code/modules/aesthetics/mobs/slime.dm
+++ b/monkestation/code/modules/aesthetics/mobs/slime.dm
@@ -7,5 +7,5 @@
 /obj/item/slime_extract
 	icon = 'monkestation/icons/mob/slimes.dmi'
 
-/obj/item/stock_parts/cell/high/slime_hypercharged
+/obj/item/stock_parts/cell/emproof/slime/hypercharged
 	icon = 'monkestation/icons/mob/slimes.dmi'


### PR DESCRIPTION
## About The Pull Request

- Normal yellow slime batteries are already EMP-proof, so this makes their more powerful crossbreed equivalents also EMP-proof.

## Why It's Good For The Game

It makes sense.

## Changelog
:cl:
balance: Hypercharged slime batteries are now EMP-proof, like their ordinary charged counterparts.
/:cl:
