### PR TITLE
List Syntax Error Fix

### DIFF
--- a/monkestation/code/modules/mob/living/carbon/human/species_type/shadowpeople.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/shadowpeople.dm
@@ -8,7 +8,7 @@
 			'sound/voice/human/malescream_3.ogg',
 			'sound/voice/human/malescream_4.ogg',
 			'sound/voice/human/malescream_5.ogg',
-			'sound/voice/human/malescream_6.ogg',
+			'sound/voice/human/malescream_6.ogg'
 		)
 
 	return pick(
@@ -16,7 +16,7 @@
 		'sound/voice/human/femalescream_2.ogg',
 		'sound/voice/human/femalescream_3.ogg',
 		'sound/voice/human/femalescream_4.ogg',
-		'sound/voice/human/femalescream_5.ogg',
+		'sound/voice/human/femalescream_5.ogg'
 	)
 /datum/species/shadow/get_laugh_sound(mob/living/carbon/human/human)
 	if(human.gender == MALE)


### PR DESCRIPTION
these are lists. commas at the end denote that there is another entry after this. this technically should cause a failure on compile. this may result in an audit of all modular files and some base tg files to ensure compliance with standards. credit to @ancient-engineer for finding this.

## Changelog

:cl: Dexee, Ancient Engineer
code: fixed a syntax issue with modular shadowpeople.dm file to prevent compiler errors.
/:cl:
