### PR TITLE
Fix weird body horror bug with guillotines

### DIFF
--- a/code/game/objects/structures/guillotine.dm
+++ b/code/game/objects/structures/guillotine.dm
@@ -254,6 +254,7 @@
 	..()
 
 /obj/structure/guillotine/post_unbuckle_mob(mob/living/M)
+	M.cut_overlays() // monkestation: bugfix
 	M.regenerate_icons()
 	M.pixel_y -= -GUILLOTINE_HEAD_OFFSET // Move their body back
 	M.layer -= GUILLOTINE_LAYER_DIFF


### PR DESCRIPTION
## About The Pull Request

Fixes this weird bug:

![2024-05-28 (1716953638) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/3e4cf467-ac5b-4324-adeb-7f8022595cc9) ![2024-05-28 (1716953253) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/9de346a4-97e3-4d8f-b1d6-ec7dea021a2e)

Fixes https://github.com/Monkestation/Monkestation2.0/issues/2067


## Changelog
:cl:
fix: Fixed a weird body horror bug that could happen with guillotines, resulting in a second, unremovable fake head.
/:cl:
