### PR TITLE
Fixes pouring reagents on brains (mannitol, plasma)

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -206,7 +206,7 @@
 		var/healto = max(0, damage - amount * 2)
 		item.reagents.remove_all(ROUND_UP(item.reagents.total_volume / amount * (damage - healto) * 0.5)) //only removes however much solution is needed while also taking into account how much of the solution is mannitol
 		set_organ_damage(healto) //heals 2 damage per unit of mannitol, and by using "set_organ_damage", we clear the failing variable if that was up
-		owner.cure_all_traumas(TRAUMA_RESILIENCE_SURGERY) // MONKESTATION EDIT: if you go out of your way to do this, then you shouldn't have to do brain surgery
+		cure_all_traumas(TRAUMA_RESILIENCE_SURGERY) // MONKESTATION EDIT: if you go out of your way to do this, then you shouldn't have to do brain surgery
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -194,9 +194,7 @@
 
 /obj/item/organ/internal/brain/proc/check_for_repair(obj/item/item, mob/user)
 	if(damage && item.is_drainable() && item.reagents.has_reagent(/datum/reagent/medicine/mannitol) && (status == ORGAN_ORGANIC)) //attempt to heal the brain
-		if(brainmob?.health <= HEALTH_THRESHOLD_DEAD) //if the brain is fucked anyway, do nothing
-			to_chat(user, span_warning("[src] is far too damaged, there's nothing else we can do for it!"))
-			return TRUE
+		// MONKESTATION NOTE: There was a check for the brain being completely dead here. But that's like, the only case when you'd want to do this. Pretty sure it isn't on tg, so I'm leaving this here for documentation.
 
 		user.visible_message(span_notice("[user] starts to slowly pour the contents of [item] onto [src]."), span_notice("You start to slowly pour the contents of [item] onto [src]."))
 		if(!do_after(user, 3 SECONDS, src))

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -206,6 +206,7 @@
 		var/healto = max(0, damage - amount * 2)
 		item.reagents.remove_all(ROUND_UP(item.reagents.total_volume / amount * (damage - healto) * 0.5)) //only removes however much solution is needed while also taking into account how much of the solution is mannitol
 		set_organ_damage(healto) //heals 2 damage per unit of mannitol, and by using "set_organ_damage", we clear the failing variable if that was up
+		owner.cure_all_traumas(TRAUMA_RESILIENCE_SURGERY) // MONKESTATION EDIT: if you go out of your way to do this, then you shouldn't have to do brain surgery
 		return TRUE
 	return FALSE
 

--- a/monkestation/code/modules/smithing/oozelings/body/organs.dm
+++ b/monkestation/code/modules/smithing/oozelings/body/organs.dm
@@ -188,18 +188,35 @@
 /// Makes it so that when a slime's core has plasma poured on it, it builds a new body and moves the brain into it.
 
 /obj/item/organ/internal/brain/slime/check_for_repair(obj/item/item, mob/user)
-	if(damage && item.is_drainable() && item.reagents.has_reagent(/datum/reagent/toxin/plasma) && item.reagents.get_reagent_amount(/datum/reagent/toxin/plasma) >= 100) //attempt to heal the brain
+	if(damage && item.is_drainable() && item.reagents.has_reagent(/datum/reagent/toxin/plasma)) //attempt to heal the brain
+		if (item.reagents.get_reagent_amount(/datum/reagent/toxin/plasma) < 100)
+			user.balloon_alert(user, "too little plasma!")
+			return FALSE
 
-		user.visible_message(span_notice("[user] starts to slowly pour the contents of [item] onto [src]. It seems to bubble and roil, beginning to stretch its cytoskeleton outwards..."), span_notice("You start to slowly pour the contents of [item] onto [src]. It seems to bubble and roil, beginning to stretch its membrane outwards..."))
+		user.visible_message(
+			span_notice("[user] starts to slowly pour the contents of [item] onto [src]. It seems to bubble and roil, beginning to stretch its cytoskeleton outwards..."),
+			span_notice("You start to slowly pour the contents of [item] onto [src]. It seems to bubble and roil, beginning to stretch its membrane outwards..."),
+			span_hear("You hear bubbling.")
+			)
+
 		if(!do_after(user, 30 SECONDS, src))
 			to_chat(user, span_warning("You failed to pour the contents of [item] onto [src]!"))
-			return TRUE
+			return FALSE
 
-		user.visible_message(span_notice("[user] pours the contents of [item] onto [src], causing it to form a proper cytoplasm and outer membrane."), span_notice("You pour the contents of [item] onto [src], causing it to form a proper cytoplasm and outer membrane."))
-		item.reagents.clear_reagents() //removes the whole shit
+		if (item.reagents.get_reagent_amount(/datum/reagent/toxin/plasma) < 100) // minor exploit but might as well patch it
+			user.balloon_alert(user, "too little plasma!")
+			return FALSE
+
+		user.visible_message(
+			span_notice("[user] pours the contents of [item] onto [src], causing it to form a proper cytoplasm and outer membrane."),
+			span_notice("You pour the contents of [item] onto [src], causing it to form a proper cytoplasm and outer membrane."),
+			span_hear("You hear a splat.")
+			)
+
+		item.reagents.remove_reagent(/datum/reagent/toxin/plasma, 100)
 		rebuild_body(user)
 		return TRUE
-	return FALSE
+	return ..()
 
 /obj/item/organ/internal/brain/slime/proc/drop_items_to_ground(turf/turf)
 	for(var/atom/movable/item as anything in stored_items)
@@ -210,7 +227,7 @@
 	if(rebuilt)
 		return
 	rebuilt = TRUE
-	set_organ_damage(-maxHealth) //heals 2 damage per unit of mannitol, and by using "set_organ_damage", we clear the failing variable if that was up
+	set_organ_damage(-maxHealth) // heals the brain fully
 
 	if(gps_active) // making sure the gps signal is removed if it's active on revival
 		gps_active = FALSE
@@ -234,8 +251,8 @@
 
 	brainmob.client?.prefs?.safe_transfer_prefs_to(new_body)
 	new_body.underwear = "Nude"
-	new_body.undershirt = "Nude" //Which undershirt the player wants
-	new_body.socks = "Nude" //Which socks the player wants
+	new_body.undershirt = "Nude"
+	new_body.socks = "Nude"
 	stored_dna.transfer_identity(new_body, transfer_SE = TRUE)
 	new_body.dna.features["mcolor"] = new_body.dna.features["mcolor"]
 	new_body.dna.update_uf_block(DNA_MUTANT_COLOR_BLOCK)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Okay so pouring mannitol on brains has been broken for a while.
As it turns out, someone added a check for if the brain is completely dead.
The fun part? That's the ONLY time you'd ever want to use mannitol pouring anyway!
So it acted as if it didn't exist. Very funny.

Also makes mannitol pouring cure traumas.
This is so you don't have to do brain surgery after going out of your way to use mannitol pouring.

Also fixes some stuff with oozeling cores.
You can now pour mannitol on them as well.
Plasma also isn't completely used up, it only uses the 100u.
It also has a new balloon message for "not enough plasma!", just in case.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good, also having to do a 30 minute maint surgery with syndie tools after realizing mannitol is broken sucks ass.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Pouring mannitol on brains now removes all basic and severe traumas.
fix: Pouring mannitol on brains works properly again.
fix: Pouring plasma on oozeling cores works better and has a warning for having too little plasma.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
