### PR TITLE
Bloodsucker fixes

### DIFF
--- a/code/__DEFINES/bloodsuckers.dm
+++ b/code/__DEFINES/bloodsuckers.dm
@@ -165,6 +165,10 @@
  */
 /// Source trait for Bloodsuckers-related traits
 #define BLOODSUCKER_TRAIT "bloodsucker_trait"
+/// Source trait for bloodsuckers in torpor.
+#define TORPOR_TRAIT "torpor_trait"
+/// Source trait for bloodsucker mesmerization.
+#define MESMERIZED_TRAIT "mesmerized_trait"
 /// Source trait for Monster Hunter-related traits
 #define HUNTER_TRAIT "monsterhunter_trait"
 /// Source trait while Feeding

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_conversion.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_conversion.dm
@@ -41,7 +41,7 @@
 	if(!master || (master == owner.current))
 		return TRUE
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = master.mind.has_antag_datum(/datum/antagonist/bloodsucker)
-	if(bloodsuckerdatum && bloodsuckerdatum.broke_masquerade)
+	if(bloodsuckerdatum?.broke_masquerade)
 		//vassal stealing
 		return TRUE
 	to_chat(owner.current, span_danger("[conversion_target]'s mind is overwhelmed with too much external force to put your own!"))
@@ -52,7 +52,7 @@
  *  time, ranges from 1 at 20 pop to 4 at 40 pop
  */
 /datum/antagonist/bloodsucker/proc/return_current_max_vassals()
-	var/total_players = GLOB.joined_player_list.len
+	var/total_players = length(GLOB.joined_player_list)
 	switch(total_players)
 		if(1 to 20)
 			return 1
@@ -72,8 +72,7 @@
 		return FALSE
 
 	//Check if they used to be a Vassal and was stolen.
-	var/datum/antagonist/vassal/old_vassal = conversion_target.mind.has_antag_datum(/datum/antagonist/vassal)
-	if(old_vassal)
+	if(IS_VASSAL(conversion_target))
 		conversion_target.mind.remove_antag_datum(/datum/antagonist/vassal)
 
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = owner.has_antag_datum(/datum/antagonist/bloodsucker)

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
@@ -341,7 +341,7 @@
 
 	// Default Report
 	var/objectives_complete = TRUE
-	if(objectives.len)
+	if(length(objectives))
 		report += printobjectives(objectives)
 		for(var/datum/objective/objective in objectives)
 			if(objective.objective_name == "Optional Objective")
@@ -351,10 +351,10 @@
 				break
 
 	// Now list their vassals
-	if(vassals.len)
-		report += "<span class='header'>Their Vassals were...</span>"
+	if(length(vassals))
+		report +=  span_header("Their Vassals were...")
 		for(var/datum/antagonist/vassal/all_vassals as anything in vassals)
-			if(!all_vassals.owner)
+			if(QDELETED(all_vassals?.owner))
 				continue
 			var/list/vassal_report = list()
 			vassal_report += "<b>[all_vassals.owner.name]</b>"
@@ -367,7 +367,7 @@
 				vassal_report += " and was the <b>Revenge Vassal</b>"
 			report += vassal_report.Join()
 
-	if(objectives.len == 0 || objectives_complete)
+	if(!length(objectives) || objectives_complete)
 		report += "<span class='greentext big'>The [name] was successful!</span>"
 	else
 		report += "<span class='redtext big'>The [name] has failed!</span>"

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_flaws.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_flaws.dm
@@ -8,24 +8,21 @@
  * person_selecting - Mob override for stuff like Admins selecting someone's clan.
  */
 /datum/antagonist/bloodsucker/proc/assign_clan_and_bane(mob/person_selecting)
-	if(my_clan)
+	if(my_clan || owner.current.has_status_effect(/datum/status_effect/frenzy))
 		return
-	if(owner.current.has_status_effect(/datum/status_effect/frenzy))
-		return
-	if(!person_selecting)
-		person_selecting = owner.current
+	person_selecting ||= owner.current
 
 	var/list/options = list()
 	var/list/radial_display = list()
 	for(var/datum/bloodsucker_clan/all_clans as anything in typesof(/datum/bloodsucker_clan))
-		if(!initial(all_clans.joinable_clan)) //flavortext only
+		if(!all_clans::joinable_clan) //flavortext only
 			continue
-		options[initial(all_clans.name)] = all_clans
+		options[all_clans::name] = all_clans
 
 		var/datum/radial_menu_choice/option = new
-		option.image = image(icon = initial(all_clans.join_icon), icon_state = initial(all_clans.join_icon_state))
-		option.info = "[initial(all_clans.name)] - [span_boldnotice(initial(all_clans.join_description))]"
-		radial_display[initial(all_clans.name)] = option
+		option.image = image(icon = all_clans::join_icon, icon_state = all_clans::join_icon_state)
+		option.info = "[all_clans::name] - [span_boldnotice(all_clans::join_description)]"
+		radial_display[all_clans::name] = option
 
 	var/chosen_clan = show_radial_menu(person_selecting, owner.current, radial_display)
 	chosen_clan = options[chosen_clan]

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_frenzy.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_frenzy.dm
@@ -67,7 +67,7 @@
 	owner.add_client_colour(/datum/client_colour/cursed_heart_blood)
 	var/obj/cuffs = user.get_item_by_slot(ITEM_SLOT_HANDCUFFED)
 	var/obj/legcuffs = user.get_item_by_slot(ITEM_SLOT_LEGCUFFED)
-	if(user.handcuffed || user.legcuffed)
+	if(!QDELETED(user.handcuffed) || !QDELETED(user.legcuffed))
 		user.clear_cuffs(cuffs, TRUE)
 		user.clear_cuffs(legcuffs, TRUE)
 	bloodsuckerdatum.frenzied = TRUE
@@ -90,6 +90,6 @@
 
 /datum/status_effect/frenzy/tick()
 	var/mob/living/carbon/human/user = owner
-	if(!bloodsuckerdatum.frenzied)
+	if(!bloodsuckerdatum?.frenzied)
 		return
 	user.adjustFireLoss(1.5 + (bloodsuckerdatum.humanity_lost / 10))

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
@@ -16,7 +16,7 @@
 	if(length(guardians) && !allow_multiple)
 		balloon_alert(user, "already have one!")
 		return
-	if(user.mind && user.mind.has_antag_datum(/datum/antagonist/changeling) && !allow_changeling)
+	if(user.mind?.has_antag_datum(/datum/antagonist/changeling) && !allow_changeling)
 		to_chat(user, ling_failure)
 		return
 	if(used)

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_hud.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_hud.dm
@@ -43,8 +43,7 @@
 	else if(bloodsucker_blood_volume > BLOOD_VOLUME_BAD)
 		valuecolor = "#FFAAAA"
 
-	if(blood_display)
-		blood_display.maptext = FORMAT_BLOODSUCKER_HUD_TEXT(valuecolor, bloodsucker_blood_volume)
+	blood_display?.maptext = FORMAT_BLOODSUCKER_HUD_TEXT(valuecolor, bloodsucker_blood_volume)
 
 	if(vamprank_display)
 		if(bloodsucker_level_unspent > 0)

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
@@ -10,10 +10,10 @@
 	if(!owner)
 		INVOKE_ASYNC(src, PROC_REF(HandleDeath))
 		return
-	if(HAS_TRAIT(owner.current, TRAIT_NODEATH))
+	if(HAS_TRAIT_FROM(owner.current, TRAIT_NODEATH, TORPOR_TRAIT))
 		check_end_torpor()
 	// Deduct Blood
-	if(owner.current.stat == CONSCIOUS && !HAS_TRAIT(owner.current, TRAIT_IMMOBILIZED) && !HAS_TRAIT(owner.current, TRAIT_NODEATH))
+	if(owner.current.stat == CONSCIOUS && !HAS_TRAIT(owner.current, TRAIT_IMMOBILIZED) && !HAS_TRAIT_FROM(owner.current, TRAIT_NODEATH, TORPOR_TRAIT))
 		INVOKE_ASYNC(src, PROC_REF(AddBloodVolume), -BLOODSUCKER_PASSIVE_BLOOD_DRAIN) // -.1 currently
 	if(HandleHealing())
 		if((COOLDOWN_FINISHED(src, bloodsucker_spam_healing)) && bloodsucker_blood_volume > 0)
@@ -83,7 +83,7 @@
 /datum/antagonist/bloodsucker/proc/HandleHealing(mult = 1)
 	var/actual_regen = bloodsucker_regen_rate + additional_regen
 	// Don't heal if I'm staked or on Masquerade (+ not in a Coffin). Masqueraded Bloodsuckers in a Coffin however, will heal.
-	if(owner.current.am_staked() || (HAS_TRAIT(owner.current, TRAIT_MASQUERADE) && !HAS_TRAIT(owner.current, TRAIT_NODEATH)))
+	if(owner.current.am_staked() || (HAS_TRAIT(owner.current, TRAIT_MASQUERADE) && !HAS_TRAIT_FROM(owner.current, TRAIT_NODEATH, TORPOR_TRAIT)))
 		return FALSE
 	owner.current.adjustCloneLoss(-1 * (actual_regen * 4) * mult, 0)
 	owner.current.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1 * (actual_regen * 4) * mult) //adjustBrainLoss(-1 * (actual_regen * 4) * mult, 0)
@@ -95,7 +95,7 @@
 	var/fireheal = 0 // BURN: Heal in Coffin while Fakedeath, or when damage above maxhealth (you can never fully heal fire)
 	// Checks if you're in a coffin here, additionally checks for Torpor right below it.
 	var/amInCoffin = istype(user.loc, /obj/structure/closet/crate/coffin)
-	if(amInCoffin && HAS_TRAIT(user, TRAIT_NODEATH))
+	if(amInCoffin && HAS_TRAIT_FROM(user, TRAIT_NODEATH, TORPOR_TRAIT))
 		if(HAS_TRAIT(owner.current, TRAIT_MASQUERADE) && (COOLDOWN_FINISHED(src, bloodsucker_spam_healing)))
 			to_chat(user, span_alert("You do not heal while your Masquerade ability is active."))
 			COOLDOWN_START(src, bloodsucker_spam_healing, BLOODSUCKER_SPAM_MASQUERADE)
@@ -108,7 +108,7 @@
 		if(check_limbs(costMult))
 			return TRUE
 	// In Torpor, but not in a Coffin? Heal faster anyways.
-	else if(HAS_TRAIT(user, TRAIT_NODEATH))
+	else if(HAS_TRAIT_FROM(user, TRAIT_NODEATH, TORPOR_TRAIT))
 		fireheal = min(user.getFireLoss_nonProsthetic(), actual_regen) / 1.2 // 20% slower than being in a coffin
 		mult *= 3
 	// Heal if Damaged
@@ -123,7 +123,7 @@
 	var/limb_regen_cost = 50 * -costMult
 	var/mob/living/carbon/user = owner.current
 	var/list/missing = user.get_missing_limbs()
-	if(missing.len && (bloodsucker_blood_volume < limb_regen_cost + 5))
+	if(length(missing) && (bloodsucker_blood_volume < limb_regen_cost + 5))
 		return FALSE
 	for(var/missing_limb in missing) //Find ONE Limb and regenerate it.
 		user.regenerate_limb(missing_limb, FALSE)
@@ -155,7 +155,7 @@
 		organ.set_organ_damage(0)
 	if(!HAS_TRAIT(bloodsuckeruser, TRAIT_MASQUERADE))
 		var/obj/item/organ/internal/heart/current_heart = bloodsuckeruser.get_organ_slot(ORGAN_SLOT_HEART)
-		current_heart.beating = FALSE
+		current_heart?.beating = FALSE
 	var/obj/item/organ/internal/eyes/current_eyes = bloodsuckeruser.get_organ_slot(ORGAN_SLOT_EYES)
 	if(current_eyes)
 		current_eyes.flash_protect = max(initial(current_eyes.flash_protect) - 1, FLASH_PROTECTION_SENSITIVE)
@@ -199,7 +199,7 @@
 		FinalDeath()
 		return
 	// Temporary Death? Convert to Torpor.
-	if(HAS_TRAIT(owner.current, TRAIT_NODEATH))
+	if(HAS_TRAIT_FROM(owner.current, TRAIT_NODEATH, TORPOR_TRAIT))
 		return
 	to_chat(owner.current, span_danger("Your immortal body will not yet relinquish your soul to the abyss. You enter Torpor."))
 	check_begin_torpor(TRUE)
@@ -215,7 +215,7 @@
 	if(bloodsucker_blood_volume >= FRENZY_THRESHOLD_EXIT && frenzied)
 		owner.current.remove_status_effect(/datum/status_effect/frenzy)
 	// BLOOD_VOLUME_BAD: [224] - Jitter
-	if(bloodsucker_blood_volume < BLOOD_VOLUME_BAD && prob(0.5) && !HAS_TRAIT(owner.current, TRAIT_NODEATH) && !HAS_TRAIT(owner.current, TRAIT_MASQUERADE))
+	if(bloodsucker_blood_volume < BLOOD_VOLUME_BAD && prob(0.5) && !HAS_TRAIT_FROM(owner.current, TRAIT_NODEATH, TORPOR_TRAIT) && !HAS_TRAIT(owner.current, TRAIT_MASQUERADE))
 		owner.current.set_timed_status_effect(3 SECONDS, /datum/status_effect/jitter, only_if_higher = TRUE)
 	// BLOOD_VOLUME_SURVIVE: [122] - Blur Vision
 	if(bloodsucker_blood_volume < BLOOD_VOLUME_SURVIVE)

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_misc_procs.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_misc_procs.dm
@@ -87,7 +87,7 @@
 ///Disables all powers, accounting for torpor
 /datum/antagonist/bloodsucker/proc/DisableAllPowers(forced = FALSE)
 	for(var/datum/action/cooldown/bloodsucker/power as anything in powers)
-		if(forced || ((power.check_flags & BP_CANT_USE_IN_TORPOR) && HAS_TRAIT(owner.current, TRAIT_NODEATH)))
+		if(forced || ((power.check_flags & BP_CANT_USE_IN_TORPOR) && HAS_TRAIT_FROM(owner.current, TRAIT_NODEATH, TORPOR_TRAIT)))
 			if(power.active)
 				power.DeactivatePower()
 

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_objectives.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_objectives.dm
@@ -32,7 +32,7 @@
 /// Check Vassals and get their occupations
 /datum/objective/bloodsucker/proc/get_vassal_occupations()
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = owner.has_antag_datum(/datum/antagonist/bloodsucker)
-	if(!bloodsuckerdatum || !bloodsuckerdatum.vassals.len)
+	if(!length(bloodsuckerdatum?.vassals))
 		return FALSE
 	var/list/all_vassal_jobs = list()
 	var/vassal_job
@@ -310,7 +310,7 @@
 	var/list/datum/mind/monsters = list()
 	for(var/datum/antagonist/monster in GLOB.antagonists)
 		var/datum/mind/brain = monster.owner
-		if(!brain || brain == owner)
+		if(QDELETED(brain) || brain == owner)
 			continue
 		if(brain.current.stat == DEAD)
 			continue
@@ -319,7 +319,7 @@
 		if(brain.has_antag_datum(/datum/antagonist/changeling))
 			monsters += brain
 
-	return completed || !monsters.len
+	return completed || !length(monsters)
 
 
 

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_overwrites.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_overwrites.dm
@@ -20,12 +20,8 @@
 /mob/living/carbon/transfer_blood_to(atom/movable/AM, amount, forced)
 	. = ..()
 
-	if(!mind)
-		return
-	var/datum/antagonist/bloodsucker/bloodsuckerdatum = mind.has_antag_datum(/datum/antagonist/bloodsucker)
-	if(!bloodsuckerdatum)
-		return
-	bloodsuckerdatum.bloodsucker_blood_volume -= amount
+	var/datum/antagonist/bloodsucker/bloodsuckerdatum = mind?.has_antag_datum(/datum/antagonist/bloodsucker)
+	bloodsuckerdatum?.bloodsucker_blood_volume -= amount
 
 /// Prevents using a Memento Mori
 /obj/item/clothing/neck/necklace/memento_mori/memento(mob/living/carbon/human/user)
@@ -42,10 +38,9 @@
 
 // Used when analyzing a Bloodsucker, Masquerade will hide brain traumas (Unless you're a Beefman)
 /mob/living/carbon/get_traumas()
-	if(!mind)
+	if(QDELETED(mind))
 		return ..()
-	var/datum/antagonist/bloodsucker/bloodsuckerdatum = IS_BLOODSUCKER(src)
-	if(bloodsuckerdatum && HAS_TRAIT(src, TRAIT_MASQUERADE))
+	if(IS_BLOODSUCKER(src) && HAS_TRAIT(src, TRAIT_MASQUERADE))
 		return
 	return ..()
 

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_shaded.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_shaded.dm
@@ -23,7 +23,7 @@
 
 /obj/item/soulstone/bloodsucker/get_ghost_to_replace_shade(mob/living/carbon/victim, mob/user)
 	var/mob/dead/observer/chosen_ghost = victim.get_ghost(FALSE, TRUE)
-	if(!chosen_ghost || !chosen_ghost.client)
+	if(QDELETED(chosen_ghost?.client))
 		victim.dust()
 		return FALSE
 	victim.unequip_everything()

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_sol.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_sol.dm
@@ -66,7 +66,7 @@
 		if(owner.current.am_staked() && COOLDOWN_FINISHED(src, bloodsucker_spam_sol_burn))
 			to_chat(owner.current, span_userdanger("You are staked! Remove the offending weapon from your heart before sleeping."))
 			COOLDOWN_START(src, bloodsucker_spam_sol_burn, BLOODSUCKER_SPAM_SOL) //This should happen twice per Sol
-		if(!HAS_TRAIT(owner.current, TRAIT_NODEATH))
+		if(!HAS_TRAIT_FROM(owner.current, TRAIT_NODEATH, TORPOR_TRAIT))
 			check_begin_torpor(TRUE)
 			owner.current.add_mood_event("vampsleep", /datum/mood_event/coffinsleep)
 		return
@@ -122,7 +122,7 @@
 	var/total_burn = user.getFireLoss_nonProsthetic()
 	var/total_damage = total_brute + total_burn
 	/// Checks - Not daylight & Has more than 10 Brute/Burn & not already in Torpor
-	if(!SSsunlight.sunlight_active && total_damage >= 10 && !HAS_TRAIT(owner.current, TRAIT_NODEATH))
+	if(!SSsunlight.sunlight_active && total_damage >= 10 && !HAS_TRAIT_FROM(owner.current, TRAIT_NODEATH, TORPOR_TRAIT))
 		torpor_begin()
 
 /datum/antagonist/bloodsucker/proc/check_end_torpor()
@@ -147,7 +147,7 @@
 	// Force them to go to sleep
 	REMOVE_TRAIT(owner.current, TRAIT_SLEEPIMMUNE, BLOODSUCKER_TRAIT)
 	// Without this, you'll just keep dying while you recover.
-	owner.current.add_traits(list(TRAIT_NODEATH, TRAIT_FAKEDEATH, TRAIT_DEATHCOMA, TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHIGHPRESSURE), BLOODSUCKER_TRAIT)
+	owner.current.add_traits(list(TRAIT_NODEATH, TRAIT_FAKEDEATH, TRAIT_DEATHCOMA, TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHIGHPRESSURE), TORPOR_TRAIT)
 	owner.current.set_timed_status_effect(0 SECONDS, /datum/status_effect/jitter, only_if_higher = TRUE)
 	// Disable ALL Powers
 	DisableAllPowers()
@@ -155,7 +155,7 @@
 /datum/antagonist/bloodsucker/proc/torpor_end()
 	owner.current.grab_ghost()
 	to_chat(owner.current, span_warning("You have recovered from Torpor."))
-	owner.current.remove_traits(list(TRAIT_NODEATH, TRAIT_FAKEDEATH, TRAIT_DEATHCOMA, TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHIGHPRESSURE), BLOODSUCKER_TRAIT)
+	REMOVE_TRAITS_IN(owner.current, TORPOR_TRAIT)
 	if(!HAS_TRAIT(owner.current, TRAIT_MASQUERADE))
 		ADD_TRAIT(owner.current, TRAIT_SLEEPIMMUNE, BLOODSUCKER_TRAIT)
 	heal_vampire_organs()

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_traumas.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_traumas.dm
@@ -56,7 +56,7 @@
 
 	// Delete Next Portal if it's time (it will remove its partner)
 	var/obj/effect/client_image_holder/phobetor/first_on_the_stack = created_firsts[1]
-	if(created_firsts.len && world.time >= first_on_the_stack.created_on + first_on_the_stack.exist_length)
+	if(length(created_firsts) && world.time >= first_on_the_stack.created_on + first_on_the_stack.exist_length)
 		var/targetGate = first_on_the_stack
 		created_firsts -= targetGate
 		qdel(targetGate)

--- a/monkestation/code/modules/bloodsuckers/clans/_clan_base.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/_clan_base.dm
@@ -150,7 +150,7 @@
 		if(initial(power.purchase_flags) & BLOODSUCKER_CAN_BUY && !(locate(power) in bloodsuckerdatum.powers))
 			options[initial(power.name)] = power
 
-	if(options.len < 1)
+	if(length(options) < 1)
 		to_chat(bloodsuckerdatum.owner.current, span_notice("You grow more ancient by the night!"))
 	else
 		// Give them the UI to purchase a power.
@@ -242,7 +242,7 @@
 		option.info = "[initial(vassaldatums.name)] - [span_boldnotice(initial(vassaldatums.vassal_description))]"
 		radial_display[initial(vassaldatums.name)] = option
 
-	if(!options.len)
+	if(!length(options))
 		return
 
 	to_chat(bloodsuckerdatum.owner.current, span_notice("You can change who this Vassal is, who are they to you?"))

--- a/monkestation/code/modules/bloodsuckers/clans/tremere.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/tremere.dm
@@ -41,7 +41,7 @@
 			continue
 		options[initial(power.name)] = power
 
-	if(options.len < 1)
+	if(length(options) < 1)
 		to_chat(bloodsuckerdatum.owner.current, span_notice("You grow more ancient by the night!"))
 	else
 		// Give them the UI to purchase a power.

--- a/monkestation/code/modules/bloodsuckers/clans/venture.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/venture.dm
@@ -32,7 +32,7 @@
 		if(initial(power.purchase_flags) & VASSAL_CAN_BUY && !(locate(power) in vassaldatum.powers))
 			options[initial(power.name)] = power
 
-	if(options.len < 1)
+	if(length(options) < 1)
 		to_chat(bloodsuckerdatum.owner.current, span_notice("You grow more ancient by the night!"))
 	else
 		// Give them the UI to purchase a power.

--- a/monkestation/code/modules/bloodsuckers/controllers/sunlight.dm
+++ b/monkestation/code/modules/bloodsuckers/controllers/sunlight.dm
@@ -38,7 +38,7 @@ SUBSYSTEM_DEF(sunlight)
 			issued_XP = FALSE
 			//randomize the next sol timer
 			time_til_cycle = round(rand((TIME_BLOODSUCKER_NIGHT-TIME_BLOODSUCKER_SOL_DELAY), (TIME_BLOODSUCKER_NIGHT+TIME_BLOODSUCKER_SOL_DELAY)), 1)
-			message_admins("BLOODSUCKER NOTICE: Daylight Ended. Resetting to Night (Lasts for [time_til_cycle / 60] minutes.")
+			message_admins("BLOODSUCKER NOTICE: Daylight Ended. Resetting to Night (Lasts for [DisplayTimeText(time_til_cycle * 0.1)])")
 			SEND_SIGNAL(src, COMSIG_SOL_END)
 			warn_daylight(
 				danger_level = DANGER_LEVEL_SOL_ENDED,
@@ -52,14 +52,14 @@ SUBSYSTEM_DEF(sunlight)
 			SEND_SIGNAL(src, COMSIG_SOL_NEAR_START)
 			warn_daylight(
 				danger_level = DANGER_LEVEL_FIRST_WARNING,
-				vampire_warning_message = span_danger("Solar Flares will bombard the station with dangerous UV radiation in [TIME_BLOODSUCKER_DAY_WARN / 60] minutes. <b>Prepare to seek cover in a coffin or closet.</b>"),
+				vampire_warning_message = span_danger("Solar Flares will bombard the station with dangerous UV radiation in [DisplayTimeText(TIME_BLOODSUCKER_DAY_WARN * 0.1)]. <b>Prepare to seek cover in a coffin or closet.</b>"),
 			)
 		if(TIME_BLOODSUCKER_DAY_FINAL_WARN)
-			message_admins("BLOODSUCKER NOTICE: Daylight beginning in [TIME_BLOODSUCKER_DAY_FINAL_WARN] seconds.)")
+			message_admins("BLOODSUCKER NOTICE: Daylight beginning in [DisplayTimeText(TIME_BLOODSUCKER_DAY_FINAL_WARN * 0.1)].)")
 			warn_daylight(
 				danger_level = DANGER_LEVEL_SECOND_WARNING,
-				vampire_warning_message = span_userdanger("Solar Flares are about to bombard the station! You have [TIME_BLOODSUCKER_DAY_FINAL_WARN] seconds to find cover!"),
-				vassal_warning_message = span_danger("In [TIME_BLOODSUCKER_DAY_FINAL_WARN] seconds, your master will be at risk of a Solar Flare. Make sure they find cover!"),
+				vampire_warning_message = span_userdanger("Solar Flares are about to bombard the station! You have [DisplayTimeText(TIME_BLOODSUCKER_DAY_FINAL_WARN * 0.1)] to find cover!"),
+				vassal_warning_message = span_danger("In [DisplayTimeText(TIME_BLOODSUCKER_DAY_FINAL_WARN * 0.1)], your master will be at risk of a Solar Flare. Make sure they find cover!"),
 			)
 		if(TIME_BLOODSUCKER_BURN_INTERVAL)
 			warn_daylight(
@@ -70,10 +70,10 @@ SUBSYSTEM_DEF(sunlight)
 			sunlight_active = TRUE
 			//set the timer to countdown daytime now.
 			time_til_cycle = TIME_BLOODSUCKER_DAY
-			message_admins("BLOODSUCKER NOTICE: Daylight Beginning (Lasts for [TIME_BLOODSUCKER_DAY / 60] minutes.)")
+			message_admins("BLOODSUCKER NOTICE: Daylight Beginning (Lasts for [DisplayTimeText(TIME_BLOODSUCKER_DAY * 0.1)])")
 			warn_daylight(
 				danger_level = DANGER_LEVEL_SOL_ROSE,
-				vampire_warning_message = span_userdanger("Solar flares bombard the station with deadly UV light! Stay in cover for the next [TIME_BLOODSUCKER_DAY / 60] minutes or risk Final Death!"),
+				vampire_warning_message = span_userdanger("Solar flares bombard the station with deadly UV light! Stay in cover for the next [DisplayTimeText(TIME_BLOODSUCKER_DAY * 0.1)] or risk Final Death!"),
 				vassal_warning_message = span_userdanger("Solar flares bombard the station with UV light!"),
 			)
 

--- a/monkestation/code/modules/bloodsuckers/monster_hunters/hunter_rulesets.dm
+++ b/monkestation/code/modules/bloodsuckers/monster_hunters/hunter_rulesets.dm
@@ -44,7 +44,7 @@
 			living_players -= player
 
 /datum/dynamic_ruleset/midround/monsterhunter/ready(forced = FALSE)
-	if(required_candidates > living_players.len)
+	if(required_candidates > length(living_players))
 		return FALSE
 	var/count = 0
 	for(var/datum/antagonist/monster as anything in GLOB.antagonists)

--- a/monkestation/code/modules/bloodsuckers/monster_hunters/hunting_contracts.dm
+++ b/monkestation/code/modules/bloodsuckers/monster_hunters/hunting_contracts.dm
@@ -42,7 +42,7 @@
 	data["bought"] = bought
 	data["items"] = list()
 	data["objectives"] = list()
-	if(weapons.len)
+	if(length(weapons))
 		for(var/datum/hunter_weapons/contraband as anything in weapons)
 			data["items"] += list(list(
 				"id" = contraband.type,

--- a/monkestation/code/modules/bloodsuckers/powers/_base_power.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/_base_power.dm
@@ -54,7 +54,7 @@
 	return ..()
 
 /datum/action/cooldown/bloodsucker/IsAvailable(feedback = FALSE)
-	return next_use_time <= world.time
+	return COOLDOWN_FINISHED(src, next_use_time)
 
 /datum/action/cooldown/bloodsucker/Grant(mob/user)
 	. = ..()
@@ -76,7 +76,7 @@
 	return TRUE
 
 /datum/action/cooldown/bloodsucker/proc/can_pay_cost()
-	if(!owner || !owner.mind)
+	if(QDELETED(owner) || QDELETED(owner.mind))
 		return FALSE
 	// Cooldown?
 	if(!COOLDOWN_FINISHED(src, next_use_time))
@@ -108,7 +108,7 @@
 	if(!isliving(user))
 		return FALSE
 	// Torpor?
-	if((check_flags & BP_CANT_USE_IN_TORPOR) && HAS_TRAIT(user, TRAIT_NODEATH))
+	if((check_flags & BP_CANT_USE_IN_TORPOR) && HAS_TRAIT_FROM(user, TRAIT_NODEATH, TORPOR_TRAIT))
 		to_chat(user, span_warning("Not while you're in Torpor."))
 		return FALSE
 	// Frenzy?
@@ -186,9 +186,11 @@
 /datum/action/cooldown/bloodsucker/process(seconds_per_tick)
 	SHOULD_CALL_PARENT(TRUE) //Need this to call parent so the cooldown system works
 	. = ..()
+	if(!active) // if we're not active anyways, then we shouldn't be processing!!!
+		return PROCESS_KILL
 	if(!ContinueActive(owner)) // We can't afford the Power? Deactivate it.
 		DeactivatePower()
-		return FALSE
+		return PROCESS_KILL
 	// We can keep this up (For now), so Pay Cost!
 	if(!(power_flags & BP_AM_COSTLESS_UNCONSCIOUS) && owner.stat != CONSCIOUS)
 		if(bloodsuckerdatum_power)

--- a/monkestation/code/modules/bloodsuckers/powers/go_home.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/go_home.dm
@@ -38,7 +38,7 @@
 	if(!.)
 		return FALSE
 	/// Have No Lair (NOTE: You only got this power if you had a lair, so this means it's destroyed)
-	if(!istype(bloodsuckerdatum_power) || !bloodsuckerdatum_power.coffin)
+	if(!istype(bloodsuckerdatum_power) || QDELETED(bloodsuckerdatum_power.coffin))
 		owner.balloon_alert(owner, "coffin was destroyed!")
 		return FALSE
 	return TRUE
@@ -69,7 +69,7 @@
 		return FALSE
 	if(!isturf(owner.loc))
 		return FALSE
-	if(!bloodsuckerdatum_power.coffin)
+	if(QDELETED(bloodsuckerdatum_power.coffin))
 		user.balloon_alert(user, "coffin destroyed!")
 		to_chat(owner, span_warning("Your coffin has been destroyed! You no longer have a destination."))
 		return FALSE
@@ -84,9 +84,9 @@
 	var/drop_item = FALSE
 	var/turf/current_turf = get_turf(owner)
 	// If we aren't in the dark, anyone watching us will cause us to drop out stuff
-	if(current_turf && current_turf.lighting_object && current_turf.get_lumcount() >= 0.2)
+	if(!QDELETED(current_turf?.lighting_object) && current_turf.get_lumcount() >= 0.2)
 		for(var/mob/living/watchers in viewers(world.view, get_turf(owner)) - owner)
-			if(!watchers.client)
+			if(QDELETED(watchers.client))
 				continue
 			if(watchers.has_unlimited_silicon_privilege)
 				continue

--- a/monkestation/code/modules/bloodsuckers/powers/targeted/_base_targeted.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/targeted/_base_targeted.dm
@@ -22,7 +22,7 @@
 		unset_click_ability(remove_from)
 
 /datum/action/cooldown/bloodsucker/targeted/Trigger(trigger_flags, atom/target)
-	if((active) && can_deactivate())
+	if(active && can_deactivate())
 		DeactivatePower()
 		return FALSE
 	if(!can_pay_cost(owner) || !can_use(owner, trigger_flags))
@@ -32,7 +32,7 @@
 		to_chat(owner, span_announce("[prefire_message]"))
 
 	ActivatePower(trigger_flags)
-	if(target)
+	if(!QDELETED(target))
 		return InterceptClickOn(owner, null, target)
 
 	return set_click_ability(owner)

--- a/monkestation/code/modules/bloodsuckers/powers/targeted/brawn.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/targeted/brawn.dm
@@ -78,11 +78,7 @@
 
 // This is its own proc because its done twice, to repeat code copypaste.
 /datum/action/cooldown/bloodsucker/targeted/brawn/proc/break_closet(mob/living/carbon/human/user, obj/structure/closet/closet)
-	if(closet)
-		closet.welded = FALSE
-		closet.locked = FALSE
-		closet.broken = TRUE
-		closet.open()
+	closet?.bust_open()
 
 /datum/action/cooldown/bloodsucker/targeted/brawn/proc/escape_puller()
 	if(!owner.pulledby) // || owner.pulledby.grab_state <= GRAB_PASSIVE)

--- a/monkestation/code/modules/bloodsuckers/powers/targeted/lunge.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/targeted/lunge.dm
@@ -29,10 +29,10 @@
 	if(!.)
 		return FALSE
 	// Are we being grabbed?
-	if(user.pulledby && user.pulledby.grab_state >= GRAB_AGGRESSIVE)
+	if(!QDELETED(user.pulledby) && user.pulledby.grab_state >= GRAB_AGGRESSIVE)
 		owner.balloon_alert(user, "grabbed!")
 		return FALSE
-	if(user.pulling)
+	if(!QDELETED(user.pulling))
 		owner.balloon_alert(user, "grabbing someone!")
 		return FALSE
 	return TRUE

--- a/monkestation/code/modules/bloodsuckers/powers/targeted/trespass.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/targeted/trespass.dm
@@ -71,7 +71,7 @@
 	)
 	// Effect Origin
 	var/sound_strength = max(60, 70 - level_current * 10)
-	playsound(get_turf(owner), 'sound/magic/summon_karp.ogg', sound_strength, 1)
+	playsound(get_turf(owner), 'sound/magic/summon_karp.ogg', vol = sound_strength, vary = TRUE)
 	var/datum/effect_system/steam_spread/bloodsucker/puff = new /datum/effect_system/steam_spread()
 	puff.set_up(3, 0, my_turf)
 	puff.start()
@@ -99,7 +99,7 @@
 	user.density = 1
 	user.invisibility = invis_was
 	// Effect Destination
-	playsound(get_turf(owner), 'sound/magic/summon_karp.ogg', 60, 1)
+	playsound(get_turf(owner), 'sound/magic/summon_karp.ogg', vol = 60, vary = TRUE)
 	puff = new /datum/effect_system/steam_spread/()
 	puff.effect_type = /obj/effect/particle_effect/fluid/smoke/vampsmoke
 	puff.set_up(3, 0, target_turf)

--- a/monkestation/code/modules/bloodsuckers/powers/vassal/vassal_fold.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/vassal/vassal_fold.dm
@@ -27,7 +27,7 @@
 		return FALSE
 
 	if(trigger_flags & TRIGGER_SECONDARY_ACTION)
-		if(!revenge_vassal.ex_vassals.len)
+		if(!length(revenge_vassal.ex_vassals))
 			owner.balloon_alert(owner, "no vassals!")
 			return FALSE
 		return TRUE

--- a/monkestation/code/modules/bloodsuckers/structures/bloodsucker_objects.dm
+++ b/monkestation/code/modules/bloodsuckers/structures/bloodsucker_objects.dm
@@ -93,7 +93,7 @@
 		return TRUE
 	if(stat >= UNCONSCIOUS)
 		return TRUE
-	if(HAS_TRAIT(src, TRAIT_NODEATH))
+	if(HAS_TRAIT_FROM(src, TRAIT_NODEATH, TORPOR_TRAIT))
 		return TRUE
 	return FALSE
 

--- a/monkestation/code/modules/bloodsuckers/vassals/types/revenge.dm
+++ b/monkestation/code/modules/bloodsuckers/vassals/types/revenge.dm
@@ -20,12 +20,12 @@
 /datum/antagonist/vassal/revenge/roundend_report()
 	var/list/report = list()
 	report += printplayer(owner)
-	if(objectives.len)
+	if(length(objectives))
 		report += printobjectives(objectives)
 
 	// Now list their vassals
-	if(ex_vassals.len)
-		report += "<span class='header'>The Vassals brought back into the fold were...</span>"
+	if(length(ex_vassals))
+		report += span_header("The Vassals brought back into the fold were...")
 		for(var/datum/antagonist/ex_vassal/all_vassals as anything in ex_vassals)
 			if(!all_vassals.owner)
 				continue

--- a/monkestation/code/modules/bloodsuckers/vassals/vassal_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/vassals/vassal_datum.dm
@@ -100,7 +100,7 @@
 	UnregisterSignal(owner.current, COMSIG_ATOM_EXAMINE)
 	UnregisterSignal(SSsunlight, COMSIG_SOL_WARNING_GIVEN)
 	//Free them from their Master
-	if(master && master.owner)
+	if(!QDELETED(master?.owner))
 		if(special_type && master.special_vassals[special_type])
 			master.special_vassals[special_type] -= src
 		master.vassals -= src
@@ -109,7 +109,7 @@
 	for(var/allstatus_traits in owner.current._status_traits)
 		REMOVE_TRAIT(owner.current, allstatus_traits, BLOODSUCKER_TRAIT)
 	//Remove Recuperate Power
-	while(powers.len)
+	while(length(powers))
 		var/datum/action/cooldown/bloodsucker/power = pick(powers)
 		powers -= power
 		power.Remove(owner.current)

--- a/monkestation/code/modules/bloodsuckers/vassals/vassal_misc_procs.dm
+++ b/monkestation/code/modules/bloodsuckers/vassals/vassal_misc_procs.dm
@@ -69,4 +69,4 @@
 	//send alerts of completion
 	to_chat(master, span_danger("You have turned [vassal_owner.current] into your [vassaldatum.name]! They will no longer be deconverted upon Mindshielding!"))
 	to_chat(vassal_owner, span_notice("As Blood drips over your body, you feel closer to your Master... You are now the Favorite Vassal!"))
-	vassal_owner.current.playsound_local(null, 'sound/magic/mutate.ogg', 75, FALSE, pressure_affected = FALSE)
+	vassal_owner.current.playsound_local(null, 'sound/magic/mutate.ogg', vol = 75, vary = FALSE, pressure_affected = FALSE)


### PR DESCRIPTION

## Changelog
:cl:
fix: Fixed rare cases where a bloodsucker would be stuck in permanent torpor, i.e if they were a species such as zombie or skeleton.
fix: Fixed bloodsucker abilities such as Mesmerize spamming balloon alerts after success.
fix: Fixed various runtime errors relating to bloodsuckers.
/:cl:
