### PR TITLE
Removes Supermatter Syndrome

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/stage3.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/stage3.dm
@@ -492,52 +492,6 @@ GLOBAL_LIST_INIT(disease_hivemind_users, list())
 		mob.adjustBruteLoss(-get_damage)
 		mob.adjustToxLoss(max(1,get_damage * multiplier / 5))
 
-/datum/symptom/mommi_hallucination
-	name = "Supermatter Syndrome"
-	desc = "Causes the infected to experience engineering-related hallucinations."
-	stage = 3
-	badness = EFFECT_DANGER_ANNOYING
-
-/datum/symptom/mommi_hallucination/activate(mob/living/carbon/mob)
-	if(prob(50))
-		mob << sound('sound/effects/supermatter.ogg', volume = 25)
-
-	var/mob/living/silicon/robot/mommi = /mob/living/silicon/robot
-	for(var/mob/living/M in viewers(mob))
-		if(M == mob)
-			continue
-
-		var/image/crab = image(icon = null)
-		crab.appearance = initial(mommi.appearance)
-
-		crab.loc = M
-		crab.override = 1
-
-		var/client/client = mob.client
-		if(client)
-			client.images += crab
-		var/duration = rand(60 SECONDS, 120 SECONDS)
-
-		spawn(duration)
-			if(client)
-				client.images.Remove(crab)
-
-	var/list/turf_list = list()
-	for(var/turf/turf in spiral_block(get_turf(mob), 40))
-		if(prob(4))
-			turf_list += turf
-	if(turf_list.len)
-		for(var/turf/open/floor/turf in turf_list)
-			var/image/supermatter = image('icons/obj/engine/supermatter.dmi', turf ,"sm", ABOVE_MOB_LAYER)
-
-			var/client/client = mob.client
-			if(client)
-				client.images += supermatter
-			var/duration = rand(60 SECONDS, 120 SECONDS)
-
-			spawn(duration)
-				if(client)
-					client.images.Remove(supermatter)
 
 
 /datum/symptom/wendigo_hallucination


### PR DESCRIPTION

## About The Pull Request

Removes the "Supermatter Syndrome" pathology symptom, which makes you hallucinate supermatters everywhere and make people see cyborgs and such.

## Why It's Good For The Game

I don't know why but the SM hallucination specifically is *genuinely disturbing*, and it creeps me out to the point of having to alt-tab out of the game whenever it happens.

## Changelog
:cl:
del: Removed the Supermatter Syndrome symptom.
/:cl:
