### PR TITLE
Allow all silicons and simple/basic bots to listen to the DJ station

### DIFF
--- a/monkestation/code/modules/cassettes/machines/dj_station.dm
+++ b/monkestation/code/modules/cassettes/machines/dj_station.dm
@@ -182,8 +182,9 @@ GLOBAL_VAR(dj_booth)
 
 	var/list/viable_z = SSmapping.levels_by_any_trait(list(ZTRAIT_STATION, ZTRAIT_MINING, ZTRAIT_CENTCOM, ZTRAIT_RESERVED))
 	for(var/mob/person as anything in GLOB.player_list)
-		if(isAI(person) || isobserver(person) || isaicamera(person) || iscyborg(person))
+		if(issilicon(person) || isobserver(person) || isaicamera(person) || isbot(person))
 			active_listeners |=	person.client
+			continue
 		if(iscarbon(person))
 			var/mob/living/carbon/anything = person
 			if(!(anything in people_with_signals))


### PR DESCRIPTION
## About The Pull Request
Previously, the DJ station would only play to mobs of certain types. Among other things, this included AIs and Cyborgs, but not pAIs or simple/basic robots (i.e. Medibots).

This PR changes the DJ station, such that pAIs and simple/basic robots can now tune in too.

It also adds a small optimization, by telling the loop to continue to the next player mob, instead of then checking if the person is a carbon (which will always fail).

## Why It's Good For The Game
We already allow AIs and Cyborgs to listen to the DJ station - why not pAIs and simple/basic bots too?

## Changelog

:cl: MichiRecRoom
qol: Personal AIs and simple bots (such as Medibots) can now listen to the curator radio.
/:cl:
