### PR TITLE
OpenDream/WebView2 TGUI fix

### DIFF
--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -510,9 +510,6 @@ window.replaceHtml = function (inline_html) {
       + "<!-- tgui:inline-html-end -->"
   );
 };
-
-// Signal tgui that we're ready to receive updates
-Byond.sendMessage('ready');
 </script>
 
 <style>
@@ -657,5 +654,10 @@ Thank you for your cooperation.
   </div>
 </noscript>
 
+<script>
+// Signal tgui that we're ready to receive updates
+Byond.sendMessage('ready');
+</script>
+  
 </body>
 </html>

--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -53,7 +53,7 @@
   })();
 
   // Basic checks to detect whether this page runs in BYOND
-  var isByond = (Byond.TRIDENT !== null || window.cef_to_byond)
+  var isByond = (Byond.TRIDENT !== null || navigator.userAgent.includes('Edg/') || window.cef_to_byond)
     && location.hostname === '127.0.0.1'
     && location.search !== '?external';
     //As of BYOND 515 the path doesn't seem to include tmp dir anymore if you're trying to open tgui in external browser and looking why it doesn't work
@@ -658,6 +658,6 @@ Thank you for your cooperation.
 // Signal tgui that we're ready to receive updates
 Byond.sendMessage('ready');
 </script>
-  
+
 </body>
 </html>


### PR DESCRIPTION
Port of https://github.com/tgstation/tgstation/pull/79244

Modern browsers run the ready script before the DOM is loaded. Also future proofs us for when Lummox upgrades the web engine.