### PR TITLE
Makes the c38 revolver a small size item

### DIFF
--- a/monkestation/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/monkestation/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -1,0 +1,3 @@
+//While small it's good to stay modular where you can
+/obj/item/gun/ballistic/revolver/c38
+	w_class = WEIGHT_CLASS_SMALL

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6525,6 +6525,7 @@
 #include "monkestation\code\modules\power\singularity\particle_accelerator\particle_accelerator.dm"
 #include "monkestation\code\modules\power\singularity\particle_accelerator\particle_controller.dm"
 #include "monkestation\code\modules\power\singularity\particle_accelerator\particle_emitter.dm"
+#include "monkestation\code\modules\projectiles\guns\ballistic\revolver.dm"
 #include "monkestation\code\modules\projectiles\guns\ballistic\ryanecorp_whispering_jester.dm"
 #include "monkestation\code\modules\projectiles\guns\special\meat_hook.dm"
 #include "monkestation\code\modules\projectiles\projectile\bullets\c45_caseless.dm"


### PR DESCRIPTION

## About The Pull Request
Lowers the c38 revolver (pretty much just the detective revolver) into a small size item. This will allow you to fit it in your pocket or under your hat!
## Why It's Good For The Game
The snub nose revolver is a pretty dang small gun. Would make sense that you could fit in in your pockets, also the detective pulling their revolver out of their hat is quite funny. While this would be a buff, it's not really that great to have it in your pocket as you can fit less items overall in the holster so it's still genuinely better to keep it in there for storage space.
## Changelog
:cl:
add: The detective's revolver is now a small sized item
/:cl:
