### PR TITLE
Remove purity adjustment for overdose thresholds

### DIFF
--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -209,7 +209,9 @@ Primarily used in reagents/reaction_agents
 /// Called when this reagent is first added to a mob
 /datum/reagent/proc/on_mob_add(mob/living/L, amount)
 	SHOULD_CALL_PARENT(TRUE)
-	overdose_threshold /= max(normalise_creation_purity(), 1) //Maybe??? Seems like it would help pure chems be even better but, if I normalised this to 1, then everything would take a 25% reduction
+	// MONKESTATION REMOVAL START - Purity is disabled and we shouldn't change the overdose thresholds for things behind people's backs.
+	// overdose_threshold /= max(normalise_creation_purity(), 1) //Maybe??? Seems like it would help pure chems be even better but, if I normalised this to 1, then everything would take a 25% reduction
+	// MONKESTATION REMOVAL END
 	if(added_traits)
 		L.add_traits(added_traits, "added:[type]")
 


### PR DESCRIPTION
## About The Pull Request

Basically, fermichem has a hidden feature that automatically adjusts the overdose threshold for reagents based on their purity.
This PR removes that, because we don't have purity and also there are no mentions of this anywhere else in the game.
## Why It's Good For The Game

It's a bad, hidden feature that turns all of our overdose thresholds into unpredictable decimals.
We don't even use the system that this implements anymore, so even if it was good, it's going into the trash anyway.
## Changelog

:cl:
fix: Remove purity adjustment for overdose thresholds, as we don't even use reagent purity here.
/:cl:
