### PR TITLE
Make PACO ammo fit in shoes.

### DIFF
--- a/code/datums/storage/subtypes/pockets.dm
+++ b/code/datums/storage/subtypes/pockets.dm
@@ -93,6 +93,7 @@
 		/obj/item/suppressor,
 		/obj/item/ammo_box/magazine/m9mm,
 		/obj/item/ammo_box/magazine/m10mm,
+		/obj/item/ammo_box/magazine/m35 //Monkestation Edit
 		/obj/item/ammo_box/magazine/m45,
 		/obj/item/ammo_box/magazine/toy/pistol,
 		/obj/item/ammo_casing,

--- a/code/datums/storage/subtypes/pockets.dm
+++ b/code/datums/storage/subtypes/pockets.dm
@@ -93,7 +93,7 @@
 		/obj/item/suppressor,
 		/obj/item/ammo_box/magazine/m9mm,
 		/obj/item/ammo_box/magazine/m10mm,
-		/obj/item/ammo_box/magazine/m35 //Monkestation Edit
+		/obj/item/ammo_box/magazine/m35, //Monkestation Edit
 		/obj/item/ammo_box/magazine/m45,
 		/obj/item/ammo_box/magazine/toy/pistol,
 		/obj/item/ammo_casing,


### PR DESCRIPTION
## About The Pull Request

Adds paco ammo to the list of items that can fit inside shoes

## Why It's Good For The Game

Security officers spawn with exactly two magazines (+1 can be found in the locker) and how many slots do jackboots have? Exactly two! This is a dream for a perfectionist. Magazines also take inventory space that instead could be used for other things, like donuts.

## Changelog

:cl:
add: You can now put PACO ammo in your jackboots!
/:cl: