### PR TITLE
[port] Adds right click functionality for stamps

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -422,8 +422,8 @@
 	return ..()
 
 /// Secondary right click interaction to quickly stamp things
-/obj/item/paper/item_interaction_secondary(mob/living/user, obj/item/tool, list/modifiers)
-	var/list/writing_stats = tool.get_writing_implement_details()
+/obj/item/paper/attackby_secondary(obj/item/attacking_item, mob/living/user, params)
+	var/list/writing_stats = attacking_item.get_writing_implement_details()
 
 	if(!length(writing_stats))
 		return NONE
@@ -434,12 +434,12 @@
 
 	add_stamp(writing_stats["stamp_class"], rand(1, 300), rand(1, 400), stamp_icon_state = writing_stats["stamp_icon_state"])
 	user.visible_message(
-		span_notice("[user] quickly stamps [src] with [tool] without looking."),
-		span_notice("You quickly stamp [src] with [tool] without looking."),
+		span_notice("[user] quickly stamps [src] with [attacking_item] without looking."),
+		span_notice("You quickly stamp [src] with [attacking_item] without looking."),
 	)
 	playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
 
-	return ITEM_INTERACT_BLOCKING // Stop the UI from opening.
+	return TOOL_ACT_SIGNAL_BLOCKING // Stop the UI from opening.
 /**
  * Attempts to ui_interact the paper to the given user, with some sanity checking
  * to make sure the camera still exists via the weakref and that this paper is still

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -408,8 +408,8 @@
 	// Handle stamping items.
 	if(writing_stats["interaction_mode"] == MODE_STAMPING)
 		if(!user.can_read(src) || user.is_blind())
-			//The paper's stampable window area is assumed approx 400x500
-			add_stamp(writing_stats["stamp_class"], rand(0, 400), rand(0, 500), rand(0, 360), writing_stats["stamp_icon_state"])
+			//The paper's stampable window area is assumed approx 300x400
+			add_stamp(writing_stats["stamp_class"], rand(0, 300), rand(0, 400), rand(0, 360), writing_stats["stamp_icon_state"])
 			user.visible_message(span_notice("[user] blindly stamps [src] with \the [attacking_item]!"))
 			to_chat(user, span_notice("You stamp [src] with \the [attacking_item] the best you can!"))
 			playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
@@ -421,6 +421,25 @@
 	ui_interact(user)
 	return ..()
 
+/// Secondary right click interaction to quickly stamp things
+/obj/item/paper/item_interaction_secondary(mob/living/user, obj/item/tool, list/modifiers)
+	var/list/writing_stats = tool.get_writing_implement_details()
+
+	if(!length(writing_stats))
+		return NONE
+	if(writing_stats["interaction_mode"] != MODE_STAMPING)
+		return NONE
+	if(!user.can_read(src) || user.is_blind()) // Just leftclick instead
+		return NONE
+
+	add_stamp(writing_stats["stamp_class"], rand(1, 300), rand(1, 400), stamp_icon_state = writing_stats["stamp_icon_state"])
+	user.visible_message(
+		span_notice("[user] quickly stamps [src] with [tool] without looking."),
+		span_notice("You quickly stamp [src] with [tool] without looking."),
+	)
+	playsound(src, 'sound/items/handling/standard_stamp.ogg', 50, vary = TRUE)
+
+	return ITEM_INTERACT_BLOCKING // Stop the UI from opening.
 /**
  * Attempts to ui_interact the paper to the given user, with some sanity checking
  * to make sure the camera still exists via the weakref and that this paper is still


### PR DESCRIPTION
## About The Pull Request
Adds right click functionality to the rubber stamp from https://github.com/tgstation/tgstation/pull/82993, mostly useful for cargo so you don't need to open the writing menu on paper over and over and over again
## Why It's Good For The Game
we can officially stampmax cargo
## Proof of Working
![image](https://github.com/Monkestation/Monkestation2.0/assets/39929315/55de7052-ccde-40aa-bd41-e853b6faefa1)

I can't prove I right clicked, but the text is there for it, source:Dude trust me
## Changelog
:cl:
add: Stamp Right click functionality
/:cl:
