### PR TITLE
Removes knockdown from command and detective batongs

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -18,9 +18,9 @@
 	/// Used interally, you don't want to modify
 	var/cooldown_check = 0
 	/// Default wait time until can stun again.
-	var/cooldown = (4 SECONDS) //monkestation edit
+	var/cooldown = (1.5 SECONDS)
 	/// The length of the knockdown applied to a struck living, non-cyborg mob.
-	var/knockdown_time = (1.5 SECONDS)
+	var/knockdown_time = (0 SECONDS) //monkestation edit
 	/// If affect_cyborg is TRUE, this is how long we stun cyborgs for on a hit.
 	var/stun_time_cyborg = (5 SECONDS)
 	/// The length of the knockdown applied to the user on clumsy_check()

--- a/monkestation/code/modules/antagonists/contractor/items/baton.dm
+++ b/monkestation/code/modules/antagonists/contractor/items/baton.dm
@@ -22,6 +22,7 @@
 	cooldown = 2.5 SECONDS
 	force_say_chance = 80 //very high force say chance because it's funny
 	stamina_damage = 170
+	knockdown_time = 1.5 SECONDS
 	clumsy_knockdown_time = 24 SECONDS
 	affect_cyborg = TRUE
 	on_stun_sound = 'sound/effects/contractorbatonhit.ogg'


### PR DESCRIPTION
## About The Pull Request
Removes knockdown from command telebatons and det's batong
Command batong takes 2 hits to stamcrit
Detective's batong takes 3 hits to stamcrit (they're not supposed to have better security batongs)
## Why It's Good For The Game
This is what people wanted, not a 4 second cooldown with a knockdown.
## Changelog
:cl: KnigTheThrasher
balance: Removed knockdown from command and detective batongs, cooldown reduced back to 1.5 seconds as a compensation
/:cl:
