### PR TITLE
Fix Adminwho delays and client crashing

### DIFF
--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -194,7 +194,7 @@ GLOBAL_PROTECT(href_token)
 		return cached_feedback_link
 
 	if (!SSdbcore.IsConnected())
-		return FALSE
+		return null
 
 	var/datum/db_query/feedback_query = SSdbcore.NewQuery("SELECT feedback FROM [format_table_name("admin")] WHERE ckey = '[owner.ckey]'")
 
@@ -205,7 +205,8 @@ GLOBAL_PROTECT(href_token)
 
 	if(!feedback_query.NextRow())
 		qdel(feedback_query)
-		return FALSE // no feedback link exists
+		cached_feedback_link = NO_FEEDBACK_LINK // monkestation edit: fallback to prevent issues
+		return null // no feedback link exists
 
 	cached_feedback_link = feedback_query.item[1] || NO_FEEDBACK_LINK
 	qdel(feedback_query)


### PR DESCRIPTION

## Changelog
:cl:
fix: Adminwho should no longer have a weird delay every time it's ran.
fix: Clicking on an admin's name in Adminwho should no longer crash.
/:cl:
