### PR TITLE
Remove duplicate APC from Icebox random bar theaters

### DIFF
--- a/_maps/~monkestation/RandomBars/Icebox/clockwork_icebox.dmm
+++ b/_maps/~monkestation/RandomBars/Icebox/clockwork_icebox.dmm
@@ -107,7 +107,6 @@
 "eZ" = (
 /obj/structure/table/bronze,
 /obj/item/gun/ballistic/revolver/russian,
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/carpet/lone,
 /area/station/service/theater)

--- a/_maps/~monkestation/RandomBars/Icebox/green_bar_disco.dmm
+++ b/_maps/~monkestation/RandomBars/Icebox/green_bar_disco.dmm
@@ -220,7 +220,6 @@
 	dir = 6
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/carpet/green,
 /area/station/service/theater)
 "lG" = (

--- a/_maps/~monkestation/RandomBars/Icebox/icebox_bar_abductor.dmm
+++ b/_maps/~monkestation/RandomBars/Icebox/icebox_bar_abductor.dmm
@@ -619,7 +619,6 @@
 	dir = 1
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/circuit,
 /area/station/service/theater)
 "EH" = (

--- a/_maps/~monkestation/RandomBars/Icebox/icebox_bar_arcade.dmm
+++ b/_maps/~monkestation/RandomBars/Icebox/icebox_bar_arcade.dmm
@@ -209,7 +209,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/eighties,
 /area/station/service/theater)
 "kp" = (


### PR DESCRIPTION

## About The Pull Request

Exactly what it says. This seems to be the origin of the CI failures on icebox.

## Why It's Good For The Game

Fixes mapping errors and hopefully stops the dumb CI failures.

## Changelog
:cl:
fix: Removed duplicate APC from Icebox random bar theaters.
/:cl:
