### PR TITLE
[PORT] Lets Lizards Customize Hiss Length

### DIFF
--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -157,6 +157,7 @@
 	speech_args[SPEECH_MESSAGE] = message
 
 	//MONKESTATION EDIT END
+
 /obj/item/organ/internal/tongue/lizard/silver
 	name = "silver tongue"
 	desc = "A genetic branch of the high society Silver Scales that gives them their silverizing properties. To them, it is everything, and society traitors have their tongue forcibly revoked. Oddly enough, it itself is just blue."

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -128,6 +128,15 @@
 	modifies_speech = TRUE
 	languages_native = list(/datum/language/draconic)
 
+	/// How long is our hissssssss?
+	var/draw_length = 3
+
+/obj/item/organ/internal/tongue/lizard/Initialize(mapload)
+	. = ..()
+	draw_length = rand(2, 6)
+	if(prob(10))
+		draw_length += 2
+
 /obj/item/organ/internal/tongue/lizard/modify_speech(datum/source, list/speech_args)
 	var/static/regex/lizard_hiss = new("s+", "g")
 	var/static/regex/lizard_hiSS = new("S+", "g")
@@ -137,12 +146,12 @@
 	var/static/regex/lizard_eckS = new(@"\bX([\-|r|R]|\b)", "g")
 	var/message = speech_args[SPEECH_MESSAGE]
 	if(message[1] != "*")
-		message = lizard_hiss.Replace(message, "sss")
-		message = lizard_hiSS.Replace(message, "SSS")
-		message = lizard_kss.Replace(message, "$1kss")
-		message = lizard_kSS.Replace(message, "$1KSS")
-		message = lizard_ecks.Replace(message, "ecks$1")
-		message = lizard_eckS.Replace(message, "ECKS$1")
+		message = lizard_hiss.Replace(message, repeat_string(draw_length, "s"))
+		message = lizard_hiSS.Replace(message, repeat_string(draw_length, "S"))
+		message = lizard_kss.Replace(message, "$1k[repeat_string(max(draw_length - 1, 1), "s")]")
+		message = lizard_kSS.Replace(message, "$1K[repeat_string(max(draw_length - 1, 1), "S")]")
+		message = lizard_ecks.Replace(message, "eck[repeat_string(max(draw_length - 2, 1), "s")]$1")
+		message = lizard_eckS.Replace(message, "ECK[repeat_string(max(draw_length - 2, 1), "S")]$1")
 	speech_args[SPEECH_MESSAGE] = message
 
 /obj/item/organ/internal/tongue/lizard/silver

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -128,6 +128,8 @@
 	modifies_speech = TRUE
 	languages_native = list(/datum/language/draconic)
 
+	//MONKESTATION EDIT START
+
 	/// How long is our hissssssss?
 	var/draw_length = 3
 
@@ -154,6 +156,7 @@
 		message = lizard_eckS.Replace(message, "ECK[repeat_string(max(draw_length - 2, 1), "S")]$1")
 	speech_args[SPEECH_MESSAGE] = message
 
+	//MONKESTATION EDIT END
 /obj/item/organ/internal/tongue/lizard/silver
 	name = "silver tongue"
 	desc = "A genetic branch of the high society Silver Scales that gives them their silverizing properties. To them, it is everything, and society traitors have their tongue forcibly revoked. Oddly enough, it itself is just blue."

--- a/monkestation/code/modules/client/preferences/species_features/lizard.dm
+++ b/monkestation/code/modules/client/preferences/species_features/lizard.dm
@@ -1,0 +1,20 @@
+/datum/preference/numeric/hiss_length
+	savefile_key = "hiss_length"
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	priority = PREFERENCE_PRIORITY_NAMES
+	can_randomize = FALSE
+	minimum = 2
+	maximum = 6
+
+/datum/preference/numeric/hiss_length/create_default_value()
+	return 3
+
+/datum/preference/numeric/hiss_length/is_accessible(datum/preferences/preferences)
+	return ..() && ispath(preferences.read_preference(/datum/preference/choiced/species), /datum/species/lizard)
+
+/datum/preference/numeric/hiss_length/apply_to_human(mob/living/carbon/human/target, value)
+	var/obj/item/organ/internal/tongue/lizard/tongue = target.get_organ_slot(ORGAN_SLOT_TONGUE)
+	if(!istype(tongue))
+		return
+	tongue.draw_length = value

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6332,6 +6332,7 @@
 #include "monkestation\code\modules\client\preferences\species_features\floran.dm"
 #include "monkestation\code\modules\client\preferences\species_features\goblin.dm"
 #include "monkestation\code\modules\client\preferences\species_features\ipc.dm"
+#include "monkestation\code\modules\client\preferences\species_features\lizard.dm"
 #include "monkestation\code\modules\client\preferences\species_features\secondary_mut_color.dm"
 #include "monkestation\code\modules\client\preferences\species_features\simians.dm"
 #include "monkestation\code\modules\client\verbs\looc.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/_modular_species_features.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/_modular_species_features.tsx
@@ -1,0 +1,7 @@
+import { FeatureNumberInput, FeatureNumeric } from './base';
+
+export const hiss_length: FeatureNumeric = {
+  name: 'Hiss Length',
+  description: 'How long do you hissssss for?',
+  component: FeatureNumberInput,
+};


### PR DESCRIPTION

## About The Pull Request
Ports

- https://github.com/MrMelbert/MapleStationCode/pull/496
## Why It's Good For The Game
More lizard customization, lets you customize how long you hiss for (2,3,4,5,6's). Funny.
## Changelog
:cl: MrMelbert, KnigTheThrasher
add: Lizards can customize their lisp
code: Added a modular file for species features
/:cl:
