### PR TITLE
Lizards and moths can now have hair

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -5,7 +5,6 @@
 		NO_DNA_COPY,
 		NOTRANSSTING,
 		NO_UNDERWEAR,
-		HAIR // monke edit: androids can have hair (again, it's the future, why not)
 	)
 	inherent_traits = list(
 		TRAIT_CAN_USE_FLIGHT_POTION,

--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -5,6 +5,7 @@
 		NO_DNA_COPY,
 		NOTRANSSTING,
 		NO_UNDERWEAR,
+		HAIR // monke edit: androids can have hair (again, it's the future, why not)
 	)
 	inherent_traits = list(
 		TRAIT_CAN_USE_FLIGHT_POTION,

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -9,6 +9,7 @@
 		MUTCOLORS_SECONDARY,
 		EYECOLOR,
 		LIPS,
+		HAIR // monke edit: lizards can have hair (it's the future, why not)
 	)
 	inherent_traits = list(
 		TRAIT_CAN_USE_FLIGHT_POTION,

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -5,6 +5,7 @@
 	species_traits = list(
 		LIPS,
 		HAS_MARKINGS,
+		HAIR // monke edit: moths can have hair (it's the future, why not)
 	)
 	inherent_traits = list(
 		TRAIT_CAN_USE_FLIGHT_POTION,


### PR DESCRIPTION
## About The Pull Request

This allows lizards and moths to have hair.

I asked Ook for his opinion:
> hair is hair. In an age where you can have chemicals that can rapidly transform your body, you can have hair

## Why It's Good For The Game

More character customization and unique-ness is always nice for RP

## Testing screenshots

![2024-02-15 (1708028014) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/8035b377-4baa-46d7-91e9-0bdcfe68f1b5)
![2024-02-15 (1708028046) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/3ce6a93a-725a-43aa-96cf-fa2227023880)


## Changelog
:cl:
add: Nanotrasen has rescinded their restrictions on species such as lizards and moths growing hair.
/:cl:
