### PR TITLE
Allow airlock helpers to work with windoors

### DIFF
--- a/_maps/~monkestation/RandomBars/Tram/tram_bar_beachside.dmm
+++ b/_maps/~monkestation/RandomBars/Tram/tram_bar_beachside.dmm
@@ -426,8 +426,7 @@
 "nN" = (
 /obj/structure/ladder,
 /obj/machinery/door/window/left/directional/north{
-	name = "Bar Backroom Access";
-	req_one_access = list("bar")
+	name = "Bar Backroom Access"
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/east,

--- a/_maps/~monkestation/RandomBars/Tram/tram_bar_beachside.dmm
+++ b/_maps/~monkestation/RandomBars/Tram/tram_bar_beachside.dmm
@@ -605,8 +605,7 @@
 	name = "Kitchen Counter Shutters"
 	},
 /obj/machinery/door/window/left/directional/west{
-	name = "Kitchen";
-	req_one_access = list("kitchen")
+	name = "Kitchen"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/open/floor/wood,
@@ -820,7 +819,6 @@
 /area/station/commons/lounge)
 "zo" = (
 /obj/machinery/door/window/left/directional/south{
-	req_one_access = list("kitchen");
 	name = "Kitchen"
 	},
 /obj/effect/turf_decal/siding/wood,
@@ -877,8 +875,7 @@
 /area/station/commons/lounge)
 "AC" = (
 /obj/machinery/door/window/left/directional/east{
-	name = "Bar";
-	req_one_access = list("bar")
+	name = "Bar"
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1558,7 +1555,6 @@
 /area/station/commons/lounge)
 "TG" = (
 /obj/machinery/door/window/left/directional/south{
-	req_one_access = list("kitchen");
 	name = "Kitchen Coldroom Access"
 	},
 /obj/effect/turf_decal/siding/wood{

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -110,6 +110,7 @@
 	layer = DOOR_HELPER_LAYER
 	late = TRUE
 
+/* replaced in monkestation\code\modules\mapping\mapping_helpers.dm
 /obj/effect/mapping_helpers/airlock/Initialize(mapload)
 	. = ..()
 	if(!mapload)
@@ -121,6 +122,7 @@
 		log_mapping("[src] failed to find an airlock at [AREACOORD(src)]")
 	else
 		payload(airlock)
+*/
 
 /obj/effect/mapping_helpers/airlock/LateInitialize()
 	. = ..()

--- a/monkestation/code/modules/mapping/access_helpers.dm
+++ b/monkestation/code/modules/mapping/access_helpers.dm
@@ -1,3 +1,18 @@
+/obj/effect/mapping_helpers/airlock/access/any/payload_windoor(obj/machinery/door/window/windoor)
+	if(windoor.req_access != null)
+		log_mapping("[src] at [AREACOORD(src)] tried to set req_one_access, but req_access was already set!")
+	else
+		var/list/access_list = get_access()
+		windoor.req_one_access += access_list
+
+/obj/effect/mapping_helpers/airlock/access/all/payload_windoor(obj/machinery/door/window/windoor)
+	if(windoor.req_one_access != null)
+		log_mapping("[src] at [AREACOORD(src)] tried to set req_one_access, but req_access was already set!")
+	else
+		var/list/access_list = get_access()
+		windoor.req_access += access_list
+
+
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen/east_offset
 	offset_dir = EAST
 

--- a/monkestation/code/modules/mapping/mapping_helpers.dm
+++ b/monkestation/code/modules/mapping/mapping_helpers.dm
@@ -50,3 +50,30 @@
 
 /obj/effect/area_power_helper/requires_power
 	set_state = TRUE
+
+/obj/effect/mapping_helpers/airlock/Initialize(mapload)
+	. = ..()
+	if(!mapload)
+		log_mapping("[src] spawned outside of mapload!")
+		return
+
+	var/turf/spot = (offset_dir ? get_step(src, offset_dir) : loc)
+	if(!try_for_airlock(spot) && !try_for_windoor(spot))
+		log_mapping("[src] failed to find an airlock at [AREACOORD(src)]")
+
+/obj/effect/mapping_helpers/airlock/proc/try_for_airlock(turf/spot)
+	. = FALSE
+	var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in spot
+	if(!QDELETED(airlock))
+		payload(airlock)
+		return TRUE
+
+/obj/effect/mapping_helpers/airlock/proc/try_for_windoor(turf/spot)
+	. = FALSE
+	var/obj/machinery/door/window/windoor = locate(/obj/machinery/door/window) in spot
+	if(!QDELETED(windoor))
+		payload_windoor(windoor)
+		return TRUE
+
+/obj/effect/mapping_helpers/airlock/proc/payload_windoor(obj/machinery/door/window/windoor)
+	return


### PR DESCRIPTION

## About The Pull Request

Should prevent [test failures like this](https://github.com/Monkestation/Monkestation2.0/actions/runs/8532263923/job/23373412963?pr=1565#step:10:124), plus manually setting accesses is blegh.

## Changelog
:cl:
fix: Airlock mapping helpers now work with windoors.
/:cl:
