### PR TITLE
BoxStation Post-Merge Fixes 2

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -112,6 +112,7 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/bush/flowers_pp/style_random,
 /mob/living/basic/butterfly,
 /turf/open/floor/grass,
 /area/station/command/bridge)
@@ -200,6 +201,7 @@
 /area/station/maintenance/starboard/aft)
 "adK" = (
 /obj/structure/flora/bush/jungle,
+/obj/item/food/grown/banana,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
 "adP" = (
@@ -242,7 +244,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/random/directional/north,
+/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "aeM" = (
@@ -506,9 +508,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "ajR" = (
-/obj/structure/chair/stool/directional/west,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/obj/structure/sign/poster/random/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/mess,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "ajT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -687,6 +691,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"anO" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer2{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "anP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -754,8 +765,7 @@
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "apw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "apA" = (
@@ -841,7 +851,6 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "aqP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Turbine Access"
@@ -2077,7 +2086,9 @@
 /area/station/security/prison/safe)
 "aNk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "aNs" = (
@@ -2802,7 +2813,6 @@
 /obj/effect/spawner/random/structure/table,
 /obj/item/poster/random_official,
 /obj/effect/spawner/random/bureaucracy/stamp,
-/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "aYs" = (
@@ -2877,6 +2887,7 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "baq" = (
+/obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/leafy,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
@@ -3125,7 +3136,7 @@
 /area/station/service/chapel)
 "beM" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/table,
+/obj/effect/spawner/random/structure/table_or_rack,
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
@@ -3636,7 +3647,7 @@
 	name = "Radiation Shutters"
 	},
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/storage)
 "bna" = (
 /obj/structure/sink/directional/south,
 /obj/structure/mirror/directional/north,
@@ -4178,9 +4189,13 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/chapel/funeral)
 "bve" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/cup/bucket,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/sign/poster/official/random/directional/north,
+/obj/structure/table,
+/turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "bvm" = (
 /obj/machinery/light/directional/east,
@@ -4488,6 +4503,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/effect/landmark/start/scientist,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "bAX" = (
@@ -4816,6 +4832,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/construction)
+"bGu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/carpet/red,
+/area/station/commons/dorms)
 "bGw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -5760,6 +5781,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "bWR" = (
+/obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
@@ -6119,7 +6141,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/secondary/service)
+/area/station/service/bar)
 "cch" = (
 /obj/structure/chair{
 	dir = 8
@@ -6227,7 +6249,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/security/detectives_office/private_investigators_office)
+/area/station/security/detectives_office)
 "cdE" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
@@ -7142,6 +7164,12 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
+"cub" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/commons/dorms)
 "cud" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -7449,9 +7477,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cAm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
 "cAy" = (
@@ -7553,10 +7578,6 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/table,
-/obj/item/paper{
-	name = "Message to Atmospherics";
-	default_raw_text = "<p>Due to station space contraints the HFR has been put into its own satellite.<br>So get your modsuits on and head to the external airlock in Atmospherics Storage.<p>"
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "cCv" = (
@@ -8223,6 +8244,7 @@
 /area/station/science/ordnance)
 "cNk" = (
 /obj/machinery/light/directional/north,
+/obj/structure/flora/bush/jungle/a/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "cNm" = (
@@ -9402,7 +9424,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "dgl" = (
-/obj/effect/spawner/structure/window/reinforced,
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "dgy" = (
@@ -10473,12 +10495,8 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "dzH" = (
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/iron/dark,
+/obj/structure/flora/bush/jungle/b/style_random,
+/turf/open/floor/grass,
 /area/station/hallway/primary/central)
 "dzI" = (
 /obj/effect/turf_decal/box,
@@ -10486,10 +10504,11 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/surgery)
 "dzP" = (
-/obj/structure/flora/bush/leafy,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/leafy,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "dzR" = (
@@ -11012,6 +11031,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "dIG" = (
@@ -11132,6 +11155,13 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
+"dKB" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/command/bridge)
 "dKQ" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
@@ -11210,6 +11240,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "dMV" = (
@@ -12013,6 +12047,7 @@
 	},
 /area/station/cargo/office)
 "eaf" = (
+/obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
@@ -12271,9 +12306,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "eeM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/button/door/directional/south{
 	id = "dorm_6";
 	name = "Dorm Bolt Control";
@@ -12380,7 +12412,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/detectives_office/private_investigators_office)
+/area/station/security/detectives_office)
 "ehj" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/structure/cable,
@@ -13877,6 +13909,7 @@
 /turf/open/floor/wood,
 /area/station/security/prison/rec)
 "eJD" = (
+/obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
@@ -15823,9 +15856,9 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "fsd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos)
+/obj/structure/flora/rock/pile/jungle/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/primary/central)
 "fsm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16755,7 +16788,7 @@
 /obj/structure/chair/office,
 /obj/effect/landmark/start/detective,
 /turf/open/floor/iron/dark,
-/area/station/security/detectives_office/private_investigators_office)
+/area/station/security/detectives_office)
 "fLf" = (
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/structure/disposalpipe/segment{
@@ -17767,7 +17800,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/dresser,
 /turf/open/floor/iron/dark,
-/area/station/security/detectives_office/private_investigators_office)
+/area/station/security/detectives_office)
 "gcq" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -17970,9 +18003,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "ggR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /turf/open/floor/carpet/red,
 /area/station/commons/dorms)
 "ggV" = (
@@ -18278,6 +18308,13 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
+"gmK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/station/commons/dorms)
 "gmN" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
@@ -18985,6 +19022,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
+"gyt" = (
+/obj/structure/flora/grass/jungle/b/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/leavy/style_random,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/grass,
+/area/station/command/bridge)
 "gyv" = (
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -19074,7 +19119,10 @@
 	},
 /obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/binary/pump/on/scrubbers/visible/layer2{
+	dir = 4;
+	name = "External Ports to Filter"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 10
 	},
@@ -19591,7 +19639,6 @@
 /obj/structure/flora/grass/jungle/b/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
-/obj/item/food/grown/banana,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -20332,9 +20379,10 @@
 /turf/open/floor/wood,
 /area/station/security/prison/rec)
 "gRZ" = (
-/obj/structure/flora/bush/leafy,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/leafy,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "gSl" = (
@@ -21022,10 +21070,6 @@
 "heD" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/item/paper{
-	name = "Message to Security";
-	default_raw_text = "<p>We have sent two extra uniform crates, a blueshift and a formal, to the armory.<p>"
-	},
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
 "heI" = (
@@ -21909,17 +21953,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "hus" = (
-/obj/structure/flora/grass/jungle/b/style_random,
-/obj/structure/flora/bush/fullgrass/style_random,
-/obj/structure/flora/bush/leafy,
-/mob/living/carbon/human/species/monkey{
-	name = "Fortunato";
-	desc = "The monkey lays on its back, its lungs withering in its glass coffin, banging on the walls in desperate search of escape, but it can't escape. Not without your help. But you're not helping."
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/grass,
-/area/station/command/bridge)
+/obj/structure/sign/poster/official/random/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/central)
 "hux" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -22206,9 +22246,12 @@
 /turf/closed/wall,
 /area/station/maintenance/central)
 "hya" = (
-/obj/effect/spawner/structure/window,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer2{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/commons/locker)
+/area/station/engineering/atmos)
 "hyd" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -23049,7 +23092,7 @@
 "hNJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/mob_spawn/corpse/human/damaged,
+/obj/effect/mob_spawn/corpse/human/assistant,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "hNM" = (
@@ -23426,9 +23469,10 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "hUt" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron,
-/area/station/commons/dorms)
+/obj/structure/chair/stool/directional/south,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark/side,
+/area/station/commons/fitness)
 "hUA" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24308,7 +24352,7 @@
 "imr" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/light/directional/south,
-/obj/structure/closet/emcloset,
+/mob/living/carbon/human/species/monkey,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
 "imt" = (
@@ -24609,7 +24653,7 @@
 	name = "Arrivals"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/primary/port)
 "iqM" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
@@ -24768,8 +24812,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "itA" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/closed/wall/r_wall,
+/turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "itB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
@@ -24792,11 +24837,14 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "itL" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/detectives_office/private_investigators_office)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "itM" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Telecomms Monitoring";
@@ -25006,7 +25054,6 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Hallway - Central North"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "ivi" = (
@@ -25275,8 +25322,8 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
 "izu" = (
-/mob/living/carbon/human/species/monkey,
-/turf/open/water/jungle,
+/obj/structure/water_source/puddle,
+/turf/open/floor/grass,
 /area/station/hallway/primary/central)
 "izU" = (
 /obj/machinery/light/floor/has_bulb,
@@ -25353,6 +25400,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/prison)
+"iBz" = (
+/obj/machinery/light/small/directional/west,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "iBE" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
@@ -25842,6 +25894,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "iJI" = (
@@ -25882,7 +25935,7 @@
 	},
 /obj/item/storage/secure/briefcase,
 /turf/open/floor/iron/dark,
-/area/station/security/detectives_office/private_investigators_office)
+/area/station/security/detectives_office)
 "iKB" = (
 /obj/machinery/gibber,
 /turf/open/floor/iron/freezer,
@@ -25938,9 +25991,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "iLp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/button/door/directional/north{
 	id = "dorm_5";
 	name = "Dorm Bolt Control";
@@ -26209,7 +26259,7 @@
 	name = "Central Access"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/port)
 "iOT" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
@@ -26548,10 +26598,6 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
-/obj/item/paper/crumpled/bloody{
-	name = "Bloody Crumpled Note";
-	default_raw_text = "<p style="text-align:center"><i>Great holes<br>secretly are digged<br>where earth's pores<br>ought to suffice<br>and things have learnt to walk<br>that ought to crawl<p>"
-	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "iWu" = (
@@ -26821,13 +26867,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "jaQ" = (
-/obj/effect/turf_decal/tile/dark_blue/fourcorners,
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/chair/stool/directional/east,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/central)
+/area/station/commons/fitness)
 "jbg" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -26870,9 +26915,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/mess)
 "jbQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /turf/open/floor/wood/large,
 /area/station/commons/dorms)
 "jbR" = (
@@ -28048,10 +28090,6 @@
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light/small/directional/east,
 /obj/structure/table,
-/obj/item/paper{
-	name = "Message to Atmospherics";
-	default_raw_text = "<p>Due to station space contraints the HFR has been put into its own satellite.<br>So get your modsuits on and head to the external airlock in Atmospherics Storage.<p>"
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage)
 "jyf" = (
@@ -28060,8 +28098,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
 "jyz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/wood/large,
 /area/station/commons/dorms)
 "jyE" = (
@@ -28304,6 +28343,11 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/showroomfloor,
 /area/station/maintenance/starboard/aft)
+"jDp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "jDq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28369,8 +28413,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
 "jEW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
 "jEX" = (
@@ -28465,7 +28510,7 @@
 	},
 /obj/machinery/vending/engivend,
 /obj/machinery/camera/directional/west{
-	c_tag = "Engineering Equipment Storage";
+	c_tag = "Engineering - Equipment Storage";
 	name = "engineering camera"
 	},
 /obj/structure/sign/warning/electric_shock/directional/west,
@@ -28556,6 +28601,16 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/shower)
+"jHh" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "jHl" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -28601,9 +28656,6 @@
 	},
 /area/station/commons/fitness/recreation)
 "jHT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/button/door/directional/north{
 	id = "dorm_4";
 	name = "Dorm Bolt Control";
@@ -28909,11 +28961,6 @@
 /obj/item/folder/red{
 	pixel_x = -7
 	},
-/obj/item/paper{
-	name = "Message to Security";
-	default_raw_text = "<p>We have sent two extra uniform crates, a blueshift and a formal, to the armory.<p>";
-	pixel_x = -7
-	},
 /obj/item/pen{
 	pixel_x = -7
 	},
@@ -29012,9 +29059,6 @@
 /turf/open/floor/engine/telecomms,
 /area/station/tcommsat/server)
 "jOr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /turf/open/floor/wood/tile,
 /area/station/commons/dorms)
 "jOx" = (
@@ -30355,6 +30399,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "kne" = (
+/obj/structure/flora/bush/jungle/b/style_random,
 /mob/living/basic/butterfly,
 /turf/open/floor/grass,
 /area/station/command/bridge)
@@ -31020,7 +31065,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/bar,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/secondary/service)
+/area/station/service/bar/backroom)
 "kyX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -31135,6 +31180,7 @@
 "kBh" = (
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/light/small/directional/north,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
@@ -31370,7 +31416,10 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/binary/pump/on/supply/visible/layer4{
+	dir = 8;
+	name = "Air to External Ports"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 9
 	},
@@ -31424,6 +31473,7 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "kGs" = (
+/obj/structure/flora/grass/jungle/a/style_random,
 /obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
@@ -31457,8 +31507,6 @@
 /area/station/service/library/artgallery)
 "kHk" = (
 /obj/structure/sign/warning/secure_area/directional/south,
-/obj/effect/spawner/random/structure/table,
-/obj/effect/spawner/random/engineering/toolbox,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -32602,10 +32650,6 @@
 "kYB" = (
 /obj/structure/table,
 /obj/item/storage/cans/sixbeer,
-/obj/item/paper{
-	name = "Message to Security";
-	default_raw_text = "<p>We have sent two extra uniform crates, a blueshift and a formal, to the armory.<p>"
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "kYJ" = (
@@ -33809,6 +33853,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "luJ" = (
+/obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /obj/item/food/grown/banana,
 /turf/open/floor/grass,
@@ -34348,9 +34393,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "lEf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /turf/open/floor/carpet/blue,
 /area/station/commons/dorms)
 "lEp" = (
@@ -34977,6 +35019,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "lNx" = (
@@ -35307,9 +35350,6 @@
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/cmo)
 "lVj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/button/door/directional/north{
 	id = "dorm_1";
 	name = "Dorm Bolt Control";
@@ -35717,6 +35757,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 10
 	},
+/obj/structure/sign/departments/cargo/directional/west,
 /turf/open/floor/iron/dark/side{
 	dir = 10
 	},
@@ -35777,6 +35818,11 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
+"mcG" = (
+/obj/effect/spawner/random/structure/table,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "mcP" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -35814,7 +35860,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron/dark/textured,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/storage)
 "mdw" = (
 /obj/machinery/shower/directional/east,
 /obj/effect/decal/cleanable/dirt,
@@ -35825,7 +35871,7 @@
 /area/station/cargo/storage)
 "mdZ" = (
 /obj/machinery/camera/directional/west{
-	c_tag = "Engineering Secure Storage"
+	c_tag = "Engineering - Secure Storage"
 	},
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
@@ -35989,7 +36035,7 @@
 /area/station/science/xenobiology)
 "mih" = (
 /obj/machinery/light/directional/east,
-/obj/machinery/power/rad_collector,
+/obj/machinery/power/energy_accumulator/tesla_coil,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "mij" = (
@@ -36743,6 +36789,13 @@
 	},
 /turf/open/floor/plating/reinforced,
 /area/station/science/xenobiology)
+"mtH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer2{
+	dir = 5
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "mtN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36819,9 +36872,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/cargo)
 "mvb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/button/door/directional/south{
 	id = "dorm_2";
 	name = "Dorm Bolt Control";
@@ -37468,7 +37518,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/primary/port)
 "mIl" = (
 /obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 1
@@ -38384,8 +38434,10 @@
 /turf/open/floor/iron/dark/side,
 /area/station/cargo/miningoffice)
 "mZv" = (
-/mob/living/basic/butterfly,
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/mob/living/basic/butterfly,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "mZG" = (
@@ -39590,8 +39642,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "ntG" = (
-/obj/structure/flora/bush/leafy,
-/mob/living/carbon/human/species/monkey,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/leavy/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
 "ntI" = (
@@ -39623,10 +39675,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "nul" = (
-/obj/machinery/light/small/directional/west,
-/obj/effect/spawner/random/trash/graffiti,
-/turf/open/floor/plating,
-/area/station/maintenance/port/fore)
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/lavendergrass/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/primary/central)
 "nus" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39672,6 +39724,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"nvj" = (
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/central)
 "nvr" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -39872,9 +39933,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "nyH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "nyI" = (
@@ -40147,6 +40205,7 @@
 /area/station/maintenance/central)
 "nCB" = (
 /obj/structure/chair/sofa/middle/maroon,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -40356,6 +40415,12 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"nGw" = (
+/obj/structure/flora/grass/jungle/a/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/sunny/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/primary/central)
 "nGz" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners{
 	dir = 1
@@ -40400,10 +40465,10 @@
 /area/station/medical/paramedic)
 "nHp" = (
 /obj/structure/flora/grass/jungle/a/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
 "nHx" = (
-/obj/structure/closet/firecloset/full,
 /obj/machinery/camera/autoname/directional/south{
 	dir = 5
 	},
@@ -42441,13 +42506,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "opP" = (
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/effect/mapping_helpers/apc/cell_10k,
+/obj/effect/mapping_helpers/apc/full_charge,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "opU" = (
@@ -42816,6 +42882,14 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"ows" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/central)
 "owt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42896,7 +42970,8 @@
 "oxS" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
-/obj/structure/closet/emcloset,
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
 "oxX" = (
@@ -43928,6 +44003,7 @@
 /area/station/security/execution)
 "oQn" = (
 /obj/structure/chair/sofa/right/maroon,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -44303,8 +44379,7 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oWT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/blue,
 /area/station/commons/dorms)
 "oWV" = (
@@ -45607,6 +45682,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/transfer)
+"puN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/carpet/purple,
+/area/station/commons/dorms)
 "puO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46099,10 +46179,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "pDn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/atmos)
+/obj/structure/flora/bush/jungle/a/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/primary/central)
 "pDB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -46173,7 +46252,7 @@
 /area/station/security/office)
 "pEy" = (
 /obj/machinery/camera/directional/east{
-	c_tag = "Engineering - SMES";
+	c_tag = "Engineering - SMES, Main";
 	name = "engineering camera"
 	},
 /obj/machinery/power/terminal{
@@ -47477,6 +47556,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
+"qdV" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/item/seeds/banana,
+/turf/open/floor/grass,
+/area/station/hallway/primary/central)
 "qdZ" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -47702,6 +47786,7 @@
 /area/station/commons/dorms)
 "qiw" = (
 /obj/structure/chair/stool/directional/west,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/side{
 	dir = 10
 	},
@@ -47753,6 +47838,10 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"qkl" = (
+/obj/item/seeds/banana,
+/turf/open/floor/grass,
+/area/station/hallway/primary/central)
 "qkv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -48111,9 +48200,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
 "qqD" = (
-/obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "qqJ" = (
@@ -50010,6 +50100,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "qZF" = (
+/obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
@@ -50692,6 +50783,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"rlP" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/turf/open/floor/grass,
+/area/station/command/bridge)
 "rlQ" = (
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -50830,9 +50927,10 @@
 /area/station/security/brig)
 "roo" = (
 /obj/structure/flora/bush/fullgrass/style_random,
-/mob/living/basic/butterfly,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/mob/living/basic/butterfly,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "rot" = (
@@ -51343,10 +51441,6 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/item/paper{
-	name = "Important Note";
-	default_raw_text = "<p>Please make sure that the condemned individual is already restrained and in the room.</p><h1>The Flames of Justice</h1><p>This section will instruct you on how to utilize the burn chamber part of the Justice Chamber.<br>1. Access the nearby air alarm.<br>2. Turn all of the siphoning vents in the chamber off and set the pressure regulator from external to internal, the value can be kept at 2000 kPa or raised higher. Turn the non-siphoning vent in the chamber off as well.<br>3. Set all of the scrubbers to expanded range. The scrubbers in the airlock and room must be set to filter out CO2 (Carbon Dioxide), H2O (Water Vapor), Tritium, and Plasma. The scrubber in the chamber should be set to filter out CO2 (Carbon Dioxide), H2O (Water Vapor), and Tritium.<br>4. Place the condemned individual in the chamber.<br>5. Go back to the air alarm and set the scrubber in the chamber to filter out N2 (Nitrogen) and pump in Plasma for 15 seconds.<br>6. Once there is little to no N2 (Nitrogen) ignite the gas in the chamber, after 30 seconds turn the siphoning vents on and leave them on until the fire is extinguished. Turn them off once the fire is completely gone and the chamber has returned to a relatively safe temperature.<br>7. Turn the non-siphoning vent on and remove the N2 (Nitrogen) filter from the scrubber in the chamber.<br>8. Retrieve any body or bodies present in the chamber once it is safe enough to enter.</p><h1>Engineer's Notes</h1><p>1. Please make a note of the id string of the vents and scrubbers, we don't want anyone accidentally venting the room instead of the chamber.<br>2. The chair, flasher, and lights have been removed from the chamber. Extensive testing showed that they would always melt.<br>3. Both space heaters must be activated and moved, one should be in the airlock and one should be outside the airlock.<br>4. Do not get flammable gas stuck in either of the airlocks, trapped gases can combust and damage them.<br>5. Drag corpses behind you and move them to whichever part of the floor doesn't have a space heater on it, then make sure that the interior airlock is closed before opening the exterior airlock.</p>"
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "rxc" = (
@@ -51530,7 +51624,7 @@
 	name = "Garden"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/commons/locker)
+/area/station/service/hydroponics/garden)
 "rAq" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 8
@@ -52568,6 +52662,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
+/obj/structure/sign/departments/cargo/directional/east,
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron/dark/side{
 	dir = 6
@@ -53453,6 +53548,7 @@
 "shC" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/leavy/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "shF" = (
@@ -54009,7 +54105,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/trinary/mixer/layer4{
-	dir = 1
+	dir = 1;
+	name = "turbine mixer"
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
@@ -54194,13 +54291,13 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "svQ" = (
-/obj/item/seeds/banana,
-/obj/item/seeds/banana,
-/obj/item/seeds/banana,
-/turf/open/floor/grass,
-/area/station/hallway/primary/central)
+/obj/structure/chair/stool/directional/north,
+/obj/effect/landmark/start/hangover,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/commons/fitness)
 "svV" = (
-/obj/structure/closet/firecloset/full,
 /obj/machinery/camera/autoname/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
@@ -54857,6 +54954,13 @@
 /obj/effect/spawner/random/maintenance/eight,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"sKq" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer2{
+	dir = 9
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "sKr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -54878,6 +54982,16 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
+"sKX" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "sKY" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
@@ -56436,7 +56550,7 @@
 /obj/item/folder/red,
 /obj/item/pen,
 /turf/open/floor/iron/dark,
-/area/station/security/detectives_office/private_investigators_office)
+/area/station/security/detectives_office)
 "tlp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -57352,6 +57466,13 @@
 /obj/item/storage/box/monkeycubes,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"tzi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/station/commons/dorms)
 "tzk" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 6
@@ -57687,6 +57808,17 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics)
+"tGD" = (
+/obj/effect/turf_decal/trimline/purple/line,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/central)
 "tGK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -57718,6 +57850,7 @@
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/light/small/directional/north,
 /obj/structure/chair,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "tHx" = (
@@ -58915,7 +59048,7 @@
 "ueL" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/station/security/detectives_office/private_investigators_office)
+/area/station/security/detectives_office)
 "ufg" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/nitrous_input{
 	dir = 8
@@ -59373,6 +59506,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
 "ukC" = (
@@ -59679,6 +59813,11 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"uou" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer2,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos)
 "uov" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -59825,6 +59964,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"urJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/directional/north,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/plating,
+/area/station/maintenance/port/aft)
 "urW" = (
 /turf/open/floor/iron/dark,
 /area/station/security/prison/workout)
@@ -61418,7 +61563,7 @@
 	},
 /obj/machinery/duct,
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/secondary/service)
+/area/station/service/hydroponics)
 "uVn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -61542,9 +61687,6 @@
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "uWn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/button/door/directional/south{
 	id = "dorm_3";
 	name = "Dorm Bolt Control";
@@ -61559,6 +61701,7 @@
 /area/station/engineering/atmos/storage)
 "uWp" = (
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/bush/jungle/c/style_random,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "uWr" = (
@@ -61621,7 +61764,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/security/detectives_office/private_investigators_office)
+/area/station/security/detectives_office)
 "uXH" = (
 /obj/machinery/shower/directional/north,
 /turf/open/floor/iron/showroomfloor,
@@ -61741,6 +61884,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/command/gateway)
+"uZH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/carpet/blue,
+/area/station/commons/dorms)
 "uZR" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -61925,6 +62073,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"vcA" = (
+/obj/structure/flora/grass/jungle/b/style_random,
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/primary/central)
 "vcC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62065,11 +62218,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/fore)
 "vfi" = (
-/obj/effect/spawner/random/structure/table,
-/obj/item/clothing/mask/gas,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/port/aft)
+/obj/structure/flora/rock/pile/jungle/large/style_random,
+/obj/structure/flora/tree/jungle/small/style_random,
+/turf/open/floor/grass,
+/area/station/hallway/primary/central)
 "vfw" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/engine,
@@ -63266,8 +63418,7 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
 "vAH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/purple,
 /area/station/commons/dorms)
 "vAP" = (
@@ -63523,7 +63674,7 @@
 	name = "Central Access"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/port)
 "vEp" = (
 /obj/structure/dresser,
 /turf/open/floor/wood,
@@ -63811,6 +63962,11 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/freezerchamber)
+"vJk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/atmos)
 "vJw" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/duct,
@@ -64083,6 +64239,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/office)
+"vOT" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "vOV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -64597,7 +64758,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
-/area/station/security/detectives_office/private_investigators_office)
+/area/station/security/detectives_office)
 "vXb" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -65168,12 +65329,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "whN" = (
-/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance/two,
-/obj/effect/mob_spawn/corpse/human/damaged,
-/obj/item/restraints/handcuffs/cable/zipties/used,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
 "wia" = (
@@ -65859,7 +66018,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/security/detectives_office/private_investigators_office)
+/area/station/security/detectives_office)
 "wuH" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 4
@@ -66705,6 +66864,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "wJP" = (
@@ -66714,6 +66874,7 @@
 /area/station/construction)
 "wJW" = (
 /obj/structure/chair/stool/directional/north,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark/side{
 	dir = 6
 	},
@@ -67067,11 +67228,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "wPH" = (
-/obj/structure/flora/bush/flowers_br/style_random,
-/obj/item/toy/plush/beeplushie,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/item/toy/plush/beeplushie,
 /turf/open/floor/grass,
 /area/station/command/bridge)
 "wPK" = (
@@ -67222,6 +67384,15 @@
 "wRN" = (
 /turf/closed/wall,
 /area/station/science/ordnance/bomb)
+"wRW" = (
+/obj/effect/turf_decal/tile/dark_blue/fourcorners,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/iron/dark,
+/area/station/hallway/primary/central)
 "wSk" = (
 /obj/structure/sign/warning/electric_shock,
 /turf/closed/wall,
@@ -67361,10 +67532,6 @@
 	},
 /obj/item/gun/ballistic/rifle/boltaction/surplus,
 /obj/item/ammo_box/a762/surplus,
-/obj/item/paper{
-	name = "Rifle Crate Note";
-	default_raw_text = "<p>When being used this rifle is to be kept in the Justice Chamber.<br>When not in use it is to be put away in the Justice Chamber storage room.<p>"
-	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
 "wVk" = (
@@ -68267,6 +68434,11 @@
 	dir = 6
 	},
 /area/station/commons/fitness/recreation)
+"xlS" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/item/food/grown/banana,
+/turf/open/floor/grass,
+/area/station/hallway/primary/central)
 "xlW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69107,6 +69279,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "xAf" = (
@@ -69954,6 +70130,7 @@
 /area/station/service/janitor)
 "xRs" = (
 /obj/structure/chair/sofa/left/maroon,
+/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -70457,6 +70634,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
+"xZd" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/structure/table_or_rack,
+/obj/effect/spawner/random/maintenance/two,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science)
 "xZj" = (
 /obj/structure/table,
 /obj/item/storage/crayons,
@@ -71048,6 +71231,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "yiC" = (
@@ -78654,7 +78838,7 @@ ksa
 ksa
 uiu
 kXx
-tUH
+pRn
 wGf
 veQ
 mXM
@@ -78911,7 +79095,7 @@ ksa
 ksa
 uiu
 kXx
-tUH
+pRn
 bnB
 kfl
 smB
@@ -83247,12 +83431,12 @@ ibw
 fPN
 fPN
 fPN
-uho
-uho
-uho
-uho
-uho
-uho
+jmh
+jmh
+jmh
+jmh
+jmh
+jmh
 fGO
 xxP
 kvC
@@ -84248,14 +84432,14 @@ ldX
 fHK
 tSN
 frx
-frx
+jaQ
 fHK
 fHK
 fHK
 fHK
 fHK
 fHK
-frx
+jaQ
 frx
 tSN
 fHK
@@ -85016,7 +85200,7 @@ edD
 fPN
 slu
 fCT
-xqC
+hUt
 mFS
 kOr
 kOr
@@ -85286,7 +85470,7 @@ kOr
 kOr
 kOr
 mFS
-foP
+svQ
 fCT
 jjz
 hYZ
@@ -85297,15 +85481,15 @@ hYZ
 xJK
 xrJ
 wIG
-hUt
+wIG
 pbv
 xrJ
 itN
 kxo
-hya
+ndi
 rAl
-hya
-sDz
+ndi
+jmh
 ezf
 ezf
 xiC
@@ -86301,7 +86485,7 @@ iCB
 fPN
 idJ
 fCT
-xqC
+hUt
 mFS
 kOr
 kOr
@@ -86314,7 +86498,7 @@ jbH
 kOr
 kOr
 mFS
-foP
+svQ
 fCT
 xdJ
 hYZ
@@ -86326,7 +86510,7 @@ xJK
 juk
 dru
 fnN
-ajR
+fnN
 qTI
 pBz
 kxo
@@ -87348,13 +87532,13 @@ aJq
 kxo
 hkO
 oWT
-oWT
+uZH
 kWj
 pYI
 hoa
 gLN
 vlr
-jyz
+gmK
 jyz
 qik
 kxo
@@ -88376,13 +88560,13 @@ xZj
 kxo
 sLn
 vAH
-vAH
+puN
 oqC
 pYI
 hoa
 gLN
 nJi
-jEW
+tzi
 jEW
 gOR
 kxo
@@ -88670,9 +88854,9 @@ xVa
 xVa
 xVa
 xVa
-hdj
+pEY
 uVl
-hdj
+pEY
 bnl
 bnl
 ohf
@@ -89404,14 +89588,14 @@ gXm
 kxo
 tiN
 apw
-apw
+bGu
 uuD
 pYI
 hoa
 gLN
 uWF
 aNk
-aNk
+cub
 liE
 kxo
 eeV
@@ -89924,9 +90108,9 @@ szb
 szb
 szb
 kxo
-kxo
-kxo
-kxo
+fPN
+fPN
+fPN
 fPN
 fPN
 lwm
@@ -90172,19 +90356,19 @@ peS
 oHl
 ksa
 ksa
+xXP
 ksa
 xXP
 ksa
-ksa
-ksa
 xXP
-ksa
-ksa
 ksa
 ksa
 ksa
 ksa
 fPN
+fhe
+noO
+oSr
 pWi
 hqv
 uRq
@@ -90429,18 +90613,18 @@ oHl
 oHl
 ksa
 ksa
+xXP
+ksa
+xXP
 ksa
 xXP
 ksa
 ksa
 ksa
-xXP
 ksa
-ksa
-ksa
-ksa
-ksa
-ksa
+fPN
+fPN
+fPN
 fPN
 iYK
 nZL
@@ -90466,7 +90650,7 @@ eBn
 vEB
 oOl
 dhZ
-hdj
+oLg
 wWh
 qBU
 qBU
@@ -90686,12 +90870,12 @@ ksa
 xXP
 ksa
 ksa
+xXP
 ksa
 xXP
 ksa
-ksa
-ksa
 xXP
+ksa
 ksa
 ksa
 ksa
@@ -90943,12 +91127,12 @@ ksa
 xXP
 ksa
 ksa
+xXP
 ksa
 xXP
 ksa
-ksa
-ksa
 xXP
+ksa
 ksa
 ksa
 ksa
@@ -90980,7 +91164,7 @@ aMD
 wfJ
 lIY
 ozj
-hdj
+oLg
 mmV
 lUP
 oEc
@@ -91237,7 +91421,7 @@ nSy
 wfJ
 bGl
 pCo
-hdj
+oLg
 bwa
 lUP
 oFj
@@ -91459,8 +91643,8 @@ fhe
 ydN
 edD
 dUu
-nul
-dhd
+rSo
+iBz
 hcB
 fPN
 nGn
@@ -91494,7 +91678,7 @@ oLg
 oET
 oLg
 oLg
-hdj
+oLg
 oWj
 eAj
 hoe
@@ -91751,7 +91935,7 @@ vLL
 rHN
 ehj
 oyo
-hdj
+sHs
 kJu
 lUP
 jMj
@@ -92008,7 +92192,7 @@ tLj
 pXb
 bHn
 iFL
-hdj
+sHs
 cMU
 eNC
 flR
@@ -92522,7 +92706,7 @@ fZB
 fZB
 xsm
 peO
-hdj
+sHs
 jKE
 ipC
 nus
@@ -92779,7 +92963,7 @@ kfN
 nJy
 sHs
 opU
-hdj
+sHs
 hdj
 hdj
 fYg
@@ -94116,7 +94300,7 @@ ulW
 sLl
 lmm
 cVw
-lmm
+itL
 lmm
 xsi
 rlK
@@ -94370,10 +94554,10 @@ wEB
 wRe
 nwz
 wEB
-okg
-okg
+urJ
 nwz
-vfi
+nwz
+nwz
 kHk
 xba
 vHT
@@ -94627,11 +94811,11 @@ wEB
 wRe
 cuU
 wEB
-nwz
-nwz
-nwz
-nwz
-nwz
+okg
+okg
+cuU
+mcG
+orM
 xba
 aTB
 oPA
@@ -95144,8 +95328,8 @@ djD
 aNz
 mdZ
 rFn
-lOo
-lOo
+jhE
+jhE
 fxk
 tHx
 sNp
@@ -95400,9 +95584,9 @@ xba
 djD
 djD
 djD
-rFn
-mwn
-mwn
+lkR
+jhE
+jhE
 fxk
 bGX
 yeq
@@ -95657,9 +95841,9 @@ xba
 dbG
 btl
 btl
-uAg
-lOo
-lOo
+rFn
+jhE
+jhE
 fxk
 lYL
 adw
@@ -95914,9 +96098,9 @@ xba
 dbG
 btl
 btl
-lkR
-jhE
-jhE
+rFn
+lOo
+lOo
 fxk
 bGX
 adw
@@ -96171,9 +96355,9 @@ xba
 kVD
 jvA
 pan
-rFn
-jhE
-jhE
+uAg
+mwn
+mwn
 fxk
 mUZ
 adw
@@ -96370,9 +96554,9 @@ hjB
 pte
 qdE
 qdE
-qdE
 ekL
 wuH
+qdE
 qdE
 qdE
 cOn
@@ -96430,7 +96614,7 @@ rFn
 rFn
 rFn
 mih
-jhE
+lOo
 fxk
 bGX
 qRc
@@ -96628,8 +96812,8 @@ cjW
 tnt
 fEX
 fEX
-jaQ
 tgq
+nvj
 wJK
 kew
 kew
@@ -96883,10 +97067,10 @@ gbD
 hjB
 xLi
 wAZ
-bve
 nmw
-nmw
+qkl
 ftk
+qkl
 oxS
 kew
 rPK
@@ -97140,11 +97324,11 @@ gbD
 wXC
 cjW
 wAZ
-svQ
+nmw
 fuf
-ftk
-ftk
-lOJ
+dzH
+bXB
+qdV
 arQ
 skJ
 qGt
@@ -97399,7 +97583,7 @@ cjW
 wAZ
 fHb
 ftk
-ftk
+uiA
 eJD
 lOJ
 arQ
@@ -97911,7 +98095,7 @@ gbD
 hjB
 xLi
 wAZ
-ftk
+fsd
 uiA
 eaf
 baq
@@ -98147,7 +98331,7 @@ bMX
 inF
 hjG
 iKf
-itL
+ueL
 cdA
 ueL
 fPN
@@ -98168,10 +98352,10 @@ gbD
 hjB
 cjW
 wAZ
-ftk
-ftk
-ftk
-ftk
+uiA
+tJM
+eBj
+fsd
 lOJ
 arQ
 fVn
@@ -98682,7 +98866,7 @@ gbD
 hjB
 cjW
 wAZ
-ftk
+bXB
 qZF
 lOJ
 snq
@@ -98939,7 +99123,7 @@ gbD
 rBj
 cjW
 wAZ
-ftk
+izu
 rkX
 lOJ
 snq
@@ -98962,7 +99146,7 @@ lXN
 lDX
 ogT
 kne
-uWp
+rlP
 oKy
 gbD
 qvB
@@ -99129,7 +99313,7 @@ mGg
 oER
 oER
 mkI
-ajn
+oER
 dKa
 fuS
 dHX
@@ -99205,7 +99389,7 @@ uxh
 cYh
 efb
 jit
-meB
+gyt
 kpu
 mEy
 meB
@@ -99386,7 +99570,7 @@ sJm
 sJm
 uCx
 tsn
-ajn
+oER
 wrx
 qnN
 sHk
@@ -99453,7 +99637,7 @@ gbD
 cjW
 haO
 bKb
-ftk
+sPC
 fuf
 lOJ
 snq
@@ -99462,7 +99646,7 @@ ttl
 nkf
 gyv
 jit
-hus
+meB
 haH
 meN
 dKm
@@ -99643,7 +99827,7 @@ sJm
 sJm
 sJm
 dSd
-ajn
+oER
 uBI
 fuS
 eog
@@ -99900,7 +100084,7 @@ jJt
 gBr
 gBr
 qPN
-rhW
+tFK
 gJM
 gJM
 gJM
@@ -99968,7 +100152,7 @@ whh
 hNM
 udd
 ftk
-sPC
+nul
 lOJ
 snq
 kjH
@@ -100157,7 +100341,7 @@ rHA
 tFK
 tFK
 tFK
-rhW
+tFK
 ksa
 uoo
 ksa
@@ -100997,7 +101181,7 @@ jze
 fEz
 ftk
 pCf
-lOJ
+xlS
 snq
 mLN
 cYh
@@ -101011,7 +101195,7 @@ pSY
 qqD
 nBH
 sXC
-qqD
+dKB
 lXN
 gQT
 lXN
@@ -101252,7 +101436,7 @@ gbD
 oPl
 rcS
 wAZ
-ftk
+bXB
 tJM
 lOJ
 snq
@@ -101509,7 +101693,7 @@ gbD
 wXC
 cjW
 wAZ
-nHp
+nGw
 rkX
 lOJ
 snq
@@ -101767,7 +101951,7 @@ hjB
 cjW
 wAZ
 ftk
-nHp
+vcA
 lOJ
 snq
 snq
@@ -102023,8 +102207,8 @@ gbD
 hjB
 cjW
 wAZ
-ftk
-nHp
+fsd
+kGs
 nHp
 nfw
 nHx
@@ -102532,12 +102716,12 @@ fAQ
 wEA
 fqJ
 mZc
-xwg
+ows
 gbD
 hjB
 xLi
 wAZ
-ftk
+fuf
 eaf
 uiA
 baq
@@ -102797,7 +102981,7 @@ wAZ
 fHb
 rkX
 ftk
-fHb
+vfi
 eaf
 rTS
 rFd
@@ -103044,16 +103228,16 @@ wEA
 gsz
 cTL
 wEA
-kuz
+wEA
 mZc
-xAc
+bve
 gbD
 hjB
 cjW
 wAZ
 ftk
 luJ
-ftk
+fuf
 ntG
 lOJ
 tdz
@@ -103557,7 +103741,7 @@ wEA
 voi
 mZc
 aYu
-cMA
+ajR
 pxU
 mZc
 aeJ
@@ -103566,9 +103750,9 @@ hjB
 xLi
 wAZ
 ftk
-uiA
 ftk
 ftk
+pDn
 imr
 rTS
 ePf
@@ -103817,15 +104001,15 @@ mZc
 mZc
 mZc
 mZc
-xAc
+hus
 gbD
 hjB
 cjW
 tnt
 flc
 flc
-dzH
 qxm
+wRW
 yiw
 rTS
 rTS
@@ -104074,15 +104258,15 @@ nfz
 cTL
 wEA
 mZc
-xAc
+tGD
 gbD
 hjB
 oPl
 mzq
 mzq
-mzq
 sFl
 sHR
+mzq
 mzq
 mzq
 cOn
@@ -104156,7 +104340,7 @@ pfo
 pfo
 pfo
 pfo
-jaf
+gzZ
 kPo
 wCX
 uWo
@@ -104331,7 +104515,7 @@ wEA
 tJZ
 dOt
 mZc
-xAc
+bve
 gbD
 qet
 gbD
@@ -104845,7 +105029,7 @@ bLy
 bLy
 bLy
 bLy
-oIP
+gGh
 wzL
 wzL
 wzL
@@ -104927,7 +105111,7 @@ pfo
 pfo
 pfo
 ksu
-jaf
+gzZ
 kwk
 cgm
 jDD
@@ -105604,11 +105788,11 @@ nZW
 czt
 wEA
 mZc
-tTk
+xZd
 tTk
 beM
 xgz
-tTk
+xZd
 bLy
 xzs
 gqj
@@ -106975,13 +107159,13 @@ ciT
 gYt
 ciT
 tjI
-ciT
-ciT
-fsd
+vOT
+mtH
+jaf
 aqP
-fsd
-ciT
-ciT
+jaf
+hya
+vOT
 efs
 gkZ
 aQu
@@ -107233,11 +107417,11 @@ qYS
 uQk
 rZN
 uQk
-kiv
-kDG
-pDn
-kDG
-maz
+sKX
+gkZ
+hGk
+gkZ
+anO
 uoo
 vKf
 uoo
@@ -107256,9 +107440,9 @@ kiv
 xiW
 uoo
 uoo
+fdt
 uoo
-uoo
-uoo
+fdt
 uoo
 uoo
 uoo
@@ -107490,11 +107674,11 @@ dJc
 fdT
 pHI
 wFB
-uoo
-gkZ
-hGk
-gkZ
-tXu
+jHh
+jDp
+uou
+jDp
+sKq
 wFB
 bll
 fdT
@@ -107747,11 +107931,11 @@ tas
 cyF
 juj
 wFB
-uoo
+tXu
 gkZ
 hGk
 gkZ
-tXu
+uoo
 wFB
 gFm
 owH
@@ -108004,11 +108188,11 @@ dFT
 ril
 gZH
 wFB
-uoo
-gkZ
-hGk
-gkZ
-tXu
+fgv
+kDG
+vJk
+kDG
+maz
 wFB
 coh
 vze
@@ -108798,9 +108982,9 @@ uoo
 uoo
 uoo
 uoo
+fdt
 uoo
-uoo
-uoo
+fdt
 uoo
 uoo
 uoo
@@ -109040,7 +109224,7 @@ dgl
 txI
 txI
 txI
-dgl
+txI
 txI
 ksa
 uoo
@@ -110587,8 +110771,8 @@ mQF
 uHo
 ipj
 txI
-ksa
-ksa
+uoo
+uoo
 ksa
 ksa
 ksa

--- a/_maps/~monkestation/RandomBars/Box/bloody_bar.dmm
+++ b/_maps/~monkestation/RandomBars/Box/bloody_bar.dmm
@@ -111,7 +111,7 @@
 /turf/open/floor/cult,
 /area/station/commons/lounge)
 "rV" = (
-/obj/effect/decal/cleanable/blood/old,
+/obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/cult,
 /area/station/commons/lounge)
 "sW" = (
@@ -333,14 +333,6 @@
 	},
 /turf/open/floor/cult,
 /area/station/commons/lounge)
-"SU" = (
-/obj/structure/table/wood/fancy/red,
-/obj/item/paper/crumpled/bloody{
-	name = "Bloody Crumpled Note";
-	default_raw_text = "<p style="text-align:center"><i>It calls me<br>in a sea of flesh<br>we will become one<br>but I can never go back<br>to being me<p>"
-	},
-/turf/open/floor/cult,
-/area/station/commons/lounge)
 "Uu" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/wood/large,
@@ -368,6 +360,7 @@
 /area/station/commons/lounge)
 "UO" = (
 /obj/effect/decal/remains/human,
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/cult,
 /area/station/commons/lounge)
 "VJ" = (
@@ -477,7 +470,7 @@ QE
 uS
 ue
 uS
-SU
+uS
 Bl
 Bl
 zU

--- a/_maps/~monkestation/RandomBars/Box/clockwork_bar.dmm
+++ b/_maps/~monkestation/RandomBars/Box/clockwork_bar.dmm
@@ -153,11 +153,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/bronze,
 /area/station/commons/lounge)
-"wY" = (
-/obj/structure/chair/bronze,
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/bronze,
-/area/station/commons/lounge)
 "xT" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -346,13 +341,6 @@
 /obj/structure/fluff/clockwork/alloy_shards/large,
 /turf/open/floor/bronze,
 /area/station/commons/lounge)
-"Up" = (
-/obj/structure/chair/bronze{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/bronze,
-/area/station/commons/lounge)
 "Uz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -514,9 +502,9 @@ RG
 TL
 mm
 Jy
-Up
+cu
 qG
-wY
+si
 Jy
 JZ
 TL
@@ -567,7 +555,7 @@ zp
 "}
 (10,1,1) = {"
 OD
-wY
+si
 Jy
 JZ
 OD
@@ -577,7 +565,7 @@ cr
 OD
 mm
 Jy
-Up
+cu
 Rp
 ca
 jv

--- a/_maps/~monkestation/RandomBars/Box/vietmoth_bar.dmm
+++ b/_maps/~monkestation/RandomBars/Box/vietmoth_bar.dmm
@@ -1,4 +1,8 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ak" = (
+/obj/structure/flora/bush/jungle/c/style_random,
+/turf/open/floor/grass,
+/area/station/commons/lounge)
 "cc" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -21,7 +25,6 @@
 /obj/structure/chair/wood{
 	dir = 1
 	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/grass,
 /area/station/commons/lounge)
 "dx" = (
@@ -53,6 +56,11 @@
 	},
 /turf/open/misc/dirt/jungle,
 /area/station/service/theater)
+"gM" = (
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_pp/style_random,
+/turf/open/floor/grass,
+/area/station/commons/lounge)
 "gY" = (
 /obj/machinery/media/jukebox,
 /obj/machinery/light/directional/north,
@@ -156,6 +164,7 @@
 /turf/open/floor/grass,
 /area/station/commons/lounge)
 "pg" = (
+/obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/leavy/style_random,
 /turf/open/floor/grass,
 /area/station/commons/lounge)
@@ -177,7 +186,6 @@
 /area/station/service/theater)
 "qi" = (
 /obj/structure/chair/wood,
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/grass,
 /area/station/commons/lounge)
 "tT" = (
@@ -231,6 +239,7 @@
 /turf/open/floor/grass,
 /area/station/service/theater)
 "wF" = (
+/obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
 /area/station/commons/lounge)
@@ -288,6 +297,14 @@
 /area/station/commons/lounge)
 "BD" = (
 /obj/machinery/restaurant_portal/bar,
+/turf/open/floor/grass,
+/area/station/commons/lounge)
+"CE" = (
+/obj/structure/flora/rock/pile/style_random,
+/turf/open/floor/grass,
+/area/station/commons/lounge)
+"CX" = (
+/obj/structure/flora/bush/jungle/a/style_random,
 /turf/open/floor/grass,
 /area/station/commons/lounge)
 "Dd" = (
@@ -356,6 +373,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/station/commons/lounge)
+"Ke" = (
+/obj/structure/flora/rock/style_random,
+/turf/open/floor/grass,
+/area/station/commons/lounge)
 "Mu" = (
 /obj/machinery/light/directional/east,
 /turf/open/misc/dirt/jungle,
@@ -397,10 +418,12 @@
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/light/small/directional/west,
 /obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/commons/lounge)
 "QO" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/commons/lounge)
 "QW" = (
@@ -452,8 +475,8 @@ YM
 ir
 nj
 OP
-nj
-nj
+gM
+CE
 yJ
 "}
 (2,1,1) = {"
@@ -477,13 +500,13 @@ yJ
 "}
 (3,1,1) = {"
 Ub
-nj
+CX
 TV
 nj
 vy
 nj
 jK
-nj
+QO
 dx
 dx
 Dg
@@ -525,7 +548,7 @@ fg
 nR
 Oz
 pg
-nj
+CE
 uo
 wM
 QW
@@ -537,7 +560,7 @@ Ub
 gY
 nj
 lY
-nj
+Ke
 mL
 MI
 fm
@@ -582,7 +605,7 @@ wF
 nj
 nj
 ZB
-nj
+ak
 wd
 pP
 jB
@@ -591,7 +614,7 @@ NP
 "}
 (9,1,1) = {"
 Ub
-nj
+gM
 ir
 nj
 mC

--- a/_maps/~monkestation/RandomEngines/BoxStation/empty.dmm
+++ b/_maps/~monkestation/RandomEngines/BoxStation/empty.dmm
@@ -9,12 +9,10 @@
 "c" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "e" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "f" = (
@@ -30,7 +28,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engine Room"
@@ -123,7 +120,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -145,7 +141,6 @@
 "M" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "N" = (
@@ -179,8 +174,8 @@ R
 B
 B
 B
+B
 R
-f
 f
 A
 A
@@ -206,9 +201,9 @@ f
 i
 M
 M
+B
 b
 R
-A
 A
 A
 m
@@ -234,9 +229,9 @@ f
 R
 Q
 M
-W
+B
+B
 R
-f
 f
 A
 m
@@ -262,9 +257,9 @@ f
 R
 K
 M
+W
 B
 E
-A
 A
 A
 m
@@ -291,8 +286,8 @@ R
 D
 M
 B
+B
 E
-f
 f
 A
 m
@@ -318,9 +313,9 @@ f
 R
 K
 M
+o
 B
 E
-A
 A
 A
 m
@@ -346,9 +341,9 @@ f
 R
 B
 M
-o
+B
+B
 R
-f
 f
 A
 m
@@ -374,9 +369,9 @@ m
 R
 B
 M
+B
 b
 R
-A
 A
 A
 m
@@ -403,8 +398,8 @@ R
 B
 M
 B
+B
 R
-f
 f
 A
 m

--- a/_maps/~monkestation/RandomEngines/BoxStation/particle_accelerator.dmm
+++ b/_maps/~monkestation/RandomEngines/BoxStation/particle_accelerator.dmm
@@ -335,10 +335,6 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
 /obj/structure/table,
-/obj/item/paper{
-	name = "Important Note";
-	default_raw_text = "<p>Please do not wire these SMES units into the grid, these are specifically for the station-side particle accelerator.<br>Also, DO NOT max out these SMES units like you would the main ones. These units only need as much input/output that is needed to power the engine area and equipment.<p>"
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "vF" = (
@@ -363,12 +359,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/layer1,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engine SMES Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "wK" = (
@@ -473,6 +469,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"Cp" = (
+/obj/structure/table,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - SMES, Engine";
+	name = "engineering camera"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "Cq" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -945,7 +949,7 @@ GW
 "}
 (6,1,1) = {"
 PG
-HB
+Cp
 GK
 CY
 jL
@@ -1057,9 +1061,9 @@ El
 "}
 (10,1,1) = {"
 PG
-Cq
+aW
 zF
-Cq
+aW
 PG
 FH
 PG

--- a/_maps/~monkestation/RandomEngines/BoxStation/supermatter.dmm
+++ b/_maps/~monkestation/RandomEngines/BoxStation/supermatter.dmm
@@ -333,6 +333,14 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"kx" = (
+/obj/structure/table,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - SMES, Engine";
+	name = "engineering camera"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "kz" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -1143,12 +1151,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/layer1,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engine SMES Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "MB" = (
@@ -1336,10 +1344,6 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
 /obj/structure/table,
-/obj/item/paper{
-	name = "Important Note";
-	default_raw_text = "<p>Please do not wire these SMES units into the grid, these are specifically for the supermatter engine area.<br>Also, DO NOT max out these SMES units like you would the main ones. These units only need as much input/output that is needed to power the engine area and equipment.<p>"
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "Tk" = (
@@ -1668,7 +1672,7 @@ xP
 "}
 (6,1,1) = {"
 GP
-FD
+kx
 uh
 Ao
 QO

--- a/_maps/~monkestation/RandomEngines/BoxStation/teg.dmm
+++ b/_maps/~monkestation/RandomEngines/BoxStation/teg.dmm
@@ -1,8 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/machinery/power/generator,
+/obj/machinery/power/thermoelectric_generator,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit/green,
 /area/station/engineering/atmospherics_engine)
 "ar" = (
@@ -38,6 +39,7 @@
 "aM" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "bc" = (
@@ -148,23 +150,23 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "eE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "eK" = (
-/obj/structure/rack,
-/obj/item/pipe_dispenser,
-/turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "eQ" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
+	dir = 4;
+	name = "Mix to Burn"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
@@ -174,13 +176,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "fq" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/plating,
-/area/station/engineering/atmospherics_engine)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fr" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/effect/decal/cleanable/oil,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "ft" = (
@@ -190,7 +192,7 @@
 /area/station/engineering/atmospherics_engine)
 "fS" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
 "fT" = (
@@ -201,7 +203,6 @@
 /area/station/engineering/atmospherics_engine)
 "gd" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "gl" = (
@@ -235,12 +236,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "gZ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/obj/machinery/light/directional/south,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "hg" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -251,18 +250,22 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "hL" = (
-/obj/structure/chair/office{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "hM" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/sparker/directional/west{
+	id = "teg_igniter"
+	},
+/turf/open/floor/engine/vacuum,
 /area/station/engineering/atmospherics_engine)
 "if" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
 	dir = 4
 	},
@@ -275,9 +278,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "iy" = (
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/layer1,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "iI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -304,10 +309,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "km" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/cell_10k,
+/obj/effect/mapping_helpers/apc/full_charge,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "ku" = (
@@ -322,7 +327,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "kN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
@@ -375,8 +380,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "lY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "mc" = (
@@ -393,9 +400,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmospherics_engine)
 "ml" = (
@@ -404,7 +408,6 @@
 "mm" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "mx" = (
@@ -413,10 +416,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "mG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 8;
-	name = "Cold to Space"
+	name = "Cold Loop to Space"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
@@ -430,7 +432,6 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron,
@@ -446,15 +447,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "nh" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
 /obj/machinery/atmospherics/components/binary/pump{
+	name = "Burn Bypass";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "nw" = (
-/obj/machinery/light/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "nx" = (
@@ -479,14 +481,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "oA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
@@ -501,15 +502,14 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "pt" = (
-/obj/machinery/atmospherics/components/binary/valve/digital,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "qj" = (
@@ -530,7 +530,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "re" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/west,
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil,
@@ -542,10 +541,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "rh" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Burn Chamber"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmospherics_engine)
 "rs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
@@ -560,24 +560,20 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "rA" = (
-/obj/effect/turf_decal/delivery,
 /obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "rK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmospherics_engine)
+/obj/structure/cable,
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "rZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/engine/vacuum,
 /area/station/engineering/atmospherics_engine)
 "so" = (
 /obj/machinery/light/directional/south,
@@ -611,22 +607,18 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "tw" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = -5;
-	pixel_y = 5
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Burn Byproducts"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
@@ -647,21 +639,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/structure/cable/layer1,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Engine Room"
+	name = "Engine SMES Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron/textured,
 /area/station/engineering/atmospherics_engine)
 "tU" = (
-/obj/structure/lattice,
-/obj/structure/sign/warning/fire/directional/north,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "ug" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/glasses/meson/engine,
@@ -675,21 +668,17 @@
 "uv" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/camera/autoname/directional/east,
-/obj/structure/chair/office{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "ux" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/obj/structure/lattice,
+/obj/structure/sign/warning/secure_area/directional/north,
+/turf/open/space/basic,
+/area/space/nearstation)
 "vr" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/door/window/right/directional/south{
 	name = "Gas Canister Storage";
 	req_access = list("engineering")
@@ -698,13 +687,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "vs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "vD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/multilayer/connected,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "vF" = (
@@ -722,8 +713,9 @@
 /area/station/engineering/atmospherics_engine)
 "vX" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "wb" = (
@@ -780,15 +772,18 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "xr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/turf/open/floor/plating,
 /area/station/engineering/atmospherics_engine)
 "yc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - SMES, Engine";
+	name = "engineering camera"
 	},
-/turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "yw" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -814,18 +809,12 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmospherics_engine)
 "zy" = (
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/engineering_construction{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/book/manual/wiki/engineering_guide,
-/obj/item/book/manual/wiki/engineering_hacking{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/layer1,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "zB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
@@ -833,7 +822,9 @@
 /area/station/engineering/atmospherics_engine)
 "zR" = (
 /obj/machinery/camera/autoname/directional/east,
-/obj/machinery/atmospherics/components/binary/valve/digital,
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Hot Loop"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "zY" = (
@@ -878,23 +869,31 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/sparker/directional/east{
+	id = "teg_igniter"
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmospherics_engine)
 "Bf" = (
-/obj/structure/table/wood,
-/obj/item/analyzer,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "Bg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil{
 	pixel_x = 3;
 	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_guide,
+/obj/item/book/manual/wiki/engineering_construction{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
@@ -921,14 +920,15 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "CN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "CY" = (
@@ -953,10 +953,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "Dk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/chair/office{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "Dm" = (
@@ -986,7 +983,6 @@
 "EF" = (
 /obj/machinery/light/directional/west,
 /obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "EV" = (
@@ -998,10 +994,9 @@
 /area/space/nearstation)
 "EY" = (
 /obj/machinery/camera/autoname/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 8;
-	name = "Space to Cold"
+	name = "Space to Cold Loop"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
@@ -1021,7 +1016,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "Gk" = (
-/obj/machinery/atmospherics/components/binary/valve/digital,
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Cold Loop"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "Go" = (
@@ -1048,6 +1045,7 @@
 "GY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "Hk" = (
@@ -1057,18 +1055,17 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
+/obj/structure/cable/layer1,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
-	name = "Engine Room"
+	name = "Engine SMES Room"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/cable/layer1,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "HM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
@@ -1087,8 +1084,8 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmospherics_engine)
 "IJ" = (
-/obj/machinery/igniter{
-	id = "teg_igniter"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmospherics_engine)
@@ -1110,11 +1107,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "JE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/station/engineering/atmospherics_engine)
 "Kd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
@@ -1126,7 +1125,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "KF" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector{
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 1
 	},
 /turf/open/floor/engine/vacuum,
@@ -1141,15 +1140,14 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "Lj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/structure/sign/warning/secure_area/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Lr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/rack,
 /obj/item/crowbar/large,
 /obj/item/flashlight,
+/obj/item/pipe_dispenser,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "LC" = (
@@ -1167,7 +1165,6 @@
 "LQ" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/warning/no_smoking/directional/east,
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "LZ" = (
@@ -1178,7 +1175,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "Mh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
@@ -1206,9 +1202,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "MW" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/general/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmospherics_engine)
+/obj/structure/cable/layer1,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "Nj" = (
 /obj/machinery/button/door/directional/south{
 	id = "teg_vent";
@@ -1229,12 +1225,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmospherics_engine)
 "NF" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "Ot" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/plating,
@@ -1244,7 +1239,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "OH" = (
@@ -1259,9 +1253,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "Pq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/south,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "Pv" = (
@@ -1284,9 +1278,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "QH" = (
-/obj/structure/chair/office,
-/turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/obj/structure/cable/multilayer/connected,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 "QU" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -1295,14 +1289,14 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "Rl" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/cup/soda_cans/cola,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/layer_manifold/general/visible,
+/turf/open/floor/plating,
 /area/station/engineering/atmospherics_engine)
 "Rr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/layer1,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	name = "Waste Release"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "RA" = (
@@ -1334,8 +1328,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "SM" = (
+/obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/decal/cleanable/oil,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "SO" = (
@@ -1373,7 +1370,6 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -1381,18 +1377,16 @@
 /area/station/engineering/atmospherics_engine)
 "Ut" = (
 /obj/structure/sign/warning/fire/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "Uz" = (
-/obj/structure/chair/office{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "UF" = (
 /obj/machinery/camera/autoname/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/reinforced,
 /obj/item/analyzer,
 /obj/item/analyzer{
@@ -1407,7 +1401,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "UT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/warning/no_smoking/directional/west,
 /obj/structure/closet/emcloset,
 /turf/open/floor/iron,
@@ -1466,7 +1459,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "Yl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
+/obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -1498,20 +1491,20 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "ZT" = (
+/obj/structure/cable/layer1,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/engineering/main)
 
 (1,1,1) = {"
 Wg
 cp
 cp
 cp
+cp
 Wg
-ml
 ml
 ml
 Dt
@@ -1535,11 +1528,11 @@ ml
 "}
 (2,1,1) = {"
 Hk
-To
-To
+iy
+zy
 nw
+gZ
 Wg
-dh
 dh
 dh
 EV
@@ -1564,10 +1557,10 @@ ml
 (3,1,1) = {"
 Wg
 XD
-To
-AP
+ZT
+cp
+rK
 Wg
-ml
 ml
 ml
 EV
@@ -1592,10 +1585,10 @@ ml
 (4,1,1) = {"
 Wg
 cj
-To
-cp
+ZT
+dy
+eK
 gl
-dh
 dh
 dh
 EV
@@ -1620,10 +1613,10 @@ ml
 (5,1,1) = {"
 Wg
 LD
-To
-cp
+ZT
+MW
+QH
 gl
-ml
 ml
 ml
 EV
@@ -1647,11 +1640,11 @@ ml
 "}
 (6,1,1) = {"
 Wg
-cj
+yc
 To
-cp
+AP
+tU
 gl
-dh
 dh
 dh
 EV
@@ -1677,9 +1670,9 @@ ml
 Wg
 cp
 To
-dy
+cp
+rK
 Wg
-ml
 ml
 ml
 EV
@@ -1706,8 +1699,8 @@ Wg
 cp
 To
 nw
+gZ
 Wg
-dh
 dh
 dh
 EV
@@ -1734,8 +1727,8 @@ Wg
 cp
 To
 cp
+cp
 Wg
-ml
 ml
 ml
 EV
@@ -1789,14 +1782,14 @@ ml
 Vv
 Jo
 Ak
-NF
+ja
 re
 ug
-rZ
+lb
 EF
 mG
-RA
-RA
+lb
+lb
 EY
 Lr
 Vv
@@ -1823,10 +1816,10 @@ lb
 lb
 hg
 OH
-lY
+lm
 ry
 DS
-SM
+lb
 gd
 UT
 Bg
@@ -1851,7 +1844,7 @@ sX
 lb
 hg
 DS
-yc
+qj
 lb
 ar
 lm
@@ -1882,13 +1875,13 @@ mH
 fr
 Jo
 ja
-vW
-lb
-lb
-WP
-lb
-WP
-yc
+lY
+RA
+RA
+SM
+SM
+RA
+iI
 eC
 Vv
 dh
@@ -1930,10 +1923,10 @@ Vv
 gD
 Sd
 ts
-Rr
-Rr
 vs
 vs
+vs
+eE
 vD
 vX
 aa
@@ -1942,7 +1935,7 @@ Pq
 QE
 QE
 rA
-gZ
+lb
 lb
 lb
 Bh
@@ -1988,7 +1981,7 @@ wu
 wb
 wx
 wx
-iy
+lb
 hg
 MD
 GJ
@@ -1996,7 +1989,7 @@ QA
 TT
 up
 up
-ux
+up
 AM
 AM
 up
@@ -2075,7 +2068,7 @@ YB
 so
 QE
 yw
-WP
+lb
 eQ
 lb
 Uf
@@ -2087,7 +2080,7 @@ Vv
 Vv
 Vv
 Vv
-ml
+Zc
 hs
 vF
 hs
@@ -2104,14 +2097,14 @@ RA
 RA
 wi
 RA
-ZT
+OO
 iI
 kV
 HO
-fq
-rh
+No
+lH
 bU
-SO
+hM
 SO
 Wj
 Dq
@@ -2129,16 +2122,16 @@ nx
 lb
 ig
 lv
-Gk
+rh
 if
-xr
+lv
 vP
-xr
+lv
 nh
 Pv
-No
-lH
-No
+xr
+fq
+xr
 KF
 IJ
 mh
@@ -2155,7 +2148,7 @@ wK
 pg
 nx
 lb
-iy
+lb
 lb
 lb
 rs
@@ -2164,11 +2157,11 @@ yO
 yO
 Yj
 lA
-hM
-fS
+No
+lH
 bU
 SO
-SO
+rZ
 AZ
 Dq
 mW
@@ -2180,26 +2173,26 @@ ml
 (25,1,1) = {"
 Vv
 QA
-ds
+hL
 tp
 CY
 SB
 sJ
 up
-WP
-hL
-hL
-Gr
+lb
+lb
+lb
+lb
 Ut
-MW
-JE
-JE
-JE
-JE
-JE
-rK
 Vv
-tU
+Vv
+Vv
+Vv
+Vv
+JE
+Vv
+Vv
+Zc
 hs
 hs
 hs
@@ -2214,19 +2207,19 @@ md
 md
 Vv
 Aa
-QH
-Rl
-zy
-eE
+lb
+lb
+lb
+Gr
 pt
-YM
-wU
-wU
+Rl
 Lj
-wU
-wU
-wU
-Mu
+Lj
+Lj
+Lj
+NF
+ml
+dh
 ml
 ml
 dh
@@ -2242,19 +2235,19 @@ ml
 md
 qO
 lb
-QH
+lb
 Bf
 tw
 Dk
-eK
-Vv
-Zc
-Zc
-Zc
+lb
+ax
 dh
 dh
+fS
 dh
+fS
 dh
+fS
 dh
 dh
 dh
@@ -2272,17 +2265,17 @@ So
 IL
 LQ
 uv
-Uz
 lb
-FS
-Vv
-ml
-ml
-dh
-ml
-dh
-vF
-hs
+Uz
+Rr
+YM
+wU
+wU
+wU
+wU
+wU
+wU
+Mu
 ml
 ml
 ml
@@ -2304,13 +2297,13 @@ Vv
 Vv
 Vv
 Vv
-dh
-dh
+ux
 dh
 dh
 dh
 vF
 hs
+ml
 ml
 ml
 ml

--- a/monkestation/code/random_rooms/engines/boxstation.dm
+++ b/monkestation/code/random_rooms/engines/boxstation.dm
@@ -26,5 +26,5 @@
 	centerspawner = FALSE
 	template_height = 26
 	template_width = 29
-	weight = 0 // Changed from 4 to 0 until PR 1521 gets merged.
+	weight = 4 // Should probably be rarer than the other two engines.
 	station_name = "Box Station"


### PR DESCRIPTION

## About The Pull Request
This pull request re-enables the TEG engine and slightly adjusts things in its room, it also adjusts the random engine template a little, removes all of the custom notes (they caused issues with MapDiffBot2), and makes many other miscellaneous additions, changes, and fixes.

## Why It's Good For The Game
The TEG gets re-enabled and there's a little more stuff.

## Changelog
:cl:
add: added miscellaneous things around parts of the map.
del: removed all custom notes.
fix: fixed the teg engine map file and miscellaneous things around parts of the map.
code: changed the code in `monkestation/code/random_rooms/engines/boxstation.dm` to re-enable the teg engine.
/:cl:
