### PR TITLE
Adjust multiple plant genes scalings 

### DIFF
--- a/code/__DEFINES/spacevines.dm
+++ b/code/__DEFINES/spacevines.dm
@@ -40,10 +40,10 @@
 #define MAX_POSSIBLE_PRODUCTIVITY_VALUE 10
 
 /// Kudzu spread cap is a scaled version of production speed, such that the better the production speed, ie. the lower the speed value is, the faster is spreads
-#define SPREAD_CAP_LINEAR_COEFF 4
-#define SPREAD_CAP_CONSTANT_TERM 20
+#define SPREAD_CAP_LINEAR_COEFF 0.36
+#define SPREAD_CAP_CONSTANT_TERM 24
 /// Kudzu spread multiplier is a reciporal function of production speed, such that the better the production speed, ie. the lower the speed value is, the faster it spreads
-#define SPREAD_MULTIPLIER_MAX 50
+#define SPREAD_MULTIPLIER_MAX 20
 
 /// Kudzu's maximum possible maximum mutation severity (assuming ideal potency), used to balance mutation appearance chance
 #define IDEAL_MAX_SEVERITY 20

--- a/code/__HELPERS/math_curves/qp_sigmoid.dm
+++ b/code/__HELPERS/math_curves/qp_sigmoid.dm
@@ -1,0 +1,4 @@
+// defines a half sigmoid function in the Q p-adic field of numbers
+
+/proc/qp_sigmoid(mid_point, max_value, x)
+    return (max_value * x)/(mid_point + abs(x))

--- a/code/modules/events/space_vines/vine_controller.dm
+++ b/code/modules/events/space_vines/vine_controller.dm
@@ -35,11 +35,11 @@ GLOBAL_LIST_INIT(vine_mutations_list, init_vine_mutation_list())
 		event.announce_to_ghosts(vine)
 	START_PROCESSING(SSobj, src)
 	if(potency != null)
-		mutativeness = potency * MUTATIVENESS_SCALE_FACTOR // If potency is 100, 20 mutativeness; if 1: 0.2 mutativeness
+		mutativeness = qp_sigmoid(100, 30, potency)
 		max_mutation_severity = round(potency * MAX_SEVERITY_LINEAR_COEFF + MAX_SEVERITY_CONSTANT_TERM) // If potency is 100, 25 max mutation severity; if 1, 10 max mutation severity
-	if(production != null && production <= MAX_POSSIBLE_PRODUCTIVITY_VALUE) //Prevents runtime in case production is set to 11.
-		spread_cap = SPREAD_CAP_LINEAR_COEFF * (MAX_POSSIBLE_PRODUCTIVITY_VALUE + 1 - production) + SPREAD_CAP_CONSTANT_TERM //Best production speed of 1 increases spread_cap to 60, worst production speed of 10 lowers it to 24, even distribution
-		spread_multiplier = SPREAD_MULTIPLIER_MAX / (MAX_POSSIBLE_PRODUCTIVITY_VALUE + 1 - production) // Best production speed of 1: 10% of total vines will spread per second, worst production speed of 10: 1% of total vines (with minimum of 1) will spread per second
+	if(production != null)
+		spread_cap = min(production * SPREAD_CAP_LINEAR_COEFF + SPREAD_CAP_CONSTANT_TERM, 60) // clamps at 60 to keep the original balancing
+		spread_multiplier = qp_sigmoid(100, SPREAD_MULTIPLIER_MAX, production) // gets to 10% at 100 production instead of 1 production, gets close to 20% at +infinity
 	if(event != null) // spawned by space vine event
 		max_mutation_severity += MAX_SEVERITY_EVENT_BONUS
 		minimum_spread_rate = 3

--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -432,7 +432,9 @@
 
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
 	var/mob/living/spawned_mob = new killer_plant(our_plant.drop_location())
-	spawned_mob.maxHealth += round(min(our_seed.endurance, 90) * mob_health_multiplier)
+	var/health_mid_point = 150
+	var/health_max_value = 40 
+	spawned_mob.maxHealth += qp_sigmoid(health_mid_point, health_max_value, our_seed.endurance)
 	spawned_mob.health = spawned_mob.maxHealth
 	if(ishostile(spawned_mob))
 		var/mob/living/simple_animal/hostile/spawned_simplemob = spawned_mob
@@ -441,9 +443,12 @@
 		spawned_simplemob.move_to_delay -= round(our_seed.production * mob_speed_multiplier)
 
 	if(isbasicmob(spawned_mob))
+		var/damage_mid_point = 100
+		var/damage_max_value = 14
+		var/mob_damage = qp_sigmoid(damage_mid_point, damage_max_value, our_seed.potency)
 		var/mob/living/basic/spawned_basicmob = spawned_mob
-		spawned_basicmob.melee_damage_lower += round(min(our_seed.potency, 100) * mob_melee_multiplier)
-		spawned_basicmob.melee_damage_upper += round(min(our_seed.potency, 100) * mob_melee_multiplier)
+		spawned_basicmob.melee_damage_lower += mob_damage
+		spawned_basicmob.melee_damage_upper += mob_damage
 		// basic mob speeds aren't exactly equivalent to simple animal's "move to delay" but this seems balanced enough.
 		var/calculated_speed = initial(spawned_basicmob.speed) - round((min(our_seed.production, 25) * mob_speed_multiplier), 0.01)
 		spawned_basicmob.set_varspeed(calculated_speed)


### PR DESCRIPTION
## About The Pull Request

The purpose of this pull request is to adjust multiple plant gene scalings that were used with the old botany system of clamped stats, a qp_sigmoid function was implemented to properly use the limitless stats of new botany, the function approaches a coder defined value we call max_value as it's input approach +infinity, you can also set a midpoint where for x = midpoint the return value of qp_sigmoid will be max_value/2.

Bug fixes were also made to kudzu vine spreading rate that were still using production 1 as fastest value, uses qp_sigmoid, no nerfs or buffs were made, only direct adjustments.
## Why It's Good For The Game

Makes plant scaling more natural with our current infinite stats growing of plants, qp_sigmoid has diminishing returns as x grows to a large number so there is no gamebreaking changes, only adjustments, all scaling curves were made to be similar to current balance state
## Changelog

:cl:
add: adds qp_sigmoid function
fix: fixed a bug where kudzu vine used production 1 as maximum spread scaling
code: adjusted kudzu vine consts
code: adjusted battery plant gene zap damage to have  sigmoid scaling instead of linear scaling
balance: buffed battery plant gene zap probability chance at really high levels of potency
balance: nerfed battery plant gene zap probability chance at really low levels of potency
code: adjusted prickle adhesion plant gene to have sigmoid scaling instead of linear scaling in force and reagent injection
code: adjusted killer tomatos health to have sigmoid scaling instead of linear scaling
balance: killer tomatos have slightly more health at really high levels of endurance
code: adjusted killer tomatos damage to have sigmoid scaling instead of linear scaling
balance: killer tomatos have slightly more damage at really high levels of potency
:cl:
