### PR TITLE
Comms console sleeper agent hack effect now injects storyteller events instead of dynamic rulesets

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -885,6 +885,19 @@
 
 
 		if(HACK_SLEEPER) // Trigger one or multiple sleeper agents with the crew (or for latejoining crew)
+			// monkestation start: inject storyteller events instead of dynamic rulesets
+			var/event_to_spawn = pick_weight(list(
+				/datum/round_event_control/antagonist/solo/traitor/midround = 75,
+				// hmmm, let's rarely spawn some non-traitor antags just to spice things up a bit
+				/datum/round_event_control/antagonist/solo/heretic/midround = 15,
+				/datum/round_event_control/antagonist/solo/from_ghosts/wizard = 1
+			))
+			force_event_after(event_to_spawn, "[hacker] hacking a communications console", rand(20 SECONDS, 1 MINUTES))
+			priority_announce(
+				"Attention crew, it appears that someone on your station has hijacked your telecommunications and broadcasted an unknown signal.",
+				"[command_name()] High-Priority Update",
+			)
+			/*
 			var/datum/dynamic_ruleset/midround/sleeper_agent_type = /datum/dynamic_ruleset/midround/from_living/autotraitor
 			var/datum/game_mode/dynamic/dynamic = SSticker.mode
 			var/max_number_of_sleepers = clamp(round(length(GLOB.alive_player_list) / 20), 1, 3)
@@ -904,6 +917,7 @@
 					"Attention crew, it appears that someone on your station has hijacked your telecommunications and broadcasted an unknown signal.",
 					"[command_name()] High-Priority Update",
 				)
+			*/ // monkestation end
 
 #undef HACK_PIRATE
 #undef HACK_FUGITIVES


### PR DESCRIPTION

## About The Pull Request

This makes it so the `HACK_SLEEPER` result of the comms console hack will force a midround antag event, instead of injecting a dynamic ruleset.

There's also an uncommon chance to instead trigger midround heretics, and a quite rare chance of catching the attention of the Wizard Federation, bringing a wizard to the station.

## Why It's Good For The Game

Dynamic isn't supposed to be used here, and it can cause issues (like the fact that it doesn't prompt like storyteller midrounds do), so this makes things more consistent.

Also, the uncommon possibility of spawning non-traitor antags is a fun way to add variety to things.

## Changelog
:cl:
fix: Traitors hacking communication consoles will no longer trigger dynamic rulesets instead of storyteller events.
add: The "unknown signal" comms console hack now has a somewhat low chance of spawning certain non-traitor antagonists instead.
/:cl:
