### PR TITLE
Fix for starthistle

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -294,6 +294,9 @@
 			if(prob(10) && has_viable_mutations())
 				t_prod = create_valid_mutation(output_loc)
 			else
+				if(!product)
+					t_amount++
+					continue
 				t_prod = new product(output_loc, src)
 				if(parent.myseed.plantname != initial(parent.myseed.plantname))
 					t_prod.name = parent.myseed.plantname


### PR DESCRIPTION
## About The Pull Request
Makes it so that harvesting starthistle can't exit early without reducing its growth.
## Why It's Good For The Game
Starthistle used to be able to be harvested a near infinite amount of times in quick succession. This makes it act like other non-perennial growth plants.
## Changelog
:cl:
fix: Plants with no product defined will no longer have a chance to return early on harvest.
/:cl:
