### PR TITLE
Gives ashwalkers hard soles and adds a new quirk

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -30,6 +30,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Quadruple Amputee", "Paraplegic"),
 		list("Quadruple Amputee", "Frail"),
 		list("Gigantism", "Dwarfism"),
+		list("Light Step","Hardened Soles"), //MONKESTATION ADDITION
 		list("Social Anxiety", "Mute"),
 		list("Mute", "Soft-Spoken"),
 		list("Stormtrooper Aim", "Big Hands"),

--- a/code/datums/quirks/positive_quirks.dm
+++ b/code/datums/quirks/positive_quirks.dm
@@ -157,7 +157,7 @@
 	name = "Light Step"
 	desc = "You walk with a gentle step; footsteps and stepping on sharp objects is quieter and less painful. Also, your hands and clothes will not get messed in case of stepping in blood."
 	icon = FA_ICON_SHOE_PRINTS
-	value = 4
+	value = 2 //MONKESTATION EDIT: changed 4 to 2 (on pair with hardned soles, the difference is less bloody clothes vs no knockdown when stepping on glass)
 	mob_trait = TRAIT_LIGHT_STEP
 	gain_text = span_notice("You walk with a little more litheness.")
 	lose_text = span_danger("You start tromping around like a barbarian.")

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -135,6 +135,7 @@ Lizard subspecies: ASHWALKERS
 	inherent_traits = list(
 		//TRAIT_LITERATE,
 		TRAIT_VIRUSIMMUNE,
+		TRAIT_HARD_SOLES //MONKESTATION ADDITION
 	)
 	species_language_holder = /datum/language_holder/lizard/ash
 	/*digitigrade_customization = DIGITIGRADE_FORCED*/ //MONKESTATION REMOVAL: not needed

--- a/monkestation/code/datums/quirks/positive_quirks.dm
+++ b/monkestation/code/datums/quirks/positive_quirks.dm
@@ -48,6 +48,17 @@
 	var/mob/living/carbon/human/holder = quirk_holder
 	holder.max_food_buffs --
 
+
+/datum/quirk/hardened_soles
+	name = "Hardened Soles"
+	desc = "You're used to walking barefoot, and won't receive the negative effects of doing so."
+	value = 2
+	mob_trait = TRAIT_HARD_SOLES
+	gain_text = span_notice("The ground doesn't feel so rough on your feet anymore.")
+	lose_text = span_danger("You start feeling the ridges and imperfections on the ground.")
+	medical_record_text = "Patient's feet are more resilient against traction."
+	icon = FA_ICON_LINES_LEANING
+
 /datum/quirk/fluffy_tongue
 	name = "Fluffy Tongue"
 	desc = "After spending too much time watching anime you have developed a horrible speech impediment."

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/lizardpeople.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/lizardpeople.dm
@@ -1,6 +1,11 @@
 /datum/species/lizard
 	payday_modifier = 1
-
+	special_step_sounds = list(
+		'sound/effects/footstep/hardclaw1.ogg',
+		'sound/effects/footstep/hardclaw2.ogg',
+		'sound/effects/footstep/hardclaw3.ogg',
+		'sound/effects/footstep/hardclaw4.ogg',
+	)
 /datum/species/lizard/get_scream_sound(mob/living/carbon/human/human)
 	if(human.gender ==MALE)
 		return pick(


### PR DESCRIPTION

## About The Pull Request
Ashwalkers will no longer get paralyzed when they step on a cacti in their base, changed lizard footsteps to claws (more fitting with their footprints) and added a quirk that makes you immune to glass shards and stuff (costs 2 points)
## Why It's Good For The Game
Makes a satyr trait useable for others if they choose to do so, ashwalkers will no longer fuckin die while they step on a cactus (lol), makes lizard footsteps sounds less meaty.
## Changelog
:cl:
add: Added hard soles to ashwalkers (they no longer get paralyzed when stepping on their cati)
add: Added hard soles as a quirk (2 points)
balance: Changed light step cost to 2 points to be on pair with hard soles
sound: Changed lizard footsteps to claws
/:cl:
