### PR TITLE
Healing holoparas (and other mobs that heal on touch) are slime-friendly

### DIFF
--- a/code/datums/components/healing_touch.dm
+++ b/code/datums/components/healing_touch.dm
@@ -201,7 +201,7 @@
 		updating_health = FALSE,
 	)
 	healed += target.adjustOxyLoss(-heal_oxy, updating_health = FALSE, required_biotype = valid_biotypes)
-	healed += target.adjustToxLoss(-heal_tox, updating_health = FALSE, required_biotype = valid_biotypes)
+	healed += target.adjustToxLoss(-heal_tox, updating_health = FALSE, forced = TRUE, required_biotype = valid_biotypes)
 	//MONKESTATION REMOVAL START
 	// While removing this could cause some issues, keeping it seems to cause more than it would
 	// solve. In particular, the above procs are somewhat bugged and don't return the values we


### PR DESCRIPTION

## Changelog
:cl:
fix: Healing holoparas (and other mobs that heal on touch) are slime-friendly and won't damage them anymore.
/:cl:
