### PR TITLE
Add research program for nanites

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -106,6 +106,9 @@ SUBSYSTEM_DEF(research)
 				bitcoins = single_server_income.Copy()
 				break //Just need one to work.
 
+		if (techweb_list.nanite_bonus)
+			bitcoins[TECHWEB_POINT_TYPE_GENERIC] += techweb_list.nanite_bonus
+
 		if(!isnull(techweb_list.last_income))
 			var/income_time_difference = world.time - techweb_list.last_income
 			techweb_list.last_bitcoins = bitcoins  // Doesn't take tick drift into account

--- a/code/modules/research/techweb/_techweb.dm
+++ b/code/modules/research/techweb/_techweb.dm
@@ -56,6 +56,8 @@
 	var/should_generate_points = FALSE
 	///A multiplier applied to all research gain, cut in half if the Master server was sabotaged.
 	var/income_modifier = 1
+	///An additive bonus applied to all research gain, given by the Research Network Integration nanite program
+	var/nanite_bonus = 0
 	///The amount of research points generated the techweb generated the latest time it generated.
 	var/last_income
 

--- a/monkestation/code/modules/research/designs/nanite_designs.dm
+++ b/monkestation/code/modules/research/designs/nanite_designs.dm
@@ -33,6 +33,13 @@
 	program_type = /datum/nanite_program/monitoring
 	category = list("Utility Nanites")
 
+/datum/design/nanites/research
+	name = "Research Network Integration"
+	desc = "The nanites form a data processing unit that actively contributes processing power to the main research network. Higher usage rates may cause unwanted thermal effects."
+	id = "research_nanites"
+	program_type = /datum/nanite_program/research
+	category = list("Utility Nanites")
+
 /datum/design/nanites/self_scan
 	name = "Host Scan"
 	desc = "The nanites display a detailed readout of a body scan to the host."

--- a/monkestation/code/modules/research/designs/nanite_designs.dm
+++ b/monkestation/code/modules/research/designs/nanite_designs.dm
@@ -35,7 +35,7 @@
 
 /datum/design/nanites/research
 	name = "Research Network Integration"
-	desc = "The nanites form a data processing unit that actively contributes processing power to the main research network. Higher usage rates may cause unwanted thermal effects."
+	desc = "The nanites contribute processing power to the research network, generating useful data and heat while consuming nanites. Requires a live host."
 	id = "research_nanites"
 	program_type = /datum/nanite_program/research
 	category = list("Utility Nanites")

--- a/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
@@ -50,7 +50,7 @@
 
 /datum/nanite_program/research
 	name = "Research Network Integration"
-	desc = "The nanites form a data processing unit that actively contributes processing power to the main research network. Higher usage rates may cause unwanted thermal effects and increase nanite consumption."
+	desc = "The nanites contribute processing power to the research network, generating useful data and heat. Higher usage rates will consume more nanites. Requires a live host."
 	rogue_types = list(/datum/nanite_program/spreading, /datum/nanite_program/mitosis) // it researches itself into oblivion
 	use_rate = 0.5
 
@@ -58,6 +58,9 @@
 
 /datum/nanite_program/research/register_extra_settings()
 	extra_settings[NES_MODE] = new /datum/nanite_extra_setting/type("Slow", list("Slow (1x)", "Fast (2x)", "Bitcoin Miner (10x)"))
+
+/datum/nanite_program/research/check_conditions()
+	return host_mob.stat != DEAD && ..()
 
 /datum/nanite_program/research/enable_passive_effect()
 	. = ..()

--- a/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
@@ -117,7 +117,7 @@
 
 /datum/nanite_program/research/disable_passive_effect()
 	. = ..()
-	SSresearch.science_tech.nanite_bonus -= research_speed
+	SSresearch.science_tech.nanite_bonus -= use_rate
 	host_mob.remove_body_temperature_change(NANITE_RESEARCH_CHANGE)
 
 /datum/nanite_program/research/set_extra_setting(setting, value)

--- a/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
@@ -121,6 +121,22 @@
 	SSresearch.science_tech.nanite_bonus -= research_speed
 	host_mob.remove_body_temperature_change(NANITE_RESEARCH_CHANGE)
 
+/datum/nanite_program/research/set_extra_setting(setting, value)
+	. = ..()
+
+	if (setting != NES_MODE)
+		return
+
+	var/datum/nanite_extra_setting/mode = extra_settings[NES_MODE]
+	switch (mode.get_value())
+		if (NANITE_RESEARCH_SLOW)
+			research_speed = 1
+		if (NANITE_RESEARCH_FAST)
+			research_speed = 2
+		if (NANITE_RESEARCH_SUPERFAST)
+			research_speed = 10 // oh god
+	use_rate = initial(use_rate) * research_speed
+
 #undef NANITE_RESEARCH_CHANGE
 #undef NANITE_RESEARCH_SLOW
 #undef NANITE_RESEARCH_FAST

--- a/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
@@ -113,7 +113,7 @@
 
 	if (COOLDOWN_FINISHED(src, next_warning_time))
 		to_chat(host_mob, message)
-		next_warning_time = world.time + 10 SECONDS
+		COOLDOWN_START(src, next_warning_time, 10 SECONDS)
 
 /datum/nanite_program/research/disable_passive_effect()
 	. = ..()

--- a/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
@@ -59,7 +59,7 @@
 
 	var/research_speed
 	var/current_mode
-	var/next_warning_time = 0
+	COOLDOWN_DECLARE(next_warning_time)
 
 /datum/nanite_program/research/register_extra_settings()
 	extra_settings[NES_MODE] = new /datum/nanite_extra_setting/type(NANITE_RESEARCH_SLOW, list(NANITE_RESEARCH_SLOW, NANITE_RESEARCH_FAST, NANITE_RESEARCH_SUPERFAST))

--- a/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
@@ -111,7 +111,7 @@
 	use_rate = initial(use_rate) * research_speed
 	SSresearch.science_tech.nanite_bonus += use_rate
 
-	if (world.time > next_warning_time)
+	if (COOLDOWN_FINISHED(src, next_warning_time))
 		to_chat(host_mob, message)
 		next_warning_time = world.time + 10 SECONDS
 

--- a/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
@@ -58,6 +58,7 @@
 	use_rate = 0.5
 
 	var/research_speed
+	var/current_research_bonus
 	var/current_mode
 	COOLDOWN_DECLARE(next_warning_time)
 
@@ -109,7 +110,8 @@
 
 	host_mob.add_body_temperature_change(NANITE_RESEARCH_CHANGE, research_speed * 15)
 	use_rate = initial(use_rate) * research_speed
-	SSresearch.science_tech.nanite_bonus += use_rate
+	current_research_bonus = use_rate
+	SSresearch.science_tech.nanite_bonus += current_research_bonus
 
 	if (COOLDOWN_FINISHED(src, next_warning_time))
 		to_chat(host_mob, message)
@@ -117,7 +119,7 @@
 
 /datum/nanite_program/research/disable_passive_effect()
 	. = ..()
-	SSresearch.science_tech.nanite_bonus -= use_rate
+	SSresearch.science_tech.nanite_bonus -= current_research_bonus
 	host_mob.remove_body_temperature_change(NANITE_RESEARCH_CHANGE)
 
 /datum/nanite_program/research/set_extra_setting(setting, value)

--- a/monkestation/code/modules/research/techweb/all_nodes.dm
+++ b/monkestation/code/modules/research/techweb/all_nodes.dm
@@ -46,6 +46,7 @@
 		"sensor_voice_nanites",
 		"stealth_nanites",
 		"voice_nanites",
+		"research_nanites",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 500, TECHWEB_POINT_TYPE_NANITES = 500)
 


### PR DESCRIPTION
## About The Pull Request

Adds the "Research Network Integration" program to nanites.

It converts nanites into research points and heat with 3 available modes.
1. Slow (1x)
2. Fast (2x)
3. Bitcoin Miner (10x)

Ook's idea btw but I like it too so here it is.
And yes the fastest mode does cook you to death.

Also, it heats up the nearby environment too. (not a lot though)
## Why It's Good For The Game

It's one of the very, very few ways to gain extra research points.
The only other way as of right now is discount experiments and their refunds.
Also it's cool. Plus bitcoin mining everyone to death is funny.
## Changelog
:cl:
add: Nanites are now capable of contributing to the research network.
/:cl:
