### PR TITLE
Add a full "hair recolor" to hair dye spray.

### DIFF
--- a/code/game/objects/items/dyekit.dm
+++ b/code/game/objects/items/dyekit.dm
@@ -42,9 +42,14 @@
 	if(!do_after(user, 3 SECONDS, target))
 		return
 	var/gradient_key = beard_or_hair == "Hair" ? GRADIENT_HAIR_KEY : GRADIENT_FACIAL_HAIR_KEY
-	LAZYSETLEN(human_target.grad_style, GRADIENTS_LEN)
-	LAZYSETLEN(human_target.grad_color, GRADIENTS_LEN)
-	human_target.grad_style[gradient_key] = new_grad_style
-	human_target.grad_color[gradient_key] = sanitize_hexcolor(new_grad_color)
+	// MONKESTATION EDIT START
+	if(new_grad_style == "None")
+		human_target.set_haircolor(sanitize_hexcolor(new_grad_color))
+	else
+		LAZYSETLEN(human_target.grad_style, GRADIENTS_LEN)
+		LAZYSETLEN(human_target.grad_color, GRADIENTS_LEN)
+		human_target.grad_style[gradient_key] = new_grad_style
+		human_target.grad_color[gradient_key] = sanitize_hexcolor(new_grad_color)
+	// MONKESTATION EDIT END
 	playsound(src, 'sound/effects/spray.ogg', 5, TRUE, 5)
 	human_target.update_body_parts()


### PR DESCRIPTION

## About The Pull Request
Changes the little used hair dye spray bottle to allow it to fully recolor your hair instead of just being used for applying gradients since it feels like it should be able to to that anyway.
## Why It's Good For The Game
Functions as an extra in-game customization option that would have otherwise been locked to Genetics jankiness.
## Changelog
:cl:
add: Added the ability for hair dye spray to fully change your hair color by selecting "None" in the "Choose Gradient" popup list.
fix: #2062
\:cl:
