### PR TITLE
Fixes the PTL capping its power at 2.5 Terawatts

### DIFF
--- a/code/__DEFINES/power.dm
+++ b/code/__DEFINES/power.dm
@@ -15,8 +15,8 @@
 
 GLOBAL_VAR_INIT(CHARGELEVEL, 0.001) // Cap for how fast cells charge, as a percentage-per-tick (.001 means cellcharge is capped to 1% per second)
 
-#define KW * 1000
-#define MW * 1000000
-#define GW * 1000000000
-#define TW * 1000000000000
-#define PW * 1000000000000000
+#define KW *1000
+#define MW KW*1000
+#define GW MW*1000
+#define TW GW*1000
+#define PW TW*1000


### PR DESCRIPTION

## About The Pull Request

replaces
```
#define KW * 1000
#define MW * 1000000
#define GW * 1000000000
#define TW * 1000000000000
#define PW * 1000000000000000
```
with
```
#define KW *1000
#define MW KW*1000
#define GW MW*1000
#define TW GW*1000
#define PW TW*1000
```
because byond apparently literally prefers more readable code to the point that it will start to create bugs out of nowhere just so you need to make cleaner code

## Why It's Good For The Game

PTL work gud, i shall make millions in seconds now :3

## Changelog

:cl:
fix: the PTL no longer caps its power output at 2.5 Terawatts due to an obscure bug
/:cl:
