### PR TITLE
Fix dissection experiment not working

### DIFF
--- a/code/game/machinery/computer/operating_computer.dm
+++ b/code/game/machinery/computer/operating_computer.dm
@@ -25,12 +25,15 @@
 
 /obj/machinery/computer/operating/LateInitialize()
 	. = ..()
-
+	var/static/list/dissection_signals = list(
+		COMSIG_OPERATING_COMPUTER_DISSECTION_COMPLETE = TYPE_PROC_REF(/datum/component/experiment_handler, try_run_dissection_experiment)
+	)
 	experiment_handler = AddComponent(
 		/datum/component/experiment_handler, \
 		allowed_experiments = list(/datum/experiment/dissection), \
 		config_flags = EXPERIMENT_CONFIG_ALWAYS_ACTIVE, \
 		config_mode = EXPERIMENT_CONFIG_ALTCLICK, \
+		experiment_signals = dissection_signals, \
 	)
 
 /obj/machinery/computer/operating/Destroy()


### PR DESCRIPTION
It was broken around https://github.com/Monkestation/Monkestation2.0/commit/906dae530607598bdbc7102e8a2ae7126463faf6, as nothing ever gave the dissection completion signal as an argument to the operating computer's AddComponent.

Fixes https://github.com/Monkestation/Monkestation2.0/issues/980.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fix dissection experiment never completing.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
