### PR TITLE
Bugfix: Nuclear Operatives Assault Pod now usable again

### DIFF
--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -45,7 +45,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(!is_reserved_level(z))
+	if(is_station_level(z))
 		to_chat(user, span_warning("Pods are one way!"))
 		return FALSE
 	return TRUE

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -45,7 +45,7 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(is_station_level(z))
+	if(!is_centcom_level(z))
 		to_chat(user, span_warning("Pods are one way!"))
 		return FALSE
 	return TRUE


### PR DESCRIPTION

## About The Pull Request
Syndibase was moved to centcom so asault pod wouldnt leave anymore because it thought it was in a reserved Z level. Changed to check for station level instead.

## Why It's Good For The Game
Assault pod hasnt worked for a little while. Bugfix.

## Changelog

:cl:
fix: Changes Assault Pod Level trait check from not Reserved (centcom and station) to station level trait (just station)
/:cl:

