### PR TITLE
Fix midround prompt icons for changelings and paradox clones

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -100,8 +100,8 @@
 /datum/antagonist/brother/antag_panel_data()
 	return "Conspirators : [get_brother_names()]"
 
-/datum/antagonist/brother/proc/get_base_preview_icon()
-	RETURN_TYPE(/icon)
+// monkestation start: refactor to use [get_base_preview_icon] for better midround polling images
+/datum/antagonist/brother/get_base_preview_icon()
 	var/mob/living/carbon/human/dummy/consistent/brother1 = new
 	var/mob/living/carbon/human/dummy/consistent/brother2 = new
 
@@ -130,8 +130,8 @@
 	return final_icon
 
 /datum/antagonist/brother/get_preview_icon()
-	RETURN_TYPE(/icon)
 	return finish_preview_icon(get_base_preview_icon())
+// monkestation end
 
 /datum/antagonist/brother/proc/get_brother_names()
 	var/list/brothers = team.members - owner

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -983,7 +983,9 @@
 
 	return parts.Join("<br>")
 
-/datum/antagonist/changeling/get_preview_icon()
+// monkestation start: refactor to use [get_base_preview_icon] for better midround polling images
+/datum/antagonist/changeling/get_base_preview_icon()
+	RETURN_TYPE(/icon)
 	var/icon/final_icon = render_preview_outfit(/datum/outfit/changeling)
 	var/icon/split_icon = render_preview_outfit(/datum/outfit/job/engineer)
 
@@ -995,7 +997,11 @@
 
 	final_icon.Blend(split_icon, ICON_OVERLAY)
 
-	return finish_preview_icon(final_icon)
+	return final_icon
+
+/datum/antagonist/changeling/get_preview_icon()
+	return finish_preview_icon(get_base_preview_icon())
+// monkestation end
 
 /datum/antagonist/changeling/ui_data(mob/user)
 	var/list/data = list()

--- a/code/modules/antagonists/paradox_clone/paradox_clone.dm
+++ b/code/modules/antagonists/paradox_clone/paradox_clone.dm
@@ -9,13 +9,19 @@
 	///Weakref to the mind of the original, the clone's target.
 	var/datum/weakref/original_ref
 
-/datum/antagonist/paradox_clone/get_preview_icon()
+// monkestation start: refactor to use [get_base_preview_icon] for better midround polling images
+/datum/antagonist/paradox_clone/get_base_preview_icon()
+	RETURN_TYPE(/icon)
 	var/icon/final_icon = render_preview_outfit(preview_outfit)
 
 	final_icon.Blend(make_background_clone_icon(preview_outfit), ICON_UNDERLAY, -8, 0)
-	final_icon.Scale(64, 64)
+	return final_icon
 
-	return finish_preview_icon(final_icon)
+/datum/antagonist/paradox_clone/get_preview_icon()
+	var/icon/base_preview = get_base_preview_icon()
+	base_preview.Scale(64, 64)
+	return finish_preview_icon(base_preview)
+// monkestation end
 
 /datum/antagonist/paradox_clone/proc/make_background_clone_icon(datum/outfit/clone_fit)
 	var/mob/living/carbon/human/dummy/consistent/clone = new

--- a/monkestation/code/modules/antagonists/_common/antag_datum.dm
+++ b/monkestation/code/modules/antagonists/_common/antag_datum.dm
@@ -18,8 +18,15 @@
 	else
 		hosts_mind.add_antag_datum(type)
 
-/datum/antagonist/proc/render_poll_preview()
+/datum/antagonist/proc/get_base_preview_icon() as /icon
+	RETURN_TYPE(/icon)
+	return null
+
+/datum/antagonist/proc/render_poll_preview() as /image
 	RETURN_TYPE(/image)
+	var/icon/base_preview = get_base_preview_icon()
+	if(base_preview)
+		return image(base_preview)
 	if(preview_outfit)
 		var/icon/rendered_outfit = render_preview_outfit(preview_outfit)
 		if(rendered_outfit)

--- a/monkestation/code/modules/antagonists/brother/brother.dm
+++ b/monkestation/code/modules/antagonists/brother/brother.dm
@@ -42,9 +42,6 @@
 	team.forge_brother_objectives()
 	hosts_mind.add_antag_datum(/datum/antagonist/brother, team)
 
-/datum/antagonist/brother/render_poll_preview()
-	return image(get_base_preview_icon())
-
 /datum/antagonist/brother/proc/communicate(message)
 	if(!istext(message) || !length(message) || QDELETED(owner) || QDELETED(team))
 		return


### PR DESCRIPTION

## About The Pull Request

![2024-05-27 (1716822446) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/c3fdcbfe-59eb-4fd8-8164-186064bcabf7)

![image](https://github.com/Monkestation/Monkestation2.0/assets/65794972/0bae07d6-ccb9-469e-9cb6-ae3d41f0c3c6)

## Changelog
:cl:
fix: Fixed midround prompt icons for changelings and paradox clones.
/:cl:
