### PR TITLE
Fix a runtime in SSachievements

### DIFF
--- a/code/controllers/subsystem/achievements.dm
+++ b/code/controllers/subsystem/achievements.dm
@@ -59,10 +59,9 @@ SUBSYSTEM_DEF(achievements)
 				most_unlocked_achievement = instance
 	qdel(query)
 
-	for(var/i in GLOB.clients)
-		var/client/C = i
-		if(!C.player_details.achievements.initialized)
-			C.player_details.achievements.InitializeData()
+	for(var/client/player as anything in GLOB.clients)
+		if(player?.player_details?.achievements && !player.player_details.achievements.initialized)
+			player.player_details.achievements.InitializeData()
 
 	return SS_INIT_SUCCESS
 


### PR DESCRIPTION
Fixes this, which I assume is due to some edge-case of someone logging out or something

![2024-02-20 (1708477286) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/c8c6d3af-4af5-4890-96ec-8a52f71ce24b)


## Changelog
:cl:
fix: Fixed a potential roundstart runtime in the Achievements subsystem.
/:cl:
