### PR TITLE
Overdosing on Radiohydrate (immune suppressant) lowers your antibodies, nerf to Aetericilide

### DIFF
--- a/monkestation/code/modules/virology/disease/_disease.dm
+++ b/monkestation/code/modules/virology/disease/_disease.dm
@@ -381,6 +381,9 @@ GLOBAL_LIST_INIT(virusDB, list())
 	if(mob.immune_system)
 		if(prob(8))
 			mob.immune_system.NaturalImmune()
+		//Slowly decay back to regular strength immune system while you are sick
+		if(mob.immune_system.strength > 1)
+			mob.immune_system.strength = max(mob.immune_system.strength - 0.01, 1)
 
 	if(!mob.immune_system.CanInfect(src))
 		cure(mob)

--- a/monkestation/code/modules/virology/immune_systems/_immune_system.dm
+++ b/monkestation/code/modules/virology/immune_systems/_immune_system.dm
@@ -113,9 +113,6 @@
 					antibodies[A] = min(antibodies[A] + 1, 100)
 
 /datum/immune_system/proc/NaturalImmune() //called with a 8% chance every time a virus activates
-	// Immune strength over base amount should decay over time while sick
-	if(strength > 1)
-		strength = max(strength - 0.05, 0)
 	for (var/datum/disease/advanced/disease as anything in host.diseases)
 		for (var/A in disease.antigen)
 			var/tally = 1.5

--- a/monkestation/code/modules/virology/immune_systems/_immune_system.dm
+++ b/monkestation/code/modules/virology/immune_systems/_immune_system.dm
@@ -113,6 +113,9 @@
 					antibodies[A] = min(antibodies[A] + 1, 100)
 
 /datum/immune_system/proc/NaturalImmune() //called with a 8% chance every time a virus activates
+	// Immune strength over base amount should decay over time while sick
+	if(strength > 1)
+		strength = max(strength - 0.05, 0)
 	for (var/datum/disease/advanced/disease as anything in host.diseases)
 		for (var/A in disease.antigen)
 			var/tally = 1.5

--- a/monkestation/code/modules/virology/reagents/immune_healers.dm
+++ b/monkestation/code/modules/virology/reagents/immune_healers.dm
@@ -23,6 +23,20 @@
 		"level" = -0.05,
 		"threshold" = 1,
 		) //level is in precentage
+	overdose_threshold = 20 //about double the amount needed to bring your immune strength to 0
+
+/datum/reagent/medicine/immune_healer/immune_suppressant/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	if(affected_mob.immune_system.antibodies && affected_mob.immune_system.strength == 0)
+		var/list/possible_antibodies = list()
+		//only reduce antibodies that arent 1
+		for(var/antibody as anything in affected_mob.immune_system.antibodies)
+			if(affected_mob.immune_system.antibodies[antibody] > 1)
+				possible_antibodies += antibody
+		//checks if there are any antibodies to remove
+		if(length(possible_antibodies) > 0)
+			var/affected_antibody = pick(possible_antibodies)
+			affected_mob.immune_system.antibodies[affected_antibody] = max(affected_mob.immune_system.antibodies[affected_antibody] - 1, 1)
+	..()
 
 /datum/reagent/medicine/immune_healer/immune_booster
 	name = "Aetericilide"


### PR DESCRIPTION
## About The Pull Request

Adds overdosing on Radiohydrate, decaying your antigens down to 1 while you are overdosing.
Nerfs the more powerful immune suppressant slightly (it is still much better)

## Why It's Good For The Game

If your beneficial disease is weaker than your natural antibodies you can still gain the full effect.
Aetericilide currently keeps your immune strength at 5 unless you have a very resilient disease, and even then it is a slow decay until cured. Meaning you can take some and can ignore diseases for the rest of the round. Now it slowly decays back down to base strength while you are sick with any disease.

## Changelog

:cl:
add: Radiohydrate now has an overdose threshold of 20u
add: While overdosing on Radiohydrate, your antigens slowly decay
balance: Having a higher than normal immune strength now decays whenever you are sick
/:cl: