### PR TITLE
Lowered the frequency of random diseases and fake diseases.

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -24,7 +24,7 @@
 	typepath = /datum/round_event/disease_outbreak
 	max_occurrences = 1
 	min_players = 10
-	weight = 5
+	weight = 4
 	category = EVENT_CATEGORY_HEALTH
 	description = "A 'classic' virus will infect some members of the crew."
 	min_wizard_trigger_potency = 2

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -143,7 +143,7 @@
 	name = "Disease Outbreak: Advanced"
 	typepath = /datum/round_event/disease_outbreak/advanced
 	category = EVENT_CATEGORY_HEALTH
-	weight = 7 //monkestation change 15 ==> 7
+	weight = 5 //monkestation change 15 ==> 5
 	min_players = 35 // To avoid shafting lowpop
 	earliest_start = 15 MINUTES // give the chemist a chance
 	description = "An 'advanced' disease will infect some members of the crew."

--- a/code/modules/events/fake_virus.dm
+++ b/code/modules/events/fake_virus.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/fake_virus
 	name = "Fake Virus"
 	typepath = /datum/round_event/fake_virus
-	weight = 20
+	weight = 15 //MONKESTATION CHANGE: 20 ==> 15
 	category = EVENT_CATEGORY_HEALTH
 	description = "Some crewmembers suffer from temporary hypochondria."
 


### PR DESCRIPTION

## About The Pull Request
Lowers the weight of rolling a fake disease event to 15 from 20, the chance to roll an advanced disease down to 5 from 7, and the chance of rolling a classic disease to 4 from 5
## Why It's Good For The Game
The advanced disease is a subtype of the standard disease which means both have a chance of rolling during the round, as well as we can have both of them occur per round. I feel like the chances should be lower to compensate for how we have both of them on the same list of events. Also I think we can all agree that the fake disease happens way too much. I get a lot of announcements about real/fake diseases and I feel like they shouldn't happen so often. Also I cannot stand Duke Nukem gagging into a microphone any longer.
## Changelog
:cl:
balance: Lowered the chance of both real and fake diseases occuring
/:cl:
