### PR TITLE
IPCs can now have a gender set, and thus have pronouns

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -196,18 +196,20 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	load_metacoins(parent.ckey)
 	load_inventory(parent.ckey)
 
+	var/needs_update_monkestation = save_data_needs_update_monkestation(savefile.get_entry())
 	load_preferences_monkestation()
 
 	// Custom hotkeys
 	key_bindings = savefile.get_entry("key_bindings", key_bindings)
 
 	//try to fix any outdated data if necessary
-	if(needs_update >= 0)
+	if(needs_update >= 0 || needs_update_monkestation >= 0) //MONKESTATION EDIT: Modular updates
 		var/bacpath = "[path].updatebac" //todo: if the savefile version is higher then the server, check the backup, and give the player a prompt to load the backup
 		if (fexists(bacpath))
 			fdel(bacpath) //only keep 1 version of backup
 		fcopy(savefile.path, bacpath) //byond helpfully lets you use a savefile for the first arg.
 		update_preferences(needs_update, savefile) //needs_update = savefile_version if we need an update (positive integer)
+		update_preferences_monkestation(needs_update_monkestation, savefile) //MONKESTATION ADDITION: Modular updates
 
 	check_keybindings() // this apparently fails every time and overwrites any unloaded prefs with the default values, so don't load anything after this line or it won't actually save
 	key_bindings_by_key = get_key_bindings_by_key(key_bindings)
@@ -220,7 +222,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	key_bindings = sanitize_keybindings(key_bindings)
 	favorite_outfits = SANITIZE_LIST(favorite_outfits)
 
-	if(needs_update >= 0) //save the updated version
+	if(needs_update >= 0 || needs_update_monkestation >= 0) //save the updated version //MONKESTATION EDIT: Modular updates
 		var/old_default_slot = default_slot
 		var/old_max_save_slots = max_save_slots
 
@@ -304,12 +306,14 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//Quirks
 	all_quirks = save_data?["all_quirks"]
 
+	var/needs_update_monkestation = save_data_needs_update_monkestation(save_data)
 	load_character_monkestation(save_data)
 
 	//try to fix any outdated data if necessary
 	//preference updating will handle saving the updated data for us.
-	if(needs_update >= 0)
+	if(needs_update >= 0 || needs_update_monkestation >= 0) //MONKESTATION EDIT: Modular updates
 		update_character(needs_update, save_data) //needs_update == savefile_version if we need an update (positive integer)
+		update_character_monkestation(needs_update_monkestation, save_data) //MONKESTATION ADDITION: Modular updates
 
 	//Sanitize
 	randomise = SANITIZE_LIST(randomise)

--- a/monkestation/code/modules/client/preference_savefile.dm
+++ b/monkestation/code/modules/client/preference_savefile.dm
@@ -9,6 +9,17 @@
 
 
 
+/datum/preferences/proc/save_data_needs_update_monkestation(list/save_data)
+	if(!save_data) // empty list, either savefile isnt loaded or its a new char
+		return MODULAR_SAVEFILE_UP_TO_DATE
+	/* // Should probably add a minimum save data number... I have no idea what to set it at though.
+	if(save_data["modular_version"] < MODULAR_SAVEFILE_VERSION_MIN)
+		return -2
+	*/
+	if(save_data["modular_version"] < MODULAR_SAVEFILE_VERSION_MAX)
+		return save_data["modular_version"]
+	return MODULAR_SAVEFILE_UP_TO_DATE
+
 /datum/preferences/proc/load_character_monkestation(list/save_data)
 	if(!save_data)
 		save_data = list()
@@ -42,9 +53,6 @@
 	loadout_list = sanitize_loadout_list(save_loadout)
 	special_loadout_list = texted_special_save_loadouts
 
-	if(needs_update >= 0)
-		update_character_monkestation(needs_update, save_data) // needs_update == savefile_version if we need an update (positive integer)
-
 
 /// Brings a savefile up to date with modular preferences. Called if savefile_needs_update_monkestation() returned a value higher than 0
 /datum/preferences/proc/update_character_monkestation(current_version, list/save_data)
@@ -59,6 +67,7 @@
 	save_data["alt_job_titles"] = alt_job_titles
 
 /datum/preferences/proc/save_preferences_monkestation()
+	savefile.set_entry("modular_version", MODULAR_SAVEFILE_VERSION_MAX)
 	write_jobxp_preferences()
 	savefile.set_entry("channel_volume", channel_volume)
 	savefile.set_entry("saved_tokens", saved_tokens)
@@ -83,3 +92,5 @@
 	lootboxes_owned = savefile.get_entry("lootboxes_owned", lootboxes_owned)
 	antag_rep = savefile.get_entry("antag_rep", antag_rep)
 
+/datum/preferences/proc/update_preferences_monkestation(current_version, datum/json_savefile/json_savefile)
+	return

--- a/monkestation/code/modules/client/preference_savefile.dm
+++ b/monkestation/code/modules/client/preference_savefile.dm
@@ -3,7 +3,7 @@
  * You can't really use the non-modular version, least you eventually want asinine merge
  * conflicts and/or potentially disastrous issues to arise, so here's your own.
  */
-#define MODULAR_SAVEFILE_VERSION_MAX 3
+#define MODULAR_SAVEFILE_VERSION_MAX 4
 
 #define MODULAR_SAVEFILE_UP_TO_DATE -1
 
@@ -56,7 +56,9 @@
 
 /// Brings a savefile up to date with modular preferences. Called if savefile_needs_update_monkestation() returned a value higher than 0
 /datum/preferences/proc/update_character_monkestation(current_version, list/save_data)
-	return
+	if(current_version < 4)
+		to_chat(world, "Updating Character: [save_data["real_name"]]")
+		monkestation_set_ipc_genders(save_data)
 
 
 /// Saves the modular customizations of a character on the savefile

--- a/monkestation/code/modules/client/preference_savefile.dm
+++ b/monkestation/code/modules/client/preference_savefile.dm
@@ -57,7 +57,6 @@
 /// Brings a savefile up to date with modular preferences. Called if savefile_needs_update_monkestation() returned a value higher than 0
 /datum/preferences/proc/update_character_monkestation(current_version, list/save_data)
 	if(current_version < 4)
-		to_chat(world, "Updating Character: [save_data["real_name"]]")
 		monkestation_set_ipc_genders(save_data)
 
 

--- a/monkestation/code/modules/client/preferences/migrations/update_ipc_genders.dm
+++ b/monkestation/code/modules/client/preferences/migrations/update_ipc_genders.dm
@@ -1,0 +1,18 @@
+
+// IPCs were once not allowed to have genders - and thus, not allowed to have pronouns. Due to
+// gender not being saved unless it's been changed, this means plenty of IPCs don't have a gender in
+// their save data, or may even have a old gender.
+//
+// If the old data has no gender, the game will normally randomly pick a gender to give them. For
+// IPCs, this is no concern, as they get set back to PLURAL immediately. But, with the change
+// allowing them to have genders, this means they'll normally get a random gender - which can lead
+// to confusion among players when their IPC suddenly has a random gender that they didn't expect.
+//
+// The same can also happen if the save data has an old gender that they don't even remember
+// setting - or assumed that it was changed to plural.
+//
+// To solve this, if the character is an IPC and the character data is too old, we set their gender
+// to plural during loading of the character.
+/datum/preferences/proc/monkestation_set_ipc_genders(list/save_data)
+	if(save_data["species"] == SPECIES_IPC)
+		save_data["gender"] = PLURAL

--- a/monkestation/code/modules/smithing/ipcs/species.dm
+++ b/monkestation/code/modules/smithing/ipcs/species.dm
@@ -9,7 +9,7 @@
 	name = "\improper Integrated Positronic Chassis"
 	id = SPECIES_IPC
 	inherent_biotypes = MOB_ROBOTIC | MOB_HUMANOID
-	sexes = FALSE
+	visual_gender = FALSE
 	inherent_traits = list(
 		TRAIT_ROBOT_CAN_BLEED,
 		TRAIT_CAN_STRIP,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6301,6 +6301,7 @@
 #include "monkestation\code\modules\client\preferences\sounds.dm"
 #include "monkestation\code\modules\client\preferences\alt_jobs\_job.dm"
 #include "monkestation\code\modules\client\preferences\alt_jobs\titles.dm"
+#include "monkestation\code\modules\client\preferences\migrations\update_ipc_genders.dm"
 #include "monkestation\code\modules\client\preferences\species_features\arachnid.dm"
 #include "monkestation\code\modules\client\preferences\species_features\ethereal.dm"
 #include "monkestation\code\modules\client\preferences\species_features\floran.dm"


### PR DESCRIPTION
## About The Pull Request
Previously, IPCs were always stuck to they/them. In a sense, this made sense - they're robots. However, in the year of 2564 (or whatever it was), as IPCs become more plentiful, and the people become more accepting, it's only natural that some IPCs may choose to go by she/her or he/him.

This PR makes changes to that effect. To prevent existing characters from being affected, a savedata migration was added that affects any IPCs whose `modular_version` was less than `4`, setting their gender to PLURAL.

This PR also fixes modular savefile updates, so that they actually update the savefile.

## Why It's Good For The Game
IPCs can have pronouns now.

## Changelog

:cl: MichiRecRoom
add: IPCs can now have a gender set. Existing IPCs will (until manually updated) default to Other (they/them) to match previous behavior, and new IPCs will be given a random gender. This has no visual effect - it only affects their pronouns!
/:cl:
