### PR TITLE
[PORT] Bumping into a door in a stealth implant opens the door (if you have access)

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -28,22 +28,32 @@
 	var/operating = FALSE
 	var/glass = FALSE
 	var/welded = FALSE
-	var/heat_proof = FALSE // For rglass-windowed airlocks and firedoors
-	var/emergency = FALSE // Emergency access override
-	var/sub_door = FALSE // true if it's meant to go under another door.
+	/// For rglass-windowed airlocks and firedoors
+	var/heat_proof = FALSE
+	/// Emergency access override
+	var/emergency = FALSE
+	/// true if it's meant to go under another door.
+	var/sub_door = FALSE
 	var/closingLayer = CLOSED_DOOR_LAYER
-	var/autoclose = FALSE //does it automatically close after some time
-	var/safe = TRUE //whether the door detects things and mobs in its way and reopen or crushes them.
-	var/locked = FALSE //whether the door is bolted or not.
+	///does it automatically close after some time
+	var/autoclose = FALSE
+	///whether the door detects things and mobs in its way and reopen or crushes them.
+	var/safe = TRUE
+	///whether the door is bolted or not.
+	var/locked = FALSE
 	var/datum/effect_system/spark_spread/spark_system
-	var/real_explosion_block //ignore this, just use explosion_block
-	var/red_alert_access = FALSE //if TRUE, this door will always open on red alert
+	///ignore this, just use explosion_block
+	var/real_explosion_block
+	///if TRUE, this door will always open on red alert
+	var/red_alert_access = FALSE
 	/// Checks to see if this airlock has an unrestricted "sensor" within (will set to TRUE if present).
 	var/unres_sensor = FALSE
 	/// Unrestricted sides. A bitflag for which direction (if any) can open the door with no access
 	var/unres_sides = NONE
-	var/can_crush = TRUE /// Whether or not the door can crush mobs.
-	var/can_open_with_hands = TRUE /// Whether or not the door can be opened by hand (used for blast doors and shutters)
+	/// Whether or not the door can crush mobs.
+	var/can_crush = TRUE
+	/// Whether or not the door can be opened by hand (used for blast doors and shutters)
+	var/can_open_with_hands = TRUE
 	/// Whether or not this door can be opened through a door remote, ever
 	var/opens_with_door_remote = FALSE
 	/// Special operating mode for elevator doors

--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -41,6 +41,9 @@
 
 /obj/structure/closet/cardboard/agent/Bump(atom/A)
 	. = ..()
+	if(istype(A, /obj/machinery/door))
+		for(var/mob/mob_in_box in contents)
+			A.Bumped(mob_in_box)
 	if(isliving(A))
 		reveal()
 


### PR DESCRIPTION
## About The Pull Request

Bumping into a door in a stealth implant opens the door (if you have access)

Port of https://github.com/tgstation/tgstation/pull/82224, from https://github.com/Monkestation/Monkestation2.0/pull/1810

## Why It's Good For The Game

![image](https://github.com/tgstation/tgstation/assets/66163761/d00bf8b6-5a60-4c64-8035-27c400b1960d) Reduces jank by allowing stealth boxes to open doors.

## Changelog
:cl: Absolucy, Xander3359
qol: You can now open airlocks (That you have access to) while inside a stealth implant box
/:cl:

---------