### PR TITLE
[PORT] Less laughing from trace nitrous

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -48,6 +48,7 @@
 	var/safe_plasma_min = 0
 	///How much breath partial pressure is a safe amount of plasma. 0 means that we are immune to plasma.
 	var/safe_plasma_max = 0.05
+	var/n2o_detect_min = 0.08 //Minimum n2o for effects
 	var/n2o_para_min = 1 //Sleeping agent
 	var/n2o_sleep_min = 5 //Sleeping agent
 	var/BZ_trip_balls_min = 1 //BZ gas
@@ -507,12 +508,12 @@
 /obj/item/organ/internal/lungs/proc/too_much_n2o(mob/living/carbon/breather, datum/gas_mixture/breath, n2o_pp, old_n2o_pp)
 	if(n2o_pp < n2o_para_min)
 		// Small amount of N2O, small side-effects.
-		if(n2o_pp <= 0.01)
-			if(old_n2o_pp > 0.01)
+		if(n2o_pp <= n2o_detect_min)
+			if(old_n2o_pp > n2o_detect_min)
 				return BREATH_LOST
 			return
 		// No alert for small amounts, but the mob randomly feels euphoric.
-		if(old_n2o_pp >= n2o_para_min || old_n2o_pp <= 0.01)
+		if(old_n2o_pp >= n2o_para_min || old_n2o_pp <= n2o_detect_min)
 			breather.clear_alert(ALERT_TOO_MUCH_N2O)
 
 		if(prob(20))


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/81223, from https://github.com/Monkestation/Monkestation2.0/pull/1810

I've increased the minimum amount of n2o required in the air to cause giggling. Threshold is still well below the para and sleep values.

This should stop people randomly getting drugged and giggly from trace amounts of gas.

I'm not gonna lie I had no idea how to fully dial this in, so the numbers are an arbitrary ~~10x increase from .01 mol to .1 mol~~ 8x increase from .01 mol to .08 mol.


## Why It's Good For The Game

After "extensive" real life testing I've determined that giggling and euphoria from trace amounts of the gas is unrealistic.

Also it would be a lot less annoying. @Cheshify also called it qol so I'm sticking with that.

<img alt="220f1c0470cef181192facef1374bf5c"
src="https://github.com/tgstation/tgstation/assets/26744576/1f42cc27-24d0-42c1-a233-f0bae9f1aa77">


## Changelog
:cl: Absolucy, Swiftfeather
qol: Increased threshold of trace n2o required to make euphoria and giggles happen.
/:cl:
