### PR TITLE
Fix blank events being considered

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -14,10 +14,13 @@ SUBSYSTEM_DEF(events)
 	var/wizardmode = FALSE
 
 /datum/controller/subsystem/events/Initialize()
-	for(var/type in typesof(/datum/round_event_control))
-		var/datum/round_event_control/event = new type()
-		if(!event.typepath || !event.valid_for_map())
-			continue //don't want this one! leave it for the garbage collector
+	for(var/datum/round_event_control/event_type as anything in typesof(/datum/round_event_control))
+		if(!event_type::typepath || !event_type::name)
+			continue
+		var/datum/round_event_control/event = new event_type
+		if(!event.valid_for_map())
+			qdel(event)
+			continue
 		control += event //add it to the list of all events (controls)
 	reschedule()
 	// Instantiate our holidays list if it hasn't been already

--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -168,11 +168,12 @@ SUBSYSTEM_DEF(gamemode)
 	for(var/type in subtypesof(/datum/storyteller))
 		storytellers[type] = new type()
 
-	for(var/type in typesof(/datum/round_event_control))
-		var/datum/round_event_control/event = new type()
-		if(!event.typepath || !event.name)
-			continue //don't want this one! leave it for the garbage collector
+	for(var/datum/round_event_control/event_type as anything in typesof(/datum/round_event_control))
+		if(!event_type::typepath || !event_type::name)
+			continue
+		var/datum/round_event_control/event = new event_type
 		if(!event.valid_for_map())
+			qdel(event)
 			continue // event isn't good for this map no point in trying to add it to the list
 		control += event //add it to the list of all events (controls)
 	getHoliday()


### PR DESCRIPTION

## Changelog
:cl:
fix: Fix invalid events (with blank names) being considered to run.
/:cl:
