### PR TITLE
Players now keep their name when turned into a gorilla

### DIFF
--- a/code/modules/clothing/head/mind_monkey_helmet.dm
+++ b/code/modules/clothing/head/mind_monkey_helmet.dm
@@ -94,7 +94,7 @@
 				if(2) //brain death
 					magnification.apply_damage(500,BRAIN,BODY_ZONE_HEAD,FALSE,FALSE,FALSE)
 				if(3) //primal gene (gorilla)
-					magnification.gorillize()
+					magnification.gorillize(FALSE) // monkestation edit: don't keep monkey name for gorilla
 				if(4) //genetic mass susceptibility (gib)
 					magnification.gib()
 	//either used up correctly or taken off before polling finished (punish this by destroying the helmet)

--- a/monkestation/code/modules/mob/transform_procs.dm
+++ b/monkestation/code/modules/mob/transform_procs.dm
@@ -1,0 +1,9 @@
+/mob/living/carbon/gorillize(keep_name = null)
+	var/old_name = real_name || name
+	if(isnull(keep_name))
+		keep_name = !isnull(key)
+	var/mob/living/basic/gorilla/gorilla = ..()
+	if(keep_name && old_name && gorilla)
+		gorilla.name = gorilla.real_name = old_name
+		gorilla.update_name_tag(old_name)
+	return gorilla

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6590,6 +6590,7 @@
 #include "monkestation\code\modules\mining\accelerators\shotgun.dm"
 #include "monkestation\code\modules\mob\mob.dm"
 #include "monkestation\code\modules\mob\mob_defines.dm"
+#include "monkestation\code\modules\mob\transform_procs.dm"
 #include "monkestation\code\modules\mob\dead\new_player\new_player.dm"
 #include "monkestation\code\modules\mob\dead\new_player\sprite_accessories\_base.dm"
 #include "monkestation\code\modules\mob\dead\new_player\sprite_accessories\anime.dm"


### PR DESCRIPTION

## About The Pull Request

When a mob is turned into a gorilla, if they're controlled by a player, their previous name will be carried over to the gorilla.

## Why It's Good For The Game

Kinda dumb to have your name become Gorilla (42), despite the fact you're still you, but now as a gorilla.

## Changelog
:cl:
qol: Players now keep their name when turned into a gorilla.
/:cl:
