### PR TITLE
Makes AI's no longer able to prevent a slasher from using the incorporeal ability

### DIFF
--- a/monkestation/code/modules/antagonists/slasher/abilities/incorporealize.dm
+++ b/monkestation/code/modules/antagonists/slasher/abilities/incorporealize.dm
@@ -46,6 +46,15 @@
 			continue
 		if(isdead(watcher))
 			continue
+		if(isaicamera(watcher))
+			var/mob/camera/ai_eye/ai_eye = watcher
+			var/mob/living/silicon/ai/true_ai = ai_eye.ai
+			true_ai.disconnect_shell() // should never happen, lets try it anyway
+			true_ai.view_core()
+			to_chat(true_ai, span_warning("UNEXPECTED ENERGY SURGE -- RETURNING TO THE CORE"))
+			do_sparks(3, FALSE, true_ai)
+			true_ai.adjustBruteLoss(30) // same as a light explosion, to dis-encurage the AI always watching the slasher and telling their location
+			continue
 
 		target.balloon_alert(owner, "you can only vanish unseen.")
 		return


### PR DESCRIPTION

## About The Pull Request

Makes slashers able to use incorporeal whilst an AI is watching them
This will cause the AI to return to their core, spark and get damage equivilant to a light explosion

## Why It's Good For The Game

Because the invisible man watching you 24/7, reporting your location and preventing you from incorporealizing is unfun gameplay for the slasher

## Changelog

:cl:
balance: AI's now do not have a good time when trying to prevent slashers from incorporealizing
/:cl:
