### PR TITLE
Emergency shield gen fix

### DIFF
--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -294,7 +294,7 @@
 	max_integrity = 300
 	var/active = FALSE
 	var/locked = TRUE
-	var/shield_range = 8
+	var/shield_range = 12 //monke edit
 	var/obj/structure/cable/attached // the attached cable
 
 /obj/machinery/power/shieldwallgen/xenobiologyaccess //use in xenobiology containment


### PR DESCRIPTION
## About The Pull Request
Changes shield gen range to 12, needed for Metastation's xenobio.
## Why It's Good For The Game
If xenos spawn in metastation and they try to turn the shield on they're screwed
## Changelog
:cl: Syndie Kate
fix: Metastation xenobiology fields work now
balance: Shield generators range is now 12, from 8.
/:cl:
