### PR TITLE
Species without a stomach in the first place can ingest reagents without one

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -507,10 +507,12 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 		update_mutations_overlay()// no lizard with human hulk overlay please.
 
 
-/mob/proc/has_dna()
+/mob/proc/has_dna() as /datum/dna
+	RETURN_TYPE(/datum/dna)
 	return
 
 /mob/living/carbon/has_dna()
+	RETURN_TYPE(/datum/dna)
 	return dna
 
 /// Returns TRUE if the mob is allowed to mutate via its DNA, or FALSE if otherwise.

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -464,12 +464,18 @@
 	else
 		if(!ignore_stomach && (methods & INGEST) && iscarbon(target))
 			var/mob/living/carbon/eater = target
-			var/obj/item/organ/internal/stomach/belly = eater.get_organ_slot(ORGAN_SLOT_STOMACH)
-			if(!belly)
-				eater.expel_ingested(my_atom, amount)
-				return
-			R = belly.reagents
-			target_atom = belly
+			// monkestation edit: species without a stomach in the first place don't need one to ingest things
+			if(eater.has_dna()?.species?.mutantstomach != null)
+				var/obj/item/organ/internal/stomach/belly = eater.get_organ_slot(ORGAN_SLOT_STOMACH)
+				if(!belly)
+					eater.expel_ingested(my_atom, amount)
+					return
+				R = belly.reagents
+				target_atom = belly
+			else
+				R = target.reagents
+				target_atom = target
+			// monkestation end
 		else if(!target.reagents)
 			return
 		else


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/Monkestation/Monkestation2.0/assets/65794972/bbf99f56-a908-4a20-99d3-924b28781b44)

## Why It's Good For The Game

it's kinda dumb that species that don't have a stomach in the first place throw up if they try to ingest something - the lack of one in the first place likely means they just don't need one in the first place, right? why would they need one to be surgically added?

## Changelog
:cl:
fix: Species without a stomach in the first place can now ingest reagents without one, instead of just throwing them up immediately.
/:cl:
