### PR TITLE
Return proper init values for SSgamemode and SSholomaps

### DIFF
--- a/monkestation/code/modules/holomaps/subsystem.dm
+++ b/monkestation/code/modules/holomaps/subsystem.dm
@@ -27,8 +27,9 @@ SUBSYSTEM_DEF(holomaps)
 	flags |= SS_NO_INIT // Make extra sure we don't initialize twice.
 
 /datum/controller/subsystem/holomaps/Initialize(timeofday)
-	generate_holomaps()
-	return ..()
+	if (generate_holomaps())
+		return SS_INIT_SUCCESS
+	return SS_INIT_FAILURE
 
 // Holomap generation.
 

--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -189,8 +189,7 @@ SUBSYSTEM_DEF(gamemode)
 		event_pools[event.track] += event //Add it to the categorized event pools
 
 	load_roundstart_data()
-
-//	return ..()
+	return SS_INIT_SUCCESS
 
 
 /datum/controller/subsystem/gamemode/fire(resumed = FALSE)


### PR DESCRIPTION

## Changelog
:cl:
fix: The Gamemode and Holomaps subsystem will no longer claim to have loaded with errors, when they in fact loaded just fine.
/:cl:
