### PR TITLE
[PORT] Client colo(u)r no longer uses Client.color, now coloring the render game plane instead

### DIFF
--- a/code/__HELPERS/colors.dm
+++ b/code/__HELPERS/colors.dm
@@ -42,24 +42,24 @@
 	var/textb = copytext(HTMLstring, 6, 8)
 	return rgb(255 - hex2num(textr), 255 - hex2num(textg), 255 - hex2num(textb))
 
-///Flash a color on the client
+///Flash a color on the passed mob
 /proc/flash_color(mob_or_client, flash_color="#960000", flash_time=20)
-	var/client/flashed_client
+	var/mob/flashed_mob
 	if(ismob(mob_or_client))
-		var/mob/client_mob = mob_or_client
-		if(client_mob.client)
-			flashed_client = client_mob.client
-		else
-			return
+		flashed_mob = mob_or_client
 	else if(istype(mob_or_client, /client))
-		flashed_client = mob_or_client
+		var/client/flashed_client = mob_or_client
+		flashed_mob = flashed_client.mob
 
-	if(!istype(flashed_client))
+	if(!istype(flashed_mob))
 		return
 
-	var/animate_color = flashed_client.color
-	flashed_client.color = flash_color
-	animate(flashed_client, color = animate_color, time = flash_time)
+	var/datum/client_colour/temp/temp_color = new(flashed_mob)
+	temp_color.colour = flash_color
+	temp_color.fade_in = flash_time * 0.25
+	temp_color.fade_out = flash_time * 0.25
+	QDEL_IN(temp_color, (flash_time * 0.5) + 1)
+	flashed_mob.add_client_colour(temp_color)
 
 /// Blends together two colors (passed as 3 or 4 length lists) using the screen blend mode
 /// Much like multiply, screen effects the brightness of the resulting color
@@ -94,4 +94,3 @@
 
 
 #define RANDOM_COLOUR (rgb(rand(0,255),rand(0,255),rand(0,255)))
-

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -38,35 +38,32 @@
 /datum/client_colour/Destroy()
 	if(!QDELETED(owner))
 		owner.client_colours -= src
-		if(fade_out)
-			owner.animate_client_colour(fade_out)
-		else
-			owner.update_client_colour()
+		owner.animate_client_colour(fade_out)
 	owner = null
 	return ..()
 
 ///Sets a new colour, then updates the owner's screen colour.
 /datum/client_colour/proc/update_colour(new_colour, anim_time, easing = 0)
 	colour = new_colour
-	if(anim_time)
-		owner.animate_client_colour(anim_time, easing)
-	else
-		owner.update_client_colour()
+	owner.animate_client_colour(anim_time, easing)
 
 /**
  * Adds an instance of colour_type to the mob's client_colours list
  * colour_type - a typepath (subtyped from /datum/client_colour)
  */
-/mob/proc/add_client_colour(colour_type)
-	if(!ispath(colour_type, /datum/client_colour) || QDELING(src))
+/mob/proc/add_client_colour(colour_type_or_datum)
+	if(QDELING(src))
 		return
-
-	var/datum/client_colour/colour = new colour_type(src)
-	BINARY_INSERT(colour, client_colours, /datum/client_colour, colour, priority, COMPARE_KEY)
-	if(colour.fade_in)
-		animate_client_colour(colour.fade_in)
+	var/datum/client_colour/colour
+	if(istype(colour_type_or_datum, /datum/client_colour))
+		colour = colour_type_or_datum
+	else if(ispath(colour_type_or_datum, /datum/client_colour))
+		colour = new colour_type_or_datum(src)
 	else
-		update_client_colour()
+		CRASH("Invalid colour type or datum for add_client_color: [colour_type_or_datum || "null"]")
+
+	BINARY_INSERT(colour, client_colours, /datum/client_colour, colour, priority, COMPARE_KEY)
+	animate_client_colour(colour.fade_in)
 	return colour
 
 /**
@@ -77,8 +74,7 @@
 	if(!ispath(colour_type, /datum/client_colour))
 		return
 
-	for(var/cc in client_colours)
-		var/datum/client_colour/colour = cc
+	for(var/datum/client_colour/colour as anything in client_colours)
 		if(colour.type == colour_type)
 			qdel(colour)
 			break
@@ -123,30 +119,48 @@
 	};\
 	target = _our_colour\
 
+#define CLIENT_COLOR_FILTER_KEY "fake_client_color"
 
 /**
  * Resets the mob's client.color to null, and then reapplies a new color based
  * on the client_colour datums it currently has.
  */
 /mob/proc/update_client_colour()
-	if(!client)
+	if(isnull(hud_used))
 		return
-	client.color = ""
-	if(!client_colours.len)
-		return
-	MIX_CLIENT_COLOUR(client.color)
+
+	var/new_color = ""
+	if(length(client_colours))
+		MIX_CLIENT_COLOUR(new_color)
+
+	for(var/atom/movable/screen/plane_master/game_plane as anything in hud_used.get_true_plane_masters(RENDER_PLANE_GAME))
+		if(new_color)
+			game_plane.add_filter(CLIENT_COLOR_FILTER_KEY, 2, color_matrix_filter(new_color))
+		else
+			game_plane.remove_filter(CLIENT_COLOR_FILTER_KEY)
 
 ///Works similarly to 'update_client_colour', but animated.
-/mob/proc/animate_client_colour(anim_time = 20, anim_easing = 0)
-	if(!client)
+/mob/proc/animate_client_colour(anim_time = 2 SECONDS, anim_easing = NONE)
+	if(anim_time <= 0)
+		return update_client_colour()
+	if(isnull(hud_used))
 		return
-	if(!client_colours.len)
-		animate(client, color = "", time = anim_time, easing = anim_easing)
-		return
-	MIX_CLIENT_COLOUR(var/anim_colour)
-	animate(client, color = anim_colour, time = anim_time, easing = anim_easing)
+
+	var/anim_color = ""
+	if(length(client_colours))
+		MIX_CLIENT_COLOUR(anim_color)
+
+	for(var/atom/movable/screen/plane_master/game_plane as anything in hud_used.get_true_plane_masters(RENDER_PLANE_GAME))
+		if(anim_color)
+			game_plane.add_filter(CLIENT_COLOR_FILTER_KEY, 2, color_matrix_filter())
+			game_plane.transition_filter(CLIENT_COLOR_FILTER_KEY, color_matrix_filter(anim_color), anim_time, anim_easing)
+		else
+			game_plane.transition_filter(CLIENT_COLOR_FILTER_KEY, color_matrix_filter(), anim_time, anim_easing)
+			// This leaves a blank color filter on the hud which is, fine I guess?
 
 #undef MIX_CLIENT_COLOUR
+
+#undef CLIENT_COLOR_FILTER_KEY
 
 /datum/client_colour/glass_colour
 	priority = PRIORITY_LOW
@@ -217,6 +231,9 @@
 	priority = PRIORITY_ABSOLUTE
 	override = TRUE
 	colour = list(0.8,0,0,0, 0,0,0,0, 0,0,1,0, 0,0,0,1, 0,0,0,0)
+
+/datum/client_colour/temp
+	priority = PRIORITY_HIGH
 
 #undef PRIORITY_ABSOLUTE
 #undef PRIORITY_HIGH


### PR DESCRIPTION

## About The Pull Request
Ports #81328
## Why It's Good For The Game
Blind QOL + better color overlay for huds and glasses
## Testing Screenshots

![ui](https://github.com/Monkestation/Monkestation2.0/assets/152086196/12fe7f5f-1e5b-4e27-9b98-f22773575c6e)

This is sechud btw
![glasses](https://github.com/Monkestation/Monkestation2.0/assets/152086196/4c53f619-6656-4ce2-b384-74777c8c4be4)

## Changelog
:cl: MrMelbert
qol: Glasses colors should be a lot less harsh, and being blind no longer also blinds your hud.
/:cl:
