### PR TITLE
Removes Advanced Tranquility from the maint pill pool

### DIFF
--- a/monkestation/code/modules/reagents/misc.dm
+++ b/monkestation/code/modules/reagents/misc.dm
@@ -5,6 +5,9 @@
 /datum/reagent/romerol
 	restricted = TRUE
 
+/datum/reagent/gondola_mutation_toxin/virtual_domain
+	restricted = TRUE // STOP SHOVING ALL THE WINDOWS AROUND
+
 // Reagents that shouldn't be in the random pool, as they're either completely useless or shouldn't exist on their own.
 /datum/reagent/slime_ooze
 	restricted = TRUE


### PR DESCRIPTION

## About The Pull Request

This bans Advanced Tranquility from maint pills - it's only intended for use for bitrunner stuff, and it makes a stupid subtype of gondolas that can push objects around, often breaking windows and shit.

The normal Tranquility that makes normal gondolas is still in the pool.

## Why It's Good For The Game

![image](https://github.com/Monkestation/Monkestation2.0/assets/65794972/ce40d784-98ee-472c-9fe4-67c46c637613)

## Changelog
:cl:
del: Removes Advanced Tranquility, which is only intended for bitrunner stuff, from the maint pill pool. Normal Tranquility is still available.
/:cl:
