### PR TITLE
Fix the title and version being /tg/station and such

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -5,7 +5,7 @@ GLOBAL_DATUM_INIT(revdata, /datum/getrev, new)
 
 GLOBAL_VAR(host)
 GLOBAL_VAR(station_name)
-GLOBAL_VAR_INIT(game_version, "/tg/Station 13")
+GLOBAL_VAR_INIT(game_version, "MonkeStation 2.0") // monkestation edit: rebranding
 GLOBAL_VAR_INIT(changelog_hash, "")
 GLOBAL_VAR_INIT(hub_visibility, FALSE)
 

--- a/code/world.dm
+++ b/code/world.dm
@@ -15,7 +15,7 @@
 	view = "15x15"
 	hub = "Exadv1.spacestation13"
 	hub_password = "kMZy3U5jJHSiBQjr"
-	name = "/tg/ Station 13"
+	name = "MonkeStation 2.0" // monkestation edit: rebranding
 	fps = 20
 #ifdef FIND_REF_NO_CHECK_TICK
 	loop_checks = FALSE


### PR DESCRIPTION
## Changelog
:cl:
fix: The game window should no longer be titled "/tg/station 13" during early initialization.
/:cl:
