### PR TITLE
[PORT] Half tile firelock and stairs fixes

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -698,6 +698,11 @@
 /obj/machinery/door/firedoor/border_only/Initialize(mapload)
 	. = ..()
 	adjust_lights_starting_offset()
+	var/static/list/loc_connections = list(
+		COMSIG_ATOM_EXIT = PROC_REF(on_exit),
+	)
+
+	AddElement(/datum/element/connect_loc, loc_connections)
 
 /obj/machinery/door/firedoor/border_only/adjust_lights_starting_offset()
 	light_xoffset = 0

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -11,6 +11,7 @@
 	icon = 'icons/obj/stairs.dmi'
 	icon_state = "stairs"
 	anchored = TRUE
+	move_resist = INFINITY
 
 	var/force_open_above = FALSE // replaces the turf above this stair obj with /turf/open/openspace
 	var/terminator_mode = STAIR_TERMINATOR_AUTOMATIC


### PR DESCRIPTION

## About The Pull Request
Ports #75120, #77625
## Why It's Good For The Game
Fixes simplemobs breaking stairs and the weird half tile firelocks not being solid. 
## Changelog
:cl: MrMelbert, mc-oofert
fix: Stairs are now resistant to being shoved by mobs with high move force.
fix: fixed border-only firedoors being able to be walked through while closed
/:cl:
