### PR TITLE
TRAIT_EASILY_WOUNDED and TRAIT_HARDLY_WOUNDED now balance out

### DIFF
--- a/code/modules/surgery/bodyparts/wounds.dm
+++ b/code/modules/surgery/bodyparts/wounds.dm
@@ -56,13 +56,15 @@
 		return
 
 	// note that these are fed into an exponent, so these are magnified
+	// monkestation edit: balance out TRAIT_EASILY_WOUNDED and TRAIT_HARDLY_WOUNDED
 	if(HAS_TRAIT(owner, TRAIT_EASILY_WOUNDED))
-		damage *= 1.5
+		if(!HAS_TRAIT(owner, TRAIT_HARDLY_WOUNDED))
+			damage *= 1.5
+	else if(HAS_TRAIT(owner, TRAIT_HARDLY_WOUNDED))
+		damage *= 0.85
 	else
 		damage = min(damage, WOUND_MAX_CONSIDERED_DAMAGE)
-
-	if(HAS_TRAIT(owner,TRAIT_HARDLY_WOUNDED))
-		damage *= 0.85
+	// monkestation end
 
 	if(HAS_TRAIT(owner, TRAIT_EASYDISMEMBER))
 		damage *= 1.1


### PR DESCRIPTION
## Changelog
:cl:
balance: Having both the "easily wounded" and "hardly wounded" traits will now act like you have neither, resulting in you taking the normal amount of wound damage.
/:cl:
