### PR TITLE
Prisoners riot when nuke ops declare war.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -142,7 +142,6 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		prisoner.faction |= ROLE_SYNDICATE
 		to_chat(human_target, span_warning("TEST!"))
 		to_chat(human_target, span_userdanger("TEST!"))
-	
 
 /obj/item/nuclear_challenge/proc/check_allowed(mob/living/user)
 	if(declaring_war)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -86,7 +86,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 			A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
 
 	distribute_tc()
-	prison_riot()
+	prison_riot() //Monke Edit, prisoners riot when nukies declare war.
 	CONFIG_SET(number/shuttle_refuel_delay, max(CONFIG_GET(number/shuttle_refuel_delay), CHALLENGE_SHUTTLE_DELAY))
 	SSblackbox.record_feedback("amount", "nuclear_challenge_mode", 1)
 
@@ -131,17 +131,20 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 				C.visible_message(span_notice("[C] coughs up a half-digested telecrystal"),span_notice("You cough up a half-digested telecrystal!"))
 				break
 
-/obj/item/nuclear_challenge/proc/prison_riot()
+/obj/item/nuclear_challenge/proc/prison_riot() // Monke function to make prisoners riot when war is declared.
 	for(var/mob/living/carbon/human/prisoner in GLOB.player_list)
-		if(!(prisoner.mind.assigned_role.job_flags & JOB_PRISONER))
-			return
+		if(!(prisoner.mind.assigned_role.title == JOB_PRISONER))
+			continue
 		var/datum/antagonist/nukeop/nuke_datum = new()
 		nuke_datum.send_to_spawnpoint = FALSE
 		nuke_datum.nukeop_outfit = null
 		prisoner.mind.add_antag_datum(nuke_datum)
+		prisoner.grant_language(/datum/language/codespeak) // Codespeak manual effects.
+		prisoner.remove_blocked_language(/datum/language/codespeak, source=LANGUAGE_ALL)
+		ADD_TRAIT(prisoner, TRAIT_TOWER_OF_BABEL, MAGIC_TRAIT)
 		prisoner.faction |= ROLE_SYNDICATE
-		to_chat(prisoner, span_warning("TEST!"))
-		to_chat(prisoner, span_userdanger("TEST!"))
+		to_chat(prisoner, span_userdanger("The syndicate is coming to wage war against your captors! Aid the nuclear operatives in any way possible!"))
+		to_chat(prisoner, span_notice("The syndicate has managed to inform you of the nuke code and taught you codespeak."))
 
 /obj/item/nuclear_challenge/proc/check_allowed(mob/living/user)
 	if(declaring_war)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -145,7 +145,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		prisoner.faction |= ROLE_SYNDICATE
 		to_chat(prisoner, span_userdanger("The syndicate is coming to wage war against your captors! Aid the nuclear operatives in any way possible!"))
 		to_chat(prisoner, span_notice("The syndicate has managed to inform you of the nuke code and taught you codespeak."))
-		for(var/datum/job/job as anything in SSjob.joinable_occupations) // I assume there's a better way tp do this, but I don't know what, to make sure no more prisoners join after the riot has started.
+		for(var/datum/job/job as anything in SSjob.joinable_occupations) // I assume there's a better way to do this, but I don't know what, to make sure no more prisoners join after the riot has started.
 			if(!(job.title == JOB_PRISONER))
 				continue
 			job.allow_bureaucratic_error = FALSE

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -86,6 +86,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 			A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
 
 	distribute_tc()
+	prison_riot()
 	CONFIG_SET(number/shuttle_refuel_delay, max(CONFIG_GET(number/shuttle_refuel_delay), CHALLENGE_SHUTTLE_DELAY))
 	SSblackbox.record_feedback("amount", "nuclear_challenge_mode", 1)
 
@@ -130,6 +131,18 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 				C.visible_message(span_notice("[C] coughs up a half-digested telecrystal"),span_notice("You cough up a half-digested telecrystal!"))
 				break
 
+/obj/item/nuclear_challenge/proc/prison_riot()
+	for(var/mob/living/carbon/human/prisoner in GLOB.player_list)
+		if(!(prisoner.mind.assigned_role.job_flags & JOB_PRISONER))
+			return
+		var/datum/antagonist/nukeop/nuke_datum = new()
+		nuke_datum.send_to_spawnpoint = FALSE
+		nuke_datum.nukeop_outfit = null
+		prisoner.mind?.add_antag_datum(nuke_datum)
+		prisoner.faction |= ROLE_SYNDICATE
+		to_chat(human_target, span_warning("TEST!"))
+		to_chat(human_target, span_userdanger("TEST!"))
+	
 
 /obj/item/nuclear_challenge/proc/check_allowed(mob/living/user)
 	if(declaring_war)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -145,6 +145,11 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		prisoner.faction |= ROLE_SYNDICATE
 		to_chat(prisoner, span_userdanger("The syndicate is coming to wage war against your captors! Aid the nuclear operatives in any way possible!"))
 		to_chat(prisoner, span_notice("The syndicate has managed to inform you of the nuke code and taught you codespeak."))
+		for(var/datum/job/job as anything in SSjob.joinable_occupations) // I assume there's a better way tp do this, but I don't know what, to make sure no more prisoners join after the riot has started.
+			if(!(job.title == JOB_PRISONER))
+				continue
+			job.allow_bureaucratic_error = FALSE
+			job.total_positions = 0
 
 /obj/item/nuclear_challenge/proc/check_allowed(mob/living/user)
 	if(declaring_war)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -138,10 +138,10 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		var/datum/antagonist/nukeop/nuke_datum = new()
 		nuke_datum.send_to_spawnpoint = FALSE
 		nuke_datum.nukeop_outfit = null
-		prisoner.mind?.add_antag_datum(nuke_datum)
+		prisoner.mind.add_antag_datum(nuke_datum)
 		prisoner.faction |= ROLE_SYNDICATE
-		to_chat(human_target, span_warning("TEST!"))
-		to_chat(human_target, span_userdanger("TEST!"))
+		to_chat(prisoner, span_warning("TEST!"))
+		to_chat(prisoner, span_userdanger("TEST!"))
 
 /obj/item/nuclear_challenge/proc/check_allowed(mob/living/user)
 	if(declaring_war)

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -367,7 +367,7 @@
 
 /datum/team/nuclear/proc/are_all_operatives_dead()
 	for(var/datum/mind/operative_mind as anything in members)
-		if(ishuman(operative_mind.current) && (operative_mind.current.stat != DEAD))
+		if(ishuman(operative_mind.current) && (operative_mind.current.stat != DEAD) && !(operative_mind.assigned_role.title == JOB_PRISONER)) //Monke edit, prisoners don't count for if all operatives aare dead.
 			return FALSE
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

When nuke ops declare war, prisoners are given the nuke op antag datum, codespeak, and a message encouraging them to help the nuclear operatives. Prisoners do not count for the check for if all operatives are dead or not.

## Why It's Good For The Game

1. War ops tend to lose, this buffs them. (Riot will always fail I know but it denies crew the manpower and is a small distraction.)
2. Better flavor, prisoners shouldn't be free manpower.
3. Adds a little spice to the period between war declaration and nukies coming.

## Changelog
:cl:
add: Prisoners riot when nuke ops declare war.
/:cl:
