### PR TITLE
Equalizes pay for all roundstart races

### DIFF
--- a/monkestation/code/modules/mob/living/carbon/human/species_type/ethereal.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/ethereal.dm
@@ -2,6 +2,7 @@
 	return 'monkestation/sound/voice/laugh/ethereal/ethereal_laugh_1.ogg'
 
 /datum/species/ethereal
+	payday_modifier = 1
 	sexes = TRUE
 	species_traits = list(
 		DYNCOLORS,

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/floran.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/floran.dm
@@ -24,7 +24,6 @@
 	heatmod = 0.67 //Same as lizard people
 	coldmod = 1.5 //Same as lizard people
 	speedmod = -0.1 //Same as arachnids
-	payday_modifier = 0.75
 	meat = /obj/item/food/meat/slab/human/mutant/plant
 	exotic_blood = /datum/reagent/water
 	// disliked_food = VEGETABLES | FRUIT | GRAIN

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/flypeople.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/flypeople.dm
@@ -1,3 +1,6 @@
+/datum/species/fly
+	payday_modifier = 1
+
 /datum/species/fly/get_scream_sound(mob/living/carbon/human/human)
 	if(human.gender == MALE)
 		if(prob(1))

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/goblin.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/goblin.dm
@@ -29,7 +29,7 @@
 	maxhealthmod = 0.75
 	stunmod = 0.75
 	speedmod = -0.25
-	payday_modifier = 0.75
+	payday_modifier = 1
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/goblin,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/goblin,

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/lizardpeople.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/lizardpeople.dm
@@ -1,3 +1,6 @@
+/datum/species/lizard
+	payday_modifier = 1
+
 /datum/species/lizard/get_scream_sound(mob/living/carbon/human/human)
 	if(human.gender ==MALE)
 		return pick(

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/plasmamen.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/plasmamen.dm
@@ -1,2 +1,5 @@
+/datum/species/plasmaman
+	payday_modifier = 1
+
 /datum/species/plasmaman/get_laugh_sound(mob/living/carbon/human/human)
 	return 'monkestation/sound/voice/laugh/skeleton/skeleton_laugh.ogg'


### PR DESCRIPTION

## About The Pull Request
Removes the 25% decrease to pay for lizards, ethereals, plasmamen, flies, florans, and goblins.
## Why It's Good For The Game
I don't like space racism
## Changelog
:cl:
add: Equalized pay for most roundstart species.
/:cl:
