### PR TITLE
Buffs the syndicate heels

### DIFF
--- a/monkestation/code/modules/clothing/shoes/shoe.dm
+++ b/monkestation/code/modules/clothing/shoes/shoe.dm
@@ -63,8 +63,8 @@
 	force = 10
 	throwforce = 15
 	sharpness = SHARP_POINTY
-	attack_verb_continuous = list("attacks", "slices", "slashes", "cuts")
-	attack_verb_simple = list("attack", "slice", "slash", "cut")
+	attack_verb_continuous = list("attacks", "slices", "slashes", "cuts", "stabs")
+	attack_verb_simple = list("attack", "slice", "slash", "cut", "stab")
 	greyscale_colors = null
 	greyscale_config = null
 	greyscale_config_worn = null

--- a/monkestation/code/modules/clothing/shoes/shoe.dm
+++ b/monkestation/code/modules/clothing/shoes/shoe.dm
@@ -60,10 +60,11 @@
 	icon_state = "heels_syndi"
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	strip_delay = 2 SECONDS
-	force = 5
-	throwforce = 10
-	attack_verb_continuous = list("attacks", "slices", "dices", "slashes", "cuts")
-	attack_verb_simple = list("attack", "slice", "dice", "slash", "cut")
+	force = 10
+	throwforce = 15
+	sharpness = SHARP_POINTY
+	attack_verb_continuous = list("attacks", "slices", "slashes", "cuts")
+	attack_verb_simple = list("attack", "slice", "slash", "cut")
 	greyscale_colors = null
 	greyscale_config = null
 	greyscale_config_worn = null


### PR DESCRIPTION

## About The Pull Request
Increases the damage of syndicate heels to 10 and the thrown damage to 15. Making it about on par with the a knife. Also makes it a stabbing weapon since that's what I intended for it to do in the first place.
## Why It's Good For The Game
Currently they are pretty much worse than being bare handed making them completely useless in a fight. This should make them vaguely more useful.
## Changelog
:cl:
add: Buffed syndicate heels damage and made them a pointy weapon
/:cl:
