### PR TITLE
Allow engineers to unlock air alarms

### DIFF
--- a/monkestation/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/monkestation/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -1,0 +1,3 @@
+/obj/machinery/airalarm
+	req_access = null
+	req_one_access = list(ACCESS_ATMOSPHERICS, ACCESS_ENGINE_EQUIP)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6081,6 +6081,7 @@
 #include "monkestation\code\modules\art_sci_overrides\faults\whispers.dm"
 #include "monkestation\code\modules\art_sci_overrides\faults\zap.dm"
 #include "monkestation\code\modules\assembly\flash.dm"
+#include "monkestation\code\modules\atmospherics\machinery\air_alarm\_air_alarm.dm"
 #include "monkestation\code\modules\atmospherics\machinery\air_alarm\air_alarm_ac.dm"
 #include "monkestation\code\modules\ballpit\ballbit_sink.dm"
 #include "monkestation\code\modules\ballpit\ballpit.dm"


### PR DESCRIPTION

## About The Pull Request

This allows normal station engineers to unlock default air alarms.

## Why It's Good For The Game

If you're fixing up an area, it's not uncommon to have to turn the air alarm to contaminated/draught/refill, and it's dumb that you don't have access, especially when you can just effortlessly unlock it with a multitool in a few seconds anyways.

## Changelog
:cl:
qol: Allow normal engis to unlock air alarms.
/:cl:
