### PR TITLE
antag token notification improvements

### DIFF
--- a/code/__HELPERS/~monkestation-helpers/announcements.dm
+++ b/code/__HELPERS/~monkestation-helpers/announcements.dm
@@ -1,5 +1,3 @@
-#define MAJOR_ANNOUNCEMENT_TITLE(string) ("<span class='major_announcement_title'>" + string + "</span>")
-
 /proc/send_formatted_admin_message(
 	text,
 	title = "Admin Alert",
@@ -15,5 +13,3 @@
 	SEND_ADMINCHAT_MESSAGE(finalized_announcement)
 	if(sound_override)
 		SEND_ADMINS_NOTFICATION_SOUND(sound_override)
-
-#undef MAJOR_ANNOUNCEMENT_TITLE

--- a/code/__HELPERS/~monkestation-helpers/announcements.dm
+++ b/code/__HELPERS/~monkestation-helpers/announcements.dm
@@ -1,0 +1,19 @@
+#define MAJOR_ANNOUNCEMENT_TITLE(string) ("<span class='major_announcement_title'>" + string + "</span>")
+
+/proc/send_formatted_admin_message(
+	text,
+	title = "Admin Alert",
+	sound_override = 'sound/effects/adminhelp.ogg',
+	color_override = "red"
+)
+	if(isnull(text))
+		return
+	var/list/announcement_strings = list()
+	announcement_strings += SUBHEADER_ANNOUNCEMENT_TITLE(title)
+	announcement_strings += span_major_announcement_text(text)
+	var/finalized_announcement = create_announcement_div(jointext(announcement_strings, ""), color_override)
+	SEND_ADMINCHAT_MESSAGE(finalized_announcement)
+	if(sound_override)
+		SEND_ADMINS_NOTFICATION_SOUND(sound_override)
+
+#undef MAJOR_ANNOUNCEMENT_TITLE

--- a/monkestation/code/modules/client/verbs.dm
+++ b/monkestation/code/modules/client/verbs.dm
@@ -57,9 +57,12 @@ GLOBAL_LIST_INIT(antag_token_config, load_antag_token_config())
 	client_token_holder.in_queue = new chosen_antagonist
 
 	to_chat(src, span_boldnotice("Your request has been sent to the admins."))
-	SEND_NOTFIED_ADMIN_MESSAGE('sound/items/bikehorn.ogg', "[span_admin("[span_prefix("ANTAG TOKEN:")] <EM>[key_name(src)]</EM> \
-							[ADMIN_APPROVE_ANTAG_TOKEN(src)] [ADMIN_REJECT_ANTAG_TOKEN(src)] | \
-							[src] has requested to use their antag token to be a [chosen_antagonist::name].")]")
+	send_formatted_admin_message( \
+		"[ADMIN_LOOKUPFLW(src)] has requested to use their antag token to be a [chosen_antagonist::name].\n\n[ADMIN_APPROVE_ANTAG_TOKEN(src)] | [ADMIN_REJECT_ANTAG_TOKEN(src)]",	\
+		title = "Antag Token Request", \
+		color_override = "orange" \
+	)
+	client_token_holder.antag_timeout = addtimer(CALLBACK(client_token_holder, TYPE_PROC_REF(/datum/meta_token_holder, timeout_antag_token)), 5 MINUTES, TIMER_STOPPABLE | TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_DELETE_ME)
 
 /client/verb/trigger_token_event()
 	set category = "IC"
@@ -92,9 +95,12 @@ GLOBAL_LIST_INIT(antag_token_config, load_antag_token_config())
 			client_token_holder.queued_token_event = selected_event
 			to_chat(src, span_boldnotice("Your request has been sent."))
 			logger.Log(LOG_CATEGORY_META, "[usr] has requested to use their event tokens to trigger [selected_event.event_name]([selected_event]).")
-			SEND_NOTFIED_ADMIN_MESSAGE('sound/items/bikehorn.ogg', "[span_admin("[span_prefix("TOKEN EVENT:")] <EM>[key_name(src)]</EM> \
-																				[ADMIN_APPROVE_TOKEN_EVENT(src)] [ADMIN_REJECT_TOKEN_EVENT(src)] | \
-																				[src] has requested use their event tokens to trigger [selected_event.event_name]([selected_event]).")]")
+			send_formatted_admin_message( \
+				"[ADMIN_LOOKUPFLW(src)] has requested use their event tokens to trigger [selected_event.event_name]([selected_event]).\n\n[ADMIN_APPROVE_TOKEN_EVENT(src)] | [ADMIN_REJECT_TOKEN_EVENT(src)]",	\
+				title = "Event Token Request", \
+				color_override = "orange" \
+			)
+			client_token_holder.event_timeout = addtimer(CALLBACK(client_token_holder, TYPE_PROC_REF(/datum/meta_token_holder, timeout_event_token)), 5 MINUTES, TIMER_STOPPABLE | TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_DELETE_ME)
 			return
 		to_chat(src, "You dont have enough tokens to trigger this event.")
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -537,6 +537,7 @@
 #include "code\__HELPERS\sorts\InsertSort.dm"
 #include "code\__HELPERS\sorts\MergeSort.dm"
 #include "code\__HELPERS\sorts\TimSort.dm"
+#include "code\__HELPERS\~monkestation-helpers\announcements.dm"
 #include "code\__HELPERS\~monkestation-helpers\icon_smoothing.dm"
 #include "code\__HELPERS\~monkestation-helpers\time.dm"
 #include "code\__HELPERS\~monkestation-helpers\virology.dm"


### PR DESCRIPTION

## About The Pull Request

![2024-03-24 (1711328639) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/2c23ef4c-796f-453e-bdc5-7c0ae67100df)

Token requests time out after 5 minutes

## Changelog
:cl:
qol: Antag/event token requests now time out after 5 minutes of inaction.
admin: Improved the admin notification for token requests.
sound: Added a sound whenever an token is rejected.
/:cl:
