### PR TITLE
Chemistry updates & fix for Krokodil.

### DIFF
--- a/monkestation/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/monkestation/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -1,0 +1,32 @@
+/datum/reagent/drug/krokodil
+	name = "Krokodil"
+	description = "Cools and calms you down. If overdosed it will deal significant Brain and Toxin damage."
+	reagent_state = LIQUID
+	color = "#0064B4"
+	overdose_threshold = 20
+	ph = 9
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	addiction_types = list(/datum/addiction/opioids = 18) //7.2 per 2 seconds
+
+
+/datum/reagent/drug/krokodil/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	var/high_message = pick("You feel calm.", "You feel collected.", "You feel like you need to relax.")
+	if(SPT_PROB(2.5, seconds_per_tick))
+		to_chat(affected_mob, span_notice("[high_message]"))
+	affected_mob.add_mood_event("smacked out", /datum/mood_event/narcotic_heavy, name)
+	if(current_cycle == 35)
+		if(!istype(affected_mob.dna.species, /datum/species/human/krokodil_addict))
+			to_chat(affected_mob, span_userdanger("Your skin falls off easily!"))
+			var/mob/living/carbon/human/affected_human = affected_mob
+			affected_human.facial_hairstyle = "Shaved"
+			affected_human.hairstyle = "Bald"
+			affected_human.update_body_parts() // makes you loose hair as well
+			affected_mob.set_species(/datum/species/human/krokodil_addict)
+			affected_mob.adjustBruteLoss(50 * REM, FALSE, required_bodytype = affected_bodytype) // holy shit your skin just FELL THE FUCK OFF
+	..()
+
+/datum/reagent/drug/krokodil/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
+	affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.25 * REM * seconds_per_tick, required_organtype = affected_organtype)
+	affected_mob.adjustToxLoss(0.25 * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
+	..()
+	. = TRUE

--- a/monkestation/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/monkestation/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -1,4 +1,4 @@
-/datum/reagent/drug/krokodil
+/datum/reagent/drug/krokodil // Needed to modularize due to original TG krokodil having a fermi-chem purity requirement for making krokodil zombies.
 	name = "Krokodil"
 	description = "Cools and calms you down. If overdosed it will deal significant Brain and Toxin damage."
 	reagent_state = LIQUID
@@ -14,7 +14,7 @@
 	if(SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[high_message]"))
 	affected_mob.add_mood_event("smacked out", /datum/mood_event/narcotic_heavy, name)
-	if(current_cycle == 35)
+	if(current_cycle == 35) // Previously required a chem purity of 0.6 or lower to create krokodil zombies w/ fermi-chem.
 		if(!istype(affected_mob.dna.species, /datum/species/human/krokodil_addict))
 			to_chat(affected_mob, span_userdanger("Your skin falls off easily!"))
 			var/mob/living/carbon/human/affected_human = affected_mob
@@ -30,3 +30,5 @@
 	affected_mob.adjustToxLoss(0.25 * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
 	..()
 	. = TRUE
+
+

--- a/monkestation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/monkestation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -17,8 +17,8 @@
 	var/uh_oh_message = pick("You rub your eyes.", "Your eyes lose focus for a second.", "Your stomach cramps!")
 	if (SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[uh_oh_message]"))
-	affected_mob.adjustOrganLoss(ORGAN_SLOT_STOMACH, 0.5 * REM * 1, required_organtype = affected_organtype) // Kills your stomach.
-	affected_mob.adjustOrganLoss(ORGAN_SLOT_EYES, 0.5 * REM * 1, required_organtype = affected_organtype) // Kills your eyes too.
+	affected_mob.adjustOrganLoss(ORGAN_SLOT_STOMACH, 2 * REM * 1, required_organtype = affected_organtype) // Kills your stomach.
+	affected_mob.adjustOrganLoss(ORGAN_SLOT_EYES, 2 * REM * 1, required_organtype = affected_organtype) // Kills your eyes too.
 
 
 
@@ -65,6 +65,6 @@
 	var/tummy_ache_message = pick("Your stomach rumbles.", "Your stomach is upset!", "You don't feel very good...")
 	if (SPT_PROB(2.5, seconds_per_tick))
 		to_chat(affected_mob, span_notice("[tummy_ache_message]"))
-	affected_mob.adjustOrganLoss(ORGAN_SLOT_STOMACH, 0.5 * REM * 1, required_organtype = affected_organtype) // Tumby hurty...
+	affected_mob.adjustOrganLoss(ORGAN_SLOT_STOMACH, 2 * REM * 1, required_organtype = affected_organtype) // Tumby hurty...
 
 

--- a/monkestation/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/monkestation/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1,0 +1,70 @@
+/datum/reagent/acetone_oxide // Overriding to give this an actual function as liquid fire.
+	name = "Acetone Oxide"
+	description = "Enslaved oxygen"
+	reagent_state = LIQUID
+	color = "#C8A5DC"
+	taste_description = "acid"
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+
+/datum/reagent/acetone_oxide/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)//Splashing people kills people!
+	. = ..()
+	if(methods & TOUCH | VAPOR | INGEST)
+		exposed_mob.adjustFireLoss(((reac_volume * 2) / 1.65))
+		exposed_mob.adjust_fire_stacks((reac_volume / 5))
+
+/datum/reagent/acetone_oxide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired) // Old acetone oxide didn't have a metabolism effect!
+	. = ..()
+	var/uh_oh_message = pick("You rub your eyes.", "Your eyes lose focus for a second.", "Your stomach cramps!")
+	if (SPT_PROB(2.5, seconds_per_tick))
+		to_chat(affected_mob, span_notice("[uh_oh_message]"))
+	affected_mob.adjustOrganLoss(ORGAN_SLOT_STOMACH, 0.5 * REM * 1, required_organtype = affected_organtype) // Kills your stomach.
+	affected_mob.adjustOrganLoss(ORGAN_SLOT_EYES, 0.5 * REM * 1, required_organtype = affected_organtype) // Kills your eyes too.
+
+
+
+/datum/reagent/hydrogen_peroxide // The wimpier cousin to Acetone Oxide which burns half as hot. Also needed an override because it's wimpy in TG code.
+	name = "Hydrogen Peroxide"
+	description = "An ubiquitous chemical substance that is composed of hydrogen and oxygen and oxygen." //intended intended
+	color = "#AAAAAA77" // rgb: 170, 170, 170, 77 (alpha)
+	taste_description = "burning water"
+	ph = 6.2
+	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
+	turf_exposure = TRUE
+
+/datum/glass_style/shot_glass/hydrogen_peroxide
+	required_drink_type = /datum/reagent/hydrogen_peroxide
+	icon_state = "shotglassclear"
+
+/datum/glass_style/drinking_glass/hydrogen_peroxide
+	required_drink_type = /datum/reagent/hydrogen_peroxide
+	name = "glass of oxygenated water"
+	desc = "The father of all refreshments. Surely it tastes great, right?"
+	icon_state = "glass_clear"
+
+/*
+ * Water reaction to turf
+ */
+
+/datum/reagent/hydrogen_peroxide/expose_turf(turf/open/exposed_turf, reac_volume)
+	. = ..()
+	if(!istype(exposed_turf))
+		return
+	if(reac_volume >= 5)
+		exposed_turf.MakeSlippery(TURF_WET_WATER, 10 SECONDS, min(reac_volume*1.5 SECONDS, 60 SECONDS))
+/*
+ * Water reaction to a mob
+ */
+
+/datum/reagent/hydrogen_peroxide/expose_mob(mob/living/exposed_mob, methods=TOUCH, reac_volume)//Splashing people with h2o2 can burn them !
+	. = ..()
+	if(methods & TOUCH)
+		exposed_mob.adjustFireLoss(((reac_volume * 2) / 3))
+
+/datum/reagent/hydrogen_peroxide/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired) // Old h2o2 didn't have a metabolizing effect either!
+	. = ..()
+	var/tummy_ache_message = pick("Your stomach rumbles.", "Your stomach is upset!", "You don't feel very good...")
+	if (SPT_PROB(2.5, seconds_per_tick))
+		to_chat(affected_mob, span_notice("[tummy_ache_message]"))
+	affected_mob.adjustOrganLoss(ORGAN_SLOT_STOMACH, 0.5 * REM * 1, required_organtype = affected_organtype) // Tumby hurty...
+
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6817,6 +6817,7 @@
 #include "monkestation\code\modules\reagents\reagent_containers.dm"
 #include "monkestation\code\modules\reagents\reagents.dm"
 #include "monkestation\code\modules\reagents\sunset_sarsaparilla.dm"
+#include "monkestation\code\modules\reagents\chemistry\reagents\drug_reagents.dm"
 #include "monkestation\code\modules\reagents\fun\austrialium.dm"
 #include "monkestation\code\modules\reagents\fun\liquid_justice.dm"
 #include "monkestation\code\modules\reagents\fun\shakeium.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6818,6 +6818,7 @@
 #include "monkestation\code\modules\reagents\reagents.dm"
 #include "monkestation\code\modules\reagents\sunset_sarsaparilla.dm"
 #include "monkestation\code\modules\reagents\chemistry\reagents\drug_reagents.dm"
+#include "monkestation\code\modules\reagents\chemistry\reagents\other_reagents.dm"
 #include "monkestation\code\modules\reagents\fun\austrialium.dm"
 #include "monkestation\code\modules\reagents\fun\liquid_justice.dm"
 #include "monkestation\code\modules\reagents\fun\shakeium.dm"


### PR DESCRIPTION
## About The Pull Request
Removes the chemical purity requirement from Krokodil to turn people into fake zombies & adds more functionality to the chems Hydrogen Peroxide & Acetone Oxide, effectively making them unique toxins that instantly deal burn damage on touch & deal organ damage on ingestion.
## Why It's Good For The Game
Allows more chemicals to be used in chemical grenades that do no damage to the environment with the same instantaneous damaging effect of an actual bomb (possibly for assasinations in maintenance) & removes some leftover fermichem taint that shouldn't even be there in the first place.
## Changelog
:cl:
add: Hydrogen Peroxide & Acetone Oxide now do organ damage on consumption (but not on touch).
fix: Acetone Oxide & Hydrogen Peroxide now do damage appropriate to the volume touched.
fix: #1889
\:cl:
