### PR TITLE
Nerfs abductor batons

### DIFF
--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -375,6 +375,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 /obj/item/melee/baton/abductor/baton_effect(mob/living/target, mob/living/user, modifiers, stun_override)
 	switch (mode)
 		if(BATON_STUN)
+			if(!use_charge(user)) // monkestation edit: limited charges
+				return
 			target.visible_message(span_danger("[user] stuns [target] with [src]!"),
 				span_userdanger("[user] stuns you with [src]!"))
 			target.set_jitter_if_lower(40 SECONDS)
@@ -383,6 +385,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 			SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK)
 			target.Paralyze(knockdown_time * (HAS_TRAIT(target, TRAIT_BATON_RESISTANCE) ? 0.1 : 1))
 		if(BATON_SLEEP)
+			if(!use_charge(user)) // monkestation edit: limited charges
+				return
 			SleepAttack(target,user)
 		if(BATON_CUFF)
 			CuffAttack(target,user)

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -370,13 +370,15 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 /obj/item/melee/baton/abductor/baton_attack(mob/target, mob/living/user, modifiers)
 	if(!AbductorCheck(user))
 		return BATON_ATTACK_DONE
+	// monkestation edit: limited charges
+	if((mode == BATON_STUN || mode == BATON_SLEEP) && !use_charge(user))
+		return BATON_ATTACK_DONE
+	// monkestation end
 	return ..()
 
 /obj/item/melee/baton/abductor/baton_effect(mob/living/target, mob/living/user, modifiers, stun_override)
 	switch (mode)
 		if(BATON_STUN)
-			if(!use_charge(user)) // monkestation edit: limited charges
-				return
 			target.visible_message(span_danger("[user] stuns [target] with [src]!"),
 				span_userdanger("[user] stuns you with [src]!"))
 			target.set_jitter_if_lower(40 SECONDS)
@@ -385,8 +387,6 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 			SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK)
 			target.Paralyze(knockdown_time * (HAS_TRAIT(target, TRAIT_BATON_RESISTANCE) ? 0.1 : 1))
 		if(BATON_SLEEP)
-			if(!use_charge(user)) // monkestation edit: limited charges
-				return
 			SleepAttack(target,user)
 		if(BATON_CUFF)
 			CuffAttack(target,user)

--- a/monkestation/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/monkestation/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -36,4 +36,3 @@
 	else
 		to_chat(user, span_warning("[icon2html(src, user)] Out of charges! Wait [DisplayTimeText(COOLDOWN_TIMELEFT(src, next_charge))] for the next charge!"))
 		return FALSE
-

--- a/monkestation/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/monkestation/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -1,0 +1,39 @@
+/obj/item/melee/baton/abductor
+	var/charges = 3
+	var/max_charges = 3
+	var/charge_rate = 5 SECONDS
+	var/charging = FALSE
+	COOLDOWN_DECLARE(next_charge)
+
+/obj/item/melee/baton/abductor/Destroy(force)
+	STOP_PROCESSING(SSobj, src)
+	return ..()
+
+/obj/item/melee/baton/abductor/examine(mob/user)
+	. = ..()
+	if(isobserver(user) || AbductorCheck(user))
+		. += span_notice("It has <b>[charges]</b> charge\s remaining.")
+		. += span_notice("It takes [DisplayTimeText(charge_rate)] to regenerate 1 charge.")
+
+/obj/item/melee/baton/abductor/process(seconds_per_tick)
+	if(COOLDOWN_FINISHED(src, next_charge))
+		charges = min(charges + 1, max_charges)
+		playsound(src, 'sound/machines/twobeep.ogg', vol = 10, vary = TRUE, extrarange = SILENCED_SOUND_EXTRARANGE, falloff_distance = 0)
+		COOLDOWN_START(src, next_charge, charge_rate)
+	if(charges >= max_charges)
+		charging = FALSE
+		return PROCESS_KILL
+
+/obj/item/melee/baton/abductor/proc/use_charge(mob/living/user)
+	if(!charging)
+		charging = TRUE
+		START_PROCESSING(SSobj, src)
+		COOLDOWN_START(src, next_charge, charge_rate)
+	if(charges >= 1)
+		charges--
+		to_chat(user, span_notice("[icon2html(src, user)] <b>[charges]</b> charge\s remaining."))
+		return TRUE
+	else
+		to_chat(user, span_warning("[icon2html(src, user)] Out of charges! Wait [DisplayTimeText(COOLDOWN_TIMELEFT(src, next_charge))] for the next charge!"))
+		return FALSE
+

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5904,6 +5904,7 @@
 #include "monkestation\code\modules\antagonists\_common\antag_datum.dm"
 #include "monkestation\code\modules\antagonists\_common\antag_hud.dm"
 #include "monkestation\code\modules\antagonists\abductor\abductor.dm"
+#include "monkestation\code\modules\antagonists\abductor\equipment\gear\abductor_items.dm"
 #include "monkestation\code\modules\antagonists\abductor\equipment\glands\blood.dm"
 #include "monkestation\code\modules\antagonists\abductor\equipment\glands\plasma.dm"
 #include "monkestation\code\modules\antagonists\abductor\equipment\glands\slime.dm"


### PR DESCRIPTION
## About The Pull Request

https://github.com/Monkestation/Monkestation2.0/assets/65794972/1d46b5d8-9bd9-4b2a-9fea-f3d12f2a65fa

Similar to monke 1.0's batons

## Why It's Good For The Game

It's not really fun for an ayylmao to just stun-sleep everyone in a room with very little counter

## Changelog
:cl:
balance: Abductor batons now have 3 charges, with a single charge regenerating every 5 seconds. A charge is needed to stun or sleep someone with the baton.
/:cl:
