### PR TITLE
Fix various traitor issues

### DIFF
--- a/code/controllers/subsystem/traitor.dm
+++ b/code/controllers/subsystem/traitor.dm
@@ -44,6 +44,9 @@ SUBSYSTEM_DEF(traitor)
 	category_handler = new()
 	traitor_debug_panel = new(category_handler)
 
+	for(var/theft_item in subtypesof(/datum/objective_item/steal))
+		new theft_item
+
 	if(fexists(configuration_path))
 		var/list/data = json_decode(file2text(file(configuration_path)))
 		for(var/typepath in data)

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -48,6 +48,7 @@
 	has_progression = FALSE,
 	datum/uplink_handler/uplink_handler_override,
 )
+
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
 
@@ -119,6 +120,7 @@
 /// Sets the telecrystals of the uplink. It is bad practice to use this outside of the component itself.
 /datum/component/uplink/proc/set_telecrystals(new_telecrystal_amount)
 	uplink_handler.telecrystals = new_telecrystal_amount
+	uplink_handler.on_update()
 
 /datum/component/uplink/InheritComponent(datum/component/uplink/uplink)
 	lockable |= uplink.lockable
@@ -144,6 +146,11 @@
 
 	if(istype(item, /obj/item/stack/telecrystal))
 		load_tc(user, item)
+
+	if(!istype(item))
+		return
+
+	SEND_SIGNAL(item, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, user, src)
 
 /datum/component/uplink/proc/on_examine(datum/source, mob/user, list/examine_list)
 	SIGNAL_HANDLER

--- a/code/datums/elements/uplink_reimburse.dm
+++ b/code/datums/elements/uplink_reimburse.dm
@@ -1,5 +1,5 @@
 /**
- * Uplinik Reimburse element.
+ * Uplink Reimburse element.
  * When element is applied onto items, it allows them to be reimbursed if an user pokes an item with a uplink component with them.
  *
  * Element is only compatible with items.
@@ -21,9 +21,11 @@
 
 	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(target, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, PROC_REF(reimburse))
-
+	RegisterSignal(target,COMSIG_TRAITOR_ITEM_USED(target.type), PROC_REF(used))
+	
 /datum/element/uplink_reimburse/Detach(datum/target)
-	UnregisterSignal(target, list(COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_EXAMINE))
+	UnregisterSignal(target, list(COMSIG_ATOM_EXAMINE, COMSIG_TRAITOR_ITEM_USED(target.type), COMSIG_ITEM_ATTEMPT_TC_REIMBURSE))
+
 
 	return ..()
 
@@ -47,3 +49,8 @@
 	do_sparks(2, source = uplink_comp.uplink_handler)
 	uplink_comp.add_telecrystals(refundable_tc)
 	qdel(refund_item)
+/// If the item is used, it needs to no longer be refundable
+/datum/element/uplink_reimburse/proc/used(datum/target)
+	SIGNAL_HANDLER
+	
+	Detach(target)

--- a/code/datums/elements/uplink_reimburse.dm
+++ b/code/datums/elements/uplink_reimburse.dm
@@ -1,0 +1,49 @@
+/**
+ * Uplinik Reimburse element.
+ * When element is applied onto items, it allows them to be reimbursed if an user pokes an item with a uplink component with them.
+ *
+ * Element is only compatible with items.
+ */
+
+/datum/element/uplink_reimburse
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 1
+	/// TC to refund!
+	var/refundable_tc = 1
+
+/datum/element/uplink_reimburse/Attach(datum/target, refundable_tc = 1)
+	. = ..()
+
+	if(!isitem(target))
+		return ELEMENT_INCOMPATIBLE
+
+	src.refundable_tc = refundable_tc
+
+	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+	RegisterSignal(target, COMSIG_ITEM_ATTEMPT_TC_REIMBURSE, PROC_REF(reimburse))
+
+/datum/element/uplink_reimburse/Detach(datum/target)
+	UnregisterSignal(target, list(COMSIG_ATOM_ATTACKBY, COMSIG_ATOM_EXAMINE))
+
+	return ..()
+
+///signal called on parent being examined
+/datum/element/uplink_reimburse/proc/on_examine(datum/target, mob/user, list/examine_list)
+	SIGNAL_HANDLER
+
+	if(!IS_TRAITOR(user) && !IS_NUKE_OP(user))
+		examine_list += span_warning("There's a label on the side, but it's written in indecipherable gibberish. You have no idea what it means!")
+		return
+
+	examine_list += span_notice("There's a label written in codespeak on the side, saying that this item can be refunded for [refundable_tc] by applying it onto an uplink.")
+
+/datum/element/uplink_reimburse/proc/reimburse(obj/item/refund_item, mob/user, datum/component/uplink/uplink_comp)
+	SIGNAL_HANDLER
+
+	if(!uplink_comp)
+		CRASH("No uplink component in arguments detected")
+
+	to_chat(user, span_notice("You tap [uplink_comp.uplink_handler] with [refund_item], and a moment after [refund_item] disappears in a puff of red smoke!"))
+	do_sparks(2, source = uplink_comp.uplink_handler)
+	uplink_comp.add_telecrystals(refundable_tc)
+	qdel(refund_item)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -584,12 +584,6 @@ GLOBAL_LIST_EMPTY(possible_items)
 /datum/objective/steal/get_target()
 	return steal_target
 
-/datum/objective/steal/New()
-	..()
-	if(!GLOB.possible_items.len)//Only need to fill the list when it's needed.
-		for(var/I in subtypesof(/datum/objective_item/steal))
-			new I
-
 /datum/objective/steal/find_target(dupe_search_range, list/blacklist)
 	var/list/datum/mind/owners = get_owners()
 	if(!dupe_search_range)

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -272,8 +272,7 @@
 		playsound(user.loc, 'sound/effects/glassbr1.ogg', 100, TRUE)
 		qdel(src)
 	else
-		to_chat(user, span_warning("You can't seem to work up the nerve to shatter the bottle! Perhaps you should try again later."))
-
+		to_chat(user, span_warning("The bottle's contents usually pop and boil constantly, but right now they're eerily still and calm. Perhaps you should try again later."))
 
 /obj/item/antag_spawner/slaughter_demon/spawn_antag(client/C, turf/T, kind = "", datum/mind/user)
 	var/mob/living/basic/demon/spawned = new demon_type(T)

--- a/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
+++ b/code/modules/antagonists/traitor/objectives/hack_comm_console.dm
@@ -15,6 +15,8 @@
 	var/progression_objectives_minimum = 20 MINUTES
 
 /datum/traitor_objective/hack_comm_console/can_generate_objective(datum/mind/generating_for, list/possible_duplicates)
+	if(length(possible_duplicates) > 0)
+		return FALSE
 	if(SStraitor.get_taken_count(/datum/traitor_objective/hack_comm_console) > 0)
 		return FALSE
 	if(handler.get_completion_progression(/datum/traitor_objective) < progression_objectives_minimum)

--- a/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
+++ b/code/modules/antagonists/traitor/objectives/locate_weakpoint.dm
@@ -27,6 +27,8 @@
 	var/area/weakpoint_area
 
 /datum/traitor_objective/locate_weakpoint/can_generate_objective(datum/mind/generating_for, list/possible_duplicates)
+	if(length(possible_duplicates) > 0)
+		return FALSE
 	if(handler.get_completion_progression(/datum/traitor_objective) < progression_objectives_minimum)
 		return FALSE
 	if(SStraitor.get_taken_count(/datum/traitor_objective/locate_weakpoint) > 0)

--- a/code/modules/mob/living/basic/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_creator.dm
@@ -104,9 +104,10 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/candidate = pick(candidates)
 		spawn_guardian(user, candidate, guardian_path)
+		used = TRUE
+		SEND_SIGNAL(src, COMSIG_TRAITOR_ITEM_USED(type))
 	else
 		to_chat(user, failure_message)
-		used = FALSE
 
 /// Actually create our guy
 /obj/item/guardian_creator/proc/spawn_guardian(mob/living/user, mob/dead/candidate, guardian_path)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -17,6 +17,7 @@
 		uplink_item.name += " ([round(((initial(uplink_item.cost)-uplink_item.cost)/initial(uplink_item.cost))*100)]% off!)"
 		uplink_item.desc += " Normally costs [initial(uplink_item.cost)] TC. All sales final. [pick(disclaimer)]"
 		uplink_item.item = taken_item.item
+		uplink_item.discounted = TRUE
 
 		sales += uplink_item
 	return sales
@@ -35,8 +36,6 @@
 	var/desc = "item description"
 	/// Path to the item to spawn.
 	var/item = null
-	/// Alternative path for refunds, in case the item purchased isn't what is actually refunded (ie: holoparasites).
-	var/refund_path = null
 	/// Cost of the item.
 	var/cost = 0
 	/// Amount of TC to refund, in case there's a TC penalty for refunds.
@@ -47,6 +46,8 @@
 	var/surplus = 100
 	/// Whether this can be discounted or not
 	var/cant_discount = FALSE
+	/// If discounted, is true. Used to send a signal to update reimbursement.
+	var/discounted = FALSE
 	/// If this value is changed on two items they will share stock, defaults to not sharing stock with any other item
 	var/stock_key = UPLINK_SHARED_STOCK_UNIQUE
 	/// How many items of this stock can be purchased.
@@ -125,6 +126,8 @@
 		A = new spawn_path(get_turf(user))
 	else
 		A = spawn_path
+	if(refundable)
+		A.AddElement(/datum/element/uplink_reimburse, (refund_amount ? refund_amount : cost))
 	if(ishuman(user) && isitem(A))
 		var/mob/living/carbon/human/H = user
 		if(H.put_in_hands(A))

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -89,6 +89,7 @@
 	surplus = 40 //monkestation edit: from 0 to 40
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	restricted = TRUE
+	refundable = TRUE
 
 /datum/uplink_item/dangerous/revolver
 	name = "Syndicate Revolver"

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -551,6 +551,7 @@
 	cost = 20
 	purchasable_from = UPLINK_CLOWN_OPS
 	restricted = TRUE
+	refundable = TRUE
 
 /datum/uplink_item/support/reinforcement
 	name = "Reinforcements"
@@ -558,16 +559,15 @@
 		They'll come equipped with a mere surplus SMG, so arming them is recommended."
 	item = /obj/item/antag_spawner/nuke_ops
 	cost = 25
-	refundable = TRUE
 	purchasable_from = UPLINK_NUKE_OPS
 	restricted = TRUE
+	refundable = TRUE
 
 /datum/uplink_item/support/reinforcement/assault_borg
 	name = "Syndicate Assault Cyborg"
 	desc = "A cyborg designed and programmed for systematic extermination of non-Syndicate personnel. \
 			Comes equipped with a self-resupplying LMG, a grenade launcher, energy sword, emag, pinpointer, flash and crowbar."
 	item = /obj/item/antag_spawner/nuke_ops/borg_tele/assault
-	refundable = TRUE
 	cost = 65
 	restricted = TRUE
 
@@ -577,7 +577,6 @@
 			It comes equipped with a nanite hypospray, a medical beamgun, combat defibrillator, full surgical kit including an energy saw, an emag, pinpointer and flash. \
 			Thanks to its organ storage bag, it can perform surgery as well as any humanoid."
 	item = /obj/item/antag_spawner/nuke_ops/borg_tele/medical
-	refundable = TRUE
 	cost = 35
 	restricted = TRUE
 
@@ -587,7 +586,6 @@
 			Aside from regular Engineering equipment, it comes with a special destination tagger that lets it traverse disposals networks. \
 			Its chameleon projector lets it disguise itself as a Nanotrasen cyborg, on top it has thermal vision and a pinpointer."
 	item = /obj/item/antag_spawner/nuke_ops/borg_tele/saboteur
-	refundable = TRUE
 	cost = 35
 	restricted = TRUE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1407,6 +1407,7 @@
 #include "code\datums\elements\unfriend_attacker.dm"
 #include "code\datums\elements\update_icon_blocker.dm"
 #include "code\datums\elements\update_icon_updates_onmob.dm"
+#include "code\datums\elements\uplink_reimburse.dm"
 #include "code\datums\elements\venomous.dm"
 #include "code\datums\elements\volatile_gas_storage.dm"
 #include "code\datums\elements\waddling.dm"


### PR DESCRIPTION
Ports the following /tg/ PRs:

- https://github.com/tgstation/tgstation/pull/75816
- https://github.com/tgstation/tgstation/pull/78045
- https://github.com/tgstation/tgstation/pull/78431
- https://github.com/tgstation/tgstation/pull/82083

## Changelog
:cl:
fix: (Xander3359) Fix hack comms console/locate weakpoint objective showing up multiple times
fix: (Jacquerel) Traitors should generate with "free objective" less often, and will once more be assigned to steal things.
fix: (carlarctg) Fixed being unable to reimburse syndicate spawners via uplinks. This includes nukie reinforcements, cyborgs, and holoparasite injectors.
refactor: (carlarctg) Turned TC reimbursement into a bespoke element.
spellcheck: (carlarctg) Tuned demon's blood message when there's no ghosts to pick to be a little more understandable and sensible.
/:cl:
