### PR TITLE
Fix Persuasion Rack Bugs

### DIFF
--- a/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
+++ b/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
@@ -130,6 +130,8 @@
 	var/disloyalty_confirm = FALSE
 	/// Prevents popup spam.
 	var/disloyalty_offered = FALSE
+	// Prevent spamming torture via spam click. Otherwise they're able to lose a lot of blood quickly
+	var/torture_debounce = FALSE
 
 /obj/structure/bloodsucker/vassalrack/Initialize(mapload)
 	. = ..()
@@ -282,6 +284,9 @@
 			balloon_alert(user, "someone else's vassal!")
 			return FALSE
 
+	if(isanimal_or_basicmob(target))
+		balloon_alert(user, "you can't torture an animal or basic mob!")
+		return FALSE
 	var/disloyalty_requires = RequireDisloyalty(user, target)
 
 	if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
@@ -294,44 +299,49 @@
 
 	// Conversion Process
 	if(convert_progress)
-		balloon_alert(user, "spilling blood...")
-		bloodsuckerdatum.AddBloodVolume(-TORTURE_BLOOD_HALF_COST)
-		if(!do_torture(user, target))
-			return FALSE
-		bloodsuckerdatum.AddBloodVolume(-TORTURE_BLOOD_HALF_COST)
-		// Prevent them from unbuckling themselves as long as we're torturing.
-		target.Paralyze(1 SECONDS)
-		convert_progress--
+		//Are we currently torturing this person? If so, do not spill blood more.
+		if(!torture_debounce)
+			//We're torturing. Do not start another torture on this rack.
+			torture_debounce = TRUE
+			balloon_alert(user, "spilling blood...")
+			bloodsuckerdatum.AddBloodVolume(-TORTURE_BLOOD_HALF_COST)
+			if(!do_torture(user, target))
+				return FALSE
+			bloodsuckerdatum.AddBloodVolume(-TORTURE_BLOOD_HALF_COST)
+			// Prevent them from unbuckling themselves as long as we're torturing.
+			target.Paralyze(1 SECONDS)
+			convert_progress--
 
-		// We're done? Let's see if they can be Vassal.
-		if(convert_progress)
-			balloon_alert(user, "needs more persuasion...")
+			// We're done? Let's see if they can be Vassal.
+			if(convert_progress)
+				balloon_alert(user, "needs more persuasion...")
+				return
+
+			if(disloyalty_requires)
+				balloon_alert(user, "has external loyalties! more persuasion required!")
+			else
+				balloon_alert(user, "ready for communion!")
+				return
+
+			if(!disloyalty_confirm && disloyalty_requires)
+				if(!do_disloyalty(user, target))
+					return
+				if(!disloyalty_confirm)
+					balloon_alert(user, "refused persuasion!")
+				else
+					balloon_alert(user, "ready for communion!")
+				return
+	//If they don't need any more torture, start converting them into a vassal!
+	else
+		user.balloon_alert_to_viewers("smears blood...", "painting bloody marks...")
+		if(!do_after(user, 5 SECONDS, target))
+			balloon_alert(user, "interrupted!")
 			return
-
-		if(disloyalty_requires)
-			balloon_alert(user, "has external loyalties! more persuasion required!")
-		else
-			balloon_alert(user, "ready for communion!")
-		return
-
-	if(!disloyalty_confirm && disloyalty_requires)
-		if(!do_disloyalty(user, target))
-			return
-		if(!disloyalty_confirm)
-			balloon_alert(user, "refused persuasion!")
-		else
-			balloon_alert(user, "ready for communion!")
-		return
-
-	user.balloon_alert_to_viewers("smears blood...", "painting bloody marks...")
-	if(!do_after(user, 5 SECONDS, target))
-		balloon_alert(user, "interrupted!")
-		return
-	// Convert to Vassal!
-	bloodsuckerdatum.AddBloodVolume(-TORTURE_CONVERSION_COST)
-	if(bloodsuckerdatum.make_vassal(target))
-		remove_loyalties(target)
-		SEND_SIGNAL(bloodsuckerdatum, BLOODSUCKER_MADE_VASSAL, user, target)
+		// Convert to Vassal!
+		bloodsuckerdatum.AddBloodVolume(-TORTURE_CONVERSION_COST)
+		if(bloodsuckerdatum.make_vassal(target))
+			remove_loyalties(target)
+			SEND_SIGNAL(bloodsuckerdatum, BLOODSUCKER_MADE_VASSAL, user, target)
 
 /obj/structure/bloodsucker/vassalrack/proc/do_torture(mob/living/user, mob/living/carbon/target, mult = 1)
 	// Fifteen seconds if you aren't using anything. Shorter with weapons and such.
@@ -363,6 +373,8 @@
 	torture_time = max(5 SECONDS, torture_time * 10)
 	// Now run process.
 	if(!do_after(user, (torture_time * mult), target))
+		//Torture failed. You can start again.
+		torture_debounce = FALSE
 		return FALSE
 
 	if(held_item)
@@ -374,6 +386,8 @@
 	INVOKE_ASYNC(target, TYPE_PROC_REF(/mob, emote), "scream")
 	target.set_timed_status_effect(5 SECONDS, /datum/status_effect/jitter, only_if_higher = TRUE)
 	target.apply_damages(brute = torture_dmg_brute, burn = torture_dmg_burn, def_zone = selected_bodypart.body_zone)
+	//Torture succeeded. You may torture again.
+	torture_debounce = FALSE
 	return TRUE
 
 /// Offer them the oppertunity to join now.

--- a/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
+++ b/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
@@ -284,7 +284,7 @@
 			balloon_alert(user, "someone else's vassal!")
 			return FALSE
 
-	if(isanimal_or_basicmob(target))
+	if(!ishuman(target))
 		balloon_alert(user, "you can't torture an animal or basic mob!")
 		return FALSE
 	var/disloyalty_requires = RequireDisloyalty(user, target)

--- a/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
+++ b/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
@@ -302,36 +302,36 @@
 		//Are we currently torturing this person? If so, do not spill blood more.
 		if(blood_draining)
 			return
-			//We're torturing. Do not start another torture on this rack.
-			blood_draining = TRUE
-			balloon_alert(user, "spilling blood...")
-			bloodsuckerdatum.AddBloodVolume(-TORTURE_BLOOD_HALF_COST)
-			if(!do_torture(user, target))
-				return FALSE
-			bloodsuckerdatum.AddBloodVolume(-TORTURE_BLOOD_HALF_COST)
-			// Prevent them from unbuckling themselves as long as we're torturing.
-			target.Paralyze(1 SECONDS)
-			convert_progress--
+		//We're torturing. Do not start another torture on this rack.
+		blood_draining = TRUE
+		balloon_alert(user, "spilling blood...")
+		bloodsuckerdatum.AddBloodVolume(-TORTURE_BLOOD_HALF_COST)
+		if(!do_torture(user, target))
+			return FALSE
+		bloodsuckerdatum.AddBloodVolume(-TORTURE_BLOOD_HALF_COST)
+		// Prevent them from unbuckling themselves as long as we're torturing.
+		target.Paralyze(1 SECONDS)
+		convert_progress--
 
-			// We're done? Let's see if they can be Vassal.
-			if(convert_progress)
-				balloon_alert(user, "needs more persuasion...")
+		// We're done? Let's see if they can be Vassal.
+		if(convert_progress)
+			balloon_alert(user, "needs more persuasion...")
+			return
+
+		if(disloyalty_requires)
+			balloon_alert(user, "has external loyalties! more persuasion required!")
+		else
+			balloon_alert(user, "ready for communion!")
+			return
+
+		if(!disloyalty_confirm && disloyalty_requires)
+			if(!do_disloyalty(user, target))
 				return
-
-			if(disloyalty_requires)
-				balloon_alert(user, "has external loyalties! more persuasion required!")
+			if(!disloyalty_confirm)
+				balloon_alert(user, "refused persuasion!")
 			else
 				balloon_alert(user, "ready for communion!")
-				return
-
-			if(!disloyalty_confirm && disloyalty_requires)
-				if(!do_disloyalty(user, target))
-					return
-				if(!disloyalty_confirm)
-					balloon_alert(user, "refused persuasion!")
-				else
-					balloon_alert(user, "ready for communion!")
-				return
+			return
 	//If they don't need any more torture, start converting them into a vassal!
 	else
 		user.balloon_alert_to_viewers("smears blood...", "painting bloody marks...")

--- a/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
+++ b/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
@@ -300,7 +300,8 @@
 	// Conversion Process
 	if(convert_progress)
 		//Are we currently torturing this person? If so, do not spill blood more.
-		if(!torture_debounce)
+		if(torture_debounce)
+			return
 			//We're torturing. Do not start another torture on this rack.
 			torture_debounce = TRUE
 			balloon_alert(user, "spilling blood...")

--- a/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
+++ b/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
@@ -131,7 +131,7 @@
 	/// Prevents popup spam.
 	var/disloyalty_offered = FALSE
 	// Prevent spamming torture via spam click. Otherwise they're able to lose a lot of blood quickly
-	var/torture_debounce = FALSE
+	var/blood_draining = FALSE
 
 /obj/structure/bloodsucker/vassalrack/Initialize(mapload)
 	. = ..()
@@ -300,10 +300,10 @@
 	// Conversion Process
 	if(convert_progress)
 		//Are we currently torturing this person? If so, do not spill blood more.
-		if(torture_debounce)
+		if(blood_draining)
 			return
 			//We're torturing. Do not start another torture on this rack.
-			torture_debounce = TRUE
+			blood_draining = TRUE
 			balloon_alert(user, "spilling blood...")
 			bloodsuckerdatum.AddBloodVolume(-TORTURE_BLOOD_HALF_COST)
 			if(!do_torture(user, target))
@@ -375,7 +375,7 @@
 	// Now run process.
 	if(!do_after(user, (torture_time * mult), target))
 		//Torture failed. You can start again.
-		torture_debounce = FALSE
+		blood_draining = FALSE
 		return FALSE
 
 	if(held_item)
@@ -388,7 +388,7 @@
 	target.set_timed_status_effect(5 SECONDS, /datum/status_effect/jitter, only_if_higher = TRUE)
 	target.apply_damages(brute = torture_dmg_brute, burn = torture_dmg_burn, def_zone = selected_bodypart.body_zone)
 	//Torture succeeded. You may torture again.
-	torture_debounce = FALSE
+	blood_draining = FALSE
 	return TRUE
 
 /// Offer them the oppertunity to join now.


### PR DESCRIPTION
Prevents basicmob torture, while also preventing the user from spamming the rack (which would make them lose a lot of blood)
## About The Pull Request

Prevents basicmob torture, while also preventing the user from spamming the rack (which would make them lose a lot of blood).

## Why It's Good For The Game

Spamming the rack to instantly lose all of your blood does not seem intended, and seems very harmful. Also, based on the other people you're allowed to torture, I don't think you were supposed to be able to torture simplemobs in the first place.

If you were supposed to be able to torture basic mobs, tell me, and I can fix that.

## Changelog



:cl:
fix: Bloodsuckers are unable to spam click the persuasion rack and lose all their blood, as part of the new clan training.
fix: Bloodsuckers will not torture basic mobs or animals, after a clan agreement involving the Animal Rights Consortium.
/:cl:
