### PR TITLE
[PORT] Fix organs being replaced when not needed

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -422,9 +422,12 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				qdel(existing_organ)
 			continue
 
-		if(!isnull(old_species) && !isnull(existing_organ))
-			if(existing_organ.type != old_species.get_mutant_organ_type_for_slot(slot))
-				continue // we don't want to remove organs that are not the default for this species
+		// we don't want to remove organs that are not the default for this species
+		if(!isnull(existing_organ))
+			if(!isnull(old_species) && existing_organ.type != old_species.get_mutant_organ_type_for_slot(slot))
+				continue
+			else if(!replace_current && existing_organ.type != get_mutant_organ_type_for_slot(slot))
+				continue
 
 		// at this point we already know new_organ is not null
 		if(existing_organ?.type == new_organ)


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/81575

## Changelog
:cl: 00-Steven
fix: Ethereal heart revive doesn't delete organs alien to your species, like prosthetics, cybernetics, and possibly itself.
fix: Nightmare heart revive doesn't delete organs alien to your species, like itself, upon which it would stop the conversion to shadowperson.
fix: Bloodsucker torpor, doesn't delete organs alien to your species, which would result in things such as wings being lost (therefore preventing ultrakill jokes from lasting more than 10 minutes)
/:cl:
