### PR TITLE
Fixes Aetericilide not working entirely.

### DIFF
--- a/monkestation/code/modules/virology/disease/_disease.dm
+++ b/monkestation/code/modules/virology/disease/_disease.dm
@@ -381,9 +381,9 @@ GLOBAL_LIST_INIT(virusDB, list())
 	if(mob.immune_system)
 		if(prob(8))
 			mob.immune_system.NaturalImmune()
-		//Slowly decay back to regular strength immune system while you are sick
-		if(mob.immune_system.strength > 1)
-			mob.immune_system.strength = max(mob.immune_system.strength - 0.01, 1)
+			//Slowly decay back to regular strength immune system while you are sick
+			if(mob.immune_system.strength > 1)
+				mob.immune_system.strength = max(1, mob.immune_system.strength - 0.01)
 
 	if(!mob.immune_system.CanInfect(src))
 		cure(mob)


### PR DESCRIPTION

## About The Pull Request
Makes Aetericilide work again.

Currently this was decaying the immune system whenever diseases were activated, which happens FAR more than chemicals are ticked. Meaning you could drink aetericilide nonstop and have no changes.  This pr fixes this issue by making it happen in sync with all other immune mechanics.

## Why It's Good For The Game
I think its bad for bugs to exist.

## Changelog
:cl:
fix: fixes Aetericilide being useless.
/:cl:
