### PR TITLE
Sleeping carp deflect projection deflection also works in combat mode

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -138,7 +138,10 @@
 	return ..()
 
 /datum/martial_art/the_sleeping_carp/proc/can_deflect(mob/living/carp_user)
-	if(!can_use(carp_user) || !carp_user.throw_mode)
+	if(!can_use(carp_user))
+		return FALSE
+	// monke edit: allow deflecting in combat mode too
+	if(!carp_user.throw_mode && !(carp_user.istate & ISTATE_BLOCKING))
 		return FALSE
 	if(carp_user.incapacitated(IGNORE_GRAB)) //NO STUN
 		return FALSE
@@ -191,7 +194,7 @@
 	[span_notice("Gnashing Teeth")]: Punch Punch. Deal additional damage every second (consecutive) punch!\n\
 	[span_notice("Crashing Wave Kick")]: Punch Shove. Launch your opponent away from you with incredible force!\n\
 	[span_notice("Keelhaul")]: Punch Grab. Kick an opponent to the floor, knocking them down! If your opponent is already prone, this move will disarm them and deal additional stamina damage to them.\n\
-	<span class='notice'>While in throw mode (and not stunned, not a hulk, and not in a mech), you can reflect all projectiles that come your way, sending them back at the people who fired them! \
+	<span class='notice'>While in throw or combat mode (and not stunned, not a hulk, and not in a mech), you can reflect all projectiles that come your way, sending them back at the people who fired them! \
 	Also, you are more resilient against suffering wounds in combat, and your limbs cannot be dismembered. This grants you extra staying power during extended combat, especially against slashing and other bleeding weapons. \
 	You are not invincible, however- while you may not suffer debilitating wounds often, you must still watch your health and should have appropriate medical supplies for use during downtime. \
 	In addition, your training has imbued you with a loathing of guns, and you can no longer use them.</span>")


### PR DESCRIPTION
## Why It's Good For The Game

Throw mode is finnicky and is way too easy to accidentally disable with a wrong click.

## Changelog
:cl:
qol: Sleeping carp projection deflection now also works in combat mode (or grab/harm if you use intents). It still also works in throw mode.
/:cl:
