### PR TITLE
Fix recipes for same-color crossbreeds

### DIFF
--- a/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/burning.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/burning.dm
@@ -9,7 +9,7 @@
 
 /datum/compressor_recipe/crossbreed/burning/orange
 	required_oozes = list(
-		/datum/reagent/slime_ooze/orange = 1000,
+		/datum/reagent/slime_ooze/orange = CROSSBREED_RECIPE_OOZE_AMOUNT * 2,
 		)
 	output_item = /obj/item/slimecross/burning/orange
 

--- a/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/charged.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/charged.dm
@@ -38,7 +38,7 @@
 
 /datum/compressor_recipe/crossbreed/charged/yellow
 	required_oozes = list(
-		/datum/reagent/slime_ooze/yellow = 1000,
+		/datum/reagent/slime_ooze/yellow = CROSSBREED_RECIPE_OOZE_AMOUNT * 2,
 		)
 	output_item = /obj/item/slimecross/charged/yellow
 

--- a/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/chilling.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/chilling.dm
@@ -52,7 +52,7 @@
 
 /datum/compressor_recipe/crossbreed/chilling/darkblue
 	required_oozes = list(
-		/datum/reagent/slime_ooze/darkblue = 1000,
+		/datum/reagent/slime_ooze/darkblue = CROSSBREED_RECIPE_OOZE_AMOUNT * 2,
 		)
 	output_item = /obj/item/slimecross/chilling/darkblue
 

--- a/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/consuming.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/consuming.dm
@@ -52,7 +52,7 @@
 
 /datum/compressor_recipe/crossbreed/consuming/silver
 	required_oozes = list(
-		/datum/reagent/slime_ooze/silver = 1000,
+		/datum/reagent/slime_ooze/silver = CROSSBREED_RECIPE_OOZE_AMOUNT * 2,
 		)
 	output_item = /obj/item/slimecross/consuming/silver
 

--- a/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/industrial.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/industrial.dm
@@ -10,7 +10,7 @@
 
 /datum/compressor_recipe/crossbreed/industrial/metal
 	required_oozes = list(
-		/datum/reagent/slime_ooze/metal = 1000,
+		/datum/reagent/slime_ooze/metal = CROSSBREED_RECIPE_OOZE_AMOUNT * 2,
 		)
 	output_item = /obj/item/slimecross/industrial/metal
 

--- a/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/prismatic.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/prismatic.dm
@@ -52,7 +52,7 @@
 
 /datum/compressor_recipe/crossbreed/prismatic/pyrite
 	required_oozes = list(
-		/datum/reagent/slime_ooze/pyrite = 1000,
+		/datum/reagent/slime_ooze/pyrite = CROSSBREED_RECIPE_OOZE_AMOUNT * 2,
 		)
 	output_item = /obj/item/slimecross/prismatic/pyrite
 

--- a/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/recurring.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/recurring.dm
@@ -52,7 +52,7 @@
 
 /datum/compressor_recipe/crossbreed/recurring/cerulean
 	required_oozes = list(
-		/datum/reagent/slime_ooze/cerulean = 1000,
+		/datum/reagent/slime_ooze/cerulean = CROSSBREED_RECIPE_OOZE_AMOUNT * 2,
 		)
 	output_item = /obj/item/slimecross/recurring/cerulean
 

--- a/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/regenerative.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/regenerative.dm
@@ -52,7 +52,7 @@
 
 /datum/compressor_recipe/crossbreed/regenerative/purple
 	required_oozes = list(
-		/datum/reagent/slime_ooze/purple = 1000,
+		/datum/reagent/slime_ooze/purple = REGEN_CROSSBREED_RECIPE_OOZE_AMOUNT * 2,
 		)
 	output_item = /obj/item/slimecross/regenerative/purple
 

--- a/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/reproductive.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/reproductive.dm
@@ -52,7 +52,7 @@
 
 /datum/compressor_recipe/crossbreed/reproductive/grey
 	required_oozes = list(
-		/datum/reagent/slime_ooze/grey = 1000,
+		/datum/reagent/slime_ooze/grey = CROSSBREED_RECIPE_OOZE_AMOUNT * 2,
 		)
 	output_item = /obj/item/slimecross/reproductive/grey
 

--- a/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/selfsustaining.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/selfsustaining.dm
@@ -52,7 +52,7 @@
 
 /datum/compressor_recipe/crossbreed/selfsustaining/darkpurple
 	required_oozes = list(
-		/datum/reagent/slime_ooze/darkpurple = 1000,
+		/datum/reagent/slime_ooze/darkpurple = CROSSBREED_RECIPE_OOZE_AMOUNT * 2,
 		)
 	output_item = /obj/item/slimecross/selfsustaining/darkpurple
 

--- a/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/stabilized.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_compressor/recipes/stabilized.dm
@@ -52,7 +52,7 @@
 
 /datum/compressor_recipe/crossbreed/stabilized/blue
 	required_oozes = list(
-		/datum/reagent/slime_ooze/blue = 1000,
+		/datum/reagent/slime_ooze/blue = CROSSBREED_RECIPE_OOZE_AMOUNT * 2,
 		)
 	output_item = /obj/item/slimecross/stabilized/blue
 


### PR DESCRIPTION
## Changelog
:cl:
fix: Fix recipes for same-color crossbreeds requiring 1000u of ooze instead of 500u.
/:cl:
