### PR TITLE
Nerfs probability that a rat decides to bite a cable

### DIFF
--- a/code/datums/ai/hunting_behavior/hunting_mouse.dm
+++ b/code/datums/ai/hunting_behavior/hunting_mouse.dm
@@ -11,7 +11,7 @@
 	finding_behavior = /datum/ai_behavior/find_hunt_target/mouse_cable
 	hunt_targets = list(/obj/structure/cable)
 	hunt_range = 0 // Only look below us
-	hunt_chance = 5
+	hunt_chance = 1
 
 // When looking for a cable, we can only bite things we can reach.
 /datum/ai_behavior/find_hunt_target/mouse_cable


### PR DESCRIPTION
## About The Pull Request

Rats are 5x less likely to decide to bite a cable

**Port of https://github.com/tgstation/tgstation/pull/81364**

## Why It's Good For The Game

Way back when I converted rats to basic mobs, *something* went wrong and rats bite cables wayyyy too often now - it's not uncommon to see a rat has de-cabled an entire section of maint due to some good luck.

Funny but not how it functioned originally. I always intended to tone it back down and just never got around to it.

## Changelog

:cl: Absolucy, Melbert
balance: Rats are now 5x less likely to decide to eat a cable when idling. (1%, down from 5%)
/:cl: