### PR TITLE
Add Fix-Chat and Refresh-TGUI to the Help menu at the top

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -10,21 +10,21 @@ macro "default"
 
 
 menu "menu"
-	elem
+	elem 
 		name = "&File"
 		command = ""
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Quick screenshot\tF2"
 		command = ".screenshot auto"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Save screenshot as...\tShift+F2"
 		command = ".screenshot"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = ""
 		command = ""
 		category = "&File"
@@ -34,7 +34,7 @@ menu "menu"
 		command = ".reconnect"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Quit\tAlt-F4"
 		command = ".quit"
 		category = "&File"
@@ -43,16 +43,27 @@ menu "menu"
 		name = "&Help"
 		command = ""
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Admin Help\tF1"
 		command = "adminhelp"
 		category = "&Help"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Hotkeys"
 		command = "Hotkeys-Help"
 		category = "&Help"
 		saved-params = "is-checked"
+	elem 
+		name = "Refresh TGUI"
+		command = "refresh-tgui"
+		category = "&Help"
+		saved-params = "is-checked"
+	elem 
+		name = "Fix Chat"
+		command = "fix-chat"
+		category = "&Help"
+		saved-params = "is-checked"
+
 
 window "mainwindow"
 	elem "mainwindow"
@@ -121,12 +132,13 @@ window "mapwindow"
 		pos = 0,464
 		size = 280x16
 		anchor1 = 0,100
-		is-visible = true
+		anchor2 = -1,-1
+		text-color = #ffffff
+		background-color = #222222
+		border = line
+		saved-params = ""
 		text = ""
 		align = left
-		background-color = #222222
-		text-color = #ffffff
-		border = line
 
 window "infowindow"
 	elem "infowindow"
@@ -209,11 +221,8 @@ window "outputwindow"
 		size = 640x480
 		anchor1 = -1,-1
 		anchor2 = -1,-1
-		background-color = none
 		saved-params = "pos;size;is-minimized;is-maximized"
 		is-pane = true
-		outer-size = 656x538
-		inner-size = 640x499
 	elem "input"
 		type = INPUT
 		pos = 2,460
@@ -229,7 +238,6 @@ window "outputwindow"
 		size = 40x20
 		anchor1 = 100,100
 		anchor2 = -1,-1
-		background-color = none
 		border = line
 		saved-params = "is-checked"
 		text = "OOC"
@@ -242,7 +250,6 @@ window "outputwindow"
 		size = 40x20
 		anchor1 = 100,100
 		anchor2 = -1,-1
-		background-color = none
 		border = line
 		saved-params = "is-checked"
 		text = "Say"
@@ -255,7 +262,6 @@ window "outputwindow"
 		size = 40x20
 		anchor1 = 100,100
 		anchor2 = -1,-1
-		background-color = none
 		border = line
 		saved-params = "is-checked"
 		text = "Me"
@@ -341,7 +347,6 @@ window "statwindow"
 		size = 1x1
 		anchor1 = -1,-1
 		anchor2 = -1,-1
-		background-color = none
 		is-visible = false
 		saved-params = ""
 


### PR DESCRIPTION

## About The Pull Request

![2024-02-18 (1708306326) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/17a6ea87-6fde-46aa-9471-d850b593a5cf)
![2024-02-18 (1708306464) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/c06505c9-d204-4292-a901-e4aef0b0edad)


## Why It's Good For The Game

Makes it easier for players to try to fix clientside webview weirdness without memorizing verbs in the command bar

## Changelog
:cl:
add: Added "Refresh TGUI" and "Fix Chat" buttons to the Help menu at the top of the game window.
/:cl:
