### PR TITLE
Science finally gets good imprinters

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -44248,7 +44248,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "oZb" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -29525,7 +29525,6 @@
 /turf/closed/wall,
 /area/station/commons/vacant_room/commissary)
 "hgL" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -29543,6 +29542,7 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "hgS" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -13416,13 +13416,13 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "elf" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/machinery/button/door/directional/north{
 	id = "rnd";
 	name = "Shutters Control Button";
 	pixel_x = 7;
 	req_access = list("research")
 	},
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron/checker,
 /area/station/science/lab)
 "elj" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -8918,7 +8918,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "dfv" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -8931,6 +8930,7 @@
 	receive_ore_updates = 1;
 	can_send_announcements = 1
 	},
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "dfD" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3918,7 +3918,7 @@
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "bpA" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "bpD" = (

--- a/_maps/map_files/NorthStar/north_star.dmm
+++ b/_maps/map_files/NorthStar/north_star.dmm
@@ -90322,7 +90322,6 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/service)
 "yjG" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/cold/no_nightlight/directional/south,
 /obj/machinery/camera/autoname/directional/east,
@@ -90330,6 +90329,7 @@
 	id = "scilockup";
 	name = "Science Lockdown"
 	},
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "yjJ" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -62591,7 +62591,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "tdm" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/firealarm/directional/south{
@@ -62601,6 +62600,7 @@
 	pixel_x = -9;
 	pixel_y = -24
 	},
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/iron,
 /area/station/science/lab)
 "tdw" = (


### PR DESCRIPTION

## About The Pull Request
Sci gets regular imprinters instead of the sci kind
## Why It's Good For The Game
They need a lot of these machines for things like cloning but this also just allows sci to be more freeform in the content they choose to explore. This is also just something that can be done roundstart anyhow.
## Changelog
:cl:
balance: Sci gets regular circuit imprinters and can print everything from them
/:cl:
