### PR TITLE
[PORT] Suit sensors can now be quick-maxed by ctrl clicking

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -60,6 +60,7 @@
 
 	if(isnull(held_item) && has_sensor == HAS_SENSORS)
 		context[SCREENTIP_CONTEXT_RMB] = "Toggle suit sensors"
+		context[SCREENTIP_CONTEXT_CTRL_LMB] = "Set suit sensors to tracking"
 		. = CONTEXTUAL_SCREENTIP_SET
 
 	if(istype(held_item, /obj/item/clothing/accessory) && length(attached_accessories) < max_number_of_accessories)
@@ -323,6 +324,16 @@
 		var/mob/living/carbon/human/H = loc
 		if(H.w_uniform == src)
 			H.update_suit_sensors()
+
+/obj/item/clothing/under/CtrlClick(mob/user)
+	. = ..()
+	if(!.)
+		return
+	if(!can_toggle_sensors(user))
+		return
+
+	sensor_mode = SENSOR_COORDS
+	balloon_alert(user, "set to tracking")
 
 /// Checks if the toggler is allowed to toggle suit sensors currently
 /obj/item/clothing/under/proc/can_toggle_sensors(mob/toggler)


### PR DESCRIPTION
Port of https://github.com/tgstation/tgstation/pull/83265, from https://github.com/Monkestation/Monkestation2.0/pull/1810.

Ctrl clicking your jumpsuit will max its suit sensors

https://github.com/tgstation/tgstation/assets/96586172/3b7275ee-404a-49d1-b378-63de794d22ee
Nice little change that makes maxing your sensors easier <!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
:cl: Absolucy, grungussuss
qol: suit sensors can now be maxed by ctrl clicking your jumpsuit\
/:cl:
