### PR TITLE
Makes chainsaw arm mechanical.

### DIFF
--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -126,7 +126,7 @@
 		display_pain(target, "You feel a strange sensation from your new [parse_zone(target_zone)].", TRUE)
 		if(istype(tool, /obj/item/chainsaw))
 			qdel(tool)
-			bodypart_to_attach.bodypart_flags |= BODYPART_ROBOTIC
+			bodypart_to_attach.bodypart_flags |= BODYTYPE_ROBOTIC
 			var/obj/item/chainsaw/mounted_chainsaw/new_arm = new(target)
 			target_zone == BODY_ZONE_R_ARM ? target.put_in_r_hand(new_arm) : target.put_in_l_hand(new_arm)
 			return

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -126,6 +126,7 @@
 		display_pain(target, "You feel a strange sensation from your new [parse_zone(target_zone)].", TRUE)
 		if(istype(tool, /obj/item/chainsaw))
 			qdel(tool)
+			bodypart_to_attach.bodypart_flags |= BODYPART_ROBOTIC
 			var/obj/item/chainsaw/mounted_chainsaw/new_arm = new(target)
 			target_zone == BODY_ZONE_R_ARM ? target.put_in_r_hand(new_arm) : target.put_in_l_hand(new_arm)
 			return

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -126,7 +126,8 @@
 		display_pain(target, "You feel a strange sensation from your new [parse_zone(target_zone)].", TRUE)
 		if(istype(tool, /obj/item/chainsaw))
 			qdel(tool)
-			bodypart_to_attach.bodypart_flags |= BODYTYPE_ROBOTIC
+			bodypart_to_attach.bodytype |= BODYTYPE_ROBOTIC
+			bodypart_to_attach.bodytype &= ~BODYTYPE_ORGANIC
 			var/obj/item/chainsaw/mounted_chainsaw/new_arm = new(target)
 			target_zone == BODY_ZONE_R_ARM ? target.put_in_r_hand(new_arm) : target.put_in_l_hand(new_arm)
 			return


### PR DESCRIPTION

## About The Pull Request
Makes the chainsaw arm robotic, which makes it repaired by welding instead of suturing.

## Why It's Good For The Game
A chainsaw is a machine that should be repaired like a machine, instead of being healed with chems and sutures.

## Changelog
:cl:
fix: Mounted Chainsaw arm is now treated like it's robotic.
/:cl:
