### PR TITLE
fix modular computers being borked

### DIFF
--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -42,6 +42,7 @@
 /obj/machinery/modular_computer/Initialize(mapload)
 	. = ..()
 	cpu = new(src)
+	cpu.physical = src
 	cpu.screen_on = TRUE
 	update_appearance()
 


### PR DESCRIPTION

## Changelog
:cl:
fix: fix modular computers (i.e hop's id console) being borked
/:cl:
