### PR TITLE
[PORT] Fixes rescue chasm fishing (+ some qol)

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -6,12 +6,6 @@ GLOBAL_LIST_EMPTY(deadmins) //all ckeys who have used the de-admin verb.
 GLOBAL_LIST_EMPTY(directory) //all ckeys with associated client
 GLOBAL_LIST_EMPTY(stealthminID) //reference list with IDs that store ckeys, for stealthmins
 
-GLOBAL_LIST_INIT(dangerous_turfs, typecacheof(list(
-	/turf/open/lava,
-	/turf/open/chasm,
-	/turf/open/space,
-	/turf/open/openspace)))
-
 /// List of types of abstract mob which shouldn't usually exist in the world on its own if we're spawning random mobs
 GLOBAL_LIST_INIT(abstract_mob_types, list(
 	/mob/living/basic/blob_minion,

--- a/code/datums/ai/idle_behaviors/idle_random_walk.dm
+++ b/code/datums/ai/idle_behaviors/idle_random_walk.dm
@@ -10,7 +10,10 @@
 
 	if(SPT_PROB(walk_chance, seconds_per_tick) && (living_pawn.mobility_flags & MOBILITY_MOVE) && isturf(living_pawn.loc) && !living_pawn.pulledby)
 		var/move_dir = pick(GLOB.alldirs)
-		living_pawn.Move(get_step(living_pawn, move_dir), move_dir)
+		var/turf/destination_turf = get_step(living_pawn, move_dir)
+		if(!destination_turf?.can_cross_safely(living_pawn))
+			return
+		living_pawn.Move(destination_turf, move_dir)
 
 /datum/idle_behavior/idle_random_walk/less_walking
 	walk_chance = 10
@@ -69,7 +72,7 @@
 		var/turf/possible_step = get_step(living_pawn, direction)
 		if(get_dist(possible_step, target) > minimum_distance)
 			continue
-		if(possible_step.is_blocked_turf())
+		if(possible_step.is_blocked_turf() || !possible_step.can_cross_safely(living_pawn))
 			continue
 		possible_turfs += possible_step
 

--- a/code/datums/ai/movement/ai_movement_basic_avoidance.dm
+++ b/code/datums/ai/movement/ai_movement_basic_avoidance.dm
@@ -17,8 +17,8 @@
 	. = ..()
 	var/turf/target_turf = get_step_towards(source.moving, source.target)
 
-	if(is_type_in_typecache(target_turf, GLOB.dangerous_turfs))
-		. = FALSE
+	if(!target_turf?.can_cross_safely(source.moving))
+		. = MOVELOOP_SKIP_STEP
 	return .
 
 /// Move immediately and don't update our facing

--- a/code/datums/ai/movement/ai_movement_dumb.dm
+++ b/code/datums/ai/movement/ai_movement_dumb.dm
@@ -15,6 +15,6 @@
 	. = ..()
 	var/turf/target_turf = get_step_towards(source.moving, source.target)
 
-	if(is_type_in_typecache(target_turf, GLOB.dangerous_turfs))
-		. = FALSE
+	if(!target_turf?.can_cross_safely(source.moving))
+		. = MOVELOOP_SKIP_STEP
 	return .

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -235,13 +235,13 @@ GLOBAL_LIST_EMPTY(chasm_fallen_mobs)
 
 /obj/effect/abstract/chasm_storage/Entered(atom/movable/arrived)
 	. = ..()
-	if (isliving(arrived))
+	if(isliving(arrived))
 		RegisterSignal(arrived, COMSIG_LIVING_REVIVE, PROC_REF(on_revive))
 		GLOB.chasm_fallen_mobs += arrived
 
 /obj/effect/abstract/chasm_storage/Exited(atom/movable/gone)
 	. = ..()
-	if (isliving(gone))
+	if(isliving(gone))
 		UnregisterSignal(gone, COMSIG_LIVING_REVIVE)
 		GLOB.chasm_fallen_mobs -= gone
 

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -24,6 +24,7 @@
 		/obj/effect/light_emitter/tendril,
 		/obj/effect/collapse,
 		/obj/effect/particle_effect/ion_trails,
+		/obj/effect/particle_effect/sparks,
 		/obj/effect/dummy/phased_mob,
 		/obj/effect/mapping_helpers,
 		/obj/effect/wisp,
@@ -40,6 +41,7 @@
 	RegisterSignal(parent, COMSIG_ATOM_ABSTRACT_ENTERED, PROC_REF(entered))
 	RegisterSignal(parent, COMSIG_ATOM_ABSTRACT_EXITED, PROC_REF(exited))
 	RegisterSignal(parent, COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON, PROC_REF(initialized_on))
+	RegisterSignal(parent, COMSIG_ATOM_INTERCEPT_TELEPORTING, PROC_REF(block_teleport))
 	//allow catwalks to give the turf the CHASM_STOPPED trait before dropping stuff when the turf is changed.
 	//otherwise don't do anything because turfs and areas are initialized before movables.
 	if(!mapload)
@@ -60,6 +62,9 @@
 /datum/component/chasm/proc/initialized_on(datum/source, atom/movable/movable, mapload)
 	SIGNAL_HANDLER
 	drop_stuff(movable)
+
+/datum/component/chasm/proc/block_teleport()
+	return COMPONENT_BLOCK_TELEPORT
 
 /datum/component/chasm/proc/on_chasm_stopped(datum/source)
 	SIGNAL_HANDLER

--- a/code/datums/components/fishing_spot.dm
+++ b/code/datums/components/fishing_spot.dm
@@ -40,6 +40,8 @@
 	if(denial_reason)
 		to_chat(user, span_warning(denial_reason))
 		return COMPONENT_NO_AFTERATTACK
+	// In case the fishing source has anything else to do before beginning to fish.
+	fish_source.on_start_fishing(rod, user, parent)
 	start_fishing_challenge(rod, user)
 	return COMPONENT_NO_AFTERATTACK
 

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -66,6 +66,7 @@
 
 	if(!forced)
 		if(!check_teleport_valid(teleatom, destination, channel))
+			teleatom.balloon_alert(teleatom, "something holds you back!")
 			return FALSE
 
 	if(isobserver(teleatom))

--- a/code/game/turfs/open/chasm.dm
+++ b/code/game/turfs/open/chasm.dm
@@ -79,6 +79,9 @@
 /turf/open/chasm/proc/apply_components()
 	AddComponent(/datum/component/chasm, GET_TURF_BELOW(src))
 
+/turf/open/chasm/can_cross_safely(atom/movable/crossing)
+	return HAS_TRAIT(src, TRAIT_CHASM_STOPPED) || HAS_TRAIT(crossing, TRAIT_MOVE_FLYING)
+
 // Chasms for Lavaland, with planetary atmos and lava glow
 /turf/open/chasm/lavaland
 	initial_gas_mix = LAVALAND_DEFAULT_ATMOS

--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -324,6 +324,9 @@
 
 	return FALSE
 
+/turf/open/lava/can_cross_safely(atom/movable/crossing)
+	return HAS_TRAIT(src, TRAIT_LAVA_STOPPED) || HAS_TRAIT(crossing, immunity_trait ) || HAS_TRAIT(crossing, TRAIT_MOVE_FLYING)
+
 /turf/open/lava/smooth
 	name = "lava"
 	baseturfs = /turf/open/lava/smooth

--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -162,6 +162,9 @@
 	PlaceOnTop(/turf/open/floor/plating, flags = flags)
 	PlaceOnTop(new_floor_path, flags = flags)
 
+/turf/open/openspace/can_cross_safely(atom/movable/crossing)
+	return HAS_TRAIT(crossing, TRAIT_MOVE_FLYING)
+
 /turf/open/openspace/icemoon
 	name = "ice chasm"
 	baseturfs = /turf/open/openspace/icemoon

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -250,6 +250,9 @@ GLOBAL_VAR_INIT(starlight_color, pick(COLOR_TEAL, COLOR_GREEN, COLOR_CYAN, COLOR
 	destination_y = dest_y
 	destination_z = dest_z
 
+/turf/open/space/can_cross_safely(atom/movable/crossing)
+	return HAS_TRAIT(crossing, TRAIT_SPACEWALK)
+
 /turf/open/space/openspace
 	icon = 'icons/turf/floors.dmi'
 	icon_state = MAP_SWITCH("pure_white", "invisible")

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -766,3 +766,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 	explosive_resistance -= get_explosive_block()
 	inherent_explosive_resistance = explosion_block
 	explosive_resistance += get_explosive_block()
+
+/// Returns whether it is safe for an atom to move across this turf
+/turf/proc/can_cross_safely(atom/movable/crossing)
+	return TRUE

--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -40,22 +40,21 @@ GLOBAL_LIST_INIT_TYPED(chasm_detritus_types, /datum/chasm_detritus, init_chasm_d
 		),
 	)
 
-/datum/chasm_detritus/proc/dispense_reward(turf/fishing_spot, turf/fisher_turf)
-	if (prob(default_contents_chance))
+/datum/chasm_detritus/proc/dispense_detritus(mob/fisherman, turf/fishing_spot)
+	if(prob(default_contents_chance))
 		var/default_spawn = pick(default_contents[default_contents_key])
-		return new default_spawn(fisher_turf)
-	return find_chasm_contents(fishing_spot, fisher_turf)
+		return new default_spawn(get_turf(fisherman))
+	return find_chasm_contents(fishing_spot, get_turf(fisherman))
 
 /// Returns the chosen detritus from the given list of things to choose from
 /datum/chasm_detritus/proc/determine_detritus(list/chasm_stuff)
 	return pick(chasm_stuff)
 
-/// Returns an objected which is currently inside of a nearby chasm.
-/datum/chasm_detritus/proc/find_chasm_contents(datum/source, turf/fishing_spot, turf/fisher_turf)
-	SIGNAL_HANDLER
+/// Returns an object which is currently inside of a nearby chasm.
+/datum/chasm_detritus/proc/find_chasm_contents(turf/fishing_spot, turf/fisher_turf)
 	var/list/chasm_contents = get_chasm_contents(fishing_spot)
 
-	if (!length(chasm_contents))
+	if(!length(chasm_contents))
 		var/default_spawn = pick(default_contents[default_contents_key])
 		return new default_spawn(fisher_turf)
 
@@ -63,7 +62,7 @@ GLOBAL_LIST_INIT_TYPED(chasm_detritus_types, /datum/chasm_detritus, init_chasm_d
 
 /datum/chasm_detritus/proc/get_chasm_contents(turf/fishing_spot)
 	. = list()
-	for (var/obj/effect/abstract/chasm_storage/storage in range(5, fishing_spot))
+	for(var/obj/effect/abstract/chasm_storage/storage in range(5, fishing_spot))
 		for (var/thing as anything in storage.contents)
 			. += thing
 
@@ -76,7 +75,7 @@ GLOBAL_LIST_INIT_TYPED(chasm_detritus_types, /datum/chasm_detritus, init_chasm_d
 
 /datum/chasm_detritus/restricted/get_chasm_contents(turf/fishing_spot)
 	. = list()
-	for (var/obj/effect/abstract/chasm_storage/storage in range(5, fishing_spot))
+	for(var/obj/effect/abstract/chasm_storage/storage in range(5, fishing_spot))
 		for (var/thing as anything in storage.contents)
 			if(!istype(thing, chasm_storage_restricted_type))
 				continue

--- a/code/modules/fishing/fish/chasm_detritus.dm
+++ b/code/modules/fishing/fish/chasm_detritus.dm
@@ -40,24 +40,24 @@ GLOBAL_LIST_INIT_TYPED(chasm_detritus_types, /datum/chasm_detritus, init_chasm_d
 		),
 	)
 
-/datum/chasm_detritus/proc/dispense_reward(turf/fishing_spot)
+/datum/chasm_detritus/proc/dispense_reward(turf/fishing_spot, turf/fisher_turf)
 	if (prob(default_contents_chance))
 		var/default_spawn = pick(default_contents[default_contents_key])
-		return new default_spawn(fishing_spot)
-	return find_chasm_contents(fishing_spot)
+		return new default_spawn(fisher_turf)
+	return find_chasm_contents(fishing_spot, fisher_turf)
 
 /// Returns the chosen detritus from the given list of things to choose from
 /datum/chasm_detritus/proc/determine_detritus(list/chasm_stuff)
 	return pick(chasm_stuff)
 
 /// Returns an objected which is currently inside of a nearby chasm.
-/datum/chasm_detritus/proc/find_chasm_contents(datum/source, turf/fishing_spot)
+/datum/chasm_detritus/proc/find_chasm_contents(datum/source, turf/fishing_spot, turf/fisher_turf)
 	SIGNAL_HANDLER
 	var/list/chasm_contents = get_chasm_contents(fishing_spot)
 
 	if (!length(chasm_contents))
 		var/default_spawn = pick(default_contents[default_contents_key])
-		return new default_spawn(fishing_spot)
+		return new default_spawn(fisher_turf)
 
 	return determine_detritus(chasm_contents)
 

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -169,21 +169,24 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 			fish_table -= reward_path
 
 	var/atom/movable/reward = spawn_reward(reward_path, fisherman, fishing_spot)
-	if(!reward) //baloon alert instead
+	if(!reward) //balloon alert instead
 		fisherman.balloon_alert(fisherman,pick(duds))
 		return
 	if(isitem(reward)) //Try to put it in hand
 		INVOKE_ASYNC(fisherman, TYPE_PROC_REF(/mob, put_in_hands), reward)
+	else // for fishing things like corpses, move them to the turf of the fisherman
+		INVOKE_ASYNC(reward, TYPE_PROC_REF(/atom/movable, forceMove), get_turf(fisherman))
 	fisherman.balloon_alert(fisherman, "caught [reward]!")
+
 	SEND_SIGNAL(fisherman, COMSIG_MOB_FISHING_REWARD_DISPENSED, reward)
 	return reward
 
 /// Spawns a reward from a atom path right where the fisherman is. Part of the dispense_reward() logic.
-/datum/fish_source/proc/spawn_reward(reward_path, mob/fisherman,  turf/fishing_spot)
+/datum/fish_source/proc/spawn_reward(reward_path, mob/fisherman, turf/fishing_spot)
 	if(reward_path == FISHING_DUD)
 		return
 	if(ispath(reward_path, /datum/chasm_detritus))
-		return GLOB.chasm_detritus_types[reward_path].dispense_reward(fishing_spot, get_turf(fisherman))
+		return GLOB.chasm_detritus_types[reward_path].dispense_detritus(fisherman, fishing_spot)
 	if(!ispath(reward_path, /atom/movable))
 		CRASH("Unsupported /datum path [reward_path] passed to fish_source/proc/spawn_reward()")
 	var/atom/movable/reward = new reward_path(get_turf(fisherman))

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -183,7 +183,7 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 	if(reward_path == FISHING_DUD)
 		return
 	if(ispath(reward_path, /datum/chasm_detritus))
-		return GLOB.chasm_detritus_types[reward_path].dispense_reward(fishing_spot)
+		return GLOB.chasm_detritus_types[reward_path].dispense_reward(fishing_spot, get_turf(fisherman))
 	if(!ispath(reward_path, /atom/movable))
 		CRASH("Unsupported /datum path [reward_path] passed to fish_source/proc/spawn_reward()")
 	var/atom/movable/reward = new reward_path(get_turf(fisherman))

--- a/code/modules/fishing/sources/_fish_source.dm
+++ b/code/modules/fishing/sources/_fish_source.dm
@@ -69,6 +69,10 @@ GLOBAL_LIST_INIT(specific_fish_icons, zebra_typecacheof(list(
 /datum/fish_source/proc/reason_we_cant_fish(obj/item/fishing_rod/rod, mob/fisherman)
 	return rod.reason_we_cant_fish(src)
 
+/// Called below above proc, in case the fishing source has anything to do that isn't denial
+/datum/fish_source/proc/on_start_fishing(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
+	return
+
 /**
  * Calculates the difficulty of the minigame:
  *

--- a/code/modules/fishing/sources/source_types.dm
+++ b/code/modules/fishing/sources/source_types.dm
@@ -193,6 +193,13 @@
 
 	fishing_difficulty = FISHING_DEFAULT_DIFFICULTY + 5
 
+/datum/fish_source/chasm/on_start_fishing(obj/item/fishing_rod/rod, mob/fisherman, atom/parent)
+	. = ..()
+	if(istype(rod.hook, /obj/item/fishing_hook/rescue))
+		to_chat(fisherman, span_notice("The rescue hook falls straight down the chasm! Hopefully it catches a corpse."))
+		return
+	to_chat(fisherman, span_danger("Your fishing hook makes a soft 'thud' noise as it gets stuck on the wall of the chasm. It doesn't look like it's going to catch much of anything, except maybe some detritus."))
+
 /datum/fish_source/chasm/roll_reward(obj/item/fishing_rod/rod, mob/fisherman)
 	var/rolled_reward = ..()
 
@@ -200,6 +207,8 @@
 		return rolled_reward
 
 	return rod.hook.chasm_detritus_type
+
+/datum/fish_source/chasm
 
 /datum/fish_source/lavaland
 	catalog_description = "Lava vents"

--- a/code/modules/mob_spawn/corpses/species_corpses.dm
+++ b/code/modules/mob_spawn/corpses/species_corpses.dm
@@ -2,6 +2,8 @@
 //corpses that only differentiate themselves by representing a species
 
 /obj/effect/mob_spawn/corpse/human/skeleton
+	//these are also fished in chasms so it wouldn't hurt giving them an apter name than "mob spawner"
+	name = "skeleton"
 	mob_species = /datum/species/skeleton
 
 /obj/effect/mob_spawn/corpse/human/zombie


### PR DESCRIPTION

## About The Pull Request

Ports:
- https://github.com/tgstation/tgstation/pull/78111
- https://github.com/tgstation/tgstation/pull/78418
- https://github.com/tgstation/tgstation/pull/80102
- https://github.com/tgstation/tgstation/pull/79428
- https://github.com/tgstation/tgstation/pull/83781

## Changelog
:cl:
fix: (Ghommie) Fixed fishing skeleton mob spawners that immediately crumble back into the void of whatever chasm you fished them from.
fix: (vinylspiders) Rescue hooks will once again drop the mob next to the fisherman instead of just displaying a balloon alert and doing nothing.
balance: (Tattle) You can no longer teleport into chasms.
fix: (lizardqueenlexi) Basic mobs will no longer randomly walk into terrain that harms or kills them.
qol: (carlarctg) Adds a chat message for fishing in a chasm with a normal and rescue hook, to clarify that only rescue hooks can drag up corpses.
/:cl:
