### PR TITLE
Add files via upload

### DIFF
--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -16,6 +16,18 @@
 				)
 	crate_name = "cargo supplies crate"
 
+/datum/supply_pack/service/bitrun_crate
+	name = "Bitrunning supplies crate"
+	desc = "Seems like we need new machinery, the gamers broke it once more."
+	cost = CARGO_CRATE_VALUE * 2.25
+	acces = ACCESS_BIT_DEN
+	contains = list(/obj/item/circuitboard/machine/netpod = 3,
+				/obj/item/circuitboard/machine/quantum_server,
+				/obj/item/circuitboard/machine/byteforge,
+				/obj/item/circuitboard/computer/quantum_console
+			)
+	crate_name = "Bitrunning supplies crate"
+
 /datum/supply_pack/service/noslipfloor
 	name = "High-traction Floor Tiles"
 	desc = "Make slipping a thing of the past with thirty industrial-grade anti-slip floor tiles!"


### PR DESCRIPTION

## About The Pull Request

Since currently most jobs on the server can have their equipment replaced through crates, I thought bitrunners needed one aswell and here it is.

## Why It's Good For The Game

Due to the difficulty to produce bitrunning related equipment, if there is a breach or wish to do something with bitrunners in it's current state it would unnecessary hard to do such.

## Changelog

:cl:
add: Added a new crate in the service tab of the supply consoles : 3 netpod boards, 1 quantum server board, 1 quantum console board, 1 byteforge board.
/:cl:

