### PR TITLE
Replace the nanite toggle software error with something more bearable

### DIFF
--- a/monkestation/code/modules/research/nanites/nanite_programs.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs.dm
@@ -29,6 +29,9 @@
 	//The following vars are customizable
 	var/activated = TRUE //If FALSE, the program won't process, disables passive effects, can't trigger and doesn't consume nanites
 
+	/// Whether or not the program is forcibly disabled by a software error. This is cleared by cloud syncs.
+	var/force_disabled = FALSE
+
 	var/timer_restart = 0 //When deactivated, the program will wait X deciseconds before self-reactivating. Also works if the program begins deactivated.
 	var/timer_shutdown = 0 //When activated, the program will wait X deciseconds before self-deactivating. Also works if the program begins activated.
 	var/timer_trigger = 0 //[Trigger only] While active, the program will attempt to trigger once every x deciseconds.
@@ -91,6 +94,8 @@
 	target.deactivation_code = deactivation_code
 	target.kill_code = kill_code
 	target.trigger_code = trigger_code
+
+	target.force_disabled = force_disabled
 
 	target.rules = list()
 	for(var/R in rules)
@@ -199,6 +204,8 @@
 //If false, disables active, passive effects, and triggers without consuming nanites
 //Can be used to avoid consuming nanites for nothing
 /datum/nanite_program/proc/check_conditions()
+	if (force_disabled)
+		return FALSE
 	if (!LAZYLEN(rules))
 		return TRUE
 	for(var/R in rules)
@@ -286,8 +293,8 @@
 			kill_code = 0
 			trigger_code = 0
 		if(3)
-			host_mob.investigate_log("[src] nanite program was toggled by software error.", INVESTIGATE_NANITES)
-			toggle() //enable/disable
+			host_mob.investigate_log("[src] nanite program was disabled by software error.", INVESTIGATE_NANITES)
+			force_disabled = TRUE
 		if(4)
 			if(can_trigger)
 				host_mob.investigate_log("[src] nanite program was triggered by software error.", INVESTIGATE_NANITES)

--- a/monkestation/code/modules/virology/reagents/antipathenogenics.dm
+++ b/monkestation/code/modules/virology/reagents/antipathenogenics.dm
@@ -19,7 +19,7 @@
 
 /datum/reagent/consumable/nutriment/soup/chicken_noodle_soup
 	data = list(
-		"threshhold" = 20
+		"threshold" = 20
 	)
 
 /datum/reagent/consumable/nutriment/soup/chicken_noodle_soup/on_mob_life(mob/living/carbon/M, seconds_per_tick, times_fired)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I've replaced the nanite software_error type 3 "Fuck you this program is disabled forever!" with something more bearable.
It now disables it forcibly until the next cloud sync.

Oh yeah I also saw a random thresHHold typo with Chicken Noodle Soup so I fixed that. It's a 1 letter change and I CBA to make another PR for it.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Having an obscure error where the only counter is to put a restart timer of 1s on every single program ever (thus doubling the time it takes to program your nanites) is extremely meta, extremely annoying and not fun whatsoever.

So yeah, this PR removes that and replaces it with something less infuriating. No amount of cloud syncs fix the old one, this one is fixed by a cloud sync as errors should be. (for the most part)

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The nanite "Toggle" error has been replaced with a "Disable" error that temporarily forces the nanite program to be inactive. It's fixed by cloud syncs automatically, unlike the previous permanent version.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
