### PR TITLE
Fix floorpills not actually filtering consumables like it should

### DIFF
--- a/monkestation/code/__HELPERS/reagents.dm
+++ b/monkestation/code/__HELPERS/reagents.dm
@@ -4,9 +4,9 @@
 	if(!random_reagents)
 		random_reagents = list()
 		for(var/datum/reagent/reagent_path as anything in subtypesof(/datum/reagent))
-			if(istype(reagent_path, /datum/reagent/consumable) && !initial(reagent_path.bypass_restriction))
+			if(ispath(reagent_path, /datum/reagent/consumable) && !reagent_path::bypass_restriction)
 				continue
-			if(initial(reagent_path.restricted))
+			if(reagent_path::restricted)
 				continue
 			random_reagents += reagent_path
 	var/picked_reagent = pick(random_reagents)


### PR DESCRIPTION

## About The Pull Request

you need to use `ispath`, not `istype` here.

## Changelog
:cl:
fix: Fixed floorpills rolling random drinks that should've been filtered out (but weren't due to a bad check).
/:cl:
