### PR TITLE
baton/telebaton nerfs

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -310,7 +310,6 @@
 	bare_wound_bonus = 5
 	clumsy_knockdown_time = 15 SECONDS
 	active = FALSE
-	cooldown = 1.5 SECONDS //monkestation edit
 
 	/// The sound effecte played when our baton is extended.
 	var/on_sound = 'sound/weapons/batonextend.ogg'

--- a/monkestation/code/game/objects/items/melee/baton.dm
+++ b/monkestation/code/game/objects/items/melee/baton.dm
@@ -1,0 +1,3 @@
+/obj/item/melee/baton
+	cooldown = 2 SECONDS
+	stamina_damage = 40

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5764,6 +5764,7 @@
 #include "monkestation\code\game\objects\items\guns\SRN.dm"
 #include "monkestation\code\game\objects\items\guns\wt_ammo.dm"
 #include "monkestation\code\game\objects\items\implants\hardlight.dm"
+#include "monkestation\code\game\objects\items\melee\baton.dm"
 #include "monkestation\code\game\objects\items\objects\items\robot\robot_upgrades.dm"
 #include "monkestation\code\game\objects\items\storage\book.dm"
 #include "monkestation\code\game\objects\items\storage\boxes.dm"


### PR DESCRIPTION

## About The Pull Request

- Raises baton cooldown to 2 seconds
- Lowers baton stamina damage to 40

might need to play with the numbers a bit

## Why It's Good For The Game

Because an "I win stick" where you're effectively done for if you get clicked *once* is not fun for anyone, except maybe validhunters I guess, but those aren't the people we want around here anyways.

They should be more of a "gtfo me" tool, rather than a "you're stunlocked for eternity" tool.

## Changelog
:cl:
balance: Nerfed the police and telescopic baton, extending their cooldown and reducing their stamina damage.
/:cl:
