### PR TITLE
Fixes hand-held artefacts not triggering their faults if in a player's inventory

### DIFF
--- a/monkestation/code/modules/art_sci_overrides/faults/_fault.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/_fault.dm
@@ -14,4 +14,3 @@
 /datum/artifact_fault/on_trigger(datum/component/artifact/component)
 	if(component.active)
 		component.artifact_deactivate()
-

--- a/monkestation/code/modules/art_sci_overrides/faults/explosion.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/explosion.dm
@@ -3,13 +3,10 @@
 	trigger_chance = 3
 	visible_message = "reaches a catastrophic overload, cracks forming at its surface!"
 
-
 /datum/artifact_fault/explosion/on_trigger(datum/component/artifact/component)
 	component.holder.Shake(duration = 5 SECONDS, shake_interval = 0.08 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(payload), component), 5 SECONDS)
 
-
 /datum/artifact_fault/explosion/proc/payload(datum/component/artifact/component)
 	explosion(component.holder, light_impact_range = 2, explosion_cause = src)
 	qdel(component.holder)
-  

--- a/monkestation/code/modules/art_sci_overrides/faults/ignite.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/ignite.dm
@@ -4,6 +4,11 @@
 	visible_message = "starts rapidly heating up while covering everything around it in something that seems to be oil."
 
 /datum/artifact_fault/ignite/on_trigger(datum/component/artifact/component)
-	for(var/mob/living/living in range(rand(3, 5), component.parent))
+	var/center_turf = get_turf(component.parent)
+
+	if(!center_turf)
+		CRASH("[src] had attempted to trigger, but failed to find the center turf!")
+
+	for(var/mob/living/living in range(rand(3, 5), center_turf))
 		living.adjust_fire_stacks(10)
 		living.ignite_mob()

--- a/monkestation/code/modules/art_sci_overrides/faults/just_death.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/just_death.dm
@@ -7,7 +7,13 @@
 /datum/artifact_fault/death/on_trigger(datum/component/artifact/component)
 	var/list/mobs = list()
 	var/mob/living/carbon/human
-	for(var/mob/living/carbon/mob in range(rand(3, 4), component.holder))
+
+	var/center_turf = get_turf(component.parent)
+
+	if(!center_turf)
+		CRASH("[src] had attempted to trigger, but failed to find the center turf!")
+
+	for(var/mob/living/carbon/mob in range(rand(3, 4), center_turf))
 		mobs += mob
 	human = pick(mobs)
 	if(!human)

--- a/monkestation/code/modules/art_sci_overrides/faults/just_death.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/just_death.dm
@@ -3,7 +3,6 @@
 	trigger_chance = 1
 	visible_message = "blows someone up with mind."
 
-
 /datum/artifact_fault/death/on_trigger(datum/component/artifact/component)
 	var/list/mobs = list()
 	var/mob/living/carbon/human

--- a/monkestation/code/modules/art_sci_overrides/faults/reagents.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/reagents.dm
@@ -8,7 +8,13 @@
 	. = ..()
 	if(!length(reagents))
 		return
-	for(var/mob/living/carbon/living in range(rand(3, 5), component.parent))
+
+	var/center_turf = get_turf(component.parent)
+
+	if(!center_turf)
+		CRASH("[src] had attempted to trigger, but failed to find the center turf!")
+
+	for(var/mob/living/carbon/living in range(rand(3, 5), center_turf))
 		living.reagents.add_reagent(pick(reagents), rand(1, 5))
 		to_chat(living, span_warning("You feel a soft prick."))
 

--- a/monkestation/code/modules/art_sci_overrides/faults/say.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/say.dm
@@ -7,7 +7,12 @@
 	if(!length(speech))
 		return
 
-	for(var/mob/living/living in range(rand(7, 10), component.parent))
+	var/center_turf = get_turf(component.parent)
+
+	if(!center_turf)
+		CRASH("[src] had attempted to trigger, but failed to find the center turf!")
+
+	for(var/mob/living/living in range(rand(7, 10), center_turf))
 		if(prob(50))
 			living.say("; [pick(speech)]")
 		else

--- a/monkestation/code/modules/art_sci_overrides/faults/warps.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/warps.dm
@@ -8,7 +8,11 @@
 	if(!length(warp_areas))
 		warp_areas = GLOB.the_station_areas
 	var/turf/safe_turf = get_safe_random_station_turf(warp_areas)
+	var/center_turf = get_turf(component.parent)
 
-	for(var/mob/living/living in range(rand(3, 5), component.parent))
+	if(!center_turf)
+		CRASH("[src] had attempted to trigger, but failed to find the center turf!")
+
+	for(var/mob/living/living in range(rand(3, 5), center_turf))
 		living.forceMove(safe_turf)
 		to_chat(living, span_warning("You feel woozy after being warped around."))

--- a/monkestation/code/modules/art_sci_overrides/faults/whispers.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/whispers.dm
@@ -7,5 +7,10 @@
 	if(!length(whispers))
 		return
 
-	for(var/mob/living/living in range(rand(7, 10), component.parent))
+	var/center_turf = get_turf(component.parent)
+
+	if(!center_turf)
+		CRASH("[src] had attempted to trigger, but failed to find the center turf!")
+
+	for(var/mob/living/living in range(rand(7, 10), center_turf))
 		to_chat(living, span_hear("[pick(whispers)]"))


### PR DESCRIPTION

## About The Pull Request

Right now if for an example the combustion fault tries to trigger, but is currently in player's inventory it will fail to find any targets
This basically causes the faults to be less noticable and also can cause glitches where everyone sees the message about the artefact igniting everyone, but nothing happens due to the targets failing to be found

## Why It's Good For The Game

being sent false messages on your chat from artefact faults inside of peoples backpacks is a bit jank. This fixes it into the intended behavior

## Changelog

:cl:
fix: Artefacts will no longer fail to activate their faults inside of peoples backpacks. Beware!
/:cl:
