### PR TITLE
You can now light cigarettes on ethereals!

### DIFF
--- a/monkestation/code/modules/mob/living/carbon/human/species_type/ethereal.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/ethereal.dm
@@ -9,3 +9,20 @@
 		HAIR,
 		FACEHAIR,
 	)
+
+/datum/species/ethereal/on_species_gain(mob/living/carbon/new_ethereal, datum/species/old_species, pref_load)
+	. = ..()
+	RegisterSignal(new_ethereal, COMSIG_ATOM_AFTER_ATTACKEDBY, PROC_REF(on_after_attackedby))
+
+/datum/species/ethereal/on_species_loss(mob/living/carbon/human/former_ethereal, datum/species/new_species, pref_load)
+	. = ..()
+	UnregisterSignal(former_ethereal, COMSIG_ATOM_AFTER_ATTACKEDBY)
+
+/datum/species/ethereal/proc/on_after_attackedby(mob/living/lightbulb, obj/item/item, mob/living/user, proximity_flag, click_parameters)
+	SIGNAL_HANDLER
+	var/obj/item/clothing/mask/cigarette/cig = item
+	if(!proximity_flag || !istype(cig) || !istype(user) || cig.lit)
+		return
+	cig.light()
+	user.visible_message(span_notice("[user] quickly strikes [item] across [lightbulb]'s skin, [lightbulb.p_their()] warmth lighting it!"))
+	return COMPONENT_NO_AFTERATTACK


### PR DESCRIPTION
## Why It's Good For The Game

it's funny, and a new way of harmlessly screwing with @KittyNoodle

## Testing Proof

![2024-02-23 (1708739196) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/0d189238-d46f-4642-9c10-37c00f99bc02)

## Changelog
:cl:
add: You can now light cigarettes by striking it across your local ethereal! Don't worry, it doesn't harm them, although they may find it annoying.
/:cl:
