### PR TITLE
[PORT] Removes unnecessary list of components with `/datum/component` as its key from `/datum`'s `_datum_components`

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -241,8 +241,8 @@
 	var/current_type = parent_type
 	//and since most components are root level + 1, this won't even have to run
 	while (current_type != /datum/component)
-		current_type = type2parent(current_type)
 		. += current_type
+		current_type = type2parent(current_type)
 
 // The type arg is casted so initial works, you shouldn't be passing a real instance into this
 /**

--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -237,12 +237,12 @@
  */
 /datum/component/proc/_GetInverseTypeList(our_type = type)
 	//we can do this one simple trick
+	. = list(our_type)
 	var/current_type = parent_type
-	. = list(our_type, current_type)
 	//and since most components are root level + 1, this won't even have to run
 	while (current_type != /datum/component)
 		current_type = type2parent(current_type)
-	. += current_type
+		. += current_type
 
 // The type arg is casted so initial works, you shouldn't be passing a real instance into this
 /**
@@ -478,15 +478,16 @@
 	var/list/dc = _datum_components
 	if(!dc)
 		return
-	var/comps = dc[/datum/component]
-	if(islist(comps))
-		for(var/datum/component/I in comps)
-			if(I.can_transfer)
-				target.TakeComponent(I)
-	else
-		var/datum/component/C = comps
-		if(C.can_transfer)
-			target.TakeComponent(comps)
+	for(var/component_key in dc)
+		var/component_or_list = dc[component_key]
+		if(islist(component_or_list))
+			for(var/datum/component/I in component_or_list)
+				if(I.can_transfer)
+					target.TakeComponent(I)
+		else
+			var/datum/component/C = component_or_list
+			if(C.can_transfer)
+				target.TakeComponent(C)
 
 /**
  * Return the object that is the host of any UI's that this component has

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -121,13 +121,14 @@
 	//BEGIN: ECS SHIT
 	var/list/dc = _datum_components
 	if(dc)
-		var/all_components = dc[/datum/component]
-		if(length(all_components))
-			for(var/datum/component/component as anything in all_components)
-				qdel(component, FALSE, TRUE)
-		else
-			var/datum/component/C = all_components
-			qdel(C, FALSE, TRUE)
+		for(var/component_key in dc)
+			var/component_or_list = dc[component_key]
+			if(islist(component_or_list))
+				for(var/datum/component/component as anything in component_or_list)
+					qdel(component, FALSE, TRUE)
+			else
+				var/datum/component/C = component_or_list
+				qdel(C, FALSE, TRUE)
 		dc.Cut()
 
 	_clear_signal_refs()

--- a/code/modules/admin/view_variables/topic_basic.dm
+++ b/code/modules/admin/view_variables/topic_basic.dm
@@ -98,9 +98,7 @@
 		if(!check_rights(NONE))
 			return
 		var/mass_remove = href_list[VV_HK_MASS_REMOVECOMPONENT]
-		var/list/components = list()
-		for(var/datum/component/component in target.GetComponents(/datum/component))
-			components += component.type
+		var/list/components = target._datum_components.Copy()
 		var/list/names = list()
 		names += "---Components---"
 		if(length(components))


### PR DESCRIPTION
# PLEASE PLEASE PLEASE TESTMERGE THIS FIRST
While tg doesn't seem to have had any issues with these changes in the 10 months since they were merged, we have added our own components - and there are far too many of those to test them on my own. Thus, it's far easier and far better to just testmerge it for a while.

## About The Pull Request
Ports the following PR from tgstation:

* https://github.com/tgstation/tgstation/pull/77615

And the following other PRs, which fix stuff caused by the above PR:

* https://github.com/tgstation/tgstation/pull/77784 (fixes an issue with plumbing)
* https://github.com/tgstation/tgstation/pull/82461 (fixes the "Remove Component/Element" option in the VV window)

## Why It's Good For The Game
From the ported PR: "Avoids the questionably useful list of components with /datum/component as its key from _datum_components."

Thus, reduces memory usage.

## Changelog
N/A, nothing user-facing as best as I can tell
