### PR TITLE
extrapolator-b-gon

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/l3closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/l3closet.dm
@@ -20,8 +20,8 @@
 	new /obj/item/clothing/head/bio_hood/virology(src)
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/tank/internals/oxygen(src)
-	new /obj/item/extrapolator(src)
-	new /obj/item/extrapolator(src)
+//	new /obj/item/extrapolator(src) // monkestation edit - extrapolators are worthless for pathology
+//	new /obj/item/extrapolator(src)
 
 
 /obj/structure/closet/l3closet/security

--- a/code/modules/jobs/job_types/virologist.dm
+++ b/code/modules/jobs/job_types/virologist.dm
@@ -46,7 +46,7 @@
 	id_trim = /datum/id_trim/job/virologist
 	uniform = /obj/item/clothing/under/rank/medical/virologist
 	backpack_contents = list(
-		/obj/item/extrapolator = 1,
+//		/obj/item/extrapolator = 1, //monkestation edit - extrapolator is useless with pathology.
 		/obj/item/storage/box/vials = 1,
 	)
 	suit = /obj/item/clothing/suit/toggle/labcoat/virologist


### PR DESCRIPTION

## About The Pull Request

Extrapolators are worthless and shall be removed from roundstart kits.
## Why It's Good For The Game

Excess baggage.
## Changelog
:cl:
del: Virus extrapolators no longer spawn in l3 bioclosets or pathologist kits.
/:cl:
