### PR TITLE
Brads office for CentCom

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1281,6 +1281,9 @@
 /obj/structure/bed/maint,
 /obj/item/bedsheet/centcom,
 /obj/item/pillow,
+/obj/item/photo{
+	desc = "It's a family photograph. The edges of the picture are faded and the identities of anyone in it are lost to time."
+	},
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -1616,12 +1619,12 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/borbop)
 "el" = (
-/obj/structure/window/reinforced/tinted/frosted,
 /obj/machinery/light/small/maintenance/directional/west,
 /obj/structure/showcase/machinery/cloning_pod{
 	name = "Brad Pod";
 	desc = "Out of everything in this room, this is the only thing that is free from grime."
 	},
+/obj/structure/window/reinforced/tinted,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "em" = (
@@ -4063,10 +4066,10 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/hall)
 "lv" = (
-/obj/structure/window/reinforced/tinted/frosted,
 /obj/structure/table/wood,
 /obj/item/trash/tray,
 /obj/item/trash/energybar,
+/obj/structure/window/reinforced/tinted,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "lw" = (
@@ -4563,9 +4566,7 @@
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
 "mN" = (
-/obj/item/photo{
-	desc = "It's a family photograph. The edges of the picture are faded and the identities of anyone in it are lost to time."
-	},
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/white/corner,
 /area/centcom/central_command_areas/admin)
 "mO" = (
@@ -5140,7 +5141,7 @@
 /area/centcom/wizard_station)
 "ox" = (
 /obj/machinery/light/small/maintenance/directional/east,
-/obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/filingcabinet/employment,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "oy" = (
@@ -5932,7 +5933,8 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "qz" = (
-/turf/open/floor/carpet/lone,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "qA" = (
 /obj/structure/extinguisher_cabinet/directional/west,
@@ -6274,8 +6276,8 @@
 	},
 /area/centcom/syndicate_mothership/control)
 "rw" = (
-/obj/structure/window/reinforced/tinted/frosted,
 /obj/item/chair/wood,
+/obj/structure/window/reinforced/tinted,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "rx" = (
@@ -6526,6 +6528,7 @@
 /area/centcom/syndicate_mothership/control)
 "sh" = (
 /obj/item/kirbyplants/random,
+/obj/structure/sign/poster/official/no_erp/directional/west,
 /turf/open/floor/mineral/titanium/white,
 /area/centcom/central_command_areas/admin)
 "si" = (
@@ -8443,10 +8446,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership)
-"xx" = (
-/obj/structure/sign/poster/official/no_erp/directional/west,
-/turf/closed/indestructible/riveted,
-/area/centcom/central_command_areas/admin)
 "xy" = (
 /obj/structure/closet/secure_closet/contraband/armory,
 /turf/open/floor/iron/dark,
@@ -10357,8 +10356,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range_checkpoint_control)
 "CE" = (
-/obj/structure/window/reinforced/tinted/frosted,
 /obj/machinery/light/small/maintenance/directional/east,
+/obj/structure/window/reinforced/tinted,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "CF" = (
@@ -14561,7 +14560,11 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/admin)
 "Oo" = (
-/obj/structure/filingcabinet/employment,
+/obj/structure/table/reinforced,
+/obj/machinery/fax{
+	fax_name = "Brad";
+	name = "Brads Fax Machine"
+	},
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
@@ -52893,7 +52896,7 @@ Mc
 Mc
 Mc
 IS
-qz
+QV
 VD
 QK
 lv
@@ -53150,7 +53153,7 @@ Mc
 dQ
 Mc
 ky
-qz
+QV
 Ou
 Me
 rw
@@ -53923,7 +53926,7 @@ Mc
 On
 On
 On
-xx
+On
 On
 On
 On

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -4074,9 +4074,8 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/turf/open/floor/iron/white/side{
-	dir = 4
-	},
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "lw" = (
 /obj/structure/sign/poster/contraband/lizard{
@@ -4200,8 +4199,8 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "lL" = (
-/obj/structure/chair/comfy/beige,
-/turf/open/floor/iron/white/smooth_large,
+/obj/structure/chair/office,
+/turf/open/floor/iron/white/side,
 /area/centcom/central_command_areas/admin)
 "lM" = (
 /obj/structure/toilet{
@@ -6297,8 +6296,9 @@
 	},
 /area/centcom/syndicate_mothership/control)
 "rw" = (
+/obj/structure/window/reinforced/tinted,
 /obj/item/chair/wood,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "rx" = (
 /obj/structure/table/reinforced,
@@ -7131,6 +7131,11 @@
 /obj/machinery/chem_dispenser/fullupgrade,
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
+"tF" = (
+/obj/machinery/door/window,
+/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "tG" = (
 /obj/structure/railing{
 	dir = 6
@@ -7303,7 +7308,7 @@
 	name = "Brad Pod";
 	desc = "Out of everything in this room, this is the only thing that is free from grime."
 	},
-/turf/open/floor/iron/white/side{
+/turf/open/floor/iron/white/corner{
 	dir = 8
 	},
 /area/centcom/central_command_areas/admin)
@@ -9971,9 +9976,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/any/admin/captain,
-/turf/open/floor/iron/white/corner{
-	dir = 8
-	},
+/turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "Bt" = (
 /obj/effect/turf_decal/siding/wood{
@@ -10302,7 +10305,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
-/turf/open/floor/iron/white/side,
+/turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "Co" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -10408,9 +10411,8 @@
 /area/centcom/central_command_areas/firing_range_checkpoint_control)
 "CE" = (
 /obj/machinery/light/small/maintenance/directional/east,
-/turf/open/floor/iron/white/side{
-	dir = 8
-	},
+/obj/structure/window/reinforced/tinted,
+/turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "CF" = (
 /obj/machinery/suit_storage_unit/industrial,
@@ -13841,7 +13843,7 @@
 /obj/machinery/door/window{
 	dir = 1
 	},
-/turf/open/floor/iron/white/side,
+/turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "Mf" = (
 /obj/effect/turf_decal/siding/dark{
@@ -14005,7 +14007,7 @@
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "MA" = (
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/white/side,
 /area/centcom/central_command_areas/admin)
 "MB" = (
 /obj/structure/hedge,
@@ -15510,7 +15512,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
-/turf/open/floor/iron/white/corner,
+/turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "QL" = (
 /obj/structure/chair/office/tactical,
@@ -53477,7 +53479,7 @@ On
 qz
 QV
 Cn
-MA
+tF
 MA
 PI
 Ye

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1284,6 +1284,7 @@
 /obj/item/photo{
 	desc = "It's a family photograph. The edges of the picture are faded and the identities of anyone in it are lost to time."
 	},
+/obj/structure/sign/poster/official/work_for_a_future/directional/south,
 /turf/open/floor/iron/white/corner{
 	dir = 1
 	},
@@ -1620,11 +1621,10 @@
 /area/centcom/central_command_areas/borbop)
 "el" = (
 /obj/machinery/light/small/maintenance/directional/west,
-/obj/structure/showcase/machinery/cloning_pod{
-	name = "Brad Pod";
-	desc = "Out of everything in this room, this is the only thing that is free from grime."
-	},
 /obj/structure/window/reinforced/tinted,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "em" = (
@@ -4070,6 +4070,9 @@
 /obj/item/trash/tray,
 /obj/item/trash/energybar,
 /obj/structure/window/reinforced/tinted,
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "lw" = (
@@ -4567,6 +4570,7 @@
 /area/centcom/syndicate_mothership/control)
 "mN" = (
 /obj/structure/table/reinforced,
+/obj/structure/sign/poster/official/moth_meth/directional/west,
 /turf/open/floor/iron/white/corner,
 /area/centcom/central_command_areas/admin)
 "mO" = (
@@ -4938,6 +4942,10 @@
 "nU" = (
 /obj/machinery/vending/boozeomat,
 /turf/open/floor/carpet/executive,
+/area/centcom/central_command_areas/admin)
+"nW" = (
+/obj/structure/sign/poster/official/bless_this_spess/directional/west,
+/turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "nX" = (
 /obj/structure/hedge,
@@ -5934,6 +5942,9 @@
 /area/centcom/syndicate_mothership)
 "qz" = (
 /obj/effect/spawner/random/trash/cigbutt,
+/obj/structure/sign/poster/official/cleanliness/directional/north,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "qA" = (
@@ -6528,7 +6539,6 @@
 /area/centcom/syndicate_mothership/control)
 "sh" = (
 /obj/item/kirbyplants/random,
-/obj/structure/sign/poster/official/no_erp/directional/west,
 /turf/open/floor/mineral/titanium/white,
 /area/centcom/central_command_areas/admin)
 "si" = (
@@ -7280,6 +7290,10 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin_hangout)
 "ug" = (
+/obj/structure/showcase/machinery/cloning_pod{
+	name = "Brad Pod";
+	desc = "Out of everything in this room, this is the only thing that is free from grime."
+	},
 /turf/open/floor/iron/white/corner{
 	dir = 8
 	},
@@ -9942,6 +9956,14 @@
 /obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/hall)
+"Bs" = (
+/obj/structure/sign/poster/official/no_erp/directional/east,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "Bt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -10251,6 +10273,15 @@
 "Cn" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "Co" = (
@@ -13785,6 +13816,10 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/records/security/laptop/syndie,
 /obj/effect/spawner/random/entertainment/drugs,
+/obj/machinery/door/window{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "Mf" = (
@@ -15441,10 +15476,18 @@
 /area/centcom/central_command_areas/admin_hangout)
 "QK" = (
 /obj/structure/table/wood,
-/obj/structure/chem_separator,
+/obj/structure/chem_separator{
+	pixel_x = 2
+	},
 /obj/item/reagent_containers/cup/beaker{
-	pixel_x = 5;
-	pixel_y = -2
+	pixel_x = 8;
+	pixel_y = -3
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
@@ -52640,7 +52683,7 @@ Mc
 Mc
 On
 RY
-QV
+nW
 QV
 el
 mN
@@ -53669,7 +53712,7 @@ Mc
 On
 ox
 QV
-QV
+Bs
 CE
 ug
 du

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1622,9 +1622,16 @@
 "el" = (
 /obj/machinery/light/small/maintenance/directional/west,
 /obj/structure/window/reinforced/tinted,
-/obj/effect/spawner/random/trash/garbage,
-/obj/effect/spawner/random/trash/garbage,
-/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage{
+	pixel_x = 5;
+	pixel_y = -3
+	},
+/obj/effect/spawner/random/trash/garbage{
+	pixel_x = -4
+	},
+/obj/effect/spawner/random/trash/garbage{
+	pixel_y = 9
+	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "em" = (
@@ -5941,10 +5948,17 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "qz" = (
-/obj/effect/spawner/random/trash/cigbutt,
+/obj/effect/spawner/random/trash/cigbutt{
+	pixel_y = -2
+	},
 /obj/structure/sign/poster/official/cleanliness/directional/north,
-/obj/effect/spawner/random/trash/garbage,
-/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage{
+	pixel_x = 9;
+	pixel_y = 8
+	},
+/obj/effect/spawner/random/trash/garbage{
+	pixel_x = -6
+	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "qA" = (
@@ -10276,9 +10290,18 @@
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/spawner/random/trash/garbage,
-/obj/effect/spawner/random/trash/garbage,
-/obj/effect/spawner/random/trash/garbage,
-/obj/effect/spawner/random/trash/garbage,
+/obj/effect/spawner/random/trash/garbage{
+	pixel_x = -5;
+	pixel_y = -3
+	},
+/obj/effect/spawner/random/trash/garbage{
+	pixel_x = 7;
+	pixel_y = -1
+	},
+/obj/effect/spawner/random/trash/garbage{
+	pixel_x = -3;
+	pixel_y = 5
+	},
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -892,7 +892,9 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "cv" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/closet/crate/bin{
+	name = "treat storage"
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "cw" = (
@@ -941,7 +943,9 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
 "cC" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/closet/crate/bin{
+	name = "treat storage"
+	},
 /obj/structure/light_prism,
 /turf/open/floor/plating/abductor,
 /area/centcom/central_command_areas/admin)
@@ -1273,6 +1277,14 @@
 /obj/structure/closet/mini_fridge,
 /turf/open/floor/iron/dark/small,
 /area/centcom/central_command_areas/admin)
+"du" = (
+/obj/structure/bed/maint,
+/obj/item/bedsheet/centcom,
+/obj/item/pillow,
+/turf/open/floor/iron/white/corner{
+	dir = 1
+	},
+/area/centcom/central_command_areas/admin)
 "dv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
@@ -1465,7 +1477,9 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/admin_hangout)
 "dU" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/closet/crate/bin{
+	name = "treat storage"
+	},
 /turf/open/misc/grass,
 /area/centcom/central_command_areas/admin)
 "dV" = (
@@ -1601,6 +1615,15 @@
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/borbop)
+"el" = (
+/obj/structure/window/reinforced/tinted/frosted,
+/obj/machinery/light/small/maintenance/directional/west,
+/obj/structure/showcase/machinery/cloning_pod{
+	name = "Brad Pod";
+	desc = "Out of everything in this room, this is the only thing that is free from grime."
+	},
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "em" = (
 /obj/machinery/chem_mass_spec,
 /turf/open/floor/mineral/titanium/tiled/yellow,
@@ -1948,6 +1971,11 @@
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/borbop)
+"fr" = (
+/obj/machinery/door/window,
+/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "fs" = (
 /obj/structure/flora/tree/pine/style_random,
 /turf/open/misc/asteroid/snow/airless,
@@ -2993,11 +3021,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/closet/crate/bin{
-	pixel_x = 1;
-	pixel_y = 20;
-	density = 0
-	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin)
 "it" = (
@@ -3686,6 +3709,13 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/botany)
+"ky" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Brad Lods 'Office'"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/admin)
 "kz" = (
 /obj/machinery/door/airlock/maintenance/external{
 	name = "Bunk Room 1"
@@ -4032,6 +4062,13 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/hall)
+"lv" = (
+/obj/structure/window/reinforced/tinted/frosted,
+/obj/structure/table/wood,
+/obj/item/trash/tray,
+/obj/item/trash/energybar,
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "lw" = (
 /obj/structure/sign/poster/contraband/lizard{
 	pixel_x = -32
@@ -4153,6 +4190,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"lL" = (
+/obj/structure/chair/comfy/beige,
+/turf/open/floor/iron/white/side,
+/area/centcom/central_command_areas/admin)
 "lM" = (
 /obj/structure/toilet{
 	dir = 1
@@ -4521,6 +4562,12 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
+"mN" = (
+/obj/item/photo{
+	desc = "It's a family photograph. The edges of the picture are faded and the identities of anyone in it are lost to time."
+	},
+/turf/open/floor/iron/white/corner,
+/area/centcom/central_command_areas/admin)
 "mO" = (
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/dark/textured_half{
@@ -5091,6 +5138,11 @@
 	},
 /turf/open/floor/carpet,
 /area/centcom/wizard_station)
+"ox" = (
+/obj/machinery/light/small/maintenance/directional/east,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "oy" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /obj/effect/turf_decal/siding/dark,
@@ -5110,7 +5162,9 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "oA" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/closet/crate/bin{
+	name = "treat storage"
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
@@ -5877,6 +5931,9 @@
 	},
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
+"qz" = (
+/turf/open/floor/carpet/lone,
+/area/centcom/central_command_areas/admin)
 "qA" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark/textured_large,
@@ -6216,6 +6273,11 @@
 	dir = 4
 	},
 /area/centcom/syndicate_mothership/control)
+"rw" = (
+/obj/structure/window/reinforced/tinted/frosted,
+/obj/item/chair/wood,
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "rx" = (
 /obj/structure/table/reinforced,
 /obj/item/knife/combat/survival{
@@ -7214,6 +7276,11 @@
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin_hangout)
+"ug" = (
+/turf/open/floor/iron/white/corner{
+	dir = 8
+	},
+/area/centcom/central_command_areas/admin)
 "uh" = (
 /turf/open/floor/carpet/purple,
 /area/centcom/central_command_areas/admin)
@@ -8376,6 +8443,10 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership)
+"xx" = (
+/obj/structure/sign/poster/official/no_erp/directional/west,
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/admin)
 "xy" = (
 /obj/structure/closet/secure_closet/contraband/armory,
 /turf/open/floor/iron/dark,
@@ -9338,7 +9409,9 @@
 /turf/open/floor/plating/abductor,
 /area/centcom/central_command_areas/admin)
 "zY" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/closet/crate/bin{
+	name = "treat storage"
+	},
 /turf/open/floor/circuit,
 /area/centcom/central_command_areas/admin)
 "zZ" = (
@@ -10176,6 +10249,11 @@
 /obj/structure/desk_bell,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/borbop)
+"Cn" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "Co" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
@@ -10278,6 +10356,11 @@
 /obj/item/megaphone/sec,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range_checkpoint_control)
+"CE" = (
+/obj/structure/window/reinforced/tinted/frosted,
+/obj/machinery/light/small/maintenance/directional/east,
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "CF" = (
 /obj/machinery/suit_storage_unit/industrial,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east,
@@ -10352,7 +10435,9 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "CR" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/closet/crate/bin{
+	name = "treat storage"
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/centcom/central_command_areas/admin)
 "CS" = (
@@ -11185,6 +11270,14 @@
 /obj/effect/landmark/basketball/game_area,
 /turf/open/space/basic,
 /area/space)
+"Fk" = (
+/obj/machinery/modular_computer/preset/id/centcom{
+	dir = 1
+	},
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/centcom/central_command_areas/admin)
 "Fl" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
@@ -13672,7 +13765,9 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/botany)
 "Mb" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/closet/crate/bin{
+	name = "treat storage"
+	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "Mc" = (
@@ -13687,6 +13782,12 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/supply)
+"Me" = (
+/obj/structure/table/wood,
+/obj/machinery/computer/records/security/laptop/syndie,
+/obj/effect/spawner/random/entertainment/drugs,
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "Mf" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -13848,6 +13949,9 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
+"MA" = (
+/turf/open/floor/iron/white/side,
+/area/centcom/central_command_areas/admin)
 "MB" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/dark{
@@ -14456,6 +14560,12 @@
 "On" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/admin)
+"Oo" = (
+/obj/structure/filingcabinet/employment,
+/turf/open/floor/iron/white/corner{
+	dir = 4
+	},
+/area/centcom/central_command_areas/admin)
 "Op" = (
 /obj/structure/railing/wood,
 /obj/structure/table/reinforced,
@@ -14504,6 +14614,10 @@
 /obj/structure/railing,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
+"Ou" = (
+/obj/structure/chair/plastic,
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "Ov" = (
 /obj/structure/chair/wood/wings,
 /turf/open/floor/engine/cult,
@@ -14930,11 +15044,18 @@
 /area/centcom/central_command_areas/supply)
 "PH" = (
 /obj/machinery/firealarm/directional/south,
-/obj/structure/closet/crate/bin,
+/obj/structure/closet/crate/bin{
+	name = "treat storage"
+	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
+"PI" = (
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/centcom/central_command_areas/admin)
 "PJ" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -15315,6 +15436,15 @@
 /obj/structure/railing/wood,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin_hangout)
+"QK" = (
+/obj/structure/table/wood,
+/obj/structure/chem_separator,
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 5;
+	pixel_y = -2
+	},
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "QL" = (
 /obj/structure/chair/office/tactical,
 /turf/open/floor/carpet/royalblue,
@@ -15381,7 +15511,9 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "QW" = (
-/obj/structure/closet/crate/bin,
+/obj/structure/closet/crate/bin{
+	name = "treat storage"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/centcom/central_command_areas/admin)
 "QX" = (
@@ -15756,6 +15888,13 @@
 /obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/botany)
+"RY" = (
+/obj/machinery/light/small/maintenance/directional/west,
+/obj/effect/spawner/random/trash/bin{
+	name = "treat storage"
+	},
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "RZ" = (
 /obj/structure/chair/bronze{
 	name = "gamer chair mk2"
@@ -17050,6 +17189,12 @@
 	dir = 4
 	},
 /area/centcom/syndicate_mothership/control)
+"VD" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/centcom/central_command_areas/admin)
 "VE" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/ballistic/automatic/wt550,
@@ -17799,7 +17944,9 @@
 /area/centcom/syndicate_mothership/control)
 "XK" = (
 /obj/machinery/firealarm/directional/south,
-/obj/structure/closet/crate/bin,
+/obj/structure/closet/crate/bin{
+	name = "treat storage"
+	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -17929,6 +18076,10 @@
 /obj/structure/closet/crate/science,
 /obj/item/clothing/head/beret/science/rd,
 /turf/open/floor/carpet/purple,
+/area/centcom/central_command_areas/admin)
+"Ye" = (
+/obj/structure/curtain/bounty,
+/turf/closed/indestructible/fakeglass,
 /area/centcom/central_command_areas/admin)
 "Yf" = (
 /obj/effect/turf_decal/siding/wood{
@@ -18121,6 +18272,24 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
+"YO" = (
+/obj/structure/table/reinforced,
+/obj/item/stamp/centcom{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/obj/item/paper_bin{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/pen/fourcolor{
+	pixel_y = 6;
+	pixel_x = 5
+	},
+/turf/open/floor/iron/white/side{
+	dir = 1
+	},
+/area/centcom/central_command_areas/admin)
 "YP" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/spawner/random/structure/closet_maintenance,
@@ -52467,12 +52636,12 @@ Mc
 Mc
 Mc
 On
-pi
-pi
-pi
-uD
-gf
-Hp
+RY
+QV
+QV
+el
+mN
+Oo
 On
 On
 Zf
@@ -52724,13 +52893,13 @@ Mc
 Mc
 Mc
 IS
-pi
-pi
-XN
-eU
-pi
-pi
-Zf
+qz
+VD
+QK
+lv
+lL
+Fk
+Ye
 aa
 aa
 aa
@@ -52980,14 +53149,14 @@ CS
 Mc
 dQ
 Mc
-CS
-pi
-pi
-XN
-NK
-JC
-pi
-Zf
+ky
+qz
+Ou
+Me
+rw
+MA
+YO
+Ye
 aa
 aa
 aa
@@ -53238,13 +53407,13 @@ Mc
 Mc
 Mc
 On
-pi
-pi
-pi
-pi
-pi
-pi
-Zf
+qz
+QV
+Cn
+fr
+MA
+PI
+Ye
 aa
 aa
 aa
@@ -53495,12 +53664,12 @@ Mc
 Mc
 Mc
 On
-cv
-pi
-SI
-SI
-oT
-Ly
+ox
+QV
+QV
+CE
+ug
+du
 On
 aa
 aa
@@ -53754,7 +53923,7 @@ Mc
 On
 On
 On
-On
+xx
 On
 On
 On

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1981,11 +1981,6 @@
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/borbop)
-"fr" = (
-/obj/machinery/door/window,
-/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
-/turf/open/floor/iron/grimy,
-/area/centcom/central_command_areas/admin)
 "fs" = (
 /obj/structure/flora/tree/pine/style_random,
 /turf/open/misc/asteroid/snow/airless,
@@ -4076,11 +4071,12 @@
 /obj/structure/table/wood,
 /obj/item/trash/tray,
 /obj/item/trash/energybar,
-/obj/structure/window/reinforced/tinted,
 /obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/white/side{
+	dir = 4
+	},
 /area/centcom/central_command_areas/admin)
 "lw" = (
 /obj/structure/sign/poster/contraband/lizard{
@@ -4205,7 +4201,7 @@
 /area/centcom/central_command_areas/supply)
 "lL" = (
 /obj/structure/chair/comfy/beige,
-/turf/open/floor/iron/white/side,
+/turf/open/floor/iron/white/smooth_large,
 /area/centcom/central_command_areas/admin)
 "lM" = (
 /obj/structure/toilet{
@@ -6302,8 +6298,7 @@
 /area/centcom/syndicate_mothership/control)
 "rw" = (
 /obj/item/chair/wood,
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/white/smooth_large,
 /area/centcom/central_command_areas/admin)
 "rx" = (
 /obj/structure/table/reinforced,
@@ -7308,7 +7303,7 @@
 	name = "Brad Pod";
 	desc = "Out of everything in this room, this is the only thing that is free from grime."
 	},
-/turf/open/floor/iron/white/corner{
+/turf/open/floor/iron/white/side{
 	dir = 8
 	},
 /area/centcom/central_command_areas/admin)
@@ -9976,7 +9971,9 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/any/admin/captain,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/white/corner{
+	dir = 8
+	},
 /area/centcom/central_command_areas/admin)
 "Bt" = (
 /obj/effect/turf_decal/siding/wood{
@@ -10305,7 +10302,7 @@
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/white/side,
 /area/centcom/central_command_areas/admin)
 "Co" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
@@ -10411,8 +10408,9 @@
 /area/centcom/central_command_areas/firing_range_checkpoint_control)
 "CE" = (
 /obj/machinery/light/small/maintenance/directional/east,
-/obj/structure/window/reinforced/tinted,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/white/side{
+	dir = 8
+	},
 /area/centcom/central_command_areas/admin)
 "CF" = (
 /obj/machinery/suit_storage_unit/industrial,
@@ -13839,11 +13837,11 @@
 /obj/structure/table/wood,
 /obj/machinery/computer/records/security/laptop/syndie,
 /obj/effect/spawner/random/entertainment/drugs,
+/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
 /obj/machinery/door/window{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/white/side,
 /area/centcom/central_command_areas/admin)
 "Mf" = (
 /obj/effect/turf_decal/siding/dark{
@@ -14007,7 +14005,7 @@
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "MA" = (
-/turf/open/floor/iron/white/side,
+/turf/open/floor/iron/white/smooth_large,
 /area/centcom/central_command_areas/admin)
 "MB" = (
 /obj/structure/hedge,
@@ -15507,12 +15505,12 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/structure/window/reinforced/tinted{
 	dir = 8
 	},
-/turf/open/floor/iron/grimy,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/turf/open/floor/iron/white/corner,
 /area/centcom/central_command_areas/admin)
 "QL" = (
 /obj/structure/chair/office/tactical,
@@ -53479,7 +53477,7 @@ On
 qz
 QV
 Cn
-fr
+MA
 MA
 PI
 Ye


### PR DESCRIPTION

## About The Pull Request
I made my trash den to really give CentCom that grimey air that it was lacking (ignore the office with the loafer). :)
## Why It's Good For The Game
It's the only office on the CC level that doesn't contain gamer gear.
## Changelog
:cl:
add: Added Brads office to the CentCom level.
del: Removed a placeholder office to replace it with the new one.
\:cl:
