### PR TITLE
You can now properly surgically reattach an oozeling's head

### DIFF
--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -20,9 +20,10 @@
 	if(!iscarbon(target))
 		return FALSE
 	var/mob/living/carbon/carbon_target = target
-	if(!isoozeling(target) || user.zone_selected == BODY_ZONE_HEAD)
-		if(!carbon_target.get_bodypart(user.zone_selected)) //can only start if limb is missing
-			return TRUE
+	// you can only start the surgery if the limb is missing.
+	// for oozelings, this surgery is only available on the head.
+	if((!isoozeling(target) || user.zone_selected == BODY_ZONE_HEAD) && !carbon_target.get_bodypart(user.zone_selected))
+		return TRUE
 	return FALSE
 
 

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -20,7 +20,7 @@
 	if(!iscarbon(target))
 		return FALSE
 	var/mob/living/carbon/carbon_target = target
-	if(!isoozeling(target))
+	if(!isoozeling(target) || user.zone_selected == BODY_ZONE_HEAD)
 		if(!carbon_target.get_bodypart(user.zone_selected)) //can only start if limb is missing
 			return TRUE
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This allows you to start prosthetic replacement surgery on decapitated oozeling's head.

Due to a lazy check in prosthetic replacement, the surgery would never be an option, and you'd have to use ligament hook to re-attach their head.

## Why It's Good For The Game

Kinda dumb that you can't reattach their head, considering they can't regrow it lol, and I'm pretty sure the oozeling check in prosthetic replacement is so you don't replace the limbs that they can just regrow.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You can now properly surgically reattach an oozeling's head.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
