### PR TITLE
Fix weird oozeling revival bug that results in their items being sent to the void

### DIFF
--- a/monkestation/code/modules/smithing/oozelings/body/organs.dm
+++ b/monkestation/code/modules/smithing/oozelings/body/organs.dm
@@ -217,26 +217,26 @@
 		qdel(GetComponent(/datum/component/gps))
 
 	//we have the plasma. we can rebuild them.
-	var/mob/living/carbon/human/new_body = new /mob/living/carbon/human(src.loc)
+	var/mob/living/carbon/human/new_body = new /mob/living/carbon/human(drop_location())
 
 	new_body.underwear = "Nude"
 	new_body.undershirt = "Nude" //Which undershirt the player wants
 	new_body.socks = "Nude" //Which socks the player wants
-	stored_dna.transfer_identity(new_body, transfer_SE=1)
+	stored_dna.transfer_identity(new_body, transfer_SE = TRUE)
 	new_body.dna.features["mcolor"] = new_body.dna.features["mcolor"]
 	new_body.dna.update_uf_block(DNA_MUTANT_COLOR_BLOCK)
 	new_body.real_name = new_body.dna.real_name
 	new_body.name = new_body.dna.real_name
-	new_body.updateappearance(mutcolor_update=1)
+	new_body.updateappearance(mutcolor_update = TRUE)
 	new_body.domutcheck()
-	new_body.forceMove(get_turf(src))
-	new_body.blood_volume = BLOOD_VOLUME_SAFE+60
+	new_body.forceMove(drop_location())
+	new_body.blood_volume = BLOOD_VOLUME_SAFE + 60
 	REMOVE_TRAIT(new_body, TRAIT_NO_TRANSFORM, REF(src))
-	if(brainmob)
+	if(!QDELETED(brainmob))
 		SSquirks.AssignQuirks(new_body, brainmob.client)
 	var/obj/item/organ/internal/brain/new_body_brain = new_body.get_organ_slot(ORGAN_SLOT_BRAIN)
 	qdel(new_body_brain)
-	src.forceMove(new_body)
+	forceMove(new_body)
 	Insert(new_body)
 	for(var/obj/item/bodypart/bodypart as anything in new_body.bodyparts)
 		if(!istype(bodypart, /obj/item/bodypart/chest))
@@ -246,8 +246,7 @@
 	new_body.visible_message(span_warning("[new_body]'s torso \"forms\" from their core, yet to form the rest."))
 	to_chat(owner, span_purple("Your torso fully forms out of your core, yet to form the rest."))
 
-	if(brainmob)
-		brainmob.mind.transfer_to(new_body)
-		new_body.grab_ghost()
+	brainmob?.mind?.transfer_to(new_body)
+	new_body.grab_ghost()
 
-	drop_items_to_ground(get_turf(new_body))
+	drop_items_to_ground(new_body.drop_location())


### PR DESCRIPTION
this bug can actually destroy the NUKE DISK, so, somewhat important.

## Changelog
:cl:
fix: Fixed a weird oozeling revival bug that results in their items being sent to the void.
/:cl:
