### PR TITLE
Reduce meteor weights

### DIFF
--- a/code/modules/events/meteors/meteor_wave_events.dm
+++ b/code/modules/events/meteors/meteor_wave_events.dm
@@ -3,7 +3,7 @@
 /datum/round_event_control/meteor_wave
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
-	weight = 2
+	weight = 2 // monke edit: 4 to 2
 	min_players = 15
 	max_occurrences = 3
 	earliest_start = 60 MINUTES //monke edit: 25 to 60
@@ -59,7 +59,7 @@
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
-	weight = 4
+	weight = 4 // monke edit: 5 to 4
 	min_players = 20
 	max_occurrences = 3
 	earliest_start = 75 MINUTES //monke edit: 35 to 75
@@ -71,7 +71,7 @@
 /datum/round_event_control/meteor_wave/catastrophic
 	name = "Meteor Wave: Catastrophic"
 	typepath = /datum/round_event/meteor_wave/catastrophic
-	weight = 6
+	weight = 6 // monke edit: 7 to 6
 	min_players = 25
 	max_occurrences = 3
 	earliest_start = 90 MINUTES //monke edit: 45 to 90

--- a/code/modules/events/meteors/meteor_wave_events.dm
+++ b/code/modules/events/meteors/meteor_wave_events.dm
@@ -62,7 +62,7 @@
 	weight = 4 // monke edit: 5 to 4
 	min_players = 20
 	max_occurrences = 3
-	earliest_start = 75 MINUTES //monke edit: 35 to 75
+	earliest_start = 80 MINUTES //monke edit: 35 to 80
 	description = "A meteor wave with higher chance of big meteors."
 
 /datum/round_event/meteor_wave/threatening
@@ -74,7 +74,7 @@
 	weight = 6 // monke edit: 7 to 6
 	min_players = 25
 	max_occurrences = 3
-	earliest_start = 90 MINUTES //monke edit: 45 to 90
+	earliest_start = 100 MINUTES //monke edit: 45 to 100
 	description = "A meteor wave that might summon a tunguska class meteor."
 
 /datum/round_event/meteor_wave/catastrophic

--- a/code/modules/events/meteors/meteor_wave_events.dm
+++ b/code/modules/events/meteors/meteor_wave_events.dm
@@ -3,7 +3,7 @@
 /datum/round_event_control/meteor_wave
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
-	weight = 4
+	weight = 2
 	min_players = 15
 	max_occurrences = 3
 	earliest_start = 60 MINUTES //monke edit: 25 to 60
@@ -59,7 +59,7 @@
 /datum/round_event_control/meteor_wave/threatening
 	name = "Meteor Wave: Threatening"
 	typepath = /datum/round_event/meteor_wave/threatening
-	weight = 5
+	weight = 4
 	min_players = 20
 	max_occurrences = 3
 	earliest_start = 75 MINUTES //monke edit: 35 to 75
@@ -71,7 +71,7 @@
 /datum/round_event_control/meteor_wave/catastrophic
 	name = "Meteor Wave: Catastrophic"
 	typepath = /datum/round_event/meteor_wave/catastrophic
-	weight = 7
+	weight = 6
 	min_players = 25
 	max_occurrences = 3
 	earliest_start = 90 MINUTES //monke edit: 45 to 90


### PR DESCRIPTION
## About The Pull Request

Lowers meteor weights and slightly ups the timers for severe waves.

I've put off doing this for ages. Not anymore. I am so done with meteor spam.
## Why It's Good For The Game

I've had like 20 rounds ruined by meteors at this point.

They lack player interaction and only serve to call the shuttle.
## Changelog
:cl:
balance: Lowered meteor weights.
/:cl:
