### PR TITLE
Fixes invisible simian husks.

### DIFF
--- a/monkestation/code/modules/surgery/bodyparts/simian_bodyparts.dm
+++ b/monkestation/code/modules/surgery/bodyparts/simian_bodyparts.dm
@@ -1,5 +1,6 @@
 /obj/item/bodypart/head/simian
 	icon_greyscale =  'monkestation/icons/mob/species/simian/bodyparts.dmi'
+	icon_husk = 'monkestation/icons/mob/species/simian/bodyparts.dmi'
 	husk_type = "simian"
 	limb_id = SPECIES_SIMIAN
 	is_dimorphic = FALSE
@@ -9,6 +10,7 @@
 
 /obj/item/bodypart/chest/simian
 	icon_greyscale =  'monkestation/icons/mob/species/simian/bodyparts.dmi'
+	icon_husk = 'monkestation/icons/mob/species/simian/bodyparts.dmi'
 	husk_type = "simian"
 	limb_id = SPECIES_SIMIAN
 	is_dimorphic = FALSE
@@ -18,6 +20,7 @@
 
 /obj/item/bodypart/arm/left/simian
 	icon_greyscale =  'monkestation/icons/mob/species/simian/bodyparts.dmi'
+	icon_husk = 'monkestation/icons/mob/species/simian/bodyparts.dmi'
 	husk_type = "simian"
 	limb_id = SPECIES_SIMIAN
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC | BODYTYPE_CUSTOM
@@ -26,6 +29,7 @@
 
 /obj/item/bodypart/arm/right/simian
 	icon_greyscale =  'monkestation/icons/mob/species/simian/bodyparts.dmi'
+	icon_husk = 'monkestation/icons/mob/species/simian/bodyparts.dmi'
 	husk_type = "simian"
 	limb_id = SPECIES_SIMIAN
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC | BODYTYPE_CUSTOM
@@ -34,6 +38,7 @@
 
 /obj/item/bodypart/leg/left/simian
 	icon_greyscale =  'monkestation/icons/mob/species/simian/bodyparts.dmi'
+	icon_husk = 'monkestation/icons/mob/species/simian/bodyparts.dmi'
 	husk_type = "simian"
 	limb_id = SPECIES_SIMIAN
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC | BODYTYPE_CUSTOM
@@ -41,6 +46,7 @@
 
 /obj/item/bodypart/leg/right/simian
 	icon_greyscale =  'monkestation/icons/mob/species/simian/bodyparts.dmi'
+	icon_husk = 'monkestation/icons/mob/species/simian/bodyparts.dmi'
 	husk_type = "simian"
 	limb_id = SPECIES_SIMIAN
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ORGANIC | BODYTYPE_CUSTOM


### PR DESCRIPTION

## About The Pull Request
Fixes #1605 
## Why It's Good For The Game
Having your charred corpse be invisible is not ideal.
## Changelog
:cl:
fix: Simians no longer turn invisible when husked.
/:cl:
