### PR TITLE
damned rabbit mask antifacehugger flag

### DIFF
--- a/monkestation/code/modules/bloodsuckers/monster_hunters/hunter_weapons.dm
+++ b/monkestation/code/modules/bloodsuckers/monster_hunters/hunter_weapons.dm
@@ -363,6 +363,7 @@
 	icon_state = "rabbit_mask"
 	worn_icon = 'monkestation/icons/bloodsuckers/worn_mask.dmi'
 	worn_icon_state = "rabbit_mask"
+	clothing_flags = SNUG_FIT
 	flags_inv = HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	flash_protect = FLASH_PROTECTION_WELDER


### PR DESCRIPTION

## About The Pull Request

FIXES #1274 

## Why It's Good For The Game

The tag says it protects from facehuggers. This should keep from being knocked off.

## Changelog

:cl:
fix: damned rabbit mask no longer can be knocked off and provides protection from facehuggers.
/:cl:
