### PR TITLE
Dark Matt-eor announcements no longer falsely claim it missed

### DIFF
--- a/code/modules/meteors/meteor_dark_matteor.dm
+++ b/code/modules/meteors/meteor_dark_matteor.dm
@@ -62,6 +62,7 @@
 
 /obj/effect/meteor/dark_matteor/handle_stopping()
 	. = ..()
-	if(previous_security_level && SSsecurity_level.get_current_level_as_number() != SEC_LEVEL_DELTA)
-		SSsecurity_level.set_level(previous_security_level)
-	priority_announce("Wow. The Dark Matt-eor actually missed your station. Don't forget to thank your Chaplain for his apparent divine intervention.", "Meteor Update")
+	if(!successfully_hit) // monkestation edit: bugfix for meteor improperly being announced as missed
+		if(previous_security_level && SSsecurity_level.get_current_level_as_number() != SEC_LEVEL_DELTA)
+			SSsecurity_level.set_level(previous_security_level)
+		priority_announce("Wow. The Dark Matt-eor actually missed your station. Don't forget to thank your Chaplain for his apparent divine intervention.", "Meteor Update")

--- a/monkestation/code/modules/meteors/meteor_dark_matteor.dm
+++ b/monkestation/code/modules/meteors/meteor_dark_matteor.dm
@@ -1,0 +1,9 @@
+/obj/effect/meteor/dark_matteor
+	/// If the dark matter singuloth successfully spawned on the station z-level.
+	var/successfully_hit = FALSE
+
+/obj/effect/meteor/dark_matteor/make_debris()
+	var/turf/current_turf = get_turf(src)
+	if(is_station_level(current_turf.z))
+		successfully_hit = TRUE
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6507,6 +6507,7 @@
 #include "monkestation\code\modules\mentor\mentor_pm.dm"
 #include "monkestation\code\modules\mentor\mentor_say.dm"
 #include "monkestation\code\modules\mentor\mentor_who.dm"
+#include "monkestation\code\modules\meteors\meteor_dark_matteor.dm"
 #include "monkestation\code\modules\metrics\metric_subsystem.dm"
 #include "monkestation\code\modules\metrics\subsystem_analytics\generics.dm"
 #include "monkestation\code\modules\microfusion\code\cargo_stuff.dm"


### PR DESCRIPTION
![2024-05-07 (1715078970) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/389f7d45-0030-4d67-ae31-6a1da333f05b)

Fixes https://github.com/Monkestation/Monkestation2.0/issues/1948

## Changelog
:cl:
fix: Dark Matt-eor announcements no longer falsely claim it missed.
/:cl:
