### PR TITLE
Let's you store tiny items in bunny suits.

### DIFF
--- a/monkestation/code/modules/clothing/under/costume.dm
+++ b/monkestation/code/modules/clothing/under/costume.dm
@@ -140,6 +140,11 @@ BUNNY SUITS
 	body_parts_covered = CHEST|GROIN|LEGS
 	alt_covers_chest = TRUE
 
+/obj/item/clothing/under/costume/playbunny/Initialize(mapload)
+	. = ..()
+
+	create_storage(storage_type = /datum/storage/pockets/tiny)
+
 /obj/item/clothing/under/syndicate/syndibunny //heh
 	name = "blood-red bunny suit"
 	desc = "The staple of any bunny themed syndicate assassins. Are those carbon nanotube stockings?"
@@ -148,6 +153,11 @@ BUNNY SUITS
 	icon_state = "syndibunny"
 	body_parts_covered = CHEST|GROIN|LEGS
 
+/obj/item/clothing/under/syndicate/syndibunny/Initialize(mapload)
+	. = ..()
+
+	create_storage(storage_type = /datum/storage/pockets/small)
+
 /obj/item/clothing/under/costume/playbunny/magician
 	name = "magician's bunny suit"
 	desc = "The staple of any bunny themed stage magician."
@@ -155,6 +165,20 @@ BUNNY SUITS
 	greyscale_config = null
 	greyscale_config_worn = null
 	greyscale_colors = null
+	greyscale_config_worn_digitigrade = null
+
+/obj/item/clothing/under/costume/playbunny/magician/Initialize(mapload)
+	. = ..()
+
+	create_storage(storage_type = /datum/storage/pockets/tiny/magician)
+
+/datum/storage/pockets/tiny/magician/New() //this is probably a good idea
+	. = ..()
+	var/static/list/exception_cache = typecacheof(list(
+		/obj/item/gun/magic/wand,
+		/obj/item/warp_whistle,
+	))
+	exception_hold = exception_cache
 
 /obj/item/clothing/under/costume/playbunny/centcom
 	name = "centcom bunnysuit"


### PR DESCRIPTION
## About The Pull Request
Gives a bonus tiny pocket slot to the bunny suit and a small pocket slot to the syndicate one. Also let's the magician one hold wands and the warp whistle.
## Why It's Good For The Game
The_Awful requested it and it seemed funny.
## Changelog
:cl: The_Awful and DimWhat
add: Added the ability to store a bonus tiny item in bunnysuits. The syndi one holds small items.
/:cl:
