### PR TITLE
Formally update the BYOND version requirements in the config (and in dependencies.sh)

### DIFF
--- a/.tgs.yml
+++ b/.tgs.yml
@@ -3,7 +3,7 @@
 version: 1
 # The BYOND version to use (kept in sync with dependencies.sh by the "TGS Test Suite" CI job)
 # Must be interpreted as a string, keep quoted
-byond: "515.1633"
+byond: "515.1637"
 # Folders to create in "<instance_path>/Configuration/GameStaticFiles/"
 static_files:
   # Config directory should be static

--- a/config/config.txt
+++ b/config/config.txt
@@ -362,14 +362,14 @@ AUTOADMIN_RANK Game Master
 ## These trigger for any version below (non-inclusive) the given version, so 510 triggers on 509 or lower.
 ## These messages will be followed by one stating the clients current version and the required version for clarity.
 ## If CLIENT_WARN_POPUP is uncommented a popup window with the message will be displayed instead
-#CLIENT_WARN_VERSION 511
-#CLIENT_WARN_BUILD 1421
+#CLIENT_WARN_VERSION 515
+#CLIENT_WARN_BUILD 1635
 #CLIENT_WARN_POPUP
-#CLIENT_WARN_MESSAGE Byond released 511 as the stable release. You can set the framerate your client runs at, which makes the game feel very different and cool. Shortly after its release we will end up using 511 client features and you will be forced to update.
-CLIENT_ERROR_VERSION 511
+#CLIENT_WARN_MESSAGE Byond released 515 as the stable release. This comes bundled with a host of niceties, including image generation for UIs and :: operators.
+CLIENT_ERROR_VERSION 515
 CLIENT_ERROR_MESSAGE Your version of byond is not supported. Please upgrade.
-## The minimum build needed for joining the server, if using 512, a good minimum build would be 1421 as that disables the Middle Mouse Button exploit.
-CLIENT_ERROR_BUILD 1421
+## The minimum build needed for joining the server.
+CLIENT_ERROR_BUILD 1590
 
 ## TOPIC RATE LIMITING
 ## This allows you to limit how many topic calls (clicking on an interface window) the client can do in any given game second and/or game minute.

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,7 +5,7 @@
 
 # byond version
 export BYOND_MAJOR=515
-export BYOND_MINOR=1633
+export BYOND_MINOR=1637
 
 #rust_g git tag
 export RUST_G_VERSION=3.1.0


### PR DESCRIPTION
## About The Pull Request
For over two months, Monkestation has required BYOND v515 to connect. From <https://discord.com/channels/748354466335686736/850822606160003082/1226596547400040592>:

> Dexee — 04/07/2024 2:16 PM
> After the round that is currently ongoing, you will be required to be on BYOND Version 515 to connect and play on MonkeStation. Please update to version 515 for the most stable experience.

This PR formalizes this, by changing the default configuration to require version 515. Users below 515.1635 (but above 515.1590) will still be able to connect, but are given a warning to update.

This change is pulled from https://github.com/tgstation/tgstation/pull/83084. However, since that change primarily concerned the lootpanel, I've manually recreated the change instead of cherry-picking, as cherry-picking would bring in a commit message that is unrelated and possibly confusing.

## Why It's Good For The Game
Formally requires clients to use BYOND 515. (Assuming borbop isn't just overriding this in their own configs...)

## Changelog
N/A. While this is a client-facing change, the only thing that users with incompatible clients can do is immediately be disconnected - and they'll be given a chat message with the relevant details.