### PR TITLE
Re-enables Peacekeeper

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -166,8 +166,9 @@
 			"Janitor" = /obj/item/robot_model/janitor,
 			"Service" = /obj/item/robot_model/service,
 		)
-		if(!CONFIG_GET(flag/disable_peaceborg))
-			GLOB.cyborg_model_list["Peacekeeper"] = /obj/item/robot_model/peacekeeper
+		//if(!CONFIG_GET(flag/disable_peaceborg)) monkestation edit
+		GLOB.cyborg_model_list["Peacekeeper"] = /obj/item/robot_model/peacekeeper
+
 		if(!CONFIG_GET(flag/disable_secborg))
 			GLOB.cyborg_model_list["Security"] = /obj/item/robot_model/security
 


### PR DESCRIPTION

## About The Pull Request
Does what it says on the tin. Only changes 2 lines to use what was already there.

## Why It's Good For The Game
Removes **HUMAN HARM**

## Changelog
:cl:
add: Re-adds Peacekeeper borgs to the radial menu of selectable borg types.
/:cl:
