### PR TITLE
Metabolic Synthesis Nanite Program works on hungrier people now.

### DIFF
--- a/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
@@ -255,7 +255,7 @@
 	return ..()
 
 /datum/nanite_program/metabolic_synthesis/active_effect()
-	host_mob.adjust_nutrition(-0.5)
+	host_mob.adjust_nutrition(-0.25)
 
 /datum/nanite_program/access
 	name = "Subdermal ID"

--- a/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
@@ -250,7 +250,7 @@
 	if(!iscarbon(host_mob))
 		return FALSE
 	var/mob/living/carbon/C = host_mob
-	if(C.nutrition <= NUTRITION_LEVEL_WELL_FED)
+	if(C.nutrition <= NUTRITION_LEVEL_STARVING) //It's the nanite programmer's job to make sure nanites don't starve the host, also allows a saboteur to starve everyone who has nanites.
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
Reduces the threshold for allowing metabolic synthesis program to work, and takes half the amount of hunger.
## Why It's Good For The Game
It's the nanite programmer's job to make sure nanites don't starve the host, also allows a saboteur to starve everyone who has nanites. Apparently metabolic synthesis took quite a lot of nutrition earlier.

## Changelog
:cl:
tweak: Metabolic synthesis nanite program now has a lower hunger threshold to work.
balance: Metabolic synthesis now takes half the hunger.
/:cl:
