### PR TITLE
Take advantage of how `thing.get_all_contents()` already includes `src` as part of the contents list

### DIFF
--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -202,10 +202,12 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 	var/atom/movable/stored_obj
 
 /obj/item/extraction_pack/proc/check_for_living_mobs(atom/A)
+	/* // MONKESTATION REMOVAL START - atom.get_all_contents() already includes `src` in the list.
 	if(isliving(A))
 		var/mob/living/L = A
 		if(L.stat != DEAD)
 			return TRUE
+	*/ // MONKESTATION REMOVAL END
 	for(var/thing in A.get_all_contents())
 		if(isliving(A))
 			var/mob/living/L = A

--- a/monkestation/code/modules/antagonists/clock_cult/reebe_modules.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/reebe_modules.dm
@@ -81,10 +81,6 @@ GLOBAL_LIST_EMPTY(abscond_markers)
 	anchored = TRUE
 
 /obj/effect/servant_blocker/CanPass(atom/movable/mover, border_dir)
-	if(ismob(mover))
-		var/mob/passing_mob = mover
-		if(IS_CLOCK(passing_mob))
-			return FALSE
 	for(var/mob/held_mob in mover.get_all_contents())
 		if(IS_CLOCK(held_mob))
 			return FALSE

--- a/monkestation/code/modules/ghost_players/area_changes.dm
+++ b/monkestation/code/modules/ghost_players/area_changes.dm
@@ -118,7 +118,7 @@
 	. = ..()
 
 	// For the atom that just entered this area, as well as each of its contents...
-	for(var/atom/movable/atom_inside in thing.get_all_contents())
+	for(var/atom/movable/atom_inside as anything in thing.get_all_contents())
 		// ...check if any of them are a ghost player mob...
 		if(istype(atom_inside, /mob/living/carbon/human/ghost))
 			// ...and if so, run the checks.

--- a/monkestation/code/modules/ghost_players/area_changes.dm
+++ b/monkestation/code/modules/ghost_players/area_changes.dm
@@ -117,15 +117,12 @@
 /area/Entered(atom/movable/thing)
 	. = ..()
 
-	if(istype(thing, /mob/living/carbon/human/ghost))
-		// If this is a ghost, run the teleport checks
-		teleport_ghost_mob_if_needed(thing)
-	else
-		// Else, loop through this thing's contents...
-		for(var/atom/movable/atom_inside in thing.get_all_contents())
-			if(istype(atom_inside, /mob/living/carbon/human/ghost))
-				// ...and for any ghosts, run the checks
-				teleport_ghost_mob_if_needed(atom_inside)
+	// For the atom that just entered this area, as well as each of its contents...
+	for(var/atom/movable/atom_inside in thing.get_all_contents())
+		// ...check if any of them are a ghost player mob...
+		if(istype(atom_inside, /mob/living/carbon/human/ghost))
+			// ...and if so, run the checks.
+			teleport_ghost_mob_if_needed(atom_inside)
 
 // Teleports a ghost's mob to ghostspawn, if this area does not meet certain requirements.
 /area/proc/teleport_ghost_mob_if_needed(mob/living/carbon/human/ghost/ghost)
@@ -135,8 +132,6 @@
 	should_teleport |= (!(area_flags & GHOST_AREA))
 	// ...this is an area ghosts are prohibited to inhabit during a round, and the round is ongoing
 	should_teleport |= ((area_flags & NO_GHOSTS_DURING_ROUND) && SSticker.current_state != GAME_STATE_FINISHED)
-	// Note: I realize the above bits seem sort of like the same thing. But in refactoring this, I
-	// decided to leave both checks in.
 
 	if(should_teleport)
 		ghost.move_to_ghostspawn()

--- a/monkestation/code/modules/ghost_players/job_helpers/firing_range_helper.dm
+++ b/monkestation/code/modules/ghost_players/job_helpers/firing_range_helper.dm
@@ -84,8 +84,6 @@
 	anchored = TRUE
 
 /obj/effect/gun_check_blocker/CanPass(atom/movable/mover, border_dir)
-	if(istype(mover, /obj/item/gun))
-		return FALSE
 	for(var/object in mover.get_all_contents())
 		if(istype(object, /obj/item/gun))
 			return FALSE


### PR DESCRIPTION
## About The Pull Request
Certain objects in SS13 make checks on both an atom and that atom's contents. For example, `/obj/effect/gun_check_blocker/CanPass()` checks the atom and all of the atom's contents, preventing the atom from moving through it if any of them are of type `/obj/item/gun`.

However, when doing this, the code assumes that `thing.get_all_contents()` does not include `thing` - and so, performs the check twice - once on `thing`, and once on every object in `thing.get_all_contents()`.

Yet, `/atom/proc/get_all_contents()` already includes `src` as part of the list. In fact, it even initializes the list with `src` in it:

https://github.com/Monkestation/Monkestation2.0/blob/72a3063f9f98cba2b83c3331531fbfd5f0100f03/code/__HELPERS/atoms.dm#L4-L12

This PR takes advantage of this fact, removing the redundant check on `thing`, as `thing` will just be checked again within the `for` loop over `thing.get_all_contents()`.

## Why It's Good For The Game
Removes redundant code, resulting in a little less CPU time used checking an atom and all its contents.

## Changelog
N/A - this does not include any changes that players would notice.