### PR TITLE
Fix SM cascade eating the server itself on icebox

### DIFF
--- a/code/datums/components/supermatter_crystal.dm
+++ b/code/datums/components/supermatter_crystal.dm
@@ -300,7 +300,7 @@
 			near_mob.show_message(span_hear("An unearthly ringing fills your ears, and you find your skin covered in new radiation burns."), MSG_AUDIBLE)
 	consume_returns(matter_increase, damage_increase)
 	var/obj/machinery/power/supermatter_crystal/our_crystal = parent
-	if(istype(parent))
+	if(istype(our_crystal))
 		our_crystal.log_activation(who = consumed_object)
 
 /datum/component/supermatter_crystal/proc/consume_returns(matter_increase = 0, damage_increase = 0)

--- a/code/modules/power/supermatter/supermatter_delamination/cascade_delam_objects.dm
+++ b/code/modules/power/supermatter/supermatter_delamination/cascade_delam_objects.dm
@@ -22,6 +22,9 @@
 
 /obj/crystal_mass/Initialize(mapload, dir_to_remove)
 	. = ..()
+	// sanity check, I'm just throwing shit at the wall to hope one of these checks prevents the server crash bug
+	if(!isturf(loc) || QDELING(loc))
+		return INITIALIZE_HINT_QDEL
 	icon_state = "crystal_cascade_[rand(1,6)]"
 	START_PROCESSING(SSsupermatter_cascade, src)
 
@@ -44,7 +47,7 @@
 	if(!COOLDOWN_FINISHED(src, sm_wall_cooldown))
 		return
 
-	if(!available_dirs || available_dirs.len <= 0)
+	if(!length(available_dirs))
 		return PROCESS_KILL
 
 	COOLDOWN_START(src, sm_wall_cooldown, rand(0, 3 SECONDS))
@@ -54,7 +57,12 @@
 
 	icon_state = "crystal_cascade_[rand(1,6)]"
 
-	if(!next_turf || locate(/obj/crystal_mass) in next_turf)
+	// we gotta stop the cascade from eating reality itself, so we're going to go a bit overboard on the checks here.
+	// ensure the next turf actually fucking exists
+	if(!istype(next_turf) || QDELING(next_turf))
+		return
+	// ensure there's no crystal mass in the next turf
+	if(locate(/obj/crystal_mass) in next_turf)
 		return
 
 	for(var/atom/movable/checked_atom as anything in next_turf)


### PR DESCRIPTION
## Testing proof

![2024-02-21 (1708531926) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/c8b4d50b-9ac2-4b33-b103-39f67df90024)

## Changelog
:cl:
fix: Fix the supermatter cascade eating the server itself on icebox
fix: Fixed a runtime with the SM cascade from a mistyped check
/:cl:
