### PR TITLE
Removes pointless elite mob pop-up.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -357,7 +357,6 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		to_chat(mychild, "<b>Your max health has been halved, but can now heal by standing on your tumor. Note, it's your only way to heal.\n\
 			Bear in mind, if anyone interacts with your tumor, you'll be resummoned here to carry out another fight. In such a case, you will regain your full max health.\n\
 			Also, be weary of your fellow inhabitants, they likely won't be happy to see you!</b>")
-		to_chat(mychild, "<span class='big bold'>Note that you are a lavaland monster, and thus not allied to the station. You should not cooperate or act friendly with any station crew unless under extreme circumstances!</span>")
 
 /obj/item/tumor_shard
 	name = "tumor shard"


### PR DESCRIPTION

## About The Pull Request
This removes the pop-up in chat stating "Note that you are a lavaland monster, and thus not allied to the station. You should not cooperate or act friendly with any station crew unless under extreme circumstances!". Players are frustrated as it is vague, and doesn't serve much of a purpose for monkestation as our roleplay tends to be less restricted.
## Why It's Good For The Game
Being less vague makes it easier on both sides, admins and players alike.
## Changelog
:cl:

qol: Removed vague elite lavaland mob text.

/:cl:
