### PR TITLE
[PORT] makes mice not spawn on multiz cable hubs

### DIFF
--- a/code/controllers/subsystem/minor_mapping.dm
+++ b/code/controllers/subsystem/minor_mapping.dm
@@ -64,7 +64,9 @@ SUBSYSTEM_DEF(minor_mapping)
 	for(var/turf/open/floor/plating/T in all_turfs)
 		if(T.is_blocked_turf())
 			continue
-		if(locate(/obj/structure/cable) in T)
+		//dont include multiz cables in the list because repairing them sucks
+		var/cable = locate(/obj/structure/cable) in T
+		if(cable && !istype(cable, /obj/structure/cable/multilayer/multiz))
 			exposed_wires += T
 
 	return shuffle(exposed_wires)


### PR DESCRIPTION
## About The Pull Request

port of https://github.com/tgstation/tgstation/pull/77753

makes them not spawn on multiz cable hubs

## Why It's Good For The Game

this is good because rats can no longer spawn on some isolated cable hub in the middle of nowhere in maint and depower an entire floor

## Changelog
:cl:
qol: rats no longer spawn on multiz cable hubs
/:cl: