### PR TITLE
[PORT] Reworks stop, drop, roll into a gradual, interruptable thing, that repeats until extinguished

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -294,13 +294,17 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 /atom/movable/screen/alert/fire/Click()
 	. = ..()
 	if(!.)
-		return
+		return FALSE
 
 	var/mob/living/living_owner = owner
+	if(!living_owner.can_resist())
+		return FALSE
 
 	living_owner.changeNext_move(CLICK_CD_RESIST)
-	if(living_owner.mobility_flags & MOBILITY_MOVE)
-		return living_owner.resist_fire()
+	if(!(living_owner.mobility_flags & MOBILITY_MOVE))
+		return FALSE
+
+	return living_owner.resist_fire()
 
 /atom/movable/screen/alert/give // information set when the give alert is made
 	icon_state = "default"

--- a/code/datums/status_effects/buffs/stop_drop_roll.dm
+++ b/code/datums/status_effects/buffs/stop_drop_roll.dm
@@ -1,0 +1,66 @@
+/datum/status_effect/stop_drop_roll
+	id = "stop_drop_roll"
+	alert_type = null
+
+	tick_interval = 0.8 SECONDS
+
+/datum/status_effect/stop_drop_roll/on_apply()
+	if(!iscarbon(owner))
+		return FALSE
+
+	var/actual_interval = initial(tick_interval)
+	if(!owner.Knockdown(actual_interval * 2, ignore_canstun = TRUE) || owner.body_position != LYING_DOWN)
+		to_chat(owner, span_warning("You try to stop, drop, and roll - but you can't get on the ground!"))
+		return FALSE
+
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(stop_rolling))
+	RegisterSignal(owner, COMSIG_LIVING_SET_BODY_POSITION, PROC_REF(body_position_changed))
+	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, id) // they're kinda busy!
+
+	owner.visible_message(
+		span_danger("[owner] rolls on the floor, trying to put [owner.p_them()]self out!"),
+		span_notice("You stop, drop, and roll!"),
+	)
+	// Start with one weaker roll
+	owner.spin(spintime = actual_interval, speed = actual_interval / 4)
+	owner.adjust_fire_stacks(-0.25)
+	return TRUE
+
+/datum/status_effect/stop_drop_roll/on_remove()
+	UnregisterSignal(owner, list(COMSIG_MOVABLE_MOVED, COMSIG_LIVING_SET_BODY_POSITION))
+	REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, id)
+
+/datum/status_effect/stop_drop_roll/tick(seconds_between_ticks)
+	if(HAS_TRAIT(owner, TRAIT_IMMOBILIZED) || HAS_TRAIT(owner, TRAIT_INCAPACITATED))
+		qdel(src)
+		return
+
+	var/actual_interval = initial(tick_interval)
+	if(!owner.Knockdown(actual_interval * 1.2, ignore_canstun = TRUE))
+		stop_rolling()
+		return
+
+	owner.spin(spintime = actual_interval, speed = actual_interval / 4)
+	owner.adjust_fire_stacks(-1)
+
+	if(owner.fire_stacks > 0)
+		return
+
+	owner.visible_message(
+		span_danger("[owner] successfully extinguishes [owner.p_them()]self!"),
+		span_notice("You extinguish yourself."),
+	)
+	qdel(src)
+
+/datum/status_effect/stop_drop_roll/proc/stop_rolling(datum/source, ...)
+	SIGNAL_HANDLER
+
+	if(!QDELING(owner))
+		to_chat(owner, span_notice("You stop rolling around."))
+	qdel(src)
+
+/datum/status_effect/stop_drop_roll/proc/body_position_changed(datum/source, new_value, old_value)
+	SIGNAL_HANDLER
+
+	if(new_value != LYING_DOWN)
+		stop_rolling()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -223,16 +223,7 @@
 		buckled.user_unbuckle_mob(src,src)
 
 /mob/living/carbon/resist_fire()
-	adjust_fire_stacks(-5)
-	Paralyze(60, ignore_canstun = TRUE)
-	spin(32,2)
-	visible_message(span_danger("[src] rolls on the floor, trying to put [p_them()]self out!"), \
-		span_notice("You stop, drop, and roll!"))
-	sleep(3 SECONDS)
-	if(fire_stacks <= 0 && !QDELETED(src))
-		visible_message(span_danger("[src] successfully extinguishes [p_them()]self!"), \
-			span_notice("You extinguish yourself."))
-	return
+	return !!apply_status_effect(/datum/status_effect/stop_drop_roll)
 
 /mob/living/carbon/resist_restraints()
 	var/obj/item/I = null

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1168,7 +1168,7 @@
 	buckled.user_unbuckle_mob(src,src)
 
 /mob/living/proc/resist_fire()
-	return
+	return FALSE
 
 /mob/living/proc/resist_restraints()
 	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1569,6 +1569,7 @@
 #include "code\datums\status_effects\song_effects.dm"
 #include "code\datums\status_effects\stacking_effect.dm"
 #include "code\datums\status_effects\wound_effects.dm"
+#include "code\datums\status_effects\buffs\stop_drop_roll.dm"
 #include "code\datums\status_effects\buffs\stun_asorption.dm"
 #include "code\datums\status_effects\debuffs\blindness.dm"
 #include "code\datums\status_effects\debuffs\choke.dm"


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/79694 from /tg/

## Why It's Good For The Game

Getting stunned for 6 seconds because you decide to stop and roll is a little silly. Reasonably you could stop rolling and get back up should the need arise, such as "oh god there's more fire I gotta relocate".

By changing it to a gradual thing, it makes it a bit more reasonable and fair.

- New players who immediately slam "STOP DROP ROLL" because the alert on their screen tells them to are no longer helpless for 6 whole seconds
- People who hit the resist key, intending to interact with something else (such as a bola) are no longer stuck rolling when they did not want to

## Changelog
:cl: Absolucy, Melbert
balance: Stop, drop, and roll no longer instantly clears 5 fire stacks off of you - Instead, it will clear 1 fire stack off of you every time you roll, with a roll every 0.8 seconds.
balance: Stop, drop, and roll no longer stuns you for 6 seconds. Instead, it will knock you to the floor while you are rolling. Moving around or getting up will cancel the roll, and you cannot use items while rolling around.
balance: Stop, drop, and roll will now repeat until the fire is put out or you get up.
/:cl:
