### PR TITLE
Makes you lie down when buckled to surgery tables, removes need for restraints 

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -102,9 +102,12 @@
 
 /obj/structure/table/attack_hand(mob/living/user, list/modifiers)
 	if(Adjacent(user) && user.pulling)
-		if(isliving(user.pulling) && climbable)
+		if(isliving(user.pulling))
 			var/mob/living/pushed_mob = user.pulling
 			if(pushed_mob.buckled)
+				if(pushed_mob.buckled == src)
+					//Already buckled to the table, you probably meant to unbuckle them
+					return ..()
 				to_chat(user, span_warning("[pushed_mob] is buckled to [pushed_mob.buckled]!"))
 				return
 			if((user.istate & ISTATE_HARM))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -23,6 +23,8 @@
 	pass_flags_self = PASSTABLE | LETPASSTHROW
 	layer = TABLE_LAYER
 	obj_flags = CAN_BE_HIT | IGNORE_DENSITY
+	///TRUE if the table can be climbed on and have living mobs placed on it normally, FALSE otherwise
+	var/climbable = TRUE
 	var/frame = /obj/structure/table_frame
 	var/framestack = /obj/item/stack/rods
 	var/glass_shard_type = /obj/item/shard
@@ -44,7 +46,8 @@
 		buildstack = _buildstack
 	AddElement(/datum/element/footstep_override, priority = STEP_SOUND_TABLE_PRIORITY)
 	AddElement(/datum/element/elevation, pixel_shift = 12)
-	AddElement(/datum/element/climbable)
+	if(climbable)
+		AddElement(/datum/element/climbable)
 
 	var/static/list/loc_connections = list(
 		COMSIG_CARBON_DISARM_COLLIDE = PROC_REF(table_carbon),
@@ -99,7 +102,7 @@
 
 /obj/structure/table/attack_hand(mob/living/user, list/modifiers)
 	if(Adjacent(user) && user.pulling)
-		if(isliving(user.pulling))
+		if(isliving(user.pulling) && climbable)
 			var/mob/living/pushed_mob = user.pulling
 			if(pushed_mob.buckled)
 				to_chat(user, span_warning("[pushed_mob] is buckled to [pushed_mob.buckled]!"))
@@ -711,8 +714,8 @@
 	smoothing_groups = null
 	canSmoothWith = null
 	can_buckle = 1
-	buckle_lying = NO_BUCKLE_LYING
-	buckle_requires_restraints = TRUE
+	buckle_lying = 90
+	climbable = FALSE
 	custom_materials = list(/datum/material/silver =SHEET_MATERIAL_AMOUNT)
 	var/mob/living/carbon/patient = null
 	var/obj/machinery/computer/operating/computer = null
@@ -724,6 +727,7 @@
 		if(computer)
 			computer.table = src
 			break
+
 	RegisterSignal(loc, COMSIG_ATOM_ENTERED, PROC_REF(mark_patient))
 	RegisterSignal(loc, COMSIG_ATOM_EXITED, PROC_REF(unmark_patient))
 


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/75840 and https://github.com/tgstation/tgstation/pull/76643

Also, makes laying on surgical tables look right after https://github.com/Monkestation/Monkestation2.0/pull/1327

## Why It's Good For The Game

This is a quality of life change for medbay (and anyone doing surgery). It's kind of dumb that people stand up when buckled to surgery tables, this makes you no longer have to ask them to lie down, especially nice for dealing with patients who may still be AFK after getting out of crit.

This also makes surgery a little easier on unwilling victims, no longer requiring you use a regular/roller bed or crit them/keep them stunned.

## Changelog
:cl: Absolucy, JupiterJaeden, FlufflesTheDog
qol: people now lie down when buckled to surgery tables, and you no longer need cuffs to buckle someone to a surgery table
/:cl:
