### PR TITLE
Changeling blind stings no longer stack

### DIFF
--- a/monkestation/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/monkestation/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -1,0 +1,12 @@
+/datum/action/changeling/sting/blind/sting_action(mob/user, mob/living/carbon/target)
+	var/obj/item/organ/internal/eyes/eyes = target.get_organ_slot(ORGAN_SLOT_EYES)
+	if(!eyes)
+		user.balloon_alert(user, "no eyes!")
+		return FALSE
+
+	log_combat(user, target, "stung", "blind sting")
+	to_chat(target, span_danger("Your eyes burn horrifically!"))
+	eyes.apply_organ_damage(eyes.maxHealth * 0.8, maximum = eyes.maxHealth * 0.8)
+	target.set_temp_blindness_if_lower(40 SECONDS)
+	target.set_eye_blur_if_lower(80 SECONDS)
+	return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5880,6 +5880,7 @@
 #include "monkestation\code\modules\antagonists\brother\actions\gear.dm"
 #include "monkestation\code\modules\antagonists\brother\gear\_gear.dm"
 #include "monkestation\code\modules\antagonists\brother\gear\recipes.dm"
+#include "monkestation\code\modules\antagonists\changeling\powers\tiny_prick.dm"
 #include "monkestation\code\modules\antagonists\clock_cult\area.dm"
 #include "monkestation\code\modules\antagonists\clock_cult\dynamic_ruleset.dm"
 #include "monkestation\code\modules\antagonists\clock_cult\globals.dm"


### PR DESCRIPTION
## Why It's Good For The Game

because it sucks being made nearly perma-blind by lings

## Changelog
:cl:
balance: Changeling blind stings no longer stack.
/:cl:
