### PR TITLE
Freerunning quirk fixes

### DIFF
--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -151,5 +151,9 @@
 
 ///Tries to climb onto the target if the forced movement of the mob allows it
 /datum/element/climbable/proc/attempt_sprint_climb(datum/source, mob/bumpee)
-	if(do_after(bumpee, climb_time * 1.2, source))
-		do_climb(source, bumpee)
+	if(HAS_TRAIT(bumpee, TRAIT_FREERUNNING))
+		if(do_after(bumpee, climb_time, source))
+			do_climb(source, bumpee)
+	else
+		if(do_after(bumpee, climb_time * 1.2, source))
+			do_climb(source, bumpee)

--- a/monkestation/code/datums/components/carbon_sprint.dm
+++ b/monkestation/code/datums/components/carbon_sprint.dm
@@ -55,11 +55,10 @@
 					dust.appear("sprint_cloud_tiny", direct, get_turf(carbon_parent), 0.3 SECONDS)
 					last_dust = world.time
 				sustained_moves = 0
-		if(HAS_TRAIT(src, TRAIT_FREERUNNING))
-			carbon_parent.stamina.adjust(-STAMINA_SPRINT_COST/2)
+		if(HAS_TRAIT(carbon_parent, TRAIT_FREERUNNING))
+			carbon_parent.stamina.adjust(-STAMINA_SPRINT_COST * 0.7) //0.5 * cost Means almost infinnite sprint due to regen
 		else
 			carbon_parent.stamina.adjust(-STAMINA_SPRINT_COST)
-
 	else if(sprinting)
 		stopSprint()
 


### PR DESCRIPTION
## About The Pull Request
Fixes: #1369 
Climbing is always faster when you have the freerunning trait. Sprinting stamina drain is now correctly reduced when you have the freerunning trait.

## Why It's Good For The Game
Climbing was only faster when you click dragged yourself onto the climbable object. Now it also applies if you sprint into it.
Sprinting was ignoring the freerunning trait due to checking the wrong thing for the freerunning trait.

## Changelog
:cl:
fix: Sprinting now correctly checks the sprinter for the frerunning trait.
fix: Freeruning trait now accelerates climbing onto objects when sprinting into it.
/:cl:
