### PR TITLE
[REPLACEMENT] Gets rid of rubbish rad collectors, makes them more interesting instead.

### DIFF
--- a/monkestation/code/modules/power/singularity/rad_collector.dm
+++ b/monkestation/code/modules/power/singularity/rad_collector.dm
@@ -70,8 +70,8 @@
 
 /obj/machinery/power/rad_collector/process(seconds_per_tick)
 	if(loaded_tank)
+		var/datum/gas_mixture/tank_mix = loaded_tank.return_air()
 		if(active)
-			var/datum/gas_mixture/tank_mix = loaded_tank.return_air()
 			for(var/id in tank_mix.gases)
 				if(tank_mix.gases[id][MOLES] >= 10) //Stops cheesing.
 					power_coeff += (GLOB.meta_gas_info[id][META_GAS_SPECIFIC_HEAT]) //250 (plasma), 2000 (hypernobi), etc etc

--- a/monkestation/code/modules/power/singularity/rad_collector.dm
+++ b/monkestation/code/modules/power/singularity/rad_collector.dm
@@ -234,7 +234,7 @@
 
 /obj/machinery/power/rad_collector/rad_act(intensity)
 	if(loaded_tank && active && intensity > RAD_COLLECTOR_EFFICIENCY)
-		stored_energy += ((intensity+power_coeff))-RAD_COLLECTOR_EFFICIENCY)*RAD_COLLECTOR_COEFFICIENT
+		stored_energy += ((intensity+power_coeff)-RAD_COLLECTOR_EFFICIENCY)*RAD_COLLECTOR_COEFFICIENT
 
 #undef RAD_COLLECTOR_EFFICIENCY
 #undef RAD_COLLECTOR_COEFFICIENT

--- a/monkestation/code/modules/power/singularity/rad_collector.dm
+++ b/monkestation/code/modules/power/singularity/rad_collector.dm
@@ -23,7 +23,7 @@
 
 /obj/machinery/power/rad_collector //Still use this for compat reasons
 	name = "Particle Capture Array"
-	desc = "A device which uses a large plasma-glass sheet to 'catch' particles, harvesting their stored energy. Do not taunt. Can be loaded with plasma to produce additional power."
+	desc = "A device which uses a large plasma-glass sheet to 'catch' particles, harvesting their stored energy. Do not taunt. Can be loaded with a variety of gases to produce additional power."
 	icon = 'monkestation/icons/obj/engine/singularity.dmi'
 	icon_state = "ca"
 	anchored = FALSE
@@ -63,7 +63,7 @@
 	if(istype(projectile,/obj/projectile/energy/nuclear_particle))
 		var/obj/projectile/energy/nuclear_particle/proj = projectile
 		var/final_output = (proj.stored_energy += power_coeff)
-		stored_energy += (final_output*2.5) //yippiee!!!
+		stored_energy += (final_output*1.4) //2.5 yields ~145KW/s avg per collector.
 		return
 
 /obj/machinery/power/rad_collector/process(seconds_per_tick)
@@ -71,7 +71,7 @@
 		power_coeff -= 0.5 //Half power
 	var/datum/gas_mixture/tank_mix = loaded_tank.return_air()
 
-	if(!tank_mix)
+	if(!tank_mix && loaded_tank)
 		investigate_log("<font color='red'>out of gas.</font>.", INVESTIGATE_ENGINE)
 		playsound(src, 'sound/machines/ding.ogg', 50, TRUE)
 		power_coeff = 0 //Should NEVER happen.

--- a/monkestation/code/modules/power/singularity/rad_collector.dm
+++ b/monkestation/code/modules/power/singularity/rad_collector.dm
@@ -70,7 +70,7 @@
 
 /obj/machinery/power/rad_collector/process(seconds_per_tick)
 	if(loaded_tank)
-		if(!active)
+		if(active)
 			var/datum/gas_mixture/tank_mix = loaded_tank.return_air()
 			for(var/id in tank_mix.gases)
 				if(tank_mix.gases[id][MOLES] >= 10) //Stops cheesing.

--- a/monkestation/code/modules/power/singularity/rad_collector.dm
+++ b/monkestation/code/modules/power/singularity/rad_collector.dm
@@ -48,6 +48,8 @@
 	//Multiplier for tanks and gases insidee
 	var/power_coeff = 1
 
+/obj/machinery/power/rad_collector/anchored
+
 /obj/machinery/power/rad_collector/Initialize(mapload) //all start anchored now. No more accidental mismaps.
 	. = ..()
 	set_anchored(TRUE)

--- a/monkestation/code/modules/power/singularity/rad_collector.dm
+++ b/monkestation/code/modules/power/singularity/rad_collector.dm
@@ -16,8 +16,8 @@
 /obj/projectile/energy/nuclear_particle/Initialize(mapload)
 	. = ..()
 	if(!stored_energy) //Will generate a random value on every initialise
-		stored_energy = rand(0,150) //SUPER lethal. Eeyikes!
-		damage = (stored_energy)/3 //OOPSIES.
+		stored_energy = rand(150,30000) //SUPER lethal. Eeyikes!
+		damage = max((stored_energy/10),80) //Yeowch-tier
 
 //replacing this dumbass machine with something more fun.
 
@@ -62,7 +62,8 @@
 /obj/machinery/power/rad_collector/proc/eat_some_bullets(datum/source, obj/projectile/projectile)
 	if(istype(projectile,/obj/projectile/energy/nuclear_particle))
 		var/obj/projectile/energy/nuclear_particle/proj = projectile
-		stored_energy += (proj.stored_energy*2.5) //yippiee!!!
+		var/final_output = (proj.stored_energy += power_coeff)
+		stored_energy += (final_output*2.5) //yippiee!!!
 		return
 
 /obj/machinery/power/rad_collector/process(seconds_per_tick)
@@ -233,7 +234,7 @@
 
 /obj/machinery/power/rad_collector/rad_act(intensity)
 	if(loaded_tank && active && intensity > RAD_COLLECTOR_EFFICIENCY)
-		stored_energy += (intensity-RAD_COLLECTOR_EFFICIENCY)*RAD_COLLECTOR_COEFFICIENT
+		stored_energy += ((intensity+power_coeff))-RAD_COLLECTOR_EFFICIENCY)*RAD_COLLECTOR_COEFFICIENT
 
 #undef RAD_COLLECTOR_EFFICIENCY
 #undef RAD_COLLECTOR_COEFFICIENT

--- a/monkestation/code/modules/power/singularity/rad_collector.dm
+++ b/monkestation/code/modules/power/singularity/rad_collector.dm
@@ -48,11 +48,12 @@
 	//Multiplier for tanks and gases insidee
 	var/power_coeff = 1
 
-/obj/machinery/power/rad_collector/anchored
+/obj/machinery/power/rad_collector/anchored/Initialize(mapload) 
+	. = ..()
+	set_anchored(TRUE)
 
 /obj/machinery/power/rad_collector/Initialize(mapload) //all start anchored now. No more accidental mismaps.
 	. = ..()
-	set_anchored(TRUE)
 	RegisterSignal(src, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(eat_some_bullets)) //Specifically handles the next part...
 
 /obj/machinery/power/rad_collector/Destroy()

--- a/monkestation/code/modules/power/singularity/rad_collector.dm
+++ b/monkestation/code/modules/power/singularity/rad_collector.dm
@@ -52,7 +52,7 @@
 	. = ..()
 	set_anchored(TRUE)
 
-/obj/machinery/power/rad_collector/Initialize(mapload) //all start anchored now. No more accidental mismaps.
+/obj/machinery/power/rad_collector/Initialize(mapload)
 	. = ..()
 	RegisterSignal(src, COMSIG_ATOM_PRE_BULLET_ACT, PROC_REF(eat_some_bullets)) //Specifically handles the next part...
 

--- a/monkestation/code/modules/power/singularity/rad_collector.dm
+++ b/monkestation/code/modules/power/singularity/rad_collector.dm
@@ -70,15 +70,16 @@
 
 /obj/machinery/power/rad_collector/process(seconds_per_tick)
 	if(loaded_tank)
-		var/datum/gas_mixture/tank_mix = loaded_tank.return_air()
-		for(var/id in tank_mix.gases)
-			if(tank_mix.gases[id][MOLES] >= 10) //Stops cheesing.
-				power_coeff += (GLOB.meta_gas_info[id][META_GAS_SPECIFIC_HEAT]) //250 (plasma), 2000 (hypernobi), etc etc
-				var/gasdrained = min(power_production_drain * drain_ratio * seconds_per_tick, tank_mix.gases[id][MOLES])
-				tank_mix.gases[id][MOLES] -= gasdrained
-				tank_mix.assert_gas(/datum/gas/hydrogen) //Produce Hydrogen. Mostly because it explodes.
-				tank_mix.gases[/datum/gas/hydrogen][MOLES] += gasdrained
-				tank_mix.garbage_collect()
+		if(!active)
+			var/datum/gas_mixture/tank_mix = loaded_tank.return_air()
+			for(var/id in tank_mix.gases)
+				if(tank_mix.gases[id][MOLES] >= 10) //Stops cheesing.
+					power_coeff += (GLOB.meta_gas_info[id][META_GAS_SPECIFIC_HEAT]) //250 (plasma), 2000 (hypernobi), etc etc
+					var/gasdrained = min(power_production_drain * drain_ratio * seconds_per_tick, tank_mix.gases[id][MOLES])
+					tank_mix.gases[id][MOLES] -= gasdrained
+					tank_mix.assert_gas(/datum/gas/hydrogen) //Produce Hydrogen. Mostly because it explodes.
+					tank_mix.gases[/datum/gas/hydrogen][MOLES] += gasdrained
+					tank_mix.garbage_collect()
 		if(!tank_mix && loaded_tank)
 			investigate_log("<font color='red'>out of gas.</font>.", INVESTIGATE_ENGINE)
 			playsound(src, 'sound/machines/ding.ogg', 50, TRUE)

--- a/monkestation/code/modules/power/singularity/rad_collector.dm
+++ b/monkestation/code/modules/power/singularity/rad_collector.dm
@@ -17,7 +17,7 @@
 	. = ..()
 	if(!stored_energy) //Will generate a random value on every initialise
 		stored_energy = rand(150,30000) //SUPER lethal. Eeyikes!
-		damage = max((stored_energy/10),80) //Yeowch-tier
+		damage = max((stored_energy*0.1),80) //Yeowch-tier
 
 //replacing this dumbass machine with something more fun.
 
@@ -75,6 +75,7 @@
 		investigate_log("<font color='red'>out of gas.</font>.", INVESTIGATE_ENGINE)
 		playsound(src, 'sound/machines/ding.ogg', 50, TRUE)
 		power_coeff = 0 //Should NEVER happen.
+		return //Immediately stop processing past this point to prevent atmos/MC crashes
 
 	for(var/id in tank_mix.gases)
 		if(tank_mix.gases[id][MOLES] >= 10) //Stops cheesing.


### PR DESCRIPTION
## About The Pull Request
I have no idea how these work :D
## Why It's Good For The Game
using old and deprecated code for a main source of power generation was asking for problems.

This upgrades them to be able to 'catch' nuclear particles and generate power; along with buffing nuclear particles
Also lets atmosians break the game again (probably)
![image](https://github.com/Monkestation/Monkestation2.0/assets/65188584/e6255681-35d3-4a26-b84d-0bb0b8c5f355)
![image](https://github.com/Monkestation/Monkestation2.0/assets/65188584/38d64535-f888-4986-bd7a-734c2c230c6c)
![image](https://github.com/Monkestation/Monkestation2.0/assets/65188584/369850ee-3447-4aa6-82ad-715baaacd27c)
![image](https://github.com/Monkestation/Monkestation2.0/assets/65188584/9238f0c1-5c9c-4f3b-b13b-f125c00cdfdb)

Also technically buffs the singularity because you can toss hypernobi or another high-heat capacity gas in a tank and into the collectors to produce a ton more power (encouraging people to actually upgrade the damn thing)

## Changelog
:cl:
tweak: Adjusts rad collectors to instead collect 'particles' to fit their theme with being singulo-only
add: Adds the ability for rad collectors to collect fusion particles.
add: Fusion particle random strength generation (will be tied into fusion power/SM power whenever I update them too)
tweak: Radiation Collector -> Particle Collector
add: Particle Collectors now scale power generation based on the thermal capacity of the gas they have received. E.G Hypernobi most efficient -> Hydrogen least.
/:cl:
