### PR TITLE
[PORT] Adds tinyfans to the arrival shuttles

### DIFF
--- a/_maps/shuttles/arrival_box.dmm
+++ b/_maps/shuttles/arrival_box.dmm
@@ -14,6 +14,7 @@
 /area/shuttle/arrival)
 "d" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "e" = (

--- a/_maps/shuttles/arrival_delta.dmm
+++ b/_maps/shuttles/arrival_delta.dmm
@@ -39,6 +39,7 @@
 /area/shuttle/arrival)
 "ah" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "ai" = (

--- a/_maps/shuttles/arrival_donut.dmm
+++ b/_maps/shuttles/arrival_donut.dmm
@@ -56,6 +56,7 @@
 /area/shuttle/arrival)
 "o" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "p" = (

--- a/_maps/shuttles/arrival_kilo.dmm
+++ b/_maps/shuttles/arrival_kilo.dmm
@@ -101,6 +101,7 @@
 	dir = 8
 	},
 /obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "ap" = (
@@ -323,6 +324,11 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/arrival)
+"NS" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
+/turf/open/floor/plating,
+/area/shuttle/arrival)
 
 (1,1,1) = {"
 aa
@@ -358,7 +364,7 @@ aX
 aW
 aQ
 aY
-af
+NS
 "}
 (5,1,1) = {"
 ae
@@ -376,7 +382,7 @@ rV
 ay
 aV
 aN
-af
+NS
 "}
 (7,1,1) = {"
 af
@@ -385,7 +391,7 @@ rV
 az
 aV
 aN
-af
+NS
 "}
 (8,1,1) = {"
 af
@@ -394,7 +400,7 @@ rV
 ab
 aV
 aN
-af
+NS
 "}
 (9,1,1) = {"
 ac
@@ -444,9 +450,9 @@ ag
 (14,1,1) = {"
 ag
 ac
-af
-af
-af
+NS
+NS
+NS
 ac
 ag
 "}

--- a/_maps/shuttles/arrival_northstar.dmm
+++ b/_maps/shuttles/arrival_northstar.dmm
@@ -180,6 +180,7 @@
 /area/shuttle/arrival)
 "Z" = (
 /obj/effect/spawner/structure/window/survival_pod,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 

--- a/_maps/shuttles/arrival_pubby.dmm
+++ b/_maps/shuttles/arrival_pubby.dmm
@@ -14,6 +14,7 @@
 /area/shuttle/arrival)
 "d" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "e" = (
@@ -68,6 +69,7 @@
 	name = "Ship Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating,
 /area/shuttle/arrival)
 "n" = (


### PR DESCRIPTION
Port of https://github.com/tgstation/tgstation/pull/82915, from https://github.com/Monkestation/Monkestation2.0/pull/1810

This PR adds tinyfans all arrivals shuttles

Sometimes arrivals shuttle gets depressurized due the state of the arrivals wings and air going out of doors this means if a new player joins the game they are immediatly met with the suffocation indictator while a veteran might know his way around it a new player would not this gives them a little more breathing space in to whats supposed to be a non griefable area

:cl: Absolucy, improvedname
qol: Arrivals shuttle is now more player friendly
/:cl: