### PR TITLE
Fix a weird runtime that broke telecomms

### DIFF
--- a/code/game/communications.dm
+++ b/code/game/communications.dm
@@ -66,26 +66,27 @@
 GLOBAL_LIST_EMPTY(all_radios)
 
 /proc/add_radio(obj/item/radio, freq)
-	if(!freq || !radio)
+	if(!freq || QDELETED(radio))
 		return
 	if(!GLOB.all_radios["[freq]"])
 		GLOB.all_radios["[freq]"] = list(radio)
 		return freq
 
 	GLOB.all_radios["[freq]"] |= radio
+	list_clear_nulls(GLOB.all_radios["[freq]"]) // sanity check, because oh god how does this happen
 	return freq
 
 /proc/remove_radio(obj/item/radio, freq)
-	if(!freq || !radio)
+	if(!freq || QDELETED(radio))
 		return
 	if(!GLOB.all_radios["[freq]"])
 		return
-
 	GLOB.all_radios["[freq]"] -= radio
 
 /proc/remove_radio_all(obj/item/radio)
 	for(var/freq in GLOB.all_radios)
 		GLOB.all_radios["[freq]"] -= radio
+		list_clear_nulls(GLOB.all_radios["[freq]"])
 
 // For information on what objects or departments use what frequencies,
 // see __DEFINES/radio.dm. Mappers may also select additional frequencies for

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -177,6 +177,8 @@
 					radios += independent_radio
 
 	for(var/obj/item/radio/called_radio as anything in radios)
+		if(QDELETED(called_radio))
+			return
 		called_radio.on_recieve_message()
 
 	// From the list of radios, find all mobs who can hear those.
@@ -198,10 +200,9 @@
 	var/rendered = virt.compose_message(virt, language, message, frequency, spans)
 
 	for(var/atom/movable/hearer as anything in receive)
-		if(!hearer)
+		if(QDELETED(hearer))
 			stack_trace("null found in the hearers list returned by the spatial grid. this is bad")
 			continue
-
 		hearer.Hear(rendered, virt, language, message, frequency, spans, message_mods)
 
 	// This following recording is intended for research and feedback in the use of department radio channels


### PR DESCRIPTION

## About The Pull Request

Fixes this strange runtime, which occurs due to nulls in the radio lists: 
![image](https://github.com/Monkestation/Monkestation2.0/assets/65794972/4060d410-6d3a-46e6-ac5b-85cbe5c4e457)

This both makes sure to clear the radio lists of nulls, and adds `QDELETED` checks to tcomms code.

## Why It's Good For The Game

telecomms breaking is bad

## Changelog
:cl:
fix: Fix a weird runtime that broke telecomms
/:cl:
