### PR TITLE
Allows arachnids to pick their gender and technically their body type

### DIFF
--- a/monkestation/code/modules/mob/living/carbon/human/species_type/arachnid.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/arachnid.dm
@@ -3,7 +3,7 @@
 	plural_form = "Arachnids"
 	id = SPECIES_ARACHNIDS
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN
-	sexes = FALSE
+	visual_gender = FALSE
 	species_traits = list(
 		MUTCOLORS,
 		EYECOLOR,


### PR DESCRIPTION

## About The Pull Request
Allows players to select their gender if they are an arachnid during character creation. You can also select your bodytype however this has no visual changes, much like lizards.
## Why It's Good For The Game
I see no reason why they should be restricted from having a gender. Let people use their pronouns.
## Changelog
:cl:
add: Arachnids have adopted the concept of gender.
/:cl:
