### PR TITLE
banishes the bunnywand to hell

### DIFF
--- a/monkestation/code/modules/bunny_wizard/wizard_items.dm
+++ b/monkestation/code/modules/bunny_wizard/wizard_items.dm
@@ -51,11 +51,14 @@
 		charges--
 		return
 
+//directly to hell with you
+/*
 /datum/spellbook_entry/item/wandbunny
 	name = "Wand of Bunnies"
 	desc = "An artefact that spits bolts of lagomorphic energy which cause the target's appearence and clothing to change. Unlike most wands, it is able to recharge its own power. This magic doesn't effect machines or animals."
 	item_path = /obj/item/gun/magic/wand/bunny
 	category = "Offensive"
+*/
 
 /mob/living/carbon/human/proc/bunnify(mob/target)
 	var/obj/effect/particle_effect/fluid/smoke/exit_poof = new(get_turf(src))


### PR DESCRIPTION

## About The Pull Request
Removes bunnywand from wiz item selection
## Why It's Good For The Game
This item is horrible to play with and against and should be sent to the deepest pits of hell for its sins. I absolutely hate it.

It instantly unequips your entire inventory and forces you into a permanent bunnysuit which is also called the playbunny suit.
The cursed outfits also completely remove your ability to use most clothing slots.

It sucks and should be removed
## Changelog
:cl:
del: Removes bunnywand from wiz item selection
/:cl:
