### PR TITLE
Small atmospheric mapping improvement/fix

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -2470,7 +2470,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aRj" = (
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "aRl" = (
@@ -54407,8 +54407,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "Plasma to Pure";
-	piping_layer = 4
+	name = "Plasma to Pure"
 	},
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -2470,7 +2470,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "aRj" = (
-/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "aRl" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -1534,7 +1534,7 @@
 "aeR" = (
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/basic,
-/area/space)
+/area/space/nearstation)
 "aeS" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 6
@@ -13617,11 +13617,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/crew_quarters/dorms)
-"dkm" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/space/basic,
-/area/space)
 "dkD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -19105,10 +19100,6 @@
 	},
 /turf/open/space/openspace,
 /area/space)
-"eYo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos)
 "eYs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/white/line{
@@ -24863,7 +24854,7 @@
 "gTl" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
-/area/station/engineering/atmos)
+/area/station/maintenance/disposal/incinerator)
 "gTr" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -31170,10 +31161,6 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
-"iXx" = (
-/obj/structure/lattice,
-/turf/open/misc/asteroid/airless,
-/area/space)
 "iXG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -45046,7 +45033,7 @@
 "nrQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
-/area/station/engineering/atmos)
+/area/station/maintenance/disposal/incinerator)
 "nrR" = (
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/surgery{
@@ -115233,9 +115220,9 @@ bNz
 bNz
 bNz
 bNz
-kfT
-kfT
-dkm
+pHM
+pHM
+mzx
 vXM
 vXM
 vXM
@@ -115492,7 +115479,7 @@ ceI
 bHy
 vXM
 vXM
-dkm
+mzx
 vXM
 vXM
 vXM
@@ -115749,7 +115736,7 @@ xoW
 bHy
 vXM
 vXM
-dkm
+mzx
 vXM
 vXM
 vXM
@@ -116006,7 +115993,7 @@ xoW
 bHy
 vXM
 vXM
-dkm
+mzx
 vXM
 vXM
 vXM
@@ -116263,7 +116250,7 @@ bNN
 bHy
 vXM
 vXM
-dkm
+mzx
 vXM
 vXM
 vXM
@@ -116520,7 +116507,7 @@ svo
 bHy
 vXM
 vXM
-dkm
+mzx
 vXM
 vXM
 vXM
@@ -116777,7 +116764,7 @@ svo
 bHy
 vXM
 vXM
-dkm
+mzx
 vXM
 vXM
 vXM
@@ -117034,7 +117021,7 @@ gjj
 bHy
 vXM
 vXM
-dkm
+mzx
 vXM
 vXM
 vXM
@@ -117289,9 +117276,9 @@ bNz
 bNz
 bNz
 bNz
-kfT
-kfT
-dkm
+pHM
+pHM
+mzx
 vXM
 vXM
 vXM
@@ -117533,16 +117520,16 @@ eeZ
 nrQ
 nrQ
 gTl
-eYo
+cjG
 djX
 nAc
 qga
 cBx
 sKF
-xkr
+qud
 vXM
 vXM
-dkm
+mzx
 vXM
 vXM
 vXM
@@ -117799,7 +117786,7 @@ qWU
 vXM
 vXM
 vXM
-dkm
+mzx
 vXM
 vXM
 vXM
@@ -118056,7 +118043,7 @@ qha
 vXM
 vXM
 vXM
-dkm
+mzx
 vXM
 vXM
 vXM
@@ -118313,7 +118300,7 @@ qWU
 vXM
 vXM
 vXM
-dkm
+mzx
 vXM
 vXM
 vXM
@@ -118567,9 +118554,9 @@ qWU
 auo
 qWU
 qWU
-kfT
-kfT
-kfT
+pHM
+pHM
+pHM
 aeR
 vXM
 vXM
@@ -118823,8 +118810,8 @@ auf
 jxs
 aup
 hVG
-tCf
-tCf
+aac
+aac
 vXM
 vXM
 vXM
@@ -119080,8 +119067,8 @@ wAQ
 qWU
 uue
 qWU
-tCf
-tCf
+aac
+aac
 vXM
 vXM
 vXM
@@ -119337,10 +119324,10 @@ xOL
 qWU
 lPO
 qWU
-iXx
-iXx
-kfT
-kfT
+vBT
+vBT
+pHM
+pHM
 aeR
 vXM
 vXM

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2207,11 +2207,11 @@
 /turf/open/floor/plating/airless,
 /area/station/asteroid)
 "ahv" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 1
 	},
-/turf/closed/mineral/random/stationside/asteroid/porus,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/space/basic,
 /area/station/asteroid)
 "ahw" = (
 /obj/effect/turf_decal/trimline/white/warning{

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2211,7 +2211,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/sand/plating,
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/station/asteroid)
 "ahw" = (
 /obj/effect/turf_decal/trimline/white/warning{

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -3345,7 +3345,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "asQ" = (
 /obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron,
@@ -7350,10 +7350,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"bla" = (
-/obj/effect/turf_decal/sand/plating,
-/turf/open/space/basic,
-/area/station/asteroid)
 "blo" = (
 /obj/structure/filingcabinet/security,
 /obj/machinery/button/door/directional/east{
@@ -8751,7 +8747,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "bHA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/power/terminal{
@@ -9115,7 +9111,7 @@
 /area/station/science/xenobiology)
 "bNz" = (
 /turf/closed/wall/r_wall,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "bNA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9158,7 +9154,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "bNV" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
@@ -9185,7 +9181,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "bOi" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/floor/grass,
@@ -9984,7 +9980,7 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "cbc" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
@@ -10306,7 +10302,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "ceJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/button/door/directional/east{
@@ -11644,7 +11640,7 @@
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
-/area/space)
+/area/station/engineering/atmos)
 "cBA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -14408,7 +14404,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "dyE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -17027,11 +17023,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "eno" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/turf/open/floor/plating/airless,
+/area/station/asteroid)
 "ens" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
@@ -17250,7 +17244,7 @@
 "eqY" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "erb" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -18139,7 +18133,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "eGk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/light/directional/south,
@@ -21418,13 +21412,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"fKf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "fKg" = (
 /obj/machinery/air_sensor/nitrogen_tank,
 /turf/open/floor/engine/n2,
@@ -22683,7 +22670,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "gjs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -25676,7 +25663,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "hja" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -28174,7 +28161,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "ica" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -32775,7 +32762,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/asteroid)
+/area/station/maintenance/disposal/incinerator)
 "jxz" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Supply Door Airlock"
@@ -34780,6 +34767,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lower)
+"kfz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "kfD" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/door/airlock/external{
@@ -38306,12 +38300,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/engine,
 /area/station/science/lower)
-"ljF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmospherics_engine)
 "ljI" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Experimentation Lab"
@@ -39406,7 +39394,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "lAN" = (
 /obj/effect/turf_decal/trimline/dark_red/warning{
 	dir = 9
@@ -45724,7 +45712,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "nDj" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -48904,7 +48892,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "oGF" = (
 /obj/machinery/rnd/production/techfab/department/cargo,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -53646,7 +53634,7 @@
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/plating,
-/area/space)
+/area/station/engineering/atmos)
 "qgd" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -55495,7 +55483,7 @@
 /obj/effect/turf_decal/bot/left,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "qKl" = (
 /obj/structure/shipping_container/nthi,
 /obj/effect/decal/cleanable/dirt,
@@ -55656,7 +55644,7 @@
 /obj/effect/turf_decal/bot/right,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "qMZ" = (
 /obj/structure/ladder,
 /obj/structure/lattice/catwalk,
@@ -56310,7 +56298,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "qXj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
@@ -57147,7 +57135,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "rjx" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -57812,7 +57800,7 @@
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "run" = (
 /turf/closed/wall/r_wall,
 /area/station/security/medical)
@@ -59098,7 +59086,7 @@
 	network = list("ss13","engineering")
 	},
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "rRk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -59228,7 +59216,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "rUd" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrigright";
@@ -60786,7 +60774,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "svu" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/light/dim/directional/south,
@@ -61773,7 +61761,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/space/nearstation)
+/area/station/engineering/atmos)
 "sKN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -65313,7 +65301,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "tQN" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -65952,7 +65940,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "ubC" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron,
@@ -66548,7 +66536,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "ulz" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -68172,7 +68160,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "uKv" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -69353,7 +69341,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "vcS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70523,7 +70511,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "vtb" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/white/full,
@@ -72852,9 +72840,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/greater)
-"wfW" = (
-/turf/open/space/basic,
-/area/station/asteroid)
 "wgc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -74271,7 +74256,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "wBV" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
@@ -74753,7 +74738,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "wJM" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -75583,7 +75568,7 @@
 /obj/effect/turf_decal/box/white,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "wZq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
@@ -76402,7 +76387,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "xpb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -76547,6 +76532,12 @@
 /obj/item/clothing/head/utility/hardhat/orange,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/lesser)
+"xsq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/hfr_room)
 "xss" = (
 /obj/structure/reagent_dispensers/cooking_oil,
 /obj/effect/decal/cleanable/dirt,
@@ -78026,7 +78017,7 @@
 /obj/item/hfr_box/body/waste_output,
 /obj/item/circuitboard/machine/crystallizer,
 /turf/open/floor/iron,
-/area/station/engineering/atmospherics_engine)
+/area/station/engineering/atmos/hfr_room)
 "xTr" = (
 /obj/effect/turf_decal/trimline/dark_green/filled/corner{
 	dir = 8
@@ -112645,7 +112636,7 @@ eaq
 eaq
 eaq
 eaq
-fKf
+kfz
 pvw
 qpu
 qpu
@@ -113674,7 +113665,7 @@ lrX
 lrX
 wQm
 gCh
-eno
+gqL
 aYB
 wQm
 wQm
@@ -115234,7 +115225,7 @@ jqS
 fHz
 fjQ
 bNz
-ljF
+xsq
 bNz
 bNz
 bNz
@@ -117267,15 +117258,15 @@ hZr
 hZr
 hZr
 hZr
-qWU
-qWU
-qWU
-qWU
-qWU
-qWU
-qWU
-qWU
-qWU
+hZr
+hZr
+hZr
+hZr
+hZr
+hZr
+hZr
+hZr
+hZr
 aeL
 aeL
 aeL
@@ -117801,7 +117792,7 @@ gwy
 qjJ
 cjG
 ngg
-hZr
+qWU
 qWU
 qWU
 qWU
@@ -119086,7 +119077,7 @@ rnA
 hBY
 atX
 wAQ
-hee
+qWU
 uue
 qWU
 tCf
@@ -119596,9 +119587,9 @@ aaa
 aaa
 aaa
 aak
-bwF
-pHM
-bla
+aak
+eno
+aak
 aeQ
 aeQ
 cpx
@@ -119855,7 +119846,7 @@ wQP
 wQP
 aac
 aac
-wfW
+aak
 wQP
 inP
 inP

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -78934,9 +78934,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"yhN" = (
-/turf/closed/mineral/random/stationside/asteroid/porus,
-/area/space)
 "yhR" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -112125,10 +112122,10 @@ hZr
 hZr
 aaa
 aaa
-yhN
-yhN
-tCf
-yhN
+aaa
+aaa
+aac
+aaa
 aeL
 aeL
 aeL
@@ -112385,7 +112382,7 @@ fjQ
 fjQ
 fjQ
 aeL
-yhN
+aaa
 aeL
 aeL
 aeL

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -1532,11 +1532,9 @@
 /turf/open/floor/plating/airless,
 /area/station/asteroid)
 "aeR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
-/obj/effect/turf_decal/sand/plating,
-/obj/effect/turf_decal/sand/plating,
-/turf/open/floor/plating/airless,
-/area/station/asteroid)
+/obj/effect/spawner/random/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "aeS" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 6
@@ -3428,8 +3426,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "aum" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/machinery/firealarm/directional/west,
+/obj/machinery/electrolyzer,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -6695,11 +6697,6 @@
 /area/station/hallway/primary/tram/right)
 "aYB" = (
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "aYF" = (
@@ -7353,6 +7350,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"bla" = (
+/obj/effect/turf_decal/sand/plating,
+/turf/open/space/basic,
+/area/station/asteroid)
 "blo" = (
 /obj/structure/filingcabinet/security,
 /obj/machinery/button/door/directional/east{
@@ -8401,6 +8402,10 @@
 /obj/item/clothing/gloves/latex/nitrile,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
+"bBC" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "bBH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -11635,6 +11640,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/medical/pathology)
+"cBx" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/plating,
+/area/space)
 "cBA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil/slippery,
@@ -13024,6 +13034,8 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dbi" = (
@@ -13116,6 +13128,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
+"ddI" = (
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "ddM" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -13607,9 +13622,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/crew_quarters/dorms)
 "dkm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/station/maintenance/disposal/incinerator)
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "dkD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -14286,9 +14302,11 @@
 /turf/open/floor/grass,
 /area/station/commons/dorms)
 "dww" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/station/maintenance/disposal/incinerator)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "dwy" = (
 /obj/machinery/light/blacklight/directional/south,
 /obj/structure/sign/poster/official/random/directional/south,
@@ -14315,8 +14333,6 @@
 /area/station/command/heads_quarters/captain/private)
 "dxd" = (
 /obj/effect/spawner/random/engineering/tracking_beacon,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dxq" = (
@@ -14837,6 +14853,16 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/central/lesser)
+"dGi" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "dGk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -16106,9 +16132,10 @@
 /turf/open/floor/iron,
 /area/station/security/prison/safe)
 "eaq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "eay" = (
@@ -17000,13 +17027,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "eno" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ens" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19088,9 +19112,8 @@
 /turf/open/space/openspace,
 /area/space)
 "eYo" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "eYs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -20026,6 +20049,12 @@
 /obj/structure/cable,
 /turf/open/space/openspace,
 /area/station/solars/port)
+"fnT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "fnZ" = (
 /turf/open/floor/iron,
 /area/station/security/checkpoint/science)
@@ -21533,9 +21562,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
 "fMm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fMs" = (
@@ -22688,6 +22715,8 @@
 /obj/machinery/atmospherics/components/binary/pump/off{
 	name = "Port to Incinerator"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gjM" = (
@@ -23730,6 +23759,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
+"gCh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/obj/machinery/meter,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "gCq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -24833,11 +24867,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "gTl" = (
-/obj/structure/lattice/catwalk,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "gTr" = (
 /obj/structure/cable,
@@ -29625,6 +29656,20 @@
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"iyO" = (
+/obj/machinery/power/smes{
+	capacity = 9e+006;
+	charge = 10000
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Atmospherics Incinerator";
+	dir = 4;
+	network = list("ss13","engineering")
+	},
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "iyS" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/junction{
@@ -30626,9 +30671,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "iQZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/machinery/button/door/directional/north{
 	id = "warehouse2"
 	},
@@ -31135,10 +31177,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "iXx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/misc/asteroid/airless,
+/area/space)
 "iXG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -31321,6 +31362,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/storage)
+"jaV" = (
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "jaW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32712,6 +32763,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/vaporwave,
 /area/station/service/library/upper)
+"jxs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/asteroid)
 "jxz" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Supply Door Airlock"
@@ -33041,25 +33098,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock/cafeteria)
 "jCT" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Atmospherics South-West";
-	dir = 10;
-	network = list("ss13","engineering")
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jDd" = (
@@ -34955,18 +34996,13 @@
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
 "kkb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kkc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/maintenance/disposal/incinerator)
 "kkd" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -41133,10 +41169,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "mfB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 1
-	},
-/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mfC" = (
@@ -44180,6 +44214,8 @@
 	dir = 8
 	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ngo" = (
@@ -45006,11 +45042,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "nrQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall,
 /area/station/engineering/atmos)
 "nrR" = (
 /obj/structure/table/glass,
@@ -47762,8 +47795,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "omm" = (
@@ -48059,6 +48090,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)
+"osu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "osB" = (
 /obj/effect/turf_decal/siding/thinplating,
 /turf/open/floor/glass/reinforced,
@@ -50964,17 +51001,6 @@
 /turf/open/floor/wood/parquet,
 /area/station/medical/psychology)
 "pts" = (
-/obj/machinery/power/smes{
-	capacity = 9e+006;
-	charge = 10000
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Atmospherics Incinerator";
-	dir = 9;
-	network = list("ss13","engineering")
-	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "ptB" = (
@@ -51161,6 +51187,13 @@
 /obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"pvw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "pvC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -51825,6 +51858,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/crew_quarters/dorms)
+"pDT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/lattice/catwalk,
+/obj/structure/sign/warning/vacuum/external/directional/south,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "pDZ" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/red/corner{
@@ -51868,8 +51909,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pEZ" = (
@@ -53588,12 +53627,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/dorms)
 "qga" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/obj/structure/lattice/catwalk,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/turf/open/floor/plating,
+/area/space)
 "qgd" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -54103,12 +54142,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "qpu" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qpW" = (
@@ -56828,9 +56863,11 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "rge" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/disposal/incinerator)
 "rgg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -61715,8 +61752,13 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "sKF" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/space/basic,
+/obj/structure/lattice/catwalk,
+/obj/machinery/door/airlock/external,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/space/nearstation)
 "sKN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -62043,8 +62085,6 @@
 	dir = 5
 	},
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sPI" = (
@@ -65229,6 +65269,11 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"tQu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tQy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -68311,15 +68356,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/central/greater)
 "uNI" = (
-/obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -69069,11 +69107,22 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security)
 "uZJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Atmospherics South-West";
+	dir = 10;
+	network = list("ss13","engineering")
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "uZQ" = (
@@ -71856,13 +71905,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "vPw" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/west,
-/obj/machinery/electrolyzer,
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -72796,6 +72838,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/greater)
+"wfW" = (
+/turf/open/space/basic,
+/area/station/asteroid)
 "wgc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -78898,14 +78943,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "yhN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
+/turf/closed/mineral/random/stationside/asteroid/porus,
+/area/space)
 "yhR" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -79171,11 +79210,13 @@
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "ykO" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 6
+	},
+/obj/structure/cable,
+/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ykR" = (
 /obj/structure/disposalpipe/segment,
@@ -112068,7 +112109,7 @@ lbz
 ohY
 roB
 roB
-sHH
+ddI
 aTl
 bUh
 tcO
@@ -112086,26 +112127,26 @@ hZr
 hZr
 hZr
 hZr
+hZr
+hZr
+hZr
+hZr
+aaa
+aaa
+yhN
+yhN
+tCf
+yhN
+aeL
+aeL
+aeL
+aeL
+aac
 aaa
 aaa
 aaa
 aaa
 aac
-aaa
-vXM
-vXM
-vXM
-vXM
-aac
-aaa
-aaa
-aaa
-aaa
-aac
-aac
-vXM
-vXM
-vXM
 vXM
 vXM
 vXM
@@ -112340,6 +112381,10 @@ wAb
 qGE
 uNI
 jCT
+wQm
+wQm
+jaV
+uZJ
 dLQ
 tug
 fjQ
@@ -112347,22 +112392,18 @@ fjQ
 fjQ
 fjQ
 fjQ
-vXM
-aaa
-vXM
-vXM
-vXM
-vXM
+aeL
+yhN
+aeL
+aeL
+aeL
+aeL
 aac
 aaa
 aaa
 aaa
 aaa
 aac
-aac
-vXM
-vXM
-vXM
 vXM
 vXM
 vXM
@@ -112585,17 +112626,21 @@ hmF
 iQU
 gqL
 xat
-gqL
-gqL
-gqL
-gqL
-gqL
-gqL
-gqL
-wQm
-wQm
-wQm
+ykO
+eaq
+eaq
+eaq
+eaq
+eaq
+pvw
 qpu
+qpu
+qpu
+qpu
+qpu
+qpu
+qpu
+dGi
 hIO
 jLU
 hYd
@@ -112604,22 +112649,18 @@ eIM
 awE
 awE
 fjQ
-vXM
+aeL
 aaa
 aaa
-vXM
-vXM
-aaa
-aac
-aaa
-aaa
-aaa
+aeL
+aeL
 aaa
 aac
-vXM
-vXM
-vXM
-vXM
+aaa
+aaa
+aaa
+aaa
+aac
 vXM
 vXM
 vXM
@@ -112842,17 +112883,21 @@ fLg
 hMh
 kaN
 nVP
+fnT
+wQm
+wQm
+fja
+wQm
 mfB
-mfB
-mfB
-mfB
-mfB
-mfB
-yhN
-nrQ
-mfB
-mfB
-qga
+gqL
+wQm
+wQm
+wQm
+wQm
+wQm
+wQm
+wQm
+fja
 exl
 oNq
 pHM
@@ -112861,7 +112906,7 @@ fKg
 cyZ
 nGt
 fjQ
-vXM
+aeL
 aaa
 aaa
 aac
@@ -112872,10 +112917,6 @@ aaa
 aaa
 aaa
 aac
-vXM
-vXM
-vXM
-vXM
 vXM
 vXM
 vXM
@@ -113104,9 +113145,13 @@ wQm
 wQm
 fja
 wQm
-wQm
+fMm
 gqL
-uZJ
+wQm
+wQm
+wQm
+wQm
+wQm
 wQm
 kdw
 aOV
@@ -113118,7 +113163,7 @@ xTM
 awE
 rAf
 fjQ
-vXM
+aeL
 aac
 aaa
 aaa
@@ -113127,10 +113172,6 @@ aaa
 aaa
 aaa
 aac
-vXM
-vXM
-vXM
-vXM
 vXM
 vXM
 vXM
@@ -113361,9 +113402,13 @@ kQr
 asQ
 oqh
 wQm
+fMm
+gqL
 wQm
-eaq
-uZJ
+wQm
+wQm
+wQm
+wQm
 wQm
 oaX
 tsp
@@ -113375,7 +113420,7 @@ fjQ
 fjQ
 fjQ
 fjQ
-vXM
+aeL
 aaa
 aaa
 aaa
@@ -113384,10 +113429,6 @@ aaa
 aaa
 aaa
 aac
-vXM
-vXM
-vXM
-vXM
 vXM
 vXM
 vXM
@@ -113618,9 +113659,13 @@ lrX
 lrX
 lrX
 wQm
-wQm
-wQm
+gCh
+eno
 aYB
+wQm
+wQm
+wQm
+wQm
 wQm
 oaX
 lLP
@@ -113632,7 +113677,7 @@ mwt
 nBA
 nBA
 fjQ
-vXM
+aeL
 aaa
 aaa
 aaa
@@ -113642,10 +113687,6 @@ aaa
 aac
 aac
 aac
-vXM
-vXM
-vXM
-vXM
 vXM
 vXM
 vXM
@@ -113876,20 +113917,24 @@ lAO
 ram
 vRm
 fMm
-kkc
-kkb
+gqL
+wQm
+wQm
+wQm
+wQm
+wQm
 wQm
 oaX
 fhG
 hBH
 oNq
-vXM
+aeL
 ahD
 koq
 bEi
 eOU
 fjQ
-vXM
+aeL
 aaa
 aaa
 aaa
@@ -113899,10 +113944,6 @@ aac
 aac
 aac
 aac
-vXM
-vXM
-vXM
-vXM
 vXM
 vXM
 vXM
@@ -114133,8 +114174,12 @@ wAG
 rvK
 vkO
 sjc
-wQm
+gqL
 dxd
+wQm
+wQm
+wQm
+wQm
 wQm
 lXH
 riD
@@ -114146,7 +114191,7 @@ ljZ
 nBA
 lrw
 fjQ
-vXM
+aeL
 aac
 aaa
 aaa
@@ -114156,10 +114201,6 @@ aac
 aac
 aac
 aac
-vXM
-vXM
-vXM
-vXM
 vXM
 vXM
 vXM
@@ -114393,6 +114434,10 @@ lKI
 gjC
 sPC
 wQm
+wQm
+wQm
+wQm
+wQm
 oaX
 vwz
 idq
@@ -114403,7 +114448,7 @@ fjQ
 fjQ
 fjQ
 fjQ
-vXM
+aeL
 aac
 aaa
 aaa
@@ -114413,10 +114458,6 @@ aaa
 aac
 aac
 aac
-vXM
-vXM
-vXM
-vXM
 vXM
 vXM
 vXM
@@ -114647,8 +114688,12 @@ ora
 ora
 qkS
 vEq
-wQm
+gqL
 omj
+wQm
+wQm
+wQm
+wQm
 wQm
 oaX
 sGQ
@@ -114660,15 +114705,11 @@ eEK
 jqS
 jqS
 fjQ
-vXM
+aeL
 aac
 aac
 aac
 aac
-vXM
-vXM
-vXM
-vXM
 vXM
 vXM
 vXM
@@ -114907,6 +114948,10 @@ taw
 ngl
 pEL
 taw
+taw
+taw
+taw
+taw
 ssw
 fja
 cPD
@@ -114917,18 +114962,14 @@ gMi
 sbh
 pwv
 fjQ
-vXM
+aeL
 aac
 aaa
 aac
 aac
-vXM
-vXM
-vXM
-rge
-vXM
-vXM
-vXM
+aeL
+aeL
+aeL
 vXM
 vXM
 vXM
@@ -115165,6 +115206,10 @@ dbc
 mtv
 nBe
 hyR
+dww
+dww
+dww
+osu
 tHz
 lqs
 rpd
@@ -115183,13 +115228,9 @@ bNz
 bNz
 bNz
 bNz
-pHM
-pHM
-mzx
-vXM
-vXM
-vXM
-vXM
+kfT
+kfT
+dkm
 vXM
 vXM
 vXM
@@ -115422,6 +115463,10 @@ uOZ
 uOg
 jEd
 wIY
+kkb
+kkb
+kkb
+kkb
 btw
 shA
 hZr
@@ -115442,11 +115487,7 @@ ceI
 bHy
 vXM
 vXM
-mzx
-vXM
-vXM
-vXM
-vXM
+dkm
 vXM
 vXM
 vXM
@@ -115679,6 +115720,10 @@ vRQ
 lEp
 xxf
 hZr
+hZr
+hZr
+hZr
+hZr
 hAW
 wox
 hZr
@@ -115699,11 +115744,7 @@ xoW
 bHy
 vXM
 vXM
-mzx
-vXM
-vXM
-vXM
-vXM
+dkm
 vXM
 vXM
 vXM
@@ -115936,6 +115977,10 @@ oFH
 nYX
 jUW
 mHw
+tQu
+tQu
+tQu
+tQu
 orh
 okv
 inb
@@ -115956,11 +116001,7 @@ xoW
 bHy
 vXM
 vXM
-mzx
-vXM
-vXM
-vXM
-vXM
+dkm
 vXM
 vXM
 vXM
@@ -116193,6 +116234,10 @@ sxA
 ahD
 pNk
 hZr
+aeL
+aeL
+aeL
+hZr
 cPM
 dGw
 hZr
@@ -116213,11 +116258,7 @@ bNN
 bHy
 vXM
 vXM
-mzx
-vXM
-vXM
-vXM
-vXM
+dkm
 vXM
 vXM
 vXM
@@ -116450,6 +116491,10 @@ qTR
 mDC
 tnq
 hZr
+aeL
+aeL
+aeL
+hZr
 ykm
 rxs
 lDj
@@ -116470,11 +116515,7 @@ svo
 bHy
 vXM
 vXM
-mzx
-vXM
-vXM
-vXM
-vXM
+dkm
 vXM
 vXM
 vXM
@@ -116707,6 +116748,10 @@ fjb
 ueZ
 fjb
 hZr
+aeL
+aeL
+aeL
+hZr
 diq
 pvG
 lDj
@@ -116727,11 +116772,7 @@ svo
 bHy
 vXM
 vXM
-mzx
-vXM
-vXM
-vXM
-vXM
+dkm
 vXM
 vXM
 vXM
@@ -116964,6 +117005,10 @@ dWj
 tLM
 fjb
 hZr
+aeL
+aeL
+aeL
+hZr
 bQQ
 hUw
 vWZ
@@ -116984,11 +117029,7 @@ gjj
 bHy
 vXM
 vXM
-mzx
-vXM
-vXM
-vXM
-vXM
+dkm
 vXM
 vXM
 vXM
@@ -117221,6 +117262,10 @@ qWU
 qWU
 qWU
 qWU
+aeL
+aeL
+aeL
+hZr
 kpg
 bLd
 wDh
@@ -117228,7 +117273,7 @@ tVg
 gmR
 xwG
 xwG
-ykO
+pDT
 hZr
 bNz
 bNz
@@ -117239,13 +117284,9 @@ bNz
 bNz
 bNz
 bNz
-pHM
-pHM
-mzx
-vXM
-vXM
-vXM
-vXM
+kfT
+kfT
+dkm
 vXM
 vXM
 vXM
@@ -117478,25 +117519,25 @@ uBQ
 kbw
 thz
 qWU
+qWU
+qWU
+qWU
+qWU
 sDZ
 eeZ
-dkm
-dkm
-dww
-cjG
-djX
-nAc
+nrQ
+nrQ
 gTl
 eYo
-eno
-qud
+djX
+nAc
+qga
+cBx
+sKF
+xkr
 vXM
 vXM
-mzx
-vXM
-vXM
-vXM
-vXM
+dkm
 vXM
 vXM
 vXM
@@ -117736,24 +117777,24 @@ kbw
 xsj
 qWU
 vPw
+kkc
+pts
+pts
+aum
 tzL
 kyz
 gwy
 qjJ
 cjG
 ngg
+hZr
 qWU
 qWU
 qWU
-qWU
 vXM
 vXM
 vXM
-mzx
-vXM
-vXM
-vXM
-vXM
+dkm
 vXM
 vXM
 vXM
@@ -117992,6 +118033,10 @@ aVg
 kbw
 kbw
 xbf
+pts
+pts
+pts
+pts
 hUf
 lEI
 saj
@@ -118006,11 +118051,7 @@ qha
 vXM
 vXM
 vXM
-mzx
-vXM
-vXM
-vXM
-vXM
+dkm
 vXM
 vXM
 vXM
@@ -118249,6 +118290,10 @@ ozd
 vHy
 kbw
 xbf
+pts
+pts
+pts
+pts
 tFe
 wlM
 xWc
@@ -118263,11 +118308,7 @@ qWU
 vXM
 vXM
 vXM
-mzx
-vXM
-vXM
-vXM
-vXM
+dkm
 vXM
 vXM
 vXM
@@ -118506,6 +118547,10 @@ bsf
 rtO
 sHv
 xbf
+pts
+pts
+pts
+pts
 sJW
 gqV
 pGM
@@ -118517,14 +118562,10 @@ qWU
 auo
 qWU
 qWU
-pHM
-pHM
-pHM
-sKF
-vXM
-vXM
-vXM
-vXM
+kfT
+kfT
+kfT
+aeR
 vXM
 vXM
 vXM
@@ -118764,21 +118805,21 @@ ciI
 xsj
 qWU
 iQZ
+pts
+pts
+pts
+rge
 vde
 atC
 gqV
 atP
 efz
 auf
-aum
+jxs
 aup
 hVG
-aac
-aac
-vXM
-vXM
-vXM
-vXM
+tCf
+tCf
 vXM
 vXM
 vXM
@@ -119021,21 +119062,21 @@ dfH
 haI
 qWU
 pts
+bBC
+pts
+pts
+iyO
 tuj
 jsJ
 rnA
 hBY
 atX
 wAQ
-qWU
+hee
 uue
 qWU
-aac
-aac
-vXM
-vXM
-vXM
-vXM
+tCf
+tCf
 vXM
 vXM
 vXM
@@ -119277,6 +119318,10 @@ tOe
 qWU
 qWU
 qWU
+qWU
+qWU
+qWU
+qWU
 rRy
 rRy
 rRy
@@ -119287,15 +119332,11 @@ xOL
 qWU
 lPO
 qWU
-vBT
-vBT
-pHM
-pHM
-vXM
-vXM
-vXM
-vXM
-vXM
+iXx
+iXx
+kfT
+kfT
+aeR
 vXM
 vXM
 vXM
@@ -119540,10 +119581,10 @@ aaa
 aaa
 aaa
 aaa
-aeQ
-aeR
-iXx
-aeQ
+aak
+bwF
+pHM
+bla
 aeQ
 aeQ
 cpx
@@ -119551,8 +119592,8 @@ vXM
 vXM
 vXM
 vXM
-vXM
-vXM
+aeR
+aeR
 vXM
 vXM
 vXM
@@ -119800,7 +119841,7 @@ wQP
 wQP
 aac
 aac
-aac
+wfW
 wQP
 inP
 inP

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -2211,8 +2211,8 @@
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2{
 	dir = 1
 	},
-/turf/open/space/openspace,
-/area/space/nearstation)
+/turf/closed/mineral/random/stationside/asteroid/porus,
+/area/station/asteroid)
 "ahw" = (
 /obj/effect/turf_decal/trimline/white/warning{
 	dir = 10
@@ -33101,6 +33101,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jDd" = (
@@ -180760,10 +180761,10 @@ aaa
 aaa
 aaa
 aaa
-jhd
-jhd
-jhd
-jhd
+aaa
+aaa
+aaa
+aaa
 jhd
 jhd
 jhd
@@ -181017,10 +181018,10 @@ aaa
 aaa
 aaa
 aaa
-jhd
-jhd
-jhd
-jhd
+aaa
+aaa
+aaa
+aaa
 jhd
 jhd
 jhd
@@ -181274,10 +181275,10 @@ aaa
 aaa
 aaa
 aaa
-jhd
-jhd
-jhd
-jhd
+aaa
+aaa
+aaa
+aaa
 jhd
 jhd
 jhd
@@ -181531,10 +181532,10 @@ aaa
 aaa
 aaa
 aaa
-jhd
-jhd
-jhd
-jhd
+aaa
+aaa
+aaa
+aaa
 jhd
 jhd
 jhd
@@ -181788,10 +181789,10 @@ aaa
 aaa
 aaa
 aaa
-jhd
-jhd
-jhd
-jhd
+aaa
+aaa
+aaa
+aaa
 jhd
 jhd
 jhd
@@ -182045,10 +182046,10 @@ aaa
 aaa
 aaa
 aaa
-jhd
-jhd
-jhd
-jhd
+aaa
+aaa
+aaa
+aaa
 jhd
 jhd
 jhd
@@ -182302,10 +182303,10 @@ aaa
 aaa
 aaa
 aaa
-jhd
-jhd
-jhd
-jhd
+aaa
+aaa
+aaa
+aaa
 jhd
 jhd
 jhd
@@ -182559,10 +182560,10 @@ aaa
 aaa
 aaa
 aaa
-jhd
-jhd
-jhd
-jhd
+aaa
+aaa
+aaa
+aaa
 jhd
 jhd
 jhd
@@ -182816,10 +182817,10 @@ aaa
 aaa
 aaa
 aaa
-jhd
-jhd
-jhd
-jhd
+aaa
+aaa
+aaa
+aaa
 jhd
 jhd
 jhd
@@ -183069,7 +183070,7 @@ aac
 aac
 aeQ
 ahv
-jhd
+aaa
 jhd
 jhd
 jhd
@@ -183839,7 +183840,7 @@ aaa
 aaa
 aaa
 aaa
-jhd
+aaa
 jhd
 jhd
 jhd

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -21418,6 +21418,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"fKf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron,
+/area/station/engineering/atmos)
 "fKg" = (
 /obj/machinery/air_sensor/nitrogen_tank,
 /turf/open/floor/engine/n2,
@@ -38299,6 +38306,12 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/engine,
 /area/station/science/lower)
+"ljF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmospherics_engine)
 "ljI" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Experimentation Lab"
@@ -112632,7 +112645,7 @@ eaq
 eaq
 eaq
 eaq
-eaq
+fKf
 pvw
 qpu
 qpu
@@ -114968,9 +114981,9 @@ aac
 aaa
 aac
 aac
-aeL
-aeL
-aeL
+vXM
+vXM
+vXM
 vXM
 vXM
 vXM
@@ -115221,7 +115234,7 @@ jqS
 fHz
 fjQ
 bNz
-bNz
+ljF
 bNz
 bNz
 bNz


### PR DESCRIPTION
## About The Pull Request

Fixing Atmosia on the mapping side.

## Why It's Good For The Game

Currently, several maps including Icebox and Tramstation are quite alienating for atmospheric technician by either having some small mapping issues such as the plasma pump not being linked or simply a lack of space for a burn chamber, this PR aims to fix give them a bit of space while fixing a small issue on icebox.

## Changelog

:cl:
add: Expanded Atmospheric and the incinerator room within Tramstation to actually allow atmospheric technician to work
![image](https://github.com/Monkestation/Monkestation2.0/assets/158485251/2dcdbd87-250c-4dc2-85c0-4a58b7fe9eb9)

fix:  Fixed the plasma pump being on the wrong layer within atmospheric on Icebox

:cl:


