### PR TITLE
Fix runtime in extrapolator_act

### DIFF
--- a/monkestation/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/monkestation/code/modules/mob/living/carbon/carbon_defense.dm
@@ -1,12 +1,11 @@
-/mob/living/carbon/extrapolator_act(mob/user, obj/item/extrapolator/E, scan = TRUE)
-	if(istype(E) && diseases.len)
+/mob/living/carbon/extrapolator_act(mob/user, obj/item/extrapolator/extrapolator, scan = TRUE)
+	if(istype(extrapolator) && length(diseases))
 		if(scan)
-			E.scan(src, diseases, user)
+			extrapolator.scan(src, diseases, user)
 		else
-			E.extrapolate(src, diseases, user)
+			extrapolator.extrapolate(src, diseases, user)
 		return TRUE
-	else
-		return FALSE
+	return FALSE
 
 /mob/living/carbon/is_pepper_proof(check_flags = ALL)
 	if(HAS_TRAIT(src, TRAIT_NOBREATH) && is_eyes_covered())


### PR DESCRIPTION

![image](https://github.com/Monkestation/Monkestation2.0/assets/65794972/87ad83f6-02a9-48ae-b44a-2ad60c59c646)


## Changelog
:cl:
fix: Fixed a runtime error relating to viral extrapolators.
/:cl:
