### PR TITLE
Pathology tweaks

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/stage4.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/stage4.dm
@@ -316,7 +316,7 @@
 /datum/symptom/retrovirus/activate(mob/living/carbon/affected_mob)
 	if(!iscarbon(affected_mob))
 		return
-	switch(max_multiplier)
+	switch(multiplier)
 		if(1)
 			if(prob(4))
 				to_chat(affected_mob, span_danger("Your head hurts."))

--- a/monkestation/code/modules/virology/items/antibodyscanner.dm
+++ b/monkestation/code/modules/virology/items/antibodyscanner.dm
@@ -115,6 +115,8 @@
 			if(ID in GLOB.virusDB)
 				var/datum/data/record/V = GLOB.virusDB[ID]
 				info += "<br><i>[V.fields["name"]][V.fields["nickname"] ? " \"[V.fields["nickname"]]\"" : ""] detected. Strength: [D.strength]. Robustness: [D.robustness]. Antigen: [D.get_antigen_string()]</i>"
+				for(var/datum/symptom/e in D.symptoms)
+					info += "<br><b>Stage [e.stage] - [e.name]</b> (Danger: [e.badness]): <i>[e.desc]</i>"
 			else
 				info += "<br><i>Unknown [D.form] detected. Strength: [D.strength]</i>"
 

--- a/monkestation/code/modules/virology/reagents/immune_healers.dm
+++ b/monkestation/code/modules/virology/reagents/immune_healers.dm
@@ -3,9 +3,9 @@
 	description = "A powerful immune enhancing drug, often used in small doses to counteract immunodeficiency."
 	color = "#667056"
 	ph = 7.4
-	metabolization_rate = 0.2 * REAGENTS_METABOLISM
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	data = list(
-		"level" = 0.05,
+		"level" = 0.1,//fast at bringing your immune strength back to your initial level
 		"threshold" = 1,
 		) //level is in precentage
 
@@ -43,9 +43,9 @@
 	description = "An immune system enhancement drug, able to increase the power of a person's immune system up to 5 times its starting level."
 	color = "#16eedc"
 	ph = 6.3
-	metabolization_rate = REAGENTS_METABOLISM
+	metabolization_rate = 0.2 * REAGENTS_METABOLISM
 	data = list(
-		"level" = 0.05,
+		"level" = 0.01,//very slow, meaning it will do little when you are already sick
 		"threshold" = 5,
 		) //level is in precentage
 

--- a/monkestation/code/modules/virology/reagents/immune_healers.dm
+++ b/monkestation/code/modules/virology/reagents/immune_healers.dm
@@ -46,7 +46,7 @@
 	metabolization_rate = 0.2 * REAGENTS_METABOLISM
 	data = list(
 		"level" = 0.01,//very slow, meaning it will do little when you are already sick
-		"threshold" = 5,
+		"threshold" = 3,
 		) //level is in precentage
 
 /datum/chemical_reaction/immune_healer


### PR DESCRIPTION
## About The Pull Request
Makes aetericilide a very slow acting immune booster for when you aren't sick and aluxive to be a fast acting immune booster that will keep your immune strength at max while it is in your system.

Fixes the retrovirus from doing its more dangerous effects no matter what to requiring its multiplier to be increased first.

Makes the immunity scanner show symptoms for recorded diseases.
![image](https://github.com/Monkestation/Monkestation2.0/assets/155601848/05f63c7d-e289-4b6f-85bd-d00199dffee6)
## Why It's Good For The Game
There is now a reason to use aluxive over aetericilide.
You can show people that a disease is beneficial.
## Changelog
:cl:
add: Immunity scanner now shows symptoms for recorded diseases.
balance: Aluxive has a stronger instant effect.
balance: Aetericilide is effective as preventative medication but not much value once infected. (Also its max strength was lowered to 3x base strength from 5x base strength)
fix: Retrovirus now utilizes its multiplier for its effects rather than its constant max_multiplier.
/:cl:
