### PR TITLE
Bci show charge by default fix

### DIFF
--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -143,6 +143,7 @@
 	bci = shell
 
 	show_charge_meter.set_value(TRUE)
+	update_charge_action()
 
 	RegisterSignal(shell, COMSIG_ORGAN_IMPLANTED, PROC_REF(on_organ_implanted))
 	RegisterSignal(shell, COMSIG_ORGAN_REMOVED, PROC_REF(on_organ_removed))

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -143,7 +143,6 @@
 	bci = shell
 
 	show_charge_meter.set_value(TRUE)
-	update_charge_action()
 
 	RegisterSignal(shell, COMSIG_ORGAN_IMPLANTED, PROC_REF(on_organ_implanted))
 	RegisterSignal(shell, COMSIG_ORGAN_REMOVED, PROC_REF(on_organ_removed))
@@ -180,10 +179,10 @@
 /obj/item/circuit_component/bci_core/proc/on_organ_implanted(datum/source, mob/living/carbon/owner)
 	SIGNAL_HANDLER
 
-	update_charge_action()
-
 	user_port.set_output(owner)
 	user = WEAKREF(owner)
+
+	update_charge_action()
 
 	RegisterSignal(owner, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	RegisterSignal(owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, PROC_REF(on_borg_charge))


### PR DESCRIPTION
## About The Pull Request

BCIs wouldnt show charge by default the first time implanted in a person, unless you remember to change the value. This was due to it checking if it should add the Show Charge action before it set the weakref to the user.


## Why It's Good For The Game

Shit was brokey and annoying to get around.

## Changelog

:cl:
fix: BCIs now correctly show their charge by default.
/:cl:

