### PR TITLE
Geneticist gets shifted to medsci.

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -482,7 +482,7 @@
 	assignment = "Geneticist"
 	trim_state = "trim_geneticist"
 	department_color = COLOR_SCIENCE_PINK
-	subdepartment_color = COLOR_SCIENCE_PINK
+	subdepartment_color = COLOR_MEDICAL_BLUE
 	sechud_icon_state = SECHUD_GENETICIST
 	minimal_access = list(
 		ACCESS_GENETICS,

--- a/code/modules/jobs/job_types/geneticist.dm
+++ b/code/modules/jobs/job_types/geneticist.dm
@@ -41,7 +41,7 @@
 	suit = /obj/item/clothing/suit/toggle/labcoat/genetics
 	suit_store = /obj/item/flashlight/pen
 	belt = /obj/item/modular_computer/pda/geneticist
-	ears = /obj/item/radio/headset/headset_sci
+	ears = /obj/item/radio/headset/headset_medsci
 	shoes = /obj/item/clothing/shoes/sneakers/white
 	l_pocket = /obj/item/sequence_scanner
 


### PR DESCRIPTION
## About this PR
Geneticist now gets a medsci headset and a blue ID Bar.
No access has been changed.

## Why It's Good For The Game
Geneticists have cloning now, and are a big part of being revived. With multiple clonings per round, and no access to medical radio, they are a bitch and a half to contact. This lets medical easily cooperate with the geneticist's extra tasks.
## Changelog
:cl:
add: Geneticist is now a medsci role.
/:cl:
