### PR TITLE
Soft-spoken trait no longer applies to radio messages

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -142,6 +142,9 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			say_dead(original_message)
 			return
 
+	/*if(HAS_TRAIT(src, TRAIT_SOFTSPOKEN) && !HAS_TRAIT(src, TRAIT_SIGN_LANG)) MONKESTATION EDIT: Moved to be after radios.
+		message_mods[WHISPER_MODE] = MODE_WHISPER*/
+
 	if(client && SSlag_switch.measures[SLOWMODE_SAY] && !HAS_TRAIT(src, TRAIT_BYPASS_MEASURES) && !forced && src == usr)
 		if(!COOLDOWN_FINISHED(client, say_slowmode))
 			to_chat(src, span_warning("Message not sent due to slowmode. Please wait [SSlag_switch.slowmode_cooldown/10] seconds between messages.\n\"[message]\""))

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -142,9 +142,6 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			say_dead(original_message)
 			return
 
-	if(HAS_TRAIT(src, TRAIT_SOFTSPOKEN) && !HAS_TRAIT(src, TRAIT_SIGN_LANG)) // softspoken trait only applies to spoken languages
-		message_mods[WHISPER_MODE] = MODE_WHISPER
-
 	if(client && SSlag_switch.measures[SLOWMODE_SAY] && !HAS_TRAIT(src, TRAIT_BYPASS_MEASURES) && !forced && src == usr)
 		if(!COOLDOWN_FINISHED(client, say_slowmode))
 			to_chat(src, span_warning("Message not sent due to slowmode. Please wait [SSlag_switch.slowmode_cooldown/10] seconds between messages.\n\"[message]\""))
@@ -230,6 +227,9 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 			message_mods[WHISPER_MODE] = MODE_WHISPER
 	if(radio_return & NOPASS)
 		return TRUE
+
+	if(HAS_TRAIT(src, TRAIT_SOFTSPOKEN) && !HAS_TRAIT(src, TRAIT_SIGN_LANG)) // MONKESTATION EDIT: Moved TRAIT_SOFTSPOKEN check to be after radios.
+		message_mods[WHISPER_MODE] = MODE_WHISPER
 
 	//No screams in space, unless you're next to someone.
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
## About The Pull Request

Makes whispering caused by the soft-spoken trait no longer apply to radio messages.

Code bounty by "visha" for 20 bucks.
## Why It's Good For The Game

The idea of soft spoken is that you can't talk to people without going close to them.
Not being able to talk on radios makes sense, but it's just not fun gameplay wise.
I can't walk across the map to the other department at all times, even if I wanted to.
Thus, I feel like the "basically can't use radio" part is too debilitating for a -2 trait.

Side note, whispering on radios is weird and uses stars() *twice*, making the message completely incomprehensible.
The first stars() is when you say the message and the second stars() is when others hear it.
## Changelog
:cl:
balance: Soft-spoken no longer affects radio messages.
/:cl:
