### PR TITLE
Makes clown dagger slippery and funny, clown bible too.

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -407,7 +407,20 @@
 	sharpness = SHARP_EDGED
 	attack_verb_continuous = list("attacks", "slashes", "stabs", "slices", "tears", "lacerates", "rips", "dices", "cuts")
 	attack_verb_simple = list("attack", "slash", "stab", "slice", "tear", "lacerate", "rip", "dice", "cut")
-	menu_description = "A sharp dagger. Fits in pockets. Can be worn on the belt. Honk."
+	menu_description = "A sharp dagger. Fits in pockets. Slippery. Can be worn on the belt. Honk."
+
+/obj/item/nullrod/clown/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slippery, 140) //Same as maximum potency banana peel.
+	
+/obj/item/nullrod/clown/afterattack(atom/target, mob/living/user)
+	. = ..()
+	if(!isliving(target))
+		return
+	var/mob/living/living_target = target
+	living_target.emote("laugh")
+	living_target.add_mood_event("chemical_laughter", /datum/mood_event/chemical_laughter)
+	user.add_mood_event("chemical_laughter", /datum/mood_event/chemical_laughter) //Hitting people with it makes you feel good.
 
 #define CHEMICAL_TRANSFER_CHANCE 30
 

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -77,9 +77,11 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 		if("honk1")
 			user.dna.add_mutation(/datum/mutation/human/clumsy)
 			user.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/clown_hat(user), ITEM_SLOT_MASK)
+			AddComponent(/datum/component/slippery, 40) //Same as a synthesized banana peel.
 		if("honk2")
 			user.dna.add_mutation(/datum/mutation/human/clumsy)
 			user.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/clown_hat(user), ITEM_SLOT_MASK)
+			AddComponent(/datum/component/slippery, 40) //Same as a synthesized banana peel.
 		if("insuls")
 			var/obj/item/clothing/gloves/color/fyellow/insuls = new
 			insuls.name = "insuls"


### PR DESCRIPTION
Makes clown dagger slippery, makes victim laugh, gives victim and attacker positive moodlet.
## About The Pull Request
-Clown dagger is now as slippery as maximum potency banana peel.
-Clown dagger forces victim to laugh.
-Clown dagger gives both victim and attacker positive moodlet.
-Choosing honk bible makes the bible slippery.

## Why It's Good For The Game
Makes clown dagger and bible more unique.
Slips are strong, but the slip could also easily hurt the wielder if they accidentally step on it, and it's also not unlikely that a chaplain using it for slipping is going to have it stolen.
Honk!
## Changelog
:cl:
add: Clown dagger is now as slippery as maximum potency banana peel.
add: Clown dagger forces victim to laugh.
add: Clown dagger gives both victim and attacker positive moodlet.
add: Choosing clown bible makes the bible slippery.
/:cl:
