### PR TITLE
Address some cases of inconsistent nametags

### DIFF
--- a/code/datums/components/phylactery.dm
+++ b/code/datums/components/phylactery.dm
@@ -183,6 +183,7 @@
 	// Fix their name
 	lich.dna.real_name = lich_mind.name
 	lich.real_name = lich_mind.name
+	lich.update_name_tag(lich_mind.name) // monkestation edit: name tags
 	// Slap the lich mind in and get their ghost
 	lich_mind.transfer_to(lich)
 	lich_mind.grab_ghost(force = TRUE)

--- a/code/datums/status_effects/debuffs/dna_transformation.dm
+++ b/code/datums/status_effects/debuffs/dna_transformation.dm
@@ -37,6 +37,7 @@
 	new_dna.transfer_identity(transforming)
 	transforming.real_name = new_dna.real_name
 	transforming.name = transforming.get_visible_name()
+	transforming.update_name_tag() // monkestation edit: name tags
 	transforming.updateappearance(mutcolor_update = TRUE)
 	transforming.domutcheck()
 	return TRUE

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -224,6 +224,7 @@
 	borg.mmi.brainmob.real_name = brainopsname
 	borg.mmi.brainmob.name = brainopsname
 	borg.real_name = borg.name
+	borg.update_name_tag() // monkestation edit: name tags
 
 	borg.key = C.key
 

--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -63,6 +63,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	var/new_name = "[initial(name)] ([rand(1, 999)])"
 	name = new_name
 	real_name = new_name
+	update_name_tag() // monkestation edit: name tags
 	last_attack = world.time
 	var/datum/blobstrain/BS = pick(GLOB.valid_blobstrains)
 	set_strain(BS)

--- a/code/modules/mob/living/basic/guardian/guardian_fluff.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_fluff.dm
@@ -44,6 +44,7 @@
 /datum/guardian_fluff/proc/apply(mob/living/basic/guardian/guardian)
 	guardian.name = name
 	guardian.real_name = name
+	guardian.update_name_tag() // monkestation edit: name tags
 	guardian.bubble_icon = bubble_icon
 	guardian.icon_living = icon_state
 	guardian.icon_state = icon_state

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -127,6 +127,7 @@ Des: Removes all infected images from the alien.
 	if(!alien_name_regex.Find(name))
 		new_xeno.name = name
 		new_xeno.real_name = real_name
+		new_xeno.update_name_tag() // monkestation edit: name tags
 	if(mind)
 		mind.name = new_xeno.real_name
 		mind.transfer_to(new_xeno)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -48,7 +48,7 @@
 
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()
-	update_name_tag(name)
+	update_name_tag(name) // monkestation edit: name tags
 
 	if(stat != DEAD)
 		return TRUE

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -556,6 +556,7 @@
 				if(dna.previous["name"])
 					real_name = dna.previous["name"]
 					name = real_name
+					update_name_tag() // monkestation edit: name tags
 					dna.previous.Remove("name")
 				if(dna.previous["UE"])
 					dna.unique_enzymes = dna.previous["UE"]

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1542,6 +1542,7 @@
 	SEND_SIGNAL(src, COMSIG_LIVING_ON_WABBAJACKED, new_mob)
 	new_mob.name = real_name
 	new_mob.real_name = real_name
+	new_mob.update_name_tag(real_name) // monkestation edit: name tags
 
 	// Transfer mind to the new mob (also handles actions and observers and stuff)
 	if(mind)
@@ -1755,7 +1756,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	if(registered_z && old_level_new_clients == 0)
 		for(var/datum/ai_controller/controller as anything in SSai_controllers.ai_controllers_by_zlevel[registered_z])
 			controller.set_ai_status(AI_STATUS_OFF)
-	
+
 	//Check the amount of clients exists on the Z level we're moving towards, excluding ourselves.
 	var/new_level_old_clients = SSmobs.clients_by_zlevel[new_z].len
 

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -221,6 +221,7 @@
 	eyeobj.setLoc(loc)
 	eyeobj.name = "[name] (AI Eye)"
 	eyeobj.real_name = eyeobj.name
+	eyeobj.update_name_tag() // monkestation edit: name tags
 	set_eyeobj_visible(TRUE)
 
 /mob/living/silicon/ai/proc/set_eyeobj_visible(state = TRUE)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -823,6 +823,7 @@
 	braintype = "AI Shell"
 	name = "Empty AI Shell-[ident]"
 	real_name = name
+	update_name_tag() // monkestation edit: name tags
 	GLOB.available_ai_shells |= src
 	if(!QDELETED(builtInCamera))
 		builtInCamera.c_tag = real_name //update the camera name too
@@ -842,6 +843,7 @@
 	GLOB.available_ai_shells -= src
 	name = "Unformatted Cyborg-[ident]"
 	real_name = name
+	update_name_tag() // monkestation edit: name tags
 	if(!QDELETED(builtInCamera))
 		builtInCamera.c_tag = real_name
 	diag_hud_set_aishell()
@@ -855,6 +857,7 @@
 /mob/living/silicon/robot/proc/deploy_init(mob/living/silicon/ai/AI)
 	real_name = "[AI.real_name] [designation] Shell-[ident]"
 	name = real_name
+	update_name_tag() // monkestation edit: name tags
 	if(!QDELETED(builtInCamera))
 		builtInCamera.c_tag = real_name //update the camera name too
 	mainframe = AI

--- a/code/modules/mob_spawn/corpses/nonhuman_corpses.dm
+++ b/code/modules/mob_spawn/corpses/nonhuman_corpses.dm
@@ -15,6 +15,7 @@
 	. = ..()
 	dead_ai.name = src.name
 	dead_ai.real_name = src.name
+	dead_ai.update_name_tag(src.name) // monkestation edit: name tags
 
 ///dead slimes, with a var for whatever color you want.
 /obj/effect/mob_spawn/corpse/slime

--- a/code/modules/pai/card.dm
+++ b/code/modules/pai/card.dm
@@ -195,6 +195,7 @@
 	var/mob/living/silicon/pai/new_pai = new(src)
 	new_pai.name = candidate.name || pick(GLOB.ninja_names)
 	new_pai.real_name = new_pai.name
+	new_pai.update_name_tag(new_pai.name) // monkestation edit: name tags
 	new_pai.key = candidate.ckey
 	set_personality(new_pai)
 	SSpai.candidates -= ckey

--- a/code/modules/pai/debug.dm
+++ b/code/modules/pai/debug.dm
@@ -24,6 +24,7 @@
 
 	pai.name = chosen_name
 	pai.real_name = pai.name
+	pai.update_name_tag() // monkestation edit: name tags
 	pai.key = choice.key
 	card.set_personality(pai)
 	if(SSpai.candidates[key])

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -137,6 +137,7 @@
 	var/mob/living/carbon/C = clone
 	if(istype(C) && istype(O))
 		C.real_name = O.real_name
+		C.update_name_tag(C.real_name) // monkestation edit: name tags
 		O.dna.transfer_identity(C)
 		C.updateappearance(mutcolor_update=1)
 	if(owner.mind)
@@ -739,6 +740,7 @@
 	var/mob/living/carbon/C = clone
 	if(istype(C) && istype(O))
 		C.real_name = O.real_name
+		C.update_name_tag(C.real_name) // monkestation edit: name tags
 		O.dna.transfer_identity(C)
 		C.updateappearance(mutcolor_update=1)
 	return ..()
@@ -820,6 +822,7 @@
 		var/mob/living/carbon/human/H = owner
 		originalDNA.transfer_identity(H)
 		H.real_name = originalname
+		H.update_name_tag(originalname) // monkestation edit: name tags
 		H.updateappearance(mutcolor_update=1)
 
 /datum/status_effect/brokenpeace

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -247,6 +247,7 @@ Regenerative extracts:
 		T.dna.transfer_identity(D)
 		D.updateappearance(mutcolor_update=1)
 		D.real_name = T.real_name
+		D.update_name_tag(D.real_name) // monkestation edit: name tags
 	dummy.adjustBruteLoss(target.getBruteLoss())
 	dummy.adjustFireLoss(target.getFireLoss())
 	dummy.adjustToxLoss(target.getToxLoss())

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -665,6 +665,7 @@
 		newname = "Pet Slime"
 	M.name = newname
 	M.real_name = newname
+	M.update_name_tag(newname) // monkestation edit: name tags
 	qdel(src)
 
 /obj/item/slimepotion/slime/sentience

--- a/monkestation/code/game/objects/items/choice_beacon.dm
+++ b/monkestation/code/game/objects/items/choice_beacon.dm
@@ -69,6 +69,7 @@
 	pod.explosionSize = list(0,0,0,0)
 	your_pet.name = name
 	your_pet.real_name = name
+	your_pet.update_name_tag() // monkestation edit: name tags
 
 	if(isbasicmob(your_pet))
 		var/mob/living/basic/pet = your_pet

--- a/monkestation/code/modules/possession/_mob_holder.dm
+++ b/monkestation/code/modules/possession/_mob_holder.dm
@@ -63,6 +63,7 @@
 	desc = stored_item.desc
 	name = stored_item.name
 	real_name = stored_item.name
+	update_name_tag()
 
 /mob/living/basic/possession_holder/create_overlay_index()
 	var/list/new_overlays[2]

--- a/monkestation/code/modules/ranching/name_tags/name_tag.dm
+++ b/monkestation/code/modules/ranching/name_tags/name_tag.dm
@@ -58,6 +58,8 @@
 		QDEL_NULL(shadow)
 
 /mob/proc/update_name_tag(passed_name)
+	if(QDELETED(name_tag))
+		return
 	if(!passed_name)
 		passed_name = name
 

--- a/monkestation/code/modules/ranching/name_tags/name_tag.dm
+++ b/monkestation/code/modules/ranching/name_tags/name_tag.dm
@@ -66,6 +66,14 @@
 		passed_name = copytext(passed_name, 1, the_check)
 	name_tag.set_name(name)
 
+/mob/fully_replace_character_name(oldname, newname)
+	. = ..()
+	if(oldname != real_name)
+		update_name_tag(real_name)
+
+/mob/living/set_name()
+	. = ..()
+	update_name_tag()
 
 /obj/effect/name_tag
 	plane = PLANE_NAME_TAGS

--- a/monkestation/code/modules/slimecore/mobs/_base_slime.dm
+++ b/monkestation/code/modules/slimecore/mobs/_base_slime.dm
@@ -303,6 +303,7 @@
 		else
 			name = "[current_color.name] [(slime_flags & ADULT_SLIME) ? "adult" : "baby"] slime ([number])"
 		real_name = name
+	update_name_tag()
 	return ..()
 
 /mob/living/basic/slime/proc/start_split()

--- a/monkestation/code/modules/virology/disease/symtoms/restricted/stage1.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/restricted/stage1.dm
@@ -48,6 +48,7 @@
 			new_mob.mind.add_antag_datum(transformed_antag_datum)
 		new_mob.name = affected_mob.real_name
 		new_mob.real_name = new_mob.name
+		new_mob.update_name_tag()
 		qdel(affected_mob)
 
 /datum/symptom/transformation/proc/replace_banned_player(mob/living/new_mob, mob/living/affected_mob) // This can run well after the mob has been transferred, so need a handle on the new mob to kill it if needed.


### PR DESCRIPTION
## Changelog
:cl:
fix: Nametags should be far more consistent with the mob's actual name now.
/:cl:
