### PR TITLE
Clockwork Bar in Boxstation Random Bars now points to an actual file

### DIFF
--- a/monkestation/code/random_rooms/bars/boxstation.dm
+++ b/monkestation/code/random_rooms/bars/boxstation.dm
@@ -12,7 +12,7 @@
 /datum/map_template/random_room/random_bar/box_base/clockwork
 	name = "Clockwork Bar"
 	room_id = "box_clockwork"
-	mappath = "_maps/~monkestation/RandomBars/Box/clockwork_icebox.dmm"
+	mappath = "_maps/~monkestation/RandomBars/Box/clockwork_bar.dmm"
 	weight = 2
 
 /datum/map_template/random_room/random_bar/box_base/cult


### PR DESCRIPTION
## About The Pull Request
Fixes #1958. Fixes #1959.

The "part-1" in the branch title signifies my intention to go a little further with a future PR. At a minimum, I want to change the random bar system to do the following when given a non-existent mappath:
1. Throw a runtime that is quite clearly a "Tried to load non-existent random bar."
2. Fill the bar areas with a floor, to ensure that the station does not get spaced from a bar loading.

That all said, this PR only fixes the file path. The above is simply safeguards I wish to implement against a potential failure.

## Why It's Good For The Game
https://www.youtube.com/watch?v=dQw4w9WgXcQ&pp=ygUIcmlja3JvbGw%3D

## Changelog
N/A