### PR TITLE
Write byond-tracy output file to tracy.loc in log folder

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -65,7 +65,8 @@
 // If this is uncommented, we do a single run though of the game setup and tear down process with unit tests in between
 // #define UNIT_TESTS
 
-// If this is uncommented, will attempt to load and initialize prof.dll/libprof.so.
+// If this is uncommented, will attempt to load and initialize prof.dll/libprof.so by default.
+// Even if it's not defined, you can pass "tracy" via -params in order to try to load it.
 // We do not ship byond-tracy. Build it yourself here: https://github.com/mafemergency/byond-tracy/
 // #define USE_BYOND_TRACY
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -1,11 +1,13 @@
 #define RESTART_COUNTER_PATH "data/round_counter.txt"
-
+/// Load byond-tracy. If USE_BYOND_TRACY is defined, then this is ignored and byond-tracy is always loaded.
+#define USE_TRACY_PARAMETER "tracy"
 /// Force the log directory to be something specific in the data/logs folder
 #define OVERRIDE_LOG_DIRECTORY_PARAMETER "log-directory"
 /// Prevent the master controller from starting automatically
 #define NO_INIT_PARAMETER "no-init"
 
 GLOBAL_VAR(restart_counter)
+GLOBAL_VAR(tracy_log)
 
 /**
  * WORLD INITIALIZATION
@@ -62,10 +64,12 @@ GLOBAL_VAR(restart_counter)
 #ifdef USE_BYOND_TRACY
 #warn USE_BYOND_TRACY is enabled
 	if(!tracy_initialized)
-		init_byond_tracy()
+#else
+	if(!tracy_initialized && (USE_TRACY_PARAMETER in params))
+#endif
+		GLOB.tracy_log = init_byond_tracy()
 		Genesis(tracy_initialized = TRUE)
 		return
-#endif
 
 	Profile(PROFILE_RESTART)
 	Profile(PROFILE_RESTART, type = "sendmaps")
@@ -215,6 +219,9 @@ GLOBAL_VAR(restart_counter)
 
 	GLOB.demo_log = "[GLOB.demo_directory]/[GLOB.round_id]_demo.txt" //Guh //Monkestation Edit: REPLAYS
 	logger.init_logging()
+
+	if(GLOB.tracy_log)
+		rustg_file_write("[GLOB.tracy_log]", "[GLOB.log_directory]/tracy.loc")
 
 	var/latest_changelog = file("[global.config.directory]/../html/changelogs/archive/" + time2text(world.timeofday, "YYYY-MM") + ".yml")
 	GLOB.changelog_hash = fexists(latest_changelog) ? md5(latest_changelog) : 0 //for telling if the changelog has changed recently
@@ -475,7 +482,9 @@ GLOBAL_VAR(restart_counter)
 			CRASH("Unsupported platform: [system_type]")
 
 	var/init_result = call_ext(library, "init")("block")
-	if (init_result != "0")
+	if(length(init_result) != 0 && init_result[1] == ".") // if first character is ., then it returned the output filename
+		return init_result
+	else if(init_result != "0")
 		CRASH("Error initializing byond-tracy: [init_result]")
 
 /world/proc/init_debugger()
@@ -490,4 +499,5 @@ GLOBAL_VAR(restart_counter)
 
 #undef NO_INIT_PARAMETER
 #undef OVERRIDE_LOG_DIRECTORY_PARAMETER
+#undef USE_TRACY_PARAMETER
 #undef RESTART_COUNTER_PATH


### PR DESCRIPTION
## About The Pull Request

With Paradise's byond-tracy, as of https://github.com/ParadiseSS13/byond-tracy/commit/93021a79ed70d7431358948dde82f4222527376a, `init()` will return the output file path on success, instead of just "0".

This writes said path to `tracy.loc` in the log directory, making it easy to associate a specific .utracy file with a specific round.

This is still backwards compatible with versions of byond-tracy that return "0" on success, including the original version that streams the trace directly - `tracy.loc` will just not be created, however **93021a7 will not initialize properly without this PR, due to not returning "0"**

Also made it so you can pass "-params tracy" in order to load tracy when `USE_BYOND_TRACY` isn't defined - said define will just make it _always_ load tracy regardless of params.

## Changelog

No user-facing changes