### PR TITLE
Fixes particle weather immunity check

### DIFF
--- a/monkestation/code/modules/outdoors/code/datum/particle_weathers/_particle_weather.dm
+++ b/monkestation/code/modules/outdoors/code/datum/particle_weathers/_particle_weather.dm
@@ -285,6 +285,10 @@ GLOBAL_LIST_EMPTY(siren_objects)
 
 	//If mob is not in a turf
 	var/turf/mob_turf = get_turf(mob_to_check)
+
+	if((immunity_type && HAS_TRAIT(mob_to_check, immunity_type)) || HAS_TRAIT(mob_to_check, TRAIT_WEATHER_IMMUNE))
+		return
+
 	var/atom/loc_to_check = mob_to_check.loc
 	while(loc_to_check != mob_turf)
 		if((immunity_type && HAS_TRAIT(loc_to_check, immunity_type)) || HAS_TRAIT(loc_to_check, TRAIT_WEATHER_IMMUNE))


### PR DESCRIPTION
## About The Pull Request
Being immune to the snow actually means you are immune to snow
## Why It's Good For The Game
Clothes that make you immune to snowstorms now should always work
## Changelog
:cl:
fix: particle weather immunity check now checks the immunity of mobs directly on a tile
/:cl: