### PR TITLE
Bioscramblers can no longer give people an Atomic Ass

### DIFF
--- a/code/__DEFINES/research/anomalies.dm
+++ b/code/__DEFINES/research/anomalies.dm
@@ -74,7 +74,7 @@ GLOBAL_LIST_INIT(bioscrambler_organs_blacklist, typecacheof(list(
 	/obj/item/organ/internal/heart/gondola,
 	/obj/item/organ/internal/tongue/gondola,
 	/obj/item/organ/internal/empowered_borer_egg,
-	/obj/item/organ/internal/butt/atomic
+	/obj/item/organ/internal/butt/atomic,
 )) - subtypesof(/obj/item/organ/external/wings/functional) - typesof(/obj/item/organ/external/wings/moth))
 
 /// List of body parts we can apply to people

--- a/code/__DEFINES/research/anomalies.dm
+++ b/code/__DEFINES/research/anomalies.dm
@@ -73,7 +73,8 @@ GLOBAL_LIST_INIT(bioscrambler_organs_blacklist, typecacheof(list(
 	/obj/item/organ/internal/liver/gondola,
 	/obj/item/organ/internal/heart/gondola,
 	/obj/item/organ/internal/tongue/gondola,
-	/obj/item/organ/internal/empowered_borer_egg
+	/obj/item/organ/internal/empowered_borer_egg,
+	/obj/item/organ/internal/butt/atomic
 )) - subtypesof(/obj/item/organ/external/wings/functional) - typesof(/obj/item/organ/external/wings/moth))
 
 /// List of body parts we can apply to people


### PR DESCRIPTION

## About The Pull Request

This blacklists the Atomic Ass (which is supposed to be admin-only anyways, according to the code) from the bioscrambler

## Why It's Good For The Game

Because having an atomic ass explosion (much less two) bc someone decided to passionately make out with a bioscrambler artifact is not fun.

## Changelog
:cl:
del: Bioscramblers can no longer give people an Atomic Ass.
/:cl:
