### PR TITLE
Silicons are no longer soulless after suiciding

### DIFF
--- a/monkestation/code/modules/mob/living/silicon/death.dm
+++ b/monkestation/code/modules/mob/living/silicon/death.dm
@@ -1,0 +1,12 @@
+// MONKESTATION NOTE: Prevents silicons from losing their soul when suiciding since they can be ordered to do so.
+
+/mob/living/silicon/set_suicide(suicide_state)
+	return
+
+/mob/living/silicon/final_checkout(obj/item/suicide_tool, apply_damage)
+	if(apply_damage) // copy paste for the most part
+		apply_suicide_damage()
+
+	suicide_log(suicide_tool)
+	death(FALSE)
+	ghostize(TRUE) // except this is set to TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6669,6 +6669,7 @@
 #include "monkestation\code\modules\mob\living\carbon\human\species_type\simian.dm"
 #include "monkestation\code\modules\mob\living\carbon\human\species_type\skeletons.dm"
 #include "monkestation\code\modules\mob\living\carbon\human\species_type\zombies.dm"
+#include "monkestation\code\modules\mob\living\silicon\death.dm"
 #include "monkestation\code\modules\mob\living\simple_animal\megafauna\wendigo.dm"
 #include "monkestation\code\modules\mob\living\simple_animal\pets\bees.dm"
 #include "monkestation\code\modules\mob\living\simple_animal\pets\honk_platinum.dm"


### PR DESCRIPTION

## About The Pull Request

When you use the suicide verb to kill yourself as a silicon, you can still re-enter your corpse and get revived.
## Why It's Good For The Game

Makes ordering silicons to suicide a non-issue and if you need to go soulless, just use DNR.
## Changelog
:cl:
balance: Silicons will no longer become soulless if they suicide.
/:cl:
