### PR TITLE
Fixes exploitable memory leak regarding Rod of Asclepius and Telepathy

### DIFF
--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -106,22 +106,25 @@
 		return
 	var/failText = span_warning("The snake seems unsatisfied with your incomplete oath and returns to its previous place on the rod, returning to its dormant, wooden state. You must stand still while completing your oath!")
 	to_chat(itemUser, span_notice("The wooden snake that was carved into the rod seems to suddenly come alive and begins to slither down your arm! The compulsion to help others grows abnormally strong..."))
-	if(do_after(itemUser, 40, target = itemUser))
+	//The "iscarbon" is to prevent telekinetic grabs using the rod.
+	//If we don't do this, we create a memory leak if someone uses telekinetic grab on the rod and binds it.
+	//For consistency (and the safety - we want to prevent this at all costs), we do this on each step.
+	if(do_after(itemUser, 40, target = itemUser) && iscarbon(src.loc))
 		itemUser.say("I swear to fulfill, to the best of my ability and judgment, this covenant:", forced = "hippocratic oath")
 	else
 		to_chat(itemUser, failText)
 		return
-	if(do_after(itemUser, 20, target = itemUser))
+	if(do_after(itemUser, 20, target = itemUser) && iscarbon(src.loc))
 		itemUser.say("I will apply, for the benefit of the sick, all measures that are required, avoiding those twin traps of overtreatment and therapeutic nihilism.", forced = "hippocratic oath")
 	else
 		to_chat(itemUser, failText)
 		return
-	if(do_after(itemUser, 30, target = itemUser))
+	if(do_after(itemUser, 30, target = itemUser) && iscarbon(src.loc))
 		itemUser.say("I will remember that I remain a member of society, with special obligations to all my fellow human beings, those sound of mind and body as well as the infirm.", forced = "hippocratic oath")
 	else
 		to_chat(itemUser, failText)
 		return
-	if(do_after(itemUser, 30, target = itemUser))
+	if(do_after(itemUser, 30, target = itemUser) && iscarbon(src.loc))
 		itemUser.say("If I do not violate this oath, may I enjoy life and art, respected while I live and remembered with affection thereafter. May I always act so as to preserve the finest traditions of my calling and may I long experience the joy of healing those who seek my help.", forced = "hippocratic oath")
 	else
 		to_chat(itemUser, failText)


### PR DESCRIPTION
## About The Pull Request

Fixes an exploitable bug that causes increasing amounts of lag regarding the Rod of Asclepius and Telepathy. Prevented by checking that the owner is a carbon.

The reason this causes lag is likely due to growing arms to "regain" the rod of asclepius, which just continues to grow and grow. Eventually, this even turns your sprite into an error.

Closes #1519 

## Why It's Good For The Game

Memory leaks / bugs that cause lag - and those exploitable by griefers, especially, bad.

## Changelog

:cl:
fix: Rod of Asclepius can no longer be used with telepathy. The geneticist responsible has been forced to roll a boulder for the rest of time.
/:cl:
