### PR TITLE
[PORT] Blindness related stuff and colorblindness brain trauma

### DIFF
--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -265,3 +265,18 @@
 			speak_dejavu += speech_args[SPEECH_MESSAGE]
 	else
 		speak_dejavu += speech_args[SPEECH_MESSAGE]
+
+/datum/brain_trauma/mild/color_blindness
+	name = "Achromatopsia"
+	desc = "Patient's occipital lobe is unable to recognize and interpret color, rendering the patient completely colorblind."
+	scan_desc = "colorblindness"
+	gain_text = span_warning("The world around you seems to lose its color.")
+	lose_text = span_notice("The world feels bright and colorful again.")
+
+/datum/brain_trauma/mild/color_blindness/on_gain()
+	owner.add_client_colour(/datum/client_colour/monochrome/colorblind)
+	return ..()
+
+/datum/brain_trauma/mild/color_blindness/on_lose(silent)
+	owner.remove_client_colour(/datum/client_colour/monochrome/colorblind)
+	return ..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -104,6 +104,8 @@
 			to_chat(user, "[span_warning("\The [src] isn't bright enough to see anything!")] ")
 			return
 
+		var/render_list = list()//information will be packaged in a list for clean display to the user
+
 		switch(user.zone_selected)
 			if(BODY_ZONE_PRECISE_EYES)
 				if((M.head && M.head.flags_cover & HEADCOVERSEYES) || (M.wear_mask && M.wear_mask.flags_cover & MASKCOVERSEYES) || (M.glasses && M.glasses.flags_cover & GLASSESCOVERSEYES))
@@ -111,32 +113,44 @@
 					return
 
 				var/obj/item/organ/internal/eyes/E = M.get_organ_slot(ORGAN_SLOT_EYES)
+				var/obj/item/organ/internal/brain = M.get_organ_slot(ORGAN_SLOT_BRAIN)
 				if(!E)
 					to_chat(user, span_warning("[M] doesn't have any eyes!"))
 					return
 
+				M.flash_act(visual = TRUE, length = (user.combat_mode) ? 2.5 SECONDS : 1 SECONDS) // Apply a 1 second flash effect to the target. The duration increases to 2.5 Seconds if you have combat mode on.
+
 				if(M == user) //they're using it on themselves
-					if(M.flash_act(visual = 1))
-						M.visible_message(span_notice("[M] directs [src] to [M.p_their()] eyes."), span_notice("You wave the light in front of your eyes! Trippy!"))
+					user.visible_message(span_warning("[user] shines [src] into [M.p_their()] eyes."), ignored_mobs = user)
+					render_list += span_info("You direct [src] to into your eyes:\n")
+
+					if(M.is_blind())
+						render_list += "<span class='notice ml-1'>You're not entirely certain what you were expecting...</span>\n"
 					else
-						M.visible_message(span_notice("[M] directs [src] to [M.p_their()] eyes."), span_notice("You wave the light in front of your eyes."))
+						render_list += "<span class='notice ml-1'>Trippy!</span>\n"
+
 				else
-					user.visible_message(span_warning("[user] directs [src] to [M]'s eyes."), \
-						span_danger("You direct [src] to [M]'s eyes."))
-					if(M.stat == DEAD || (M.is_blind()) || !M.flash_act(visual = 1)) //mob is dead or fully blind
-						to_chat(user, span_warning("[M]'s pupils don't react to the light!"))
-					else if(M.dna && M.dna.check_mutation(/datum/mutation/human/xray)) //mob has X-ray vision
-						to_chat(user, span_danger("[M]'s pupils give an eerie glow!"))
-					else //they're okay!
-						to_chat(user, span_notice("[M]'s pupils narrow."))
+					user.visible_message(span_warning("[user] directs [src] to [M]'s eyes."), ignored_mobs = user)
+					render_list += span_info("You direct [src] to [M]'s eyes:\n")
+
+					if(M.stat == DEAD || M.is_blind())
+						render_list += "<span class='danger ml-1'>[M.p_their(TRUE)] pupils don't react to the light!</span>\n"//mob is dead
+					else if(brain.damage > 20)
+						render_list += "<span class='danger ml-1'>[M.p_their(TRUE)] pupils contract unevenly!</span>\n"//mob has sustained damage to their brain
+					else
+						render_list += "<span class='notice ml-1'>[M.p_their(TRUE)] pupils narrow.</span>\n"//they're okay :D
+
+					if(M.dna && M.dna.check_mutation(/datum/mutation/human/xray))
+						render_list += "<span class='danger ml-1'>[M.p_their(TRUE)] pupils give an eerie glow!</span>\n"//mob has X-ray vision
+
+				//display our packaged information in an examine block for easy reading
+				to_chat(user, examine_block(jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
 
 			if(BODY_ZONE_PRECISE_MOUTH)
 
 				if(M.is_mouth_covered())
 					to_chat(user, span_warning("You're going to need to remove that [(M.head && M.head.flags_cover & HEADCOVERSMOUTH) ? "helmet" : "mask"] first!"))
 					return
-
-				var/their = M.p_their()
 
 				var/list/mouth_organs = new
 				for(var/obj/item/organ/organ as anything in M.organs)
@@ -158,7 +172,7 @@
 				for(var/datum/action/item_action/hands_free/activate_pill/AP in M.actions)
 					pill_count++
 
-				if(M == user)
+				if(M == user)//if we're looking on our own mouth
 					var/can_use_mirror = FALSE
 					if(isturf(user.loc))
 						var/obj/structure/mirror/mirror = locate(/obj/structure/mirror, user.loc)
@@ -173,27 +187,57 @@
 								if(WEST)
 									can_use_mirror = mirror.pixel_x < 0
 
-					M.visible_message(span_notice("[M] directs [src] to [their] mouth."), \
-					span_notice("You point [src] into your mouth."))
+					M.visible_message(span_notice("[M] directs [src] to [ M.p_their()] mouth."), ignored_mobs = user)
+					render_list += span_info("You point [src] into your mouth:\n")
 					if(!can_use_mirror)
 						to_chat(user, span_notice("You can't see anything without a mirror."))
 						return
 					if(organ_count)
-						to_chat(user, span_notice("Inside your mouth [organ_count > 1 ? "are" : "is"] [organ_list]."))
+						render_list += "<span class='notice ml-1'>Inside your mouth [organ_count > 1 ? "are" : "is"] [organ_list].</span>\n"
 					else
-						to_chat(user, span_notice("There's nothing inside your mouth."))
+						render_list += "<span class='notice ml-1'>There's nothing inside your mouth.</span>\n"
 					if(pill_count)
-						to_chat(user, span_notice("You have [pill_count] implanted pill[pill_count > 1 ? "s" : ""]."))
+						render_list += "<span class='notice ml-1'>You have [pill_count] implanted pill[pill_count > 1 ? "s" : ""].</span>\n"
 
-				else
-					user.visible_message(span_notice("[user] directs [src] to [M]'s mouth."),\
-						span_notice("You direct [src] to [M]'s mouth."))
+				else //if we're looking in someone elses mouth
+					user.visible_message(span_notice("[user] directs [src] to [M]'s mouth."), ignored_mobs = user)
+					render_list += span_info("You point [src] into [M]'s mouth:\n")
 					if(organ_count)
-						to_chat(user, span_notice("Inside [their] mouth [organ_count > 1 ? "are" : "is"] [organ_list]."))
+						render_list += "<span class='notice ml-1'>Inside [ M.p_their()] mouth [organ_count > 1 ? "are" : "is"] [organ_list].</span>\n"
 					else
-						to_chat(user, span_notice("[M] doesn't have any organs in [their] mouth."))
+						render_list += "<span class='notice ml-1'>[M] doesn't have any organs in [ M.p_their()] mouth.</span>\n"
 					if(pill_count)
-						to_chat(user, span_notice("[M] has [pill_count] pill[pill_count > 1 ? "s" : ""] implanted in [their] teeth."))
+						render_list += "<span class='notice ml-1'>[M] has [pill_count] pill[pill_count > 1 ? "s" : ""] implanted in [ M.p_their()] teeth.</span>\n"
+
+				//assess any suffocation damage
+				var/hypoxia_status = M.getOxyLoss() > 20
+
+				if(M == user)
+					if(hypoxia_status)
+						render_list += "<span class='danger ml-1'>Your lips appear blue!</span>\n"//you have suffocation damage
+					else
+						render_list += "<span class='notice ml-1'>Your lips appear healthy.</span>\n"//you're okay!
+				else
+					if(hypoxia_status)
+						render_list += "<span class='danger ml-1'>[M.p_their(TRUE)] lips appear blue!</span>\n"//they have suffocation damage
+					else
+						render_list += "<span class='notice ml-1'>[M.p_their(TRUE)] lips appear healthy.</span>\n"//they're okay!
+
+				//assess blood level
+				if(M == user)
+					render_list += span_info("You press a finger to your gums:\n")
+				else
+					render_list += span_info("You press a finger to [M.p_their()] gums:\n")
+
+				if(M.blood_volume <= BLOOD_VOLUME_SAFE && M.blood_volume > BLOOD_VOLUME_OKAY)
+					render_list += "<span class='danger ml-1'>Color returns slowly!</span>\n"//low blood
+				else if(M.blood_volume <= BLOOD_VOLUME_OKAY)
+					render_list += "<span class='danger ml-1'>Color does not return!</span>\n"//critical blood
+				else
+					render_list += "<span class='notice ml-1'>Color returns quickly.</span>\n"//they're okay :D
+
+				//display our packaged information in an examine block for easy reading
+				to_chat(user, examine_block(jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
 
 	else
 		return ..()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -118,7 +118,7 @@
 					to_chat(user, span_warning("[M] doesn't have any eyes!"))
 					return
 
-				M.flash_act(visual = TRUE, length = (user.combat_mode) ? 2.5 SECONDS : 1 SECONDS) // Apply a 1 second flash effect to the target. The duration increases to 2.5 Seconds if you have combat mode on.
+				M.flash_act(visual = TRUE, length = (user.istate & ISTATE_HARM) ? 2.5 SECONDS : 1 SECONDS) // Apply a 1 second flash effect to the target. The duration increases to 2.5 Seconds if you have combat mode on.
 
 				if(M == user) //they're using it on themselves
 					user.visible_message(span_warning("[user] shines [src] into [M.p_their()] eyes."), ignored_mobs = user)

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -47,11 +47,15 @@
 	if(!do_alert)
 		return ..()
 
-	// Cache the list before we open the box.
-	var/list/alerted = viewers(7, src)
+	// Get mobs in view before we open the box.
+	var/list/alerted = list()
+	for(var/mob/living/alerted_mob in viewers(7, src))
+		if(alerted_mob.stat != CONSCIOUS || alerted_mob.is_blind())
+			continue
+		alerted += alerted_mob
 
 	// There are no mobs to alert?
-	if(!(locate(/mob/living) in alerted))
+	if(!length(alerted))
 		return ..()
 
 	. = ..()
@@ -62,11 +66,10 @@
 
 	COOLDOWN_START(src, alert_cooldown, time_between_alerts)
 
-	for(var/mob/living/alerted_mob in alerted)
-		if(alerted_mob.stat == CONSCIOUS)
-			if(!alerted_mob.incapacitated(IGNORE_RESTRAINTS))
-				alerted_mob.face_atom(src)
-			alerted_mob.do_alert_animation()
+	for(var/mob/living/alerted_mob as anything in alerted)
+		if(!alerted_mob.incapacitated(IGNORE_RESTRAINTS))
+			alerted_mob.face_atom(src)
+		alerted_mob.do_alert_animation()
 
 	playsound(loc, 'sound/machines/chime.ogg', 50, FALSE, -5)
 

--- a/code/game/objects/structures/headpike.dm
+++ b/code/game/objects/structures/headpike.dm
@@ -47,11 +47,11 @@
 	. = ..()
 	if(!victim)
 		return
-	var/mutable_appearance/MA = new()
-	MA.copy_overlays(victim)
-	MA.pixel_y = 12
-	MA.pixel_x = pixel_x
-	. += victim
+	var/mutable_appearance/appearance = new()
+	appearance.copy_overlays(victim)
+	appearance.pixel_y = 12
+	appearance.layer = layer + 0.1
+	. += appearance
 
 /obj/structure/headpike/handle_atom_del(atom/A)
 	if(A == victim)

--- a/code/modules/client/client_colour.dm
+++ b/code/modules/client/client_colour.dm
@@ -209,6 +209,9 @@
 	fade_in = 20
 	fade_out = 20
 
+/datum/client_colour/monochrome/colorblind
+	priority = PRIORITY_HIGH
+
 /datum/client_colour/monochrome/trance
 	priority = PRIORITY_NORMAL
 

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -187,26 +187,118 @@
 
 	var/mob/living/carbon/carbon_patient = M
 	var/body_part = parse_zone(user.zone_selected)
+	var/oxy_loss = carbon_patient.getOxyLoss()
 
-	var/heart_strength = span_danger("no")
-	var/lung_strength = span_danger("no")
+	var/heart_strength
+	var/pulse_pressure
 
 	var/obj/item/organ/internal/heart/heart = carbon_patient.get_organ_slot(ORGAN_SLOT_HEART)
 	var/obj/item/organ/internal/lungs/lungs = carbon_patient.get_organ_slot(ORGAN_SLOT_LUNGS)
+	var/obj/item/organ/internal/liver/liver = carbon_patient.get_organ_slot(ORGAN_SLOT_LIVER)
+	var/obj/item/organ/internal/appendix/appendix = carbon_patient.get_organ_slot(ORGAN_SLOT_APPENDIX)
 
-	if(carbon_patient.stat != DEAD && !(HAS_TRAIT(carbon_patient, TRAIT_FAKEDEATH)))
-		if(istype(heart))
-			heart_strength = (heart.beating ? "a healthy" : span_danger("an unstable"))
-		if(istype(lungs))
-			lung_strength = ((carbon_patient.failed_last_breath || carbon_patient.losebreath) ? span_danger("strained") : "healthy")
+	var/render_list = list()//information will be packaged in a list for clean display to the user
 
-	user.visible_message(span_notice("[user] places [src] against [carbon_patient]'s [body_part] and listens attentively."), ignored_mobs = user)
+	//determine what specific action we're taking
+	switch (body_part)
+		if(BODY_ZONE_CHEST)//Listening to the chest
+			user.visible_message(span_notice("[user] places [src] against [carbon_patient]'s [body_part] and listens attentively."), ignored_mobs = user)
+			if(!user.can_hear())
+				to_chat(user, span_notice("You place [src] against [carbon_patient]'s [body_part]. Fat load of good it does you though, since you can't hear"))
+				return
+			else
+				render_list += span_info("You place [src] against [carbon_patient]'s [body_part]:\n")
 
-	var/diagnosis = (body_part == BODY_ZONE_CHEST ? "You hear [heart_strength] pulse and [lung_strength] respiration" : "You faintly hear [heart_strength] pulse")
-	if(!user.can_hear())
-		diagnosis = "Fat load of good it does you though, since you can't hear"
+			//assess breathing
+			if(!lungs)//sanity check, enusure patient actually has lungs
+				render_list += "<span class='danger ml-1'>[M] doesn't have any lungs!</span>\n"
+			else
+				if(carbon_patient.stat == DEAD || (HAS_TRAIT(carbon_patient, TRAIT_FAKEDEATH)) || (HAS_TRAIT(carbon_patient, TRAIT_NOBREATH))|| carbon_patient.failed_last_breath || carbon_patient.losebreath)//If pt is dead or otherwise not breathing
+					render_list += "<span class='danger ml-1'>[M.p_theyre(TRUE)] not breathing!</span>\n"
+				else if(lungs.damage > 10)//if breathing, check for lung damage
+					render_list += "<span class='danger ml-1'>You hear fluid in [M.p_their()] lungs!</span>\n"
+				else if(oxy_loss > 10)//if they have suffocation damage
+					render_list += "<span class='danger ml-1'>[M.p_theyre(TRUE)] breathing heavily!</span>\n"
+				else
+					render_list += "<span class='notice ml-1'>[M.p_theyre(TRUE)] breathing normally.</span>\n"//they're okay :D
 
-	to_chat(user, span_notice("You place [src] against [carbon_patient]'s [body_part]. [diagnosis]."))
+			//assess heart
+			if(body_part == BODY_ZONE_CHEST)//if we're listening to the chest
+				if(!heart)//sanity check, ensure the patient actually has a heart
+					render_list += "<span class='danger ml-1'>[M] doesn't have a heart!</span>\n"
+				else
+					if(!heart.beating || carbon_patient.stat == DEAD)
+						render_list += "<span class='danger ml-1'>You don't hear a heartbeat!</span>\n"//they're dead or their heart isn't beating
+					else if(heart.damage > 10 || carbon_patient.blood_volume <= BLOOD_VOLUME_OKAY)
+						render_list += "<span class='danger ml-1'>You hear a weak heartbeat.</span>\n"//their heart is damaged, or they have critical blood
+					else
+						render_list += "<span class='notice ml-1'>You hear a healthy heartbeat.</span>\n"//they're okay :D
+
+		if(BODY_ZONE_PRECISE_GROIN)//If we're targeting the groin
+			render_list += span_info("You carefully press down on [carbon_patient]'s abdomen:\n")
+			user.visible_message(span_notice("[user] presses their hands against [carbon_patient]'s abdomen."), ignored_mobs = user)
+
+			//assess abdominal organs
+			if(body_part == BODY_ZONE_PRECISE_GROIN)
+				var/appendix_okay = TRUE
+				var/liver_okay = TRUE
+				if(!liver)//sanity check, ensure the patient actually has a liver
+					render_list += "<span class='danger ml-1'>[M] doesn't have a liver!</span>\n"
+					liver_okay = FALSE
+				else
+					if(liver.damage > 10)
+						render_list += "<span class='danger ml-1'>[M.p_their(TRUE)] liver feels firm.</span>\n"//their liver is damaged
+						liver_okay = FALSE
+
+				if(!appendix)//sanity check, ensure the patient actually has an appendix
+					render_list += "<span class='danger ml-1'>[M] doesn't have an appendix!</span>\n"
+					appendix_okay = FALSE
+				else
+					if(appendix.damage > 10 && carbon_patient.stat == CONSCIOUS)
+						render_list += "<span class='danger ml-1'>[M] screams when you lift your hand from [M.p_their()] appendix!</span>\n"//scream if their appendix is damaged and they're awake
+						M.emote("scream")
+						appendix_okay = FALSE
+
+				if(liver_okay && appendix_okay)//if they have all their organs and have no detectable damage
+					render_list += "<span class='notice ml-1'>You don't find anything abnormal.</span>\n"//they're okay :D
+
+		if(BODY_ZONE_PRECISE_EYES)
+			balloon_alert(user, "can't do that!")
+			return
+
+		if(BODY_ZONE_PRECISE_MOUTH)
+			balloon_alert(user, "can't do that!")
+			return
+
+		else//targeting an extremity or the head
+			if(body_part ==  BODY_ZONE_HEAD)
+				render_list += span_info("You carefully press your fingers to [carbon_patient]'s neck:\n")
+				user.visible_message(span_notice("[user] presses their fingers against [carbon_patient]'s neck."), ignored_mobs = user)
+			else
+				render_list += span_info("You carefully press your fingers to [carbon_patient]'s [body_part]:\n")
+				user.visible_message(span_notice("[user] presses their fingers against [carbon_patient]'s [body_part]."), ignored_mobs = user)
+
+			//assess pulse (heart & blood level)
+			if(!heart)//sanity check, ensure the patient actually has a heart
+				render_list += "<span class='danger ml-1'>[M] doesn't have a heart!</span>\n"
+			else
+				if(!heart.beating || carbon_patient.blood_volume <= BLOOD_VOLUME_OKAY || carbon_patient.stat == DEAD)
+					render_list += "<span class='danger ml-1'>You can't find a pulse!</span>\n"//they're dead, their heart isn't beating, or they have critical blood
+				else
+					if(heart.damage > 10)
+						heart_strength = span_danger("irregular")//their heart is damaged
+					else
+						heart_strength = span_notice("regular")//they're okay :D
+
+					if(carbon_patient.blood_volume <= BLOOD_VOLUME_SAFE && carbon_patient.blood_volume > BLOOD_VOLUME_OKAY)
+						pulse_pressure = span_danger("thready")//low blood
+					else
+						pulse_pressure = span_notice("strong")//they're okay :D
+
+					render_list += "<span class='notice ml-1'>[M.p_their(TRUE)] pulse is [pulse_pressure] and [heart_strength].</span>\n"
+
+	//display our packaged information in an examine block for easy reading
+	to_chat(user, examine_block(jointext(render_list, "")), type = MESSAGE_TYPE_INFO)
 
 ///////////
 //SCARVES//


### PR DESCRIPTION

## About The Pull Request
Ports:

- #79863
- #76527
- #75800 (I fixed it up to work with monke intento,combat mode, checked it too)
- #74787
## Why It's Good For The Game
Keeps us up to date with tg, fixes 2 bugs, makes stethoscopes and penlights actually useful outside of being blind (guh, I initially wanted to add blindness support to health analyzers but I'm curious how useful this is gonna be instead), new brain trauma and funny blind interaction with cardboard boxes.
## Changelog
:cl: lizardqueenlexi, ChungusGamer666, LovliestPlant, KnigTheThrasher, MrMelbert
fix: Heads impaled on spears now render in the correct place on the tip, instead of halfway down the shaft.
fix: Blind personnel are no longer able to magically see heads impaled on spears from a distance.
add: Added colorblindness as a mild brain trauma.
add: Stethoscopes may be used on the chest, groin, or extremities to assess organ damage, blood level, and/or suffocation damage depending on the targeted area.
add: Shining flashlights into the mouth or eyes of other players will additionally assess brain health, suffocation damage, and/or blood level depending on the targeted area.
balance: Halves the duration of the flash effect from shining lights into players' eyes (2s -> 1s). Use combat mode to get the full duration.
fix: added combat mode/harm intent support for the previous pr
balance: Blind people don't get alerted when someone in a cardboard box pops out nearby
/:cl:
