### PR TITLE
Antag double rolling fix

### DIFF
--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -271,9 +271,14 @@ SUBSYSTEM_DEF(gamemode)
 		if(!observers)
 			if(!ready_players && !isliving(candidate))
 				continue
-			if(no_antags && candidate.mind.special_role)
-				log_storyteller("Candidate([candidate]) removed from rolling poll due to special_role([candidate.mind.special_role])")
-				continue
+			if(no_antags && !isnull(candidate.mind.antag_datums))
+				var/real = FALSE
+				for(var/datum/antagonist/antag_datum as anything in candidate.mind.antag_datums)
+					if(!(antag_datum.antag_flags & FLAG_FAKE_ANTAG))
+						real = TRUE
+						break
+				if(real)
+					continue
 			if(restricted_roles && (candidate.mind.assigned_role.title in restricted_roles))
 				continue
 			if(length(required_roles) && !(candidate.mind.assigned_role.title in required_roles))


### PR DESCRIPTION
## About The Pull Request

This would not fix a deeper issue of special_role not getting added, but this is overall better in general anyway

## Why It's Good For The Game

ITS BEEN MONTHS

## Changelog
:cl:
fix: You can no longer roll 2 antags at once
/:cl:
