### PR TITLE
Adds Radiomagnetic Disruptor, a nanite purging reagent

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1307,3 +1307,31 @@
 	SIGNAL_HANDLER
 	if(current_cycle >= 28)
 		return COMSIG_CARBON_BLOCK_BREATH
+
+/datum/reagent/toxin/radiomagnetic_disruptor // MONKESTATION ADDITION: NANITE REMOVAL CHEM
+	name = "Radiomagnetic Disruptor"
+	color = "#1d5a1aae" // grayish dark green
+	description = "An unpleasant-looking yet useful chemical that rapidly destroys nanites while causing toxin damage and the occasional EMP."
+	taste_description = "radio waves"
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+	overdose_threshold = 20
+	toxpwr = 1
+	var/purge_rate = 10
+
+/datum/reagent/toxin/radiomagnetic_disruptor/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	if (SPT_PROB(2, seconds_per_tick))
+		empulse(affected_mob, heavy_range = 0, light_range = 1)
+	var/datum/component/nanites/nanites = affected_mob.GetComponent(/datum/component/nanites)
+	if (nanites)
+		nanites.adjust_nanites(null, -purge_rate * seconds_per_tick)
+
+/datum/reagent/toxin/radiomagnetic_disruptor/overdose_start(mob/living/M)
+	. = ..()
+	purge_rate *= 2
+
+/datum/reagent/toxin/radiomagnetic_disruptor/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	if (SPT_PROB(5, seconds_per_tick))
+		empulse(affected_mob, heavy_range = 1, light_range = 1)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -1311,27 +1311,31 @@
 /datum/reagent/toxin/radiomagnetic_disruptor // MONKESTATION ADDITION: NANITE REMOVAL CHEM
 	name = "Radiomagnetic Disruptor"
 	color = "#1d5a1aae" // grayish dark green
-	description = "An unpleasant-looking yet useful chemical that rapidly destroys nanites while causing toxin damage and the occasional EMP."
+	description = "A toxic chemical that rapidly destroys nanites and causes highly localized EMPs."
 	taste_description = "radio waves"
-	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED | REAGENT_DEAD_PROCESS
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 20
+	self_consuming = TRUE
 	toxpwr = 1
 	var/purge_rate = 10
 
 /datum/reagent/toxin/radiomagnetic_disruptor/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
+	handle_effects(affected_mob, seconds_per_tick)
+
+/datum/reagent/toxin/radiomagnetic_disruptor/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick)
+	. = ..()
+	handle_effects(affected_mob, seconds_per_tick)
+
+/datum/reagent/toxin/radiomagnetic_disruptor/proc/handle_effects(mob/living/carbon/affected_mob, seconds_per_tick)
 	if (SPT_PROB(2, seconds_per_tick))
 		empulse(affected_mob, heavy_range = 0, light_range = 1)
 	var/datum/component/nanites/nanites = affected_mob.GetComponent(/datum/component/nanites)
 	if (nanites)
-		nanites.adjust_nanites(null, -purge_rate * seconds_per_tick)
-
-/datum/reagent/toxin/radiomagnetic_disruptor/overdose_start(mob/living/M)
-	. = ..()
-	purge_rate *= 2
+		nanites.adjust_nanites(null, -(overdosed ? purge_rate * 2 : purge_rate) * seconds_per_tick)
 
 /datum/reagent/toxin/radiomagnetic_disruptor/overdose_process(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
-	if (SPT_PROB(5, seconds_per_tick))
+	if (SPT_PROB(4, seconds_per_tick))
 		empulse(affected_mob, heavy_range = 1, light_range = 1)

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -405,3 +405,8 @@
 	purity_min = 0.4
 	reaction_flags = REACTION_PH_VOL_CONSTANT
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DAMAGING | REACTION_TAG_OTHER
+
+/datum/chemical_reaction/radiomagnetic_disruptor // MONKESTATION ADDITION: NANITE REMOVAL CHEM
+	results = list(/datum/reagent/toxin/radiomagnetic_disruptor = 2)
+	required_reagents = list(/datum/reagent/thermite = 1, /datum/reagent/uranium/radium = 1)
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE | REACTION_TAG_OTHER

--- a/monkestation/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/healing.dm
@@ -61,6 +61,8 @@
 /datum/nanite_program/purging/active_effect()
 	host_mob.adjustToxLoss(-1)
 	for(var/datum/reagent/R in host_mob.reagents.reagent_list)
+		if (istype(R, /datum/reagent/toxin/radiomagnetic_disruptor))
+			continue
 		host_mob.reagents.remove_reagent(R.type,1)
 
 /datum/nanite_program/brain_heal
@@ -155,6 +157,8 @@
 /datum/nanite_program/purging_advanced/active_effect()
 	host_mob.adjustToxLoss(-1)
 	for(var/datum/reagent/toxin/R in host_mob.reagents.reagent_list)
+		if (istype(R, /datum/reagent/toxin/radiomagnetic_disruptor))
+			continue
 		host_mob.reagents.remove_reagent(R.type,1)
 
 /datum/nanite_program/regenerative_advanced


### PR DESCRIPTION
## About The Pull Request

Made this after a 3K Monkecoin code bounty was offered to me for it.

The recipe is a 1:1 ratio of thermite to radium.
It constantly purges nanites at 10/s in normal doses and 20/s when overdosed.
It causes occasional light EMPs in normal doses and lots of heavy EMPs when overdosed.
Also, it causes some toxin damage but it's weak in comparison to proper toxins.
## Why It's Good For The Game

This provides a way for medical to remove nanites from traitors, adds a cool new toxin to the game that has unique effects and allows people to self-purge nanites in the event that they're hijacked. It's probably the most effective way of destroying infectious nanites as those are nigh-impossible to remove using EMPs and shocks alone.
## Changelog
:cl:
add: Added the Radiomagnetic Disruptor reagent which rapidly purges nanites and causes localized EMPs.
/:cl:
