### PR TITLE
[PORT] Fixed headless zambos and the oversight of no bio armor resistance 

### DIFF
--- a/code/controllers/subsystem/radiation.dm
+++ b/code/controllers/subsystem/radiation.dm
@@ -135,7 +135,7 @@ SUBSYSTEM_DEF(radiation)
 	for (var/obj/item/bodypart/limb as anything in human.bodyparts)
 		var/protected = FALSE
 
-		for (var/obj/item/clothing as anything in human.clothingonpart(limb))
+		for (var/obj/item/clothing as anything in human.get_clothing_on_part(limb))
 			if (HAS_TRAIT(clothing, TRAIT_RADIATION_PROTECTED_CLOTHING))
 				protected = TRUE
 				break

--- a/code/datums/wounds/scars/_scars.dm
+++ b/code/datums/wounds/scars/_scars.dm
@@ -178,7 +178,7 @@
 		if((human_victim.wear_mask && (human_victim.wear_mask.flags_inv & HIDEFACE)) || (human_victim.head && (human_victim.head.flags_inv & HIDEFACE)))
 			return FALSE
 	else if(limb.scars_covered_by_clothes)
-		var/num_covers = LAZYLEN(human_victim.clothingonpart(limb))
+		var/num_covers = LAZYLEN(human_victim.get_clothing_on_part(limb))
 		if(num_covers + get_dist(viewer, victim) >= visibility)
 			return FALSE
 

--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -19,8 +19,7 @@
 	if(istype(jumpsuit))
 		jumpsuit.set_armor(/datum/armor/clothing_under)
 
-//	var/obj/item/clothing/head/hat = avatar.get_clothing_on_part(HEAD) MONKEYSTATION EDIT CHANGE OLD
-	var/obj/item/clothing/head/hat = avatar.clothingonpart(HEAD) // MONKEYSTATION EDIT CHANGE NEW - we dont have TG's PR #78589 so its named a bit differently
+	var/obj/item/clothing/head/hat = avatar.get_clothing_on_part(HEAD)
 
 	if(istype(hat))
 		hat.set_armor(null)

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -104,6 +104,7 @@
 	laser = 20
 	energy = 30
 	bomb = 100
+	bio = 50
 	fire = 80
 	acid = 50
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -332,7 +332,7 @@
 	var/obj/item/bodypart/the_part = isbodypart(target_zone) ? target_zone : get_bodypart(check_zone(target_zone)) //keep these synced
 	// Loop through the clothing covering this bodypart and see if there's any thiccmaterials
 	if(!(injection_flags & INJECT_CHECK_PENETRATE_THICK))
-		for(var/obj/item/clothing/iter_clothing in clothingonpart(the_part))
+		for(var/obj/item/clothing/iter_clothing in get_clothing_on_part(the_part))
 			if(iter_clothing.clothing_flags & THICKMATERIAL)
 				. = FALSE
 				break

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -6,21 +6,21 @@
 		if(isbodypart(def_zone))
 			var/obj/item/bodypart/bp = def_zone
 			if(bp)
-				return checkarmor(def_zone, type)
+				return check_armor(def_zone, type)
 		var/obj/item/bodypart/affecting = get_bodypart(check_zone(def_zone))
 		if(affecting)
-			return checkarmor(affecting, type)
-		//If a specific bodypart is targeted, check how that bodypart is protected and return the value.
+			return check_armor(affecting, type)
+		//If a specific bodypart is targetted, check how that bodypart is protected and return the value.
 
 	//If you don't specify a bodypart, it checks ALL your bodyparts for protection, and averages out the values
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/BP = X
-		armorval += checkarmor(BP, type)
+		armorval += check_armor(BP, type)
 		organnum++
 	return (armorval/max(organnum, 1))
 
 
-/mob/living/carbon/human/proc/checkarmor(obj/item/bodypart/def_zone, damage_type)
+/mob/living/carbon/human/proc/check_armor(obj/item/bodypart/def_zone, damage_type)
 	if(!damage_type)
 		return 0
 	var/protection = 100
@@ -32,7 +32,7 @@
 	return 100 - protection
 
 ///Get all the clothing on a specific body part
-/mob/living/carbon/human/proc/clothingonpart(obj/item/bodypart/def_zone)
+/mob/living/carbon/human/proc/get_clothing_on_part(obj/item/bodypart/def_zone)
 	var/list/covering_part = list()
 	var/list/body_parts = list(head, wear_mask, wear_suit, w_uniform, back, gloves, shoes, belt, s_store, glasses, ears, wear_id, wear_neck) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)
 	for(var/bp in body_parts)

--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -85,7 +85,7 @@
 	// quick re-check to see if bare_wound_bonus applies, for the benefit of log_wound(), see about getting the check from check_woundings_mods() somehow
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_wearer = owner
-		var/list/clothing = human_wearer.clothingonpart(src)
+		var/list/clothing = human_wearer.get_clothing_on_part(src)
 		for(var/obj/item/clothing/clothes_check as anything in clothing)
 			// unlike normal armor checks, we tabluate these piece-by-piece manually so we can also pass on appropriate damage the clothing's limbs if necessary
 			if(clothes_check.get_armor_rating(WOUND))
@@ -242,7 +242,7 @@
 
 	if(owner && ishuman(owner))
 		var/mob/living/carbon/human/human_owner = owner
-		var/list/clothing = human_owner.clothingonpart(src)
+		var/list/clothing = human_owner.get_clothing_on_part(src)
 		for(var/obj/item/clothing/clothes as anything in clothing)
 			// unlike normal armor checks, we tabluate these piece-by-piece manually so we can also pass on appropriate damage the clothing's limbs if necessary
 			armor_ablation += clothes.get_armor_rating(WOUND)

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -81,7 +81,7 @@
 	if(!infection)
 		infection = new()
 		infection.Insert(target)
-		to_chat(user, span_alien("You see [target] twitch for a moment as [target.p_their()] head is covered in \a [infection] - [target.p_Theyve()] been infected."))
+		to_chat(user, span_alien("You see [target] twitch for a moment as [target.p_their()] head is covered in \a [infection] - [target.p_theyve()] been infected."))
 
 /obj/item/mutant_hand/zombie/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is ripping [user.p_their()] brains out! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -57,25 +57,6 @@
 	if(limb_armor > limb_damage)
 		return
 
-	var/obj/item/bodypart/actual_limb = target.get_bodypart(def_zone)
-
-	// What you hitting bro?
-	if(!actual_limb)
-		return
-
-	var/limb_damage = actual_limb.get_damage()
-	var/limb_armor = max(0, target.getarmor(actual_limb, BIO) - 25)
-
-	// This is a pretty jank way to do this, but in short:
-	// if they have thick material on that bodypart it will always need at least 25 previous limb damage to trigger an infection.
-	// and if their bio armor isn't thick it's a bit weaker.
-	for(var/obj/item/clothing/iter_clothing in target.get_clothing_on_part(actual_limb))
-		if(iter_clothing.clothing_flags & THICKMATERIAL)
-			limb_armor += 25
-
-	if(limb_armor > limb_damage)
-		return
-
 	var/obj/item/organ/internal/zombie_infection/infection
 	infection = target.get_organ_slot(ORGAN_SLOT_ZOMBIE)
 	if(!infection)

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -11,19 +11,23 @@
 	bare_wound_bonus = 15
 	sharpness = SHARP_EDGED
 
-/obj/item/mutant_hand/zombie/afterattack(atom/target, mob/user, proximity_flag)
+/obj/item/mutant_hand/zombie/afterattack(atom/target, mob/living/user, proximity_flag)
 	. = ..()
 	if(!proximity_flag)
 		return
 	else if(isliving(target))
 		if(ishuman(target))
-			try_to_zombie_infect(target)
+			try_to_zombie_infect(target, user, user.zone_selected)
 		else
 			. |= AFTERATTACK_PROCESSED_ITEM
 			check_feast(target, user)
 
-/proc/try_to_zombie_infect(mob/living/carbon/human/target)
+/proc/try_to_zombie_infect(mob/living/carbon/human/target, mob/living/user, def_zone = BODY_ZONE_CHEST)
 	CHECK_DNA_AND_SPECIES(target)
+
+	// Can't zombify with no head
+	if(!target.get_bodypart(BODY_ZONE_HEAD))
+		return
 
 	if(NOZOMBIE in target.dna.species.species_traits)
 		// cannot infect any NOZOMBIE subspecies (such as high functioning
@@ -34,11 +38,50 @@
 	if(istype(target) && target.reagents.has_reagent(/datum/reagent/medicine/antipathogenic/spaceacillin) && prob(75))
 		return
 
+	var/obj/item/bodypart/actual_limb = target.get_bodypart(def_zone)
+
+	// What you hitting bro?
+	if(!actual_limb)
+		return
+
+	var/limb_damage = actual_limb.get_damage()
+	var/limb_armor = max(0, target.getarmor(actual_limb, BIO) - 25)
+
+	// This is a pretty jank way to do this, but in short:
+	// if they have thick material on that bodypart it will always need at least 25 previous limb damage to trigger an infection.
+	// and if their bio armor isn't thick it's a bit weaker.
+	for(var/obj/item/clothing/iter_clothing in target.get_clothing_on_part(actual_limb))
+		if(iter_clothing.clothing_flags & THICKMATERIAL)
+			limb_armor += 25
+
+	if(limb_armor > limb_damage)
+		return
+
+	var/obj/item/bodypart/actual_limb = target.get_bodypart(def_zone)
+
+	// What you hitting bro?
+	if(!actual_limb)
+		return
+
+	var/limb_damage = actual_limb.get_damage()
+	var/limb_armor = max(0, target.getarmor(actual_limb, BIO) - 25)
+
+	// This is a pretty jank way to do this, but in short:
+	// if they have thick material on that bodypart it will always need at least 25 previous limb damage to trigger an infection.
+	// and if their bio armor isn't thick it's a bit weaker.
+	for(var/obj/item/clothing/iter_clothing in target.get_clothing_on_part(actual_limb))
+		if(iter_clothing.clothing_flags & THICKMATERIAL)
+			limb_armor += 25
+
+	if(limb_armor > limb_damage)
+		return
+
 	var/obj/item/organ/internal/zombie_infection/infection
 	infection = target.get_organ_slot(ORGAN_SLOT_ZOMBIE)
 	if(!infection)
 		infection = new()
 		infection.Insert(target)
+		to_chat(user, span_alien("You see [target] twitch for a moment as [target.p_their()] head is covered in \a [infection] - [target.p_Theyve()] been infected."))
 
 /obj/item/mutant_hand/zombie/suicide_act(mob/living/user)
 	user.visible_message(span_suicide("[user] is ripping [user.p_their()] brains out! It looks like [user.p_theyre()] trying to commit suicide!"))


### PR DESCRIPTION
## About The Pull Request
Ports

- #78589

Closes

- #1210 
- #1462 

Pretty sure this fixes every zombie related bug we have ie. armless zombies hitting people with invisible hands, headless zombies casually being immortal unless you gib them. (Checked it locally)
## Why It's Good For The Game
Fixes a lot of zombie bugs, must be good eh?
## Changelog
:cl:
fix: Fixed zombies being able to infect headless corpses (Including former zombies)
fix: Fixed bio armor being totally useless against zombies. Now it checks how hurt your limb is: If it's more than the bio armor value, you get infected. THICKMATERIAL clothing guarantees at least 25 damage required to infect you, non-thick clothing reduces effective defence by 25. In practice this means people with MODsuits, biosuits will resist infection unless they're pummeled into crit, and wearing a firesuit will save you from the first few slashes.
fix: Fixed the bomb hood armor not having the same bio armor value as bomb armor.
qol: Added a message to the zed when they succesfully infect someone.
code: Turned some proc names into snake_case rather than, uh, nospacecase.
/:cl:
