### PR TITLE
[PORT] Air alarms display location/trigger information

### DIFF
--- a/code/__DEFINES/atmospherics/atmos_machinery.dm
+++ b/code/__DEFINES/atmospherics/atmos_machinery.dm
@@ -41,6 +41,22 @@
 /// Air alarm has all components but isn't completed
 #define AIR_ALARM_BUILD_COMPLETE 2
 
+// Fire alarm buildstage [/obj/machinery/firealarm/buildstage]
+/// Fire alarm missing circuit
+#define FIRE_ALARM_BUILD_NO_CIRCUIT 0
+/// Fire alarm has circuit but is missing wires
+#define FIRE_ALARM_BUILD_NO_WIRES 1
+/// Fire alarm has all components but isn't completed
+#define FIRE_ALARM_BUILD_SECURED 2
+
+// Fault levels for air alarm display
+/// Area faults clear
+#define AREA_FAULT_NONE 0
+/// Fault triggered by manual intervention (ie: fire alarm pull)
+#define AREA_FAULT_MANUAL 1
+/// Fault triggered automatically (ie: firedoor detection)
+#define AREA_FAULT_AUTOMATIC 2
+
 // threshold_type values for [/datum/tlv/proc/set_value]  and [/datum/tlv/proc/reset_value]
 /// [/datum/tlv/var/warning_min]
 #define TLV_VAR_WARNING_MIN (1 << 0)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -36,6 +36,10 @@
 	var/list/firealarms = list()
 	///Alarm type to count of sources. Not usable for ^ because we handle fires differently
 	var/list/active_alarms = list()
+	/// The current alarm fault status
+	var/fault_status = AREA_FAULT_NONE
+	/// The source machinery for the area's fault status
+	var/fault_location
 	///List of all lights in our area
 	var/list/lights = list()
 	///We use this just for fire alarms, because they're area based right now so one alarm going poof shouldn't prevent you from clearing your alarms listing. Fire alarms and fire locks will set and clear alarms.
@@ -316,10 +320,15 @@ GLOBAL_LIST_EMPTY(teleportlocs)
  *
  * Allows interested parties (lights and fire alarms) to react
  */
-/area/proc/set_fire_effect(new_fire)
+/area/proc/set_fire_effect(new_fire, fault_type, fault_source)
 	if(new_fire == fire)
 		return
 	fire = new_fire
+	fault_status = fault_type
+	if(fire)
+		fault_location = fault_source
+	else
+		fault_location = null
 	SEND_SIGNAL(src, COMSIG_AREA_FIRE_CHANGED, fire)
 
 /**

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -76,9 +76,12 @@
 
 /obj/machinery/door/firedoor/Initialize(mapload)
 	. = ..()
+	id_tag = assign_random_name()
 	soundloop = new(src, FALSE)
 	CalculateAffectingAreas()
 	my_area = get_area(src)
+	if(name == initial(name))
+		update_name()
 	if(!merger_typecache)
 		merger_typecache = typecacheof(/obj/machinery/door/firedoor)
 
@@ -181,6 +184,10 @@
 				return CONTEXTUAL_SCREENTIP_SET
 
 	return .
+
+/obj/machinery/door/firedoor/update_name(updates)
+	. = ..()
+	name = "[get_area_name(my_area)] [initial(name)] [id_tag]"
 
 /**
  * Calculates what areas we should worry about.
@@ -324,6 +331,8 @@
 		return //We're already active
 	soundloop.start()
 	is_playing_alarm = TRUE
+	my_area.fault_status = AREA_FAULT_AUTOMATIC
+	my_area.fault_location = name
 	var/datum/merger/merge_group = GetMergeGroup(merger_id, merger_typecache)
 	for(var/obj/machinery/door/firedoor/buddylock as anything in merge_group.members)
 		buddylock.activate(code)
@@ -336,6 +345,8 @@
 /obj/machinery/door/firedoor/proc/start_deactivation_process()
 	soundloop.stop()
 	is_playing_alarm = FALSE
+	my_area.fault_status = AREA_FAULT_NONE
+	my_area.fault_location = null
 	var/datum/merger/merge_group = GetMergeGroup(merger_id, merger_typecache)
 	for(var/obj/machinery/door/firedoor/buddylock as anything in merge_group.members)
 		buddylock.reset()
@@ -372,7 +383,7 @@
 		if(LAZYLEN(place.active_firelocks) != 1)
 			continue
 		//if we're the first to activate in this particular area
-		place.set_fire_effect(TRUE) //bathe in red
+		place.set_fire_effect(TRUE, AREA_FAULT_AUTOMATIC, name) //bathe in red
 		if(place == my_area)
 			// We'll limit our reporting to just the area we're on. If the issue affects bordering areas, they can report it themselves
 			place.alarm_manager.send_alarm(ALARM_FIRE, place)
@@ -432,7 +443,7 @@
 		LAZYREMOVE(place.active_firelocks, src)
 		if(LAZYLEN(place.active_firelocks)) // If we were the last firelock still active, clear the area effects
 			continue
-		place.set_fire_effect(FALSE)
+		place.set_fire_effect(FALSE, AREA_FAULT_NONE, name)
 		if(place == my_area)
 			place.alarm_manager.clear_alarm(ALARM_FIRE, place)
 

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -50,11 +50,12 @@
 
 /obj/machinery/firealarm/Initialize(mapload, dir, building)
 	. = ..()
+	id_tag = assign_random_name()
 	if(building)
 		buildstage = ALARM_NO_CIRCUIT
 		set_panel_open(TRUE)
 	if(name == initial(name))
-		name = "[get_area_name(src)] [initial(name)]"
+		update_name()
 	my_area = get_area(src)
 	LAZYADD(my_area.firealarms, src)
 
@@ -114,7 +115,7 @@
 
 /obj/machinery/firealarm/update_name(updates)
 	. = ..()
-	name = "[get_area_name(my_area)] [initial(name)]"
+	name = "[get_area_name(my_area)] [initial(name)] [id_tag]"
 
 /obj/machinery/firealarm/on_exit_area(datum/source, area/area_to_unregister)
 	//we cannot unregister from an area we never registered to in the first place
@@ -259,6 +260,8 @@
 	if(user)
 		balloon_alert(user, "triggered alarm!")
 		user.log_message("triggered a fire alarm.", LOG_GAME)
+	my_area.fault_status = AREA_FAULT_MANUAL
+	my_area.fault_location = name
 	soundloop.start() //Manually pulled fire alarms will make the sound, rather than the doors.
 	SEND_SIGNAL(src, COMSIG_FIREALARM_ON_TRIGGER)
 	update_use_power(ACTIVE_POWER_USE)
@@ -476,6 +479,7 @@
 	. = ..()
 	if((my_area?.fire || LAZYLEN(my_area?.active_firelocks)))
 		. += "The local area hazard light is flashing."
+		. += "The fault location display is [my_area.fault_location] ([my_area.fault_status == AREA_FAULT_AUTOMATIC ? "Automatic Detection" : "Manual Trigger"])."
 		if(is_station_level(z))
 			. += "The station security alert level is [SSsecurity_level.get_current_level_as_text()]."
 		. += "<b>Left-Click</b> to activate all firelocks in this area."

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -161,6 +161,8 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 	data["dangerLevel"] = danger_level
 	data["atmosAlarm"] = !!my_area.active_alarms[ALARM_ATMOS]
 	data["fireAlarm"] = my_area.fire
+	data["faultStatus"] = my_area.fault_status
+	data["faultLocation"] = my_area.fault_location
 
 	var/turf/turf = get_turf(src)
 	var/datum/gas_mixture/environment = turf.return_air()

--- a/tgui/packages/tgui/interfaces/AirAlarm.tsx
+++ b/tgui/packages/tgui/interfaces/AirAlarm.tsx
@@ -13,6 +13,10 @@ type AirAlarmData = {
   dangerLevel: 0 | 1 | 2;
   atmosAlarm: BooleanLike; // fix this
   fireAlarm: BooleanLike;
+  faultStatus: 0 | 1 | 2;
+  faultLocation: string;
+  sensor: BooleanLike;
+  allowLinkChange: BooleanLike;
   envData: {
     name: string;
     value: string; // preformatted in backend, shorter code that way.
@@ -72,7 +76,22 @@ const AirAlarmStatus = (props, context) => {
       localStatusText: 'Danger (Internals Required)',
     },
   };
+  const faultMap = {
+    0: {
+      color: 'green',
+      areaFaultText: 'None',
+    },
+    1: {
+      color: 'purple',
+      areaFaultText: 'Manual Trigger',
+    },
+    2: {
+      color: 'average',
+      areaFaultText: 'Automatic Detection',
+    },
+  };
   const localStatus = dangerMap[data.dangerLevel] || dangerMap[0];
+  const areaFault = faultMap[data.faultStatus] || faultMap[0];
   return (
     <Section title="Air Status">
       <LabeledList>
@@ -89,15 +108,23 @@ const AirAlarmStatus = (props, context) => {
                 </LabeledList.Item>
               );
             })}
-            <LabeledList.Item label="Local status" color={localStatus.color}>
+            <LabeledList.Item label="Local Status" color={localStatus.color}>
               {localStatus.localStatusText}
             </LabeledList.Item>
             <LabeledList.Item
-              label="Area status"
+              label="Area Status"
               color={data.atmosAlarm || data.fireAlarm ? 'bad' : 'good'}>
               {(data.atmosAlarm && 'Atmosphere Alarm') ||
                 (data.fireAlarm && 'Fire Alarm') ||
                 'Nominal'}
+            </LabeledList.Item>
+            <LabeledList.Item label="Fault Status" color={areaFault.color}>
+              {areaFault.areaFaultText}
+            </LabeledList.Item>
+            <LabeledList.Item
+              label="Fault Location"
+              color={data.faultLocation ? 'blue' : 'green'}>
+              {data.faultLocation || 'None'}
             </LabeledList.Item>
           </>
         )) || (


### PR DESCRIPTION

## About The Pull Request
Ports

- #81436
## Why It's Good For The Game
Nice qol feature for engineers and atmos techs, tho it's useful for everyone in case of a firelock hell.
## Testing Screenshots

![airalarm](https://github.com/Monkestation/Monkestation2.0/assets/152086196/13dfd4e9-7584-4191-b423-2c30bfc40294)

## Changelog
:cl: lessthnthree
qol: Air alarms now display the source of triggered fire alarms/firedoors
/:cl:
