### PR TITLE
Medibots now auto-sync tech

### DIFF
--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -156,7 +156,7 @@
 /mob/living/basic/bot/medbot/LateInitialize()
 	. = ..()
 	if(!CONFIG_GET(flag/no_default_techweb_link) && !linked_techweb)
-		linked_techweb = SSresearch.science_tech
+		link_techweb(SSresearch.science_tech) // monkestation edit: techweb linking refactor
 
 /mob/living/basic/bot/medbot/update_icon_state()
 	. = ..()
@@ -187,7 +187,7 @@
 
 /mob/living/basic/bot/medbot/multitool_act(mob/living/user, obj/item/multitool/tool)
 	if(!QDELETED(tool.buffer) && istype(tool.buffer, /datum/techweb))
-		linked_techweb = tool.buffer
+		link_techweb(tool.buffer) // monkestation edit: techweb linking refactor
 	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 // Variables sent to TGUI
@@ -222,9 +222,10 @@
 		if("stationary_mode")
 			medical_mode_flags ^= MEDBOT_STATIONARY_MODE
 		if("sync_tech")
-			if(!linked_techweb)
+			if(!sync_tech())
 				to_chat(our_user, span_notice("No research techweb connected."))
 				return
+			/* monkestation start - move sync_tech into its own proc.
 			var/oldheal_amount = heal_amount
 			var/tech_boosters
 			for(var/index in linked_techweb.researched_designs)
@@ -236,6 +237,7 @@
 				heal_amount = (round(tech_boosters * 0.5, 0.1) * initial(heal_amount)) + initial(heal_amount) //every 2 tend wounds tech gives you an extra 100% healing, adjusting for unique branches (combo is bonus)
 				if(oldheal_amount < heal_amount)
 					speak("New knowledge found! Surgical efficacy improved to [round(heal_amount/initial(heal_amount)*100)]%!")
+			*/ // monkestation end
 
 	update_appearance()
 

--- a/monkestation/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/monkestation/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -1,0 +1,29 @@
+/mob/living/basic/bot/medbot/proc/link_techweb(datum/techweb/techweb)
+	if(QDELETED(techweb))
+		return FALSE
+	if(!QDELETED(linked_techweb))
+		UnregisterSignal(linked_techweb, COMSIG_TECHWEB_ADD_DESIGN)
+	linked_techweb = techweb
+	RegisterSignal(linked_techweb, COMSIG_TECHWEB_ADD_DESIGN, PROC_REF(on_techweb_add_design))
+	sync_tech()
+
+/mob/living/basic/bot/medbot/proc/on_techweb_add_design(datum/source, datum/design/design, custom)
+	SIGNAL_HANDLER
+	if(istype(design, /datum/design/surgery/healing))
+		addtimer(CALLBACK(src, PROC_REF(sync_tech)), 2.5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE) // signal is called BEFORE design is added, plus avoids spam if multiple are researched in quick succession
+
+/mob/living/basic/bot/medbot/proc/sync_tech()
+	if(QDELETED(linked_techweb))
+		return FALSE
+	var/oldheal_amount = heal_amount
+	var/tech_boosters
+	for(var/index in linked_techweb.researched_designs)
+		var/datum/design/surgery/healing/design = SSresearch.techweb_design_by_id(index)
+		if(!istype(design))
+			continue
+		tech_boosters++
+	if(tech_boosters)
+		heal_amount = (round(tech_boosters * 0.5, 0.1) * initial(heal_amount)) + initial(heal_amount) //every 2 tend wounds tech gives you an extra 100% healing, adjusting for unique branches (combo is bonus)
+		if(oldheal_amount < heal_amount)
+			speak("New knowledge found! Surgical efficacy improved to [round(heal_amount/initial(heal_amount)*100)]%!")
+	return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6549,6 +6549,7 @@
 #include "monkestation\code\modules\mob\living\living_defines.dm"
 #include "monkestation\code\modules\mob\living\status_procs.dm"
 #include "monkestation\code\modules\mob\living\basic\animatronic.dm"
+#include "monkestation\code\modules\mob\living\basic\bots\medbot\medbot.dm"
 #include "monkestation\code\modules\mob\living\basic\ggg\glerm.dm"
 #include "monkestation\code\modules\mob\living\basic\ggg\susflash.dm"
 #include "monkestation\code\modules\mob\living\basic\pets\parrot\parrot_ai\parroting_action.dm"


### PR DESCRIPTION

## About The Pull Request

This simply makes it so medibots will auto-sync whenever surgery tech is researched.

## Why It's Good For The Game

Nobody ever syncs the things (or prolly even knows they CAN sync it), which kinda sucks, because they're way more useful when you sync the tech.

## Changelog
:cl:
add: Medibots now automatically update their surgical knowledge whenever surgery tech is researched.
/:cl:
