### PR TITLE
Fixes looping sounds having invalid sound weights

### DIFF
--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -170,7 +170,7 @@
 	if(!each_once)
 		. = play_from
 		while(!isfile(.) && !isnull(.))
-			. = pick_weight(.)
+			. = pick_weight(fill_with_ones(.))
 		return .
 
 
@@ -182,7 +182,7 @@
 		// Tree is a list of lists containign files
 		// If an entry in the tree goes to 0 length, we cut it from the list
 		tree += list(.)
-		. = pick_weight(.)
+		. = pick_weight(fill_with_ones(.))
 
 	if(!isfile(.))
 		return


### PR DESCRIPTION

## About The Pull Request

I was originally going to just fix `/datum/looping_sound/computer::mid_sounds`, but imo it's kinda stupid to put `= 1` after every entry if you just want to do a normal pick, so I decided using `fill_with_ones` was a more intuitive solution.

## Changelog

No user-visible changes
