### PR TITLE
Remove remove_any from the game (ATTEMPT 2)

### DIFF
--- a/code/datums/elements/chewable.dm
+++ b/code/datums/elements/chewable.dm
@@ -52,7 +52,7 @@
 
 	var/metabolism_amount = metabolization_amount * seconds_per_tick
 	if (!reagents.trans_to(item.loc, metabolism_amount, methods = INGEST))
-		reagents.remove_any(metabolism_amount)
+		reagents.remove_all(metabolism_amount)
 
 /datum/element/chewable/proc/on_dropped(datum/source)
 	SIGNAL_HANDLER

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -399,18 +399,18 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(!istype(smoker))
 		// If not, check if it's a gas mask
 		if(!istype(smoker, /obj/item/clothing/mask/gas))
-			reagents.remove_any(to_smoke)
+			reagents.remove_all(to_smoke)
 			return
 
 		smoker = smoker.loc
 
 		// If it is, check if that mask is on a carbon mob
 		if(!istype(smoker) || smoker.get_item_by_slot(ITEM_SLOT_MASK) != loc)
-			reagents.remove_any(to_smoke)
+			reagents.remove_all(to_smoke)
 			return
 	else
 		if(src != smoker.wear_mask)
-			reagents.remove_any(to_smoke)
+			reagents.remove_all(to_smoke)
 			return
 
 	how_long_have_we_been_smokin += seconds_per_tick * (1 SECONDS)
@@ -420,7 +420,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		var/smoker_resistance = HAS_TRAIT(smoker, TRAIT_SMOKER) ? 0.5 : 1
 		smoker.adjustOrganLoss(ORGAN_SLOT_LUNGS, lung_harm*smoker_resistance)
 	if(!reagents.trans_to(smoker, to_smoke, methods = INGEST, ignore_stomach = TRUE))
-		reagents.remove_any(to_smoke)
+		reagents.remove_all(to_smoke)
 
 /obj/item/clothing/mask/cigarette/process(seconds_per_tick)
 	var/mob/living/user = isliving(loc) ? loc : null
@@ -1231,7 +1231,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	var/mob/living/carbon/vaper = loc
 	if(!iscarbon(vaper) || src != vaper.wear_mask)
-		reagents.remove_any(REAGENTS_METABOLISM)
+		reagents.remove_all(REAGENTS_METABOLISM)
 		return
 
 	if(reagents.get_reagent_amount(/datum/reagent/fuel))
@@ -1246,7 +1246,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		qdel(src)
 
 	if(!reagents.trans_to(vaper, REAGENTS_METABOLISM, methods = INGEST, ignore_stomach = TRUE))
-		reagents.remove_any(REAGENTS_METABOLISM)
+		reagents.remove_all(REAGENTS_METABOLISM)
 
 /obj/item/clothing/mask/vape/process(seconds_per_tick)
 	var/mob/living/M = loc

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -79,7 +79,7 @@
 	var/val2remove = 1
 	if(cleaner?.mind)
 		val2remove = round(cleaner.mind.get_skill_modifier(/datum/skill/cleaning, SKILL_SPEED_MODIFIER), 0.1)
-	reagents.remove_any(val2remove) //reaction() doesn't use up the reagents
+	reagents.remove_all(val2remove) //reaction() doesn't use up the reagents
 
 /obj/item/mop/cyborg/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -309,7 +309,7 @@
 			balloon_alert(user, "still recharging!")
 			return
 		COOLDOWN_START(src, resin_cooldown, 10 SECONDS)
-		R.remove_any(100)
+		R.remove_all(100)
 		var/obj/effect/resin_container/resin = new (get_turf(src))
 		user.log_message("used Resin Launcher", LOG_GAME)
 		playsound(src,'sound/items/syringeproj.ogg',40,TRUE)

--- a/code/game/objects/structures/shower.dm
+++ b/code/game/objects/structures/shower.dm
@@ -319,7 +319,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/shower, (-16))
 		if(!ismopable(movable_content)) // Mopables will be cleaned anyways by the turf wash above
 			wash_atom(movable_content) // Reagent exposure is handled in wash_atom
 
-	reagents.remove_any(SHOWER_SPRAY_VOLUME)
+	reagents.remove_all(SHOWER_SPRAY_VOLUME)
 
 /obj/machinery/shower/deconstruct(disassembled = TRUE)
 	new /obj/item/stack/sheet/iron(drop_location(), 2)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -359,7 +359,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/sink, (-14))
 		return
 
 	busy = FALSE
-	reagents.remove_any(5)
+	reagents.remove_all(5)
 	reagents.expose(user, TOUCH, 5 / max(reagents.total_volume, 5))
 	begin_reclamation()
 	if(washing_face)

--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -229,7 +229,7 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 			cold_multiplier += round(target_temp * 1.5 / T0C, 0.01)
 		dunking_target.apply_damage(min(30 * bio_multiplier * cold_multiplier, reagents.total_volume), BURN, BODY_ZONE_HEAD)
 		if(reagents.reagent_list) //This can runtime if reagents has nothing in it.
-			reagents.remove_any((reagents.total_volume/2))
+			reagents.remove_all((reagents.total_volume/2))
 		dunking_target.Paralyze(60)
 		user.changeNext_move(CLICK_CD_MELEE)
 	return ..()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1343,7 +1343,7 @@
 
 /// Tray Setters - The following procs adjust the tray or plants variables, and make sure that the stat doesn't go out of bounds.///
 /obj/machinery/hydroponics/proc/adjust_plant_nutriments(adjustamt)
-	reagents.remove_any(adjustamt)
+	reagents.remove_all(adjustamt)
 
 /obj/machinery/hydroponics/proc/increase_sustaining(amount)
 	sustaining_precent += amount

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -614,7 +614,7 @@
 
 	reagents.expose(our_turf, TOUCH, min(1, 10 / reagents.total_volume))
 	// We use more water doing this then mopping
-	reagents.remove_any(2) //reaction() doesn't use up the reagents
+	reagents.remove_all(2) //reaction() doesn't use up the reagents
 
 /datum/action/toggle_buffer/update_button_name(atom/movable/screen/movable/action_button/current_button, force)
 	if(buffer_on)

--- a/code/modules/plumbing/plumbers/destroyer.dm
+++ b/code/modules/plumbing/plumbers/destroyer.dm
@@ -20,7 +20,7 @@
 	if(reagents.total_volume)
 		if(icon_state != initial(icon_state) + "_working") //threw it here instead of update icon since it only has two states
 			icon_state = initial(icon_state) + "_working"
-		reagents.remove_any(disposal_rate * seconds_per_tick)
+		reagents.remove_all(disposal_rate * seconds_per_tick)
 		use_power(active_power_usage * seconds_per_tick)
 	else
 		if(icon_state != initial(icon_state))

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -312,41 +312,6 @@
 			return TRUE
 	return FALSE
 
-/// Remove an amount of reagents without caring about what they are
-/datum/reagents/proc/remove_any(amount = 1)
-	if(!amount)
-		return
-
-	var/list/cached_reagents = reagent_list
-	var/total_removed = 0
-	var/current_list_element = 1
-	var/initial_list_length = length(cached_reagents) //stored here because removing can cause some reagents to be deleted, ergo length change.
-	if(!initial_list_length)
-		return
-
-	current_list_element = rand(1, cached_reagents.len)
-
-	while(total_removed != amount)
-		if(total_removed >= amount)
-			break
-		if(total_volume <= 0 || !cached_reagents.len)
-			break
-
-		if(current_list_element > cached_reagents.len)
-			current_list_element = 1
-
-		var/datum/reagent/R = cached_reagents[current_list_element]
-		var/remove_amt = min(amount-total_removed,round(amount/max(1, rand(2,initial_list_length)),round(amount/10,0.01))) //double round to keep it at a somewhat even spread relative to amount without getting funky numbers.
-		//min ensures we don't go over amount.
-		remove_reagent(R.type, remove_amt)
-
-		current_list_element++
-		total_removed += remove_amt
-		update_total()
-
-	handle_reactions()
-	return total_removed //this should be amount unless the loop is prematurely broken, in which case it'll be lower. It shouldn't ever go OVER amount.
-
 /// Removes all reagents from this holder
 /datum/reagents/proc/remove_all(amount = 1)
 	var/list/cached_reagents = reagent_list

--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -23,7 +23,7 @@
 	src.location = get_turf(location)
 	src.amount = amount
 	carry?.copy_to(chemholder, 20)
-	carry?.remove_any(amount / efficiency)
+	carry?.remove_all(amount / efficiency)
 
 /// A factory which produces clouds of smoke for the smoke machine.
 /datum/effect_system/fluid_spread/smoke/chem/smoke_machine

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -124,7 +124,7 @@
 		return
 
 	var/amount_lost = intensity * 5
-	reagents.remove_any(amount_lost)
+	reagents.remove_all(amount_lost)
 
 	visible_message(span_warning("Some of [name]'s contents are let loose!"))
 	var/intensity_state = null

--- a/monkestation/code/modules/botany/components/plant_growing.dm
+++ b/monkestation/code/modules/botany/components/plant_growing.dm
@@ -126,9 +126,9 @@
 
 	if(movable_parent.reagents.total_volume > 5)
 		if(bio_boosted)
-			movable_parent.reagents.remove_any(max(1,round(movable_parent.reagents.total_volume * 0.01, CHEMICAL_QUANTISATION_LEVEL)))
+			movable_parent.reagents.remove_all(max(1,round(movable_parent.reagents.total_volume * 0.01, CHEMICAL_QUANTISATION_LEVEL)))
 		else
-			movable_parent.reagents.remove_any(max(1,round(movable_parent.reagents.total_volume * 0.025, CHEMICAL_QUANTISATION_LEVEL)))
+			movable_parent.reagents.remove_all(max(1,round(movable_parent.reagents.total_volume * 0.025, CHEMICAL_QUANTISATION_LEVEL)))
 
 	SEND_SIGNAL(movable_parent, COMSIG_NUTRIENT_UPDATE, movable_parent.reagents.total_volume / movable_parent.reagents.maximum_volume)
 

--- a/monkestation/code/modules/hydroponics/machines/splicer.dm
+++ b/monkestation/code/modules/hydroponics/machines/splicer.dm
@@ -239,6 +239,6 @@
 	seed_1.adjust_maturation(stats["maturation_change"])
 
 	seed_1.check_infusions(held_beaker.reagents.reagent_list)
-	held_beaker.reagents.remove_any(held_beaker.reagents.total_volume)
+	held_beaker.reagents.remove_all(held_beaker.reagents.total_volume)
 	stats = list()
 	potential_damage = 0

--- a/monkestation/code/modules/liquids/liquid_groups.dm
+++ b/monkestation/code/modules/liquids/liquid_groups.dm
@@ -328,7 +328,7 @@ GLOBAL_VAR_INIT(liquid_debug_colors, FALSE)
 	process_group()
 
 /datum/liquid_group/proc/remove_any(obj/effect/abstract/liquid_turf/remover, amount)
-	reagents.remove_any(amount, TRUE)
+	reagents.remove_all(amount)
 	if(!QDELETED(remover))
 		check_liquid_removal(remover, amount)
 	total_reagent_volume = reagents.total_volume


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/82020
## Why It's Good For The Game

The use of remove_any doesn't really show itself in game outside of one thing.
It completely and utterly fucks over anything beneficial. It just destroys the mixes.
This *does* affect deathmixes too but in general, the effect is very little.

You can read the port PR for a more detailed description.
## Changelog
:cl:
fix: Reagents will now be removed/transferred consistently from cigarettes, smoke machines, etc. rather than at random.
/:cl:
