### PR TITLE
Advanced/toxin medibots no longer kill oozelings

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -133,7 +133,7 @@
 		if(BURN)
 			return adjustFireLoss(heal_amount)
 		if(TOX)
-			return adjustToxLoss(heal_amount)
+			return adjustToxLoss(heal_amount, forced = TRUE) // monkestation edit: we're gonna assume anything using this proc intends to do true healing, so, let's not kill oozelings
 		if(OXY)
 			return adjustOxyLoss(heal_amount)
 		if(CLONE)


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/2092

## Changelog
:cl:
fix: Advanced and toxin-healing medibots no longer kill oozelings.
/:cl:
