### PR TITLE
Brainwashed, abductee, etc no longer disqualify you from midround antag

### DIFF
--- a/code/modules/antagonists/abductor/abductee/abductee.dm
+++ b/code/modules/antagonists/abductor/abductee/abductee.dm
@@ -9,6 +9,7 @@
 	roundend_category = "abductees"
 	antagpanel_category = ANTAG_GROUP_ABDUCTORS
 	antag_hud_name = "abductee"
+	count_against_dynamic_roll_chance = FALSE // monkestation edit
 
 /datum/antagonist/abductee/on_gain()
 	give_objective()

--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -276,7 +276,7 @@ SUBSYSTEM_DEF(gamemode)
 			if(no_antags && !isnull(candidate.mind.antag_datums))
 				var/real = FALSE
 				for(var/datum/antagonist/antag_datum as anything in candidate.mind.antag_datums)
-					if(!(antag_datum.antag_flags & FLAG_FAKE_ANTAG))
+					if(antag_datum.count_against_dynamic_roll_chance && !(antag_datum.antag_flags & FLAG_FAKE_ANTAG))
 						real = TRUE
 						break
 				if(real)


### PR DESCRIPTION

## About The Pull Request

To be specific, midround checks will ignore any antag datum with `count_against_dynamic_roll_chance` set to false.

## Why It's Good For The Game

Kinda sucks that if you end up the victim of sleeper agent surgery, or get probed by ayylmaos, you get fucked out of any chance of midround antag - which could also result in interesting situations anyways!

## Changelog
:cl:
qol: Roles such as brainwashed, abductee, etc no longer disqualify you from midround antag.
/:cl:
