### PR TITLE
Ctrl-clicking jumpsuits to max sensors now actually works (i'm an idiot)

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -322,7 +322,7 @@
 
 /obj/item/clothing/under/CtrlClick(mob/user)
 	. = ..()
-	if(!.)
+	if(.)
 		return
 	if(!can_toggle_sensors(user))
 		return


### PR DESCRIPTION
## Changelog
:cl:
fix: Ctrl-clicking jumpsuits to max sensors now actually works
/:cl:
