### PR TITLE
Fix bloodsucker torpor and oozeling bugs

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
@@ -41,6 +41,8 @@
 	var/frenzy_threshold = FRENZY_THRESHOLD_ENTER
 	///If we are currently in a Frenzy
 	var/frenzied = FALSE
+	/// Whether the death handling code is active or not.
+	var/handling_death = FALSE
 
 	///ALL Powers currently owned
 	var/list/datum/action/cooldown/bloodsucker/powers = list()
@@ -95,6 +97,14 @@
 		TRAIT_TOXIMMUNE,
 		TRAIT_HARDLY_WOUNDED,
 		TRAIT_NO_MIRROR_REFLECTION
+	)
+	/// Traits applied during Torpor.
+	var/static/list/torpor_traits = list(
+		TRAIT_DEATHCOMA,
+		TRAIT_FAKEDEATH,
+		TRAIT_NODEATH,
+		TRAIT_RESISTHIGHPRESSURE,
+		TRAIT_RESISTLOWPRESSURE
 	)
 
 /**

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_misc_procs.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_misc_procs.dm
@@ -87,7 +87,7 @@
 ///Disables all powers, accounting for torpor
 /datum/antagonist/bloodsucker/proc/DisableAllPowers(forced = FALSE)
 	for(var/datum/action/cooldown/bloodsucker/power as anything in powers)
-		if(forced || ((power.check_flags & BP_CANT_USE_IN_TORPOR) && HAS_TRAIT_FROM(owner.current, TRAIT_NODEATH, TORPOR_TRAIT)))
+		if(forced || ((power.check_flags & BP_CANT_USE_IN_TORPOR) && is_in_torpor()))
 			if(power.active)
 				power.DeactivatePower()
 

--- a/monkestation/code/modules/bloodsuckers/structures/bloodsucker_objects.dm
+++ b/monkestation/code/modules/bloodsuckers/structures/bloodsucker_objects.dm
@@ -155,7 +155,7 @@
 	if(bloodsuckerdatum)
 		// If DEAD or TORPID... Kill Bloodsucker!
 		if(target.StakeCanKillMe())
-			bloodsuckerdatum.FinalDeath()
+			bloodsuckerdatum.final_death()
 		else
 			to_chat(target, span_userdanger("You have been staked! Your powers are useless, your death forever, while it remains in place."))
 			target.balloon_alert(target, "you have been staked!")


### PR DESCRIPTION
## Changelog
:cl:
fix: Oozeling bloodsuckers will no longer be stuck in permanent torpor after reviving.
fix: Fixed other weird bugs relating to Torpor too.
qol: Oozeling changelings and bloodsuckers will now revive with all their limbs.
fix: Fixed some runtime errors relating to Torpor.
/:cl:
