### PR TITLE
Small fixes

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -7633,7 +7633,7 @@
 /obj/item/radio/headset/headset_med,
 /obj/machinery/newscaster/directional/south,
 /obj/item/clothing/glasses/science,
-/obj/item/extrapolator,
+/obj/item/restraints/handcuffs,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "cDF" = (
@@ -59061,7 +59061,7 @@
 	receive_ore_updates = 1
 	},
 /obj/item/clothing/glasses/science,
-/obj/item/extrapolator,
+/obj/item/restraints/handcuffs,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "uiu" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -50970,6 +50970,7 @@
 /obj/item/hfr_box/body/interface,
 /obj/item/hfr_box/body/moderator_input,
 /obj/item/hfr_box/body/waste_output,
+/obj/item/circuitboard/machine/crystallizer,
 /turf/open/floor/iron,
 /area/station/engineering/atmospherics_engine)
 "pxo" = (

--- a/code/game/objects/effects/spawners/random/techstorage.dm
+++ b/code/game/objects/effects/spawners/random/techstorage.dm
@@ -102,7 +102,12 @@
 		/obj/item/circuitboard/computer/med_data,
 		/obj/item/circuitboard/machine/smoke_machine,
 		/obj/item/circuitboard/machine/chem_master,
-		/obj/item/circuitboard/computer/pandemic,
+		/obj/item/circuitboard/machine/diseaseanalyser, // MONKESTATION EDIT START: FUCK THE PANDEMIC. -dexee, 4/26/24
+		/obj/item/circuitboard/computer/diseasesplicer,
+		/obj/item/circuitboard/machine/centrifuge,
+		/obj/item/circuitboard/computer/pathology_data,
+		/obj/item/circuitboard/machine/incubator,
+	//	/obj/item/circuitboard/computer/pandemic, // MONKESTATION EDIT END: fuck the pandemic. we have better disease machines
 	)
 
 /obj/effect/spawner/random/techstorage/ai_all


### PR DESCRIPTION
## About The Pull Request

Last batch of fixes from me for a bit.

## Why It's Good For The Game

## Changelog

:cl:
fix: changed the medboard spawner in tech storage to support pathology machines. rest in piss pandemic machine.
add: tram gets a crystallizer board (still a DIY project however)
fix: box station pathology now has handcuffs in exchange for the useless extrapolators.
/:cl:
