### PR TITLE
Adds liquid barriers, and maps them into xenobio

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -9605,6 +9605,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "bSa" = (
@@ -26074,6 +26075,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology)
 "eYC" = (
@@ -32762,9 +32764,6 @@
 	pixel_x = 6;
 	pixel_y = 16
 	},
-/obj/item/reagent_containers/cup/beaker/vial,
-/obj/item/reagent_containers/cup/beaker/vial,
-/obj/item/reagent_containers/cup/beaker/vial,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "gpr" = (
@@ -51019,6 +51018,7 @@
 /area/station/maintenance/fore/upper)
 "jUX" = (
 /obj/machinery/door/window/left/directional/north,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "jVd" = (
@@ -64403,6 +64403,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/liquid_barrier,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "mDi" = (
@@ -83098,6 +83099,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "qkR" = (
@@ -84015,6 +84017,7 @@
 	name = "Xenobiology Controll Room Shutters"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/control)
 "qtm" = (
@@ -84931,6 +84934,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron,
 /area/station/science/xenobiology/hallway)
 "qCg" = (
@@ -85455,6 +85459,7 @@
 /area/station/science)
 "qGA" = (
 /obj/structure/sign/departments/xenobio/directional/north,
+/obj/structure/liquid_barrier,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/upper)
 "qGC" = (
@@ -88416,6 +88421,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
 "rjO" = (
@@ -89294,6 +89300,7 @@
 	name = "Toxins Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "rsO" = (
@@ -93519,6 +93526,7 @@
 	name = "Creature Pen";
 	req_access = list("research")
 	},
+/obj/structure/liquid_barrier,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "skx" = (
@@ -104876,6 +104884,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/control)
 "uqt" = (
@@ -105851,6 +105860,7 @@
 	name = "Secure Pen"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "uzz" = (
@@ -113720,10 +113730,6 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/cable,
 /obj/machinery/disease2/centrifuge,
-/obj/item/reagent_containers/cup/beaker/vial,
-/obj/item/reagent_containers/cup/beaker/vial,
-/obj/item/reagent_containers/cup/beaker/vial,
-/obj/item/reagent_containers/cup/beaker/vial,
 /turf/open/floor/iron,
 /area/station/medical/virology)
 "wax" = (
@@ -115150,6 +115156,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "wmV" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -9113,6 +9113,7 @@
 	name = "Test Chamber";
 	req_access = list("xenobiology")
 	},
+/obj/structure/liquid_barrier,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "cYN" = (
@@ -17458,6 +17459,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "fSM" = (
@@ -27576,6 +27578,7 @@
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "jhq" = (
@@ -30875,6 +30878,7 @@
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/liquid_barrier,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "knX" = (
@@ -32337,6 +32341,7 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white/textured,
 /area/station/science/xenobiology/hallway)
 "kNJ" = (
@@ -45929,6 +45934,7 @@
 	name = "Cytology Pen"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "poG" = (
@@ -47108,6 +47114,7 @@
 	normalspeed = 0
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology)
 "pHr" = (
@@ -61798,6 +61805,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/liquid_barrier,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "uJk" = (
@@ -63387,6 +63395,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white/textured,
 /area/station/science/xenobiology/hallway)
 "vho" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -6366,6 +6366,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /obj/structure/cable,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "bxp" = (
@@ -14125,6 +14126,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "dpQ" = (
@@ -67000,6 +67002,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "pWd" = (
@@ -97846,6 +97849,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/delivery,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "xsP" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -26171,6 +26171,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
 "iwz" = (
@@ -52331,6 +52332,7 @@
 	req_access = list("xenobiology")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/obj/structure/liquid_barrier,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "qLX" = (
@@ -73165,6 +73167,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "xyx" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -16441,6 +16441,7 @@
 	},
 /obj/effect/turf_decal/tile/purple/full,
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/xenobiology)
 "fnu" = (
@@ -22076,6 +22077,7 @@
 	name = "Xenobiology Lab"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "hbf" = (
@@ -41623,6 +41625,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
 /obj/effect/mapping_helpers/airlock/access/any/science/genetics,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "nml" = (
@@ -53462,6 +53465,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "reT" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -16289,6 +16289,7 @@
 	name = "Xenobiology Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "ggi" = (
@@ -17331,6 +17332,7 @@
 	name = "Xenobio Pen 8 Blast Door"
 	},
 /obj/machinery/duct,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "gyK" = (
@@ -20910,6 +20912,7 @@
 	name = "Xenobio Pen 1 Blast Door"
 	},
 /obj/machinery/duct,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "hMy" = (
@@ -29894,6 +29897,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "kLF" = (
@@ -39945,6 +39949,7 @@
 	name = "Xenobio Pen 6 Blast Door"
 	},
 /obj/machinery/duct,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "ohE" = (
@@ -46562,6 +46567,7 @@
 	name = "Xenobiology Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "qAA" = (
@@ -46607,6 +46613,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "qBq" = (
@@ -48820,6 +48827,7 @@
 	name = "Xenobio Pen 4 Blast Door"
 	},
 /obj/machinery/duct,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "rrT" = (
@@ -49088,6 +49096,7 @@
 	name = "Maximum Security Test Chamber";
 	req_access = list("xenobiology")
 	},
+/obj/structure/liquid_barrier,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "rvL" = (
@@ -49148,6 +49157,7 @@
 	name = "Xenobio Pen 3 Blast Door"
 	},
 /obj/machinery/duct,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "rwE" = (
@@ -52545,6 +52555,7 @@
 	name = "Xenobio Pen 5 Blast Door"
 	},
 /obj/machinery/duct,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "sCz" = (
@@ -65509,6 +65520,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/engine,
 /area/station/science/cytology)
 "xfD" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -14939,6 +14939,10 @@
 	},
 /turf/open/floor/plastic,
 /area/station/engineering/break_room)
+"dIU" = (
+/obj/structure/liquid_barrier,
+/turf/open/space/basic,
+/area/space)
 "dIY" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -20988,6 +20992,7 @@
 	id = "containdeez2";
 	name = "Xenobiology Containment Blast Door"
 	},
+/obj/structure/liquid_barrier,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "fFx" = (
@@ -31656,6 +31661,7 @@
 	name = "Secure Pen"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "jge" = (
@@ -45571,6 +45577,7 @@
 	req_access = list("xenobiology")
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
+/obj/structure/liquid_barrier,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "nzh" = (
@@ -65863,6 +65870,7 @@
 	id = "containdeez6";
 	name = "Xenobiology Containment Blast Door"
 	},
+/obj/structure/liquid_barrier,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "tXY" = (
@@ -66414,6 +66422,7 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /obj/structure/disposalpipe/segment,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "uiI" = (
@@ -70370,6 +70379,7 @@
 	name = "Cytology Maintenance Hatch"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/catwalk_floor,
 /area/station/science/xenobiology)
 "vqn" = (
@@ -88201,7 +88211,7 @@ vXM
 vXM
 vXM
 vXM
-vXM
+dIU
 vXM
 vXM
 vXM

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -14939,10 +14939,6 @@
 	},
 /turf/open/floor/plastic,
 /area/station/engineering/break_room)
-"dIU" = (
-/obj/structure/liquid_barrier,
-/turf/open/space/basic,
-/area/space)
 "dIY" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -88211,7 +88207,7 @@ vXM
 vXM
 vXM
 vXM
-dIU
+vXM
 vXM
 vXM
 vXM

--- a/code/__DEFINES/dcs/signals/signals_turf.dm
+++ b/code/__DEFINES/dcs/signals/signals_turf.dm
@@ -28,6 +28,8 @@
 
 ///called on liquid creation
 #define COMSIG_TURF_LIQUIDS_CREATION "turf_liquids_creation"
+	/// Blocks the liquid from being created.
+	#define BLOCK_LIQUID_CREATION (1 << 0)
 
 #define COMSIG_TURF_MOB_FALL "turf_mob_fall"
 

--- a/code/__DEFINES/~monkestation/traits.dm
+++ b/code/__DEFINES/~monkestation/traits.dm
@@ -44,3 +44,5 @@
 // /turf/open
 /// If a trait is considered as having "coverage" by a meteor shield.
 #define TRAIT_COVERED_BY_METEOR_SHIELD		"covered_by_meteor_shield"
+/// Liquids cannot spread over this turf.
+#define TRAIT_BLOCK_LIQUID_SPREAD			"block_liquid_spread"

--- a/monkestation/code/modules/liquids/liquid_barrier.dm
+++ b/monkestation/code/modules/liquids/liquid_barrier.dm
@@ -1,0 +1,25 @@
+/obj/structure/liquid_barrier
+	name = "liquid barrier"
+	desc = "A complex draining mesh embedded in the flooring that blocks any and all liquids from passing through.\n<i>You feel like these were installed for a very good reason...</i>"
+	icon = 'monkestation/icons/obj/structures/drains.dmi'
+	icon_state = "bigdrain"
+	plane = FLOOR_PLANE
+	layer = GAS_SCRUBBER_LAYER
+	density = FALSE
+	anchored = TRUE
+	move_resist = INFINITY
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+
+/obj/structure/liquid_barrier/Initialize(mapload)
+	. = ..()
+	if(mapload && !isfloorturf(loc))
+		log_mapping("[src] mapped onto a non-floor turf at [AREACOORD(src)]!")
+	var/static/list/loc_connections = list(
+		COMSIG_TURF_LIQUIDS_CREATION = PROC_REF(on_liquid_creation),
+	)
+	AddElement(/datum/element/connect_loc, loc_connections)
+	AddElement(/datum/element/give_turf_traits, string_list(list(TRAIT_BLOCK_LIQUID_SPREAD)))
+
+/obj/structure/liquid_barrier/proc/on_liquid_creation(datum/source)
+	SIGNAL_HANDLER
+	return BLOCK_LIQUID_CREATION

--- a/monkestation/code/modules/liquids/liquid_effect.dm
+++ b/monkestation/code/modules/liquids/liquid_effect.dm
@@ -200,7 +200,8 @@
 	RegisterSignal(my_turf, COMSIG_TURF_MOB_FALL, PROC_REF(mob_fall))
 	RegisterSignal(my_turf, COMSIG_ATOM_EXAMINE, PROC_REF(examine_turf))
 
-	SEND_SIGNAL(my_turf, COMSIG_TURF_LIQUIDS_CREATION, src)
+	if(SEND_SIGNAL(my_turf, COMSIG_TURF_LIQUIDS_CREATION, src) & BLOCK_LIQUID_CREATION)
+		return INITIALIZE_HINT_QDEL
 
 	if(z)
 		QUEUE_SMOOTH(src)

--- a/monkestation/code/modules/liquids/liquid_groups.dm
+++ b/monkestation/code/modules/liquids/liquid_groups.dm
@@ -895,6 +895,8 @@ GLOBAL_VAR_INIT(liquid_debug_colors, FALSE)
 /datum/liquid_group/proc/spread_liquid(turf/new_turf, turf/source_turf)
 	if(isclosedturf(new_turf) || !source_turf.atmos_adjacent_turfs)
 		return
+	if(HAS_TRAIT(new_turf, TRAIT_BLOCK_LIQUID_SPREAD))
+		return
 	if(!(new_turf in source_turf.atmos_adjacent_turfs)) //i hate that this is needed
 		return
 	if(!source_turf.atmos_adjacent_turfs[new_turf])
@@ -904,7 +906,7 @@ GLOBAL_VAR_INIT(liquid_debug_colors, FALSE)
 		var/turf/Z_turf_below = GET_TURF_BELOW(new_turf)
 		if(!Z_turf_below)
 			return
-		if(isspaceturf(Z_turf_below))
+		if(isspaceturf(Z_turf_below) || HAS_TRAIT(Z_turf_below, TRAIT_BLOCK_LIQUID_SPREAD))
 			return FALSE
 		if(QDELETED(Z_turf_below.liquids))
 			Z_turf_below.liquids = new(Z_turf_below)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6755,6 +6755,7 @@
 #include "monkestation\code\modules\library\skill_learning\job_skillchips\shaft_miner.dm"
 #include "monkestation\code\modules\liquids\drains.dm"
 #include "monkestation\code\modules\liquids\height_floors.dm"
+#include "monkestation\code\modules\liquids\liquid_barrier.dm"
 #include "monkestation\code\modules\liquids\liquid_controller.dm"
 #include "monkestation\code\modules\liquids\liquid_effect.dm"
 #include "monkestation\code\modules\liquids\liquid_groups.dm"


### PR DESCRIPTION

## About The Pull Request

This adds "liquid barriers", which is basically a liquid-only version of tiny fans - they block all liquid flow and creation on their turf.

They're mapped very generously into xenobio, protecting every entrance/exit, xenobio containment, and non-corral pens.

![2024-06-25 (1719344737) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/79e0de96-b749-4278-92ba-fa72f0421ee0)
![2024-06-25 (1719344755) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/cf401419-0ed4-4ea8-aeff-6788fc0e8109)

## Why It's Good For The Game

Because after maxing out ooze production, all it takes is one accident for you to flood a good chunk of the station with ooze, as seen here:

https://github.com/Monkestation/Monkestation2.0/assets/65794972/c7a0bba6-5805-48c9-8ac7-275c78846731


## Changelog
:cl:
add: Added liquid barriers, currently mapped into xenobio, which block all liquid flow across them, hopefully preventing the dreaded station-wide ooze floods.
/:cl:
