### PR TITLE
[PORT] Makes brainwashing immune to mindshield implant, you can only take it off through surgery now.

### DIFF
--- a/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -56,10 +56,6 @@
 	owner.announce_objectives()
 	return ..()
 
-/datum/antagonist/brainwashed/on_mindshield(mob/implanter)
-	owner.remove_antag_datum(/datum/antagonist/brainwashed)
-	return COMPONENT_MINDSHIELD_DECONVERTED
-
 /datum/antagonist/brainwashed/admin_add(datum/mind/new_owner,mob/admin)
 	var/mob/living/carbon/C = new_owner.current
 	if(!istype(C))

--- a/monkestation/code/modules/antagonists/brainwashing/brainwashing.dm
+++ b/monkestation/code/modules/antagonists/brainwashing/brainwashing.dm
@@ -43,10 +43,6 @@
 	user.clear_alert(ALERT_BRAINWASHED)
 	UnregisterSignal(user, COMSIG_MOB_CLIENT_LOGIN)
 
-/datum/antagonist/brainwashed/on_mindshield(mob/implanter)
-	owner.remove_antag_datum(/datum/antagonist/brainwashed)
-	return COMPONENT_MINDSHIELD_DECONVERTED
-
 /datum/antagonist/brainwashed/proc/greet_on_login(mob/body)
 	SIGNAL_HANDLER
 	if(popup_shown)


### PR DESCRIPTION
## About The Pull Request

**Ports https://github.com/tgstation/tgstation/pull/81419**

What it says on the tin, Removes the mindshield effect implant on removing brainwashing, Don't worry though, you can still remove it through surgery (interdepartmental interaction!). Allows for more engaging and in-depth gameplay that focuses on making security less infallible.
## Why It's Good For The Game
This PR makes security more infallible which is a good thing, by making them more prone to infiltration and backstabbing. it enhances the paranoia aspect present in the game. no longer can you trust someone just because they are a member of security (not that they trust them completely 100% in the first place, changelings exists). allowing for more deep user-generated stories full with intrigue and depth. the stuff I feel is the core gameplay loop of SS13. By making sure you can 100% trust someone with a mindshield and redshirt you take away that feeling of dread, whether or not this person can be trusted.

Can you trust your sec buddy that was gone for a concerningly long amount of time arresting and killing a head with just a notion "oh that guy is a cling"?. what if he was brainwashed within that space of time and ordered to frame that head? That is what I absolutely love to happen.

Also to keep it in line with the hypnoflash, where you CAN do this. and the process is way easier (at a cost of high TC and unreliability). Brainwashing takes a lot more time to do. it should at least be on par with hypnotizing.
## Changelog

:cl: Absolucy, Singul0
balance: Brainwashed individuals can no longer be debrainwashed through a mindshield implant, they still protect you from brainwashing though! You just need to get medical to fix them up.
/:cl:
