### PR TITLE
Split events into several 'shared occurance' groups

### DIFF
--- a/code/__DEFINES/~monkestation/storytellers.dm
+++ b/code/__DEFINES/~monkestation/storytellers.dm
@@ -99,3 +99,10 @@
 
 #define ROUNDSTART_OBJECTIVES_BASE 40
 #define ROUNDSTART_OBJECTIVES_GAIN 2
+
+#define SHARED_HIGH_THREAT	"high threat event"
+#define SHARED_ANOMALIES	"anomalous event"
+#define SHARED_SCRUBBERS	"scrubber-related event"
+#define SHARED_METEORS		"meteor event"
+#define SHARED_BSOD			"tech malfunction event"
+#define SHARED_CHANGELING	"changelings"

--- a/monkestation/code/modules/events/scrubber_clog.dm
+++ b/monkestation/code/modules/events/scrubber_clog.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/scrubber_clog
-	shared_occurence_type = /datum/round_event_control/scrubber_clog
+	shared_occurence_type = SHARED_SCRUBBERS
 
 /datum/round_event_control/scrubber_clog/flood //I have it here cause of the extra silly spaghetti code all of the scrubbers depend on being in here
 	name = "Scrubber Clog: Flood"

--- a/monkestation/code/modules/events/scrubber_overflow.dm
+++ b/monkestation/code/modules/events/scrubber_overflow.dm
@@ -1,2 +1,2 @@
 /datum/round_event_control/scrubber_overflow
-	shared_occurence_type = /datum/round_event_control/scrubber_clog
+	shared_occurence_type = SHARED_SCRUBBERS

--- a/monkestation/code/modules/storytellers/converted_events/event_overrides.dm
+++ b/monkestation/code/modules/storytellers/converted_events/event_overrides.dm
@@ -6,7 +6,7 @@
 /datum/round_event_control/anomaly
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_DESTRUCTIVE, TAG_MAGICAL)
-	shared_occurence_type = /datum/round_event_control/anomaly
+	shared_occurence_type = SHARED_ANOMALIES
 
 /datum/round_event_control/alien_infestation
 	track = EVENT_TRACK_ROLESET
@@ -29,14 +29,17 @@
 /datum/round_event_control/brand_intelligence
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_DESTRUCTIVE, TAG_COMMUNAL)
+	shared_occurence_type = SHARED_BSOD
 
 /datum/round_event_control/bureaucratic_error
 	track = EVENT_TRACK_MAJOR // if you've ever dealt with 10 mimes you understand why.
 	tags = list(TAG_COMMUNAL)
+	shared_occurence_type = SHARED_BSOD
 
 /datum/round_event_control/camera_failure
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_COMMUNAL, TAG_SPOOKY)
+	shared_occurence_type = SHARED_BSOD
 
 /datum/round_event_control/carp_migration
 	track = EVENT_TRACK_MODERATE
@@ -52,6 +55,7 @@
 	max_occurrences = 2
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL, TAG_SPOOKY)
+	shared_occurence_type = SHARED_BSOD
 
 /datum/round_event_control/disease_outbreak
 	track = EVENT_TRACK_MAJOR
@@ -60,6 +64,7 @@
 /datum/round_event_control/electrical_storm
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_SPOOKY)
+	shared_occurence_type = SHARED_BSOD
 
 /datum/round_event_control/fake_virus
 	track = EVENT_TRACK_MUNDANE
@@ -68,6 +73,7 @@
 /datum/round_event_control/falsealarm
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_COMMUNAL)
+	shared_occurence_type = SHARED_BSOD
 
 /datum/round_event_control/fugitives
 	track = EVENT_TRACK_MAJOR
@@ -76,14 +82,17 @@
 /datum/round_event_control/gravity_generator_blackout
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL, TAG_SPACE)
+	shared_occurence_type = SHARED_BSOD
 
 /datum/round_event_control/grey_tide
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_DESTRUCTIVE, TAG_SPOOKY)
+	shared_occurence_type = SHARED_BSOD
 
 /datum/round_event_control/grid_check
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL, TAG_SPOOKY)
+	shared_occurence_type = SHARED_BSOD
 
 /datum/round_event_control/heart_attack
 	track = EVENT_TRACK_MODERATE
@@ -92,10 +101,12 @@
 /datum/round_event_control/immovable_rod
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_DESTRUCTIVE, TAG_EXTERNAL, TAG_MAGICAL)
+	shared_occurence_type = SHARED_METEORS
 
 /datum/round_event_control/ion_storm
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_TARGETED, TAG_ALIEN)
+	shared_occurence_type = SHARED_BSOD
 
 /datum/round_event_control/mass_hallucination
 	track = EVENT_TRACK_MUNDANE
@@ -104,6 +115,7 @@
 /datum/round_event_control/meteor_wave
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMMUNAL, TAG_SPACE, TAG_DESTRUCTIVE, TAG_EXTERNAL)
+	shared_occurence_type = SHARED_METEORS
 
 /datum/round_event_control/mice_migration
 	track = EVENT_TRACK_MUNDANE
@@ -133,6 +145,7 @@
 	max_occurrences = 2
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL)
+	shared_occurence_type = SHARED_BSOD
 
 /datum/round_event_control/radiation_leak
 	track = EVENT_TRACK_MODERATE
@@ -188,6 +201,7 @@
 /datum/round_event_control/space_dust
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_DESTRUCTIVE, TAG_SPACE, TAG_EXTERNAL)
+	shared_occurence_type = SHARED_METEORS
 
 /datum/round_event_control/space_dragon
 	track = EVENT_TRACK_ROLESET
@@ -216,14 +230,17 @@
 /datum/round_event_control/stray_meteor
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_DESTRUCTIVE, TAG_SPACE, TAG_EXTERNAL)
+	shared_occurence_type = SHARED_METEORS
 
 /datum/round_event_control/supermatter_surge
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_DESTRUCTIVE, TAG_COMMUNAL)
+	shared_occurence_type = SHARED_BSOD
 
 /datum/round_event_control/tram_malfunction
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_COMMUNAL)
+	shared_occurence_type = SHARED_BSOD
 
 /datum/round_event_control/wisdomcow
 	track = EVENT_TRACK_MUNDANE
@@ -232,4 +249,4 @@
 /datum/round_event_control/wormholes
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_COMMUNAL, TAG_MAGICAL)
-	shared_occurence_type = /datum/round_event_control/anomaly
+	shared_occurence_type = SHARED_ANOMALIES

--- a/monkestation/code/modules/storytellers/converted_events/solo/bloodcult.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/bloodcult.dm
@@ -4,6 +4,7 @@
 	antag_flag = ROLE_CULTIST
 	antag_datum = /datum/antagonist/cult
 	typepath = /datum/round_event/antagonist/solo/bloodcult
+	shared_occurence_type = SHARED_HIGH_THREAT
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CAPTAIN,

--- a/monkestation/code/modules/storytellers/converted_events/solo/changeling.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/changeling.dm
@@ -21,17 +21,16 @@
 	)
 	min_players = 20
 	weight = 3
+	shared_occurence_type = SHARED_CHANGELING
 
 /datum/round_event_control/antagonist/solo/changeling/roundstart
 	name = "Changelings"
 	roundstart = TRUE
 	earliest_start = 0
 	maximum_antags = 1
-	shared_occurences = list(/datum/round_event_control/antagonist/solo/changeling/midround)
 
 /datum/round_event_control/antagonist/solo/changeling/midround
 	name = "Genome Awakening (Changelings)"
 	antag_flag = ROLE_CHANGELING_MIDROUND
 	prompted_picking = TRUE
 	max_occurrences = 2
-	shared_occurences = list(/datum/round_event_control/antagonist/solo/changeling/roundstart)

--- a/monkestation/code/modules/storytellers/converted_events/solo/clockwork_cult.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/clockwork_cult.dm
@@ -4,6 +4,7 @@
 	antag_flag = ROLE_CLOCK_CULTIST
 	antag_datum = /datum/antagonist/clock_cultist
 	typepath = /datum/round_event/antagonist/solo/clockcult
+	shared_occurence_type = SHARED_HIGH_THREAT
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CAPTAIN,

--- a/monkestation/code/modules/storytellers/converted_events/solo/clown_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/clown_operative.dm
@@ -4,6 +4,7 @@
 	antag_flag = ROLE_CLOWN_OPERATIVE
 	antag_datum = /datum/antagonist/nukeop/clownop
 	typepath = /datum/round_event/antagonist/solo/clown_operative
+	shared_occurence_type = SHARED_HIGH_THREAT
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CAPTAIN,

--- a/monkestation/code/modules/storytellers/converted_events/solo/malf.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/malf.dm
@@ -13,6 +13,7 @@
 		JOB_SECURITY_ASSISTANT,
 		JOB_WARDEN,
 	)
+	shared_occurence_type = SHARED_HIGH_THREAT
 	maximum_antags = 1
 	exclusive_roles = list(JOB_AI)
 	required_enemies = 4

--- a/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
@@ -4,6 +4,7 @@
 	antag_flag = ROLE_OPERATIVE
 	antag_datum = /datum/antagonist/nukeop
 	typepath = /datum/round_event/antagonist/solo/nuclear_operative
+	shared_occurence_type = SHARED_HIGH_THREAT
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CAPTAIN,

--- a/monkestation/code/modules/storytellers/converted_events/solo/revolutionary.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/revolutionary.dm
@@ -4,6 +4,7 @@
 	antag_flag = ROLE_REV_HEAD
 	antag_datum = /datum/antagonist/rev/head/event_trigger
 	typepath = /datum/round_event/antagonist/solo/revolutionary
+	shared_occurence_type = SHARED_HIGH_THREAT
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CAPTAIN,

--- a/monkestation/code/modules/storytellers/converted_events/solo/wizard.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/wizard.dm
@@ -4,6 +4,7 @@
 	typepath = /datum/round_event/antagonist/solo/wizard
 	antag_flag = ROLE_WIZARD
 	antag_datum = /datum/antagonist/wizard
+	shared_occurence_type = SHARED_HIGH_THREAT
 	restricted_roles = list(
 		JOB_CAPTAIN,
 		JOB_HEAD_OF_SECURITY,

--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -767,7 +767,7 @@ SUBSYSTEM_DEF(gamemode)
 					event.reoccurence_penalty_multiplier = value
 				if("shared_occurence_type")
 					if(!isnull(value))
-						value = text2path(value)
+						value = "[value]"
 					event.shared_occurence_type = value
 
 /// Loads config values from game_options.txt


### PR DESCRIPTION

## About The Pull Request

This creates several shared occurance groups for events, regarding both roundstart antags, and midroung events.

## Why It's Good For The Game

because nukies-cult-nukies is hell

## Changelog
:cl:
balance: Split events into several 'shared occurance' groups, hopefully avoiding tiring situations where multiple high-threat antags or events occur back-to-back.
/:cl:
