### PR TITLE
Meteor satellites now longer shake the camera

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -514,7 +514,7 @@ SUBSYSTEM_DEF(explosions)
  * - [creaking_sound][/sound]: The sound that plays when the station creaks during the explosion.
  * - [hull_creaking_sound][/sound]: The sound that plays when the station creaks after the explosion.
  */
-/datum/controller/subsystem/explosions/proc/shake_the_room(turf/epicenter, near_distance, far_distance, quake_factor, echo_factor, creaking, sound/near_sound = sound(get_sfx(SFX_EXPLOSION)), sound/far_sound = sound('sound/effects/explosionfar.ogg'), sound/echo_sound = sound('sound/effects/explosion_distant.ogg'), sound/creaking_sound = sound(get_sfx(SFX_EXPLOSION_CREAKING)), hull_creaking_sound = sound(get_sfx(SFX_HULL_CREAKING)), pressure_affected = TRUE) // monkestation edit: add pressure_affected
+/datum/controller/subsystem/explosions/proc/shake_the_room(turf/epicenter, near_distance, far_distance, quake_factor, echo_factor, creaking, sound/near_sound = sound(get_sfx(SFX_EXPLOSION)), sound/far_sound = sound('sound/effects/explosionfar.ogg'), sound/echo_sound = sound('sound/effects/explosion_distant.ogg'), sound/creaking_sound = sound(get_sfx(SFX_EXPLOSION_CREAKING)), hull_creaking_sound = sound(get_sfx(SFX_HULL_CREAKING)), pressure_affected = TRUE, disable_shaking = FALSE) // monkestation edit: add pressure_affected, disable_shaking
 	var/frequency = get_rand_frequency()
 	var/blast_z = epicenter.z
 	if(isnull(creaking)) // Autoset creaking.
@@ -536,7 +536,7 @@ SUBSYSTEM_DEF(explosions)
 
 		if(distance <= round(near_distance + world.view - 2, 1)) // If you are close enough to see the effects of the explosion first-hand (ignoring walls)
 			listener.playsound_local(epicenter, null, 100, TRUE, frequency, pressure_affected = pressure_affected, sound_to_use = near_sound) // monkestation edit: pressure_affected
-			if(base_shake_amount > 0)
+			if(base_shake_amount > 0 && !disable_shaking) // monkestation edit: disable_shaking
 				shake_camera(listener, NEAR_SHAKE_DURATION, clamp(base_shake_amount, 0, NEAR_SHAKE_CAP))
 
 		else if(distance < far_distance) // You can hear a far explosion if you are outside the blast radius. Small explosions shouldn't be heard throughout the station.
@@ -548,7 +548,7 @@ SUBSYSTEM_DEF(explosions)
 			else
 				listener.playsound_local(epicenter, null, far_volume, TRUE, frequency, pressure_affected = pressure_affected, sound_to_use = echo_sound, distance_multiplier = 0) // monkestation edit: pressure_affected
 
-			if(base_shake_amount || quake_factor)
+			if(!disable_shaking && (base_shake_amount || quake_factor)) // monkestation edit: disable_shaking
 				base_shake_amount = max(base_shake_amount, quake_factor * 3, 0) // Devastating explosions rock the station and ground
 				shake_camera(listener, FAR_SHAKE_DURATION, min(base_shake_amount, FAR_SHAKE_CAP))
 
@@ -556,7 +556,8 @@ SUBSYSTEM_DEF(explosions)
 			var/echo_volume
 			if(quake_factor)
 				echo_volume = 60
-				shake_camera(listener, FAR_SHAKE_DURATION, clamp(quake_factor / 4, 0, FAR_SHAKE_CAP))
+				if(!disable_shaking) // monkestation edit: disable_shaking
+					shake_camera(listener, FAR_SHAKE_DURATION, clamp(quake_factor / 4, 0, FAR_SHAKE_CAP))
 			else
 				echo_volume = 40
 			listener.playsound_local(epicenter, null, echo_volume, TRUE, frequency, pressure_affected = pressure_affected, sound_to_use = echo_sound, distance_multiplier = 0) // monkestation edit: pressure_affected

--- a/monkestation/code/modules/meteor_shield/meteor_shield_zap.dm
+++ b/monkestation/code/modules/meteor_shield/meteor_shield_zap.dm
@@ -42,5 +42,6 @@
 		creaking = FALSE,
 		near_sound = sound('sound/weapons/lasercannonfire.ogg'),
 		far_sound = sound('sound/weapons/marauder.ogg'),
-		pressure_affected = FALSE
+		pressure_affected = FALSE,
+		disable_shaking = TRUE
 	)


### PR DESCRIPTION

## About The Pull Request

They weren't intended to in the first place, it's just that `SSexplosions.shake_the_room` never really expected to be used _only_ for the sound functionality, and not the shaking.

## Changelog
:cl:
fix: Meteor satellites now longer shake the camera.
/:cl:
