### PR TITLE
[PORT] Adds Subsystem Profile Focusing

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -673,9 +673,15 @@ GLOBAL_REAL(Master, /datum/controller/master)
 
 			queue_node.state = SS_RUNNING
 
+			if(queue_node.profiler_focused)
+				world.Profile(PROFILE_START)
+
 			tick_usage = TICK_USAGE
 			var/state = queue_node.ignite(queue_node_paused)
 			tick_usage = TICK_USAGE - tick_usage
+
+			if(queue_node.profiler_focused)
+				world.Profile(PROFILE_STOP)
 
 			if (state == SS_RUNNING)
 				state = SS_IDLE

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -40,6 +40,12 @@
 	///Subsystem ID. Used for when we need a technical name for the SS used by SSmetrics
 	var/ss_id = "generic_ss_id"
 
+	/**
+	 * boolean set by admins. if TRUE then this subsystem will stop the world profiler after ignite() returns and start it again when called.
+	 * used so that you can audit a specific subsystem or group of subsystems' synchronous call chain.
+	 */
+	var/profiler_focused = FALSE
+
 	/*
 	 * The following variables are managed by the MC and should not be modified directly.
 	 */


### PR DESCRIPTION
## About The Pull Request

port of https://github.com/tgstation/tgstation/pull/81461

adds a var to /subsystem that when toggled to true by an admin makes /subsystem/ignite() start the profiler before calling fire() and then stop the profiler after, this allows us to audit any individual subsystems synchronous call chain.

## Why It's Good For The Game

![Screenshot_3275](https://github.com/tgstation/tgstation/assets/15794172/27d5e4b0-ab06-451f-b4b4-97d31fd06385) when SSInput is focused

![Screenshot_3274](https://github.com/tgstation/tgstation/assets/15794172/55572861-3f71-4b6c-bb63-f1dfbbe2ab26) when SSair is focused

some subsystems are hard to profile performance issues for because theres a billion procs downstream of them in the profiler and some of them arent even unique to them (if a subsystem is spending half of its time in some procs downstream of /_SendSignal() how could you tell). now we can just do it. starting (and stopping?) the profiler itself is expensive and this messes with the full round profiler but this is worth it.

also this doesnt help with sleeping procs / timers created downstream of that subsystem.

## Changelog

:cl: Absolucy, Kylerace
admin: admins/maintainers can now make the profiler focus on specific subsystems by setting the subsystem var profile_focused to TRUE
/:cl: