### PR TITLE
[Port] Gives upload boards a GPS signal because I cannot find Anne Tagonist for the life of me after he takes my silicons away.

### DIFF
--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -93,7 +93,7 @@
 /obj/machinery/computer/proc/imprint_gps(gps_tag) // Currently used by the upload computers and communications console
 	var/tracker = gps_tag
 	if(!tracker) // Don't give a null GPS signal if there is none
-		return
+		CRASH("[src] Called imprint_gps without setting gps_tag")
 	for(var/obj/item/circuitboard/computer/board in src.contents)
 		if(!contents || board.GetComponent(/datum/component/gps))
 			return

--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -90,6 +90,16 @@
 		playsound(loc, 'sound/effects/glassbr3.ogg', 100, TRUE)
 		set_light(0)
 
+/obj/machinery/computer/proc/imprint_gps(gps_tag) // Currently used by the upload computers and communications console
+	var/tracker = gps_tag
+	if(!tracker) // Don't give a null GPS signal if there is none
+		return
+	for(var/obj/item/circuitboard/computer/board in src.contents)
+		if(!contents || board.GetComponent(/datum/component/gps))
+			return
+		board.AddComponent(/datum/component/gps, "[tracker]")
+		balloon_alert_to_viewers("board tracker enabled", vision_distance = 1)
+
 /obj/machinery/computer/emp_act(severity)
 	. = ..()
 	if (!(. & EMP_PROTECT_SELF))

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -28,7 +28,7 @@
 			current = null
 			return
 		M.install(current.laws, user)
-		imprint_gps(gps_tag = "Weak Upload Signal")
+		imprint_gps("Weak Upload Signal")
 	else
 		return ..()
 

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -7,7 +7,6 @@
 
 /obj/machinery/computer/upload/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/gps, "Encrypted Upload")
 	if(!mapload)
 		log_silicon("\A [name] was created at [loc_name(src)].")
 		message_admins("\A [name] was created at [ADMIN_VERBOSEJMP(src)].")
@@ -29,6 +28,7 @@
 			current = null
 			return
 		M.install(current.laws, user)
+		imprint_gps(gps_tag = "Weak Upload Signal")
 	else
 		return ..()
 

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -2,6 +2,11 @@
 	name = "Generic"
 	name_extension = "(Computer Board)"
 
+/obj/item/circuitboard/computer/examine()
+	. = ..()
+	if(GetComponent(/datum/component/gps))
+		. += span_info("there's a small, blinking light!")
+
 //Command
 
 /obj/item/circuitboard/computer/aiupload


### PR DESCRIPTION

## About The Pull Request
Once an upload has been used, it will then have a GPS signal at the board, rather than only on the console when build (you can just relaw an AI then screwdriver the console and the GPS signal goes bye bye right now)
In my honest opinion as a silicon main, boards shouldn't be printable, however, that just leads to a sat raid on every subversion, which while fun for me, will get boring for everyone else
This was the proposed solution on bubberstation and we (StrangeWeirdKitten) took it upstream to TG https://github.com/tgstation/tgstation/pull/82574
## Why It's Good For The Game
Law spam will be punished by anyone with a GPS knowing your exact location at all times, forcing you to ditch the board, and get a new one if you want to go for round 2
## Changelog
:cl:
add: Adds a gps component to the Upload Boards themselves
/:cl:
