### PR TITLE
BCI button icon fix

### DIFF
--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -67,13 +67,14 @@
 
 /obj/item/circuit_component/equipment_action/bci/update_action()
 	bci_action.name = button_name.value
-	bci_action.button_icon_state = "bci_[replacetextEx(lowertext(icon_options.value), " ", "_")]"
+	// Change nanite -> bci if we get a set of bci action icons instead of nanite action icons
+	bci_action.button_icon_state = "nanite_[replacetextEx(lowertext(icon_options.value), " ", "_")]"
 
 /datum/action/innate/bci_action
 	name = "Action"
 	button_icon = 'icons/mob/actions/actions_items.dmi'
 	check_flags = AB_CHECK_CONSCIOUS
-	button_icon_state = "bci_power"
+	button_icon_state = "nanite_power"
 
 	var/obj/item/circuit_component/equipment_action/bci/circuit_component
 


### PR DESCRIPTION
## About The Pull Request

BCI action icons were errors because they tried to choose bci_(icon) icons, but we only have nanite_(icon) icons (+ the list is only of nanite icons), so I just set it to choose nanite_(icons), since thats what it was trying to do and thats what we have.

![image](https://github.com/Monkestation/Monkestation2.0/assets/99915170/1208e8df-ef63-4d6d-b8a4-6afcccae3abb)

ideally we could change them to button_(icon)/action_(icon) or something similar, since they're used for both, but I don't want to risk breaking anything else and i dont think anyone is going to add any new buttons anytime soon, so i'll just leave it to whoever touches it next to decide.

## Why It's Good For The Game

Actually choose bci icons instead of having ERRORs line the top of your screen

## Changelog

:cl:
fix: BCI Actions now use icons instead of ERRORs/.
/:cl:
