### PR TITLE
Drone Station Refix

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -67577,7 +67577,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "xWJ" = (
-/obj/machinery/drone_dispenser,
+/obj/machinery/drone_dispenser/preloaded,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
 "xWQ" = (


### PR DESCRIPTION
:cl:
fix: restores prefilled drone fab on meta.
/:cl:
