### PR TITLE
Hardlight spears no longer have SPELL_REQUIRES_HUMAN

### DIFF
--- a/monkestation/code/game/objects/items/implants/hardlight.dm
+++ b/monkestation/code/game/objects/items/implants/hardlight.dm
@@ -123,6 +123,7 @@
 	cooldown_time = 20 SECONDS
 	invocation_type = INVOCATION_NONE
 
+	spell_requirements = null
 	antimagic_flags = NONE
 	spell_max_level = 5 //max is actually 7(the point where the sprites stop working), but the implant can only reach 5
 

--- a/monkestation/code/game/objects/items/implants/hardlight.dm
+++ b/monkestation/code/game/objects/items/implants/hardlight.dm
@@ -123,7 +123,7 @@
 	cooldown_time = 20 SECONDS
 	invocation_type = INVOCATION_NONE
 
-	spell_requirements = null
+	spell_requirements = NONE
 	antimagic_flags = NONE
 	spell_max_level = 5 //max is actually 7(the point where the sprites stop working), but the implant can only reach 5
 

--- a/monkestation/code/game/objects/items/implants/hardlight.dm
+++ b/monkestation/code/game/objects/items/implants/hardlight.dm
@@ -123,7 +123,6 @@
 	cooldown_time = 20 SECONDS
 	invocation_type = INVOCATION_NONE
 
-	spell_requirements = SPELL_REQUIRES_HUMAN
 	antimagic_flags = NONE
 	spell_max_level = 5 //max is actually 7(the point where the sprites stop working), but the implant can only reach 5
 


### PR DESCRIPTION

## About The Pull Request

Got xeno with hardlight spear, turns out you can't use it.
So I decided to fix that out of salt.
## Why It's Good For The Game

They have opposable thumbs and if you go through the effort you should just have it.
## Changelog
:cl:
fix: Hardlight spear implants now work on anyone with opposable thumbs rather than only humans.
/:cl:
