### PR TITLE
Makes experimental surgeries available for robotic limbs.

### DIFF
--- a/code/modules/surgery/advanced/bioware/bioware_surgery.dm
+++ b/code/modules/surgery/advanced/bioware/bioware_surgery.dm
@@ -1,5 +1,6 @@
 /datum/surgery/advanced/bioware
 	name = "Enhancement surgery"
+	requires_bodypart_type = NONE
 	var/bioware_target = BIOWARE_GENERIC
 
 /datum/surgery/advanced/bioware/can_start(mob/user, mob/living/carbon/human/target)


### PR DESCRIPTION

## About The Pull Request
Experimental surgeries, such as cortex folding, or nerve grounding, can now be performed on robotic limbs.

## Why It's Good For The Game
Augmenting limbs and changing species don't remove experimental surgeries, so this gives QOL to augmented humans and androids, who before this could get experimental surgeries, but only if they remembered to get them before augments/species change. Now, they don't have to wait to get the surgeries first for some arbitrary reason.
(Do note this does buff IPCs a bit.)

## Changelog
:cl:
add: Experimental surgeries can now be performed on robotic limbs.
/:cl:
