### PR TITLE
[PORT] Updates Node bootstrapping to v20

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,8 +11,9 @@ export BYOND_MINOR=1633
 export RUST_G_VERSION=3.1.0
 
 #node version
-export NODE_VERSION=20
-export NODE_VERSION_LTS=20.12.0
+export NODE_VERSION_LTS=20.13.0
+# compatiblility mode MUST work with windows 7
+export NODE_VERSION_COMPAT=20.2.0
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.8

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -12,7 +12,8 @@ export RUST_G_VERSION=3.1.0
 
 #node version
 export NODE_VERSION=14
-export NODE_VERSION_PRECISE=14.16.1
+export NODE_VERSION_LTS=20.12.0
+export NODE_VERSION_COMPAT=14.16.1
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.8

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,9 +11,8 @@ export BYOND_MINOR=1633
 export RUST_G_VERSION=3.1.0
 
 #node version
-export NODE_VERSION=14
+export NODE_VERSION=20
 export NODE_VERSION_LTS=20.12.0
-export NODE_VERSION_COMPAT=14.16.1
 
 # SpacemanDMM git tag
 export SPACEMAN_DMM_VERSION=suite-1.8

--- a/tgui/.prettierignore
+++ b/tgui/.prettierignore
@@ -6,6 +6,7 @@
 /yarn.lock
 /.pnp.*
 
+.swcrc
 /docs
 /public
 /packages/tgui-polyfill

--- a/tools/bootstrap/node
+++ b/tools/bootstrap/node
@@ -16,9 +16,9 @@ if [ "$TG_BOOTSTRAP_CACHE" ]; then
 fi
 OldPWD="$PWD"
 cd "$Bootstrap/../.."
-. ./dependencies.sh  # sets NODE_VERSION_PRECISE
+. ./dependencies.sh  # sets NODE_VERSION_LTS
 cd "$OldPWD"
-NodeVersion="$NODE_VERSION_PRECISE"
+NodeVersion="$NODE_VERSION_LTS"
 NodeFullVersion="node-v$NodeVersion-win-x64"
 NodeDir="$Cache/$NodeFullVersion"
 NodeExe="$NodeDir/node.exe"

--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -31,18 +31,7 @@ if ($Env:TG_BOOTSTRAP_CACHE) {
 	$Cache = $Env:TG_BOOTSTRAP_CACHE
 }
 
-# Get OS version
-$OSVersion = (Get-WmiObject -Class Win32_OperatingSystem).Version
-
-# Set Node version based on OS version
-if ($OSVersion -gt 6.1) {
- # Windows 7 is version 6.1
-	$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_COMPAT"
-}
-else {
-	$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_LTS"
-}
-
+$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_LTS"
 $NodeSource = "https://nodejs.org/download/release/v$NodeVersion/win-x64/node.exe"
 $NodeTargetDir = "$Cache\node-v$NodeVersion-x64"
 $NodeTarget = "$NodeTargetDir\node.exe"

--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -31,7 +31,18 @@ if ($Env:TG_BOOTSTRAP_CACHE) {
 	$Cache = $Env:TG_BOOTSTRAP_CACHE
 }
 
-$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_LTS"
+# Get OS version
+$OSMajor = (Get-WmiObject -Class Win32_OperatingSystem).Version.Split(".")[0]
+
+# Set Node version based on OS version
+if ($OSMajor -lt 10) {
+	# Anything under Windows 10
+	$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_COMPAT"
+}
+else {
+	$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_LTS"
+}
+
 $NodeSource = "https://nodejs.org/download/release/v$NodeVersion/win-x64/node.exe"
 $NodeTargetDir = "$Cache\node-v$NodeVersion-x64"
 $NodeTarget = "$NodeTargetDir\node.exe"

--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -32,7 +32,7 @@ if ($Env:TG_BOOTSTRAP_CACHE) {
 }
 
 # Get OS version
-$OSMajor = (Get-WmiObject -Class Win32_OperatingSystem).Version.Split(".")[0]
+[int]$OSMajor = (Get-WmiObject -Class Win32_OperatingSystem).Version.Split(".")[0]
 
 # Set Node version based on OS version
 if ($OSMajor -lt 10) {

--- a/tools/bootstrap/node_.ps1
+++ b/tools/bootstrap/node_.ps1
@@ -30,7 +30,19 @@ $Cache = "$BaseDir\.cache"
 if ($Env:TG_BOOTSTRAP_CACHE) {
 	$Cache = $Env:TG_BOOTSTRAP_CACHE
 }
-$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_PRECISE"
+
+# Get OS version
+$OSVersion = (Get-WmiObject -Class Win32_OperatingSystem).Version
+
+# Set Node version based on OS version
+if ($OSVersion -gt 6.1) {
+ # Windows 7 is version 6.1
+	$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_COMPAT"
+}
+else {
+	$NodeVersion = Extract-Variable -Path "$BaseDir\..\..\dependencies.sh" -Key "NODE_VERSION_LTS"
+}
+
 $NodeSource = "https://nodejs.org/download/release/v$NodeVersion/win-x64/node.exe"
 $NodeTargetDir = "$Cache\node-v$NodeVersion-x64"
 $NodeTarget = "$NodeTargetDir\node.exe"

--- a/tools/ci/install_node.sh
+++ b/tools/ci/install_node.sh
@@ -5,6 +5,6 @@ source dependencies.sh
 
 if [[ -e ~/.nvm/nvm.sh ]]; then
 	source ~/.nvm/nvm.sh
-	nvm install $NODE_VERSION
-	nvm use $NODE_VERSION
+	nvm install $NODE_VERSION_COMPAT
+	nvm use $NODE_VERSION_COMPAT
 fi


### PR DESCRIPTION
## About The Pull Request
Ports the following PRs:
- https://github.com/tgstation/tgstation/pull/82334
- https://github.com/tgstation/tgstation/pull/82420
- https://github.com/tgstation/tgstation/pull/83141
- https://github.com/tgstation/tgstation/pull/83190

## Why It's Good For The Game
Node v20 LTS is newer, which will presumably bring speed and stability improvements with it. Additionally, this brings our build system more into parity with tgstation.

## Changelog
No user-facing changes.

Any branches that include this change will automatically vendor and use the new version of Node. If the user has an old copy of Node v14, that copy will be untouched. If a user wishes to delete the old v14 version, they can find it at `tools/bootstrap/.cache/`.

Note that while I have tested to ensure this will successfully build, I have NOT tested if this will break anything, as the potential surface area seems much too large to test on my own.