### PR TITLE
Makes it so gigantism is not lost on bloodsucker

### DIFF
--- a/monkestation/code/datums/quirks/neutral_quirks.dm
+++ b/monkestation/code/datums/quirks/neutral_quirks.dm
@@ -14,6 +14,11 @@
 				gojira.dna.add_mutation(/datum/mutation/human/gigantism)
 		else
 			quirk_holder.update_transform(1.25) //If they can't have genes, give gigantism's effect
+
+/datum/quirk/gigantism/remove()
+	. = ..()
+	if(ishuman(quirk_holder) && HAS_TRAIT(quirk_holder, TRAIT_GENELESS))
+		quirk_holder.update_transform(0.8) //reverts forced gigantism if lost
 /datum/quirk/anime
 	name = "Anime"
 	desc = "You are an anime enjoyer! Show your enthusiasm with some fashionable attire."

--- a/monkestation/code/datums/quirks/neutral_quirks.dm
+++ b/monkestation/code/datums/quirks/neutral_quirks.dm
@@ -7,11 +7,13 @@
 
 /datum/quirk/gigantism/add()
 	. = ..()
-	if (ishuman(quirk_holder))
-		var/mob/living/carbon/human/gojira = quirk_holder
-		if(gojira.dna)
-			gojira.dna.add_mutation(/datum/mutation/human/gigantism)
-
+	if(ishuman(quirk_holder))
+		if(!HAS_TRAIT(quirk_holder, TRAIT_GENELESS))
+			var/mob/living/carbon/human/gojira = quirk_holder
+			if(gojira.dna)
+				gojira.dna.add_mutation(/datum/mutation/human/gigantism)
+		else
+			quirk_holder.update_transform(1.25) //If they can't have genes, give gigantism's effect
 /datum/quirk/anime
 	name = "Anime"
 	desc = "You are an anime enjoyer! Show your enthusiasm with some fashionable attire."


### PR DESCRIPTION

## About The Pull Request
fixes #2089
Makes gigantism still work on bloodsuckers
## Why It's Good For The Game
So people don't metagame giants becoming small
## Changelog
:cl: Syndie Kate
fix: fixes the gigantism quirk on bloodsucker
/:cl:
