### PR TITLE
Nerf to Electrical Activity plants

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -394,7 +394,7 @@
 	our_plant.investigate_log("zapped [key_name(target)] at [AREACOORD(target)]. Last touched by: [our_plant.fingerprintslast].", INVESTIGATE_BOTANY)
 	var/mob/living/carbon/target_carbon = target
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
-	var/power = our_seed.potency * rate
+	var/power = min(our_seed.potency, 100) * rate
 	if(prob(power))
 		target_carbon.electrocute_act(round(power), our_plant, 1, SHOCK_NOGLOVES)
 


### PR DESCRIPTION

## About The Pull Request

Forces the Electrical Activity plant gene back into its intended damage range- zaps now cap at 100 or the plant's potency, whichever is smaller.

## Why It's Good For The Game

Second verse, same as the first- abusing infinite stats to powergame murder is shitty. I need a drink.

## Changelog

:cl:
balance: Kneecapped instakill electrical activity plants
/:cl:

