### PR TITLE
Battlecruiser Allies now get the Syndicate faction

### DIFF
--- a/monkestation/code/modules/antagonists/battlecruiser/battlecruiser.dm
+++ b/monkestation/code/modules/antagonists/battlecruiser/battlecruiser.dm
@@ -1,0 +1,9 @@
+/datum/antagonist/battlecruiser/ally/apply_innate_effects(mob/living/mob_override)
+	. = ..()
+	var/mob/living/target = mob_override || owner.current
+	target.faction |= ROLE_SYNDICATE
+
+/datum/antagonist/battlecruiser/ally/remove_innate_effects(mob/living/mob_override)
+	. = ..()
+	var/mob/living/target = mob_override || owner.current
+	target.faction -= ROLE_SYNDICATE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5793,6 +5793,7 @@
 #include "monkestation\code\modules\aesthetics\walls\iron.dm"
 #include "monkestation\code\modules\antagonists\_common\antag_datum.dm"
 #include "monkestation\code\modules\antagonists\_common\antag_hud.dm"
+#include "monkestation\code\modules\antagonists\battlecruiser\battlecruiser.dm"
 #include "monkestation\code\modules\antagonists\brainwashing\brainwashing.dm"
 #include "monkestation\code\modules\antagonists\brainwashing\brainwashing_alert.dm"
 #include "monkestation\code\modules\antagonists\brainwashing\brainwashing_helpers.dm"


### PR DESCRIPTION
## Why It's Good For The Game

So the ally can return with the battlecruiser crew to their base, without immediately being gunned down by their turrets.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Battlecruiser Allies now get the Syndicate faction, allowing them to go back with the battlecruiser crew to their base without being gunned down by turrets.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
