### PR TITLE
Mechcomp teleporter now work across floors on multi-z maps

### DIFF
--- a/code/__HELPERS/~monkestation-helpers/mapping.dm
+++ b/code/__HELPERS/~monkestation-helpers/mapping.dm
@@ -1,0 +1,6 @@
+/proc/are_zs_connected(atom/a, atom/b)
+	a = get_turf(a)
+	b = get_turf(b)
+	if(a.z == b.z)
+		return TRUE
+	return (b.z in SSmapping.get_connected_levels(a))

--- a/monkestation/code/modules/mech_comp/objects/teleporter.dm
+++ b/monkestation/code/modules/mech_comp/objects/teleporter.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_INIT(live_teleporters, list())
 			continue
 		if(!live_teleporter.anchored)
 			continue
-		if((live_teleporter.teleID != teleID) || (live_teleporter.z != src.z) || live_teleporter.send_only)
+		if((live_teleporter.teleID != teleID) || live_teleporter.send_only || !are_zs_connected(src, live_teleporter))
 			continue
 		if(!COOLDOWN_FINISHED(live_teleporter, teleporter_cooldown))
 			continue

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -561,6 +561,7 @@
 #include "code\__HELPERS\~monkestation-helpers\clients.dm"
 #include "code\__HELPERS\~monkestation-helpers\cmp.dm"
 #include "code\__HELPERS\~monkestation-helpers\icon_smoothing.dm"
+#include "code\__HELPERS\~monkestation-helpers\mapping.dm"
 #include "code\__HELPERS\~monkestation-helpers\roundend.dm"
 #include "code\__HELPERS\~monkestation-helpers\time.dm"
 #include "code\__HELPERS\~monkestation-helpers\virology.dm"


### PR DESCRIPTION

## Changelog
:cl:
qol: Mechcomp teleporters now work across different floors on multi-z maps such as Icebox or Tram.
/:cl:
