### PR TITLE
You can now only convert people who have BB enabled in their prefs

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -49,10 +49,11 @@
 	return ..()
 
 /datum/antagonist/brother/proc/on_mob_successful_flashed_carbon(mob/living/source, mob/living/carbon/flashed, obj/item/assembly/flash/flash)
-	SIGNAL_HANDLER
+	/* SIGNAL_HANDLER */ // monkestation edit: allow used of is_banned_from
 
 	if (flashed.stat == DEAD)
 		return
+
 
 	if (flashed.stat != CONSCIOUS)
 		flashed.balloon_alert(source, "unconscious!")
@@ -61,6 +62,12 @@
 	if (isnull(flashed.mind) || !GET_CLIENT(flashed))
 		flashed.balloon_alert(source, "[flashed.p_their()] mind is vacant!")
 		return
+
+	// monkestation edit: allow people to opt-out of BB
+	if(!(ROLE_BROTHER in flashed.client?.prefs?.be_special) || is_banned_from(flashed.ckey, list(ROLE_BROTHER, ROLE_SYNDICATE)))
+		flashed.balloon_alert(source, "unwilling to play role!")
+		return
+	// monkestation end
 
 	for(var/datum/objective/brother_objective as anything in source.mind.get_all_objectives())
 		// If the objective has a target, are we flashing them?


### PR DESCRIPTION
well, if BBs aren't being disabled, this is other option.

## Changelog
:cl:
qol: Blood Brothers can now only convert people who have BB enabled in their prefs. Failing to convert will give an appropriate feedback message (and the failed convert won't notice anything other than a normal flashing).
/:cl:
