### PR TITLE
Fix runtimes related to mineral regrowth

### DIFF
--- a/monkestation/code/modules/liquids/liquid_ocean.dm
+++ b/monkestation/code/modules/liquids/liquid_ocean.dm
@@ -732,8 +732,9 @@ GLOBAL_VAR_INIT(lavaland_points_generated, 0)
 	defer_change = TRUE
 
 
-/turf/closed/mineral/random/regrowth/New(loc, _mineral_increase)
-	mineralChance += _mineral_increase
+/turf/closed/mineral/random/regrowth/New(loc, mineral_increase)
+	if(isnum(mineral_increase))
+		src.mineralChance += mineral_increase
 	. = ..()
 
 /turf/closed/mineral/random/regrowth/Destroy(force)
@@ -745,7 +746,8 @@ GLOBAL_VAR_INIT(lavaland_points_generated, 0)
 	var/mineral_increase = 0
 	if(GLOB.lavaland_points_generated > 55000)
 		mineral_increase = min(87, (GLOB.lavaland_points_generated - 55000) / 1000)
-	new /turf/closed/mineral/random/regrowth(location , mineral_increase)
+	var/turf/closed/mineral/random/regrowth/regrowth_turf = location.ChangeTurf(/turf/closed/mineral/random/regrowth, flags = CHANGETURF_INHERIT_AIR)
+	regrowth_turf?.mineralChance += mineral_increase
 
 /turf/closed/mineral/random/regrowth/underwater
 	turf_type = /turf/open/floor/plating/ocean/dark


### PR DESCRIPTION

## About The Pull Request

Should fix this sporadic runtime in CI:

```
  [01:48:54] Runtime in monkestation/code/modules/pollution/pollution.dm,32: undefined variable /turf/closed/mineral/random/regrowth/var/pollution
    proc name: Destroy (/datum/pollution/Destroy)
    src: /datum/pollution (/datum/pollution)
    call stack:
    /datum/pollution (/datum/pollution): Destroy(0)
    qdel(/datum/pollution (/datum/pollution), 0)
    /datum/pollution (/datum/pollution): scrub amount(10, 0, 1)
    Pollution (/datum/controller/subsystem/pollution): fire(0)
    Pollution (/datum/controller/subsystem/pollution): ignite(0)
    Master (/datum/controller/master): RunQueue()
    Master (/datum/controller/master): Loop(2)
    Master (/datum/controller/master): StartProcessing(0)
```

## Changelog
:cl:
fix: Fixed a runtime error relating to mineral regrowth.
/:cl:
