### PR TITLE
Adds the Chemical Sensor to the crafting menu.

### DIFF
--- a/monkestation/code/datums/components/crafting.dm
+++ b/monkestation/code/datums/components/crafting.dm
@@ -22,7 +22,8 @@
 		/obj/item/stock_parts/cell = 1,
 		/obj/item/stack/sheet/glass = 1,
 		/obj/item/stack/cable_coil = 5,
-		/obj/item/pen = 1
+		/obj/item/pen = 1,
+		/obj/item/stack/sheet/iron = 2
 	)
 	time = 4 SECONDS
 	category = CAT_CHEMISTRY

--- a/monkestation/code/datums/components/crafting.dm
+++ b/monkestation/code/datums/components/crafting.dm
@@ -12,3 +12,17 @@
 	)
 	time = 1.5 SECONDS
 	category = CAT_WEAPON_MELEE
+
+/datum/crafting_recipe/ph_sensor //Ghetto science goggles for the wanna-be Walter White's upon our grimey-ass station.
+	name = "Chemical Sensor"
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_MULTITOOL)
+	result = /obj/item/ph_meter
+	reqs = list(
+		/obj/item/stock_parts/scanning_module = 1,
+		/obj/item/stock_parts/cell = 1,
+		/obj/item/stack/sheet/glass = 1,
+		/obj/item/stack/cable_coil = 5,
+		/obj/item/pen = 1
+	)
+	time = 4 SECONDS
+	category = CAT_CHEMISTRY


### PR DESCRIPTION

## About The Pull Request
Adds the "Chemical Sensor" to the list of craftable items in the Chemistry tab for use as ghetto science goggles.
## Why It's Good For The Game
Less reasons for greyshits to tide into science if they have some semblance of grey matter residing in the coconut that takes the place of their skull.
## Changelog
:cl:
add: Added the Chemical Sensor to the crafting menu. (Not sure why it's called "ph_sensor" behind the scenes though).
/:cl:
![dreamseeker_e83i2B0nAq](https://github.com/Monkestation/Monkestation2.0/assets/135103932/e64b94b9-99f8-4afd-95fe-5ddbf63a690e)
