### PR TITLE
Ghost orbit menu now auto-updates

### DIFF
--- a/code/__DEFINES/~monkestation/dcs/signals/signals_carbon.dm
+++ b/code/__DEFINES/~monkestation/dcs/signals/signals_carbon.dm
@@ -3,3 +3,6 @@
 
 #define COMSIG_HUMAN_BEGIN_DUEL "human_begin_duel"
 #define COMSIG_HUMAN_END_DUEL "human_end_duel"
+
+/// Sent after `sec_hud_set_ID` runs - this is as close as I have right now to a "when ID changed" hook.
+#define COMSIG_HUMAN_SECHUD_SET_ID "human_sechud_set_id"

--- a/code/datums/elements/point_of_interest.dm
+++ b/code/datums/elements/point_of_interest.dm
@@ -1,6 +1,18 @@
+/* monkestation edit: added signals to autoupdate the orbit menu whenever something that might affect it happens */
 /// Designates the atom as a "point of interest", meaning it can be directly orbited
 /datum/element/point_of_interest
 	element_flags = ELEMENT_DETACH_ON_HOST_DESTROY
+	var/static/list/update_signals = list(
+		COMSIG_ATOM_ORBIT_BEGIN,
+		COMSIG_ATOM_ORBIT_STOP,
+		COMSIG_MOB_STATCHANGE,
+		COMSIG_HUMAN_SECHUD_SET_ID,
+		SIGNAL_ADDTRAIT(TRAIT_UNKNOWN)
+	) + COMSIG_LIVING_ADJUST_STANDARD_DAMAGE_TYPES
+	var/should_update = FALSE
+
+/datum/element/point_of_interest/New()
+	START_PROCESSING(SSdcs, src)
 
 /datum/element/point_of_interest/Attach(datum/target)
 	if (!isatom(target))
@@ -13,8 +25,21 @@
 		return ELEMENT_INCOMPATIBLE
 
 	SSpoints_of_interest.on_poi_element_added(target)
+	RegisterSignals(target, update_signals, PROC_REF(flag_updated))
+	flag_updated()
 	return ..()
 
 /datum/element/point_of_interest/Detach(datum/target)
 	SSpoints_of_interest.on_poi_element_removed(target)
+	UnregisterSignal(target, update_signals)
+	flag_updated()
 	return ..()
+
+/datum/element/point_of_interest/process(seconds_per_tick)
+	if(should_update)
+		INVOKE_ASYNC(GLOB.orbit_menu, TYPE_PROC_REF(/datum/orbit_menu, update_static_data_for_all_viewers))
+		should_update = FALSE
+
+/datum/element/point_of_interest/proc/flag_updated()
+	SIGNAL_HANDLER
+	should_update = TRUE

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -284,6 +284,7 @@ Security HUDs! Basic mode shows only the job.
 	if(!permit_icon_state)
 		permit_icon_state = "hudfan_no"
 	permit_holder.icon_state = permit_icon_state
+	SEND_SIGNAL(src, COMSIG_HUMAN_SECHUD_SET_ID)
 //monkestation edit end
 
 /mob/living/proc/sec_hud_set_implants()

--- a/monkestation/code/modules/antagonists/_common/antag_datum.dm
+++ b/monkestation/code/modules/antagonists/_common/antag_datum.dm
@@ -2,6 +2,16 @@
 	///The list of keys that are valid to see our antag hud/of huds we can see
 	var/list/hud_keys
 
+/datum/antagonist/on_gain()
+	. = ..()
+	if(show_to_ghosts)
+		GLOB.orbit_menu.update_static_data_for_all_viewers()
+
+/datum/antagonist/on_removal()
+	. = ..()
+	if(show_to_ghosts)
+		GLOB.orbit_menu.update_static_data_for_all_viewers()
+
 ///Set our hud_keys, please only use this proc when changing them, if override_old_keys is FALSE then we will simply add keys, otherwise we we set our keys to only be passed ones
 /datum/antagonist/proc/set_hud_keys(list/keys, override_old_keys = FALSE)
 	if(!islist(keys))


### PR DESCRIPTION


https://github.com/Monkestation/Monkestation2.0/assets/65794972/b89a2755-1b4e-4935-ac0e-f4afd8debd59



## Changelog
:cl:
qol: The ghost orbit menu now auto-updates, no more need to manually refresh it.
/:cl:
