### PR TITLE
Unknown Methamphetamine Isomer is now actually safe

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -188,7 +188,8 @@
 	affected_mob.AdjustImmobilized(-40 * REM * seconds_per_tick)
 	affected_mob.stamina.adjust(2 * REM * seconds_per_tick, TRUE)
 	affected_mob.set_jitter_if_lower(4 SECONDS * REM * seconds_per_tick)
-	affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1, 4) * REM * seconds_per_tick, required_organtype = affected_organtype)
+	if(!safe && !overdosed) // MONKESTATION EDIT: Makes Unknown Methamphetamine Isomer actually safe. "safe" is false by default.
+		affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1, 4) * REM * seconds_per_tick, required_organtype = affected_organtype)
 	if(SPT_PROB(2.5, seconds_per_tick))
 		affected_mob.emote(pick("twitch", "shiver"))
 	..()

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -188,7 +188,7 @@
 	affected_mob.AdjustImmobilized(-40 * REM * seconds_per_tick)
 	affected_mob.stamina.adjust(2 * REM * seconds_per_tick, TRUE)
 	affected_mob.set_jitter_if_lower(4 SECONDS * REM * seconds_per_tick)
-	if(!safe && !overdosed) // MONKESTATION EDIT: Makes Unknown Methamphetamine Isomer actually safe. "safe" is false by default.
+	if(!safe || overdosed) // MONKESTATION EDIT: Makes Unknown Methamphetamine Isomer actually safe. "safe" is false by default.
 		affected_mob.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1, 4) * REM * seconds_per_tick, required_organtype = affected_organtype)
 	if(SPT_PROB(2.5, seconds_per_tick))
 		affected_mob.emote(pick("twitch", "shiver"))

--- a/monkestation/code/modules/antagonists/borers/code/cortical_borer_chems.dm
+++ b/monkestation/code/modules/antagonists/borers/code/cortical_borer_chems.dm
@@ -1,21 +1,9 @@
-// Double the OD treshold, no brain damage
+/datum/reagent/drug/methamphetamine
+	var/safe = FALSE
+
+// Double the OD treshold, no brain damage or addiction
 /datum/reagent/drug/methamphetamine/borer_version
 	name = "Unknown Methamphetamine Isomer"
 	overdose_threshold = 40
-
-/datum/reagent/drug/methamphetamine/borer_version/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
-	var/high_message = pick("You feel hyper.", "You feel like you need to go faster.", "You feel like you can run the world.")
-	if(SPT_PROB(2.5, seconds_per_tick))
-		to_chat(affected_mob, span_notice("[high_message]"))
-	affected_mob.add_mood_event("tweaking", /datum/mood_event/stimulant_medium, name)
-	affected_mob.AdjustStun(-40 * REM * seconds_per_tick)
-	affected_mob.AdjustKnockdown(-40 * REM * seconds_per_tick)
-	affected_mob.AdjustUnconscious(-40 * REM * seconds_per_tick)
-	affected_mob.AdjustParalyzed(-40 * REM * seconds_per_tick)
-	affected_mob.AdjustImmobilized(-40 * REM * seconds_per_tick)
-	affected_mob.stamina.adjust(2 * REM * seconds_per_tick, TRUE)
-	affected_mob.set_jitter_if_lower(4 SECONDS * REM * seconds_per_tick)
-	if(SPT_PROB(2.5, seconds_per_tick))
-		affected_mob.emote(pick("twitch", "shiver"))
-	..()
-	. = TRUE
+	addiction_types = null
+	safe = TRUE


### PR DESCRIPTION
## About The Pull Request

It no longer causes addiction or brain damage and doesn't have doubled effects.

Previously it caused brain damage even though the borer's own description said it didn't.

Now it only causes the regular brain damage if overdosed so it's offensive power hasn't changed.
## Why It's Good For The Game

If you tell borers a chemical is safe, then it should be safe.
## Changelog
:cl:
fix: Unknown Methamphetamine Isomer (cortical borer meth) is now actually safe to use and doesn't cause brain damage or addiction. It's effects are now equivalent to regular meth instead of being doubled, too.
/:cl:
