### PR TITLE
Fixes sandevistan bundle to spawn the sandevistan instead of mantis blades

### DIFF
--- a/monkestation/code/modules/cybernetics/augments/uplink/uplink.dm
+++ b/monkestation/code/modules/cybernetics/augments/uplink/uplink.dm
@@ -13,11 +13,11 @@
 /datum/uplink_item/bundles_tc/mantis
 	name = "Mantis Blade Bundle"
 	desc = "A box containing various implants"
-	item = /obj/item/storage/box/syndie_kit/sandy
+	item = /obj/item/storage/box/syndie_kit/mantis
 	cost = 12
 	purchasable_from = UPLINK_TRAITORS
 
-/obj/item/storage/box/syndie_kit/sandy/PopulateContents()
+/obj/item/storage/box/syndie_kit/mantis/PopulateContents()
 	new /obj/item/autosurgeon/organ/cyberlink_syndicate(src)
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis(src)
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis/l(src)


### PR DESCRIPTION

## About The Pull Request
Makes the syndicate sandevistan acquirable without admin intervention.
## Why It's Good For The Game
Squashes a bug
## Changelog
:cl: Syndie Kate
fix: Made the sandevistan bundle not spawn mantis blades.
/:cl:
