### PR TITLE
You can emag jukeboxes!

### DIFF
--- a/monkestation/code/modules/cassettes/machines/media/jukebox.dm
+++ b/monkestation/code/modules/cassettes/machines/media/jukebox.dm
@@ -238,6 +238,7 @@
 		obj_flags |= EMAGGED
 		StopPlaying()
 		visible_message("<span class='danger'>\The [src] makes a fizzling sound.</span>")
+		set_hacked(1)
 		update_icon()
 		return 1
 
@@ -278,7 +279,7 @@
 		start_stop_song()
 	updateDialog()
 
-//Pre-hacked Jukebox, has the full sond list unlocked
+//Pre-hacked Jukebox, has the full song list unlocked
 /obj/machinery/media/jukebox/hacked
 	name = "DRM free space jukebox"
 	desc = "Filled with songs both past and present! Unlocked for your convenience!"


### PR DESCRIPTION

## About The Pull Request
This PR adds the power to emag jukeboxes (I mean technically you always could, but it literally did Fuck All.), doing so will:
stop currently playing song (it always did that)
enable hacked songs (this pr does that)

Oh yeah and i found a typo in a comment.
## Why It's Good For The Game
Theres a sizable library (10 songs) of hacked only songs, and currently, these are admin only. so why not give traitors who can already emag random things like the bar sign the power to emag the jukebox!
## Changelog
:cl: Tractor Mann
add: You can emag jukeboxes! you always could, but now it enables Hacked songs!
/:cl:
