### PR TITLE
Fix team-related runtimes (which broke roundend reports)

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -668,7 +668,7 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 
 	for(var/datum/team/team as anything in GLOB.antagonist_teams)
 		if(!istype(team))
-			stack_trace("Non-mind ([team?.type]) found in GLOB.antagonist_teams!")
+			stack_trace("Non-team ([team?.type]) found in GLOB.antagonist_teams!")
 			continue
 		all_teams |= team
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -678,9 +678,11 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 		//check if we should show the team
 		if(!active_teams.show_roundend_report)
 			continue
-
 		//remove the team's individual antag reports, if the team actually shows up in the report.
 		for(var/datum/mind/team_minds as anything in active_teams.members)
+			if(!istype(team_minds))
+				stack_trace("Non-mind ([team_minds?.type]) found in team.members!")
+				continue
 			if(!isnull(team_minds.antag_datums)) // is_special_character passes if they have a special role instead of an antag
 				all_antagonists -= team_minds.antag_datums
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -667,9 +667,15 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 	var/list/all_antagonists = list()
 
 	for(var/datum/team/team as anything in GLOB.antagonist_teams)
+		if(!istype(team))
+			stack_trace("Non-mind ([team?.type]) found in GLOB.antagonist_teams!")
+			continue
 		all_teams |= team
 
 	for(var/datum/antagonist/antagonists as anything in GLOB.antagonists)
+		if(!istype(antagonists))
+			stack_trace("Non-mind ([antagonists?.type]) found in GLOB.antagonists!")
+			continue
 		if(!antagonists.owner)
 			continue
 		all_antagonists |= antagonists
@@ -710,8 +716,8 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 		result += "<br><br>"
 		CHECK_TICK
 
-	if(all_antagonists.len)
-		var/datum/antagonist/last = all_antagonists[all_antagonists.len]
+	if(length(all_antagonists))
+		var/datum/antagonist/last = all_antagonists[length(all_antagonists)]
 		result += last.roundend_report_footer()
 		result += "</div>"
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -674,7 +674,7 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 
 	for(var/datum/antagonist/antagonists as anything in GLOB.antagonists)
 		if(!istype(antagonists))
-			stack_trace("Non-mind ([antagonists?.type]) found in GLOB.antagonists!")
+			stack_trace("Non-antagonist ([antagonists?.type]) found in GLOB.antagonists!")
 			continue
 		if(!antagonists.owner)
 			continue

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -33,6 +33,8 @@ GLOBAL_LIST_EMPTY(antagonist_teams)
 	return ..()
 
 /datum/team/proc/add_member(datum/mind/new_member)
+	if(!istype(new_member))
+		CRASH("Attempted to add non-mind ([new_member?.type]) as a team member!")
 	members |= new_member
 
 /datum/team/proc/remove_member(datum/mind/member)

--- a/code/modules/events/wizard/imposter.dm
+++ b/code/modules/events/wizard/imposter.dm
@@ -33,7 +33,7 @@
 		var/datum/antagonist/wizard/apprentice/imposter/imposter = new()
 		imposter.master = M
 		imposter.wiz_team = master.wiz_team
-		master.wiz_team.add_member(imposter)
+		master.wiz_team.add_member(I.mind)
 		I.mind.add_antag_datum(imposter)
 		I.mind.special_role = "imposter"
 		I.log_message("is an imposter!", LOG_ATTACK, color="red") //?


### PR DESCRIPTION

## About The Pull Request

figured this out during my wizard round

![image](https://github.com/Monkestation/Monkestation2.0/assets/65794972/71b666c6-1195-404b-b6d0-ea84ceaf4070)


## Changelog
:cl:
fix: Fixed imposter wizards breaking the roundend report.
code: Added sanity checks to some team-related code, which will runtime if they get invalid input, instead of breaking things further down the line.
/:cl:
