### PR TITLE
Soulcatchers now capitalize their messages, like other mobs

### DIFF
--- a/monkestation/code/modules/blueshift/mobs/soulcatcher.dm
+++ b/monkestation/code/modules/blueshift/mobs/soulcatcher.dm
@@ -124,7 +124,7 @@
 	datum/saymode/saymode,
 	list/message_mods = list(),
 )
-	message = trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN))
+	message = capitalize(trim(copytext_char(sanitize(message), 1, MAX_MESSAGE_LEN)))
 	if(!message || message == "")
 		return
 


### PR DESCRIPTION
## Changelog
:cl:
fix: Soulcatchers now capitalize their messages, like all other (non-ghost) mobs.
/:cl:
