### PR TITLE
[PORT] Changeling flammability stuff

### DIFF
--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -32,6 +32,8 @@
 	var/ignores_fakedeath = FALSE
 	/// used by a few powers that toggle
 	var/active = FALSE
+	/// Does this ability stop working if you are burning?
+	var/disabled_by_fire = TRUE
 
 /*
 changeling code now relies on on_purchase to grant powers.
@@ -60,6 +62,9 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
  */
 /datum/action/changeling/proc/try_to_sting(mob/living/user, mob/living/target)
 	if(!can_sting(user, target))
+		return FALSE
+	if(disabled_by_fire && user.fire_stacks && user.on_fire)
+		user.balloon_alert(user, "on fire!")
 		return FALSE
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	if(sting_action(user, target))

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -7,6 +7,7 @@
 	dna_cost = 2
 	req_human = TRUE
 	req_stat = UNCONSCIOUS
+	disabled_by_fire = FALSE
 
 //Recover from stuns.
 /datum/action/changeling/adrenaline/sting_action(mob/living/user)

--- a/code/modules/antagonists/changeling/powers/biodegrade.dm
+++ b/code/modules/antagonists/changeling/powers/biodegrade.dm
@@ -6,6 +6,7 @@
 	chemical_cost = 30 //High cost to prevent spam
 	dna_cost = 2
 	req_human = TRUE
+	disabled_by_fire = FALSE
 
 /datum/action/changeling/biodegrade/sting_action(mob/living/carbon/human/user)
 	var/used = FALSE // only one form of shackles removed per use

--- a/code/modules/antagonists/changeling/powers/defib_grasp.dm
+++ b/code/modules/antagonists/changeling/powers/defib_grasp.dm
@@ -6,6 +6,7 @@
 		while we are dead or in stasis. Will also stun cyborgs momentarily."
 	owner_has_control = FALSE
 	dna_cost = 0
+	disabled_by_fire = FALSE
 
 	/// Flags to pass to fully heal when we get zapped
 	var/heal_flags = HEAL_DAMAGE|HEAL_BODY|HEAL_STATUS|HEAL_CC_STATUS

--- a/code/modules/antagonists/changeling/powers/fakedeath.dm
+++ b/code/modules/antagonists/changeling/powers/fakedeath.dm
@@ -7,6 +7,7 @@
 	req_dna = 1
 	req_stat = DEAD
 	ignores_fakedeath = TRUE
+	disabled_by_fire = FALSE
 
 	/// How long it takes for revival to ready upon entering stasis.
 	/// The changeling can opt to stay in fakedeath for longer, though.

--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -6,6 +6,9 @@
 	chemical_cost = 20
 	dna_cost = 1
 	req_human = TRUE
+	req_stat = DEAD
+	ignores_fakedeath = TRUE
+	disabled_by_fire = FALSE
 
 /datum/action/changeling/headcrab/sting_action(mob/living/user)
 	set waitfor = FALSE

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -194,6 +194,7 @@
 	sharpness = SHARP_EDGED
 	wound_bonus = -20
 	bare_wound_bonus = 20
+	resistance_flags = FLAMMABLE //MONKESTATION ADDITION
 	var/can_drop = FALSE
 	var/fake = FALSE
 
@@ -288,6 +289,7 @@
 	throw_range = 0
 	throw_speed = 0
 	can_hold_up = FALSE
+	resistance_flags = FLAMMABLE //MONKESTATION ADDITION
 
 /obj/item/gun/magic/tentacle/Initialize(mapload, silent)
 	. = ..()
@@ -493,6 +495,7 @@
 	lefthand_file = 'icons/mob/inhands/antag/changeling_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/antag/changeling_righthand.dmi'
 	block_chance = 50
+	resistance_flags = FLAMMABLE //MONKESTATION ADDITION
 
 	var/remaining_uses //Set by the changeling ability.
 
@@ -542,6 +545,7 @@
 	flags_inv = HIDEJUMPSUIT
 	cold_protection = 0
 	heat_protection = 0
+	resistance_flags = FLAMMABLE //MONKESTATION ADDITION
 
 /datum/armor/armor_changeling
 	melee = 40
@@ -550,7 +554,7 @@
 	energy = 50
 	bomb = 10
 	bio = 10
-	fire = 90
+	/*fire = 90*/ //MONKESTATION REMOVAL
 	acid = 90
 
 /obj/item/clothing/suit/armor/changeling/Initialize(mapload)
@@ -567,6 +571,7 @@
 	item_flags = DROPDEL
 	armor_type = /datum/armor/helmet_changeling
 	flags_inv = HIDEEARS|HIDEHAIR|HIDEEYES|HIDEFACIALHAIR|HIDEFACE|HIDESNOUT
+	resistance_flags = FLAMMABLE //MONKESTATION ADDITION
 
 /datum/armor/helmet_changeling
 	melee = 40
@@ -575,7 +580,7 @@
 	energy = 50
 	bomb = 10
 	bio = 10
-	fire = 90
+	/*fire = 90*/ //MONKESTATION REMOVAL
 	acid = 90
 
 /obj/item/clothing/head/helmet/changeling/Initialize(mapload)

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -6,6 +6,7 @@
 	chemical_cost = 20
 	dna_cost = 1
 	req_human = TRUE
+	disabled_by_fire = FALSE
 
 //A flashy ability, good for crowd control and sowing chaos.
 /datum/action/changeling/resonant_shriek/sting_action(mob/user)
@@ -41,6 +42,7 @@
 	button_icon_state = "dissonant_shriek"
 	chemical_cost = 20
 	dna_cost = 1
+	disabled_by_fire = FALSE
 
 /datum/action/changeling/dissonant_shriek/sting_action(mob/user)
 	..()

--- a/code/modules/antagonists/changeling/powers/strained_muscles.dm
+++ b/code/modules/antagonists/changeling/powers/strained_muscles.dm
@@ -11,6 +11,7 @@
 	req_human = TRUE
 	var/stacks = 0 //Increments every 5 seconds; damage increases over time
 	active = FALSE //Whether or not you are a hedgehog
+	disabled_by_fire = FALSE
 
 /datum/action/changeling/strained_muscles/sting_action(mob/living/carbon/user)
 	..()


### PR DESCRIPTION
## About The Pull Request
Ports: 

- #83953

Along with adding flammability to changeling stuff (blade,tentacle,etc.). This should be testmerged first to check if full on fire resistance removal was too much (gotta check lasers that set you on fire and shit).
## Why It's Good For The Game
Gives changelings a decent weakness without nerfing their stuff (outside of removing fire resistance to make their stuff actually burn down). Gives them a reason to not go full on murderhobo on everyone since they can lit them on fire.
## Changelog
:cl: JackEnoff, KnigTheThrasher
balance: Certain changeling abilities won't work while on fire.
balance: Changeling stuff will burn down when lit on fire (can be regenerated when you aren't burning)
/:cl:
