### PR TITLE
Splicing symptom fixes

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -479,6 +479,8 @@
 		/obj/item/reagent_containers/cup/bottle,
 		/obj/item/reagent_containers/hypospray/medipen,
 		/obj/item/reagent_containers/syringe,
+		/obj/item/weapon/virusdish,//Monkestation Addition
+		/obj/item/food/monkeycube/mouse,//Monkestation Addition
 		))
 
 /*

--- a/monkestation/code/modules/virology/disease/_disease.dm
+++ b/monkestation/code/modules/virology/disease/_disease.dm
@@ -133,8 +133,9 @@ GLOBAL_LIST_INIT(virusDB, list())
 			machine = dish.loc
 
 	if(specified_stage)
-		for(var/datum/symptom/e in symptoms)
-			if(e.stage == specified_stage)
+		for(var/x in symptoms.len)
+			if(x == specified_stage)
+				var/datum/symptom/e = symptoms[x]
 				e.multiplier_tweak(0.1 * rand(1, 3))
 				minormutate(specified_stage)
 				if(e.chance == e.max_chance && prob(strength) && e.max_chance <= initial(e.max_chance) * 3)

--- a/monkestation/code/modules/virology/machines/splicer.dm
+++ b/monkestation/code/modules/virology/machines/splicer.dm
@@ -180,8 +180,8 @@
 
 	var/list/effects = dish.contained_virus.symptoms
 	for(var/x = 1 to effects.len)
-		var/datum/symptom/e = effects[x]
-		if(e.stage == target_stage)
+		if(x == target_stage)
+			var/datum/symptom/e = effects[x]
 			effects[x] = memorybank.Copy(dish.contained_virus)
 			dish.contained_virus.log += "<br />[ROUND_TIME()] [memorybank.name] spliced in by [key_name(usr)] (replaces [e.name])"
 			break


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes some niche bugs that you can run into while making viruses. Also expands the bio bags holdable list to include some items annoying to otherwise carry.

Fixes #1901
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It is a pain to store virus dishes that you do not need at the moment. Things should work.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Splicing a symptom on a symptom that isn't in its initial stage will now work
fix: Stage Occurrence mutations will now work on symptoms not in their initial stage
add: Bio bag can now carry mouse cubes and virus dishes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
