### PR TITLE
Heavily increases and randomizes the speech cooldown of parrots

### DIFF
--- a/code/modules/mob/living/basic/pets/parrot/parrot_ai/parroting_action.dm
+++ b/code/modules/mob/living/basic/pets/parrot/parrot_ai/parroting_action.dm
@@ -36,13 +36,6 @@
 			modified_speech = copytext_char(speech, 3)
 
 	else
-		// monke start - stfu poly
-		var/speak_prob = speaking_pawn.ears.use_command ? 25 : 50
-		for(var/channel in list(RADIO_KEY_COMMON, RADIO_TOKEN_COMMAND))
-			if(channel in available_channels)
-				speak_prob = max(FLOOR(speak_prob * 0.4, 5), 5)
-		use_radio = prob(speak_prob)
-		// monke end
 		if(HAS_CHANNEL_PREFIX)
 			modified_speech = "[use_radio ? pick(available_channels) : ""][copytext_char(speech, 3)]"
 		else

--- a/monkestation/code/modules/mob/living/basic/pets/parrot/parrot_ai/parroting_action.dm
+++ b/monkestation/code/modules/mob/living/basic/pets/parrot/parrot_ai/parroting_action.dm
@@ -1,0 +1,5 @@
+/datum/ai_behavior/perform_speech/parrot
+	action_cooldown = 45 SECONDS // SHUT UP
+
+/datum/ai_behavior/perform_speech/parrot/perform(seconds_per_tick, datum/ai_controller/controller, ...)
+	controller.behavior_cooldowns[src] = world.time + rand(45 SECONDS, 3 MINUTES)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6412,6 +6412,7 @@
 #include "monkestation\code\modules\mob\living\basic\animatronic.dm"
 #include "monkestation\code\modules\mob\living\basic\ggg\glerm.dm"
 #include "monkestation\code\modules\mob\living\basic\ggg\susflash.dm"
+#include "monkestation\code\modules\mob\living\basic\pets\parrot\parrot_ai\parroting_action.dm"
 #include "monkestation\code\modules\mob\living\basic\space_fauna\fugu_gland.dm"
 #include "monkestation\code\modules\mob\living\basic\vermin\mouse.dm"
 #include "monkestation\code\modules\mob\living\carbon\carbon_death.dm"


### PR DESCRIPTION

## About The Pull Request

This increases the `action_cooldown` for parrots speaking - from 7.5 seconds, to a randomized 45 seconds to 3 minutes.

Reverts https://github.com/Monkestation/Monkestation2.0/pull/950, as it's not needed anymore.

## Why It's Good For The Game

Poly saying something every 10 seconds gets annoying really fast.

## Changelog
:cl:
qol: Heavily increases and randomizes the speech cooldown of parrots.
/:cl:
