### PR TITLE
Fixes borers not being able to be taken out of a host (how did nobody come across this yet?)

### DIFF
--- a/monkestation/code/modules/antagonists/borers/code/mobs/cortical_borer.dm
+++ b/monkestation/code/modules/antagonists/borers/code/mobs/cortical_borer.dm
@@ -437,8 +437,7 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 	var/obj/item/organ/internal/borer_body/borer_organ = locate() in human_host.organs
 	if(borer_organ)
 		borer_organ.Remove(human_host)
-	var/turf/human_turf = get_turf(human_host)
-	forceMove(human_turf.drop_location())
+	forceMove(human_host.drop_location())
 	human_host = null
 
 //borers shouldnt be able to whisper...


### PR DESCRIPTION
## About The Pull Request

Makes borers able to be taken out of hosts

Fixes #1918 

## Why It's Good For The Game

i think this is good for balance and the monkestation roleplay expirience

## Changelog

:cl:
fix: borers can now be taken out of a host
/:cl:
