### PR TITLE
Removes a duplicate door when metastation rolls a singularity engine

### DIFF
--- a/_maps/~monkestation/RandomEngines/MetaStation/singularity.dmm
+++ b/_maps/~monkestation/RandomEngines/MetaStation/singularity.dmm
@@ -308,15 +308,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"yo" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Space Engine Room"
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/hidden,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "yR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -911,7 +902,7 @@ MT
 dx
 ID
 dc
-yo
+SS
 je
 je
 je


### PR DESCRIPTION

## About The Pull Request
Removes a duplicate door when meta rolls a singulo engine.

Closes

- #1453
## Why It's Good For The Game
Fixes an issue, we've got over 300 now. Let's make it smaller eh?
## Changelog
:cl: KnigTheThrasher
fix: Removed a duped door when meta rolls a sinularity engine
/:cl:
