### PR TITLE
Ventcrawling mobs now recieve a 1 second delay/warning before exiting vents

### DIFF
--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -56,8 +56,10 @@
 
 	//Handle the exit here
 	if(HAS_TRAIT(src, TRAIT_MOVE_VENTCRAWLING) && istype(loc, /obj/machinery/atmospherics) && movement_type & VENTCRAWLING)
-		visible_message(span_notice("[src] begins climbing out from the ventilation system..."), span_notice("You begin climbing out from the ventilation system..."))
+		to_chat(src, span_notice("You begin climbing out from the ventilation system..."))
 		if(has_client && isnull(client))
+			return
+		if(!do_after(src, 1 SECONDS, target = ventcrawl_target))
 			return
 		visible_message(span_notice("[src] scrambles out from the ventilation ducts!"),span_notice("You scramble out from the ventilation ducts."))
 		forceMove(ventcrawl_target.loc)


### PR DESCRIPTION
## About The Pull Request

**Port of https://github.com/tgstation/tgstation/pull/75937**

Ventcrawling mobs must now complete a 1 second long do_after before exiting a vent.

![venting sussa mongus
sus](https://github.com/tgstation/tgstation/assets/28870487/dbbfef9c-ace5-4cf3-a0a1-96b63810b08a)

## Why It's Good For The Game

Helps prevent those _wacky silly awkward moments_ where you speed into a scrubber/vent and accidentally fling yourself out into the open. Having a bit of a delay should reduce frustrations caused by situations like these.

## Changelog

:cl: Absolucy, Rhials
qol: Ventcrawling mobs have a 1 second delay/warning before exiting the ventilation.
/:cl