### PR TITLE
Fix secondary alt click

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -114,14 +114,13 @@
 				MiddleClickOn(A, params)
 			return
 		if(LAZYACCESS(modifiers, ALT_CLICK)) // alt and alt-gr (rightalt)
-			if((istate & ISTATE_SECONDARY))
-				alt_click_on_secondary(A)
-			else
-				AltClickOn(A)
+			AltClickOn(A)
 			return
 		if(LAZYACCESS(modifiers, CTRL_CLICK))
 			CtrlClickOn(A)
 			return
+	else if(LAZYACCESS(modifiers, ALT_CLICK)) // monke edit: ensure alt-secondary works
+		alt_click_on_secondary(A)
 
 	if(incapacitated(IGNORE_RESTRAINTS|IGNORE_STASIS|IGNORE_CRIT))
 		return


### PR DESCRIPTION
## Changelog
:cl:
fix: Secondary alt-click works, so you can now properly detach accessories and such.
/:cl:
