### PR TITLE
Slimes now feed faster, and attach to placed monkeys automatically

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -191,8 +191,8 @@
 		return
 
 	if(iscarbon(prey))
-		prey.adjustCloneLoss(rand(2, 4) * 0.5 * seconds_per_tick * feed_multiplier) // make slimes feed faster on mindless mobs and monkeys
-		prey.adjustToxLoss(rand(1, 2) * 0.5 * seconds_per_tick * feed_multiplier) // make slimes feed faster on mindless mobs and monkeys
+		prey.adjustCloneLoss(rand(2, 4) * 0.5 * seconds_per_tick * feed_multiplier) // monke edit: make slimes feed faster on mindless mobs and monkeys
+		prey.adjustToxLoss(rand(1, 2) * 0.5 * seconds_per_tick * feed_multiplier) // monke edit: make slimes feed faster on mindless mobs and monkeys
 
 		if(SPT_PROB(5, seconds_per_tick) && prey.client)
 			to_chat(prey, "<span class='userdanger'>[pick("You can feel your body becoming weak!", \
@@ -207,8 +207,8 @@
 		var/mob/living/animal_victim = prey
 
 		var/totaldamage = 0 //total damage done to this unfortunate animal
-		totaldamage += animal_victim.adjustCloneLoss(rand(2, 4) * 0.5 * seconds_per_tick * feed_multiplier) // make slimes feed faster on mindless mobs and monkeys
-		totaldamage += animal_victim.adjustToxLoss(rand(1, 2) * 0.5 * seconds_per_tick * feed_multiplier) // make slimes feed faster on mindless mobs and monkeys
+		totaldamage += animal_victim.adjustCloneLoss(rand(2, 4) * 0.5 * seconds_per_tick * feed_multiplier) // monke edit: make slimes feed faster on mindless mobs and monkeys
+		totaldamage += animal_victim.adjustToxLoss(rand(1, 2) * 0.5 * seconds_per_tick * feed_multiplier) // monke edit: make slimes feed faster on mindless mobs and monkeys
 
 		if(totaldamage <= 0) //if we did no(or negative!) damage to it, stop
 			Feedstop(0, 0)
@@ -218,10 +218,10 @@
 		Feedstop(0, 0)
 		return
 
-	add_nutrition((rand(7, 15) * 0.5 * seconds_per_tick * CONFIG_GET(number/damage_multiplier)) * feed_multiplier) // make slimes feed faster on mindless mobs and monkeys
+	add_nutrition((rand(7, 15) * 0.5 * seconds_per_tick * CONFIG_GET(number/damage_multiplier)) * feed_multiplier) // monke edit: make slimes feed faster on mindless mobs and monkeys
 
 	//Heal yourself.
-	adjustBruteLoss(-1.5 * seconds_per_tick * feed_multiplier) // make slimes feed faster on mindless mobs and monkeys
+	adjustBruteLoss(-1.5 * seconds_per_tick * feed_multiplier) // monke edit: make slimes feed faster on mindless mobs and monkeys
 
 /mob/living/simple_animal/slime/proc/handle_nutrition(seconds_per_tick, times_fired)
 

--- a/code/modules/mob/living/simple_animal/slime/life.dm
+++ b/code/modules/mob/living/simple_animal/slime/life.dm
@@ -165,6 +165,14 @@
 	if(stat)
 		Feedstop(silent = TRUE)
 
+	// monke start: make slimes feed faster on mindless mobs and monkeys
+	var/feed_multiplier = 1
+	if(QDELETED(prey.mind) && !istype(prey, /mob/living/simple_animal/pet) && !istype(prey, /mob/living/basic/pet)) // pets have an honorary soul in my book
+		feed_multiplier += 1
+	if(ismonkey(prey))
+		feed_multiplier += 0.5
+	// monke end
+
 	if(prey.stat == DEAD) // our victim died
 		if(!client)
 			if(!rabid && !attacked)
@@ -183,8 +191,8 @@
 		return
 
 	if(iscarbon(prey))
-		prey.adjustCloneLoss(rand(2, 4) * 0.5 * seconds_per_tick)
-		prey.adjustToxLoss(rand(1, 2) * 0.5 * seconds_per_tick)
+		prey.adjustCloneLoss(rand(2, 4) * 0.5 * seconds_per_tick * feed_multiplier) // make slimes feed faster on mindless mobs and monkeys
+		prey.adjustToxLoss(rand(1, 2) * 0.5 * seconds_per_tick * feed_multiplier) // make slimes feed faster on mindless mobs and monkeys
 
 		if(SPT_PROB(5, seconds_per_tick) && prey.client)
 			to_chat(prey, "<span class='userdanger'>[pick("You can feel your body becoming weak!", \
@@ -199,8 +207,8 @@
 		var/mob/living/animal_victim = prey
 
 		var/totaldamage = 0 //total damage done to this unfortunate animal
-		totaldamage += animal_victim.adjustCloneLoss(rand(2, 4) * 0.5 * seconds_per_tick)
-		totaldamage += animal_victim.adjustToxLoss(rand(1, 2) * 0.5 * seconds_per_tick)
+		totaldamage += animal_victim.adjustCloneLoss(rand(2, 4) * 0.5 * seconds_per_tick * feed_multiplier) // make slimes feed faster on mindless mobs and monkeys
+		totaldamage += animal_victim.adjustToxLoss(rand(1, 2) * 0.5 * seconds_per_tick * feed_multiplier) // make slimes feed faster on mindless mobs and monkeys
 
 		if(totaldamage <= 0) //if we did no(or negative!) damage to it, stop
 			Feedstop(0, 0)
@@ -210,10 +218,10 @@
 		Feedstop(0, 0)
 		return
 
-	add_nutrition((rand(7, 15) * 0.5 * seconds_per_tick * CONFIG_GET(number/damage_multiplier)))
+	add_nutrition((rand(7, 15) * 0.5 * seconds_per_tick * CONFIG_GET(number/damage_multiplier)) * feed_multiplier) // make slimes feed faster on mindless mobs and monkeys
 
 	//Heal yourself.
-	adjustBruteLoss(-1.5 * seconds_per_tick)
+	adjustBruteLoss(-1.5 * seconds_per_tick * feed_multiplier) // make slimes feed faster on mindless mobs and monkeys
 
 /mob/living/simple_animal/slime/proc/handle_nutrition(seconds_per_tick, times_fired)
 

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -210,6 +210,7 @@
 				food.LAssailant = WEAKREF(C)
 				X.monkeys--
 				X.monkeys = round(X.monkeys, 0.1) //Prevents rounding errors
+				remote_eye.auto_attach_slime(food) // monke edit: hungry slimes that aren't feeding will now immediately latch onto monkeys placed on top of them
 				to_chat(owner, span_notice("[X] now has [X.monkeys] monkeys stored."))
 		else
 			to_chat(owner, span_warning("[X] needs to have at least 1 monkey stored. Currently has [X.monkeys] monkeys stored."))
@@ -421,6 +422,7 @@
 				food.LAssailant = WEAKREF(C)
 				X.monkeys--
 				X.monkeys = round(X.monkeys, 0.1) //Prevents rounding errors
+				E.auto_attach_slime(food) // monke edit: hungry slimes that aren't feeding will now immediately latch onto monkeys placed on top of them
 				to_chat(C, span_notice("[X] now has [X.monkeys] monkeys stored."))
 		else
 			to_chat(C, span_warning("[X] needs to have at least 1 monkey stored. Currently has [X.monkeys] monkeys stored."))

--- a/monkestation/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/monkestation/code/modules/research/xenobiology/xenobio_camera.dm
@@ -1,0 +1,15 @@
+/mob/camera/ai_eye/remote/xenobio/proc/auto_attach_slime(mob/living/carbon/human/food)
+	var/mob/living/simple_animal/slime/glutton
+	for(var/mob/living/simple_animal/slime/slime in range(1, loc))
+		if(slime.ckey || slime.amount_grown >= SLIME_EVOLUTION_THRESHOLD)
+			continue
+		var/mob/living/slime_eating = slime.buckled
+		if(!isliving(slime_eating) || slime_eating.stat < DEAD)
+			continue
+		if(glutton?.is_adult && !slime.is_adult)
+			// adult slimes can react faster than baby slimes
+			continue
+		if(QDELETED(glutton) || (!glutton.is_adult && slime.is_adult) || (slime.amount_grown > glutton.amount_grown))
+			glutton = slime
+	if(!QDELETED(glutton))
+		addtimer(CALLBACK(glutton, TYPE_PROC_REF(/mob/living/simple_animal/slime, Feedon), food), rand(0.1 SECONDS, 0.9 SECONDS))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6609,6 +6609,7 @@
 #include "monkestation\code\modules\research\nanites\nanite_programs\utility.dm"
 #include "monkestation\code\modules\research\nanites\nanite_programs\weapon.dm"
 #include "monkestation\code\modules\research\techweb\all_nodes.dm"
+#include "monkestation\code\modules\research\xenobiology\xenobio_camera.dm"
 #include "monkestation\code\modules\security\code\holographic_handcuffs.dm"
 #include "monkestation\code\modules\security\code\weapons\lawbringer.dm"
 #include "monkestation\code\modules\security\code\weapons\paco.dm"


### PR DESCRIPTION

## About The Pull Request

- Slimes feed more aggressively on mindless mobs and monkeys, up to 2x faster on a mindless monkey.
- Slimes will now automatically attach onto a monkey placed next to them with a xenobio console (the slime that's grown the most will always be the one to attach, as long as it's not already feeding on something)

## Why It's Good For The Game

Makes xenobiology less frustrating due to slimes being slow as hell.

## Changelog
:cl:
balance: Slimes feed more aggressively on mindless mobs and monkeys, up to 2x faster on a mindless monkey.
qol: Slimes will now automatically attach onto a monkey placed next to them with a xenobio console (the slime that's grown the most will always be the one to attach, as long as it's not already feeding on something)
/:cl:
