### PR TITLE
The headspin dance now immobilizes you

### DIFF
--- a/monkestation/code/modules/cybernetics/elements/dancing.dm
+++ b/monkestation/code/modules/cybernetics/elements/dancing.dm
@@ -136,6 +136,7 @@
 	animate(target, pixel_y = final_pixel_y, time = 0.5 SECONDS)
 
 /datum/dance/head_spin/trigger_dance(mob/living/target)
+	ADD_TRAIT(target, TRAIT_IMMOBILIZED, type)
 	animate(target, transform = matrix(180, MATRIX_ROTATE), time = 1, loop = 0)
 	var/matrix/initial_matrix = matrix(target.transform)
 	for (var/i in 1 to 60)
@@ -180,3 +181,4 @@
 
 /datum/dance/head_spin/end_dance(mob/target)
 	continues = FALSE
+	REMOVE_TRAIT(target, TRAIT_IMMOBILIZED, type)


### PR DESCRIPTION

## About The Pull Request

https://github.com/Monkestation/Monkestation2.0/assets/65794972/98b47ab5-34f8-405a-ab9e-ce4e1fcd90a4

## Why It's Good For The Game

The headspin dance makes it unfairly hard for people to click your sprite, for _zero drawback_ (except maybe looking stupid, I guess)

this keeps the dance in, while removing its combat potential

## Changelog
:cl:
balance: The headspin dance now immobilizes you, so you can't abuse it to make it harder to hit you anymore.
/:cl:
