### PR TITLE
Admin Abuse is mandatory

### DIFF
--- a/code/__HELPERS/announcements.dm
+++ b/code/__HELPERS/announcements.dm
@@ -29,7 +29,7 @@
 	sound_override = 'sound/ai/default/attention.ogg',
 	sender_override = "Server Admin Announcement",
 	encode_title = TRUE,
-	encode_text = TRUE,
+	encode_text = FALSE, //Monkeystation Edit: Admin abuse is mandatory
 	color_override = "grey",
 )
 	if(isnull(text))

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -155,7 +155,7 @@
 	var/datum/round_event/ion_storm/add_law_only/ion = new()
 	ion.announce_chance = announce_ion_laws
 	ion.ionMessage = input
-
+	ion.start() // Monkeystation Edit: Fixes AI law additions.
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Add Custom AI Law") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/admin_call_shuttle()


### PR DESCRIPTION

![image](https://github.com/Monkestation/Monkestation2.0/assets/65188584/16d3b669-be10-4278-8a44-bdfbabac9cae)
![image](https://github.com/Monkestation/Monkestation2.0/assets/65188584/e2945db2-d0ba-4884-b796-d60d6e3aa9e6)

:cl:
fix: Admins can now abuse announcements again. (requires perms needed to restart server/start round early to use HTML)
fix: Add Admin AI law now actually works (thanks /tg/), admins can now also insert unsanitised HTML as they wish.
/:cl:
