### PR TITLE
RPLD UI now shows the sprites for new xenobio stuff

### DIFF
--- a/code/modules/asset_cache/assets/plumbing.dm
+++ b/code/modules/asset_cache/assets/plumbing.dm
@@ -36,6 +36,15 @@
 			"synthesizer_booze",
 			"tap_output",
 		),
+		/* monkestation start: xenobiology rework */
+		'monkestation/code/modules/slimecore/icons/machinery.dmi' = list(
+			"cross_compressor",
+			"ooze_sucker",
+		),
+		'monkestation/code/modules/slimecore/icons/slime_grinder.dmi' = list(
+			"slime_grinder_backdrop",
+		),
+		/* monkestation end */
 	)
 
 	for(var/icon_file as anything in essentials)


### PR DESCRIPTION

## About The Pull Request

![2024-07-02 (1719968255) ~ dreamseeker](https://github.com/Monkestation/Monkestation2.0/assets/65794972/f8eccb19-a648-4c1b-88ac-b2fdcba80a31)


## Changelog
:cl:
fix: RPLD UI now actually shows the sprites for new xenobio stuff, rather than a generic sprite.
/:cl:
