### PR TITLE
You can no longer somehow reach *around* a shield wall

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -487,6 +487,7 @@
 	density = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	light_outer_range = 3
+	pass_flags_self = parent_type::pass_flags_self & ~LETPASSCLICKS // monkestation edit: no you can't reach around the impenetrable shield
 	var/needs_power = FALSE
 	var/obj/machinery/power/shieldwallgen/gen_primary
 	var/obj/machinery/power/shieldwallgen/gen_secondary

--- a/code/modules/power/singularity/containment_field.dm
+++ b/code/modules/power/singularity/containment_field.dm
@@ -14,6 +14,7 @@
 	can_atmos_pass = ATMOS_PASS_NO
 	light_outer_range = 4
 	layer = ABOVE_OBJ_LAYER
+	pass_flags_self = parent_type::pass_flags_self & ~LETPASSCLICKS // monkestation edit: no you can't reach around the impenetrable shield
 	///First of the generators producing the containment field
 	var/obj/machinery/field/generator/field_gen_1 = null
 	///Second of the generators producing the containment field


### PR DESCRIPTION
## About The Pull Request

https://github.com/Monkestation/Monkestation2.0/assets/65794972/8326fd03-b70e-45a5-befe-eb30298057c1

## Why It's Good For The Game

Because a weird game mechanic can result in a xenobio escape, especially on some maps like Blueshift, when it doens't even make sense that you can reach AROUND the shield **wall**.

## Changelog
:cl:
fix: You can no longer somehow reach *around* a shield wall.
/:cl:
