### PR TITLE
Antag token config and UI+code improvements

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -596,13 +596,12 @@
 #undef SUMMON_POSSIBILITIES
 
 /datum/antagonist/cult/antag_token(datum/mind/hosts_mind, mob/spender)
-	. = ..()
-	var/datum/antagonist/cult/new_cultist = new()
+	var/datum/antagonist/cult/new_cultist = new
 	new_cultist.cult_team = get_team()
 	new_cultist.give_equipment = TRUE
 	if(isobserver(spender))
-		var/mob/living/carbon/human/newmob = spender.change_mob_type( /mob/living/carbon/human , null, null, TRUE )
-		newmob.equipOutfit(/datum/outfit/job/assistant)
-		newmob.mind.add_antag_datum(new_cultist)
+		var/mob/living/carbon/human/new_mob = spender.change_mob_type( /mob/living/carbon/human, delete_old_mob = TRUE)
+		new_mob.equipOutfit(/datum/outfit/job/assistant)
+		new_mob.mind.add_antag_datum(new_cultist)
 	else
 		hosts_mind.add_antag_datum(new_cultist)

--- a/code/modules/antagonists/paradox_clone/paradox_clone.dm
+++ b/code/modules/antagonists/paradox_clone/paradox_clone.dm
@@ -112,7 +112,7 @@
 		if(istype(warp_point.loc, /area/station/maintenance) && is_safe_turf(warp_point))
 			possible_spawns += warp_point
 	if(!possible_spawns.len)
-		message_admins("No valid spawn locations found for Paradox Clone token , aborting...")
+		message_admins("No valid spawn locations found for Paradox Clone token, aborting...")
 		return MAP_ERROR
 
 

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -753,12 +753,3 @@
 #undef HEAD_UPDATE_PERIOD
 #undef REVOLUTION_VICTORY
 #undef STATION_VICTORY
-
-/datum/antagonist/rev/head/antag_token(datum/mind/hosts_mind, mob/spender)
-	. = ..()
-	if(isobserver(spender))
-		var/mob/living/carbon/human/newmob = spender.change_mob_type( /mob/living/carbon/human , null, null, TRUE )
-		newmob.equipOutfit(/datum/outfit/job/assistant)
-		newmob.mind.make_rev()
-	else
-		hosts_mind.make_rev()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -400,12 +400,3 @@
 
 #undef FLAVOR_FACTION_SYNDICATE
 #undef FLAVOR_FACTION_NANOTRASEN
-
-/datum/antagonist/traitor/antag_token(datum/mind/hosts_mind, mob/spender)
-	. = ..()
-	if(isobserver(spender))
-		var/mob/living/carbon/human/newmob = spender.change_mob_type( /mob/living/carbon/human , null, null, TRUE )
-		newmob.equipOutfit(/datum/outfit/job/assistant)
-		newmob.mind.make_traitor()
-	else
-		hosts_mind.make_traitor()

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -25,8 +25,8 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 
 /datum/antagonist/wizard/antag_token(datum/mind/hosts_mind, mob/spender)
 	if(isobserver(spender))
-		var/mob/living/carbon/human/newmob = spender.change_mob_type( /mob/living/carbon/human , null, null, TRUE )
-		newmob.mind.make_wizard()
+		var/mob/living/carbon/human/new_mob = spender.change_mob_type(/mob/living/carbon/human , delete_old_mob = TRUE)
+		new_mob.mind.make_wizard()
 	else
 		hosts_mind.make_wizard()
 

--- a/config/monkestation/antag-tokens.toml
+++ b/config/monkestation/antag-tokens.toml
@@ -1,0 +1,3 @@
+low = ["traitor", "florida_man", "paradox_clone"]
+medium = ["heretic", "bloodsucker"]
+high = ["cult", "rev/head", "wizard", "clock_cultist", "ninja"]

--- a/monkestation/code/modules/antagonists/_common/antag_datum.dm
+++ b/monkestation/code/modules/antagonists/_common/antag_datum.dm
@@ -1,2 +1,8 @@
 /datum/antagonist/proc/antag_token(datum/mind/hosts_mind, mob/spender)
-	return
+	SHOULD_CALL_PARENT(FALSE)
+	if(isobserver(spender))
+		var/mob/living/carbon/human/new_mob = spender.change_mob_type(/mob/living/carbon/human, delete_old_mob = TRUE)
+		new_mob.equipOutfit(/datum/outfit/job/assistant)
+		new_mob.mind.add_antag_datum(type)
+	else
+		hosts_mind.add_antag_datum(type)

--- a/monkestation/code/modules/antagonists/clock_cult/antag_datums/clock_cultist.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/antag_datums/clock_cultist.dm
@@ -126,15 +126,6 @@
 		to_chat(owner.current, span_warning("You feel something pushing away the light of Rat'var, but you resist it!"))
 	return
 
-/datum/antagonist/clock_cultist/antag_token(datum/mind/hosts_mind, mob/spender)
-	. = ..()
-	if(isobserver(spender))
-		var/mob/living/carbon/human/newmob = spender.change_mob_type(/mob/living/carbon/human , null, null, TRUE)
-		newmob.equipOutfit(/datum/outfit/job/assistant)
-		newmob.mind.add_antag_datum(/datum/antagonist/clock_cultist)
-	else
-		hosts_mind.add_antag_datum(/datum/antagonist/clock_cultist)
-
 /datum/antagonist/clock_cultist/admin_add(datum/mind/new_owner,mob/admin)
 	new_owner.add_antag_datum(src)
 	message_admins("[key_name_admin(admin)] has made [key_name_admin(new_owner)] into a servant of Rat'var.")

--- a/monkestation/code/modules/antagonists/florida_man/_florida_man.dm
+++ b/monkestation/code/modules/antagonists/florida_man/_florida_man.dm
@@ -55,8 +55,8 @@
 /datum/antagonist/florida_man/antag_token(datum/mind/hosts_mind, mob/spender)
 	. = ..()
 	if(isobserver(spender))
-		var/mob/living/carbon/human/newmob = spender.change_mob_type( /mob/living/carbon/human , null, null, TRUE )
-		newmob.equipOutfit(/datum/outfit/florida_man_three)
-		newmob.mind.add_antag_datum(/datum/antagonist/florida_man)
+		var/mob/living/carbon/human/new_mob = spender.change_mob_type(/mob/living/carbon/human, delete_old_mob = TRUE)
+		new_mob.equipOutfit(/datum/outfit/florida_man_three)
+		new_mob.mind.add_antag_datum(/datum/antagonist/florida_man)
 	else
 		hosts_mind.add_antag_datum(/datum/antagonist/florida_man)

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
@@ -486,12 +486,3 @@
 			gourmand_objective.owner = owner
 			gourmand_objective.objective_name = "Optional Objective"
 			objectives += gourmand_objective
-
-/datum/antagonist/bloodsucker/antag_token(datum/mind/hosts_mind, mob/spender)
-	. = ..()
-	if(isobserver(spender))
-		var/mob/living/carbon/human/newmob = spender.change_mob_type( /mob/living/carbon/human , null, null, TRUE )
-		newmob.equipOutfit(/datum/outfit/job/assistant)
-		newmob.mind.make_bloodsucker(hosts_mind)
-	else
-		hosts_mind.make_bloodsucker(hosts_mind)

--- a/monkestation/code/modules/client/verbs.dm
+++ b/monkestation/code/modules/client/verbs.dm
@@ -1,22 +1,6 @@
-GLOBAL_LIST_INIT(high_threat_antags, list(
-	/datum/antagonist/cult,
-	/datum/antagonist/rev/head,
-	/datum/antagonist/wizard,
-	/datum/antagonist/clock_cultist,
-	/datum/antagonist/ninja,
-))
+GLOBAL_LIST_INIT(antag_token_config, load_antag_token_config())
 
-GLOBAL_LIST_INIT(medium_threat_antags, list(
-	/datum/antagonist/heretic,
-	/datum/antagonist/bloodsucker,
-))
-
-GLOBAL_LIST_INIT(low_threat_antags, list(
-	/datum/antagonist/florida_man,
-	/datum/antagonist/traitor,
-	/datum/antagonist/paradox_clone,
-))
-
+#define ANTAG_TOKEN_CONFIG_FILE "config/monkestation/antag-tokens.toml"
 #define ADMIN_APPROVE_ANTAG_TOKEN(user) "(<A href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];approve_antag_token=[REF(user)]'>Yes</a>)"
 #define ADMIN_REJECT_ANTAG_TOKEN(user) "(<A href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];reject_antag_token=[REF(user)]'>No</a>)"
 #define ADMIN_APPROVE_TOKEN_EVENT(user) "(<A href='?_src_=holder;[HrefToken(forceGlobal = TRUE)];approve_token_event=[REF(user)]'>Yes</a>)"
@@ -62,15 +46,14 @@ GLOBAL_LIST_INIT(low_threat_antags, list(
 				if(client_token_holder.total_low_threat_tokens <= 0)
 					return
 
-	var/datum/antagonist/chosen_antagonist
-	var/static/list/token_values = list(
-		HIGH_THREAT = GLOB.high_threat_antags,
-		MEDIUM_THREAT = GLOB.medium_threat_antags,
-		LOW_THREAT = GLOB.low_threat_antags,
-	)
-	chosen_antagonist = tgui_input_list(src, "Choose an Antagonist", "Spend Tokens", token_values[tier])
-	if(!chosen_antagonist)
+	var/list/chosen_tier = GLOB.antag_token_config[tier]
+	to_chat(world, span_boldbig("tier=[tier] / [length(chosen_tier)]"))
+	var/antag_key = tgui_input_list(src, "Choose an Antagonist", "Spend Tokens", chosen_tier)
+	to_chat(world, span_boldbig("antag_key=[antag_key]"))
+	if(!antag_key || !chosen_tier[antag_key])
 		return
+	var/datum/antagonist/chosen_antagonist = chosen_tier[antag_key]
+	to_chat(world, span_boldbig("chosen_antagonist=[chosen_antagonist]"))
 
 	client_token_holder.queued_donor = using_donor
 	client_token_holder.in_queued_tier = tier
@@ -79,7 +62,7 @@ GLOBAL_LIST_INIT(low_threat_antags, list(
 	to_chat(src, span_boldnotice("Your request has been sent to the admins."))
 	SEND_NOTFIED_ADMIN_MESSAGE('sound/items/bikehorn.ogg', "[span_admin("[span_prefix("ANTAG TOKEN:")] <EM>[key_name(src)]</EM> \
 							[ADMIN_APPROVE_ANTAG_TOKEN(src)] [ADMIN_REJECT_ANTAG_TOKEN(src)] | \
-							[src] has requested to use their antag token to be a [chosen_antagonist].")]")
+							[src] has requested to use their antag token to be a [chosen_antagonist::name].")]")
 
 /client/verb/trigger_token_event()
 	set category = "IC"
@@ -118,6 +101,57 @@ GLOBAL_LIST_INIT(low_threat_antags, list(
 			return
 		to_chat(src, "You dont have enough tokens to trigger this event.")
 
+/proc/init_antag_list(list/antag_types)
+	. = list()
+	for(var/datum/antagonist/antag_type as anything in antag_types)
+		if(istext(antag_type))
+			antag_type = text2path("/datum/antagonist/[antag_type]")
+		if(!ispath(antag_type))
+			continue
+		.[antag_type::name] = antag_type
+
+/proc/load_antag_token_config(list/antag_types)
+	var/static/default_config = list(
+		HIGH_THREAT = init_antag_list(list(
+			/datum/antagonist/cult,
+			/datum/antagonist/rev/head,
+			/datum/antagonist/wizard,
+			/datum/antagonist/clock_cultist,
+			/datum/antagonist/ninja
+		)),
+		MEDIUM_THREAT = init_antag_list(list(
+			/datum/antagonist/heretic,
+			/datum/antagonist/bloodsucker
+		)),
+		LOW_THREAT = init_antag_list(list(
+			/datum/antagonist/florida_man,
+			/datum/antagonist/traitor,
+			/datum/antagonist/paradox_clone
+		))
+	)
+	var/static/list/toml_keys = list(
+		"high" = HIGH_THREAT,
+		"medium" = MEDIUM_THREAT,
+		"low" = LOW_THREAT
+	)
+	if(!fexists(ANTAG_TOKEN_CONFIG_FILE))
+		log_config("No antag token config file found, using default config.")
+		return default_config
+	var/list/token_config = rustg_read_toml_file(ANTAG_TOKEN_CONFIG_FILE)
+	if(!length(token_config))
+		log_config("Antag token config file is empty, using default config.")
+		return default_config
+	. = list(
+		HIGH_THREAT = list(),
+		MEDIUM_THREAT = list(),
+		LOW_THREAT = list()
+	)
+	for(var/toml_key in toml_keys)
+		var/list/tier_name = toml_keys[toml_key]
+		var/list/token_list = token_config[toml_key]
+		.[tier_name] = init_antag_list(token_list)
+
+#undef ANTAG_TOKEN_CONFIG_FILE
 #undef ADMIN_APPROVE_ANTAG_TOKEN
 #undef ADMIN_REJECT_ANTAG_TOKEN
 #undef ADMIN_APPROVE_TOKEN_EVENT


### PR DESCRIPTION
## About The Pull Request

- Makes the token redeemable antags config-based instead of hardcoded. It still defaults to exactly what it was before, tho.
- The menu to choose an antag now shows the antag's name instead of the datum typepath.
- Cleaned up unneeded repetitive code for antag token granting.

## Why It's Good For The Game

Allows new antags to be added/removed from token redeems without a PR or changing the code, it's all a server-side config now.

Also makes the menu a bit less confusing, and reduces shitcode.

## Testing Screenshots

![2024-02-22 (1708619682) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/36486acd-5fb1-43ad-9967-de663f1f96f4)
![2024-02-22 (1708620392) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/9834cddd-f61d-4644-9877-fdc201aeac37)
![2024-02-22 (1708620399) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/feac9090-1da8-4cc8-b5f5-c5e32d0b4967)
![2024-02-22 (1708621602) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/cb605aab-a200-449e-bd87-804962287f0f)
![2024-02-22 (1708621612) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/a2df1929-3e0c-42b4-80a3-4ee7aeb5032d)


## Changelog
:cl:
refactor: Cleaned up unneeded repetitive code for antag token granting
config: Token redeemable antags are now config-based instead of hardcoded.
fix: The menu to choose an antag now shows the antag's name instead of the datum typepath.
/:cl:
