### PR TITLE
Security assistants can take the "Correctional Officer" alt title

### DIFF
--- a/monkestation/code/modules/jobs/job_types/security_assistant.dm
+++ b/monkestation/code/modules/jobs/job_types/security_assistant.dm
@@ -37,6 +37,7 @@
 
 	alt_titles = list(
 		"Security Assistant",
+		"Correctional Officer",
 		"Deputy",
 		"Hall Monitor",
 		"Assistant Officer",


### PR DESCRIPTION
## About The Pull Request

Security assistants can take the "Correctional Officer" alt title

## Why It's Good For The Game

Some secasses don't realize they're allowed to interact with the prison and prisoners, and some have thought they don't even have access.

I think this would provide a little prompting that it's OK for secasses to interact with the prison and prisoners.

## Changelog

:cl:
add: Secasses can now select the "Correctional Officer" alt title
/:cl:
