### PR TITLE
Spears are pointy, and have better wound bonus.

### DIFF
--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -21,8 +21,8 @@
 	sharpness = SHARP_POINTY // Monke, spears are actually pointy.
 	max_integrity = 200
 	armor_type = /datum/armor/item_spear
-	wound_bonus = 10 // Monke, spears have better wound bonus.
-	bare_wound_bonus = 5 // Monke, reduced bare wound bonus to compensate for better wound bonus.
+	wound_bonus = 8 // Monke, spears have better wound bonus.
+	bare_wound_bonus = 4 // Monke, reduced bare wound bonus to compensate for better wound bonus.
 	/// For explosive spears, what we cry out when we use this to bap someone
 	var/war_cry = "AAAAARGH!!!"
 	/// The icon prefix for this flavor of spear
@@ -81,7 +81,7 @@
 			throw_range = 8
 			throw_speed = 5
 			custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT, /datum/material/alloy/titaniumglass= HALF_SHEET_MATERIAL_AMOUNT * 2)
-			wound_bonus = 15 // Monke, spears have better wound bonus.
+			wound_bonus = 12 // Monke, spears have better wound bonus.
 			force_unwielded = 13
 			force_wielded = 18
 			icon_prefix = "speartitanium"
@@ -92,8 +92,8 @@
 			throw_range = 9
 			throw_speed = 5
 			custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT, /datum/material/alloy/plastitaniumglass= HALF_SHEET_MATERIAL_AMOUNT * 2)
-			wound_bonus = 15 // Monke, spears have better wound bonus.
-			bare_wound_bonus = 10 // Monke, reduced bare wound bonus to compensate for better wound bonus.
+			wound_bonus = 12 // Monke, spears have better wound bonus.
+			bare_wound_bonus = 8 // Monke, reduced bare wound bonus to compensate for better wound bonus.
 			force_unwielded = 13
 			force_wielded = 20
 			icon_prefix = "spearplastitanium"

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -18,11 +18,11 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("attacks", "pokes", "jabs", "tears", "lacerates", "gores")
 	attack_verb_simple = list("attack", "poke", "jab", "tear", "lacerate", "gore")
-	sharpness = SHARP_EDGED // i know the whole point of spears is that they're pointy, but edged is more devastating at the moment so
+	sharpness = SHARP_POINTY // Monke, spears are actually pointy.
 	max_integrity = 200
 	armor_type = /datum/armor/item_spear
-	wound_bonus = -15
-	bare_wound_bonus = 15
+	wound_bonus = 10 // Monke, spears have better wound bonus.
+	bare_wound_bonus = 5 // Monke, reduced bare wound bonus to compensate for better wound bonus.
 	/// For explosive spears, what we cry out when we use this to bap someone
 	var/war_cry = "AAAAARGH!!!"
 	/// The icon prefix for this flavor of spear
@@ -81,7 +81,7 @@
 			throw_range = 8
 			throw_speed = 5
 			custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT, /datum/material/alloy/titaniumglass= HALF_SHEET_MATERIAL_AMOUNT * 2)
-			wound_bonus = -10
+			wound_bonus = 15 // Monke, spears have better wound bonus.
 			force_unwielded = 13
 			force_wielded = 18
 			icon_prefix = "speartitanium"
@@ -92,8 +92,8 @@
 			throw_range = 9
 			throw_speed = 5
 			custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT, /datum/material/alloy/plastitaniumglass= HALF_SHEET_MATERIAL_AMOUNT * 2)
-			wound_bonus = -10
-			bare_wound_bonus = 20
+			wound_bonus = 15 // Monke, spears have better wound bonus.
+			bare_wound_bonus = 10 // Monke, reduced bare wound bonus to compensate for better wound bonus.
 			force_unwielded = 13
 			force_wielded = 20
 			icon_prefix = "spearplastitanium"


### PR DESCRIPTION
## About The Pull Request
- Buffed all spears' wound bonus.
- Compensated with a reduction in bare wound bonus.
- Spears are pointy sharp instead of edge sharp.
Could change values if needed.

## Why It's Good For The Game
Spears have oddly low wound bonuses, with the default spear having -15 wound bonus, and 15 bare wound bonus. Compare that to the circular saw, which has 15 wound bonus and 10 bare wound bonus. It can be very difficult to actually wound someone while using spears.
It's not good that a purpose built weapon, that is annoying to carry, is worse at wounding than some random tool anyone can just print in two seconds and stuff in their bag for if they ever happen to see a valid.
Also, the entire point of a spear is to be pointy, so it makes no sense to have spears be edged sharp instead of pointy sharp.


## Changelog
:cl:
balance: Spears are better at wounding.
tweak: Spears are pointy now.
/:cl:
