### PR TITLE
Gaining `TRAIT_VIRUSIMMUNE` now properly cures any diseases

### DIFF
--- a/code/modules/mob/living/carbon/init_signals.dm
+++ b/code/modules/mob/living/carbon/init_signals.dm
@@ -84,7 +84,12 @@
 	SIGNAL_HANDLER
 
 	for(var/datum/disease/disease as anything in diseases)
-		disease.cure(FALSE)
+		// monkestation edit start - virology (cure() on advanced diseases has the infected mob as the first argument now)
+		if(istype(disease, /datum/disease/advanced))
+			disease.cure(src, FALSE)
+		else
+			disease.cure(FALSE)
+		// monkestation end
 
 /**
  * On gain of TRAIT_TOXIMMUNE

--- a/monkestation/code/modules/virology/readme.md
+++ b/monkestation/code/modules/virology/readme.md
@@ -13,6 +13,7 @@ This PR aims to make virology not ass to play with
 
 <!-- If you had to edit, or append to any core procs in the process of making this PR, list them here. APPEND: Also, please include any files that you've changed. .DM files that is. -->
 	- code\modules\mob\living\carbon\life.dm
+	- code\modules\mob\living\carbon\init_signals.dm
 	- code\datums\diseases\_disease.dm
 	- code\game\objects\effects\decals\cleanable.dm
 	- code\game\atoms.dm


### PR DESCRIPTION
It was supposed to do this in the first place, but our virology rework added a new argument to `cure()` for advanced diseases, and presumably this was runtiming when FALSE was passed as the first argument where the mob should be.

## Changelog
:cl:
fix: Gaining TRAIT_VIRUSIMMUNE now properly cures any diseases.
/:cl:
