### PR TITLE
Adds a new traitor item, the Concussive Hammer (WIP)

### DIFF
--- a/code/game/objects/items/melee/concussive_hammer.dm
+++ b/code/game/objects/items/melee/concussive_hammer.dm
@@ -18,7 +18,7 @@
 	name = "Concuss"
 	desc = "TBD"
 	background_icon_state = ACTION_BUTTON_DEFAULT_BACKGROUND
-	spell_requirements = NONE
+	spell_requirements = SPELL_REQUIRES_HUMAN
 	antimagic_flags = NONE
 	cooldown_time = 10 //Subject to balancing
 	spell_max_level = 1

--- a/code/game/objects/items/melee/concussive_hammer.dm
+++ b/code/game/objects/items/melee/concussive_hammer.dm
@@ -10,11 +10,19 @@
 	w_class = WEIGHT_CLASS_HUGE
 	var/datum/action/cooldown/spell/touch/concuss = new
 
-/datum/action/cooldown/spell/touch/concuss
+/obj/item/melee/concussive_hammer/Destroy()
+	qdel(concuss)
+	return ..()
+
+/datum/action/cooldown/spell/pointed/concuss
 	name = "Concuss"
 	desc = "TBD"
 	background_icon_state = ACTION_BUTTON_DEFAULT_BACKGROUND
-	spell_requirements = SPELL_REQUIRES_HUMAN
+	spell_requirements = NONE
+	antimagic_flags = NONE
+	cooldown_time = 10 //Subject to balancing
+	spell_max_level = 1
+	cast_range = 1 //I know this looks horrible but this isn't possible with touch spell as both hands are holding the item
 	overlay_icon_state = "bg_default_border"
 
 /obj/item/melee/concussive_hammer/Initialize(mapload)

--- a/code/game/objects/items/melee/concussive_hammer.dm
+++ b/code/game/objects/items/melee/concussive_hammer.dm
@@ -1,4 +1,4 @@
-/obj/item/melee/concuhammer
+/obj/item/melee/concussive_hammer
 	name = "concussive hammer"
 	desc = "A pneumatic hammer with a soft rubber head encompassing the front, for syndicate agents who are against murder."
 	icon = 'icons/obj/weapons/cleric_mace.dmi' //Placeholder
@@ -14,18 +14,19 @@
 	name = "Concuss"
 	desc = "TBD"
 	background_icon_state = ACTION_BUTTON_DEFAULT_BACKGROUND
+	spell_requirements = SPELL_REQUIRES_HUMAN
 	overlay_icon_state = "bg_default_border"
 
-/obj/item/melee/concuhammer/Initialize(mapload)
+/obj/item/melee/concussive_hammer/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/two_handed)
 
-/obj/item/melee/concuhammer/equipped(mob/living/owner, slot)
+/obj/item/melee/concussive_hammer/equipped(mob/living/owner, slot)
 	. = ..()
 	if(slot & ITEM_SLOT_HANDS)
 		concuss.Grant(owner)
 
-/obj/item/melee/concuhammer/dropped(mob/living/owner, slot)
+/obj/item/melee/concussive_hammer/dropped(mob/living/owner, slot)
 	. = ..()
 	if(owner.get_item_by_slot(ITEM_SLOT_HANDS) == src)
 		concuss.Remove(owner)

--- a/code/game/objects/items/melee/concussive_hammer.dm
+++ b/code/game/objects/items/melee/concussive_hammer.dm
@@ -1,0 +1,21 @@
+/obj/item/melee/concuhammer
+	name = "concussive hammer"
+	desc = "A pneumatic hammer with a soft rubber head encompassing the front, for syndicate agents who are against murder."
+	icon = 'icons/obj/weapons/cleric_mace.dmi' //Placeholder
+	icon_state = "default"
+	inhand_icon_state = "default"
+	attack_verb_continuous = list("strikes")
+	attack_verb_simple = list("strike")
+	actions = list(/datum/action/cooldown/spell/concuss)
+
+	slot_flags = ITEM_SLOT_BELT + ITEM_SLOT_BACK
+	w_class = WEIGHT_CLASS_HUGE
+
+
+/obj/item/melee/concuhammer/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/two_handed)
+
+/datum/action/cooldown/spell/concuss
+	name = "Concuss"
+	desc = "TBD"

--- a/code/game/objects/items/melee/concussive_hammer.dm
+++ b/code/game/objects/items/melee/concussive_hammer.dm
@@ -6,16 +6,27 @@
 	inhand_icon_state = "default"
 	attack_verb_continuous = list("strikes")
 	attack_verb_simple = list("strike")
-	actions = list(/datum/action/cooldown/spell/concuss)
-
 	slot_flags = ITEM_SLOT_BELT + ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_HUGE
+	var/datum/action/cooldown/spell/touch/concuss = new
 
+/datum/action/cooldown/spell/touch/concuss
+	name = "Concuss"
+	desc = "TBD"
+	background_icon_state = ACTION_BUTTON_DEFAULT_BACKGROUND
+	overlay_icon_state = "bg_default_border"
 
 /obj/item/melee/concuhammer/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/two_handed)
 
-/datum/action/cooldown/spell/concuss
-	name = "Concuss"
-	desc = "TBD"
+/obj/item/melee/concuhammer/equipped(mob/living/owner, slot)
+	. = ..()
+	if(slot & ITEM_SLOT_HANDS)
+		concuss.Grant(owner)
+
+/obj/item/melee/concuhammer/dropped(mob/living/owner, slot)
+	. = ..()
+	if(owner.get_item_by_slot(ITEM_SLOT_HANDS) == src)
+		concuss.Remove(owner)
+

--- a/code/game/objects/items/melee/concussive_hammer.dm
+++ b/code/game/objects/items/melee/concussive_hammer.dm
@@ -8,7 +8,7 @@
 	attack_verb_simple = list("strike")
 	slot_flags = ITEM_SLOT_BELT + ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_HUGE
-	var/datum/action/cooldown/spell/touch/concuss = new
+	var/datum/action/cooldown/spell/pointed/concuss = new
 
 /obj/item/melee/concussive_hammer/Destroy()
 	qdel(concuss)
@@ -18,7 +18,7 @@
 	name = "Concuss"
 	desc = "TBD"
 	background_icon_state = ACTION_BUTTON_DEFAULT_BACKGROUND
-	spell_requirements = SPELL_REQUIRES_HUMAN
+	spell_requirements = SPELL_REQU
 	antimagic_flags = NONE
 	cooldown_time = 10 //Subject to balancing
 	spell_max_level = 1

--- a/code/game/objects/items/melee/concussive_hammer.dm
+++ b/code/game/objects/items/melee/concussive_hammer.dm
@@ -18,7 +18,7 @@
 	name = "Concuss"
 	desc = "TBD"
 	background_icon_state = ACTION_BUTTON_DEFAULT_BACKGROUND
-	spell_requirements = SPELL_REQU
+	spell_requirements = SPELL_REQUIRES_HUMAN
 	antimagic_flags = NONE
 	cooldown_time = 10 //Subject to balancing
 	spell_max_level = 1

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -460,3 +460,21 @@
 	armour_penetration = 50
 	attack_verb_continuous = list("smacks", "strikes", "cracks", "beats")
 	attack_verb_simple = list("smack", "strike", "crack", "beat")
+
+/obj/item/melee/concuhammer
+	name = "concussive hammer"
+	desc = "A pneumatic hammer with a soft rubber head encompassing the front, for syndicate agents who are against murder."
+	icon = 'icons/obj/weapons/cleric_mace.dmi' //Placeholder
+	icon_state = "default"
+	inhand_icon_state = "default"
+	attack_verb_continuous = list("strikes")
+	attack_verb_simple = list("strike")
+	//actions_types = list(/datum/action/item_action/)
+
+	slot_flags = ITEM_SLOT_BELT + ITEM_SLOT_BACK
+	w_class = WEIGHT_CLASS_HUGE
+
+
+/obj/item/melee/concuhammer/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/two_handed)

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -469,7 +469,7 @@
 	inhand_icon_state = "default"
 	attack_verb_continuous = list("strikes")
 	attack_verb_simple = list("strike")
-	//actions_types = list(/datum/action/item_action/)
+	actions = list(/datum/action/item_action/concuss)
 
 	slot_flags = ITEM_SLOT_BELT + ITEM_SLOT_BACK
 	w_class = WEIGHT_CLASS_HUGE
@@ -478,3 +478,14 @@
 /obj/item/melee/concuhammer/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/two_handed)
+
+/*/obj/item/melee/concuhammer/equipped(mob/user,slot)
+	. = ..()
+	if(true==true)
+		//A button appears
+
+/obj/item/melee/concuhammer/dropped(mob/user, slot)
+	. = ..()
+	if(true==true)
+		//The button disappears
+*/

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -460,32 +460,3 @@
 	armour_penetration = 50
 	attack_verb_continuous = list("smacks", "strikes", "cracks", "beats")
 	attack_verb_simple = list("smack", "strike", "crack", "beat")
-
-/obj/item/melee/concuhammer
-	name = "concussive hammer"
-	desc = "A pneumatic hammer with a soft rubber head encompassing the front, for syndicate agents who are against murder."
-	icon = 'icons/obj/weapons/cleric_mace.dmi' //Placeholder
-	icon_state = "default"
-	inhand_icon_state = "default"
-	attack_verb_continuous = list("strikes")
-	attack_verb_simple = list("strike")
-	actions = list(/datum/action/item_action/concuss)
-
-	slot_flags = ITEM_SLOT_BELT + ITEM_SLOT_BACK
-	w_class = WEIGHT_CLASS_HUGE
-
-
-/obj/item/melee/concuhammer/Initialize(mapload)
-	. = ..()
-	AddComponent(/datum/component/two_handed)
-
-/*/obj/item/melee/concuhammer/equipped(mob/user,slot)
-	. = ..()
-	if(true==true)
-		//A button appears
-
-/obj/item/melee/concuhammer/dropped(mob/user, slot)
-	. = ..()
-	if(true==true)
-		//The button disappears
-*/

--- a/code/modules/uplink/uplink_items/dangerous.dm
+++ b/code/modules/uplink/uplink_items/dangerous.dm
@@ -15,6 +15,14 @@
 	surplus = 50 //monkestation edit: from 10 to 50
 	purchasable_from = ~UPLINK_NUKE_OPS
 
+/datum/uplink_item/dangerous/concussive_hammer
+	name = "Concussive Hammer"
+	desc = "A pneumatic hammer designed to incapacitate victims without hurting them. \
+			To be used exclusively by Pacifists." //Might change cus I'm just the coder lol
+	item = /obj/item/melee/concussive_hammer
+	cost = 1 //Set this low for ease of access, obviously subject to change for balancing
+	surplus = 0
+
 /datum/uplink_item/dangerous/pistol
 	name = "Makarov Pistol"
 	desc = "A small, easily concealable handgun that uses 9mm auto rounds in 8-round magazines and is compatible \

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2195,6 +2195,7 @@
 #include "code\game\objects\items\implants\implantpad.dm"
 #include "code\game\objects\items\implants\implantuplink.dm"
 #include "code\game\objects\items\melee\baton.dm"
+#include "code\game\objects\items\melee\concussive_hammer.dm"
 #include "code\game\objects\items\melee\energy.dm"
 #include "code\game\objects\items\melee\misc.dm"
 #include "code\game\objects\items\rcd\RCD.dm"


### PR DESCRIPTION
I am merely the coding volunteer on this PR, @DemiPizza23 came up with the idea of this item.


## About The Pull Request
Adds a new melee weapon available to any traitor uplink at X telecrystals, but can only be properly used by people with the pacifist quirk(I'll figure out how to code this somehow). Requires to be wielded in both hands to be used. When used on a target, it will knock them backwards X amount of tiles and knock them out for X amount of seconds. If the user **isn't** a pacifist, they will instead suffer from aforementioned effect themselves when they try to use it.

## Why It's Good For The Game
"Pacifist Hammer is cool" -Pizza

## Changelog

:cl:
add: Added a new traitor item, the Conscussive Hammer
/:cl: