### PR TITLE
Curator weapons are now all renamable

### DIFF
--- a/monkestation/code/modules/jobs/job_types/curator.dm
+++ b/monkestation/code/modules/jobs/job_types/curator.dm
@@ -2,3 +2,12 @@
 	. = ..()
 	if(spawned.mind)
 		ADD_TRAIT(spawned.mind, TRAIT_OCCULTIST, JOB_TRAIT)
+
+/obj/item/melee/curator_whip
+	obj_flags = parent_type::obj_flags | UNIQUE_RENAME
+
+/obj/item/claymore/weak/ceremonial
+	obj_flags = parent_type::obj_flags | UNIQUE_RENAME
+
+/obj/item/knife/hunting
+	obj_flags = parent_type::obj_flags | UNIQUE_RENAME


### PR DESCRIPTION
## Changelog
:cl:
qol: Curators can now rename their weapons with a pen.
/:cl:
