### PR TITLE
Self sustaining plants grow without nutrients plus bugfixes

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -254,7 +254,8 @@
 		if(myseed && plant_status != HYDROTRAY_PLANT_DEAD)
 			// Advance age
 			var/growth_mult = (1.01 ** -myseed.maturation)
-			if(!(age > max(myseed.maturation, myseed.production)/* Fuck Corpse Flowers */ && (growth >= myseed.harvest_age * growth_mult) && self_sustaining))
+			//Checks if a self sustaining tray is fully grown and fully "functional" (corpse flowers require a specific age to produce miasma)
+			if(!(age > max(myseed.maturation, myseed.production) && (growth >= myseed.harvest_age * growth_mult) && self_sustaining))
 				age++
 
 			needs_update = TRUE

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -249,11 +249,13 @@
 		myseed.forceMove(src)
 
 	update_appearance()
-	if((world.time > (lastcycle + cycledelay) && waterlevel > 10 && reagents.total_volume > 2 && pestlevel < 10 && weedlevel < 10) || bio_boosted)
+	if((world.time > (lastcycle + cycledelay) && waterlevel > 10 && (reagents.total_volume > 2 || self_sustaining) && pestlevel < 10 && weedlevel < 10) || bio_boosted)
 		lastcycle = world.time
 		if(myseed && plant_status != HYDROTRAY_PLANT_DEAD)
 			// Advance age
-			age++
+			var/growth_mult = (1.01 ** -myseed.maturation)
+			if(!(age > max(myseed.maturation, myseed.production)/* Fuck Corpse Flowers */ && (growth >= myseed.harvest_age * growth_mult) && self_sustaining))
+				age++
 
 			needs_update = TRUE
 			growth += 3
@@ -270,9 +272,9 @@
 			apply_chemicals(lastuser?.resolve())
 			// Nutrients deplete slowly
 			if(bio_boosted)
-				adjust_plant_nutriments((reagents.total_volume * ((nutriment_drain_precent * 0.2) * 0.01)))
+				adjust_plant_nutriments(max(reagents.total_volume * ((nutriment_drain_precent * 0.2) * 0.01), 0.05))
 			else
-				adjust_plant_nutriments((reagents.total_volume * (nutriment_drain_precent * 0.01)))
+				adjust_plant_nutriments(max(reagents.total_volume * (nutriment_drain_precent * 0.01), 0.05))
 
 /**
  * Photosynthesis
@@ -367,7 +369,6 @@
 			if(age > (myseed.lifespan - repeated_harvest))
 				adjust_plant_health(-rand(1,5) / rating)
 
-			var/growth_mult = (1.01 ** -myseed.maturation)
 			// Harvest code
 			if(growth >= myseed.harvest_age * growth_mult)
 			//if(myseed.harvest_age < age * max(myseed.production * 0.044, 0.5) && (myseed.harvest_age) < (age - lastproduce) * max(myseed.production * 0.044, 0.5) && (!harvest && !dead))

--- a/monkestation/code/modules/hydroponics/seeds.dm
+++ b/monkestation/code/modules/hydroponics/seeds.dm
@@ -76,6 +76,9 @@
 	for(var/g in genes)
 		var/datum/plant_gene/G = g
 		S.genes += G.Copy()
+
+	for(var/datum/plant_gene/trait/traits in S.genes)
+		traits.on_new_seed(S)
 	// Copy all the stats
 	S.set_lifespan(lifespan)
 	S.set_endurance(endurance)


### PR DESCRIPTION
## About The Pull Request

Self sustaining hydroponics trays can be left alone without their growth pausing due to lack of nutrients.

## Why It's Good For The Game

I prefer this over their growth being paused when there are no nutrients

## Changelog

:cl:
add: Self Sustaining trays bypass the nutrient requirement to grow
add: Self Sustaining trays now pause aging when fully grown & functional(corpse flowers) 
fix: Corpse flowers now make miasma again
fix: Hydroponics trays now run out of nutrients entirely
/:cl: