### PR TITLE
Allows anybody with a synthetic voice box to use silicon emotes

### DIFF
--- a/code/modules/mob/living/silicon/robot/emote.dm
+++ b/code/modules/mob/living/silicon/robot/emote.dm
@@ -1,5 +1,7 @@
 /datum/emote/silicon
-	mob_type_allowed_typecache = list(/mob/living/silicon, /mob/living/simple_animal/bot)
+	// MONKESTATION REMOVAL - Replaced with `/datum/emote/silicon/can_run_emote()`, which is used to
+	// enable silicon emotes for users with synthetic voice boxes.
+	//mob_type_allowed_typecache = list(/mob/living/silicon, /mob/living/simple_animal/bot)
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/silicon/boop

--- a/monkestation/code/modules/mob/living/emote.dm
+++ b/monkestation/code/modules/mob/living/emote.dm
@@ -227,3 +227,18 @@
 		return TRUE
 	else
 		return FALSE
+
+// The below function replaces the `/datum/emote/silicon/mob_type_allowed_typecache` variable. If
+// you remove this function, be sure to replace the above variable.
+/datum/emote/silicon/can_run_emote(mob/user, status_check, intentional)
+	// Silicons can always use silicon emotes, assuming nothing else is wrong
+	if(istype(user, /mob/living/silicon) || istype(user, /mob/living/simple_animal/bot))
+		return ..()
+
+	// Allow users with synthetic voice boxes to use silicon emotes as well, because a synthetic
+	// voice box is more akin to a speaker than a human larynx.
+	var/tongue = user.get_organ_slot(ORGAN_SLOT_TONGUE)
+	if(istype(tongue, /obj/item/organ/internal/tongue/synth))
+		return ..()
+
+	return FALSE

--- a/monkestation/code/modules/mob/living/emote.dm
+++ b/monkestation/code/modules/mob/living/emote.dm
@@ -231,8 +231,8 @@
 // The below function replaces the `/datum/emote/silicon/mob_type_allowed_typecache` variable. If
 // you remove this function, be sure to replace the above variable.
 /datum/emote/silicon/can_run_emote(mob/user, status_check, intentional)
-	// Silicons can always use silicon emotes, assuming nothing else is wrong
-	if(istype(user, /mob/living/silicon) || istype(user, /mob/living/simple_animal/bot))
+	// Silicons and simple bots can always use silicon emotes, assuming nothing else is wrong
+	if(issilicon(user) || isbot(user))
 		return ..()
 
 	// Allow users with synthetic voice boxes to use silicon emotes as well, because a synthetic


### PR DESCRIPTION
## About The Pull Request
Allows anybody with a synthetic voice box to use silicon-type emotes. The specific list of emotes, as of the time of sending this PR is:
* `*boop`
* `*buzz`
* `*buzz2`
* `*chime`
* `*honk`
* `*ping`
* `*sad`
* `*warn`
* `*slowclap`

This change is justified by how the synthetic voice box is more akin to a speaker than a human larynx. Thus, anyone with a synthetic voice box should reasonably be able to use these emotes.

## Why It's Good For The Game
Allows people to lean more into having a synthetic voice box, and everything that comes with it.

## Changelog

:cl: MichiRecRoom
add: Mobs with synthetic voice boxes (such as IPCs) are now capable of using silicon-type emotes. As of the time of this change, this means they can now use: boop, buzz, buzz2, chime, honk, ping, sad, warn, slowclap.
/:cl: