### PR TITLE
fix air alarm engi access (whoops)

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -6,7 +6,10 @@
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.05
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.02
 	power_channel = AREA_USAGE_ENVIRON
-	req_access = list(ACCESS_ATMOSPHERICS)
+	// monkestation edit: let engineers unlock air alarms
+	req_access = null
+	req_one_access = list(ACCESS_ATMOSPHERICS, ACCESS_ENGINE_EQUIP)
+	// monkestation end
 	max_integrity = 250
 	integrity_failure = 0.33
 	armor_type = /datum/armor/machinery_airalarm

--- a/monkestation/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/monkestation/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -1,3 +1,0 @@
-/obj/machinery/airalarm
-	req_access = null
-	req_one_access = list(ACCESS_ATMOSPHERICS, ACCESS_ENGINE_EQUIP)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6085,7 +6085,6 @@
 #include "monkestation\code\modules\art_sci_overrides\faults\whispers.dm"
 #include "monkestation\code\modules\art_sci_overrides\faults\zap.dm"
 #include "monkestation\code\modules\assembly\flash.dm"
-#include "monkestation\code\modules\atmospherics\machinery\air_alarm\_air_alarm.dm"
 #include "monkestation\code\modules\atmospherics\machinery\air_alarm\air_alarm_ac.dm"
 #include "monkestation\code\modules\ballpit\ballbit_sink.dm"
 #include "monkestation\code\modules\ballpit\ballpit.dm"


### PR DESCRIPTION
don't ask why this is needed, idk either, but currently air alarms on master look like this:
![image](https://github.com/Monkestation/Monkestation2.0/assets/65794972/9f67cea0-f48b-430f-9758-2df42cf66928)
and this seems to fix it. bwah.

## Changelog
:cl:
fix: Engis should ACTUALLY be able to unlock air alarms now.
/:cl:
