### PR TITLE
Double the timeout on integration tests to help prevent timeouts where they otherwise wouldn't

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   run_integration_tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30 # Monkestation edit: Our CI takes nearly twice as long, so the timeout is twice as long
     services:
       mysql:
         image: mysql:latest


### PR DESCRIPTION
## About The Pull Request
I realized shortly after the workflow changes were merged that the integration tests in our CI takes nearly the whole 15 minute allotment that I ported over from tgstation.

This PR changes that timeout to 30 minutes, to hopefully curb this issue, until I can figure out if there's any way to significantly reduce the amount of time integration tests take.

## Changelog
N/A