### PR TITLE
Fix runtimes relating to oozeling revival balloon alerts

### DIFF
--- a/monkestation/code/modules/balloon_alert/balloon_alert.dm
+++ b/monkestation/code/modules/balloon_alert/balloon_alert.dm
@@ -1,0 +1,5 @@
+/atom/balloon_alert(mob/viewer, text)
+	if(istext(viewer) && isnull(text))
+		stack_trace("Attempted to call balloon_alert with only one argument! This is invalid, but we'll assume that src is the intended viewer.")
+		return ..(src, viewer)
+	return ..()

--- a/monkestation/code/modules/smithing/oozelings/body/organs.dm
+++ b/monkestation/code/modules/smithing/oozelings/body/organs.dm
@@ -219,16 +219,13 @@
 	//we have the plasma. we can rebuild them.
 	brainmob.mind.grab_ghost()
 	if(isnull(brainmob))
-		if(user)
-			user.balloon_alert("This brain is not a viable candidate for repair!")
+		user?.balloon_alert(user, "This brain is not a viable candidate for repair!")
 		return TRUE
 	if(isnull(brainmob.stored_dna))
-		if(user)
-			user.balloon_alert("This brain does not contain any dna!")
+		user?.balloon_alert(user, "This brain does not contain any dna!")
 		return TRUE
 	if(isnull(brainmob.client))
-		if(user)
-			user.balloon_alert("This brain does not contain a mind!")
+		user?.balloon_alert(user, "This brain does not contain a mind!")
 		return TRUE
 	var/mob/living/carbon/human/new_body = new /mob/living/carbon/human(drop_location())
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6105,6 +6105,7 @@
 #include "monkestation\code\modules\art_sci_overrides\faults\zap.dm"
 #include "monkestation\code\modules\assembly\flash.dm"
 #include "monkestation\code\modules\atmospherics\machinery\air_alarm\air_alarm_ac.dm"
+#include "monkestation\code\modules\balloon_alert\balloon_alert.dm"
 #include "monkestation\code\modules\ballpit\ballbit_sink.dm"
 #include "monkestation\code\modules\ballpit\ballpit.dm"
 #include "monkestation\code\modules\bitrunners\code\ability_disks.dm"


### PR DESCRIPTION
## Changelog
:cl:
fix: Fixed some errors relating to oozeling revival balloon alerts.
code: Added a stack traces + fallback behavior for invalid usage of the `balloon_alert` proc.
/:cl:
