### PR TITLE
Air Conditioning!: Air alarms now help restore a room's temperature.

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -277,6 +277,7 @@
 /obj/machinery/door/firedoor/proc/adjacent_change(turf/changed, path, list/new_baseturfs, flags, list/post_change_callbacks)
 	SIGNAL_HANDLER
 	post_change_callbacks += CALLBACK(src, PROC_REF(CalculateAffectingAreas))
+	post_change_callbacks += CALLBACK(src, PROC_REF(process_results), changed) //check the atmosphere of the changed turf so we don't hold onto alarm if a wall is built
 
 /obj/machinery/door/firedoor/proc/check_atmos(turf/checked_turf)
 	var/datum/gas_mixture/environment = checked_turf.return_air()

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -402,6 +402,30 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 			if (alarm_manager.clear_alarm(ALARM_ATMOS))
 				danger_level = AIR_ALARM_ALERT_NONE
 
+		/* monke start: air conditioning: */
+		if("air_conditioning")
+			if(!isnum(params["value"]))
+				return
+			if(params["value"])
+				stop_ac()
+			else
+				start_ac()
+			investigate_log("has had its air conditioning turned [air_conditioning ? "on" : "off"] by [key_name(usr)]", INVESTIGATE_ATMOS)
+			. = TRUE
+
+		if("set_ac_target")
+			if(!isnum(params["target"]))
+				return
+			set_ac_target(params["target"])
+			investigate_log("has had its air conditioning target set to [params["target"]] by [key_name(usr)]", INVESTIGATE_ATMOS)
+			. = TRUE
+
+		if("default_ac_target")
+			set_ac_target(initial(ac_temp_target))
+			investigate_log("has had its air conditioning target reset to default by [key_name(usr)]", INVESTIGATE_ATMOS)
+			. = TRUE
+		/* monke end */
+
 	update_appearance()
 
 	return TRUE

--- a/monkestation/code/modules/atmospherics/machinery/air_alarm/air_alarm_ac.dm
+++ b/monkestation/code/modules/atmospherics/machinery/air_alarm/air_alarm_ac.dm
@@ -86,7 +86,7 @@
 		var/previous_active = ac_active
 		ac_active = !ISINRANGE_EX(current_temp, cached_target_min, cached_target_max)
 		if(previous_active != ac_active)
-			visible_message(span_notice("[src] makes a quiet click as it [ac_active ? "starts trying to regulate" : "stops regulating"] the area's temperature."), span_hear("You hear a silent click."), vision_distance = 3)
+			visible_message(span_notice("[src] makes a quiet click as it [ac_active ? "starts trying to regulate" : "stops regulating"] the area's temperature."), blind_message = span_hear("You hear a silent click."), vision_distance = 3)
 			playsound(src, 'sound/machines/terminal_on.ogg', vol = 30, vary = TRUE, extrarange = SILENCED_SOUND_EXTRARANGE, ignore_walls = FALSE)
 			update_use_power(ac_active ? ACTIVE_POWER_USE : IDLE_POWER_USE)
 		COOLDOWN_START(src, ac_switch_cooldown, AC_SWITCH_COOLDOWN)

--- a/monkestation/code/modules/atmospherics/machinery/air_alarm/air_alarm_ac.dm
+++ b/monkestation/code/modules/atmospherics/machinery/air_alarm/air_alarm_ac.dm
@@ -1,0 +1,122 @@
+#define AC_MIN_TEMP			T20C - 5
+#define AC_MAX_TEMP			T20C + 10
+#define AC_DEFAULT_TARGET	T20C
+#define AC_TARGET_SKEW		2
+#define AC_SWITCH_COOLDOWN	5 SECONDS
+#define AC_DEFAULT_INC		1.5
+#define AC_ADJACENT_MUL		0.6
+
+/obj/machinery/airalarm
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION
+	/// Whether air conditioning is enabled or not.
+	var/air_conditioning = TRUE
+	/// Whether the air alarm is currently trying to actively regulate the temperature.
+	var/ac_active = FALSE
+	/// The amount of temperature (in K) the air conditioner will "push" towards the target temperature, per tick.
+	var/ac_temp_inc = AC_DEFAULT_INC
+	/// The minimum target temperature the air conditioner can be set to.
+	var/ac_temp_min = AC_MIN_TEMP
+	/// The maximum target temperature the air conditioner can be set to.
+	var/ac_temp_max = AC_MAX_TEMP
+	/// The target temperature the air conditioner is trying to reach, if active.
+	var/ac_temp_target = AC_DEFAULT_TARGET
+	/// The multiplier to [ac_temp_target] for tiles adjacent to the alarm.
+	var/ac_adjacent_mul = AC_ADJACENT_MUL
+	VAR_PRIVATE/cached_target_min = AC_DEFAULT_TARGET - AC_TARGET_SKEW
+	VAR_PRIVATE/cached_target_max = AC_DEFAULT_TARGET + AC_TARGET_SKEW
+	/// Cooldown for the air conditioning (de)activating, to prevent spam.
+	COOLDOWN_DECLARE(ac_switch_cooldown)
+
+/obj/machinery/airalarm/Initialize(mapload, ndir, nbuild)
+	. = ..()
+	if(air_conditioning)
+		SSair.start_processing_machine(src)
+
+/obj/machinery/airalarm/examine(mob/user)
+	. = ..()
+	. += span_notice("A small light indicates that the air conditioning is [span_bold(air_conditioning ? (ac_active ? "active" : "idle") : "disabled")].")
+
+/obj/machinery/airalarm/ui_data(mob/user)
+	. = ..()
+	.["ac"] = list(
+		"enabled" = air_conditioning,
+		"active" = ac_active,
+		"target" = ac_temp_target,
+		"min" = ac_temp_min,
+		"max" = ac_temp_max
+	)
+
+/obj/machinery/airalarm/proc/set_ac_target(new_target = AC_DEFAULT_TARGET)
+	if(new_target == ac_temp_target || !isnum(new_target) || !ISINRANGE(new_target, ac_temp_min, ac_temp_max))
+		return
+	ac_temp_target = new_target
+	cached_target_min = ac_temp_target - AC_TARGET_SKEW
+	cached_target_max = ac_temp_target + AC_TARGET_SKEW
+
+/obj/machinery/airalarm/proc/start_ac()
+	air_conditioning = TRUE
+	ac_active = FALSE
+	update_use_power(IDLE_POWER_USE)
+	SSair.start_processing_machine(src)
+
+/obj/machinery/airalarm/proc/stop_ac()
+	air_conditioning = FALSE
+	ac_active = FALSE
+	update_use_power(IDLE_POWER_USE)
+	SSair.stop_processing_machine(src)
+
+/obj/machinery/airalarm/process_atmos()
+	if(panel_open || (machine_stat & (NOPOWER | BROKEN)) || shorted)
+		return
+	if(!air_conditioning)
+		stop_ac()
+		return PROCESS_KILL
+	var/turf/open/location = get_turf(src)
+	if(!istype(location) || QDELING(location))
+		update_use_power(IDLE_POWER_USE)
+		ac_active = FALSE
+		return
+	var/datum/gas_mixture/environment = location.return_air()
+	if(QDELETED(environment))
+		update_use_power(IDLE_POWER_USE)
+		ac_active = FALSE
+		return
+	var/current_temp = environment.return_temperature()
+	if(COOLDOWN_FINISHED(src, ac_switch_cooldown))
+		var/previous_active = ac_active
+		ac_active = !ISINRANGE_EX(current_temp, cached_target_min, cached_target_max)
+		if(previous_active != ac_active)
+			visible_message(span_notice("[src] makes a quiet click as it [ac_active ? "starts trying to regulate" : "stops regulating"] the area's temperature."), span_hear("You hear a silent click."), vision_distance = 3)
+			playsound(src, 'sound/machines/terminal_on.ogg', vol = 30, vary = TRUE, extrarange = SILENCED_SOUND_EXTRARANGE, ignore_walls = FALSE)
+			update_use_power(ac_active ? ACTIVE_POWER_USE : IDLE_POWER_USE)
+		COOLDOWN_START(src, ac_switch_cooldown, AC_SWITCH_COOLDOWN)
+	if(ac_active)
+		if(current_temp < ac_temp_target)
+			environment.temperature = min(current_temp + ac_temp_inc, ac_temp_target)
+		else
+			environment.temperature = max(current_temp - ac_temp_inc, ac_temp_target)
+		air_update_turf(update = FALSE, remove = FALSE)
+		// Update the air of adjacent turfs too
+		if(!TURF_SHARES(location))
+			return
+		var/adjacent_inc = CEILING(ac_temp_inc * ac_adjacent_mul, 0.1)
+		for(var/turf/open/adjacent_turf in location.get_atmos_adjacent_turfs(alldir = TRUE))
+			if(QDELING(adjacent_turf) || isspaceturf(adjacent_turf))
+				continue
+			var/datum/gas_mixture/adj_environment = adjacent_turf.return_air()
+			if(QDELETED(adj_environment))
+				continue
+			var/adj_temp = adj_environment.return_temperature()
+			if(adj_temp < ac_temp_target)
+				adj_environment.temperature = min(adj_temp + adjacent_inc, ac_temp_target)
+			else
+				adj_environment.temperature = max(adj_temp - adjacent_inc, ac_temp_target)
+			adjacent_turf.air_update_turf(update = FALSE, remove = FALSE)
+
+#undef AC_ADJACENT_MUL
+#undef AC_DEFAULT_INC
+#undef AC_SWITCH_COOLDOWN
+#undef AC_TARGET_SKEW
+#undef AC_DEFAULT_TARGET
+#undef AC_MAX_TEMP
+#undef AC_MIN_TEMP

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5963,6 +5963,7 @@
 #include "monkestation\code\modules\art_sci_overrides\faults\warps.dm"
 #include "monkestation\code\modules\art_sci_overrides\faults\whispers.dm"
 #include "monkestation\code\modules\art_sci_overrides\faults\zap.dm"
+#include "monkestation\code\modules\atmospherics\machinery\air_alarm\air_alarm_ac.dm"
 #include "monkestation\code\modules\ballpit\ballbit_sink.dm"
 #include "monkestation\code\modules\ballpit\ballpit.dm"
 #include "monkestation\code\modules\bitrunners\code\ability_disks.dm"

--- a/tgui/packages/tgui/interfaces/AirAlarm.tsx
+++ b/tgui/packages/tgui/interfaces/AirAlarm.tsx
@@ -43,6 +43,13 @@ type AirAlarmData = {
     danger: BooleanLike;
   }[];
   thresholdTypeMap: Record<string, number>;
+  ac: {
+    enabled: BooleanLike;
+    active: BooleanLike;
+    target: number;
+    min: number;
+    max: number;
+  };
 };
 
 export const AirAlarm = (props, context) => {
@@ -118,6 +125,17 @@ const AirAlarmStatus = (props, context) => {
                 (data.fireAlarm && 'Fire Alarm') ||
                 'Nominal'}
             </LabeledList.Item>
+            <LabeledList.Item
+              label="Air Conditioning Status"
+              color={
+                data.ac.enabled ? (data.ac.active ? 'average' : 'good') : 'gray'
+              }>
+              {data.ac.enabled
+                ? data.ac.active
+                  ? 'Active'
+                  : 'Idle'
+                : 'Disabled'}
+            </LabeledList.Item>
             <LabeledList.Item label="Fault Status" color={areaFault.color}>
               {areaFault.areaFaultText}
             </LabeledList.Item>
@@ -154,6 +172,10 @@ const AIR_ALARM_ROUTES = {
   scrubbers: {
     title: 'Scrubber Controls',
     component: () => AirAlarmControlScrubbers,
+  },
+  ac: {
+    title: 'Air Conditioning Controls',
+    component: () => AirAlarmAirConditioningControls,
   },
   modes: {
     title: 'Operating Mode',
@@ -226,6 +248,12 @@ const AirAlarmControlHome = (props, context) => {
         icon="filter"
         content="Scrubber Controls"
         onClick={() => setScreen('scrubbers')}
+      />
+      <Box mt={1} />
+      <Button
+        icon="fan"
+        content="Air Conditioning Controls"
+        onClick={() => setScreen('ac')}
       />
       <Box mt={1} />
       <Button
@@ -521,6 +549,52 @@ const AirAlarmControlThresholds = (props, context) => {
           {...activeModal}
         />
       )}
+    </>
+  );
+};
+
+// Air Conditioning
+// --------------------------------------------------------
+
+const AirAlarmAirConditioningControls = (_props, context) => {
+  const {
+    act,
+    data: {
+      ac: { enabled, target, min, max },
+    },
+  } = useBackend<AirAlarmData>(context);
+  return (
+    <>
+      <Button
+        icon="fire"
+        content="Toggle Air Conditioning"
+        color={enabled && 'good'}
+        onClick={() => act('air_conditioning', { value: !!enabled })}
+      />
+      <Box mt={1} />
+      <LabeledList>
+        <LabeledList.Item label={'Target Temperature'}>
+          <>
+            <NumberInput
+              value={target}
+              minValue={min}
+              maxValue={max}
+              onChange={(_e, target: number) =>
+                act('set_ac_target', { target })
+              }
+              unit="K"
+              tooltip="Change the target temperature of the heater"
+              disabled={!enabled}
+            />
+            <Button
+              icon="thermometer-quarter"
+              content="Default"
+              color={enabled && 'good'}
+              onClick={() => act('default_ac_target')}
+            />
+          </>
+        </LabeledList.Item>
+      </LabeledList>
     </>
   );
 };


### PR DESCRIPTION
## About The Pull Request

Somewhat of a port of https://github.com/shiptest-ss13/Shiptest/pull/1398 but I ended up rewriting most of the code myself.

For reference, a single air alarm can only adjust the temperature by around 1.5 K per tick.

Also ports https://github.com/tgstation/tgstation/pull/79229

## Why It's Good For The Game

Makes fixing small breaches or fires less of a pain in the ass, and makes it so slightly-off temperatures will be fixed so everyone won't be stuck listening to the fire alarm blaring on loop for the entire round.

## Testing Evidence

![2024-03-01 (1709283682) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/e1ae39d9-02f0-4e14-86f0-d56303dad7a8) ![2024-03-01 (1709287021) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/6450de29-e1f7-492b-b26d-44785804cb02)
![2024-03-01 (1709284165) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/116a8389-6b18-4c80-9315-bfec18b1e4d6)


## Changelog
:cl:
add: Added built-in air conditioning (temperature regulation) to air alarms! While certainly not as powerful as a proper dedicated space heater, it can still help greatly with stabilizing the temperature of an area.
fix: walls built next to firelocks no longer hold onto their alarms. (Deadgebert)
/:cl:
