### PR TITLE
Fixes a typo in secass description

### DIFF
--- a/monkestation/code/modules/jobs/job_types/security_assistant.dm
+++ b/monkestation/code/modules/jobs/job_types/security_assistant.dm
@@ -1,6 +1,6 @@
 /datum/job/security_assistant
 	title = JOB_SECURITY_ASSISTANT
-	description = "Fine people for trivial things. Be an glorified hall monitor."
+	description = "Fine people for trivial things. Be a glorified hall monitor."
 	auto_deadmin_role_flags = DEADMIN_POSITION_SECURITY
 	department_head = list(JOB_HEAD_OF_SECURITY)
 	faction = FACTION_STATION


### PR DESCRIPTION

## About The Pull Request

an hall monitor -> a hall monitor
## Why It's Good For The Game

Guh.
## Changelog
:cl:
fix: The secass description now reads "a" instead of "an", happy now?
/:cl:
