### PR TITLE
Fix full-charge APC helpers

### DIFF
--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -712,7 +712,7 @@
 
 /// Used for full_charge apc helper, which sets apc charge to 100%.
 /obj/machinery/power/apc/proc/set_full_charge()
-	cell.charge = 100
+	cell.charge = cell.maxcharge
 
 /*Power module, used for APC construction*/
 /obj/item/electronics/apc


### PR DESCRIPTION

## About The Pull Request

that's... that's not a percentage.

## Changelog
:cl:
fix: Fixed full charge APC helpers resulting in APCs practically having no roundstart power instead.
/:cl:
