### PR TITLE
Minor Delta Deshittification

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2642,10 +2642,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aDe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "aDg" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate{
@@ -10505,6 +10504,15 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/space/basic,
 /area/space/nearstation)
+"cwn" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "cwt" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/oil,
@@ -15066,13 +15074,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
-"dEN" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "dEP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18414,9 +18415,12 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "evj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "3"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "evp" = (
 /obj/machinery/computer/records/medical{
 	dir = 8
@@ -24874,11 +24878,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "fZo" = (
-/obj/machinery/corral_corner{
-	mapping_id = "6"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "fZp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -27579,15 +27585,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
-"gGU" = (
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "2"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "gHh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot,
@@ -29623,6 +29620,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/bar)
+"hia" = (
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "2";
+	dir = 1
+	},
+/mob/living/basic/slime,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "hie" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -32328,14 +32333,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"hTj" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "2";
-	dir = 1
-	},
-/mob/living/basic/slime,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "hTk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34268,13 +34265,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
-"ipd" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "ipk" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -34400,9 +34390,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "irh" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "irl" = (
 /turf/closed/wall/r_wall,
 /area/station/service/lawoffice)
@@ -36519,6 +36510,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
+"iTP" = (
+/obj/machinery/corral_corner{
+	mapping_id = "2"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "6"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "iUg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42945,12 +42945,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"ktr" = (
-/obj/machinery/corral_corner{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "ktv" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/command{
@@ -43798,6 +43792,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
+"kDu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "kDA" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -45726,16 +45724,11 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "lcK" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/corral_corner{
+	mapping_id = "5"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Engine Cooling Bypass"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "lcO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/corner{
@@ -51736,14 +51729,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_showroom)
-"mBA" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "mBD" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L9"
@@ -54139,6 +54124,17 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"nfH" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Engine Cooling Bypass"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "nfR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/cyborg,
@@ -61829,8 +61825,8 @@
 /area/station/medical/pathology)
 "pff" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "pfh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72933,11 +72929,9 @@
 /turf/open/floor/plating,
 /area/station/science/research)
 "rOY" = (
+/obj/structure/cable,
 /obj/machinery/corral_corner{
-	mapping_id = "2"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "6"
+	mapping_id = "1"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -73932,6 +73926,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"sbm" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "sbD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -76550,6 +76551,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"sKa" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "sKb" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics - Air Supply";
@@ -84662,15 +84670,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
-"uIt" = (
-/obj/machinery/corral_corner{
-	mapping_id = "4"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "uIF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/air_output{
 	dir = 4
@@ -88096,13 +88095,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/service/chapel/storage)
-"vzm" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "1"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "vzt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -88201,15 +88193,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
-"vAt" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "vAu" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
@@ -92368,9 +92351,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wxz" = (
-/obj/structure/cable,
 /obj/machinery/corral_corner{
-	mapping_id = "3"
+	mapping_id = "6"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "2"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -97853,6 +97838,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
+"xSe" = (
+/obj/machinery/corral_corner{
+	mapping_id = "4"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "xSf" = (
 /obj/structure/bed,
 /obj/item/bedsheet/clown,
@@ -99016,6 +99010,12 @@
 /obj/structure/sign/calendar/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
+"yhu" = (
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "yhw" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -120333,7 +120333,7 @@ bpr
 anB
 ilG
 cwI
-irh
+pff
 msB
 kXR
 owf
@@ -120614,11 +120614,11 @@ jNn
 oQS
 tpS
 taA
-gGU
+wxz
 fMl
 ddW
 fMl
-fZo
+yhu
 mAt
 ifk
 mMb
@@ -120847,7 +120847,7 @@ vog
 anB
 aVW
 lbl
-irh
+pff
 msB
 kXR
 owf
@@ -121104,11 +121104,11 @@ hQK
 pqr
 qJs
 tcy
-irh
-irh
+pff
+pff
 ePU
-evj
-evj
+aDe
+aDe
 sHT
 sHT
 jzC
@@ -121377,7 +121377,7 @@ pTC
 hhS
 iQF
 pTC
-wxz
+evj
 gvX
 fMl
 fMl
@@ -121385,11 +121385,11 @@ fOp
 oQS
 tLp
 taA
-fZo
+yhu
 fMl
 fMl
 gvX
-dEN
+sKa
 mAt
 xIw
 pVk
@@ -121619,9 +121619,9 @@ gAw
 eNt
 ehD
 sHT
-irh
+pff
 wKu
-evj
+aDe
 sHT
 pOf
 pOf
@@ -121638,11 +121638,11 @@ tcQ
 gvX
 fMl
 fMl
-uIt
+xSe
 oQS
 tLp
 taA
-rOY
+iTP
 fMl
 fMl
 gvX
@@ -122133,11 +122133,11 @@ kZq
 fzm
 ehD
 xEt
-aDe
-pff
-aDe
+irh
+kDu
+irh
 mWF
-aDe
+irh
 xEt
 nlS
 cCY
@@ -122149,8 +122149,8 @@ elH
 iQF
 pTC
 iLv
-gvX
-hTj
+vUy
+hia
 fMl
 fMl
 oQS
@@ -122159,7 +122159,7 @@ taA
 fMl
 fMl
 mca
-gvX
+vUy
 iLv
 mAt
 ilU
@@ -122390,11 +122390,11 @@ rDq
 pjU
 qbu
 ykB
-vAt
-lcK
-mBA
+cwn
+nfH
+fZo
 jcS
-mBA
+fZo
 oDl
 sMw
 cCY
@@ -122662,11 +122662,11 @@ pTC
 woj
 qcM
 pTC
-ipd
+sbm
 gvX
 fMl
 fMl
-ktr
+lcK
 oQS
 dxU
 taA
@@ -122674,7 +122674,7 @@ nYS
 fMl
 fMl
 gvX
-vzm
+rOY
 mAt
 kzt
 xQq
@@ -123433,7 +123433,7 @@ pTC
 aMM
 fwJ
 pTC
-ktr
+lcK
 fMl
 laX
 fMl

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -232,11 +232,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "acD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/stone,
 /area/station/science/xenobiology)
 "acG" = (
@@ -723,6 +724,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
+"ahJ" = (
+/obj/machinery/corral_corner{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "ahV" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine/co2,
@@ -874,6 +881,10 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/stone,
 /area/station/smithing)
+"akP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "akS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1450,13 +1461,10 @@
 /turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aql" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible/layer1,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "aqq" = (
 /obj/machinery/sparker/directional/west{
 	id = "justicespark"
@@ -1479,6 +1487,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
+"aqt" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/station/service/abandoned_gambling_den)
 "aqy" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2641,13 +2653,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aDe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/duct,
-/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/stone,
 /area/station/science/xenobiology)
 "aDg" = (
@@ -2833,6 +2843,19 @@
 	},
 /obj/machinery/light/small/red/directional/north,
 /turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
+"aFW" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/science/xenobiology)
 "aGg" = (
 /obj/structure/table,
@@ -4925,6 +4948,10 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/grimy,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"bhu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/science/xenobiology)
 "bhw" = (
 /turf/closed/wall,
 /area/station/maintenance/department/medical/morgue)
@@ -5021,15 +5048,16 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "biu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Engine Cooling Bypass"
 	},
-/obj/machinery/duct,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "biv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/structure/cable,
@@ -5454,13 +5482,6 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/command/gateway)
-"bng" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "3"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "bnt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6450,14 +6471,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
-"bAC" = (
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "3";
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "bAK" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/status_display/evac/directional/west,
@@ -6628,14 +6641,6 @@
 /obj/item/toy/figure/scientist,
 /turf/open/floor/iron,
 /area/station/science/lab)
-"bBV" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "bCb" = (
 /obj/machinery/growing/tray,
 /obj/effect/turf_decal/tile/blue{
@@ -7421,7 +7426,8 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/green/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer5,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "bKw" = (
@@ -8532,7 +8538,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/green/visible/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "bWb" = (
@@ -9529,6 +9535,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
+"cjK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "cjN" = (
 /turf/closed/wall/r_wall,
 /area/station/security/office)
@@ -10210,13 +10226,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
-"cqV" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "2"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "crb" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/sandy_dirt,
@@ -10532,6 +10541,10 @@
 "cwh" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/pharmacy)
+"cwi" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/green/visible/layer5,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "cwk" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -10706,15 +10719,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"cys" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "cyv" = (
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/camera/directional/south{
@@ -12236,6 +12240,15 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"cRj" = (
+/obj/machinery/light/floor/has_bulb,
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "1";
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "cRv" = (
 /obj/structure/reflector/single,
 /obj/machinery/light/directional/north,
@@ -12390,14 +12403,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cTO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/stone,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "cTW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13048,14 +13056,6 @@
 /obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
-"dcy" = (
-/obj/machinery/light/floor/has_bulb,
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "4"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "dcG" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/landmark/start/depsec/science,
@@ -13791,14 +13791,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos/project)
-"dma" = (
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "6";
-	dir = 2
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "dmq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -14345,13 +14337,10 @@
 /turf/open/floor/iron,
 /area/station/science/circuits)
 "duq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/corral_corner{
+	mapping_id = "6"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/stone,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "dux" = (
 /obj/structure/table,
@@ -14611,12 +14600,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"dxb" = (
-/obj/machinery/corral_corner{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "dxe" = (
 /turf/closed/wall,
 /area/station/medical/abandoned)
@@ -16797,14 +16780,9 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "eaO" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "eaQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17994,6 +17972,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
+"eqj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/science/xenobiology)
 "eqo" = (
 /obj/machinery/computer/crew{
 	dir = 4
@@ -18171,9 +18153,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "esm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "2";
+	dir = 1
+	},
+/mob/living/basic/slime,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "eso" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
@@ -18476,9 +18462,14 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "evj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "evp" = (
 /obj/machinery/computer/records/medical{
 	dir = 8
@@ -18544,6 +18535,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"ewr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "ewL" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/contraband/prison,
@@ -18654,7 +18655,7 @@
 	name = "Radiation Shutters Control";
 	req_access = list("engineering")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/green/visible/layer5,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "exK" = (
@@ -20209,6 +20210,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"eRN" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "4"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "eSa" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -21792,10 +21800,6 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
-"fkS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/science/xenobiology)
 "fkU" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/floor/has_bulb,
@@ -24938,8 +24942,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "fZo" = (
-/obj/machinery/duct,
 /obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "5"
+	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "fZp" = (
@@ -25839,6 +25845,14 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/kitchen)
+"glr" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "glv" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -26171,10 +26185,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
-"gpa" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
 "gpd" = (
 /obj/machinery/door/window/right/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -27065,6 +27075,11 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
+"gzu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer5,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "gzz" = (
 /obj/machinery/modular_computer/preset/civilian{
 	dir = 8
@@ -28543,6 +28558,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"gSu" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/science/xenobiology)
 "gSR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -29622,6 +29644,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
+"hgU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "hgX" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -37388,17 +37420,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"jdC" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Engine Cooling Bypass"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "jdL" = (
 /turf/closed/wall,
 /area/station/maintenance/fore)
@@ -37927,10 +37948,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/port)
-"jjM" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/service/abandoned_gambling_den)
 "jjR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -38092,6 +38109,13 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"jlr" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "jlv" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Virology - Hallway";
@@ -38669,10 +38693,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
-"jsB" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/smooth,
-/area/station/science/xenobiology)
 "jsE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -41493,15 +41513,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
-"kaC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating{
-	icon_state = "foam_plating"
-	},
-/area/station/maintenance/department/science/xenobiology)
 "kaF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -41717,6 +41728,15 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
+"kcO" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "kcR" = (
 /obj/structure/sign/warning/secure_area/directional/east,
 /turf/closed/wall/r_wall,
@@ -44486,10 +44506,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"kLJ" = (
-/obj/structure/tank_holder/extinguisher,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "kLK" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -45802,10 +45818,14 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "lcK" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "lcO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/corner{
@@ -48316,14 +48336,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "lIe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/science/xenobiology)
 "lIl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -49828,6 +49843,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
+"mcq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "mcs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51323,13 +51343,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
-"muQ" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "1"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "muT" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -55026,8 +55039,7 @@
 	dir = 8
 	},
 /obj/structure/sign/warning/secure_area/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible/layer1,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "nsd" = (
@@ -56801,13 +56813,11 @@
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "nOv" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "nOz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -57996,19 +58006,6 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
-"oed" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "oel" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -58112,11 +58109,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/quartermaster)
-"ofB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "ofE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -59185,6 +59177,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"oup" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "1"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "ouu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59918,6 +59917,15 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/morgue)
+"oDW" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating{
+	icon_state = "foam_plating"
+	},
+/area/station/maintenance/department/science/xenobiology)
 "oDX" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -61916,7 +61924,7 @@
 "pff" = (
 /obj/structure/cable,
 /obj/machinery/corral_corner{
-	mapping_id = "5"
+	mapping_id = "3"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -63123,11 +63131,9 @@
 	},
 /area/station/maintenance/department/science/xenobiology)
 "pvE" = (
+/obj/machinery/duct,
 /obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/turf/open/floor/engine,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "pvI" = (
 /obj/item/kirbyplants/random,
@@ -64966,8 +64972,9 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "pQz" = (
+/obj/structure/cable,
 /obj/machinery/corral_corner{
-	mapping_id = "6"
+	mapping_id = "2"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -71443,13 +71450,6 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
-"ruD" = (
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "ruN" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -72210,6 +72210,14 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"rEv" = (
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "5";
+	dir = 2
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "rEA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -72397,6 +72405,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/fore)
+"rHv" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "rHQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -72419,9 +72431,8 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "rIb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/xenobiology)
 "rIh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -73282,13 +73293,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
-"rRe" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "4"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "rRm" = (
 /obj/structure/window/spawner/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -73867,10 +73871,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
-"rYt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "rYA" = (
 /turf/closed/wall,
 /area/station/maintenance/department/security)
@@ -75567,6 +75567,15 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"svT" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor{
+	id = "xenobio_maint_fore";
+	name = "Xenobiology Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "svW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/item/radio/intercom/directional/east,
@@ -75612,15 +75621,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"sws" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor{
-	id = "xenobio_maint_fore";
-	name = "Xenobiology Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "swD" = (
 /obj/machinery/power/emitter,
 /obj/effect/decal/cleanable/dirt,
@@ -77455,6 +77455,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
+"sSO" = (
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "6"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "sTn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -78254,14 +78263,12 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "tcQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "6";
+	dir = 2
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "tcT" = (
 /obj/structure/disposalpipe/segment{
@@ -79714,6 +79721,11 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"twB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer1,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "twC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
@@ -82660,15 +82672,6 @@
 "ufR" = (
 /turf/closed/wall/r_wall,
 /area/station/security/warden)
-"uga" = (
-/obj/machinery/light/floor/has_bulb,
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "1";
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "ugc" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/structure/sign/poster/random/directional/north,
@@ -82798,10 +82801,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/bridge)
-"uhN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/science/xenobiology)
 "uhS" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -82854,6 +82853,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"uiH" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "uiK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84079,6 +84082,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"uyG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer1,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer5,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "uyK" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/item/clothing/under/rank/security/warden/grey,
@@ -84429,6 +84437,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"uCX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "uCY" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/lavendergrass/style_random,
@@ -84635,6 +84648,13 @@
 /obj/item/clothing/mask/surgical,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"uGd" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "uGf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -85604,7 +85624,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "uSs" = (
-/obj/machinery/light/floor/has_bulb,
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "3";
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "uSL" = (
@@ -85846,13 +85870,6 @@
 "uVk" = (
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
-"uVA" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/station/science/xenobiology)
 "uVF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -87298,6 +87315,14 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/command/gateway)
+"voA" = (
+/obj/machinery/light/floor/has_bulb,
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "4"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "voE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -88487,9 +88512,9 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "vBO" = (
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/stone,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "vBX" = (
 /obj/structure/sign/nanotrasen,
@@ -90085,6 +90110,7 @@
 	dir = 1
 	},
 /obj/machinery/status_display/ai/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "vYw" = (
@@ -90184,10 +90210,6 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
-"vZw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
 "vZE" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -90497,12 +90519,7 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "wdN" = (
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "6"
-	},
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "wdO" = (
@@ -90957,6 +90974,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"wii" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "wil" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -91704,14 +91729,6 @@
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"wpM" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "2";
-	dir = 1
-	},
-/mob/living/basic/slime,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "wpO" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/structure/table,
@@ -92504,12 +92521,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wxz" = (
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "5";
-	dir = 2
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/duct,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "wxF" = (
 /obj/structure/sign/poster/random/directional/north,
@@ -95921,9 +95940,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "xsN" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/stone,
 /area/station/science/xenobiology)
@@ -118175,8 +118196,8 @@ gAw
 bDe
 nTd
 nCi
-ofB
-ofB
+vBO
+vBO
 xdn
 sfN
 uXU
@@ -118429,21 +118450,21 @@ siU
 kPO
 oTE
 gAw
-vZw
-ruD
+rIb
+jlr
 uhb
 uhb
 uhb
-jsB
-jsB
-uVA
+lIe
+lIe
+gSu
 uhb
 uhb
 uhb
 lqa
 jDc
-rIb
-gpa
+uCX
+uiH
 nCi
 aaa
 qYo
@@ -118686,8 +118707,8 @@ rCb
 vBb
 oVF
 nCi
-lIe
-kaC
+evj
+oDW
 uhb
 ebW
 kNG
@@ -118700,7 +118721,7 @@ uhb
 uhb
 uhb
 nCi
-gpa
+uiH
 nCi
 qYo
 qYo
@@ -119456,7 +119477,7 @@ xEt
 mWF
 bWp
 gAw
-fkS
+bhu
 aFU
 pVY
 rdq
@@ -119714,8 +119735,8 @@ xqC
 mAm
 gAw
 fsC
-tcQ
-uhN
+ewr
+eqj
 wSK
 gao
 rqy
@@ -119966,7 +119987,7 @@ qJI
 iQV
 nbZ
 tLC
-kLJ
+rHv
 xEt
 uwQ
 gAw
@@ -120469,7 +120490,7 @@ bpr
 anB
 ilG
 cwI
-evj
+eaO
 msB
 kXR
 owf
@@ -120498,7 +120519,7 @@ fMl
 fMl
 fMl
 iLv
-nOv
+lcK
 qCs
 jiX
 hLM
@@ -120743,8 +120764,8 @@ dhB
 gwK
 pTC
 iLv
-uSs
-dcy
+wdN
+voA
 gvX
 fMl
 oQS
@@ -120752,10 +120773,10 @@ tLp
 taA
 fMl
 gvX
-uga
+cRj
 vUy
 iLv
-oed
+aFW
 ifk
 mMb
 bNr
@@ -120983,7 +121004,7 @@ vog
 anB
 aVW
 lbl
-evj
+eaO
 msB
 kXR
 owf
@@ -120999,7 +121020,7 @@ uTb
 hHK
 kGj
 gXx
-rRe
+eRN
 fMl
 fMl
 gvX
@@ -121011,8 +121032,8 @@ nYS
 gvX
 fMl
 fMl
-muQ
-jjM
+oup
+aqt
 oUe
 jET
 kot
@@ -121240,11 +121261,11 @@ hQK
 pqr
 qJs
 tcy
-evj
-evj
+eaO
+eaO
 ePU
-esm
-esm
+akP
+akP
 sHT
 sHT
 jzC
@@ -121257,17 +121278,17 @@ feF
 gcr
 pTC
 irh
-duq
-duq
-biu
-duq
-acD
+xsN
+xsN
+wxz
+xsN
+wii
 tLp
-cTO
-duq
-biu
-duq
-duq
+hgU
+xsN
+wxz
+xsN
+xsN
 omu
 mAt
 aAx
@@ -121513,11 +121534,11 @@ pTC
 hhS
 iQF
 pTC
-pff
+fZo
 fMl
 fMl
 gvX
-dxb
+ahJ
 oQS
 tLp
 taA
@@ -121525,7 +121546,7 @@ jNn
 gvX
 fMl
 fMl
-bng
+pff
 mAt
 xIw
 pVk
@@ -121754,11 +121775,11 @@ ubM
 gAw
 eNt
 ehD
-sHT
-evj
+eaO
+eaO
 wKu
-esm
-sHT
+akP
+akP
 pOf
 pOf
 oQw
@@ -121769,17 +121790,17 @@ kmV
 pTC
 hWk
 gcr
-sws
+svT
 iLv
 iLv
 iLv
-fZo
-fZo
-aDe
+cTO
+cTO
+cjK
 dxU
-cys
-fZo
-fZo
+acD
+cTO
+cTO
 iLv
 iLv
 iLv
@@ -122028,8 +122049,8 @@ ezY
 iQF
 mQO
 iLv
-uSs
-wxz
+wdN
+rEv
 gvX
 fMl
 oQS
@@ -122037,10 +122058,10 @@ dxU
 taA
 fMl
 gvX
-bAC
 uSs
+wdN
 iLv
-nOv
+lcK
 udV
 qYr
 dqD
@@ -122268,12 +122289,12 @@ gNd
 kZq
 fzm
 ehD
-xEt
-lcK
-rYt
-lcK
-mWF
-lcK
+cwi
+gzu
+uyG
+twB
+aql
+mcq
 xEt
 nlS
 cCY
@@ -122284,7 +122305,7 @@ pTC
 elH
 iQF
 pTC
-pff
+fZo
 fMl
 fMl
 gvX
@@ -122296,7 +122317,7 @@ fOp
 gvX
 fMl
 fMl
-bng
+pff
 mAt
 ilU
 qYr
@@ -122526,11 +122547,11 @@ rDq
 pjU
 qbu
 ykB
-eaO
-jdC
-bBV
+kcO
+biu
+glr
 jcS
-bBV
+glr
 oDl
 sMw
 cCY
@@ -122542,17 +122563,17 @@ eDZ
 rrU
 pTC
 irh
-duq
-duq
-biu
-duq
-acD
+xsN
+xsN
+wxz
+xsN
+wii
 dxU
-cTO
-duq
-biu
-duq
-duq
+hgU
+xsN
+wxz
+xsN
+xsN
 omu
 mAt
 fmi
@@ -122798,11 +122819,11 @@ pTC
 woj
 qcM
 pTC
-pvE
+uGd
 fMl
 fMl
 gvX
-pQz
+duq
 oQS
 pAi
 taA
@@ -122810,7 +122831,7 @@ vVD
 gvX
 fMl
 fMl
-cqV
+pQz
 mAt
 kzt
 xQq
@@ -123060,15 +123081,15 @@ fMl
 fMl
 gvX
 fMl
-aql
-vBO
-xsN
+aDe
+pvE
+nOv
 fMl
 gvX
 fMl
 fMl
 iLv
-nOv
+lcK
 cZl
 mPF
 kxv
@@ -123313,17 +123334,17 @@ eDZ
 rwI
 mQO
 iLv
-uSs
-dma
+wdN
+tcQ
 gvX
 fMl
-aql
-vBO
-xsN
+aDe
+pvE
+nOv
 fMl
 gvX
-wpM
-uSs
+esm
+wdN
 iLv
 oVW
 oTD
@@ -123569,14 +123590,14 @@ pTC
 aMM
 fwJ
 pTC
-pQz
+duq
 fMl
 laX
 fMl
-wdN
-aql
-vBO
-xsN
+sSO
+aDe
+pvE
+nOv
 wts
 fMl
 laX

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -232,10 +232,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "acD" = (
-/obj/machinery/light/floor/has_bulb,
 /mob/living/basic/slime,
 /obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "4"
+	mapping_id = "6";
+	dir = 2
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -1451,6 +1451,11 @@
 /area/station/commons/locker)
 "aql" = (
 /obj/machinery/light/floor/has_bulb,
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "1";
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "aqq" = (
@@ -2637,6 +2642,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aDe" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
@@ -2657,9 +2663,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "aDR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/corral_corner{
+	mapping_id = "1"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "1"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "aDZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -5006,10 +5017,13 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "biu" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/obj/machinery/duct,
+/obj/structure/cable,
 /turf/open/floor/stone,
 /area/station/science/xenobiology)
 "biv" = (
@@ -5830,6 +5844,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
+"bss" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "bsx" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/yellow{
@@ -7195,6 +7217,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/ce)
+"bIo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/science/xenobiology)
 "bIr" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -7209,6 +7235,14 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/ai_monitored/command/storage/eva)
+"bIC" = (
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "2";
+	dir = 1
+	},
+/mob/living/basic/slime,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "bID" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -9412,15 +9446,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
-"ciU" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "cjj" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -12342,13 +12367,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cTO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "cTW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -12809,6 +12830,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"cZx" = (
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "6"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "cZC" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -13070,13 +13100,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pathology)
-"ddu" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "ddw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16732,16 +16755,12 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "eaO" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "1"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Engine Cooling Bypass"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "eaQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17573,16 +17592,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"elO" = (
-/obj/machinery/door/poddoor{
-	id = "xenobio_maint_fore";
-	name = "Xenobiology Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "elP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -18118,14 +18127,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "esm" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
 /obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "eso" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
@@ -18428,10 +18432,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "evj" = (
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "evp" = (
 /obj/machinery/computer/records/medical{
 	dir = 8
@@ -19688,14 +19691,6 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"eMp" = (
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "3";
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "eMu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
@@ -23383,6 +23378,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"fFJ" = (
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "fFK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24607,6 +24607,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
+"fWw" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "fWx" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
@@ -24674,11 +24678,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
-"fXg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "fXi" = (
@@ -24852,6 +24851,15 @@
 "fYU" = (
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
+"fYY" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "fZg" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -24900,9 +24908,10 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "fZo" = (
-/obj/structure/tank_holder/extinguisher,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "fZp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -25971,6 +25980,15 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/service/library)
+"gnn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "gnw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -27166,14 +27184,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/eva/abandoned)
-"gBl" = (
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "6";
-	dir = 2
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "gBm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -29481,16 +29491,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
-"hfJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "hfM" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/sign/poster/contraband/random/directional/west,
@@ -30509,6 +30509,13 @@
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/carpet/royalblack,
 /area/station/service/chapel/office)
+"hsD" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "2"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "hsK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -30852,15 +30859,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
-"hwW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "hwX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32262,6 +32260,15 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/atmos)
+"hRE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "hRH" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -35385,6 +35392,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
+"iCS" = (
+/obj/machinery/light/floor/has_bulb,
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "4"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "iDc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -40035,15 +40050,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"jJQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
 "jKb" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/white{
@@ -40310,6 +40316,16 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"jMv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "jMz" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -40349,10 +40365,10 @@
 /area/station/hallway/primary/fore)
 "jNn" = (
 /obj/machinery/corral_corner{
-	mapping_id = "1"
+	mapping_id = "3"
 	},
 /obj/machinery/slime_pen_controller{
-	mapping_id = "2"
+	mapping_id = "3"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -40406,6 +40422,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"jOl" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "jOo" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/stripes/line{
@@ -42059,13 +42088,6 @@
 /obj/structure/filingcabinet/security,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
-"kgu" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "1"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "kgx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45288,6 +45310,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"kWU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "kXa" = (
 /obj/machinery/defibrillator_mount/directional/north,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -45770,11 +45796,7 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "lcK" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "2";
-	dir = 1
-	},
-/mob/living/basic/slime,
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "lcO" = (
@@ -47421,15 +47443,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"lxH" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor{
-	id = "xenobio_maint_fore";
-	name = "Xenobiology Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "lxM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -48296,10 +48309,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "lIe" = (
-/obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "lIl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -49772,7 +49785,7 @@
 /area/station/medical/pathology)
 "mca" = (
 /obj/machinery/corral_corner{
-	mapping_id = "4"
+	mapping_id = "5"
 	},
 /obj/machinery/slime_pen_controller{
 	mapping_id = "5"
@@ -50365,6 +50378,10 @@
 "mjz" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/lesser)
+"mjD" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/station/service/abandoned_gambling_den)
 "mjK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -50618,6 +50635,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"mmW" = (
+/obj/machinery/corral_corner{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "mne" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark,
@@ -51209,14 +51232,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
-"mud" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "muh" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil,
@@ -54120,11 +54135,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"nen" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "neu" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -56783,10 +56793,9 @@
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "nOv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "nOz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
@@ -57417,6 +57426,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/pathology)
+"nWv" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "nWw" = (
 /mob/living/basic/mouse/gray,
 /obj/machinery/computer/cryopod/directional/west{
@@ -57460,6 +57476,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"nXk" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "nXo" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60595,6 +60619,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
+"oNS" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "3"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "oOh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -61876,7 +61907,7 @@
 "pff" = (
 /obj/structure/cable,
 /obj/machinery/corral_corner{
-	mapping_id = "4"
+	mapping_id = "5"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -62392,10 +62423,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/station/service/theater/abandoned)
-"pkK" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
 "pkZ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -63087,9 +63114,15 @@
 	},
 /area/station/maintenance/department/science/xenobiology)
 "pvE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/duct,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "pvI" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -64186,15 +64219,6 @@
 /obj/item/taperecorder,
 /turf/open/floor/plating,
 /area/station/security/detectives_office/private_investigators_office)
-"pHD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating{
-	icon_state = "foam_plating"
-	},
-/area/station/maintenance/department/science/xenobiology)
 "pHP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -64936,12 +64960,14 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "pQz" = (
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/effect/landmark/event_spawn,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/door/poddoor{
+	id = "xenobio_maint_fore";
+	name = "Xenobiology Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/area/station/science/xenobiology)
 "pQN" = (
 /obj/machinery/duct,
 /obj/effect/landmark/start/hangover,
@@ -69473,6 +69499,14 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"qUd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "qUi" = (
 /obj/structure/disposalpipe/sorting/mail{
 	name = "Engineering Junction"
@@ -72386,9 +72420,6 @@
 /obj/machinery/corral_corner{
 	mapping_id = "6"
 	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "1"
-	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "rIh" = (
@@ -72828,6 +72859,16 @@
 	dir = 4
 	},
 /area/station/engineering/lobby)
+"rMU" = (
+/obj/machinery/door/poddoor{
+	id = "xenobio_maint_fore";
+	name = "Xenobiology Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "rNf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
@@ -73007,7 +73048,10 @@
 /area/station/science/research)
 "rOY" = (
 /obj/machinery/corral_corner{
-	mapping_id = "5"
+	mapping_id = "4"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "4"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -73510,15 +73554,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"rUb" = (
-/obj/machinery/corral_corner{
-	mapping_id = "2"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "3"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "rUn" = (
 /obj/structure/sign/departments/science/directional/west,
 /obj/effect/turf_decal/tile/purple{
@@ -73600,10 +73635,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"rVP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/science/xenobiology)
 "rVX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74970,13 +75001,6 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/maintenance/disposal/incinerator)
-"som" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "3"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "sox" = (
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
@@ -75629,6 +75653,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"sxa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating{
+	icon_state = "foam_plating"
+	},
+/area/station/maintenance/department/science/xenobiology)
 "sxk" = (
 /obj/structure/barricade/wooden,
 /obj/structure/cable,
@@ -76693,13 +76726,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
-"sKH" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/station/science/xenobiology)
 "sKJ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
@@ -76941,6 +76967,16 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/medical/medbay)
+"sMR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "sMU" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77637,15 +77673,6 @@
 /obj/structure/sign/warning/electric_shock/directional/east,
 /turf/open/space/basic,
 /area/space)
-"sVy" = (
-/obj/machinery/corral_corner{
-	mapping_id = "3"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "4"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "sVC" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
@@ -78235,9 +78262,12 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "tcQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "tcT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78359,6 +78389,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"teQ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/science/xenobiology)
 "teU" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -80773,13 +80810,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/half,
 /area/station/security/office)
-"tKA" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "2"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "tKV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -81250,15 +81280,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/freezerchamber)
-"tPu" = (
-/obj/machinery/light/floor/has_bulb,
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "1";
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "tPv" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -82134,6 +82155,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"uar" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/science/xenobiology)
 "uaz" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -83402,6 +83427,17 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"uqd" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Engine Cooling Bypass"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "uqk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral,
@@ -85731,10 +85767,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/hfr_room)
-"uUj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
 "uUl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -86093,6 +86125,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"uZa" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "uZf" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/lavendergrass,
@@ -86572,10 +86611,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pathology)
-"vfm" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/service/abandoned_gambling_den)
 "vfw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -87314,12 +87349,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
-"vpi" = (
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "vpk" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -88476,10 +88505,8 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "vBO" = (
+/obj/machinery/duct,
 /obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "5"
-	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "vBX" = (
@@ -89851,10 +89878,10 @@
 /area/station/cargo/drone_bay)
 "vVD" = (
 /obj/machinery/corral_corner{
-	mapping_id = "5"
+	mapping_id = "2"
 	},
 /obj/machinery/slime_pen_controller{
-	mapping_id = "6"
+	mapping_id = "2"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -90484,14 +90511,12 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "wdN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "3";
+	dir = 1
 	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/stone,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "wdO" = (
 /obj/machinery/light/directional/west,
@@ -90751,19 +90776,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/service/theater/abandoned)
-"wgm" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "wgn" = (
 /obj/structure/closet/masks,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -95010,6 +95022,13 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
+"xgp" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "4"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "xgt" = (
 /obj/structure/cable,
 /obj/structure/table/wood,
@@ -95910,13 +95929,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "xsN" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "xsP" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
@@ -96020,16 +96040,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
-"xtR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/duct,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "xtZ" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/delivery,
@@ -97202,16 +97212,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
-"xHa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "xHf" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/delivery,
@@ -118185,8 +118185,8 @@ gAw
 bDe
 nTd
 nCi
-nOv
-nOv
+fZo
+fZo
 xdn
 sfN
 uXU
@@ -118439,21 +118439,21 @@ siU
 kPO
 oTE
 gAw
-tcQ
-pQz
+nOv
+uZa
 uhb
 uhb
 uhb
 wxz
 wxz
-sKH
+teQ
 uhb
 uhb
 uhb
 lqa
 jDc
-nen
-pkK
+lIe
+esm
 nCi
 aaa
 qYo
@@ -118696,8 +118696,8 @@ rCb
 vBb
 oVF
 nCi
-jJQ
-pHD
+hRE
+sxa
 uhb
 ebW
 kNG
@@ -118710,7 +118710,7 @@ uhb
 uhb
 uhb
 nCi
-pkK
+esm
 nCi
 qYo
 qYo
@@ -119466,7 +119466,7 @@ xEt
 mWF
 bWp
 gAw
-aDR
+bIo
 aFU
 pVY
 rdq
@@ -119724,8 +119724,8 @@ xqC
 mAm
 gAw
 fsC
-hfJ
-rVP
+jMv
+uar
 wSK
 gao
 rqy
@@ -119976,7 +119976,7 @@ qJI
 iQV
 nbZ
 tLC
-fZo
+fWw
 xEt
 uwQ
 gAw
@@ -120238,19 +120238,19 @@ wDw
 cMr
 gAw
 uhb
-fOp
+qUa
 fMl
 ddW
 fMl
-fOp
+qUa
 oQS
 tpS
 taA
-rIb
+aDR
 fMl
 ddW
 fMl
-vpi
+nYS
 mAt
 mAt
 cRJ
@@ -120479,7 +120479,7 @@ bpr
 anB
 ilG
 cwI
-uUj
+evj
 msB
 kXR
 owf
@@ -120508,7 +120508,7 @@ fMl
 fMl
 fMl
 iLv
-esm
+xsN
 qCs
 jiX
 hLM
@@ -120753,8 +120753,8 @@ dhB
 gwK
 pTC
 iLv
-aql
-acD
+lcK
+iCS
 gvX
 fMl
 oQS
@@ -120762,10 +120762,10 @@ tLp
 taA
 fMl
 gvX
-tPu
+aql
 vUy
 iLv
-wgm
+jOl
 ifk
 mMb
 bNr
@@ -120993,7 +120993,7 @@ vog
 anB
 aVW
 lbl
-uUj
+evj
 msB
 kXR
 owf
@@ -121009,20 +121009,20 @@ uTb
 hHK
 kGj
 gXx
-som
+xgp
 fMl
 fMl
 gvX
-sVy
+rOY
 oQS
 tLp
 taA
-vpi
+nYS
 gvX
 fMl
 fMl
-ddu
-vfm
+eaO
+mjD
 oUe
 jET
 kot
@@ -121250,11 +121250,11 @@ hQK
 pqr
 qJs
 tcy
-uUj
-uUj
+evj
+evj
 ePU
-pvE
-pvE
+cTO
+cTO
 sHT
 sHT
 jzC
@@ -121269,13 +121269,13 @@ pTC
 irh
 duq
 duq
-xtR
+pvE
 duq
-cTO
+bss
 tLp
-wdN
+sMR
 duq
-xtR
+pvE
 duq
 duq
 omu
@@ -121527,15 +121527,15 @@ pff
 fMl
 fMl
 gvX
-qUa
+mmW
 oQS
 tLp
 taA
-rUb
+jNn
 gvX
 fMl
 fMl
-tKA
+oNS
 mAt
 xIw
 pVk
@@ -121765,9 +121765,9 @@ gAw
 eNt
 ehD
 sHT
-uUj
+evj
 wKu
-pvE
+cTO
 sHT
 pOf
 pOf
@@ -121779,17 +121779,17 @@ kmV
 pTC
 hWk
 gcr
-lxH
+pQz
 iLv
 iLv
 iLv
-evj
-evj
-xHa
+vBO
+vBO
+biu
 dxU
-hwW
-evj
-evj
+gnn
+vBO
+vBO
 iLv
 iLv
 iLv
@@ -122038,7 +122038,7 @@ ezY
 iQF
 mQO
 iLv
-aql
+lcK
 uSs
 gvX
 fMl
@@ -122047,10 +122047,10 @@ dxU
 taA
 fMl
 gvX
-eMp
-aql
+wdN
+lcK
 iLv
-esm
+xsN
 udV
 qYr
 dqD
@@ -122279,11 +122279,11 @@ kZq
 fzm
 ehD
 xEt
-fXg
 aDe
-fXg
+kWU
+aDe
 mWF
-fXg
+aDe
 xEt
 nlS
 cCY
@@ -122302,11 +122302,11 @@ mca
 oQS
 dxU
 taA
-wts
+fOp
 gvX
 fMl
 fMl
-tKA
+oNS
 mAt
 ilU
 qYr
@@ -122536,11 +122536,11 @@ rDq
 pjU
 qbu
 ykB
-ciU
-eaO
-xsN
+fYY
+uqd
+nXk
 jcS
-xsN
+nXk
 oDl
 sMw
 cCY
@@ -122554,13 +122554,13 @@ pTC
 irh
 duq
 duq
-xtR
+pvE
 duq
-cTO
+bss
 dxU
-wdN
+sMR
 duq
-xtR
+pvE
 duq
 duq
 omu
@@ -122808,19 +122808,19 @@ pTC
 woj
 qcM
 pTC
-vBO
+nWv
 fMl
 fMl
 gvX
-rOY
+rIb
 oQS
 pAi
 taA
-jNn
+vVD
 gvX
 fMl
 fMl
-kgu
+hsD
 mAt
 kzt
 xQq
@@ -123070,15 +123070,15 @@ fMl
 fMl
 gvX
 fMl
-mud
-lIe
-biu
+qUd
+fFJ
+tcQ
 fMl
 gvX
 fMl
 fMl
 iLv
-esm
+xsN
 cZl
 mPF
 kxv
@@ -123321,19 +123321,19 @@ gAw
 pTC
 eDZ
 rwI
-elO
+rMU
 iLv
-aql
-gBl
-gvX
-fMl
-mud
-lIe
-biu
-fMl
-gvX
 lcK
-aql
+acD
+gvX
+fMl
+qUd
+fFJ
+tcQ
+fMl
+gvX
+bIC
+lcK
 iLv
 oVW
 oTD
@@ -123579,19 +123579,19 @@ pTC
 aMM
 fwJ
 pTC
-rOY
+rIb
 fMl
 laX
 fMl
-vVD
-mud
-lIe
-biu
-nYS
+cZx
+qUd
+fFJ
+tcQ
+wts
 fMl
 laX
 fMl
-nYS
+wts
 mAt
 iIn
 srI

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -232,9 +232,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "acD" = (
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "acG" = (
 /obj/structure/table/reinforced,
@@ -585,6 +588,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
+"agi" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "agk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1447,13 +1459,12 @@
 /turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aql" = (
+/obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "aqq" = (
 /obj/machinery/sparker/directional/west{
 	id = "justicespark"
@@ -2638,14 +2649,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aDe" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating{
-	icon_state = "foam_plating"
-	},
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "aDg" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate{
@@ -3288,6 +3295,16 @@
 /obj/structure/sign/warning/electric_shock/directional/west,
 /turf/open/space/basic,
 /area/space)
+"aLp" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "aLq" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
@@ -4783,6 +4800,10 @@
 /obj/item/storage/wallet/random,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
+"bfG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "bfM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -5017,11 +5038,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "biu" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "6"
 	},
-/turf/open/floor/stone,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "biv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -5899,16 +5920,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"bsX" = (
-/obj/machinery/duct,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "bsY" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 5
@@ -9166,6 +9177,11 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
+"cft" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "cfu" = (
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -12239,13 +12255,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"cRY" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "cSm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -12361,15 +12370,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cTO" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
 /obj/structure/cable,
+/obj/machinery/door/poddoor{
+	id = "xenobio_maint_fore";
+	name = "Xenobiology Blast Door"
+	},
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/xenobiology)
@@ -13481,15 +13486,6 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/project)
-"djj" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor{
-	id = "xenobio_maint_fore";
-	name = "Xenobiology Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "djk" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/computer/operating{
@@ -15554,13 +15550,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"dKS" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/station/science/xenobiology)
 "dLd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16765,13 +16754,9 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "eaO" = (
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "2"
-	},
-/turf/open/floor/engine,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "eaQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17609,10 +17594,6 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
-"elQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
 "elS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -17672,6 +17653,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
+"emP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "emR" = (
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
@@ -18452,9 +18442,15 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "evj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/duct,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "evp" = (
 /obj/machinery/computer/records/medical{
 	dir = 8
@@ -20185,6 +20181,10 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"eRU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "eSa" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -20415,16 +20415,6 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark/side,
 /area/station/commons/fitness/recreation)
-"eUU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "eUZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
@@ -20740,6 +20730,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"eYw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "eYy" = (
 /obj/structure/cable,
 /obj/structure/closet/secure_closet/atmospherics,
@@ -20750,11 +20745,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage)
-"eYE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "eYG" = (
 /obj/machinery/shower/directional/west{
 	name = "emergency shower"
@@ -23260,13 +23250,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/library/abandoned)
-"fCR" = (
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "fCX" = (
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/circuit,
@@ -24932,8 +24915,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "fZo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "fZp" = (
 /obj/structure/disposalpipe/segment,
@@ -31752,6 +31741,10 @@
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/iron/grimy,
 /area/station/service/bar/backroom)
+"hKx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/science/xenobiology)
 "hKC" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -32843,6 +32836,10 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
+"hYL" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "hYO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -33092,6 +33089,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
+"ibe" = (
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "5";
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "ibh" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -35297,6 +35302,11 @@
 /obj/item/stamp/rd,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
+"iBE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "iBO" = (
 /obj/machinery/power/turbine/inlet_compressor,
 /turf/open/floor/engine,
@@ -40204,6 +40214,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/evidence)
+"jLo" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "jLs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -40499,14 +40516,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"jPl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "jPm" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
@@ -42633,12 +42642,6 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/wood,
 /area/station/service/theater/abandoned)
-"knG" = (
-/obj/machinery/corral_corner{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "knH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
@@ -44052,6 +44055,10 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"kGz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/science/xenobiology)
 "kGA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/red,
@@ -44291,16 +44298,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden/abandoned)
-"kJA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "kJH" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
@@ -45422,15 +45419,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"kYa" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/red/directional/east,
-/obj/structure/tank_holder/extinguisher,
-/turf/open/floor/plating{
-	icon_state = "foam_plating"
-	},
-/area/station/maintenance/department/science/xenobiology)
 "kYb" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
@@ -45571,6 +45559,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating,
 /area/station/science/research/abandoned)
+"laE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "laJ" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
@@ -45792,8 +45784,12 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "lcK" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/smooth,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "lcO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -47094,14 +47090,6 @@
 /obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
-"ltC" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "ltD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
@@ -47438,6 +47426,10 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"lxl" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/station/service/abandoned_gambling_den)
 "lxF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -48313,8 +48305,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "lIe" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/landmark/event_spawn,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "lIl" = (
@@ -49699,6 +49693,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/xenobiology)
+"lZU" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "lZX" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
@@ -49788,11 +49791,14 @@
 /turf/open/floor/iron,
 /area/station/medical/pathology)
 "mca" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "4"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "mck" = (
 /obj/structure/chair/office,
@@ -52458,16 +52464,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
-"mIz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "mIA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -53777,16 +53773,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"mYR" = (
-/obj/machinery/door/poddoor{
-	id = "xenobio_maint_fore";
-	name = "Xenobiology Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "mZj" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	color = "#FFFF00";
@@ -56805,12 +56791,14 @@
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "nOv" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "1"
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating{
+	icon_state = "foam_plating"
 	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "nOz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
@@ -57309,10 +57297,6 @@
 /obj/effect/landmark/start/janitor,
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
-"nUE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "nUI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -59003,17 +58987,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
-"oqv" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Engine Cooling Bypass"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "oqx" = (
 /obj/machinery/deepfryer,
 /obj/effect/turf_decal/bot,
@@ -59071,6 +59044,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"orK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "orL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -60878,6 +60861,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"oRG" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "4"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "oRH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/neutral/full,
@@ -61500,15 +61490,13 @@
 /turf/open/misc/grass,
 /area/station/hallway/primary/fore)
 "pbp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/red/directional/east,
+/turf/open/floor/plating{
+	icon_state = "foam_plating"
 	},
-/obj/machinery/duct,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/area/station/maintenance/department/science/xenobiology)
 "pbq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -61712,6 +61700,16 @@
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/hfr_room)
+"pdp" = (
+/obj/machinery/door/poddoor{
+	id = "xenobio_maint_fore";
+	name = "Xenobiology Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "pdu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -62259,10 +62257,6 @@
 /obj/structure/sink/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/medbay)
-"piM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/science/xenobiology)
 "pjb" = (
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
@@ -63128,14 +63122,13 @@
 	},
 /area/station/maintenance/department/science/xenobiology)
 "pvE" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "pvI" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -64764,6 +64757,10 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
+"pNY" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/smooth,
+/area/station/science/xenobiology)
 "pOf" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -65211,6 +65208,19 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/science/circuits)
+"pTs" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "pTz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -68501,10 +68511,6 @@
 "qIH" = (
 /turf/closed/wall/r_wall,
 /area/station/security/execution/transfer)
-"qIJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
 "qIK" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/door/firedoor,
@@ -69821,15 +69827,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"qZo" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "qZs" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -72435,9 +72432,14 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "rIb" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/service/abandoned_gambling_den)
+/obj/machinery/corral_corner{
+	mapping_id = "2"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "6"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "rIh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment{
@@ -72594,6 +72596,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
+"rJM" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/science/xenobiology)
 "rJN" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/sink/kitchen/directional/south{
@@ -73053,13 +73062,10 @@
 /turf/open/floor/plating,
 /area/station/science/research)
 "rOY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/corral_corner{
+	mapping_id = "6"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/stone,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "rPc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -75325,6 +75331,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/service/bar/backroom)
+"ssH" = (
+/obj/machinery/corral_corner{
+	mapping_id = "4"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "ssM" = (
 /obj/structure/sign/departments/medbay/alt/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78249,13 +78264,10 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "tcQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/corral_corner{
+	mapping_id = "5"
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/stone,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "tcT" = (
 /obj/structure/disposalpipe/segment{
@@ -81502,13 +81514,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
-"tSS" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "tSU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -82251,6 +82256,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/medical/abandoned)
+"ubE" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Engine Cooling Bypass"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "ubL" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
@@ -84390,6 +84406,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
+"uCv" = (
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "2"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "uCC" = (
 /obj/effect/landmark/start/cyborg,
 /obj/structure/cable,
@@ -84944,13 +84969,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"uLd" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "3"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "uLe" = (
 /obj/structure/table/wood,
 /obj/machinery/light_switch/directional/west,
@@ -85599,10 +85617,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "uSs" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "4"
-	},
 /mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "6";
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "uSL" = (
@@ -86644,12 +86663,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"vgs" = (
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "vgu" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line{
@@ -86798,14 +86811,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/permabrig,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
-"vih" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "2";
-	dir = 1
-	},
-/mob/living/basic/slime,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "vii" = (
 /turf/open/floor/iron/white/side{
 	dir = 4
@@ -88492,9 +88497,11 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "vBO" = (
-/obj/machinery/duct,
 /obj/structure/cable,
-/turf/open/floor/stone,
+/obj/machinery/corral_corner{
+	mapping_id = "3"
+	},
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "vBX" = (
 /obj/structure/sign/nanotrasen,
@@ -89478,6 +89485,15 @@
 	},
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/engineering/gravity_generator)
+"vPN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "vPO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -90498,9 +90514,9 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "wdN" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "wdO" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
@@ -92492,13 +92508,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wxz" = (
-/obj/machinery/corral_corner{
-	mapping_id = "2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "6"
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "wxF" = (
 /obj/structure/sign/poster/random/directional/north,
@@ -95219,6 +95235,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/quartermaster)
+"xiD" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "1"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "xiG" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -96795,15 +96818,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"xCU" = (
-/obj/machinery/corral_corner{
-	mapping_id = "4"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "xDc" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/decal/cleanable/dirt,
@@ -97100,11 +97114,6 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
-"xGf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "xGh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
@@ -97456,14 +97465,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
-"xKi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "xKn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -97620,6 +97621,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den/gaming)
+"xMw" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "xMy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -116901,7 +116906,7 @@ aaa
 uHd
 bDe
 sPB
-kYa
+pbp
 nCi
 nCi
 nCi
@@ -118187,8 +118192,8 @@ gAw
 bDe
 nTd
 nCi
-eYE
-eYE
+eYw
+eYw
 xdn
 sfN
 uXU
@@ -118441,21 +118446,21 @@ siU
 kPO
 oTE
 gAw
-evj
-fCR
+eRU
+lIe
 uhb
 uhb
 uhb
-lcK
-lcK
-dKS
+pNY
+pNY
+rJM
 uhb
 uhb
 uhb
 lqa
 jDc
-lIe
-wdN
+iBE
+xMw
 nCi
 aaa
 qYo
@@ -118698,8 +118703,8 @@ rCb
 vBb
 oVF
 nCi
-aql
-aDe
+vPN
+nOv
 uhb
 ebW
 kNG
@@ -118712,7 +118717,7 @@ uhb
 uhb
 uhb
 nCi
-wdN
+xMw
 nCi
 qYo
 qYo
@@ -119468,7 +119473,7 @@ xEt
 mWF
 bWp
 gAw
-piM
+hKx
 aFU
 pVY
 rdq
@@ -119726,8 +119731,8 @@ xqC
 mAm
 gAw
 fsC
-mIz
-fZo
+aLp
+kGz
 wSK
 gao
 rqy
@@ -119978,7 +119983,7 @@ qJI
 iQV
 nbZ
 tLC
-xEt
+hYL
 xEt
 uwQ
 gAw
@@ -120248,11 +120253,11 @@ jNn
 oQS
 tpS
 taA
-eaO
+uCv
 fMl
 ddW
 fMl
-vgs
+rOY
 mAt
 mAt
 cRJ
@@ -120481,7 +120486,7 @@ bpr
 anB
 ilG
 cwI
-qIJ
+wdN
 msB
 kXR
 owf
@@ -120510,7 +120515,7 @@ fMl
 fMl
 fMl
 iLv
-pvE
+lZU
 qCs
 jiX
 hLM
@@ -120767,7 +120772,7 @@ fMl
 xsN
 vUy
 iLv
-cTO
+pTs
 ifk
 mMb
 bNr
@@ -120995,7 +121000,7 @@ vog
 anB
 aVW
 lbl
-qIJ
+wdN
 msB
 kXR
 owf
@@ -121011,7 +121016,7 @@ uTb
 hHK
 kGj
 gXx
-uLd
+vBO
 gvX
 fMl
 fMl
@@ -121019,12 +121024,12 @@ fOp
 oQS
 tLp
 taA
-vgs
+rOY
 fMl
 fMl
 gvX
-cRY
-rIb
+biu
+lxl
 oUe
 jET
 kot
@@ -121252,11 +121257,11 @@ hQK
 pqr
 qJs
 tcy
-qIJ
-qIJ
+wdN
+wdN
 ePU
-elQ
-elQ
+laE
+laE
 sHT
 sHT
 jzC
@@ -121269,17 +121274,17 @@ feF
 gcr
 pTC
 irh
-bsX
-rOY
-rOY
-rOY
-xKi
-dxU
-kJA
-rOY
-rOY
-rOY
-pbp
+evj
+wxz
+wxz
+wxz
+lcK
+tLp
+fZo
+wxz
+wxz
+wxz
+orK
 omu
 mAt
 aAx
@@ -121525,15 +121530,15 @@ pTC
 hhS
 iQF
 pTC
-mca
+oRG
 gvX
 fMl
 fMl
-xCU
+ssH
 oQS
-dxU
+tLp
 taA
-wxz
+rIb
 fMl
 fMl
 gvX
@@ -121767,9 +121772,9 @@ gAw
 eNt
 ehD
 sHT
-qIJ
+wdN
 wKu
-elQ
+laE
 sHT
 pOf
 pOf
@@ -121781,19 +121786,19 @@ kmV
 pTC
 hWk
 gcr
-djj
+cTO
 iLv
-acD
-acD
-acD
-acD
-eUU
+aDe
+aDe
+aDe
+aDe
+mca
 dxU
-tcQ
-acD
-acD
-acD
-acD
+emP
+aDe
+aDe
+aDe
+aDe
 iLv
 oVW
 wFP
@@ -122041,18 +122046,18 @@ iQF
 mQO
 iLv
 vUy
-vih
-fMl
+ibe
+gvX
 fMl
 oQS
 dxU
 taA
 fMl
-fMl
+gvX
 uSs
 vUy
 iLv
-pvE
+lZU
 udV
 qYr
 dqD
@@ -122281,11 +122286,11 @@ kZq
 fzm
 ehD
 xEt
-xGf
-nUE
-xGf
+cft
+bfG
+cft
 mWF
-xGf
+cft
 xEt
 nlS
 cCY
@@ -122296,7 +122301,7 @@ pTC
 elH
 iQF
 pTC
-mca
+oRG
 gvX
 fMl
 fMl
@@ -122538,11 +122543,11 @@ rDq
 pjU
 qbu
 ykB
-qZo
-oqv
-ltC
+agi
+ubE
+pvE
 jcS
-ltC
+pvE
 oDl
 sMw
 cCY
@@ -122554,17 +122559,17 @@ eDZ
 rrU
 pTC
 irh
-bsX
-rOY
-rOY
-rOY
-xKi
+evj
+wxz
+wxz
+wxz
+lcK
 dxU
-kJA
-rOY
-rOY
-rOY
-pbp
+fZo
+wxz
+wxz
+wxz
+orK
 omu
 mAt
 fmi
@@ -122810,11 +122815,11 @@ pTC
 woj
 qcM
 pTC
-tSS
+jLo
 gvX
 fMl
 fMl
-knG
+tcQ
 oQS
 pAi
 taA
@@ -122822,7 +122827,7 @@ nYS
 fMl
 fMl
 gvX
-nOv
+xiD
 mAt
 kzt
 xQq
@@ -123072,15 +123077,15 @@ vUy
 pQz
 fMl
 fMl
-jPl
-vBO
-biu
+acD
+eaO
+aql
 fMl
 fMl
 esm
 vUy
 iLv
-pvE
+lZU
 cZl
 mPF
 kxv
@@ -123323,15 +123328,15 @@ gAw
 pTC
 eDZ
 rwI
-mYR
+pdp
 iLv
 fMl
 fMl
 fMl
 fMl
-jPl
-vBO
-biu
+acD
+eaO
+aql
 fMl
 fMl
 fMl
@@ -123581,14 +123586,14 @@ pTC
 aMM
 fwJ
 pTC
-knG
+tcQ
 fMl
 laX
 fMl
 vVD
-jPl
-vBO
-biu
+acD
+eaO
+aql
 aDR
 fMl
 laX

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -236,10 +236,8 @@
 	dir = 4
 	},
 /obj/machinery/duct,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/stone,
 /area/station/science/xenobiology)
 "acG" = (
@@ -2644,12 +2642,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aDe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "aDg" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate{
@@ -7393,19 +7388,14 @@
 /turf/open/floor/wood,
 /area/station/service/theater)
 "bKp" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Engine Cooling Bypass"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /obj/effect/turf_decal/box/corners,
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold/green/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "bKw" = (
@@ -7826,6 +7816,10 @@
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "bPI" = (
 /obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Gas to Filter"
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "bPM" = (
@@ -8508,11 +8502,11 @@
 /area/station/maintenance/department/science/xenobiology)
 "bWa" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/layer_manifold/green/visible,
 /obj/machinery/status_display/evac/directional/west,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold/green/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "bWb" = (
@@ -16731,10 +16725,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
-/obj/effect/turf_decal/stripes/corner{
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/stone,
 /area/station/science/xenobiology)
 "eaQ" = (
@@ -18412,12 +18406,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "evj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "evp" = (
 /obj/machinery/computer/records/medical{
 	dir = 8
@@ -18588,13 +18580,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
 /obj/machinery/button/door/directional/west{
 	id = "engsm";
 	name = "Radiation Shutters Control";
 	req_access = list("engineering")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "exK" = (
@@ -20013,8 +20004,6 @@
 	heat_proof = 1;
 	name = "Supermatter Chamber"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -22195,6 +22184,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
+"fqU" = (
+/obj/machinery/corral_corner{
+	mapping_id = "1"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "2"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "fqY" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -27909,6 +27907,7 @@
 /obj/structure/cable,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "gKI" = (
@@ -34380,10 +34379,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "irh" = (
-/obj/machinery/corral_corner{
-	mapping_id = "2"
-	},
 /obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "1"
+	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "irl" = (
@@ -37284,6 +37283,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "jcT" = (
@@ -43789,6 +43789,10 @@
 	pixel_y = 23
 	},
 /obj/structure/sign/delamination_counter/directional/west,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Gas to Chamber"
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "kDL" = (
@@ -45321,8 +45325,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "kXR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "kXS" = (
@@ -45700,12 +45702,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "lcK" = (
-/obj/machinery/duct,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "lcO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/corner{
@@ -49127,6 +49126,7 @@
 /obj/structure/cable,
 /obj/machinery/power/energy_accumulator/grounding_rod/anchored,
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "lSh" = (
@@ -49699,10 +49699,11 @@
 /turf/open/floor/iron,
 /area/station/medical/pathology)
 "mca" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "4"
 	},
-/turf/open/floor/stone,
+/mob/living/basic/slime,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "mck" = (
 /obj/structure/chair/office,
@@ -50984,7 +50985,9 @@
 /turf/open/floor/wood,
 /area/station/service/electronic_marketing_den)
 "msB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "msF" = (
@@ -53488,6 +53491,7 @@
 /area/station/medical/paramedic)
 "mWq" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
 "mWB" = (
@@ -54916,9 +54920,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /obj/structure/sign/warning/secure_area/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "nsd" = (
@@ -56560,6 +56564,17 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
+"nMC" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Engine Cooling Bypass"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "nMD" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark/side{
@@ -59186,9 +59201,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "owf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "owj" = (
@@ -61787,12 +61800,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pathology)
 "pff" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "pfh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69519,6 +69529,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port)
+"qWU" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "qWV" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
@@ -78091,10 +78110,11 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "tcQ" = (
-/obj/machinery/corral_corner{
-	mapping_id = "1"
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "2";
+	dir = 1
 	},
-/obj/structure/cable,
+/mob/living/basic/slime,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "tcT" = (
@@ -79121,14 +79141,6 @@
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/department/medical/morgue)
 "tsa" = (
-/obj/machinery/atmospherics/components/binary/pump/layer2{
-	dir = 8;
-	name = "Gas to Chamber"
-	},
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	dir = 4;
-	name = "Chamber to Cooling"
-	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
@@ -85434,11 +85446,8 @@
 /area/station/cargo/storage)
 "uSs" = (
 /obj/machinery/duct,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/stone,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "uSL" = (
 /obj/effect/turf_decal/box/white{
@@ -86258,8 +86267,6 @@
 /area/station/science/research)
 "vcO" = (
 /obj/machinery/power/supermatter_crystal/engine,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
 "vcU" = (
@@ -89911,7 +89918,6 @@
 "vYv" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -92319,13 +92325,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wxz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "wxF" = (
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood,
@@ -93367,8 +93373,6 @@
 	heat_proof = 1;
 	name = "Supermatter Chamber"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -120287,7 +120291,7 @@ bpr
 anB
 ilG
 cwI
-sHT
+aDe
 msB
 kXR
 owf
@@ -120801,7 +120805,7 @@ vog
 anB
 aVW
 lbl
-sHT
+aDe
 msB
 kXR
 owf
@@ -121058,11 +121062,11 @@ hQK
 pqr
 qJs
 tcy
-sHT
-sHT
+aDe
+aDe
 ePU
-sHT
-sHT
+pff
+pff
 sHT
 sHT
 jzC
@@ -121331,19 +121335,19 @@ pTC
 hhS
 iQF
 pTC
-iLv
+irh
 gvX
 fMl
 fMl
-fMl
+nYS
 oQS
 tLp
 taA
-fMl
+nYS
 fMl
 fMl
 gvX
-iLv
+irh
 mAt
 xIw
 pVk
@@ -121573,9 +121577,9 @@ gAw
 eNt
 ehD
 sHT
-sHT
+aDe
 wKu
-sHT
+pff
 sHT
 pOf
 pOf
@@ -121588,7 +121592,7 @@ pTC
 hWk
 gcr
 mQO
-tcQ
+irh
 gvX
 fMl
 fMl
@@ -121845,7 +121849,7 @@ pTC
 ezY
 iQF
 pTC
-evj
+iLv
 uSs
 uSs
 uSs
@@ -121857,7 +121861,7 @@ uSs
 uSs
 uSs
 uSs
-evj
+iLv
 mAt
 udV
 qYr
@@ -122087,11 +122091,11 @@ kZq
 fzm
 ehD
 xEt
-nlS
-xEt
-nlS
+evj
+lcK
+evj
 mWF
-nlS
+evj
 xEt
 nlS
 cCY
@@ -122102,19 +122106,19 @@ pTC
 elH
 iQF
 pTC
-pff
-lcK
-mca
-mca
-mca
-wxz
+iLv
+gvX
+tcQ
+fMl
+fMl
+oQS
 dxU
-aDe
+taA
+fMl
+fMl
 mca
-mca
-mca
-lcK
-pff
+gvX
+iLv
 mAt
 ilU
 qYr
@@ -122343,12 +122347,12 @@ wYa
 rDq
 pjU
 qbu
-sMw
-oDl
-sMw
-sMw
+ykB
+qWU
+nMC
+wxz
 jcS
-sMw
+wxz
 oDl
 sMw
 cCY
@@ -122363,11 +122367,11 @@ irh
 gvX
 fMl
 fMl
-wts
+fqU
 oQS
 dxU
 taA
-qUa
+rOY
 fMl
 fMl
 gvX
@@ -122616,19 +122620,19 @@ pTC
 woj
 qcM
 pTC
-iLv
+irh
 gvX
 fMl
 fMl
-fMl
+nYS
 oQS
 dxU
 taA
-fMl
+nYS
 fMl
 fMl
 gvX
-iLv
+irh
 mAt
 kzt
 xQq

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -232,12 +232,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "acD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/light/floor/has_bulb,
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "4"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/stone,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "acG" = (
 /obj/structure/table/reinforced,
@@ -588,15 +588,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
-"agi" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "agk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1459,11 +1450,8 @@
 /turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aql" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/stone,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "aqq" = (
 /obj/machinery/sparker/directional/west{
@@ -2649,10 +2637,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aDe" = (
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "aDg" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate{
@@ -2670,14 +2657,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "aDR" = (
-/obj/machinery/corral_corner{
-	mapping_id = "1"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "1"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/science/xenobiology)
 "aDZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -3295,16 +3277,6 @@
 /obj/structure/sign/warning/electric_shock/directional/west,
 /turf/open/space/basic,
 /area/space)
-"aLp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "aLq" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
@@ -4800,10 +4772,6 @@
 /obj/item/storage/wallet/random,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
-"bfG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "bfM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -5038,11 +5006,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "biu" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "6"
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "biv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -9177,11 +9145,6 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/service/bar/backroom)
-"cft" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "cfu" = (
 /turf/open/floor/circuit/green,
 /area/station/ai_monitored/turret_protected/ai_upload)
@@ -9449,6 +9412,15 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"ciU" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "cjj" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -12370,13 +12342,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cTO" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor{
-	id = "xenobio_maint_fore";
-	name = "Xenobiology Blast Door"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "cTW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13099,6 +13070,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pathology)
+"ddu" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "ddw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -14308,13 +14286,13 @@
 /turf/open/floor/iron,
 /area/station/science/circuits)
 "duq" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "1";
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/light/floor/has_bulb,
-/mob/living/basic/slime,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "dux" = (
 /obj/structure/table,
@@ -16754,10 +16732,16 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "eaO" = (
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Engine Cooling Bypass"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "eaQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17589,6 +17573,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"elO" = (
+/obj/machinery/door/poddoor{
+	id = "xenobio_maint_fore";
+	name = "Xenobiology Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "elP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -17653,15 +17647,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"emP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "emR" = (
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
@@ -18133,12 +18118,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "esm" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "4"
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
 	},
-/obj/machinery/light/floor/has_bulb,
-/mob/living/basic/slime,
-/turf/open/floor/engine,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/science/xenobiology)
 "eso" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
@@ -18443,13 +18429,8 @@
 /area/station/service/chapel/office)
 "evj" = (
 /obj/machinery/duct,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/stone,
+/obj/structure/cable,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "evp" = (
 /obj/machinery/computer/records/medical{
@@ -19707,6 +19688,14 @@
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"eMp" = (
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "3";
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "eMu" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
@@ -20181,10 +20170,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"eRU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
 "eSa" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -20730,11 +20715,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"eYw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "eYy" = (
 /obj/structure/cable,
 /obj/structure/closet/secure_closet/atmospherics,
@@ -24696,6 +24676,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"fXg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "fXi" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sign/plaques/kiddie/badger{
@@ -24915,15 +24900,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "fZo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "fZp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -27187,6 +27166,14 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/eva/abandoned)
+"gBl" = (
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "6";
+	dir = 2
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "gBm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -29494,6 +29481,16 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
+"hfJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "hfM" = (
 /obj/effect/decal/cleanable/glass,
 /obj/structure/sign/poster/contraband/random/directional/west,
@@ -30855,6 +30852,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
+"hwW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "hwX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31741,10 +31747,6 @@
 /obj/effect/landmark/start/bartender,
 /turf/open/floor/iron/grimy,
 /area/station/service/bar/backroom)
-"hKx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/science/xenobiology)
 "hKC" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -32836,10 +32838,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
-"hYL" = (
-/obj/structure/tank_holder/extinguisher,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "hYO" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -33089,14 +33087,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"ibe" = (
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "5";
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "ibh" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -35302,11 +35292,6 @@
 /obj/item/stamp/rd,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
-"iBE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "iBO" = (
 /obj/machinery/power/turbine/inlet_compressor,
 /turf/open/floor/engine,
@@ -40050,6 +40035,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
+"jJQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "jKb" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/white{
@@ -40214,13 +40208,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/security/evidence)
-"jLo" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "jLs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -40362,10 +40349,10 @@
 /area/station/hallway/primary/fore)
 "jNn" = (
 /obj/machinery/corral_corner{
-	mapping_id = "3"
+	mapping_id = "1"
 	},
 /obj/machinery/slime_pen_controller{
-	mapping_id = "3"
+	mapping_id = "2"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -42072,6 +42059,13 @@
 /obj/structure/filingcabinet/security,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
+"kgu" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "1"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "kgx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44055,10 +44049,6 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"kGz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/science/xenobiology)
 "kGA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/red,
@@ -45559,10 +45549,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating,
 /area/station/science/research/abandoned)
-"laE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
 "laJ" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
@@ -45784,12 +45770,12 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "lcK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "2";
 	dir = 1
 	},
-/turf/open/floor/stone,
+/mob/living/basic/slime,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "lcO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -47426,10 +47412,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"lxl" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/service/abandoned_gambling_den)
 "lxF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -47439,6 +47421,15 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"lxH" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor{
+	id = "xenobio_maint_fore";
+	name = "Xenobiology Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "lxM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -48305,12 +48296,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "lIe" = (
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/effect/landmark/event_spawn,
+/obj/machinery/duct,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "lIl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -49693,15 +49682,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/xenobiology)
-"lZU" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "lZX" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
@@ -49791,14 +49771,13 @@
 /turf/open/floor/iron,
 /area/station/medical/pathology)
 "mca" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/corral_corner{
+	mapping_id = "4"
 	},
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/stone,
+/obj/machinery/slime_pen_controller{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "mck" = (
 /obj/structure/chair/office,
@@ -51230,6 +51209,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
+"mud" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "muh" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil,
@@ -54133,6 +54120,11 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"nen" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "neu" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -56791,14 +56783,10 @@
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "nOv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating{
-	icon_state = "foam_plating"
-	},
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "nOz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
@@ -59044,16 +59032,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
-"orK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "orL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -60861,13 +60839,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
-"oRG" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "4"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "oRH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/tile/neutral/full,
@@ -61700,16 +61671,6 @@
 /obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/hfr_room)
-"pdp" = (
-/obj/machinery/door/poddoor{
-	id = "xenobio_maint_fore";
-	name = "Xenobiology Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "pdu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -61915,7 +61876,7 @@
 "pff" = (
 /obj/structure/cable,
 /obj/machinery/corral_corner{
-	mapping_id = "2"
+	mapping_id = "4"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -62431,6 +62392,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/station/service/theater/abandoned)
+"pkK" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "pkZ" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -63122,13 +63087,9 @@
 	},
 /area/station/maintenance/department/science/xenobiology)
 "pvE" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "pvI" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -64225,6 +64186,15 @@
 /obj/item/taperecorder,
 /turf/open/floor/plating,
 /area/station/security/detectives_office/private_investigators_office)
+"pHD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating{
+	icon_state = "foam_plating"
+	},
+/area/station/maintenance/department/science/xenobiology)
 "pHP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -64757,10 +64727,6 @@
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
-"pNY" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/smooth,
-/area/station/science/xenobiology)
 "pOf" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
@@ -64970,14 +64936,12 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "pQz" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "2";
-	dir = 1
-	},
-/obj/machinery/light/floor/has_bulb,
-/mob/living/basic/slime,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "pQN" = (
 /obj/machinery/duct,
 /obj/effect/landmark/start/hangover,
@@ -65208,19 +65172,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/science/circuits)
-"pTs" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "pTz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -72433,10 +72384,10 @@
 /area/station/security/warden)
 "rIb" = (
 /obj/machinery/corral_corner{
-	mapping_id = "2"
+	mapping_id = "6"
 	},
 /obj/machinery/slime_pen_controller{
-	mapping_id = "6"
+	mapping_id = "1"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -72596,13 +72547,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
-"rJM" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/station/science/xenobiology)
 "rJN" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/sink/kitchen/directional/south{
@@ -73063,7 +73007,7 @@
 /area/station/science/research)
 "rOY" = (
 /obj/machinery/corral_corner{
-	mapping_id = "6"
+	mapping_id = "5"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -73566,6 +73510,15 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"rUb" = (
+/obj/machinery/corral_corner{
+	mapping_id = "2"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "3"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "rUn" = (
 /obj/structure/sign/departments/science/directional/west,
 /obj/effect/turf_decal/tile/purple{
@@ -73647,6 +73600,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"rVP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/science/xenobiology)
 "rVX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -75013,6 +74970,13 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/station/maintenance/disposal/incinerator)
+"som" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "3"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "sox" = (
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
@@ -75331,15 +75295,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
 /area/station/service/bar/backroom)
-"ssH" = (
-/obj/machinery/corral_corner{
-	mapping_id = "4"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "ssM" = (
 /obj/structure/sign/departments/medbay/alt/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -76738,6 +76693,13 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
+"sKH" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/science/xenobiology)
 "sKJ" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
@@ -77675,6 +77637,15 @@
 /obj/structure/sign/warning/electric_shock/directional/east,
 /turf/open/space/basic,
 /area/space)
+"sVy" = (
+/obj/machinery/corral_corner{
+	mapping_id = "3"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "4"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "sVC" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
@@ -78264,11 +78235,9 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "tcQ" = (
-/obj/machinery/corral_corner{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "tcT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -80804,6 +80773,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/half,
 /area/station/security/office)
+"tKA" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "2"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "tKV" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -81274,6 +81250,15 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2,
 /turf/open/floor/engine/vacuum,
 /area/station/science/ordnance/freezerchamber)
+"tPu" = (
+/obj/machinery/light/floor/has_bulb,
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "1";
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "tPv" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -82256,17 +82241,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/medical/abandoned)
-"ubE" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Engine Cooling Bypass"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "ubL" = (
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
@@ -84406,15 +84380,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"uCv" = (
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "2"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "uCC" = (
 /obj/effect/landmark/start/cyborg,
 /obj/structure/cable,
@@ -85619,8 +85584,8 @@
 "uSs" = (
 /mob/living/basic/slime,
 /obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "6";
-	dir = 1
+	mapping_id = "5";
+	dir = 2
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -85766,6 +85731,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/hfr_room)
+"uUj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "uUl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -86603,6 +86572,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/pathology)
+"vfm" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/station/service/abandoned_gambling_den)
 "vfw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/line{
@@ -87341,6 +87314,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
+"vpi" = (
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "vpk" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -88499,7 +88478,7 @@
 "vBO" = (
 /obj/structure/cable,
 /obj/machinery/corral_corner{
-	mapping_id = "3"
+	mapping_id = "5"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -89485,15 +89464,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/engineering/gravity_generator)
-"vPN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
 "vPO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -89884,7 +89854,7 @@
 	mapping_id = "5"
 	},
 /obj/machinery/slime_pen_controller{
-	mapping_id = "4"
+	mapping_id = "6"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -90514,9 +90484,15 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "wdN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "wdO" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
@@ -90775,6 +90751,19 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
 /area/station/service/theater/abandoned)
+"wgm" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "wgn" = (
 /obj/structure/closet/masks,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -92508,13 +92497,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wxz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/stone,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/smooth,
 /area/station/science/xenobiology)
 "wxF" = (
 /obj/structure/sign/poster/random/directional/north,
@@ -95235,13 +95219,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/quartermaster)
-"xiD" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "1"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "xiG" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -95933,13 +95910,13 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "xsN" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "3"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/machinery/light/floor/has_bulb,
-/mob/living/basic/slime,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "xsP" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
@@ -96043,6 +96020,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
+"xtR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/duct,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "xtZ" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/delivery,
@@ -97215,6 +97202,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
+"xHa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "xHf" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/delivery,
@@ -97621,10 +97618,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den/gaming)
-"xMw" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
 "xMy" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -118192,8 +118185,8 @@ gAw
 bDe
 nTd
 nCi
-eYw
-eYw
+nOv
+nOv
 xdn
 sfN
 uXU
@@ -118446,21 +118439,21 @@ siU
 kPO
 oTE
 gAw
-eRU
-lIe
+tcQ
+pQz
 uhb
 uhb
 uhb
-pNY
-pNY
-rJM
+wxz
+wxz
+sKH
 uhb
 uhb
 uhb
 lqa
 jDc
-iBE
-xMw
+nen
+pkK
 nCi
 aaa
 qYo
@@ -118703,8 +118696,8 @@ rCb
 vBb
 oVF
 nCi
-vPN
-nOv
+jJQ
+pHD
 uhb
 ebW
 kNG
@@ -118717,7 +118710,7 @@ uhb
 uhb
 uhb
 nCi
-xMw
+pkK
 nCi
 qYo
 qYo
@@ -119473,7 +119466,7 @@ xEt
 mWF
 bWp
 gAw
-hKx
+aDR
 aFU
 pVY
 rdq
@@ -119731,8 +119724,8 @@ xqC
 mAm
 gAw
 fsC
-aLp
-kGz
+hfJ
+rVP
 wSK
 gao
 rqy
@@ -119983,7 +119976,7 @@ qJI
 iQV
 nbZ
 tLC
-hYL
+fZo
 xEt
 uwQ
 gAw
@@ -120249,15 +120242,15 @@ fOp
 fMl
 ddW
 fMl
-jNn
+fOp
 oQS
 tpS
 taA
-uCv
+rIb
 fMl
 ddW
 fMl
-rOY
+vpi
 mAt
 mAt
 cRJ
@@ -120486,7 +120479,7 @@ bpr
 anB
 ilG
 cwI
-wdN
+uUj
 msB
 kXR
 owf
@@ -120515,7 +120508,7 @@ fMl
 fMl
 fMl
 iLv
-lZU
+esm
 qCs
 jiX
 hLM
@@ -120760,19 +120753,19 @@ dhB
 gwK
 pTC
 iLv
-vUy
-duq
-fMl
+aql
+acD
+gvX
 fMl
 oQS
 tLp
 taA
 fMl
-fMl
-xsN
+gvX
+tPu
 vUy
 iLv
-pTs
+wgm
 ifk
 mMb
 bNr
@@ -121000,7 +120993,7 @@ vog
 anB
 aVW
 lbl
-wdN
+uUj
 msB
 kXR
 owf
@@ -121016,20 +121009,20 @@ uTb
 hHK
 kGj
 gXx
-vBO
+som
+fMl
+fMl
 gvX
-fMl
-fMl
-fOp
+sVy
 oQS
 tLp
 taA
-rOY
-fMl
-fMl
+vpi
 gvX
-biu
-lxl
+fMl
+fMl
+ddu
+vfm
 oUe
 jET
 kot
@@ -121257,11 +121250,11 @@ hQK
 pqr
 qJs
 tcy
-wdN
-wdN
+uUj
+uUj
 ePU
-laE
-laE
+pvE
+pvE
 sHT
 sHT
 jzC
@@ -121274,17 +121267,17 @@ feF
 gcr
 pTC
 irh
-evj
-wxz
-wxz
-wxz
-lcK
+duq
+duq
+xtR
+duq
+cTO
 tLp
-fZo
-wxz
-wxz
-wxz
-orK
+wdN
+duq
+xtR
+duq
+duq
 omu
 mAt
 aAx
@@ -121530,19 +121523,19 @@ pTC
 hhS
 iQF
 pTC
-oRG
+pff
+fMl
+fMl
 gvX
-fMl
-fMl
-ssH
+qUa
 oQS
 tLp
 taA
-rIb
-fMl
-fMl
+rUb
 gvX
-pff
+fMl
+fMl
+tKA
 mAt
 xIw
 pVk
@@ -121772,9 +121765,9 @@ gAw
 eNt
 ehD
 sHT
-wdN
+uUj
 wKu
-laE
+pvE
 sHT
 pOf
 pOf
@@ -121786,19 +121779,19 @@ kmV
 pTC
 hWk
 gcr
-cTO
+lxH
 iLv
-aDe
-aDe
-aDe
-aDe
-mca
+iLv
+iLv
+evj
+evj
+xHa
 dxU
-emP
-aDe
-aDe
-aDe
-aDe
+hwW
+evj
+evj
+iLv
+iLv
 iLv
 oVW
 wFP
@@ -122045,8 +122038,8 @@ ezY
 iQF
 mQO
 iLv
-vUy
-ibe
+aql
+uSs
 gvX
 fMl
 oQS
@@ -122054,10 +122047,10 @@ dxU
 taA
 fMl
 gvX
-uSs
-vUy
+eMp
+aql
 iLv
-lZU
+esm
 udV
 qYr
 dqD
@@ -122286,11 +122279,11 @@ kZq
 fzm
 ehD
 xEt
-cft
-bfG
-cft
+fXg
+aDe
+fXg
 mWF
-cft
+fXg
 xEt
 nlS
 cCY
@@ -122301,19 +122294,19 @@ pTC
 elH
 iQF
 pTC
-oRG
+pff
+fMl
+fMl
 gvX
-fMl
-fMl
-qUa
+mca
 oQS
 dxU
 taA
 wts
-fMl
-fMl
 gvX
-pff
+fMl
+fMl
+tKA
 mAt
 ilU
 qYr
@@ -122543,11 +122536,11 @@ rDq
 pjU
 qbu
 ykB
-agi
-ubE
-pvE
+ciU
+eaO
+xsN
 jcS
-pvE
+xsN
 oDl
 sMw
 cCY
@@ -122559,17 +122552,17 @@ eDZ
 rrU
 pTC
 irh
-evj
-wxz
-wxz
-wxz
-lcK
+duq
+duq
+xtR
+duq
+cTO
 dxU
-fZo
-wxz
-wxz
-wxz
-orK
+wdN
+duq
+xtR
+duq
+duq
 omu
 mAt
 fmi
@@ -122815,19 +122808,19 @@ pTC
 woj
 qcM
 pTC
-jLo
+vBO
+fMl
+fMl
 gvX
-fMl
-fMl
-tcQ
+rOY
 oQS
 pAi
 taA
-nYS
-fMl
-fMl
+jNn
 gvX
-xiD
+fMl
+fMl
+kgu
 mAt
 kzt
 xQq
@@ -123073,19 +123066,19 @@ woj
 rrU
 mQO
 iLv
-vUy
-pQz
 fMl
 fMl
-acD
-eaO
-aql
+gvX
+fMl
+mud
+lIe
+biu
+fMl
+gvX
 fMl
 fMl
-esm
-vUy
 iLv
-lZU
+esm
 cZl
 mPF
 kxv
@@ -123328,19 +123321,19 @@ gAw
 pTC
 eDZ
 rwI
-pdp
+elO
 iLv
-fMl
-fMl
-fMl
-fMl
-acD
-eaO
 aql
+gBl
+gvX
 fMl
+mud
+lIe
+biu
 fMl
-fMl
-fMl
+gvX
+lcK
+aql
 iLv
 oVW
 oTD
@@ -123586,15 +123579,15 @@ pTC
 aMM
 fwJ
 pTC
-tcQ
+rOY
 fMl
 laX
 fMl
 vVD
-acD
-eaO
-aql
-aDR
+mud
+lIe
+biu
+nYS
 fMl
 laX
 fMl

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2642,6 +2642,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aDe" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
@@ -15065,6 +15066,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
+"dEN" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "dEP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18406,7 +18414,7 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "evj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
 "evp" = (
@@ -19110,17 +19118,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
-"eFC" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Engine Cooling Bypass"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "eFK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24878,9 +24875,8 @@
 /area/station/science/genetics)
 "fZo" = (
 /obj/machinery/corral_corner{
-	mapping_id = "3"
+	mapping_id = "6"
 	},
-/obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "fZp" = (
@@ -26191,14 +26187,6 @@
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/service/chapel/storage)
-"gqc" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "gqd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -27591,6 +27579,15 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/science/breakroom)
+"gGU" = (
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "2"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "gHh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/bot,
@@ -32331,6 +32328,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"hTj" = (
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "2";
+	dir = 1
+	},
+/mob/living/basic/slime,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "hTk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34263,6 +34268,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/prison/garden)
+"ipd" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "ipk" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -34388,7 +34400,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "irh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
 "irl" = (
@@ -42933,6 +42945,12 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"ktr" = (
+/obj/machinery/corral_corner{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "ktv" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/command{
@@ -45708,14 +45726,16 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "lcK" = (
-/obj/machinery/corral_corner{
-	mapping_id = "1"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "2"
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Engine Cooling Bypass"
 	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "lcO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/corner{
@@ -49711,8 +49731,7 @@
 /area/station/medical/pathology)
 "mca" = (
 /obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "2";
-	dir = 1
+	mapping_id = "4"
 	},
 /mob/living/basic/slime,
 /turf/open/floor/engine,
@@ -51717,6 +51736,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/corporate_showroom)
+"mBA" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "mBD" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L9"
@@ -58611,10 +58638,10 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "omu" = (
-/obj/machinery/corral_corner{
-	mapping_id = "4"
-	},
 /obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "2"
+	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "omv" = (
@@ -61801,12 +61828,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pathology)
 "pff" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "pfh" = (
@@ -67504,13 +67526,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/lawoffice)
-"qxX" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "4"
-	},
-/mob/living/basic/slime,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "qya" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -72919,10 +72934,10 @@
 /area/station/science/research)
 "rOY" = (
 /obj/machinery/corral_corner{
-	mapping_id = "4"
+	mapping_id = "2"
 	},
 /obj/machinery/slime_pen_controller{
-	mapping_id = "4"
+	mapping_id = "6"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -78116,7 +78131,7 @@
 "tcQ" = (
 /obj/structure/cable,
 /obj/machinery/corral_corner{
-	mapping_id = "1"
+	mapping_id = "4"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -84647,6 +84662,15 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
+"uIt" = (
+/obj/machinery/corral_corner{
+	mapping_id = "4"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "uIF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/siphon/monitored/air_output{
 	dir = 4
@@ -88072,6 +88096,13 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/service/chapel/storage)
+"vzm" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "1"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "vzt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -88170,6 +88201,15 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
+"vAt" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "vAu" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
@@ -89700,10 +89740,10 @@
 /area/station/cargo/drone_bay)
 "vVD" = (
 /obj/machinery/corral_corner{
-	mapping_id = "2"
+	mapping_id = "5"
 	},
 /obj/machinery/slime_pen_controller{
-	mapping_id = "2"
+	mapping_id = "4"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -92328,10 +92368,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wxz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "3"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "wxF" = (
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood,
@@ -120291,7 +120333,7 @@ bpr
 anB
 ilG
 cwI
-evj
+irh
 msB
 kXR
 owf
@@ -120564,19 +120606,19 @@ qZb
 dhB
 gwK
 pTC
-nYS
+fOp
 fMl
 ddW
 fMl
-aDR
+jNn
 oQS
 tpS
 taA
-jNn
+gGU
 fMl
 ddW
 fMl
-fOp
+fZo
 mAt
 ifk
 mMb
@@ -120805,7 +120847,7 @@ vog
 anB
 aVW
 lbl
-evj
+irh
 msB
 kXR
 owf
@@ -121062,11 +121104,11 @@ hQK
 pqr
 qJs
 tcy
-evj
-evj
+irh
+irh
 ePU
-irh
-irh
+evj
+evj
 sHT
 sHT
 jzC
@@ -121335,19 +121377,19 @@ pTC
 hhS
 iQF
 pTC
-tcQ
+wxz
 gvX
 fMl
 fMl
-nYS
+fOp
 oQS
 tLp
 taA
-nYS
+fZo
 fMl
 fMl
 gvX
-tcQ
+dEN
 mAt
 xIw
 pVk
@@ -121577,9 +121619,9 @@ gAw
 eNt
 ehD
 sHT
-evj
-wKu
 irh
+wKu
+evj
 sHT
 pOf
 pOf
@@ -121596,15 +121638,15 @@ tcQ
 gvX
 fMl
 fMl
-nYS
+uIt
 oQS
 tLp
 taA
-fOp
+rOY
 fMl
 fMl
 gvX
-fZo
+omu
 oVW
 wFP
 pKd
@@ -122091,11 +122133,11 @@ kZq
 fzm
 ehD
 xEt
-wxz
 aDe
-wxz
+pff
+aDe
 mWF
-wxz
+aDe
 xEt
 nlS
 cCY
@@ -122108,7 +122150,7 @@ iQF
 pTC
 iLv
 gvX
-mca
+hTj
 fMl
 fMl
 oQS
@@ -122116,7 +122158,7 @@ dxU
 taA
 fMl
 fMl
-qxX
+mca
 gvX
 iLv
 mAt
@@ -122348,11 +122390,11 @@ rDq
 pjU
 qbu
 ykB
-pff
-eFC
-gqc
+vAt
+lcK
+mBA
 jcS
-gqc
+mBA
 oDl
 sMw
 cCY
@@ -122367,11 +122409,11 @@ tcQ
 gvX
 fMl
 fMl
-lcK
+qUa
 oQS
 dxU
 taA
-rOY
+wts
 fMl
 fMl
 gvX
@@ -122620,11 +122662,11 @@ pTC
 woj
 qcM
 pTC
-tcQ
+ipd
 gvX
 fMl
 fMl
-nYS
+ktr
 oQS
 dxU
 taA
@@ -122632,7 +122674,7 @@ nYS
 fMl
 fMl
 gvX
-tcQ
+vzm
 mAt
 kzt
 xQq
@@ -123391,7 +123433,7 @@ pTC
 aMM
 fwJ
 pTC
-wts
+ktr
 fMl
 laX
 fMl
@@ -123399,11 +123441,11 @@ vVD
 oQS
 pAi
 taA
-rOY
+aDR
 fMl
 laX
 fMl
-qUa
+nYS
 mAt
 iIn
 srI

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -232,13 +232,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "acD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/duct,
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/stone,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "acG" = (
 /obj/structure/table/reinforced,
@@ -2642,9 +2638,14 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aDe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating{
+	icon_state = "foam_plating"
+	},
+/area/station/maintenance/department/science/xenobiology)
 "aDg" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate{
@@ -2815,24 +2816,20 @@
 /turf/closed/wall/r_wall,
 /area/station/command/teleporter)
 "aFU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Xenobiology Maintenance"
-	},
+/obj/effect/landmark/blobstart,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/department/science/xenobiology)
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/small/red/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "aGg" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -5020,12 +5017,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "biu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/light/small/red/directional/north,
-/turf/open/floor/iron/smooth,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "biv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
@@ -5903,6 +5899,16 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"bsX" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "bsY" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 5
@@ -10504,15 +10510,6 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cwn" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "cwt" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/oil,
@@ -10733,6 +10730,9 @@
 "cza" = (
 /obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/arc_slimes{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "czf" = (
@@ -12239,6 +12239,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"cRY" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "cSm" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -12354,9 +12361,17 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cTO" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/smooth,
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/station/science/xenobiology)
 "cTW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12787,6 +12802,9 @@
 "cZl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/kirbyplants/random,
+/obj/structure/curtain/bounty{
+	pixel_y = 32
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
 "cZo" = (
@@ -13463,6 +13481,15 @@
 /obj/structure/sign/warning/radiation,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/project)
+"djj" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor{
+	id = "xenobio_maint_fore";
+	name = "Xenobiology Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "djk" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/computer/operating{
@@ -15527,6 +15554,13 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"dKS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/science/xenobiology)
 "dLd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16731,14 +16765,13 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "eaO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/corral_corner{
+	mapping_id = "6"
 	},
-/turf/open/floor/stone,
+/obj/machinery/slime_pen_controller{
+	mapping_id = "2"
+	},
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "eaQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17576,6 +17609,10 @@
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
+"elQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "elS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -18415,12 +18452,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "evj" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "3"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "evp" = (
 /obj/machinery/computer/records/medical{
 	dir = 8
@@ -20381,6 +20415,16 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/dark/side,
 /area/station/commons/fitness/recreation)
+"eUU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "eUZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
@@ -20706,6 +20750,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage)
+"eYE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "eYG" = (
 /obj/machinery/shower/directional/west{
 	name = "emergency shower"
@@ -21856,9 +21905,7 @@
 "fmi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
-/obj/structure/curtain/bounty{
-	pixel_y = 32
-	},
+/obj/machinery/barsign/all_access/directional/north,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "fmk" = (
@@ -23213,6 +23260,13 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/library/abandoned)
+"fCR" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "fCX" = (
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/circuit,
@@ -24878,13 +24932,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "fZo" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/science/xenobiology)
 "fZp" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -29620,14 +29670,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/bar)
-"hia" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "2";
-	dir = 1
-	},
-/mob/living/basic/slime,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "hie" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -33539,7 +33581,9 @@
 "ifk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/vending/cigarette,
-/obj/structure/sign/warning/electric_shock/directional/north,
+/obj/structure/curtain/bounty{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "ifp" = (
@@ -34390,10 +34434,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "irh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "irl" = (
 /turf/closed/wall/r_wall,
 /area/station/service/lawoffice)
@@ -36510,15 +36559,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/coldroom)
-"iTP" = (
-/obj/machinery/corral_corner{
-	mapping_id = "2"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "6"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "iUg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -40459,6 +40499,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/office)
+"jPl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "jPm" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
@@ -42585,6 +42633,12 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/wood,
 /area/station/service/theater/abandoned)
+"knG" = (
+/obj/machinery/corral_corner{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "knH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
@@ -43466,7 +43520,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/north,
-/obj/machinery/barsign/all_access/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
 "kzI" = (
@@ -43792,10 +43845,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/transit_tube)
-"kDu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "kDA" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -44242,6 +44291,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden/abandoned)
+"kJA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "kJH" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 8
@@ -45363,6 +45422,15 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"kYa" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small/red/directional/east,
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/plating{
+	icon_state = "foam_plating"
+	},
+/area/station/maintenance/department/science/xenobiology)
 "kYb" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
@@ -45724,10 +45792,8 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "lcK" = (
-/obj/machinery/corral_corner{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/smooth,
 /area/station/science/xenobiology)
 "lcO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -47028,6 +47094,14 @@
 /obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
+"ltC" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "ltD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
@@ -48239,19 +48313,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "lIe" = (
-/obj/effect/landmark/blobstart,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "lIl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -49723,10 +49788,10 @@
 /turf/open/floor/iron,
 /area/station/medical/pathology)
 "mca" = (
-/obj/machinery/plumbing/ooze_sucker{
+/obj/structure/cable,
+/obj/machinery/corral_corner{
 	mapping_id = "4"
 	},
-/mob/living/basic/slime,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "mck" = (
@@ -52393,6 +52458,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
+"mIz" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "mIA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -53702,6 +53777,16 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"mYR" = (
+/obj/machinery/door/poddoor{
+	id = "xenobio_maint_fore";
+	name = "Xenobiology Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "mZj" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	color = "#FFFF00";
@@ -54124,17 +54209,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"nfH" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Engine Cooling Bypass"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "nfR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/cyborg,
@@ -56731,14 +56805,11 @@
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "nOv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/structure/tank_holder/extinguisher,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "1"
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "nOz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -57238,6 +57309,10 @@
 /obj/effect/landmark/start/janitor,
 /turf/open/floor/iron/checker,
 /area/station/service/janitor)
+"nUE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "nUI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -58634,11 +58709,14 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "omu" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "omv" = (
 /obj/structure/table,
@@ -58925,6 +59003,17 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/entry)
+"oqv" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Engine Cooling Bypass"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "oqx" = (
 /obj/machinery/deepfryer,
 /obj/effect/turf_decal/bot,
@@ -60976,6 +61065,8 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
+/obj/structure/closet/emcloset/anchored,
+/obj/structure/sign/warning/secure_area/directional/south,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/supermatter/room)
 "oTH" = (
@@ -61004,9 +61095,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/xenoblood,
-/obj/structure/curtain/bounty{
-	pixel_y = 32
-	},
+/obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den)
 "oUh" = (
@@ -61411,13 +61500,15 @@
 /turf/open/misc/grass,
 /area/station/hallway/primary/fore)
 "pbp" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small/red/directional/east,
-/turf/open/floor/plating{
-	icon_state = "foam_plating"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/duct,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "pbq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -61824,9 +61915,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pathology)
 "pff" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "2"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "pfh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -62165,6 +62259,10 @@
 /obj/structure/sink/directional/north,
 /turf/open/floor/iron,
 /area/station/medical/medbay)
+"piM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/science/xenobiology)
 "pjb" = (
 /obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
@@ -63030,13 +63128,14 @@
 	},
 /area/station/maintenance/department/science/xenobiology)
 "pvE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/turf/open/floor/plating{
-	icon_state = "foam_plating"
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
 	},
-/area/station/maintenance/department/science/xenobiology)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "pvI" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -67886,7 +67985,9 @@
 "qCs" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/vending/assist,
-/obj/structure/sign/poster/contraband/random/directional/north,
+/obj/structure/curtain/bounty{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
 "qCA" = (
@@ -68400,6 +68501,10 @@
 "qIH" = (
 /turf/closed/wall/r_wall,
 /area/station/security/execution/transfer)
+"qIJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "qIK" = (
 /obj/effect/landmark/start/hangover,
 /obj/machinery/door/firedoor,
@@ -68963,14 +69068,24 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "qOg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Xenobiology Maintenance"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/science/xenobiology)
 "qOn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
@@ -69706,6 +69821,15 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"qZo" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "qZs" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -72311,9 +72435,9 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "rIb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/structure/cable,
 /turf/closed/wall/r_wall,
-/area/station/science/xenobiology)
+/area/station/service/abandoned_gambling_den)
 "rIh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment{
@@ -72929,11 +73053,13 @@
 /turf/open/floor/plating,
 /area/station/science/research)
 "rOY" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "1"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "rPc" = (
 /obj/effect/turf_decal/stripes/line{
@@ -73926,13 +74052,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"sbm" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "sbD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -76551,13 +76670,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"sKa" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "sKb" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics - Air Supply";
@@ -78137,11 +78249,13 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "tcQ" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "4"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "tcT" = (
 /obj/structure/disposalpipe/segment{
@@ -81388,6 +81502,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
+"tSS" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "tSU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -82452,7 +82573,7 @@
 "udV" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/small/directional/north,
-/obj/structure/sign/poster/contraband/arc_slimes{
+/obj/structure/curtain/bounty{
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
@@ -84823,6 +84944,13 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"uLd" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "3"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "uLe" = (
 /obj/structure/table/wood,
 /obj/machinery/light_switch/directional/west,
@@ -85471,8 +85599,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "uSs" = (
-/obj/machinery/duct,
-/obj/structure/cable,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "4"
+	},
+/mob/living/basic/slime,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "uSL" = (
@@ -86514,6 +86644,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"vgs" = (
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "vgu" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/line{
@@ -86662,6 +86798,14 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/permabrig,
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
+"vih" = (
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "2";
+	dir = 1
+	},
+/mob/living/basic/slime,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "vii" = (
 /turf/open/floor/iron/white/side{
 	dir = 4
@@ -88348,12 +88492,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port)
 "vBO" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
 /obj/structure/cable,
-/turf/open/floor/plating{
-	icon_state = "foam_plating"
-	},
-/area/station/maintenance/department/science/xenobiology)
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "vBX" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
@@ -90356,10 +90498,9 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "wdN" = (
-/obj/structure/sign/warning/secure_area/directional/south,
-/obj/structure/closet/emcloset/anchored,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
-/area/station/engineering/supermatter/room)
+/area/station/maintenance/department/science/xenobiology)
 "wdO" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/camera/directional/west{
@@ -92352,10 +92493,10 @@
 /area/station/maintenance/port/aft)
 "wxz" = (
 /obj/machinery/corral_corner{
-	mapping_id = "6"
+	mapping_id = "2"
 	},
 /obj/machinery/slime_pen_controller{
-	mapping_id = "2"
+	mapping_id = "6"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -96654,6 +96795,15 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"xCU" = (
+/obj/machinery/corral_corner{
+	mapping_id = "4"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "xDc" = (
 /obj/effect/landmark/start/hangover,
 /obj/effect/decal/cleanable/dirt,
@@ -96950,6 +97100,11 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
+"xGf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "xGh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow{
@@ -97301,6 +97456,14 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
+"xKi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "xKn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -97838,15 +98001,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/captain)
-"xSe" = (
-/obj/machinery/corral_corner{
-	mapping_id = "4"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "xSf" = (
 /obj/structure/bed,
 /obj/item/bedsheet/clown,
@@ -99010,12 +99164,6 @@
 /obj/structure/sign/calendar/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
-"yhu" = (
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "yhw" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -115723,19 +115871,19 @@ vVc
 aaa
 aaa
 uHd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+qYo
+uHd
+qYo
+uHd
+uHd
+uHd
+uHd
+uHd
+uHd
+qYo
+uHd
+uHd
+qYo
 aaa
 aaa
 aaa
@@ -115980,20 +116128,20 @@ vVc
 aaa
 aaa
 lvw
+vVc
+wyV
+nET
+qYo
 aaa
+qYo
+qYo
 aaa
+qYo
 aaa
+nET
+qYo
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+uHd
 aaa
 aaa
 aaa
@@ -116237,21 +116385,21 @@ vVc
 qYo
 qYo
 lvw
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lcC
+cXo
+nCi
+fqm
+fqm
+fqm
+fqm
+fqm
+fqm
+fqm
+nCi
+nCi
+djY
+uHd
+uHd
 aaa
 aaa
 aaa
@@ -116494,21 +116642,21 @@ vVc
 aaa
 aaa
 uHd
-qYo
-uHd
-qYo
-uHd
-uHd
-uHd
-uHd
-uHd
-uHd
-qYo
-uHd
-uHd
-qYo
-uHd
+bDe
+cXo
+fbp
+gZb
+rjz
+vPU
+hzj
+vPU
+rjz
+pvx
+jDc
+nCi
+nCi
 aaa
+qYo
 aaa
 aaa
 aaa
@@ -116751,22 +116899,22 @@ vVc
 aaa
 aaa
 uHd
-vVc
-wyV
-nET
+bDe
+sPB
+kYa
+nCi
+nCi
+nCi
+nCi
+nCi
+nCi
+nCi
+kwd
+pKc
+nCi
 qYo
-aaa
-qYo
-qYo
-aaa
-qYo
-aaa
-nET
-qYo
-aaa
 uHd
 uHd
-aaa
 aaa
 aaa
 aaa
@@ -117008,19 +117156,19 @@ vVc
 vVc
 abj
 abj
-lcC
-cXo
-nCi
-fqm
-fqm
-fqm
-fqm
-fqm
-fqm
-fqm
+mYy
+ptY
 nCi
 nCi
-djY
+sfN
+sfN
+dCf
+sfN
+sfN
+nCi
+nCi
+cJd
+fqm
 aaa
 qYo
 aaa
@@ -117266,21 +117414,21 @@ aaa
 aaa
 aad
 bDe
-cXo
-fbp
-gZb
-rjz
-vPU
-hzj
-vPU
-rjz
-pvx
-jDc
+udp
 nCi
+sfN
+sfN
+sfN
+iJw
+sfN
+sfN
+sfN
 nCi
-qYo
-uHd
-uHd
+hHF
+nCi
+vVc
+vVc
+vVc
 uHd
 uHd
 aaa
@@ -117523,21 +117671,21 @@ aad
 aad
 aad
 bDe
-sPB
-pbp
+anG
+nCi
+kFc
+ozA
+pJz
+xcR
+sfE
+gCt
+hKC
+nCi
+mFq
 nCi
 nCi
+hCt
 nCi
-nCi
-nCi
-nCi
-nCi
-kwd
-pKc
-nCi
-aaa
-qYo
-aaa
 aaa
 uHd
 aaa
@@ -117779,22 +117927,22 @@ vVc
 vVc
 vVc
 vVc
-mYy
-ptY
-nCi
+bDe
+udp
 nCi
 sfN
 sfN
-dCf
+sfN
+sfN
+sfN
 sfN
 sfN
 nCi
+hHF
 nCi
-cJd
-fqm
-vVc
-vVc
-vVc
+bVW
+dTH
+nCi
 qYo
 lvw
 aaa
@@ -118037,20 +118185,20 @@ cgR
 gAw
 gAw
 bDe
-udp
+nTd
 nCi
+eYE
+eYE
+xdn
 sfN
-sfN
-sfN
-iJw
-sfN
+uXU
 sfN
 sfN
 nCi
-hHF
+sAi
 nCi
-nCi
-hCt
+bET
+hVB
 nCi
 aaa
 uHd
@@ -118292,22 +118440,22 @@ tYJ
 siU
 kPO
 oTE
+gAw
+evj
+fCR
+uhb
+uhb
+uhb
+lcK
+lcK
+dKS
+uhb
+uhb
+uhb
+lqa
+jDc
+lIe
 wdN
-bDe
-anG
-nCi
-kFc
-ozA
-pJz
-xcR
-sfE
-gCt
-hKC
-nCi
-mFq
-nCi
-bVW
-dTH
 nCi
 aaa
 qYo
@@ -118550,21 +118698,21 @@ rCb
 vBb
 oVF
 nCi
-bDe
-udp
+aql
+aDe
+uhb
+ebW
+kNG
+imx
+xsH
+umb
+kNG
+lZF
+uhb
+uhb
+uhb
 nCi
-sfN
-sfN
-sfN
-sfN
-sfN
-sfN
-sfN
-nCi
-hHF
-nCi
-bET
-hVB
+wdN
 nCi
 qYo
 qYo
@@ -118808,19 +118956,19 @@ lns
 nXZ
 nCi
 qOg
-nTd
-nCi
-rIb
-rIb
-xdn
-sfN
-uXU
 uhb
 uhb
+yiB
+cQT
+rvq
+kPD
+tBM
+oWn
+sHW
+uhb
+jPZ
+oia
 nCi
-sAi
-lqa
-vBO
 uGn
 nCi
 aaa
@@ -119064,19 +119212,19 @@ vHc
 hvW
 sPh
 qtC
-aql
-pvE
+uOn
 uhb
-ebW
-kNG
-imx
-xsH
-umb
-kNG
-lZF
-uhb
-nCi
-nCi
+mOS
+fPl
+jqr
+vxQ
+vxQ
+vxQ
+lzc
+plQ
+dpN
+qUB
+qUB
 nCi
 opr
 nCi
@@ -119320,20 +119468,20 @@ xEt
 mWF
 bWp
 gAw
-nCi
+piM
 aFU
-nCi
-uhb
-yiB
-cQT
-rvq
-kPD
-tBM
-oWn
-sHW
-uhb
-jPZ
-oia
+pVY
+rdq
+gwx
+mgr
+mgr
+jba
+rtv
+gII
+wbS
+qaT
+vgE
+qUB
 nCi
 mwA
 jDc
@@ -119577,20 +119725,20 @@ ifw
 xqC
 mAm
 gAw
-cTO
-uOn
+fsC
+mIz
+fZo
+wSK
+gao
+rqy
+jKx
+rTW
+tuk
+oNd
+gAV
 uhb
-mOS
-fPl
-jqr
-vxQ
-vxQ
-vxQ
-lzc
-plQ
-dpN
-qUB
-qUB
+hSi
+wXZ
 nCi
 dOA
 cay
@@ -119834,20 +119982,20 @@ xEt
 xEt
 uwQ
 gAw
-biu
-lIe
-pVY
-rdq
-gwx
-mgr
-mgr
-jba
-rtv
-gII
-wbS
-qaT
-vgE
-qUB
+uhb
+uhb
+uhb
+uhb
+uhb
+uhb
+wyq
+xTs
+dDk
+uhb
+uhb
+uhb
+uhb
+uhb
 nCi
 gJy
 smj
@@ -120091,20 +120239,20 @@ pvI
 wDw
 cMr
 gAw
-fsC
-nOv
 uhb
-wSK
-gao
-rqy
-jKx
-rTW
-tuk
-oNd
-gAV
-uhb
-hSi
-wXZ
+fOp
+fMl
+ddW
+fMl
+jNn
+oQS
+tpS
+taA
+eaO
+fMl
+ddW
+fMl
+vgs
 mAt
 mAt
 cRJ
@@ -120333,7 +120481,7 @@ bpr
 anB
 ilG
 cwI
-pff
+qIJ
 msB
 kXR
 owf
@@ -120349,20 +120497,20 @@ gAw
 sQV
 pTC
 uhb
-uhb
-uhb
-uhb
-uhb
-uhb
-wyq
-xTs
-dDk
-uhb
-uhb
-uhb
-uhb
-uhb
-mAt
+iLv
+fMl
+fMl
+fMl
+fMl
+oQS
+tLp
+taA
+fMl
+fMl
+fMl
+fMl
+iLv
+pvE
 qCs
 jiX
 hLM
@@ -120606,20 +120754,20 @@ qZb
 dhB
 gwK
 pTC
-fOp
+iLv
+vUy
+duq
 fMl
-ddW
 fMl
-jNn
 oQS
-tpS
+tLp
 taA
-wxz
 fMl
-ddW
 fMl
-yhu
-mAt
+xsN
+vUy
+iLv
+cTO
 ifk
 mMb
 bNr
@@ -120847,7 +120995,7 @@ vog
 anB
 aVW
 lbl
-pff
+qIJ
 msB
 kXR
 owf
@@ -120862,21 +121010,21 @@ cYS
 uTb
 hHK
 kGj
-mQO
-iLv
+gXx
+uLd
+gvX
 fMl
 fMl
-fMl
-fMl
+fOp
 oQS
 tLp
 taA
+vgs
 fMl
 fMl
-fMl
-fMl
-iLv
-oVW
+gvX
+cRY
+rIb
 oUe
 jET
 kot
@@ -121104,11 +121252,11 @@ hQK
 pqr
 qJs
 tcy
-pff
-pff
+qIJ
+qIJ
 ePU
-aDe
-aDe
+elQ
+elQ
 sHT
 sHT
 jzC
@@ -121120,19 +121268,19 @@ qZb
 feF
 gcr
 pTC
-iLv
-vUy
-duq
-fMl
-fMl
-oQS
-tLp
-taA
-fMl
-fMl
-xsN
-vUy
-iLv
+irh
+bsX
+rOY
+rOY
+rOY
+xKi
+dxU
+kJA
+rOY
+rOY
+rOY
+pbp
+omu
 mAt
 aAx
 nxt
@@ -121377,19 +121525,19 @@ pTC
 hhS
 iQF
 pTC
-evj
+mca
 gvX
 fMl
 fMl
-fOp
+xCU
 oQS
-tLp
+dxU
 taA
-yhu
+wxz
 fMl
 fMl
 gvX
-sKa
+pff
 mAt
 xIw
 pVk
@@ -121619,9 +121767,9 @@ gAw
 eNt
 ehD
 sHT
-pff
+qIJ
 wKu
-aDe
+elQ
 sHT
 pOf
 pOf
@@ -121633,20 +121781,20 @@ kmV
 pTC
 hWk
 gcr
-mQO
+djj
+iLv
+acD
+acD
+acD
+acD
+eUU
+dxU
 tcQ
-gvX
-fMl
-fMl
-xSe
-oQS
-tLp
-taA
-iTP
-fMl
-fMl
-gvX
-omu
+acD
+acD
+acD
+acD
+iLv
 oVW
 wFP
 pKd
@@ -121890,21 +122038,21 @@ pTC
 pTC
 ezY
 iQF
-pTC
+mQO
 iLv
-uSs
-uSs
-uSs
-uSs
-eaO
+vUy
+vih
+fMl
+fMl
+oQS
 dxU
-acD
+taA
+fMl
+fMl
 uSs
-uSs
-uSs
-uSs
+vUy
 iLv
-mAt
+pvE
 udV
 qYr
 dqD
@@ -122133,11 +122281,11 @@ kZq
 fzm
 ehD
 xEt
-irh
-kDu
-irh
+xGf
+nUE
+xGf
 mWF
-irh
+xGf
 xEt
 nlS
 cCY
@@ -122148,19 +122296,19 @@ pTC
 elH
 iQF
 pTC
-iLv
-vUy
-hia
+mca
+gvX
 fMl
 fMl
+qUa
 oQS
 dxU
 taA
+wts
 fMl
 fMl
-mca
-vUy
-iLv
+gvX
+pff
 mAt
 ilU
 qYr
@@ -122390,11 +122538,11 @@ rDq
 pjU
 qbu
 ykB
-cwn
-nfH
-fZo
+qZo
+oqv
+ltC
 jcS
-fZo
+ltC
 oDl
 sMw
 cCY
@@ -122404,21 +122552,21 @@ iKH
 pTC
 eDZ
 rrU
-mQO
-tcQ
-gvX
-fMl
-fMl
-qUa
-oQS
+pTC
+irh
+bsX
+rOY
+rOY
+rOY
+xKi
 dxU
-taA
-wts
-fMl
-fMl
-gvX
+kJA
+rOY
+rOY
+rOY
+pbp
 omu
-oVW
+mAt
 fmi
 qYr
 bcg
@@ -122662,19 +122810,19 @@ pTC
 woj
 qcM
 pTC
-sbm
+tSS
 gvX
 fMl
 fMl
-lcK
+knG
 oQS
-dxU
+pAi
 taA
 nYS
 fMl
 fMl
 gvX
-rOY
+nOv
 mAt
 kzt
 xQq
@@ -122918,21 +123066,21 @@ qdP
 pTC
 woj
 rrU
-pTC
+mQO
 iLv
 vUy
 pQz
 fMl
 fMl
-oQS
-dxU
-taA
+jPl
+vBO
+biu
 fMl
 fMl
 esm
 vUy
 iLv
-mAt
+pvE
 cZl
 mPF
 kxv
@@ -123175,15 +123323,15 @@ gAw
 pTC
 eDZ
 rwI
-mQO
+mYR
 iLv
 fMl
 fMl
 fMl
 fMl
-oQS
-dxU
-taA
+jPl
+vBO
+biu
 fMl
 fMl
 fMl
@@ -123433,14 +123581,14 @@ pTC
 aMM
 fwJ
 pTC
-lcK
+knG
 fMl
 laX
 fMl
 vVD
-oQS
-pAi
-taA
+jPl
+vBO
+biu
 aDR
 fMl
 laX

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -232,12 +232,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "acD" = (
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "6";
-	dir = 2
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "acG" = (
 /obj/structure/table/reinforced,
@@ -1450,13 +1450,12 @@
 /turf/open/floor/iron/large,
 /area/station/commons/locker)
 "aql" = (
-/obj/machinery/light/floor/has_bulb,
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "1";
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "aqq" = (
 /obj/machinery/sparker/directional/west{
@@ -2642,10 +2641,15 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "aDe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "aDg" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate{
@@ -5017,13 +5021,13 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/aft)
 "biu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/machinery/duct,
-/obj/structure/cable,
 /turf/open/floor/stone,
 /area/station/science/xenobiology)
 "biv" = (
@@ -5450,6 +5454,13 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/command/gateway)
+"bng" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "3"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "bnt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -5844,14 +5855,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
-"bss" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "bsx" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/yellow{
@@ -6447,6 +6450,14 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"bAC" = (
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "3";
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "bAK" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/status_display/evac/directional/west,
@@ -6617,6 +6628,14 @@
 /obj/item/toy/figure/scientist,
 /turf/open/floor/iron,
 /area/station/science/lab)
+"bBV" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "bCb" = (
 /obj/machinery/growing/tray,
 /obj/effect/turf_decal/tile/blue{
@@ -7217,10 +7236,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/ce)
-"bIo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/science/xenobiology)
 "bIr" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -7235,14 +7250,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/ai_monitored/command/storage/eva)
-"bIC" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "2";
-	dir = 1
-	},
-/mob/living/basic/slime,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "bID" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -10203,6 +10210,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
+"cqV" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "2"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "crb" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/sandy_dirt,
@@ -10692,6 +10706,15 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"cys" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "cyv" = (
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/camera/directional/south{
@@ -12367,9 +12390,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cTO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/station/science/xenobiology)
 "cTW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -12830,15 +12859,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
-"cZx" = (
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "6"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "cZC" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -13028,6 +13048,14 @@
 /obj/structure/table/reinforced/rglass,
 /turf/open/floor/iron,
 /area/station/medical/treatment_center)
+"dcy" = (
+/obj/machinery/light/floor/has_bulb,
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "4"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "dcG" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/landmark/start/depsec/science,
@@ -13763,6 +13791,14 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos/project)
+"dma" = (
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "6";
+	dir = 2
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "dmq" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral{
@@ -14575,6 +14611,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"dxb" = (
+/obj/machinery/corral_corner{
+	mapping_id = "5"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "dxe" = (
 /turf/closed/wall,
 /area/station/medical/abandoned)
@@ -16755,12 +16797,14 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen)
 "eaO" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "1"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "eaQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18127,9 +18171,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "esm" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "eso" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/iron,
@@ -21748,6 +21792,10 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
+"fkS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/maintenance/department/science/xenobiology)
 "fkU" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/floor/has_bulb,
@@ -23378,11 +23426,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"fFJ" = (
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "fFK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24607,10 +24650,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
-"fWw" = (
-/obj/structure/tank_holder/extinguisher,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "fWx" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 4
@@ -24851,15 +24890,6 @@
 "fYU" = (
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
-"fYY" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "fZg" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -24908,9 +24938,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "fZo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "fZp" = (
 /obj/structure/disposalpipe/segment,
@@ -25980,15 +26010,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/service/library)
-"gnn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "gnw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -26150,6 +26171,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
+"gpa" = (
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "gpd" = (
 /obj/machinery/door/window/right/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -30509,13 +30534,6 @@
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/carpet/royalblack,
 /area/station/service/chapel/office)
-"hsD" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "2"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "hsK" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -32260,15 +32278,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/atmos)
-"hRE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
 "hRH" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -35392,14 +35401,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
-"iCS" = (
-/obj/machinery/light/floor/has_bulb,
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "4"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "iDc" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -37387,6 +37388,17 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"jdC" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Engine Cooling Bypass"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "jdL" = (
 /turf/closed/wall,
 /area/station/maintenance/fore)
@@ -37915,6 +37927,10 @@
 	dir = 8
 	},
 /area/station/hallway/primary/port)
+"jjM" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/station/service/abandoned_gambling_den)
 "jjR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -38653,6 +38669,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
+"jsB" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/smooth,
+/area/station/science/xenobiology)
 "jsE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -40316,16 +40336,6 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"jMv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "jMz" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -40422,19 +40432,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"jOl" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "jOo" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/stripes/line{
@@ -41496,6 +41493,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/construction)
+"kaC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating{
+	icon_state = "foam_plating"
+	},
+/area/station/maintenance/department/science/xenobiology)
 "kaF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -44480,6 +44486,10 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"kLJ" = (
+/obj/structure/tank_holder/extinguisher,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "kLK" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -45310,10 +45320,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"kWU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "kXa" = (
 /obj/machinery/defibrillator_mount/directional/north,
 /obj/effect/turf_decal/tile/blue/fourcorners,
@@ -45796,9 +45802,10 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "lcK" = (
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "lcO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/corner{
@@ -48309,9 +48316,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "lIe" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/delivery,
 /obj/structure/cable,
-/turf/open/floor/plating,
+/turf/open/floor/iron/smooth,
 /area/station/maintenance/department/science/xenobiology)
 "lIl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -50378,10 +50389,6 @@
 "mjz" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/lesser)
-"mjD" = (
-/obj/structure/cable,
-/turf/closed/wall/r_wall,
-/area/station/service/abandoned_gambling_den)
 "mjK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -50635,12 +50642,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"mmW" = (
-/obj/machinery/corral_corner{
-	mapping_id = "5"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "mne" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/iron/dark,
@@ -51322,6 +51323,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/service/bar)
+"muQ" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "1"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "muT" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -56793,9 +56801,14 @@
 /turf/open/floor/plating,
 /area/station/security/prison/safe)
 "nOv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/iron/smooth,
-/area/station/maintenance/department/science/xenobiology)
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "nOz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
@@ -57426,13 +57439,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/medical/pathology)
-"nWv" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "nWw" = (
 /mob/living/basic/mouse/gray,
 /obj/machinery/computer/cryopod/directional/west{
@@ -57476,14 +57482,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"nXk" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "nXo" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57998,6 +57996,19 @@
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating/airless,
 /area/station/science/ordnance/bomb)
+"oed" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "xenobio_maint_aft";
+	name = "Xenobiology Blast Door"
+	},
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "oel" = (
 /obj/structure/bed,
 /obj/item/bedsheet/orange,
@@ -58101,6 +58112,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/quartermaster)
+"ofB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "ofE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -60619,13 +60635,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
-"oNS" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "3"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "oOh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -63114,14 +63123,11 @@
 	},
 /area/station/maintenance/department/science/xenobiology)
 "pvE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "6"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/duct,
-/turf/open/floor/stone,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "pvI" = (
 /obj/item/kirbyplants/random,
@@ -64960,13 +64966,10 @@
 /turf/open/floor/iron,
 /area/station/service/kitchen/abandoned)
 "pQz" = (
-/obj/structure/cable,
-/obj/machinery/door/poddoor{
-	id = "xenobio_maint_fore";
-	name = "Xenobiology Blast Door"
+/obj/machinery/corral_corner{
+	mapping_id = "6"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "pQN" = (
 /obj/machinery/duct,
@@ -69499,14 +69502,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"qUd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "qUi" = (
 /obj/structure/disposalpipe/sorting/mail{
 	name = "Engineering Junction"
@@ -71448,6 +71443,13 @@
 /obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
+"ruD" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "ruN" = (
 /obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -72417,11 +72419,10 @@
 /turf/open/floor/iron,
 /area/station/security/warden)
 "rIb" = (
-/obj/machinery/corral_corner{
-	mapping_id = "6"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/xenobiology)
 "rIh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment{
@@ -72859,16 +72860,6 @@
 	dir = 4
 	},
 /area/station/engineering/lobby)
-"rMU" = (
-/obj/machinery/door/poddoor{
-	id = "xenobio_maint_fore";
-	name = "Xenobiology Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/science/xenobiology)
 "rNf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden{
@@ -73291,6 +73282,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
+"rRe" = (
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "4"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "rRm" = (
 /obj/structure/window/spawner/directional/south,
 /obj/effect/decal/cleanable/dirt,
@@ -73869,6 +73867,10 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
+"rYt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "rYA" = (
 /turf/closed/wall,
 /area/station/maintenance/department/security)
@@ -75610,6 +75612,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
+"sws" = (
+/obj/structure/cable,
+/obj/machinery/door/poddoor{
+	id = "xenobio_maint_fore";
+	name = "Xenobiology Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/science/xenobiology)
 "swD" = (
 /obj/machinery/power/emitter,
 /obj/effect/decal/cleanable/dirt,
@@ -75653,15 +75664,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"sxa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating{
-	icon_state = "foam_plating"
-	},
-/area/station/maintenance/department/science/xenobiology)
 "sxk" = (
 /obj/structure/barricade/wooden,
 /obj/structure/cable,
@@ -76967,16 +76969,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/medical/medbay)
-"sMR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/stone,
-/area/station/science/xenobiology)
 "sMU" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -78262,11 +78254,14 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "tcQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/turf/open/floor/stone,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "tcT" = (
 /obj/structure/disposalpipe/segment{
@@ -78389,13 +78384,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"teQ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/station/science/xenobiology)
 "teU" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -82155,10 +82143,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"uar" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/science/xenobiology)
 "uaz" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -82676,6 +82660,15 @@
 "ufR" = (
 /turf/closed/wall/r_wall,
 /area/station/security/warden)
+"uga" = (
+/obj/machinery/light/floor/has_bulb,
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "1";
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "ugc" = (
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /obj/structure/sign/poster/random/directional/north,
@@ -82805,6 +82798,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/bridge)
+"uhN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/science/xenobiology)
 "uhS" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -83427,17 +83424,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"uqd" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Engine Cooling Bypass"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "uqk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral,
@@ -85618,11 +85604,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "uSs" = (
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "5";
-	dir = 2
-	},
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "uSL" = (
@@ -85864,6 +85846,13 @@
 "uVk" = (
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
+"uVA" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/science/xenobiology)
 "uVF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -86125,13 +86114,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"uZa" = (
-/obj/effect/landmark/generic_maintenance_landmark,
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/maintenance/department/science/xenobiology)
 "uZf" = (
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/lavendergrass,
@@ -88507,7 +88489,7 @@
 "vBO" = (
 /obj/machinery/duct,
 /obj/structure/cable,
-/turf/open/floor/engine,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "vBX" = (
 /obj/structure/sign/nanotrasen,
@@ -90202,6 +90184,10 @@
 	dir = 1
 	},
 /area/station/engineering/atmos)
+"vZw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/open/floor/iron/smooth,
+/area/station/maintenance/department/science/xenobiology)
 "vZE" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -90511,10 +90497,11 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "wdN" = (
-/mob/living/basic/slime,
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "3";
-	dir = 1
+/obj/machinery/corral_corner{
+	mapping_id = "6"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "6"
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
@@ -91717,6 +91704,14 @@
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"wpM" = (
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "2";
+	dir = 1
+	},
+/mob/living/basic/slime,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "wpO" = (
 /obj/machinery/status_display/ai/directional/north,
 /obj/structure/table,
@@ -92509,8 +92504,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wxz" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/smooth,
+/mob/living/basic/slime,
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "5";
+	dir = 2
+	},
+/turf/open/floor/engine,
 /area/station/science/xenobiology)
 "wxF" = (
 /obj/structure/sign/poster/random/directional/north,
@@ -95022,13 +95021,6 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
-"xgp" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "4"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "xgt" = (
 /obj/structure/cable,
 /obj/structure/table/wood,
@@ -95929,13 +95921,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "xsN" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "xenobio_maint_aft";
-	name = "Xenobiology Blast Door"
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/stone,
 /area/station/science/xenobiology)
 "xsP" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -118185,8 +118175,8 @@ gAw
 bDe
 nTd
 nCi
-fZo
-fZo
+ofB
+ofB
 xdn
 sfN
 uXU
@@ -118439,21 +118429,21 @@ siU
 kPO
 oTE
 gAw
-nOv
-uZa
+vZw
+ruD
 uhb
 uhb
 uhb
-wxz
-wxz
-teQ
+jsB
+jsB
+uVA
 uhb
 uhb
 uhb
 lqa
 jDc
-lIe
-esm
+rIb
+gpa
 nCi
 aaa
 qYo
@@ -118696,8 +118686,8 @@ rCb
 vBb
 oVF
 nCi
-hRE
-sxa
+lIe
+kaC
 uhb
 ebW
 kNG
@@ -118710,7 +118700,7 @@ uhb
 uhb
 uhb
 nCi
-esm
+gpa
 nCi
 qYo
 qYo
@@ -119466,7 +119456,7 @@ xEt
 mWF
 bWp
 gAw
-bIo
+fkS
 aFU
 pVY
 rdq
@@ -119724,8 +119714,8 @@ xqC
 mAm
 gAw
 fsC
-jMv
-uar
+tcQ
+uhN
 wSK
 gao
 rqy
@@ -119976,7 +119966,7 @@ qJI
 iQV
 nbZ
 tLC
-fWw
+kLJ
 xEt
 uwQ
 gAw
@@ -120508,7 +120498,7 @@ fMl
 fMl
 fMl
 iLv
-xsN
+nOv
 qCs
 jiX
 hLM
@@ -120753,8 +120743,8 @@ dhB
 gwK
 pTC
 iLv
-lcK
-iCS
+uSs
+dcy
 gvX
 fMl
 oQS
@@ -120762,10 +120752,10 @@ tLp
 taA
 fMl
 gvX
-aql
+uga
 vUy
 iLv
-jOl
+oed
 ifk
 mMb
 bNr
@@ -121009,7 +120999,7 @@ uTb
 hHK
 kGj
 gXx
-xgp
+rRe
 fMl
 fMl
 gvX
@@ -121021,8 +121011,8 @@ nYS
 gvX
 fMl
 fMl
-eaO
-mjD
+muQ
+jjM
 oUe
 jET
 kot
@@ -121253,8 +121243,8 @@ tcy
 evj
 evj
 ePU
-cTO
-cTO
+esm
+esm
 sHT
 sHT
 jzC
@@ -121269,13 +121259,13 @@ pTC
 irh
 duq
 duq
-pvE
+biu
 duq
-bss
+acD
 tLp
-sMR
+cTO
 duq
-pvE
+biu
 duq
 duq
 omu
@@ -121527,7 +121517,7 @@ pff
 fMl
 fMl
 gvX
-mmW
+dxb
 oQS
 tLp
 taA
@@ -121535,7 +121525,7 @@ jNn
 gvX
 fMl
 fMl
-oNS
+bng
 mAt
 xIw
 pVk
@@ -121767,7 +121757,7 @@ ehD
 sHT
 evj
 wKu
-cTO
+esm
 sHT
 pOf
 pOf
@@ -121779,17 +121769,17 @@ kmV
 pTC
 hWk
 gcr
-pQz
+sws
 iLv
 iLv
 iLv
-vBO
-vBO
-biu
+fZo
+fZo
+aDe
 dxU
-gnn
-vBO
-vBO
+cys
+fZo
+fZo
 iLv
 iLv
 iLv
@@ -122038,8 +122028,8 @@ ezY
 iQF
 mQO
 iLv
-lcK
 uSs
+wxz
 gvX
 fMl
 oQS
@@ -122047,10 +122037,10 @@ dxU
 taA
 fMl
 gvX
-wdN
-lcK
+bAC
+uSs
 iLv
-xsN
+nOv
 udV
 qYr
 dqD
@@ -122279,11 +122269,11 @@ kZq
 fzm
 ehD
 xEt
-aDe
-kWU
-aDe
+lcK
+rYt
+lcK
 mWF
-aDe
+lcK
 xEt
 nlS
 cCY
@@ -122306,7 +122296,7 @@ fOp
 gvX
 fMl
 fMl
-oNS
+bng
 mAt
 ilU
 qYr
@@ -122536,11 +122526,11 @@ rDq
 pjU
 qbu
 ykB
-fYY
-uqd
-nXk
+eaO
+jdC
+bBV
 jcS
-nXk
+bBV
 oDl
 sMw
 cCY
@@ -122554,13 +122544,13 @@ pTC
 irh
 duq
 duq
-pvE
+biu
 duq
-bss
+acD
 dxU
-sMR
+cTO
 duq
-pvE
+biu
 duq
 duq
 omu
@@ -122808,11 +122798,11 @@ pTC
 woj
 qcM
 pTC
-nWv
+pvE
 fMl
 fMl
 gvX
-rIb
+pQz
 oQS
 pAi
 taA
@@ -122820,7 +122810,7 @@ vVD
 gvX
 fMl
 fMl
-hsD
+cqV
 mAt
 kzt
 xQq
@@ -123070,15 +123060,15 @@ fMl
 fMl
 gvX
 fMl
-qUd
-fFJ
-tcQ
+aql
+vBO
+xsN
 fMl
 gvX
 fMl
 fMl
 iLv
-xsN
+nOv
 cZl
 mPF
 kxv
@@ -123321,19 +123311,19 @@ gAw
 pTC
 eDZ
 rwI
-rMU
+mQO
 iLv
-lcK
-acD
+uSs
+dma
 gvX
 fMl
-qUd
-fFJ
-tcQ
+aql
+vBO
+xsN
 fMl
 gvX
-bIC
-lcK
+wpM
+uSs
 iLv
 oVW
 oTD
@@ -123579,14 +123569,14 @@ pTC
 aMM
 fwJ
 pTC
-rIb
+pQz
 fMl
 laX
 fMl
-cZx
-qUd
-fFJ
-tcQ
+wdN
+aql
+vBO
+xsN
 wts
 fMl
 laX

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2643,8 +2643,8 @@
 /area/station/cargo/storage)
 "aDe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "aDg" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate{
@@ -18406,10 +18406,9 @@
 /turf/open/floor/iron/grimy,
 /area/station/service/chapel/office)
 "evj" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "evp" = (
 /obj/machinery/computer/records/medical{
 	dir = 8
@@ -19111,6 +19110,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
+"eFC" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1;
+	name = "Engine Cooling Bypass"
+	},
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "eFK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -22184,15 +22194,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
-"fqU" = (
-/obj/machinery/corral_corner{
-	mapping_id = "1"
-	},
-/obj/machinery/slime_pen_controller{
-	mapping_id = "2"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
 "fqY" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -26190,6 +26191,14 @@
 	},
 /turf/open/floor/iron/dark/textured_half,
 /area/station/service/chapel/storage)
+"gqc" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "gqd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34379,12 +34388,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "irh" = (
-/obj/structure/cable,
-/obj/machinery/corral_corner{
-	mapping_id = "1"
-	},
-/turf/open/floor/engine,
-/area/station/science/xenobiology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter)
 "irl" = (
 /turf/closed/wall/r_wall,
 /area/station/service/lawoffice)
@@ -45702,9 +45708,14 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/captain)
 "lcK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
+/obj/machinery/corral_corner{
+	mapping_id = "1"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "2"
+	},
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "lcO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/stripes/corner{
@@ -49700,7 +49711,8 @@
 /area/station/medical/pathology)
 "mca" = (
 /obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "4"
+	mapping_id = "2";
+	dir = 1
 	},
 /mob/living/basic/slime,
 /turf/open/floor/engine,
@@ -56564,17 +56576,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"nMC" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Engine Cooling Bypass"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "nMD" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark/side{
@@ -61800,9 +61801,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pathology)
 "pff" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter)
+/turf/open/floor/iron,
+/area/station/engineering/supermatter/room)
 "pfh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67498,6 +67504,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/lawoffice)
+"qxX" = (
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "4"
+	},
+/mob/living/basic/slime,
+/turf/open/floor/engine,
+/area/station/science/xenobiology)
 "qya" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -69529,15 +69542,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/port)
-"qWU" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
-/turf/open/floor/iron,
-/area/station/engineering/supermatter/room)
 "qWV" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
@@ -78110,11 +78114,10 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "tcQ" = (
-/obj/machinery/plumbing/ooze_sucker{
-	mapping_id = "2";
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/corral_corner{
+	mapping_id = "1"
 	},
-/mob/living/basic/slime,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "tcT" = (
@@ -92325,10 +92328,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "wxz" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
@@ -120291,7 +120291,7 @@ bpr
 anB
 ilG
 cwI
-aDe
+evj
 msB
 kXR
 owf
@@ -120805,7 +120805,7 @@ vog
 anB
 aVW
 lbl
-aDe
+evj
 msB
 kXR
 owf
@@ -121062,11 +121062,11 @@ hQK
 pqr
 qJs
 tcy
-aDe
-aDe
+evj
+evj
 ePU
-pff
-pff
+irh
+irh
 sHT
 sHT
 jzC
@@ -121335,7 +121335,7 @@ pTC
 hhS
 iQF
 pTC
-irh
+tcQ
 gvX
 fMl
 fMl
@@ -121347,7 +121347,7 @@ nYS
 fMl
 fMl
 gvX
-irh
+tcQ
 mAt
 xIw
 pVk
@@ -121577,9 +121577,9 @@ gAw
 eNt
 ehD
 sHT
-aDe
+evj
 wKu
-pff
+irh
 sHT
 pOf
 pOf
@@ -121592,7 +121592,7 @@ pTC
 hWk
 gcr
 mQO
-irh
+tcQ
 gvX
 fMl
 fMl
@@ -122091,11 +122091,11 @@ kZq
 fzm
 ehD
 xEt
-evj
-lcK
-evj
+wxz
+aDe
+wxz
 mWF
-evj
+wxz
 xEt
 nlS
 cCY
@@ -122108,7 +122108,7 @@ iQF
 pTC
 iLv
 gvX
-tcQ
+mca
 fMl
 fMl
 oQS
@@ -122116,7 +122116,7 @@ dxU
 taA
 fMl
 fMl
-mca
+qxX
 gvX
 iLv
 mAt
@@ -122348,11 +122348,11 @@ rDq
 pjU
 qbu
 ykB
-qWU
-nMC
-wxz
+pff
+eFC
+gqc
 jcS
-wxz
+gqc
 oDl
 sMw
 cCY
@@ -122363,11 +122363,11 @@ pTC
 eDZ
 rrU
 mQO
-irh
+tcQ
 gvX
 fMl
 fMl
-fqU
+lcK
 oQS
 dxU
 taA
@@ -122620,7 +122620,7 @@ pTC
 woj
 qcM
 pTC
-irh
+tcQ
 gvX
 fMl
 fMl
@@ -122632,7 +122632,7 @@ nYS
 fMl
 fMl
 gvX
-irh
+tcQ
 mAt
 kzt
 xQq


### PR DESCRIPTION

## About The Pull Request
I have modified the engine layout and xenobio layout. The engine interior is now on layer 3 like the standard, and xenobio now has six slime pens, as opposed to the incredibly low 4 prior.

## Why It's Good For The Game

DeltaSM was always a pain in the ass and a bit confusing for newer players. I doubt anyone will complain with this change.
Xenobio likewise was also way too small compared to other maps. It made slime organization much more difficult.

## Changelog

:cl:
fix: Changed Deltastation SM interior to be in line with other SM interiors.
fix: Put Deltastation xenobio in line with other stations with the layout adjusted to fit 2 new slime pens.
/:cl:

![fgdht](https://github.com/Monkestation/Monkestation2.0/assets/70340593/392268fc-7d3e-4dce-9c09-7b96ff48799a)
![xbu](https://github.com/Monkestation/Monkestation2.0/assets/70340593/dee66d39-e50b-4caf-8736-0f5250753e58)
