### PR TITLE
[PORT] Makes transferring functional wings to new bodies actually work

### DIFF
--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -8,7 +8,7 @@
 /datum/action/innate/flight/Activate()
 	var/mob/living/carbon/human/human = owner
 	var/obj/item/organ/external/wings/functional/wings = human.get_organ_slot(ORGAN_SLOT_EXTERNAL_WINGS)
-	if(wings && wings.can_fly(human))
+	if(wings?.can_fly(human))
 		wings.toggle_flight(human)
 		if(!(human.movement_type & FLYING))
 			to_chat(human, span_notice("You settle gently back onto the ground..."))
@@ -26,23 +26,26 @@
 	///Are our wings open or closed?
 	var/wings_open = FALSE
 
-/obj/item/organ/external/wings/functional/Insert(mob/living/carbon/receiver, special, drop_if_replaced)
+/obj/item/organ/external/wings/functional/Destroy()
+	QDEL_NULL(fly)
+	return ..()
+
+/obj/item/organ/external/wings/functional/Insert(mob/living/carbon/receiver, special, movement_flags)
 	. = ..()
-	if(. && isnull(fly))
+	if(!.)
+		return
+	if(QDELETED(fly))
 		fly = new
-		fly.Grant(receiver)
+	fly.Grant(receiver)
 
 /obj/item/organ/external/wings/functional/Remove(mob/living/carbon/organ_owner, special, moving)
 	. = ..()
-
-	fly.Remove(organ_owner)
-
+	fly?.Remove(organ_owner)
 	if(wings_open)
 		toggle_flight(organ_owner)
 
 /obj/item/organ/external/wings/functional/on_life(seconds_per_tick, times_fired)
 	. = ..()
-
 	handle_flight(owner)
 
 ///Called on_life(). Handle flight code and check if we're still flying

--- a/code/modules/surgery/organs/external/wings/functional_wings.dm
+++ b/code/modules/surgery/organs/external/wings/functional_wings.dm
@@ -30,7 +30,7 @@
 	QDEL_NULL(fly)
 	return ..()
 
-/obj/item/organ/external/wings/functional/Insert(mob/living/carbon/receiver, special, movement_flags)
+/obj/item/organ/external/wings/functional/Insert(mob/living/carbon/receiver, special, drop_if_replaced)
 	. = ..()
 	if(!.)
 		return


### PR DESCRIPTION
Fixes the bug where, if you surgically remove functional wings and then re-implant them (even into yourself), the new owner won't get the toggle wings button. This fixes that.

Also cleaned up some of the code.

i assume this is a bug, as it's just kinda weird that the wings that work with one body won't work if you take them out and put them back in.

:cl:
fix: When implanting functional wings into a new body, they will actually be able to use said wings now.
/:cl: