### PR TITLE
Bug Fix Pass Again

### DIFF
--- a/_maps/~monkestation/RandomBars/Icebox/MaidCafe.dmm
+++ b/_maps/~monkestation/RandomBars/Icebox/MaidCafe.dmm
@@ -93,12 +93,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
 /area/station/commons/lounge)
-"mu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/large,
-/area/station/commons/lounge)
 "mC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -880,7 +874,7 @@ zS
 zS
 VG
 zS
-mu
+zS
 zS
 Bx
 if

--- a/_maps/~monkestation/RandomEngines/MetaStation/singularity.dmm
+++ b/_maps/~monkestation/RandomEngines/MetaStation/singularity.dmm
@@ -603,11 +603,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "Rw" = (
-/obj/structure/grille,
 /obj/machinery/camera/emp_proof/directional/west{
 	c_tag = "Singularity Engine #4"
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/station/engineering/supermatter/room)
 "Sh" = (
 /obj/effect/turf_decal/stripes/line,

--- a/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
+++ b/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
@@ -78,6 +78,7 @@
 
 /datum/job/cargo_technician
 	alt_titles = list(
+		"Cargo Technician",
 		"Warehouse Technician",
 		"Deck Worker",
 		"Mailman",
@@ -258,6 +259,7 @@
 
 /datum/job/quartermaster
 	alt_titles = list(
+		"Quartermaster",
 		"Union Requisitions Officer",
 		"Deck Chief",
 		"Warehouse Supervisor",
@@ -312,6 +314,7 @@
 
 /datum/job/shaft_miner
 	alt_titles = list(
+		"Shaft Miner",
 		"Union Miner",
 		"Excavator",
 		"Spelunker",


### PR DESCRIPTION

## About The Pull Request

Takes fixes I had included in a different PR and moves them to a separate PR as the other PR will be closed in short order. Fixes as follows:

Fixes titles removed from Cargo jobs. (Thanks to the 3 AM crew for helping me investigate that shit a few days ago)
Removes an extra pipe on the Icebox Maid Cafe random bar (Causes integration test failures one after another)
Fixes the Metastation Singularity Engine template so integration tests don't fail.

## Why It's Good For The Game

It's bug fixes. If this is somehow controversial now, I will stop contributions.

## Changelog
:cl:
fix: Baseline job titles for Cargo Tech, Quartermaster and Shaft Miner return.
del: Removed a single extra air pipe on the Icebox Maid Cafe so it stops causing 11 lines of test failures
fix: Tweaks the Metastation Singularity Engine Complex to also stop unit test failures.
/:cl:
