### PR TITLE
Clean up the maint pill reagent pool to keep them somewhat interesting

### DIFF
--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -118,11 +118,6 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/opacity = 175
 	///The rate of evaporation in units per call
 	var/evaporation_rate = 1
-
-	///is this chemical exempt from istype restrictions
-	var/bypass_restriction = FALSE
-	///chemicals that aren't typepathed but are useless so we remove
-	var/restricted = FALSE
 	/// do we have a turf exposure (used to prevent liquids doing un-needed processes)
 	var/turf_exposure = FALSE
 	/// are we slippery?

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -264,8 +264,8 @@
 	, "Surely, there's no way this could go bad.", "Winners don't do dr- oh what the heck!", "Free pills? At no cost, how could I lose?")
 
 /obj/item/reagent_containers/pill/maintenance/Initialize(mapload)
-	//monkestation edit on next line: replaced get_random_reagent_id_unrestricted() with get_random_reagent_id_unrestricted_non_ethanol()
-	list_reagents = list(get_random_reagent_id_unrestricted_non_ethanol() = rand(10,50)) //list_reagents is called before init, because init generates the reagents using list_reagents
+	//monkestation edit on next line: replaced get_random_reagent_id_unrestricted() with pick_weight(GLOB.weighted_random_reagents)
+	list_reagents = list(pick_weight(GLOB.weighted_random_reagents) = rand(10,50)) //list_reagents is called before init, because init generates the reagents using list_reagents
 	. = ..()
 	if(!GLOB.pill_names.len)
 		var/json = file("strings/pill_names.json")

--- a/monkestation/code/__HELPERS/reagents.dm
+++ b/monkestation/code/__HELPERS/reagents.dm
@@ -1,13 +1,13 @@
-///Returns a random reagent object minus ethanol reagents
-/proc/get_random_reagent_id_unrestricted_non_ethanol()
-	var/static/list/random_reagents
-	if(!random_reagents)
-		random_reagents = list()
-		for(var/datum/reagent/reagent_path as anything in subtypesof(/datum/reagent))
-			if(ispath(reagent_path, /datum/reagent/consumable) && !reagent_path::bypass_restriction)
-				continue
-			if(reagent_path::restricted)
-				continue
-			random_reagents += reagent_path
-	var/picked_reagent = pick(random_reagents)
-	return picked_reagent
+GLOBAL_LIST_INIT(weighted_random_reagents, init_weighted_random_reagents())
+
+/proc/init_weighted_random_reagents()
+	var/regex/bad_desc_regex = new(@"(?:coder|adminhelp|bugged)", "i")
+	. = list()
+	for(var/datum/reagent/reagent_path as anything in subtypesof(/datum/reagent))
+		if(ispath(reagent_path, /datum/reagent/consumable) && !reagent_path::bypass_restriction)
+			continue
+		if(reagent_path::restricted || !length(reagent_path::name) || !reagent_path::random_weight)
+			continue
+		if(reagent_path::description && findtext(reagent_path::description, bad_desc_regex))
+			continue
+		.[reagent_path] = reagent_path::random_weight

--- a/monkestation/code/modules/reagents/_reagents.dm
+++ b/monkestation/code/modules/reagents/_reagents.dm
@@ -1,3 +1,9 @@
 /datum/reagent
 	/// What can process this? ORGANIC, SYNTHETIC, or ORGANIC | SYNTHETIC?. We'll assume by default that it affects organics.
 	var/process_flags = ORGANIC
+	/// Is this chemical exempt from istype restrictions?
+	var/bypass_restriction = FALSE
+	/// Chemicals that aren't typepathed but are useless so we remove.
+	var/restricted = FALSE
+	/// The weight of the reagent to use when randomly selecting a reagent.
+	var/random_weight = 10

--- a/monkestation/code/modules/reagents/misc.dm
+++ b/monkestation/code/modules/reagents/misc.dm
@@ -1,5 +1,29 @@
+/datum/reagent/medicine/potass_iodide
+	description = "Heals low toxin damage while the patient is irradiated, and will halt the damaging effects of radiation. Can be used to decontaminate irradiated items."
+
+// Reagents that shouldn't be in the random pool due to the fact they derail everything.
 /datum/reagent/romerol
 	restricted = TRUE
 
-/datum/reagent/medicine/potass_iodide
-	description = "Heals low toxin damage while the patient is irradiated, and will halt the damaging effects of radiation. Can be used to decontaminate irradiated items."
+// Reagents that shouldn't be in the random pool, as they're either completely useless or shouldn't exist on their own.
+/datum/reagent/slime_ooze
+	restricted = TRUE
+
+/datum/reagent/reaction_agent
+	restricted = TRUE
+
+/datum/reagent/catalyst_agent
+	restricted = TRUE
+
+/datum/reagent/universal_indicator
+	restricted = TRUE
+
+/datum/reagent/blob
+	restricted = TRUE
+
+// Reagents that aren't entirely useless but there's a bajillion subtypes and thus the pick is biased.
+/datum/reagent/carpet
+	random_weight = 2
+
+/datum/reagent/colorful_reagent
+	random_weight = 2


### PR DESCRIPTION
## Changelog
:cl:
fix: Reagents that shouldn't exist on their own in the first place can no longer appear in maint pills.
qol: Removed some completely useless reagents from the maint pill pool, such as those related to pH or purity.
balance: Maint pills are now less biased towards certain reagents with a large number of variants, i.e carpet or colorful reagent.
/:cl:
