### PR TITLE
Adds a hacked area pinpointer for contractors, that points to any area regardless if it has a beacon or not

### DIFF
--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -21,6 +21,8 @@
 	var/process_scan = TRUE // some pinpointers change target every time they scan, which means we can't have it change very process but instead when it turns on.
 	var/icon_suffix = "" // for special pinpointer icons
 
+	var/special_examine = FALSE // MONKESTATION ADDITION -- CONTRACTORS
+
 /obj/item/pinpointer/Initialize(mapload)
 	. = ..()
 	GLOB.pinpointer_list += src
@@ -39,6 +41,10 @@
 
 /obj/item/pinpointer/examine(mob/user)
 	. = ..()
+	// MONKESTATION ADDITION START -- CONTRACTORS -- USED BY /obj/item/pinpointer/area_pinpointer
+	if(special_examine) // need it here else it would say "it is current tracking the floor". Technically correct but not really
+		return
+	// MONKESTATION ADDITION END
 	if(target)
 		. += "It is currently tracking [target]."
 

--- a/code/game/objects/items/pinpointer.dm
+++ b/code/game/objects/items/pinpointer.dm
@@ -21,8 +21,6 @@
 	var/process_scan = TRUE // some pinpointers change target every time they scan, which means we can't have it change very process but instead when it turns on.
 	var/icon_suffix = "" // for special pinpointer icons
 
-	var/special_examine = FALSE // MONKESTATION ADDITION -- CONTRACTORS
-
 /obj/item/pinpointer/Initialize(mapload)
 	. = ..()
 	GLOB.pinpointer_list += src

--- a/monkestation/code/game/objects/items/storage/uplink_kits.dm
+++ b/monkestation/code/game/objects/items/storage/uplink_kits.dm
@@ -106,6 +106,7 @@
 
 	// Paper guide
 	new /obj/item/paper/contractor_guide(src)
+	new /obj/item/pinpointer/area_pinpointer(src)
 
 /obj/item/storage/box/syndie_kit/contract_kit/midround/PopulateContents()
 	// You get one item from each sub list

--- a/monkestation/code/modules/antagonists/contractor/datums/contractor_items.dm
+++ b/monkestation/code/modules/antagonists/contractor/datums/contractor_items.dm
@@ -61,6 +61,15 @@
 	stock = 2
 	cost = 1
 
+/datum/contractor_item/area_pinpointer
+	name = "Area Pinpointer"
+	desc = "A hacked pinpointer that uses the crew sensor network and manages to hijack the area data instead of the crew monitor data. \
+			Whilst this allows you to track any area on the station it is highly illegal due to the extensive use of resources this process requires"
+	item = /obj/item/pinpointer/area_pinpointer
+	item_icon = "search-location"
+	stock = 2
+	cost = 1
+
 /datum/contractor_item/fulton_extraction_kit
 	name = "Fulton Extraction Kit"
 	desc = "For getting your target across the station to those difficult dropoffs. Place the beacon somewhere secure, and link the pack. \

--- a/monkestation/code/modules/antagonists/contractor/datums/contractor_items.dm
+++ b/monkestation/code/modules/antagonists/contractor/datums/contractor_items.dm
@@ -61,15 +61,6 @@
 	stock = 2
 	cost = 1
 
-/datum/contractor_item/area_pinpointer
-	name = "Area Pinpointer"
-	desc = "A hacked pinpointer that uses the crew sensor network and manages to hijack the area data instead of the crew monitor data. \
-			Whilst this allows you to track any area on the station it is highly illegal due to the extensive use of resources this process requires"
-	item = /obj/item/pinpointer/area_pinpointer
-	item_icon = "search-location"
-	stock = 2
-	cost = 1
-
 /datum/contractor_item/fulton_extraction_kit
 	name = "Fulton Extraction Kit"
 	desc = "For getting your target across the station to those difficult dropoffs. Place the beacon somewhere secure, and link the pack. \

--- a/monkestation/code/modules/antagonists/contractor/datums/outfit.dm
+++ b/monkestation/code/modules/antagonists/contractor/datums/outfit.dm
@@ -18,7 +18,8 @@
 		/obj/item/storage/box/survival/syndie,
 		/obj/item/storage/box/syndie_kit/contract_kit/midround,
 		/obj/item/knife/combat/survival,
-		/obj/item/pinpointer/crew/contractor
+		/obj/item/pinpointer/crew/contractor,
+		/obj/item/pinpointer/area_pinpointer,
 	)
 
 	implants = list(

--- a/monkestation/code/modules/antagonists/contractor/items/misc.dm
+++ b/monkestation/code/modules/antagonists/contractor/items/misc.dm
@@ -7,6 +7,9 @@
 	has_owner = TRUE
 	ignore_suit_sensor_level = TRUE
 
+/obj/item/pinpointer
+	var/special_examine = FALSE
+
 /obj/item/pinpointer/area_pinpointer
 	name = "hacked pinpointer"
 	desc = "A handheld tracking device that locks onto certain signals. This one seems to have wires sticking out of it, and can point onto areas instead of humans."

--- a/monkestation/code/modules/antagonists/contractor/items/misc.dm
+++ b/monkestation/code/modules/antagonists/contractor/items/misc.dm
@@ -7,6 +7,79 @@
 	has_owner = TRUE
 	ignore_suit_sensor_level = TRUE
 
+/obj/item/pinpointer/area_pinpointer
+	name = "hacked pinpointer"
+	desc = "A handheld tracking device that locks onto certain signals. This one seems to have wires sticking out of it, and can point onto areas instead of humans."
+	icon_state = "pinpointer_syndicate"
+	worn_icon_state = "pinpointer_black"
+	special_examine = TRUE
+	var/area/examine_area
+	var/pinpointer_owner
+
+/obj/item/pinpointer/area_pinpointer/Destroy()
+	examine_area = null
+	return ..()
+
+/obj/item/pinpointer/area_pinpointer/get_direction_icon(here, there)
+	var/list/area_turfs = list()
+	area_turfs = get_area_turfs(examine_area)
+
+	var/turf/target_turf = get_turf(src)
+	for(var/turf/possible_turf as anything in area_turfs) // im a bit scared of the effects this may have on performance, but it seems fine
+		if(get_dist_euclidian(target_turf, possible_turf) <= minimum_range)
+			return "pinon[alert ? "alert" : ""]direct[icon_suffix]"
+
+	return ..()
+
+// we need to get our own examine text, since it would be "tracking the floor" otherwise
+/obj/item/pinpointer/area_pinpointer/examine(mob/user)
+	. = ..()
+	if(target)
+		. += "It is currently tracking [examine_area]."
+
+/obj/item/pinpointer/area_pinpointer/attack_self(mob/living/user)
+	if(active)
+		toggle_on()
+		user.visible_message(span_notice("[user] deactivates [user.p_their()] pinpointer."), span_notice("You deactivate your pinpointer."))
+		return
+
+	if(!pinpointer_owner)
+		pinpointer_owner = user
+
+	if(pinpointer_owner != user)
+		to_chat(user, span_notice("The pinpointer doesn't respond. It seems to only recognise its owner."))
+		return
+
+	// This list should ONLY include areas that are on our z-level and are actually recognizable, else we confuse the contractor
+	var/list/possible_areas = list()
+	for(var/area/area in GLOB.areas)
+		var/our_z = user?.z
+		var/area_z = area?.z
+		if(!our_z || !area_z)
+			// What the actual hell are you doing
+			CRASH("[src] has detected an area without a valid z-level. What")
+
+		if(our_z != area_z)
+			continue
+
+		possible_areas += area
+
+	if(!length(possible_areas))
+		CRASH("[src] has failed to detect a valid area, this should never happen!")
+
+	var/target_area = tgui_input_list(user, "Area to track", "Pinpoint", sort_list(possible_areas))
+	if(isnull(target_area))
+		return
+	if(QDELETED(src) || !user || !user.is_holding(src) || user.incapacitated())
+		return
+	examine_area = target_area
+
+	var/turf/target_turf = get_first_open_turf_in_area(target_area)
+
+	target = target_turf
+	toggle_on()
+	user.visible_message(span_notice("[user] activates [user.p_their()] pinpointer."), span_notice("You activate your pinpointer."))
+
 /obj/item/extraction_pack/contractor
 	name = "black fulton extraction pack"
 	desc = "A modified fulton pack that can be used indoors thanks to Bluespace technology. Favored by Syndicate Contractors."

--- a/monkestation/code/modules/antagonists/contractor/items/misc.dm
+++ b/monkestation/code/modules/antagonists/contractor/items/misc.dm
@@ -46,11 +46,10 @@
 	var/turf/closest_turf
 	/// Whats the range between us and the closest turf?
 	var/closest_turf_range = 255
-
-	for(var/turf/floor as anything in area_turfs) // Go over every turf, check every turfs
+	for(var/turf/floor as anything in area_turfs) // Lets go over everything and check their distances for the closest tile, what can go wrong?
+		if(floor.density) // lets ignore all walls before getting every turfs distance, to save some performance
+			continue
 		if(get_dist_euclidian(pinpointer_turf, floor) < closest_turf_range)
-			if(floor.density) // wait, thats not a floor. Thats a wall, we got catfished!
-				continue
 			closest_turf_range = get_dist_euclidian(pinpointer_turf, floor)
 			closest_turf = floor
 

--- a/monkestation/code/modules/antagonists/contractor/items/misc.dm
+++ b/monkestation/code/modules/antagonists/contractor/items/misc.dm
@@ -17,7 +17,6 @@
 	worn_icon_state = "pinpointer_black"
 	special_examine = TRUE
 	var/area/tracked_area
-	var/pinpointer_owner
 	/// We save our position every time we scan_for_target()
 	/// Its used to check if we moved so we may ignore calculations when being still, along with calculations between us and the target turfs.
 	var/turf/pinpointer_turf
@@ -74,18 +73,14 @@
 		user.visible_message(span_notice("[user] deactivates [user.p_their()] pinpointer."), span_notice("You deactivate your pinpointer."))
 		return
 
-	if(!pinpointer_owner)
-		pinpointer_owner = user
-
-	if(pinpointer_owner != user)
-		to_chat(user, span_notice("The pinpointer doesn't respond. It seems to only recognise its owner."))
-		return
+	if(!user)
+		CRASH("[src] has had attack_self attempted by a non-existing user.")
 
 	// This list should ONLY include areas that are on our z-level and are actually recognizable, else we confuse the contractor
 	var/list/possible_areas = list()
 	for(var/area/area in GLOB.areas)
-		var/our_z = user?.z
-		var/area_z = area?.z
+		var/our_z = user.z
+		var/area_z = area.z
 		if(!our_z || !area_z)
 			// What the actual hell are you doing
 			CRASH("[src] has detected an area without a valid z-level. What")
@@ -101,7 +96,7 @@
 	var/target_area = tgui_input_list(user, "Area to track", "Pinpoint", sort_list(possible_areas))
 	if(isnull(target_area))
 		return
-	if(QDELETED(src) || !user || !user.is_holding(src) || user.incapacitated())
+	if(QDELETED(src) || QDELETED(user) || !user.is_holding(src) || user.incapacitated())
 		return
 
 	tracked_area = target_area

--- a/monkestation/code/modules/antagonists/contractor/items/misc.dm
+++ b/monkestation/code/modules/antagonists/contractor/items/misc.dm
@@ -15,9 +15,13 @@
 	special_examine = TRUE
 	var/area/tracked_area
 	var/pinpointer_owner
+	/// We save our position every time we scan_for_target()
+	/// Its used to check if we moved so we may ignore calculations when being still, along with calculations between us and the target turfs.
+	var/turf/pinpointer_turf
 
 /obj/item/pinpointer/area_pinpointer/Destroy()
 	tracked_area = null
+	pinpointer_turf = null
 	return ..()
 
 // we need to get our own examine text, since it would be "tracking the floor" otherwise
@@ -37,11 +41,17 @@
 
 	return ..()
 
-/obj/item/pinpointer/area_pinpointer/scan_for_target() // may be extremelly expensive and removed
+/obj/item/pinpointer/area_pinpointer/scan_for_target()
+	var/current_turf = get_turf(src)
+
+	if(pinpointer_turf == current_turf) // if our position has not changed, we dont need to update our target.
+		return
+
+	pinpointer_turf = current_turf
+
 	var/list/area_turfs = list()
 	area_turfs = get_area_turfs(tracked_area)
 
-	var/turf/pinpointer_turf = get_turf(src)
 	/// The turf that has the lowest possible range towards us and the area
 	var/turf/closest_turf
 	/// Whats the range between us and the closest turf?

--- a/monkestation/code/modules/antagonists/contractor/items/misc.dm
+++ b/monkestation/code/modules/antagonists/contractor/items/misc.dm
@@ -109,6 +109,11 @@
 
 	pinpointer_turf = current_turf
 
+	// we dont need to track our target when they are in the area already
+	for(var/turf/possible_turf as anything in all_tracked_area_turfs)
+		if(pinpointer_turf == possible_turf)
+			return
+
 	/// The turf that has the lowest possible range towards us and the area
 	var/turf/closest_turf
 	/// Whats the range between us and the closest turf?
@@ -180,6 +185,7 @@
  * Debug area pinpointer focuses on visualization, to better show how the area pinpointer interacts with turfs
  * Red - This tile is ignored by tracking, but recognized as a part of the target area
  * Green - This tile is a potential target, but not yet our current target
+ * Yellow - The tile would be a potential target, but the tracking is currently off due to the pinpointer being in its area
  * Blue - This is the tile we are currently tracking
  */
 /obj/item/pinpointer/area_pinpointer/debug
@@ -204,6 +210,14 @@
 
 /obj/item/pinpointer/area_pinpointer/debug/scan_for_target()
 	. = ..()
+	// we dont track turfs when the person holding us is in the area we are pointing to
+	for(var/turf/possible_turf as anything in all_tracked_area_turfs)
+		if(pinpointer_turf == possible_turf)
+			for(var/turf/open/tracked_turf as anything in tracked_area_turfs)
+				tracked_turf.color = rgb(255, 255, 0)
+				tracked_turf.maptext = MAPTEXT("-")
+			return
+
 	for(var/turf/open/tracked_turf as anything in tracked_area_turfs)
 		tracked_turf.color = rgb(0, 255, 0)
 		tracked_turf.maptext = MAPTEXT("+")


### PR DESCRIPTION
## About The Pull Request

Gives contractors a pinpointer that points to any area on their current z-level
To be more specific, the closest possible tile that is not a wall
it can be alt+clicked to instead track the closest tile in the area with a door

le video:

https://github.com/Monkestation/Monkestation2.0/assets/82319946/9431e340-8e7c-4a4c-a3ae-2a18809d6266

## Why It's Good For The Game

when i wanna go to the "Bow Stern Starboard Port Gunwale Cleat Maintnance area" because of a contract i kinda need to know where the hell it is.
The bot beacons are not placed in maintnance areas and some arent even in normal ones, so this is a REALLY usefull tool

## Changelog

:cl:
add: Contractors now can purchase an area pinpointer
/:cl:
