### PR TITLE
You cannot print AI or Cyborg uploads, and you cannot print robotics control console board either.

### DIFF
--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -46,7 +46,29 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-// Monke, you cannot print upload boards.
+/*
+/datum/design/board/aiupload
+	name = "AI Upload Board"
+	desc = "Allows for the construction of circuit boards used to build an AI Upload Console."
+	id = "aiupload"
+	materials = list(/datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold =SHEET_MATERIAL_AMOUNT, /datum/material/diamond =SHEET_MATERIAL_AMOUNT, /datum/material/bluespace =SHEET_MATERIAL_AMOUNT)
+	build_path = /obj/item/circuitboard/computer/aiupload
+	category = list(
+		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_ROBOTICS
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/board/borgupload
+	name = "Cyborg Upload Board"
+	desc = "Allows for the construction of circuit boards used to build a Cyborg Upload Console."
+	id = "borgupload"
+	materials = list(/datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold =SHEET_MATERIAL_AMOUNT, /datum/material/diamond =SHEET_MATERIAL_AMOUNT, /datum/material/bluespace =SHEET_MATERIAL_AMOUNT)
+	build_path = /obj/item/circuitboard/computer/borgupload
+	category = list(
+		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_ROBOTICS
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+*/
 
 /datum/design/board/med_data
 	name = "Medical Records Board"
@@ -129,7 +151,18 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
 
-// Monke, cannot print robotics control console.
+/* Monke, cannot print robot control console board.
+/datum/design/board/robocontrol
+	name = "Robotics Control Console Board"
+	desc = "Allows for the construction of circuit boards used to build a Robotics Control console."
+	id = "robocontrol"
+	materials = list(/datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/bluespace =SHEET_MATERIAL_AMOUNT)
+	build_path = /obj/item/circuitboard/computer/robotics
+	category = list(
+		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_ROBOTICS
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+*/
 
 /datum/design/board/slot_machine
 	name = "Slot Machine Board"

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -46,27 +46,7 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
-/datum/design/board/aiupload
-	name = "AI Upload Board"
-	desc = "Allows for the construction of circuit boards used to build an AI Upload Console."
-	id = "aiupload"
-	materials = list(/datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold =SHEET_MATERIAL_AMOUNT, /datum/material/diamond =SHEET_MATERIAL_AMOUNT, /datum/material/bluespace =SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/circuitboard/computer/aiupload
-	category = list(
-		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_ROBOTICS
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
-
-/datum/design/board/borgupload
-	name = "Cyborg Upload Board"
-	desc = "Allows for the construction of circuit boards used to build a Cyborg Upload Console."
-	id = "borgupload"
-	materials = list(/datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold =SHEET_MATERIAL_AMOUNT, /datum/material/diamond =SHEET_MATERIAL_AMOUNT, /datum/material/bluespace =SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/circuitboard/computer/borgupload
-	category = list(
-		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_ROBOTICS
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+// Monke, you cannot print upload boards.
 
 /datum/design/board/med_data
 	name = "Medical Records Board"
@@ -149,16 +129,7 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING
 
-/datum/design/board/robocontrol
-	name = "Robotics Control Console Board"
-	desc = "Allows for the construction of circuit boards used to build a Robotics Control console."
-	id = "robocontrol"
-	materials = list(/datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/gold =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/silver =HALF_SHEET_MATERIAL_AMOUNT, /datum/material/bluespace =SHEET_MATERIAL_AMOUNT)
-	build_path = /obj/item/circuitboard/computer/robotics
-	category = list(
-		RND_CATEGORY_COMPUTER + RND_SUBCATEGORY_COMPUTER_ROBOTICS
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+// Monke, cannot print robotics control console.
 
 /datum/design/board/slot_machine
 	name = "Slot Machine Board"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -156,7 +156,9 @@
 		"borg_suit",
 		"borg_upgrade_rename",
 		"borg_upgrade_restart",
-		"cyborgrecharger", // Monke, cannot print cyborg upload or robotics control.
+//		"borgupload", // Monke, cannot print borg upload console.
+		"cyborgrecharger",
+//		"robocontrol", // Monke, cannot print robotics control console.
 		"sflash",
 	)
 
@@ -1027,7 +1029,8 @@
 		"borg_ai_control",
 		"intellicard",
 		"mecha_tracking_ai_control",
-		"aifixer", // Monke, cannot print upload.
+		"aifixer",
+//		"aiupload", // Monke, cannot print AI upload console.
 		"reset_module",
 		"asimov_module",
 		"default_module",

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -156,9 +156,7 @@
 		"borg_suit",
 		"borg_upgrade_rename",
 		"borg_upgrade_restart",
-		"borgupload",
-		"cyborgrecharger",
-		"robocontrol",
+		"cyborgrecharger", // Monke, cannot print cyborg upload or robotics control.
 		"sflash",
 	)
 
@@ -1029,8 +1027,7 @@
 		"borg_ai_control",
 		"intellicard",
 		"mecha_tracking_ai_control",
-		"aifixer",
-		"aiupload",
+		"aifixer", // Monke, cannot print upload.
 		"reset_module",
 		"asimov_module",
 		"default_module",

--- a/monkestation/code/modules/cargo/crates/science.dm
+++ b/monkestation/code/modules/cargo/crates/science.dm
@@ -17,15 +17,6 @@
 	desc = "Control the Silicons with upload and robotics control console boards."
 	cost = CARGO_CRATE_VALUE * 20
 	access = ACCESS_RD
-	contains = list(/obj/item/storage/lockbox/upload)
+	contains = list(/obj/item/circuitboard/computer/aiupload, /obj/item/circuitboard/computer/robotics, /obj/item/circuitboard/computer/borgupload)
 	crate_name = "secure science board crate"
 	crate_type = /obj/structure/closet/crate/secure/science
-
-/obj/item/storage/lockbox/upload
-	name = "lockbox of silicon control boards"
-	req_access = list(ACCESS_RD)
-
-/obj/item/storage/lockbox/upload/PopulateContents()
-	new /obj/item/circuitboard/computer/aiupload(src)
-	new /obj/item/circuitboard/computer/robotics(src)
-	new /obj/item/circuitboard/computer/borgupload(src)

--- a/monkestation/code/modules/cargo/crates/science.dm
+++ b/monkestation/code/modules/cargo/crates/science.dm
@@ -11,3 +11,21 @@
 					/obj/item/vacuum_pack)
 	crate_name = "xenobiology starter crate"
 	crate_type = /obj/structure/closet/crate/secure/science
+
+/datum/supply_pack/science/secureboard
+	name = "Secure Science Board Crate"
+	desc = "Control the Silicons with upload and robotics control console boards."
+	cost = CARGO_CRATE_VALUE * 20
+	access = ACCESS_RD
+	contains = list(/obj/item/storage/lockbox/upload)
+	crate_name = "secure science board crate"
+	crate_type = /obj/structure/closet/crate/secure/science
+
+/obj/item/storage/lockbox/upload
+	name = "lockbox of silicon control boards"
+	req_access = list(ACCESS_RD)
+
+/obj/item/storage/lockbox/upload/PopulateContents()
+	new /obj/item/circuitboard/computer/aiupload(src)
+	new /obj/item/circuitboard/computer/robotics(src)
+	new /obj/item/circuitboard/computer/borgupload(src)


### PR DESCRIPTION

## About The Pull Request
You cannot print the boards for AI/Cyborg upload, or robotics control console.

## Why It's Good For The Game
Subverting the AI is a trivial task. Because all you need to do is print an upload board, make it wherever you want, and upload whatever you want. There is zero reason to ever go to the AI upload or secure storage to subvert/fix AI. This change makes high-security science consoles actually secure, by forcing you to go to a secure area to get access to them.

## Changelog
:cl:
balance: You cannot print the boards for AI/Cyborg upload, or robotics control console.
/:cl:
