### PR TITLE
Fix runtimes related to opt-in checking

### DIFF
--- a/monkestation/code/modules/blueshift/optin/objectives.dm
+++ b/monkestation/code/modules/blueshift/optin/objectives.dm
@@ -8,6 +8,9 @@
 
 /// Returns whether or not our opt in levels/variables are correct for the target. If true, they can be picked as a target.
 /datum/objective/proc/opt_in_valid(datum/mind/target_mind)
+	if(ismob(target_mind))
+		var/mob/target_mob = target_mind
+		target_mind = target_mob.mind
 	return (get_opt_in_level(target_mind) <= target_mind.get_effective_opt_in_level())
 
 // ROUND REMOVE


### PR DESCRIPTION

## About The Pull Request

Related:
```
[2024-07-01 20:07:45.732] runtime error: undefined proc or verb /mob/living/carbon/human/get effective opt in level().
 - 
 - proc name: opt in valid (/datum/objective/proc/opt_in_valid)
 -   source file: monkestation/code/modules/blueshift/optin/objectives.dm,11
 -   usr: null
 -   src: generic objective (/datum/objective/sacrifice)
 -   call stack:
 - generic objective (/datum/objective/sacrifice): opt in valid(Shion Rosenthal (/mob/living/carbon/human))
 - generic objective (/datum/objective/sacrifice): find target(null, null)
 - Cult (/datum/team/cult): setup objectives()
 - /datum/round_event/antagonist/... (/datum/round_event/antagonist/solo/bloodcult): start()
 - /datum/round_event/antagonist/... (/datum/round_event/antagonist/solo/bloodcult): process(2)
 - Events (/datum/controller/subsystem/events): fire(0)
 - Events (/datum/controller/subsystem/events): ignite(0)
 - Master (/datum/controller/master): RunQueue()
 - Master (/datum/controller/master): Loop(2)
 - Master (/datum/controller/master): StartProcessing(0)
```

## Changelog
:cl:
fix: Fixed some errors with some objectives, i.e cult sacrifice, trying to find a target.
/:cl:
