### PR TITLE
Improvised Gun Improvement

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -284,6 +284,18 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/instrument/violin = 5,
 		/obj/item/instrument/violin/golden = 2,
 		) = 2,
+		
+	list(//paint
+		/obj/item/paint/anycolor = 1,
+		/obj/item/paint/black = 1,
+		/obj/item/paint/blue = 1,
+		/obj/item/paint/green = 1,
+		/obj/item/paint/paint_remover = 1,
+		/obj/item/paint/red = 1,
+		/obj/item/paint/violet = 1,
+		/obj/item/paint/white = 1,
+		/obj/item/paint/yellow = 1,
+		) = 1,
 
 	list(//fakeout items, keep this list at low relative weight
 		/obj/item/clothing/shoes/jackboots = 1,
@@ -316,18 +328,6 @@ GLOBAL_LIST_INIT(rarity_loot, list(//rare: really good items
 		/obj/item/storage/belt/security = 1,
 		) = 1,
 
-	list(//paint
-		/obj/item/paint/anycolor = 1,
-		/obj/item/paint/black = 1,
-		/obj/item/paint/blue = 1,
-		/obj/item/paint/green = 1,
-		/obj/item/paint/paint_remover = 1,
-		/obj/item/paint/red = 1,
-		/obj/item/paint/violet = 1,
-		/obj/item/paint/white = 1,
-		/obj/item/paint/yellow = 1,
-		) = 1,
-
 	list(//medical and chemicals
 		list(//medkits
 			/obj/item/storage/box/hug/medical = 1,
@@ -346,6 +346,7 @@ GLOBAL_LIST_INIT(rarity_loot, list(//rare: really good items
 		/obj/item/book/granter/crafting_recipe/maint_gun/pipegun_prime = 1,
 		/obj/item/book/granter/crafting_recipe/trash_cannon = 1,
 		/obj/item/book/granter/crafting_recipe/maint_gun/laser_musket_prime = 1,
+		/obj/item/book/granter/crafting_recipe/maint_gun/smoothbore_disabler_prime = 1,
 		/obj/item/book/granter/sign_language = 1,
 		/obj/item/disk/nuclear/fake = 1,
 		/obj/item/skillchip/brainwashing = 1,

--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -236,7 +236,6 @@
 		/obj/item/storage/toolbox = 1,
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
-	tool_paths = list(/obj/item/clothing/gloves/color/yellow, /obj/item/clothing/mask/gas, /obj/item/melee/baton/security/cattleprod)
 	time = 30 SECONDS //contemplate for a bit
 	category = CAT_WEAPON_RANGED
 
@@ -350,8 +349,7 @@
 	reqs = list(
 		/obj/item/gun/energy/disabler/smoothbore = 1,
 		/obj/item/stack/sheet/mineral/gold = 5,
-		/obj/item/stock_parts/cell/hyper = 1,
-		/datum/reagent/reaction_agent/speed_agent = 10,
+		/obj/item/stock_parts/cell/super = 1,
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
 	time = 20 SECONDS

--- a/code/datums/components/crafting/ranged_weapon.dm
+++ b/code/datums/components/crafting/ranged_weapon.dm
@@ -232,11 +232,13 @@
 		/obj/item/gun/ballistic/rifle/boltaction/pipegun = 1,
 		/obj/item/food/deadmouse = 1,
 		/datum/reagent/consumable/grey_bull = 20,
-		/obj/item/spear = 1,
 		/obj/item/storage/toolbox = 1,
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 30 SECONDS //contemplate for a bit
+	tool_paths = list(
+		/obj/item/spear
+	)
+	time = 25 SECONDS //contemplate for a bit
 	category = CAT_WEAPON_RANGED
 
 /datum/crafting_recipe/deagle_prime //When you factor in the makarov (7 tc), the toolbox (1 tc), and the emag (3 tc), this comes to a total of 17 TC or thereabouts. Igorning the 20k pricetag, obviously.
@@ -324,7 +326,7 @@
 		/datum/reagent/consumable/nuka_cola = 15,
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER) //monke edits. removed the need for the special clothing
-	time = 30 SECONDS //contemplate for a bit
+	time = 25 SECONDS //contemplate for a bit
 	category = CAT_WEAPON_RANGED
 
 /datum/crafting_recipe/smoothbore_disabler
@@ -352,5 +354,5 @@
 		/obj/item/stock_parts/cell/super = 1,
 	)
 	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 20 SECONDS
+	time = 15 SECONDS
 	category = CAT_WEAPON_RANGED

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -82,6 +82,7 @@
 /obj/item/knife/kitchen
 	name = "kitchen knife"
 	desc = "A general purpose Chef's Knife made by SpaceCook Incorporated. Guaranteed to stay sharp for years to come."
+	bayonet = TRUE
 
 /obj/item/knife/plastic
 	name = "plastic knife"

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -107,6 +107,7 @@
 	inhand_icon_state = "huntingknife"
 	icon_state = "huntingknife"
 	wound_bonus = 10
+	bayonet = TRUE
 
 /obj/item/knife/hunting/set_butchering()
 	AddComponent(/datum/component/butchering, \
@@ -172,6 +173,7 @@
 	attack_verb_simple = list("shank", "shiv")
 	armor_type = /datum/armor/none
 	custom_materials = list(/datum/material/glass = SMALL_MATERIAL_AMOUNT * 4)
+	bayonet = TRUE
 
 /obj/item/knife/shiv/Initialize(mapload)
 	flags_1 &= ~CONDUCT_1

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -134,7 +134,6 @@
 	desc = "A hunting grade survival knife."
 	force = 15
 	throwforce = 15
-	bayonet = TRUE
 
 /obj/item/knife/combat/bone
 	name = "bone dagger"

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -196,6 +196,7 @@
 	inhand_icon_state = "musket_prime"
 	worn_icon_state = "musket_prime"
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun/prime
+	can_jam = FALSE
 	projectile_damage_multiplier = 1
 
 /// MAGICAL BOLT ACTIONS + ARCANE BARRAGE? ///

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -198,7 +198,6 @@
 	inhand_icon_state = "musket_prime"
 	worn_icon_state = "musket_prime"
 	mag_type = /obj/item/ammo_box/magazine/internal/boltaction/pipegun/prime
-	can_jam = FALSE
 	projectile_damage_multiplier = 1
 
 /// MAGICAL BOLT ACTIONS + ARCANE BARRAGE? ///

--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -101,19 +101,20 @@
 	return ..()
 
 /obj/item/gun/ballistic/rifle/boltaction/attackby(obj/item/item, mob/user, params)
-	. = ..()
-	if(!can_jam)
-		balloon_alert(user, "can't jam!")
-		return
-
-	if(!bolt_locked)
+	if(!bolt_locked && !istype(item, /obj/item/knife))
 		balloon_alert(user, "bolt closed!")
 		return
 
-	if(istype(item, /obj/item/gun_maintenance_supplies) && do_after(user, 10 SECONDS, target = src))
-		user.visible_message(span_notice("[user] finishes maintenance of [src]."))
-		jamming_chance = initial(jamming_chance)
-		qdel(item)
+	. = ..()
+
+	if(istype(item, /obj/item/gun_maintenance_supplies))
+		if(!can_jam)
+			balloon_alert(user, "can't jam!")
+			return
+		if(do_after(user, 10 SECONDS, target = src))
+			user.visible_message(span_notice("[user] finishes maintaining [src]."))
+			jamming_chance = initial(jamming_chance)
+			qdel(item)
 
 /obj/item/gun/ballistic/rifle/boltaction/blow_up(mob/user)
 	. = FALSE
@@ -181,6 +182,7 @@
 	can_modify_ammo = TRUE
 	can_misfire = FALSE
 	can_bayonet = TRUE
+	knife_x_offset = 25
 	knife_y_offset = 11
 	can_be_sawn_off = FALSE
 	projectile_damage_multiplier = 0.75

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -337,7 +337,7 @@
 	tgui_icon = "eye"
 	altar_icon_state = "convertaltar-maint"
 	alignment = ALIGNMENT_EVIL //while maint is more neutral in my eyes, the flavor of it kinda pertains to rotting and becoming corrupted by the maints
-	rites_list = list(/datum/religion_rites/maint_adaptation, /datum/religion_rites/adapted_eyes, /datum/religion_rites/adapted_food, /datum/religion_rites/ritual_totem)
+	rites_list = list(/datum/religion_rites/maint_adaptation, /datum/religion_rites/adapted_eyes, /datum/religion_rites/adapted_food, /datum/religion_rites/ritual_totem, /datum/religion_rites/weapon_granter)
 	desired_items = list(/obj/item/reagent_containers = "holding organic slurry")
 
 /datum/religion_sect/maintenance/sect_bless(mob/living/blessed_living, mob/living/chap)

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -434,6 +434,26 @@
 	user.emote("laugh")
 	new /obj/item/ritual_totem(altar_turf)
 	return TRUE
+	
+/datum/religion_rites/weapon_granter
+	name = "Maintenance Knowledge"
+	desc = "Creates a tome teaching you how to make an improved improvised weapon!"
+	favor_cost = 100 //You still have to make the weapon afterwards, might want to change this though.
+	invoke_msg = "Grant me the ingenuinity of the Maintenance Khan!"
+	ritual_length = 5 SECONDS
+
+/datum/religion_rites/weapon_granter/invoke_effect(mob/living/user, atom/movable/religious_tool)
+	..()
+	var/altar_turf = get_turf(religious_tool)
+	var/blessing = pick(
+		/obj/item/book/granter/crafting_recipe/maint_gun/pipegun_prime,
+		/obj/item/book/granter/crafting_recipe/trash_cannon,
+		/obj/item/book/granter/crafting_recipe/maint_gun/laser_musket_prime,
+		/obj/item/book/granter/crafting_recipe/maint_gun/smoothbore_disabler_prime,
+	)
+		
+	new blessing(altar_turf)
+	return TRUE
 
 ///sparring god rites
 

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -437,7 +437,7 @@
 	
 /datum/religion_rites/weapon_granter
 	name = "Maintenance Knowledge"
-	desc = "Creates a tome teaching you how to make an improved improvised weapon!"
+	desc = "Creates a tome teaching you how to make an improved improvised weapon."
 	favor_cost = 100 //You still have to make the weapon afterwards, might want to change this though.
 	invoke_msg = "Grant me the ingenuinity of the Maintenance Khan!"
 	ritual_length = 5 SECONDS

--- a/code/modules/research/designs/autolathe/medsci_designs.dm
+++ b/code/modules/research/designs/autolathe/medsci_designs.dm
@@ -211,3 +211,15 @@
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL,
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/glasses
+	name = "Prescription Glasses"
+	id = "glasses"
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT)
+	build_path = /obj/item/clothing/glasses/regular
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -291,6 +291,7 @@
 		"retractor",
 		"scalpel",
 		"stethoscope",
+		"glasses",
 		"surgical_drapes",
 		"surgical_tape",
 		"surgicaldrill",

--- a/code/modules/vending/assist.dm
+++ b/code/modules/vending/assist.dm
@@ -9,11 +9,11 @@
 		/obj/item/assembly/prox_sensor = 5,
 		/obj/item/assembly/signaler = 4,
 		/obj/item/computer_disk/ordnance = 4,
-		/obj/item/stock_parts/capacitor = 3,
-		/obj/item/stock_parts/manipulator = 3,
-		/obj/item/stock_parts/matter_bin = 3,
-		/obj/item/stock_parts/micro_laser = 3,
-		/obj/item/stock_parts/scanning_module = 3,
+		/obj/item/stock_parts/capacitor = 5,
+		/obj/item/stock_parts/manipulator = 5,
+		/obj/item/stock_parts/matter_bin = 5,
+		/obj/item/stock_parts/micro_laser = 5,
+		/obj/item/stock_parts/scanning_module = 5,
 		/obj/item/wirecutters = 1,
 	)
 	contraband = list(

--- a/code/modules/vending/engineering.dm
+++ b/code/modules/vending/engineering.dm
@@ -20,6 +20,7 @@
 		/obj/item/multitool = 12,
 		/obj/item/wrench = 12,
 		/obj/item/t_scanner = 12,
+		/obj/item/stack/sticky_tape = 12,
 		/obj/item/stock_parts/cell = 8,
 		/obj/item/weldingtool = 8,
 		/obj/item/clothing/head/utility/welding = 8,

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -17,6 +17,7 @@
 		/obj/item/analyzer = 5,
 		/obj/item/t_scanner = 5,
 		/obj/item/screwdriver = 5,
+		/obj/item/stack/sticky_tape = 5, //You would find tape at a hardware store.
 		/obj/item/flashlight/glowstick = 3,
 		/obj/item/flashlight/glowstick/red = 3,
 		/obj/item/flashlight = 5,

--- a/monkestation/code/game/objects/items/guns/crank_guns.dm
+++ b/monkestation/code/game/objects/items/guns/crank_guns.dm
@@ -24,10 +24,12 @@
 /obj/projectile/beam/laser/musket
 	damage = 30
 	stamina = 45
+	wound_bonus = -10
 
 /obj/projectile/beam/laser/musket/prime
 	damage = 35
 	stamina = 60
+	wound_bonus = -10
 
 /obj/projectile/beam/disabler/smoothbore/prime
 	stamina = 65

--- a/monkestation/code/game/objects/items/venom_knife.dm
+++ b/monkestation/code/game/objects/items/venom_knife.dm
@@ -10,6 +10,7 @@
 	throw_speed = 5
 	throw_range = 7
 	custom_materials = null
+	bayonet = TRUE
 	/// The maximum amount of reagents per transfer that will be moved out of this reagent container
 	var/amount_per_transfer_from_this = 10
 	/// The different possible amounts of reagent to transfer out of the container

--- a/monkestation/code/modules/cargo/markets/market_items.dm
+++ b/monkestation/code/modules/cargo/markets/market_items.dm
@@ -15,8 +15,8 @@
 
 	price_min = CARGO_CRATE_VALUE * 4
 	price_max = CARGO_CRATE_VALUE * 5
-	stock_max = 1
-	availability_prob = 40
+	stock_max = 3
+	availability_prob = 50
 
 /datum/market_item/weapon/musket_recipe
 	name = "Journal of a Space Ranger"
@@ -25,15 +25,15 @@
 
 	price_min = CARGO_CRATE_VALUE * 4
 	price_max = CARGO_CRATE_VALUE * 5
-	stock_max = 2
-	availability_prob = 40
+	stock_max = 3
+	availability_prob = 50
 
 /datum/market_item/weapon/smoothbore_recipe
 	name = "Old Tome"
 	desc = "Ahoy Maties, I, Captain Whitebeard, have plundered the ol' Nanotrasen station, among the booty retreived was this here tome about smoothbores. Alas, I have no use for its knowlege, so I am droppin it off here."
 	item = /obj/item/book/granter/crafting_recipe/maint_gun/smoothbore_disabler_prime
 
-	price_min = CARGO_CRATE_VALUE * 6
-	price_max = CARGO_CRATE_VALUE * 8
-	stock_max = 1
-	availability_prob = 20
+	price_min = CARGO_CRATE_VALUE * 3 //Non lethal, should be cheaper than the fancy lethals.
+	price_max = CARGO_CRATE_VALUE * 4
+	stock_max = 3
+	availability_prob = 50


### PR DESCRIPTION
## About The Pull Request
This makes improvised guns both more effective and easier to craft.
Laser Muskets:
-Prescription Glasses can now be printed at autolathes and medical lathes.
-Standard, Prime, and Syndicate have a wound_bonus of -10, from -30. (Might be too much.)
Pipeguns:
-Regal Pipegun no longer requires you to have an assistant cosplay to craft.
-The spear is now considered a tool, not an ingredient for regal pipegun.
Smoothbore Disablers:
-Prime version no longer requires chemicals to craft.
-The recipe for smoothbore disabler can now be found in maintenance.

Maintenance sect now has a ritual that lets them get the books that grant you the crafting recipes for improved improvised guns.

Ports some improvements from TG for rifle.dm, that fixes bayonet offset for pipeguns, and fixes a bug that lets it balloon "can't jam" and "bolt closed" at the same time.

Other:
-Prescription Glasses can now be printed at medical lathes and autolathes.
-Sticky Tape can now be bought from YouTool and engivendor. (You would find tape at a hardware store.)
-Paint moved from rare maint loot category to uncommon. (Why would paint be as common as a book telling you how to make fancy guns?)
-More knives can be used as bayonets, allowing for ghetto bayonets.
-The recipe granters for improvised guns are now 50% likely to be available at black market (from 40%,) and have a maximum availability of 3.
-The part vendor at tool storage has more parts.

## Why It's Good For The Game
For the amount of effort it takes to make an improvised gun, you might have well just bought a russian crate or something from cargo. This is especially true for the elite versions of improvised guns, which are very difficult to get, but still are vastly inferior to stuff you could easily get from cargo. Some of the requirements for crafting are rather insane, such as the regal pipegun requiring an assistant cosplay to craft.
This makes improvised guns more worthwhile to craft.
## Changelog
:cl:
add: Prescription glasses can now be printed at autolathes and medical lathes.
add: Sticky Tape can now be bought at YouTool and Engievendor.
add: More kinds of knives can be used as bayonets.
add: Maintenance Sect has a ritual to get recipe books for elite improvised guns.
balance: Elite versions of improvised guns are now more effective and easier to craft.
fix: Fixed pipegun bayonet offset
fix: Fixed a bug where a bolt action rifle (mosin/pipegun) might balloon both "can't jam" and "bolt closed" at the same time.
/:cl:
