### PR TITLE
Properly clear callbacks from xenobiology-related components

### DIFF
--- a/monkestation/code/modules/slimecore/components/latch_feeding.dm
+++ b/monkestation/code/modules/slimecore/components/latch_feeding.dm
@@ -36,7 +36,7 @@
 	REMOVE_TRAIT(parent, TRAIT_FEEDING, LATCH_TRAIT)
 	. = ..()
 	target = null
-	qdel(check_and_replace)
+	check_and_replace = null
 
 /datum/component/latch_feeding/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_LIVING_SET_BUCKLED, PROC_REF(check_buckled))

--- a/monkestation/code/modules/slimecore/components/liquid_secretion.dm
+++ b/monkestation/code/modules/slimecore/components/liquid_secretion.dm
@@ -9,8 +9,6 @@
 	var/datum/callback/pre_secrete_callback
 	var/next_secrete = 0
 
-
-
 /datum/component/liquid_secretion/Initialize(reagent_id = /datum/reagent/water, amount = 10, secretion_interval = 1 SECONDS, pre_secrete_callback)
 	. = ..()
 
@@ -20,6 +18,11 @@
 	src.pre_secrete_callback = CALLBACK(parent, pre_secrete_callback)
 
 	START_PROCESSING(SSobj, src)
+
+/datum/component/liquid_secretion/Destroy(force, silent)
+	STOP_PROCESSING(SSobj, src)
+	pre_secrete_callback = null
+	return ..()
 
 /datum/component/liquid_secretion/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_SECRETION_UPDATE, PROC_REF(update_information)) //The only signal allowing item -> turf interaction


### PR DESCRIPTION
![image](https://github.com/Monkestation/Monkestation2.0/assets/65794972/f77863c1-2e58-4a83-92ec-492cdd1d1124)

## Changelog
:cl:
fix: Fixed a qdel runtime related to slimes.
/:cl:
