### PR TITLE
Adjust botany yield scalings

### DIFF
--- a/monkestation/code/modules/hydroponics/machines/composter.dm
+++ b/monkestation/code/modules/hydroponics/machines/composter.dm
@@ -91,7 +91,7 @@
 			biomatter_added++
 			qdel(composter)
 		else if(istype(composter, /obj/item/food))
-			biomatter_added += 4
+			biomatter_added += 5
 			qdel(composter)
 		else if(istype(composter, /mob/living/carbon) && allow_carbons)
 			var/mob/living/carbon/carbon_target = composter


### PR DESCRIPTION

## About The Pull Request

reduces plant production, reduces seed production and cap it to 3 per harvest, the cap is reached at 300 yield, below 50 yield the chance to obtain one seed is 50% so the chance to obtain a mutated seed below 50 yield is 32%, increases composter biomass generation from plants from 4 to 5 to compensate plant production nerfs, increases mutate chance from seeds to compensate the heavy seed production nerfs, the chance to obtain a mutation should only be slightly lower from what we have now, lower enough that it wont really nerf botany
## Why It's Good For The Game

Botany produces too much seeds and plants right now, it is easy to crash your own client and slow down the server, this PR reduces the impact of botany swarm of items on performance by reducing the amount of generated items without nerfing botany

## Changelog

:cl:
balance: reduced seed production and cap it a 3 seeds(reached at 300 yield)
balance: increased chance to obtain mutated seed, from 50% to 65%
balance: reduced plant production(the reduction of seeds compensates this reduction of plants by a small amount)
balance: increased composter biomass generation from plants, 4 -> 5(compensation for the reduction of plants and seeds)
code: changes the code responsible of generating seeds and plants, now uses qp_sigmoid function
:cl:
![BotanyHarvest](https://github.com/Monkestation/Monkestation2.0/assets/34388545/36225f3f-2989-44b3-a4ba-e2aaa70e65ec)
Y: harvest amount(plants and seeds)
X: yield
RED: old harvest generation
BLUE: old expected(the generation is random) seed generation
GREEN: new harvest generation
BLACK: new seed generation

