### PR TITLE
Turn nanite protocols into regular research nodes

### DIFF
--- a/monkestation/code/modules/research/techweb/all_nodes.dm
+++ b/monkestation/code/modules/research/techweb/all_nodes.dm
@@ -169,9 +169,7 @@
 		"offline_nanites",
 		"pyramid_nanites",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000, TECHWEB_POINT_TYPE_NANITES = 2500)
-	hidden = TRUE
-	experimental = TRUE
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000, TECHWEB_POINT_TYPE_NANITES = 5000)
 
 /datum/techweb_node/nanite_storage_protocols
 	id = "nanite_storage_protocols"
@@ -184,9 +182,7 @@
 		"unsafe_storage_nanites",
 		"zip_nanites",
 	)
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000, TECHWEB_POINT_TYPE_NANITES = 2500)
-	hidden = TRUE
-	experimental = TRUE
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000, TECHWEB_POINT_TYPE_NANITES = 5000)
 
 /datum/techweb_node/adv_ballistics
 	id = "adv_ballistics"


### PR DESCRIPTION

## About The Pull Request

Turns the obscure and gimped feature known as nanite protocols into a generally available research node.

The point costs for the nodes are the highest among all nanite nodes since some of them are a straight buff, but most of them do have a singificant downside.
## Why It's Good For The Game

They're cool as fuck and I have literally never seen them due to them being stuck in the bepis tech list. Bepis doesn't exist anymore and bitrunners sure as hell aren't doing it, plus they're going to prison now.

Balance wise, most of them are fine and only provide small benefits. We seriously need to touch upon nanite balance in general at some point, though. But alas, that is for later, plus we need a good starting point for when we do it.
## Changelog
:cl:
balance: Nanite protocols are back from the experimental tech junkyard.
/:cl:
