### PR TITLE
(re)adds a goose for the tram to hit

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -76098,6 +76098,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/stripes/white/line,
+/mob/living/simple_animal/hostile/retaliate/goose/vomit,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
 "xlV" = (


### PR DESCRIPTION

## About The Pull Request

re-ports https://github.com/tgstation/tgstation/pull/72795, which was lost through changes to tram over time

![2024-02-20 (1708466040) ~ strongdmm](https://github.com/Monkestation/Monkestation2.0/assets/65794972/5bc70b3d-4394-427f-bd4f-684dc9ea84fa)

## Why It's Good For The Game

there's no birdboat on tramstation. this is the funniest spot to put birdboat.

## Changelog
:cl:
add: a goose for the tram to run over
/:cl:
