### PR TITLE
Fix newly built slime pens allowing ooze to leak

### DIFF
--- a/monkestation/code/modules/slimecore/corral/corral_data.dm
+++ b/monkestation/code/modules/slimecore/corral/corral_data.dm
@@ -14,6 +14,7 @@
 
 /datum/corral_data/proc/setup_pen()
 	for(var/turf/turf as anything in corral_turfs)
+		turf.air_update_turf(update = TRUE, remove = FALSE)
 		RegisterSignal(turf, COMSIG_ATOM_ENTERED, PROC_REF(check_entered))
 		RegisterSignal(turf, COMSIG_ATOM_EXITED, PROC_REF(check_exited))
 
@@ -30,6 +31,9 @@
 
 /datum/corral_data/Destroy(force, ...)
 	QDEL_LIST(corral_connectors)
+	for(var/turf/turf as anything in corral_turfs)
+		if(!QDELETED(turf))
+			turf.air_update_turf(update = TRUE, remove = FALSE)
 	corral_turfs = null
 
 	for(var/obj/machinery/corral_corner/corner as anything in corral_corners)


### PR DESCRIPTION

## About The Pull Request

Whenever a pen is setup, this runs `air_update_turf` on all the turfs managed by said pen.

## Changelog
:cl:
fix: Fixed newly built slime pens allowing ooze to leak.
/:cl:
