### PR TITLE
Makes meters work on layers 1 and 5 again, because TG apparently does not want that for some weird reason

### DIFF
--- a/code/game/objects/items/rcd/RPD.dm
+++ b/code/game/objects/items/rcd/RPD.dm
@@ -142,6 +142,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /datum/pipe_info/meter
 	icon_state = "meter"
 	dirtype = PIPE_ONEDIR
+	all_layers = TRUE // MONKESTATION ADDITION -- TG DOES NOT WANT YOU TO KNOW THIS ONE TRICK TO MAKE METERS WORK ON LAYERS 1 AND 5
 
 /datum/pipe_info/meter/New(label)
 	name = label


### PR DESCRIPTION

## About The Pull Request

what it says on the tin

## Why It's Good For The Game

because its dumb that we DONT have that

## Changelog

:cl:
add: Meters can now be again placed on layers 1 and 5, thanks TG for removing that originally
/:cl:
