### PR TITLE
Grant the user a replacement lootbox, if saving a lootbox item fails

### DIFF
--- a/monkestation/code/modules/trading/lootbox_buying.dm
+++ b/monkestation/code/modules/trading/lootbox_buying.dm
@@ -34,6 +34,7 @@
 	if(!prefs.adjust_metacoins(ckey, -5000, donator_multipler = FALSE))
 		return
 	prefs.lootboxes_owned++
+	prefs.save_preferences()
 
 /client/proc/open_lootbox()
 	message_admins("[ckey] opened a lootbox!")
@@ -49,6 +50,7 @@
 	if(!prefs.lootboxes_owned)
 		return
 	prefs.lootboxes_owned--
+	prefs.save_preferences()
 	mob.trigger_lootbox_on_self()
 
 /proc/give_lootboxes_to_randoms(amount)
@@ -63,3 +65,4 @@
 		return
 	prefs.lootboxes_owned += amount
 	to_chat(mob, span_notice("You have been given [amount] lootboxes! Open it using the escape menu."))
+	prefs.save_preferences()

--- a/monkestation/code/modules/trading/lootbox_odds.dm
+++ b/monkestation/code/modules/trading/lootbox_odds.dm
@@ -62,33 +62,35 @@
 
 /datum/loadout_item/proc/add_to_user(client/buyer)
 	SHOULD_CALL_PARENT(TRUE)
-	var/fail_message ="<span class='warning'>Failed to add lootbox item to database. Will reattempt until added!</span>"
+	var/replacement_lootbox_message = span_warning("The item you received will not be saved, but you have been granted a replacement lootbox to use at a later point.")
 	if(!SSdbcore.IsConnected())
-		to_chat(buyer, fail_message)
+		to_chat(buyer, span_warning("Database is not connected."))
+		to_chat(buyer, replacement_lootbox_message)
+		buyer.prefs.lootboxes_owned++
 		return FALSE
 	if(!buyer?.prefs)
 		return FALSE
+	buyer.prefs.inventory += item_path
+	var/datum/db_query/query_add_gear_purchase
 	if(!buyer.prefs.inventory[item_path])
-		buyer.prefs.inventory += item_path
-		var/datum/db_query/query_add_gear_purchase = SSdbcore.NewQuery({"
+		query_add_gear_purchase = SSdbcore.NewQuery({"
 			INSERT INTO [format_table_name("metacoin_item_purchases")] (`ckey`, `item_id`, `amount`) VALUES (:ckey, :item_id, :amount)"},
 			list("ckey" = buyer.ckey, "item_id" = item_path, "amount" = 1))
-		if(!query_add_gear_purchase.Execute())
-			to_chat(buyer, fail_message)
-			qdel(query_add_gear_purchase)
-			addtimer(CALLBACK(src, PROC_REF(add_to_user), buyer), 15 SECONDS)
-			return FALSE
-		qdel(query_add_gear_purchase)
 	else
-		buyer.prefs.inventory += item_path
-		var/datum/db_query/query_add_gear_purchase = SSdbcore.NewQuery({"
+		// Note from someone who didn't make this lootbox system: This seems to be related to
+		// duplicate lootbox items, but duplicate items don't appear to run this proc, making this
+		// seemingly useless. Even then, why are we setting the amount to 1?
+		query_add_gear_purchase = SSdbcore.NewQuery({"
 			UPDATE [format_table_name("metacoin_item_purchases")] SET amount = :amount WHERE ckey = :ckey AND item_id = :item_id"},
 			list("ckey" = buyer.ckey, "item_id" = item_path, "amount" = 1))
-		if(!query_add_gear_purchase.Execute())
-			to_chat(buyer, fail_message)
-			qdel(query_add_gear_purchase)
-			return FALSE
+	if(!query_add_gear_purchase.Execute())
+		// If the query fails to execute, notify the user and give them a replacement lootbox.
+		to_chat(buyer, span_warning("Failed to add lootbox item to database."))
+		to_chat(buyer, replacement_lootbox_message)
+		buyer.prefs.lootboxes_owned++
 		qdel(query_add_gear_purchase)
+		return FALSE
+	qdel(query_add_gear_purchase)
 
 	return TRUE
 

--- a/monkestation/code/modules/trading/lootbox_odds.dm
+++ b/monkestation/code/modules/trading/lootbox_odds.dm
@@ -67,6 +67,7 @@
 		to_chat(buyer, span_warning("Database is not connected."))
 		to_chat(buyer, replacement_lootbox_message)
 		buyer.prefs.lootboxes_owned++
+		buyer.prefs.save_preferences()
 		return FALSE
 	if(!buyer?.prefs)
 		return FALSE
@@ -88,6 +89,7 @@
 		to_chat(buyer, span_warning("Failed to add lootbox item to database."))
 		to_chat(buyer, replacement_lootbox_message)
 		buyer.prefs.lootboxes_owned++
+		buyer.prefs.save_preferences()
 		qdel(query_add_gear_purchase)
 		return FALSE
 	qdel(query_add_gear_purchase)


### PR DESCRIPTION
## About The Pull Request
Sometimes saving a lootbox item can fail. If a user manages to get a lootbox, but is subsequently unable to get the item due to an error saving the item to the database, it can be frustrating to lose the Monkecoin for no gain.

This PR changes this behavior. If for any reason the lootbox item is unable to be saved to the database, then the user will receive a replacement lootbox. We will still want to find out why the lootbox item couldn't be saved to the database - but this is a useful stopgap that helps reduce the fear in buying a lootbox.

This also refactors the `/datum/loadout_item/proc/add_to_user()` proc a bit.

## Why It's Good For The Game
This change reduces the fear a user might have with buying lootboxes - once they buy a lootbox, they are guaranteed to have one until they get an item that saves successfully.

## Changelog

:cl: MichiRecRoom
qol: If a lootbox item fails to save, you will now receive a replacement lootbox that can be used at a later time, and will hopefully work then.
/:cl: