### PR TITLE
Centcom Arcade Area Movement and Addition

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -46542,6 +46542,14 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance/testlab)
+"qBJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/structure/sign/plaques/kiddie/library{
+	pixel_y = -32
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "qCa" = (
 /obj/structure/rack,
 /obj/item/storage/box/shipping,
@@ -60653,6 +60661,9 @@
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
 /obj/effect/spawner/random/bureaucracy/paper,
+/obj/item/toy/crayon/spraycan{
+	pixel_x = -4
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "vxa" = (
@@ -91085,7 +91096,7 @@ phz
 gCT
 hvJ
 qeJ
-gUt
+qBJ
 gUt
 vhB
 iyV

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -348,6 +348,11 @@
 /obj/structure/railing/wood,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/botany)
+"aY" = (
+/obj/structure/flora/grass/jungle/a/style_random,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "aZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced,
@@ -959,10 +964,10 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
 "cD" = (
-/obj/structure/chair/pew{
-	dir = 8
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/arcade)
 "cE" = (
 /obj/structure/fake_stairs/wood/directional/north,
@@ -1286,6 +1291,10 @@
 /obj/structure/closet/mini_fridge,
 /turf/open/floor/iron/dark/small,
 /area/centcom/central_command_areas/admin)
+"du" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/misc/asteroid/basalt,
+/area/centcom/central_command_areas/hall)
 "dv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
 	dir = 8
@@ -1441,6 +1450,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
 /turf/open/floor/catwalk_floor/titanium,
 /area/centcom/syndicate_mothership/control)
+"dM" = (
+/obj/effect/turf_decal/stripes{
+	dir = 6
+	},
+/obj/machinery/photocopier,
+/turf/open/floor/iron/dark/textured_corner{
+	dir = 1
+	},
+/area/centcom/central_command_areas/arcade)
 "dN" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
@@ -1477,6 +1495,15 @@
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/admin_hangout)
+"dU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/sign/painting/library_secure{
+	pixel_x = -32
+	},
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/arcade)
 "dV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1610,6 +1637,12 @@
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/borbop)
+"el" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/arcade)
 "em" = (
 /obj/machinery/chem_mass_spec,
 /turf/open/floor/mineral/titanium/tiled/yellow,
@@ -1864,10 +1897,15 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "fb" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/light/directional/south,
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/hall)
 "fc" = (
 /turf/open/floor/wood,
 /area/centcom/wizard_station)
@@ -1965,10 +2003,29 @@
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/borbop)
+"fr" = (
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/machinery/light/floor/has_bulb,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/hall)
 "fs" = (
 /obj/structure/flora/tree/pine/style_random,
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
+"ft" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atm,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/hall)
 "fu" = (
 /obj/structure/hedge,
 /turf/open/floor/iron/dark,
@@ -2017,6 +2074,12 @@
 "fB" = (
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin_hangout)
+"fC" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/flora/rock/style_random,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/misc/asteroid/basalt,
+/area/centcom/central_command_areas/hall)
 "fD" = (
 /obj/machinery/light/neon_lining{
 	icon_state = "pink2_1"
@@ -2251,6 +2314,10 @@
 /obj/effect/turf_decal/tile/red/full,
 /turf/open/floor/iron/dark/textured_half,
 /area/centcom/syndicate_mothership/control)
+"gn" = (
+/obj/structure/curtain/cloth/fancy,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/central_command_areas/hall)
 "go" = (
 /obj/structure/closet,
 /turf/open/floor/circuit,
@@ -2418,6 +2485,24 @@
 /obj/item/stack/cannonball,
 /turf/open/misc/grass,
 /area/centcom/central_command_areas/admin)
+"gI" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/trading_card_holder{
+	pixel_y = 8
+	},
+/obj/machinery/trading_card_holder{
+	pixel_y = 7;
+	pixel_x = 12;
+	summon_offset_x = 1
+	},
+/obj/machinery/trading_card_holder{
+	pixel_y = 7;
+	pixel_x = -12;
+	summon_offset_x = -1
+	},
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet/royalblue,
+/area/centcom/central_command_areas/hall)
 "gJ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -2793,6 +2878,12 @@
 /obj/item/clipboard,
 /turf/open/indestructible/hotelwood,
 /area/centcom/central_command_areas/admin)
+"hL" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/arcade)
 "hM" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
@@ -2800,11 +2891,12 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "hN" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/structure/table/wood/fancy/green,
+/obj/item/flashlight/lamp{
+	pixel_x = -6;
+	pixel_y = 3
 	},
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/arcade)
 "hO" = (
 /obj/structure/railing/corner,
@@ -2869,6 +2961,10 @@
 "hV" = (
 /obj/effect/landmark/navigate_destination/centcom/boxing,
 /turf/open/floor/carpet,
+/area/centcom/central_command_areas/hall)
+"hW" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/fakepit,
 /area/centcom/central_command_areas/hall)
 "hX" = (
 /obj/machinery/light/floor/has_bulb,
@@ -3055,6 +3151,12 @@
 	pixel_x = -32
 	},
 /turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/hall)
+"iy" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/flora/rock/style_random,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
 /area/centcom/central_command_areas/hall)
 "iz" = (
 /obj/machinery/washing_machine,
@@ -3558,6 +3660,11 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
+"jU" = (
+/obj/machinery/light/floor/has_bulb,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/arcade)
 "jV" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -3574,6 +3681,9 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/borbop)
+"jY" = (
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/arcade)
 "jZ" = (
 /obj/structure/railing/wood,
 /obj/structure/railing/wood{
@@ -3639,12 +3749,10 @@
 /turf/open/floor/plating/abductor,
 /area/centcom/central_command_areas/admin)
 "kj" = (
-/obj/item/flashlight/lamp{
-	pixel_y = -3;
-	pixel_x = -8
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/obj/structure/table/wood,
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/arcade)
 "kk" = (
 /obj/effect/turf_decal/siding/wood/corner{
@@ -3730,6 +3838,12 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/botany)
+"kx" = (
+/obj/structure/chair/sofa/corp/left,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/item/cardpack/series_one,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/hall)
 "ky" = (
 /obj/structure/chair/office,
 /turf/open/floor/iron/white/side,
@@ -3797,9 +3911,15 @@
 	},
 /area/centcom/central_command_areas/hall)
 "kJ" = (
-/obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
+/obj/item/cardpack/resin,
+/obj/item/cardpack/resin,
+/obj/item/cardpack/resin,
+/obj/item/cardpack/resin,
+/obj/item/cardpack/resin,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/hall)
 "kK" = (
 /turf/closed/indestructible/fakedoor{
 	name = "BUNKER 4337"
@@ -3845,10 +3965,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range_checkpoint_control)
 "kR" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/wood/parquet,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/arcade)
 "kS" = (
 /obj/effect/turf_decal/siding/dark,
@@ -4402,11 +4520,20 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/centcom/syndicate_mothership/control)
 "mo" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/trading_card_holder/red{
+	pixel_y = 9;
+	pixel_x = 8;
+	summon_offset_x = -1
 	},
-/turf/open/floor/iron/dark/herringbone,
-/area/centcom/central_command_areas/arcade)
+/obj/machinery/trading_card_holder/red{
+	pixel_y = 12;
+	pixel_x = -3;
+	summon_offset_x = -2
+	},
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet/black,
+/area/centcom/central_command_areas/hall)
 "mp" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -4580,6 +4707,10 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
+"mN" = (
+/obj/structure/table/wood,
+/turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/arcade)
 "mO" = (
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/dark/textured_half{
@@ -4643,12 +4774,20 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/botany)
 "mX" = (
-/obj/structure/sign/poster/contraband/random/directional/south,
-/obj/structure/chair/pew/right{
-	dir = 8
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/trading_card_holder{
+	pixel_y = 5;
+	pixel_x = 8;
+	summon_offset_x = -1
 	},
-/turf/open/floor/iron/dark/textured,
-/area/centcom/central_command_areas/arcade)
+/obj/machinery/trading_card_holder{
+	pixel_y = 2;
+	pixel_x = -3;
+	summon_offset_x = -2
+	},
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet/royalblue,
+/area/centcom/central_command_areas/hall)
 "mY" = (
 /obj/structure/table/wood,
 /obj/item/gun/magic/wand{
@@ -4670,12 +4809,9 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
 "na" = (
-/obj/structure/sign/poster/contraband/random/directional/west,
-/obj/structure/chair/pew{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
-/area/centcom/central_command_areas/arcade)
+/obj/structure/flora/grass/jungle/b/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "nb" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -4785,6 +4921,11 @@
 /obj/structure/closet/crate/cardboard/mothic,
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
+"np" = (
+/obj/structure/closet/crate/necropolis,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/misc/asteroid/basalt,
+/area/centcom/central_command_areas/hall)
 "nq" = (
 /obj/structure/stone_tile/slab,
 /turf/open/misc/snow/actually_safe,
@@ -4893,6 +5034,13 @@
 /obj/structure/hedge,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/light/directional/north,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/hall)
+"nJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/hall)
 "nK" = (
@@ -5626,8 +5774,8 @@
 /turf/open/space/basic,
 /area/space)
 "pK" = (
-/obj/effect/turf_decal/stripes,
-/turf/open/floor/iron/dark/herringbone,
+/obj/structure/curtain/cloth/fancy,
+/turf/closed/indestructible/fakeglass,
 /area/centcom/central_command_areas/arcade)
 "pL" = (
 /obj/structure/stone_tile/block{
@@ -5932,10 +6080,10 @@
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/hall)
 "qv" = (
-/obj/structure/curtain/cloth/fancy,
-/obj/structure/fake_stairs/wood/directional/west,
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/flora/grass/jungle/b/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "qw" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/machinery/light/directional/north,
@@ -5990,7 +6138,26 @@
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
 "qD" = (
-/turf/closed/wall,
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/mineral/wood/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/cardboard/fifty,
+/obj/item/stack/tile/carpet/fifty,
+/obj/item/stack/tile/carpet/fifty,
+/obj/item/stack/sheet/cloth/ten,
+/obj/structure/sign/painting/library_secure{
+	pixel_x = -32
+	},
+/obj/item/storage/box/lights/bulbs{
+	pixel_y = 8;
+	pixel_x = -6
+	},
+/turf/open/floor/iron/dark/textured_half,
 /area/centcom/central_command_areas/arcade)
 "qE" = (
 /obj/effect/turf_decal/siding/blue{
@@ -6014,45 +6181,25 @@
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
 "qI" = (
-/obj/structure/rack,
-/obj/item/screwdriver,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/mineral/wood/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/sheet/cardboard/fifty,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/pipe_cleaner_coil/random,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/obj/item/stack/sheet/cloth/ten,
-/obj/effect/turf_decal/stripes,
-/obj/item/stack/tile/carpet/fifty,
-/obj/item/stack/tile/carpet/fifty,
-/turf/open/floor/iron/dark/herringbone,
-/area/centcom/central_command_areas/arcade)
+/obj/structure/flora/rock/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "qJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck{
-	pixel_y = 6
-	},
-/turf/open/floor/wood/large,
-/area/centcom/central_command_areas/arcade)
+/obj/machinery/door/airlock/centcom,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/firing_range)
 "qK" = (
 /turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/hall)
+"qL" = (
+/obj/item/book/manual/wiki/tgc{
+	pixel_y = 12
+	},
+/obj/machinery/trading_card_button{
+	pixel_y = -3
+	},
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet/royalblue,
 /area/centcom/central_command_areas/hall)
 "qM" = (
 /turf/open/floor/glass/reinforced,
@@ -6290,6 +6437,11 @@
 	dir = 4
 	},
 /area/centcom/syndicate_mothership/control)
+"rw" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/rock/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "rx" = (
 /obj/structure/table/reinforced,
 /obj/item/knife/combat/survival{
@@ -6592,10 +6744,11 @@
 /area/centcom/central_command_areas/botany)
 "sp" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 4
+	dir = 1
 	},
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/hall)
 "sq" = (
 /obj/machinery/computer/shuttle/white_ship{
 	dir = 4
@@ -6843,8 +6996,10 @@
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "sX" = (
-/obj/structure/table/wood,
-/turf/open/floor/iron/dark/textured_large,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/arcade)
 "sY" = (
 /obj/structure/table/reinforced,
@@ -7083,48 +7238,9 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
 "tD" = (
-/obj/item/pen/fourcolor{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/obj/item/pen/fourcolor{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/pen/fourcolor{
-	pixel_x = 2;
-	pixel_y = 5
-	},
-/obj/item/pen/fourcolor{
-	pixel_x = 1;
-	pixel_y = 11
-	},
-/obj/item/pen/fourcolor{
-	pixel_x = 2;
-	pixel_y = 6
-	},
-/obj/item/pen/fourcolor{
-	pixel_x = 1;
-	pixel_y = 11
-	},
-/obj/item/pen/fourcolor{
-	pixel_x = 1;
-	pixel_y = -1
-	},
-/obj/item/pen/fourcolor{
-	pixel_x = -1;
-	pixel_y = -2
-	},
-/obj/item/pen/fourcolor{
-	pixel_x = 6
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
-/obj/structure/table,
-/obj/machinery/light/directional/north,
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/iron/dark/herringbone,
+/obj/structure/fake_stairs/wood/directional/north,
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/arcade)
 "tE" = (
 /obj/structure/sign/poster/contraband/masked_men{
@@ -7153,6 +7269,13 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/kitchen)
+"tJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/hall)
 "tK" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/dark/opposingcorners,
@@ -7211,17 +7334,10 @@
 /turf/closed/indestructible/syndicate,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "tR" = (
-/obj/effect/turf_decal/stripes{
-	dir = 6
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
-/obj/item/storage/crayons{
-	pixel_y = 10
-	},
-/obj/item/storage/crayons{
-	pixel_y = 2
-	},
-/obj/structure/table,
-/turf/open/floor/iron/dark/herringbone,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/arcade)
 "tS" = (
 /obj/machinery/light/small/maintenance/directional/west,
@@ -7238,6 +7354,21 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"tT" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/trading_card_holder{
+	pixel_y = 5;
+	pixel_x = -8;
+	summon_offset_x = 1
+	},
+/obj/machinery/trading_card_holder{
+	pixel_y = 2;
+	pixel_x = 3;
+	summon_offset_x = 2
+	},
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet/royalblue,
+/area/centcom/central_command_areas/hall)
 "tU" = (
 /turf/closed/indestructible/fakeglass,
 /area/centcom/tdome/observation)
@@ -7520,12 +7651,8 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/botany)
 "uL" = (
-/obj/item/toy/eightball{
-	pixel_y = 8;
-	pixel_x = -6
-	},
-/obj/structure/table/wood,
-/turf/open/floor/iron/dark/textured_large,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/arcade)
 "uM" = (
 /obj/structure/sign/poster/contraband/free_key,
@@ -7611,9 +7738,10 @@
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/borbop)
 "uY" = (
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
+/obj/item/stack/ore/silver,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/misc/asteroid/basalt,
+/area/centcom/central_command_areas/hall)
 "uZ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
@@ -8197,10 +8325,55 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/kitchen)
+"wD" = (
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/obj/item/toner,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/centcom/central_command_areas/arcade)
 "wE" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/carpet,
 /area/centcom/central_command_areas/kitchen)
+"wF" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/obj/item/pen/fourcolor{
+	pixel_x = 10;
+	pixel_y = 10
+	},
+/obj/item/pen/fourcolor{
+	pixel_x = 10;
+	pixel_y = -2
+	},
+/obj/item/pen/fourcolor{
+	pixel_x = 10;
+	pixel_y = 4
+	},
+/obj/machinery/atm,
+/obj/item/paper_bin{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/obj/item/paper_bin{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/arcade)
 "wG" = (
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 1
@@ -8211,6 +8384,10 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ghost_spawn)
+"wI" = (
+/obj/structure/chair/stool/directional/north,
+/turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/arcade)
 "wJ" = (
 /obj/structure/closet/crate/bin{
 	name = "treat storage"
@@ -8271,6 +8448,11 @@
 	},
 /turf/open/misc/grass,
 /area/centcom/central_command_areas/admin)
+"wR" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/hall)
 "wS" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/carpet/black,
@@ -8318,10 +8500,10 @@
 /turf/open/floor/circuit/green,
 /area/centcom/central_command_areas/admin)
 "wZ" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/chair/stool/bar/directional/north,
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/misc/asteroid/basalt,
+/area/centcom/central_command_areas/hall)
 "xa" = (
 /obj/structure/chair/office,
 /obj/structure/window/plasma/spawner/directional/west,
@@ -8531,9 +8713,8 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "xF" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
+/turf/open/floor/fakepit,
+/area/centcom/central_command_areas/hall)
 "xG" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/machinery/vending/wardrobe/det_wardrobe,
@@ -8656,43 +8837,10 @@
 /turf/open/misc/snow/actually_safe,
 /area/centcom/central_command_areas/admin)
 "xY" = (
-/obj/item/toy/cards/deck/kotahi{
-	pixel_y = 26
-	},
-/obj/item/toy/cards/deck/kotahi{
-	pixel_y = 26;
-	pixel_x = -8
-	},
-/obj/item/toy/cards/deck/kotahi{
-	pixel_y = 26;
-	pixel_x = 8
-	},
-/obj/item/toy/cards/deck/cas{
-	pixel_y = 17;
-	pixel_x = -8
-	},
-/obj/item/toy/cards/deck/cas/black{
-	pixel_x = 3;
-	pixel_y = 17
-	},
-/obj/item/folder/blue{
-	pixel_y = -6;
-	pixel_x = -8
-	},
-/obj/item/folder/red{
-	pixel_y = -3;
-	pixel_x = -3
-	},
-/obj/item/folder/white{
-	pixel_y = -5;
-	pixel_x = 5
-	},
-/obj/item/folder/yellow{
-	pixel_y = -8
-	},
-/obj/structure/table,
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron/dark/herringbone,
+/obj/structure/table/wood/poker,
+/obj/machinery/atm,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/carpet,
 /area/centcom/central_command_areas/arcade)
 "xZ" = (
 /turf/open/floor/wood/large,
@@ -8744,50 +8892,10 @@
 /turf/open/floor/circuit/green,
 /area/centcom/central_command_areas/admin)
 "yh" = (
-/obj/item/toy/figure/assistant,
-/obj/item/toy/figure/atmos,
-/obj/item/toy/figure/bartender,
-/obj/item/toy/figure/borg,
-/obj/item/toy/figure/botanist,
-/obj/item/toy/figure/captain,
-/obj/item/toy/figure/cargotech,
-/obj/item/toy/figure/ce,
-/obj/item/toy/figure/chaplain,
-/obj/item/toy/figure/chef,
-/obj/item/toy/figure/chemist,
-/obj/item/toy/figure/clown,
-/obj/item/toy/figure/cmo,
-/obj/item/toy/figure/curator,
-/obj/item/toy/figure/detective,
-/obj/item/toy/figure/dsquad,
-/obj/item/toy/figure/engineer,
-/obj/item/toy/figure/geneticist,
-/obj/item/toy/figure/hop,
-/obj/item/toy/figure/hos,
-/obj/item/toy/figure/ian,
-/obj/item/toy/figure/janitor,
-/obj/item/toy/figure/lawyer,
-/obj/item/toy/figure/md,
-/obj/item/toy/figure/mime,
-/obj/item/toy/figure/miner,
-/obj/item/toy/figure/ninja,
-/obj/item/toy/figure/paramedic,
-/obj/item/toy/figure/prisoner,
-/obj/item/toy/figure/psychologist,
-/obj/item/toy/figure/qm,
-/obj/item/toy/figure/rd,
-/obj/item/toy/figure/roboticist,
-/obj/item/toy/figure/scientist,
-/obj/item/toy/figure/secofficer,
-/obj/item/toy/figure/syndie,
-/obj/item/toy/figure/virologist,
-/obj/item/toy/figure/warden,
-/obj/item/toy/figure/wizard,
-/obj/effect/turf_decal/stripes{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/obj/structure/table,
-/turf/open/floor/iron/dark/herringbone,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/arcade)
 "yi" = (
 /obj/effect/turf_decal/siding/wood,
@@ -8977,6 +9085,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
+"yI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-22";
+	pixel_x = -4
+	},
+/obj/machinery/atm,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/borbop)
 "yJ" = (
 /obj/structure/railing/wood{
 	dir = 8
@@ -8996,9 +9115,16 @@
 /turf/open/floor/iron/dark/small,
 /area/centcom/central_command_areas/botany)
 "yL" = (
-/obj/structure/chair/stool/bar/directional/north,
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/hall)
 "yM" = (
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/carpet/purple,
@@ -9027,22 +9153,9 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
 "yO" = (
-/obj/item/paper_bin{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/paper_bin{
-	pixel_x = -8;
-	pixel_y = 5
-	},
-/obj/item/paper_bin{
-	pixel_x = 18;
-	pixel_y = 5
-	},
-/obj/machinery/atm,
-/obj/structure/table,
-/turf/open/floor/iron/dark/herringbone,
-/area/centcom/central_command_areas/arcade)
+/obj/structure/flora/bush/large/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "yP" = (
 /obj/machinery/newscaster{
 	pixel_y = -32
@@ -9087,6 +9200,10 @@
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/kitchen)
+"yV" = (
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/carpet/royalblue,
+/area/centcom/central_command_areas/hall)
 "yW" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor/iron,
@@ -9301,6 +9418,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
+"zA" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/flora/grass/jungle/a/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "zB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9558,6 +9681,17 @@
 "An" = (
 /turf/open/floor/carpet,
 /area/centcom/central_command_areas/kitchen)
+"Ao" = (
+/obj/item/book/manual/wiki/tgc{
+	pixel_y = -4
+	},
+/obj/machinery/trading_card_button/health{
+	pixel_y = 10;
+	panel_offset_y = -1
+	},
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet/black,
+/area/centcom/central_command_areas/hall)
 "Ap" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -9584,9 +9718,7 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "As" = (
-/obj/structure/fake_stairs/wood/directional/west,
-/obj/structure/curtain/cloth/fancy,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/carpet,
 /area/centcom/central_command_areas/arcade)
 "At" = (
 /obj/structure/sign/poster/contraband/bountyhunters{
@@ -9688,6 +9820,14 @@
 /obj/item/banner/command,
 /turf/open/floor/stone,
 /area/centcom/central_command_areas/evacuation/ship)
+"AE" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck{
+	pixel_y = 6
+	},
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/carpet,
+/area/centcom/central_command_areas/arcade)
 "AF" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -9826,6 +9966,11 @@
 	dir = 8
 	},
 /area/centcom/central_command_areas/hall)
+"AY" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/misc/asteroid/basalt,
+/area/centcom/central_command_areas/hall)
 "AZ" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -9837,6 +9982,12 @@
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/hall)
+"Bb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/arcade)
 "Bc" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
@@ -10152,6 +10303,10 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/admin)
+"BN" = (
+/obj/structure/flora/grass/jungle/a/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "BO" = (
 /obj/structure/bed{
 	dir = 4
@@ -10161,6 +10316,12 @@
 	},
 /turf/open/floor/iron/smooth_half,
 /area/centcom/syndicate_mothership/control)
+"BP" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/flora/grass/jungle/a/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "BQ" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/siding/thinplating/dark{
@@ -10383,10 +10544,9 @@
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation/ship)
 "Cz" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood/large,
-/area/centcom/central_command_areas/arcade)
+/obj/machinery/atm,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/botany)
 "CA" = (
 /obj/machinery/light/floor/has_bulb,
 /obj/effect/turf_decal/trimline/green,
@@ -10481,6 +10641,24 @@
 /obj/structure/injured_spawner,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
+"CR" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/trading_card_holder/red{
+	pixel_y = 6
+	},
+/obj/machinery/trading_card_holder/red{
+	pixel_y = 7;
+	pixel_x = -12;
+	summon_offset_x = -1
+	},
+/obj/machinery/trading_card_holder/red{
+	pixel_y = 7;
+	pixel_x = 12;
+	summon_offset_x = 1
+	},
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet/black,
+/area/centcom/central_command_areas/hall)
 "CS" = (
 /obj/machinery/door/airlock/centcom,
 /obj/effect/mapping_helpers/airlock/access/any/admin/captain,
@@ -10674,13 +10852,43 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "Du" = (
-/obj/item/pizzabox/meat{
-	pixel_y = 5
+/obj/structure/table,
+/obj/item/folder{
+	pixel_y = 2;
+	pixel_x = -6
 	},
-/obj/item/pizzabox/vegetable{
+/obj/item/folder{
+	pixel_y = 2;
+	pixel_x = -6
+	},
+/obj/item/folder/blue{
 	pixel_y = 9
 	},
-/obj/structure/table/wood,
+/obj/item/folder/blue{
+	pixel_y = 9
+	},
+/obj/item/folder/red{
+	pixel_y = -1;
+	pixel_x = 4
+	},
+/obj/item/folder/red{
+	pixel_y = -1;
+	pixel_x = 4
+	},
+/obj/item/folder/white,
+/obj/item/folder/white,
+/obj/item/folder/yellow{
+	pixel_y = 14;
+	pixel_x = -6
+	},
+/obj/item/folder/yellow{
+	pixel_y = 14;
+	pixel_x = -6
+	},
+/obj/structure/sign/painting/library_secure{
+	pixel_x = -32
+	},
+/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/arcade)
 "Dv" = (
@@ -10699,6 +10907,14 @@
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin)
+"Dx" = (
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/centcom/central_command_areas/arcade)
 "Dy" = (
 /obj/structure/flora/grass/both/style_random,
 /obj/structure/railing{
@@ -10753,10 +10969,9 @@
 /turf/open/floor/glass/reinforced,
 /area/centcom/central_command_areas/admin_hangout)
 "DG" = (
-/obj/structure/fake_stairs/wood/directional/south,
-/obj/structure/curtain/cloth/fancy,
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
+/obj/machinery/vending/games,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "DH" = (
 /obj/machinery/igniter/incinerator_ordmix{
 	id = "syn_ordmix_igniter"
@@ -10922,10 +11137,10 @@
 /turf/open/floor/carpet,
 /area/centcom/wizard_station)
 "Ef" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/turf/open/floor/wood/parquet,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/arcade)
 "Eg" = (
 /obj/machinery/door/airlock{
@@ -11256,6 +11471,10 @@
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/evacuation/ship)
+"EW" = (
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/carpet,
+/area/centcom/central_command_areas/arcade)
 "EY" = (
 /obj/structure/chair{
 	dir = 1
@@ -11425,6 +11644,10 @@
 /obj/structure/centcom_teleporter/spawn_area,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/hall)
+"Fy" = (
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/central_command_areas/arcade)
 "Fz" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership)
@@ -11561,11 +11784,9 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/borbop)
 "FQ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
+/obj/structure/fake_stairs/stone,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/hall)
 "FR" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/arcade)
@@ -11633,11 +11854,50 @@
 /turf/open/floor/circuit,
 /area/centcom/central_command_areas/admin)
 "Gc" = (
-/obj/structure/sign/poster/contraband/random/directional/south,
-/obj/structure/chair/pew/left{
-	dir = 4
+/obj/item/toy/figure/assistant,
+/obj/item/toy/figure/atmos,
+/obj/item/toy/figure/bartender,
+/obj/item/toy/figure/borg,
+/obj/item/toy/figure/botanist,
+/obj/item/toy/figure/captain,
+/obj/item/toy/figure/cargotech,
+/obj/item/toy/figure/ce,
+/obj/item/toy/figure/chaplain,
+/obj/item/toy/figure/chef,
+/obj/item/toy/figure/chemist,
+/obj/item/toy/figure/clown,
+/obj/item/toy/figure/cmo,
+/obj/item/toy/figure/curator,
+/obj/item/toy/figure/detective,
+/obj/item/toy/figure/dsquad,
+/obj/item/toy/figure/engineer,
+/obj/item/toy/figure/geneticist,
+/obj/item/toy/figure/hop,
+/obj/item/toy/figure/hos,
+/obj/item/toy/figure/ian,
+/obj/item/toy/figure/janitor,
+/obj/item/toy/figure/lawyer,
+/obj/item/toy/figure/md,
+/obj/item/toy/figure/mime,
+/obj/item/toy/figure/miner,
+/obj/item/toy/figure/ninja,
+/obj/item/toy/figure/paramedic,
+/obj/item/toy/figure/prisoner,
+/obj/item/toy/figure/psychologist,
+/obj/item/toy/figure/qm,
+/obj/item/toy/figure/rd,
+/obj/item/toy/figure/roboticist,
+/obj/item/toy/figure/scientist,
+/obj/item/toy/figure/secofficer,
+/obj/item/toy/figure/syndie,
+/obj/item/toy/figure/virologist,
+/obj/item/toy/figure/warden,
+/obj/item/toy/figure/wizard,
+/obj/structure/table,
+/obj/structure/sign/painting/library_secure{
+	pixel_x = -32
 	},
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/arcade)
 "Gd" = (
 /obj/structure/centcom_item_spawner/gun_and_ammo_creator,
@@ -11660,13 +11920,9 @@
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "Gg" = (
-/obj/structure/table/wood/poker,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 8;
-	pixel_x = 16
-	},
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/hall)
 "Gh" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -11863,6 +12119,12 @@
 "GG" = (
 /turf/closed/indestructible/syndicate,
 /area/centcom/syndicate_mothership/expansion_fridgerummage)
+"GH" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/arcade)
 "GI" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/machinery/vending/autodrobe/all_access,
@@ -11949,6 +12211,11 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
+"GU" = (
+/obj/structure/flora/tree/jungle/small/style_random,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "GV" = (
 /obj/structure/mop_bucket,
 /obj/item/mop,
@@ -12010,8 +12277,10 @@
 /turf/open/floor/circuit,
 /area/centcom/central_command_areas/admin)
 "Hd" = (
-/obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/wood/parquet,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/arcade)
 "He" = (
 /obj/structure/table/wood,
@@ -12101,12 +12370,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "Hq" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/table/wood/poker,
-/obj/machinery/light/directional/north,
-/turf/open/floor/wood/large,
+/obj/structure/chair/stool/directional/south,
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/arcade)
 "Hr" = (
 /obj/structure/chair/sofa/corp{
@@ -12137,11 +12402,8 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/botany)
 "Hv" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/stripes,
+/turf/open/floor/iron/dark/textured_half,
 /area/centcom/central_command_areas/arcade)
 "Hw" = (
 /obj/effect/turf_decal/siding/dark{
@@ -12377,6 +12639,17 @@
 	icon_state = "boxing"
 	},
 /area/centcom/central_command_areas/admin)
+"Ie" = (
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/item/cardpack/series_one,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/machinery/atm,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/hall)
 "If" = (
 /obj/structure/chair/stool/directional/north,
 /obj/effect/landmark/start/nukeop,
@@ -12485,6 +12758,11 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
 /turf/open/space/basic,
 /area/space/nearstation)
+"Ix" = (
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/machinery/atm,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/ghost_spawn)
 "Iy" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/structure/table/reinforced,
@@ -12731,6 +13009,10 @@
 "Ji" = (
 /turf/open/floor/carpet/neon/simple/white,
 /area/centcom/central_command_areas/admin)
+"Jj" = (
+/obj/machinery/atm,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/medical)
 "Jk" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -13137,6 +13419,11 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/centcom/central_command_areas/botany)
+"Km" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/grass/jungle/b/style_random,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "Kn" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -13228,9 +13515,11 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
 "KA" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/structure/table/wood/poker,
-/turf/open/floor/wood/large,
+/obj/structure/table/wood/fancy/green,
+/obj/effect/spawner/random/food_or_drink/pizzaparty{
+	pixel_y = 11
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/arcade)
 "KB" = (
 /obj/effect/turf_decal/siding/dark{
@@ -13304,10 +13593,9 @@
 /turf/closed/wall/mineral/titanium,
 /area/centcom/central_command_areas/evacuation/ship)
 "KI" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/turf/open/floor/wood/parquet,
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/arcade)
 "KJ" = (
 /obj/structure/chair/stool/bar/directional/east,
@@ -13851,6 +14139,11 @@
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/botany)
+"Mb" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/flora/rock/style_random,
+/turf/open/misc/asteroid/basalt,
+/area/centcom/central_command_areas/hall)
 "Mc" = (
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin)
@@ -14019,6 +14312,9 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
+"MA" = (
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "MB" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/dark{
@@ -14133,6 +14429,10 @@
 	dir = 10
 	},
 /area/centcom/central_command_areas/hall)
+"MR" = (
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/carpet/black,
+/area/centcom/central_command_areas/hall)
 "MS" = (
 /obj/machinery/door/airlock{
 	icon = 'icons/obj/doors/airlocks/station/uranium.dmi';
@@ -14182,6 +14482,11 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
+"Na" = (
+/obj/structure/fake_stairs/wood/directional/west,
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/hall)
 "Nb" = (
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
@@ -14270,10 +14575,9 @@
 /area/centcom/syndicate_mothership/control)
 "No" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 4
+	dir = 6
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/arcade)
 "Np" = (
 /obj/structure/chair/office,
@@ -14498,6 +14802,11 @@
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/hall)
+"NW" = (
+/obj/structure/table/wood/poker,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/carpet,
+/area/centcom/central_command_areas/arcade)
 "NX" = (
 /obj/structure/hive_exit,
 /turf/closed/indestructible/hive,
@@ -14522,10 +14831,8 @@
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "Oa" = (
-/obj/structure/curtain/cloth/fancy,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/centcom/central_command_areas/arcade)
+/turf/open/floor/fakespace,
+/area/centcom/central_command_areas/hall)
 "Ob" = (
 /obj/structure/fireplace{
 	pixel_x = 0
@@ -14646,6 +14953,10 @@
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/two)
+"Or" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/firing_range)
 "Os" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
@@ -14946,11 +15257,10 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/four)
 "Pn" = (
-/obj/structure/chair/pew/left{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/textured,
-/area/centcom/central_command_areas/arcade)
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/flora/grass/jungle/a/style_random,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/hall)
 "Po" = (
 /obj/machinery/vending/boozeomat,
 /obj/effect/turf_decal/siding/wood{
@@ -14967,8 +15277,11 @@
 /turf/open/floor/carpet/royalblue,
 /area/centcom/central_command_areas/admin)
 "Pq" = (
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
+/obj/structure/fake_stairs/directional{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/hall)
 "Pr" = (
 /obj/machinery/light/floor/has_bulb,
 /obj/effect/turf_decal/siding/wood{
@@ -15237,17 +15550,15 @@
 /area/centcom/ai_multicam_room)
 "Qf" = (
 /obj/machinery/vending/games,
-/turf/open/floor/iron/dark/herringbone,
-/area/centcom/central_command_areas/arcade)
-"Qg" = (
-/obj/item/knife/kitchen{
-	pixel_y = 1;
-	pixel_x = -8
-	},
-/obj/item/lighter,
-/obj/structure/table/wood,
+/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/arcade)
+"Qg" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/flora/grass/jungle/a/style_random,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "Qh" = (
 /obj/structure/hedge,
 /obj/structure/stone_tile/slab,
@@ -15350,6 +15661,17 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/iron/smooth_large,
 /area/centcom/central_command_areas/evacuation/ship)
+"Qu" = (
+/obj/item/cardpack/resin,
+/obj/item/cardpack/resin,
+/obj/item/cardpack/resin,
+/obj/item/cardpack/resin,
+/obj/item/cardpack/resin,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/hall)
 "Qv" = (
 /obj/machinery/light/floor/has_bulb,
 /obj/effect/turf_decal/siding/wood{
@@ -15555,6 +15877,11 @@
 "QV" = (
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/admin)
+"QW" = (
+/obj/structure/flora/bush/large/style_random,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
 "QX" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
@@ -15611,6 +15938,11 @@
 /obj/item/food/meat/slab/human/mutant/slime,
 /turf/open/floor/grass,
 /area/centcom/wizard_station)
+"Rh" = (
+/obj/structure/curtain/cloth/fancy,
+/obj/structure/fake_stairs/wood/directional/west,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/arcade)
 "Ri" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -15945,6 +16277,11 @@
 /obj/structure/flora/tree/jungle/style_3,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
+"Sc" = (
+/obj/structure/fake_stairs/wood/directional/south,
+/obj/structure/curtain/cloth/fancy,
+/turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/arcade)
 "Sd" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/lattice,
@@ -16081,6 +16418,13 @@
 /obj/structure/fake_stairs/wood/directional/south,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
+"Su" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/hall)
 "Sv" = (
 /obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron/dark,
@@ -16468,31 +16812,20 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "Ty" = (
-/obj/item/storage/dice{
-	pixel_y = 14;
-	pixel_x = 6
-	},
-/obj/item/storage/dice{
-	pixel_y = 14;
-	pixel_x = -6
-	},
-/obj/item/storage/dice{
-	pixel_y = 14
-	},
-/obj/item/toy/cards/deck{
-	pixel_y = 4
-	},
-/obj/item/toy/cards/deck{
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/trading_card_holder/red{
+	pixel_y = 9;
 	pixel_x = -8;
-	pixel_y = 4
+	summon_offset_x = 1
 	},
-/obj/item/toy/cards/deck{
-	pixel_x = 8;
-	pixel_y = 4
+/obj/machinery/trading_card_holder/red{
+	pixel_y = 12;
+	pixel_x = 3;
+	summon_offset_x = 2
 	},
-/obj/structure/table,
-/turf/open/floor/iron/dark/herringbone,
-/area/centcom/central_command_areas/arcade)
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet/black,
+/area/centcom/central_command_areas/hall)
 "Tz" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
@@ -16514,6 +16847,16 @@
 /obj/structure/curtain/bounty,
 /turf/closed/indestructible/fakeglass,
 /area/centcom/central_command_areas/hall)
+"TD" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/sign/painting/library_secure{
+	pixel_x = -32
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/arcade)
 "TE" = (
 /obj/structure/chair/comfy/brown{
 	color = "#596479";
@@ -16758,14 +17101,13 @@
 /turf/open/floor/wood,
 /area/centcom/wizard_station)
 "Um" = (
-/obj/structure/curtain/cloth/fancy,
-/turf/open/floor/iron/dark/textured_half,
+/obj/structure/table/wood/poker,
+/turf/open/floor/carpet,
 /area/centcom/central_command_areas/arcade)
 "Un" = (
-/obj/structure/chair/pew/right{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/textured,
+/obj/structure/sign/poster/contraband/random/directional/north,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet,
 /area/centcom/central_command_areas/arcade)
 "Uo" = (
 /obj/structure/flora/grass/brown/style_random,
@@ -16996,6 +17338,22 @@
 /obj/item/paper_bin/carbon,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range_checkpoint_control)
+"UV" = (
+/obj/effect/turf_decal/stripes{
+	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/light_switch/directional/north,
+/obj/item/storage/toolbox/syndicate{
+	pixel_y = 11
+	},
+/obj/item/storage/crayons{
+	pixel_x = -4
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/centcom/central_command_areas/arcade)
 "UX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -17398,6 +17756,11 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/borbop)
+"VY" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/flora/rock/style_random,
+/turf/open/misc/asteroid/basalt,
+/area/centcom/central_command_areas/hall)
 "VZ" = (
 /obj/structure/closet/secure_closet/ert_med,
 /obj/structure/sign/directions/medical{
@@ -17409,6 +17772,13 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/armory)
+"Wa" = (
+/obj/structure/chair/wood{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/random/directional/west,
+/turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/arcade)
 "Wb" = (
 /turf/open/floor/wood/large,
 /area/centcom/tdome/observation)
@@ -17727,6 +18097,19 @@
 "WT" = (
 /turf/open/floor/carpet/executive,
 /area/centcom/central_command_areas/admin)
+"WU" = (
+/obj/structure/table/wood/fancy/green,
+/obj/structure/sign/poster/contraband/random/directional/south,
+/obj/item/reagent_containers/cocainebrick{
+	pixel_y = 4;
+	pixel_x = -3
+	},
+/obj/item/knife/kitchen{
+	pixel_y = 21;
+	pixel_x = 9
+	},
+/turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/arcade)
 "WV" = (
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/iron/dark/herringbone,
@@ -17891,6 +18274,16 @@
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin)
+"Xo" = (
+/obj/item/coin/thunderdome{
+	pixel_y = 8
+	},
+/obj/machinery/trading_card_button/health{
+	pixel_y = -3
+	},
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet/royalblue,
+/area/centcom/central_command_areas/hall)
 "Xp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/computer/monitor,
@@ -18146,11 +18539,13 @@
 /turf/open/floor/carpet/purple,
 /area/centcom/central_command_areas/admin)
 "Yf" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
+/obj/item/storage/card_binder,
+/obj/item/storage/card_binder,
+/obj/item/storage/card_binder,
+/obj/item/storage/card_binder,
+/obj/structure/rack,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/hall)
 "Yg" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/structure/table/reinforced,
@@ -18207,6 +18602,17 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
+"Ym" = (
+/obj/item/coin/thunderdome{
+	pixel_y = -4
+	},
+/obj/machinery/trading_card_button{
+	pixel_y = 10;
+	panel_offset_y = -1
+	},
+/obj/structure/table/wood/fancy/black,
+/turf/open/floor/carpet/black,
+/area/centcom/central_command_areas/hall)
 "Yn" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/supplypod)
@@ -18283,6 +18689,11 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/centcom/wizard_station)
+"YB" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/directional/south,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/hall)
 "YC" = (
 /obj/structure/hedge,
 /obj/structure/railing/wood,
@@ -18303,6 +18714,11 @@
 "YF" = (
 /obj/structure/flora/tree/jungle/style_3,
 /obj/machinery/light/floor/has_bulb,
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/hall)
+"YG" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/flora/grass/jungle/b/style_random,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/hall)
 "YH" = (
@@ -18487,15 +18903,9 @@
 /turf/closed/indestructible/fakeglass,
 /area/centcom/central_command_areas/admin)
 "Zg" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/obj/structure/table/wood/poker,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 9
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/wood/large,
-/area/centcom/central_command_areas/arcade)
+/area/centcom/central_command_areas/hall)
 "Zh" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south{
 	name = "Tinted Window";
@@ -18648,13 +19058,11 @@
 	},
 /area/awaymission/errorroom)
 "ZF" = (
-/obj/item/reagent_containers/cocainebrick{
-	pixel_y = 8;
-	pixel_x = 5
-	},
-/obj/structure/table/wood,
-/turf/open/floor/iron/dark/textured_large,
-/area/centcom/central_command_areas/arcade)
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/item/stack/ore/glass,
+/turf/open/misc/asteroid/basalt,
+/area/centcom/central_command_areas/hall)
 "ZG" = (
 /obj/structure/table/wood,
 /obj/item/newspaper{
@@ -55825,17 +56233,17 @@ wu
 mD
 mD
 rY
-Ya
-Ya
-Ya
-Ya
-Ya
-Ya
-FR
-FR
-FR
-FR
-FR
+QC
+QC
+QC
+QC
+QC
+QC
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -56082,17 +56490,17 @@ vz
 TY
 mD
 QC
-FR
-Qf
-Ty
-xY
-qI
-kR
-Um
-Un
-na
-Gc
-FR
+QC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -56339,17 +56747,17 @@ Zb
 mD
 xG
 MP
-FR
-yO
-Hj
-Hj
-pK
-xF
-Um
-Du
-ZF
-sX
-FR
+QC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -56596,17 +57004,17 @@ aw
 ae
 ew
 ew
-FR
-tD
-mo
-yh
-tR
-xF
-Um
-Qg
-kj
-uL
-FR
+QC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -56853,17 +57261,17 @@ Mo
 pq
 ew
 ew
-DG
-KI
-Pq
-Pq
-Pq
-xF
-Um
-Pn
-cD
-mX
-FR
+QC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -57110,17 +57518,17 @@ Mo
 Jd
 ew
 dh
-DG
-KI
-Pq
-Pq
-Pq
-fb
-qD
-Oa
-Oa
-Oa
-FR
+QC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -57367,17 +57775,17 @@ Mo
 Jd
 ew
 ew
-DG
-hN
-Hd
-Hd
-Pq
-Ef
-Hv
-Yf
-Yf
-kR
-FR
+QC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -57624,17 +58032,17 @@ Mo
 pq
 ew
 GI
-FR
-Hq
-qJ
-Zg
-yL
-Pq
-Pq
-kJ
-Gg
-wZ
-FR
+QC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -57807,7 +58215,7 @@ jf
 yG
 dS
 dS
-LK
+Cz
 aX
 Wi
 XE
@@ -57881,17 +58289,17 @@ Mo
 ae
 ew
 bZ
-FR
-xZ
-xZ
-KA
-yL
-Pq
-Pq
-kJ
-uY
-wZ
-FR
+QC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -58138,17 +58546,17 @@ Mo
 ae
 ew
 Vj
-FR
-xZ
-xZ
-Cz
-sp
-sp
-sp
-No
-sp
-FQ
-FR
+QC
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 aa
 aa
 aa
@@ -58395,17 +58803,17 @@ Mo
 pq
 ew
 gc
-FR
-FR
-FR
-FR
-As
-As
-qv
-FR
-FR
-FR
-FR
+QC
+QC
+QC
+QC
+QC
+QC
+QC
+QC
+lr
+lr
+lr
 lr
 lr
 aa
@@ -60711,7 +61119,7 @@ dh
 QC
 Bo
 Bo
-Bo
+qJ
 Bo
 Bo
 Bo
@@ -61692,7 +62100,7 @@ DZ
 lI
 cV
 wc
-cU
+yI
 cw
 an
 Cm
@@ -62704,7 +63112,7 @@ An
 An
 DO
 mQ
-sO
+Ix
 zJ
 Tr
 RE
@@ -64314,7 +64722,7 @@ Bo
 Bo
 Bo
 Bo
-Bo
+Or
 xs
 Bo
 vV
@@ -64564,18 +64972,18 @@ pG
 pG
 pG
 pG
-pG
-Fn
-Fn
-Fn
-Fn
-Fn
-Fn
-Fn
-Fn
-Fn
-Fn
-Fn
+FR
+FR
+FR
+FR
+FR
+FR
+FR
+FR
+FR
+FR
+FR
+FR
 aa
 "}
 (179,1,1) = {"
@@ -64821,18 +65229,18 @@ rj
 rj
 rj
 FA
-pG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+FR
+Qf
+Gc
+Du
+qD
+dU
+TD
+Sc
+Wa
+GH
+GH
+FR
 aa
 "}
 (180,1,1) = {"
@@ -65078,18 +65486,18 @@ rj
 bX
 rj
 rj
-pG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+FR
+wF
+Fy
+jY
+Hv
+yh
+KI
+Sc
+KA
+hN
+WU
+FR
 aa
 "}
 (181,1,1) = {"
@@ -65335,18 +65743,18 @@ rj
 rj
 bX
 rj
-pG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+FR
+jY
+jY
+jY
+Hv
+yh
+uL
+Sc
+Hd
+Hd
+Hd
+FR
 aa
 "}
 (182,1,1) = {"
@@ -65592,18 +66000,18 @@ Ql
 rj
 rj
 rj
-pG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+FR
+UV
+Dx
+wD
+dM
+yh
+uL
+FR
+pK
+pK
+pK
+FR
 aa
 "}
 (183,1,1) = {"
@@ -65849,18 +66257,18 @@ NV
 aE
 aE
 Ql
-pG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+tD
+Bb
+kj
+kj
+kj
+sX
+hL
+Ef
+Hj
+Hj
+Hj
+FR
 aa
 "}
 (184,1,1) = {"
@@ -66106,18 +66514,18 @@ vp
 uQ
 uQ
 yi
-pG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+tD
+yh
+kR
+xZ
+xZ
+xZ
+kR
+uL
+Hj
+Hj
+jU
+FR
 aa
 "}
 (185,1,1) = {"
@@ -66363,18 +66771,18 @@ Dj
 ET
 ET
 YX
-pG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+tD
+el
+tR
+tR
+tR
+cD
+xZ
+uL
+Hq
+mN
+wI
+FR
 aa
 "}
 (186,1,1) = {"
@@ -66545,7 +66953,7 @@ AO
 fE
 we
 we
-Nb
+Jj
 YL
 Wv
 vS
@@ -66620,18 +67028,18 @@ YX
 rj
 rj
 rj
-pG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+FR
+As
+As
+As
+As
+yh
+xZ
+uL
+Hq
+mN
+wI
+FR
 aa
 "}
 (187,1,1) = {"
@@ -66873,22 +67281,22 @@ rj
 Xb
 vp
 yi
-rj
+Pn
 rj
 bX
 rj
-pG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+FR
+xY
+AE
+Um
+As
+yh
+xZ
+uL
+Hq
+mN
+wI
+FR
 aa
 "}
 (188,1,1) = {"
@@ -67123,7 +67531,7 @@ rj
 rj
 pG
 Ml
-KN
+kx
 rj
 bX
 rj
@@ -67134,18 +67542,18 @@ rj
 bX
 rj
 rj
-pG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+FR
+Un
+As
+NW
+As
+yh
+kR
+uL
+Hj
+Hj
+jU
+FR
 aa
 "}
 (189,1,1) = {"
@@ -67391,18 +67799,18 @@ rj
 rj
 rj
 FA
-pG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+FR
+As
+As
+As
+EW
+el
+tR
+No
+Hj
+Hj
+Hj
+FR
 aa
 "}
 (190,1,1) = {"
@@ -67635,31 +68043,31 @@ aa
 aa
 aa
 aa
-aa
 pG
 pG
 pG
 pG
 pG
 pG
+Na
+Na
+Na
 pG
 pG
 pG
 pG
-pG
-pG
-pG
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+FR
+FR
+pK
+pK
+FR
+Rh
+Rh
+Rh
+FR
+FR
+FR
+FR
 aa
 "}
 (191,1,1) = {"
@@ -67892,28 +68300,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+ZP
+aE
+aE
+QY
+aE
+aE
+nJ
+aE
+aE
+QY
+aE
+aE
+Ql
+gn
+MA
+na
+nh
+ZP
+aE
+Ql
+pG
 aa
 aa
 aa
@@ -68149,28 +68557,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+Xb
+vp
+Gg
+Gg
+Gg
+Gg
+Gg
+Gg
+Gg
+Gg
+Gg
+vp
+yi
+gn
+DG
+GU
+nh
+Xb
+vp
+YB
+pG
 aa
 aa
 aa
@@ -68406,28 +68814,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+Xb
+TF
+np
+xF
+hW
+Oa
+Oa
+Oa
+Km
+qI
+QW
+TF
+yi
+gn
+qI
+BN
+nh
+Xb
+TF
+yi
+pG
 aa
 aa
 aa
@@ -68663,28 +69071,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+sp
+TF
+fC
+VY
+wZ
+Oa
+Oa
+Oa
+zA
+YG
+Qg
+TF
+YB
+pG
+rX
+rX
+pG
+ft
+TF
+yi
+pG
 aa
 aa
 aa
@@ -68920,28 +69328,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+Xb
+TF
+FQ
+Ao
+mo
+Oa
+Oa
+Oa
+mX
+Xo
+Pq
+TF
+yi
+oo
+ZP
+aE
+aE
+qf
+TF
+yi
+pG
 aa
 aa
 aa
@@ -69177,28 +69585,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+Su
+TF
+FQ
+MR
+CR
+Oa
+Oa
+Oa
+gI
+yV
+Pq
+TF
+wR
+oo
+Xb
+vp
+TF
+TF
+vp
+YB
+pG
 aa
 aa
 aa
@@ -69434,28 +69842,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+Xb
+TF
+FQ
+Ym
+Ty
+Oa
+Oa
+Oa
+tT
+qL
+Pq
+TF
+yi
+oo
+JB
+tJ
+ET
+ET
+ET
+YX
+pG
 aa
 aa
 aa
@@ -69691,28 +70099,28 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+sp
+TF
+AY
+du
+ZF
+Oa
+Oa
+Oa
+BP
+qv
+iy
+TF
+YB
+pG
+pG
+pG
+pG
+pG
+pG
+pG
+pG
 aa
 aa
 aa
@@ -69948,21 +70356,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+Xb
+TF
+uY
+xF
+Mb
+Oa
+Oa
+Oa
+rw
+yO
+aY
+TF
+yi
+pG
 aa
 aa
 aa
@@ -70205,21 +70613,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+Xb
+vp
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+Zg
+vp
+yi
+pG
 aa
 aa
 aa
@@ -70462,21 +70870,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+JB
+ET
+ET
+tJ
+ET
+TF
+vp
+TF
+ET
+ET
+tJ
+ET
+YX
+pG
 aa
 aa
 aa
@@ -70719,21 +71127,21 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+pG
+pG
+pG
+pG
+fb
+Xb
+Yf
+yi
+kJ
+pG
+pG
+pG
+pG
+pG
 aa
 aa
 aa
@@ -70980,13 +71388,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+Ie
+Xb
+Yf
+yi
+kJ
+pG
 aa
 aa
 aa
@@ -71237,13 +71645,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+yL
+Xb
+Yf
+yi
+Qu
+pG
 aa
 aa
 aa
@@ -71494,13 +71902,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+fb
+JB
+ET
+YX
+kJ
+pG
 aa
 aa
 aa
@@ -71751,13 +72159,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+RO
+fb
+fr
+fb
+RO
+pG
 aa
 aa
 aa
@@ -72008,13 +72416,13 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+pG
+pG
+pG
+pG
+pG
+pG
+pG
 aa
 aa
 aa


### PR DESCRIPTION

## About The Pull Request
Move the centcom Arcade to a new location and adds a TGC arena next to it.

Adds a few more ATMs around CentCom so that players can trade monkecoins in an OOC manner that is safer than doing so IC on the station.
## Why It's Good For The Game
the Arcade and TGC Arena
![image](https://github.com/Monkestation/Monkestation2.0/assets/135169022/902f6c9d-0f97-4283-8fcc-01e4a6d15ed3)
Where the "Arcade" was
![image](https://github.com/Monkestation/Monkestation2.0/assets/135169022/7435bc8e-645a-4416-9894-e25cda484ab6)
## Changelog
:cl:
/:cl:
