### PR TITLE
Changed up deltas engine room piping abit

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -4025,6 +4025,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "aWk" = (
@@ -7448,8 +7449,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /obj/effect/turf_decal/box/corners,
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -7874,6 +7873,10 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "bPI" = (
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
+	},
+/obj/structure/sign/delamination_counter/directional/south,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "bPM" = (
@@ -8535,11 +8538,11 @@
 /area/station/maintenance/department/science/xenobiology)
 "bWa" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/layer_manifold/green/visible,
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "bWb" = (
@@ -10580,7 +10583,6 @@
 	},
 /area/station/commons/fitness/recreation)
 "cwI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -10662,9 +10664,9 @@
 /area/station/ai_monitored/command/storage/eva)
 "cxp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "cxs" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/engineering_all,
@@ -12856,6 +12858,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "cZC" = (
@@ -18684,7 +18687,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/machinery/button/door/directional/west{
 	id = "engsm";
 	name = "Radiation Shutters Control";
@@ -19823,6 +19825,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "eNB" = (
@@ -20079,8 +20082,6 @@
 	heat_proof = 1;
 	name = "Supermatter Chamber"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -28040,6 +28041,7 @@
 /obj/structure/cable,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "gKI" = (
@@ -34124,6 +34126,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "ilH" = (
@@ -40599,6 +40602,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "jPe" = (
@@ -43912,7 +43916,9 @@
 	dir = 1;
 	pixel_y = 23
 	},
-/obj/structure/sign/delamination_counter/directional/west,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "kDL" = (
@@ -45471,8 +45477,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kXR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "kXV" = (
@@ -45673,7 +45677,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "lbl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -49258,6 +49261,7 @@
 /obj/structure/cable,
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "lSh" = (
@@ -50044,6 +50048,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "meS" = (
@@ -51125,7 +51130,9 @@
 /turf/open/floor/wood,
 /area/station/service/electronic_marketing_den)
 "msB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "msF" = (
@@ -52691,6 +52698,11 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"mJV" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "mJW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -53618,6 +53630,7 @@
 /area/station/medical/paramedic)
 "mWq" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
 "mWy" = (
@@ -55131,9 +55144,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /obj/structure/sign/warning/secure_area/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "nsd" = (
@@ -58713,9 +58725,8 @@
 /area/station/medical/treatment_center)
 "okr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "oks" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59524,9 +59535,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "owf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "owj" = (
@@ -61370,6 +61379,7 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "oVd" = (
@@ -68807,14 +68817,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/hallway)
 "qJs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "qJy" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
@@ -78523,7 +78528,6 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "tcy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
@@ -79562,14 +79566,6 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/medical/morgue)
 "tsa" = (
-/obj/machinery/atmospherics/components/binary/pump/layer2{
-	dir = 8;
-	name = "Gas to Chamber"
-	},
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	dir = 4;
-	name = "Chamber to Cooling"
-	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
@@ -84526,6 +84522,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
+"uzU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "uzZ" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
@@ -86747,8 +86748,6 @@
 /area/station/science/research)
 "vcO" = (
 /obj/machinery/power/supermatter_crystal/engine,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "vcU" = (
@@ -87765,7 +87764,6 @@
 /area/station/maintenance/department/security)
 "vqu" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "vqx" = (
@@ -90445,11 +90443,11 @@
 "vYv" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/machinery/status_display/ai/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "vYw" = (
@@ -93866,8 +93864,6 @@
 	heat_proof = 1;
 	name = "Supermatter Chamber"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -97388,6 +97384,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "xGi" = (
@@ -119732,7 +119729,7 @@ rVD
 gAw
 llz
 meL
-ehD
+xEt
 nEO
 haw
 tqa
@@ -119989,7 +119986,7 @@ ntd
 wvl
 gmx
 xGh
-cxp
+nlS
 sHT
 wgC
 iRx
@@ -120246,7 +120243,7 @@ rVD
 jMM
 gAw
 jPd
-ehD
+xEt
 sHT
 dHx
 fNc
@@ -120761,7 +120758,7 @@ bpr
 anB
 ilG
 cwI
-sHT
+okr
 msB
 kXR
 owf
@@ -121275,7 +121272,7 @@ vog
 anB
 aVW
 lbl
-sHT
+okr
 msB
 kXR
 owf
@@ -121530,13 +121527,13 @@ sAm
 mHg
 hQK
 pqr
-qJs
+fzm
 tcy
-sHT
-sHT
+okr
+cxp
 ePU
-sHT
-sHT
+uzU
+qJs
 sHT
 sHT
 jzC
@@ -121787,8 +121784,8 @@ dPB
 nVr
 sTn
 eHy
-qJs
-cxp
+fzm
+nlS
 sHT
 kDE
 tsa
@@ -122045,11 +122042,11 @@ eaQ
 ubM
 gAw
 eNt
-ehD
+mJV
 sHT
-sHT
+okr
 wKu
-sHT
+qJs
 sHT
 pOf
 pOf
@@ -122302,7 +122299,7 @@ jZV
 gAw
 gAw
 ljO
-okr
+ehD
 bWa
 nrP
 bKp


### PR DESCRIPTION
Removed the multi/layered piping and switched it with basically an imitation of what other SM chambers do (As in pipes going trough walls)
## About The Pull Request

Ive changed up deltas SM piping, moved the delaminations counter down to not block the meters aswell. Had to move the output/lime/waste pipes above the engine room a tile up to keep things tidy though.
## Why It's Good For The Game

It makes modifications to the SM engine room far easier, specifically installing multi layered cooling, which previously was tedious and annoying.

## Changelog
:cl:
qol: Changed deltas SM engine room piping, making modifications (specifically in-chamber cooling) less tedious to achieve.
/:cl:
![image](https://github.com/Monkestation/Monkestation2.0/assets/157312222/4fe2e4a1-2f59-4db1-88ed-82074310003f)
