### PR TITLE
Fix roundstart antag rulesets breaking with the Late Arrivals trait

### DIFF
--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -261,7 +261,10 @@ SUBSYSTEM_DEF(gamemode)
 		else if(living_players && isliving(player))
 			if(!ishuman(player) && !isAI(player))
 				continue
-			if(!(player.z in SSmapping.levels_by_trait(ZTRAIT_STATION)))
+			// I split these checks up to make the code more readable ~Lucy
+			var/is_on_station = is_station_level(player.z)
+			var/is_late_arrival = HAS_TRAIT(SSstation, STATION_TRAIT_LATE_ARRIVALS) && istype(get_area(player), /area/shuttle/arrival)
+			if(!is_on_station && !is_late_arrival)
 				continue
 			candidate_candidates += player
 


### PR DESCRIPTION
## Changelog
:cl:
fix: Roundstart antags should now be properly created when the Late Arrivals station trait rolls.
/:cl:
