### PR TITLE
Re-fixes runaway anomalies

### DIFF
--- a/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
+++ b/code/game/objects/effects/anomalies/anomalies_bioscrambler.dm
@@ -64,6 +64,8 @@
 			continue
 		if (target.stat >= UNCONSCIOUS)
 			continue // Don't just haunt a corpse
+		if (contained && get_area(target) != impact_area) // monkestation edit: fix "runaway" bioscramblers
+			continue
 		var/distance_from_target = get_dist(src, target)
 		if(distance_from_target >= closest_distance)
 			continue

--- a/monkestation/code/game/objects/effects/anomalies/_anomalies.dm
+++ b/monkestation/code/game/objects/effects/anomalies/_anomalies.dm
@@ -1,6 +1,23 @@
+/obj/effect/anomaly
+	/// If TRUE, the anomaly is contained to its impact_area.
+	var/contained = FALSE
+
 /obj/effect/anomaly/proc/scan_anomaly(mob/user, obj/item/scanner)
 	if(!aSignal)
 		return FALSE
 	playsound(get_turf(user), 'sound/machines/ping.ogg', vol = 30, vary = TRUE, extrarange = SHORT_RANGE_SOUND_EXTRARANGE, ignore_walls = FALSE)
 	to_chat(user, span_boldnotice("Analyzing... [src]'s unstable field is fluctuating along frequency [format_frequency(aSignal.frequency)], code [aSignal.code]."))
 	return TRUE
+
+/obj/effect/anomaly/stabilize(anchor, has_core)
+	. = ..()
+	contained = TRUE
+
+/obj/effect/anomaly/Move(atom/newloc, direct, glide_size_override, update_dir)
+	if(contained)
+		if(impact_area != get_area(newloc))
+			return FALSE
+		else if(impact_area != get_area(src)) // if we somehow escaped ANYWAYS, let's just go poof
+			qdel(src)
+			return FALSE
+	return ..()


### PR DESCRIPTION

During one of my /tg/ port fixes, I reverted https://github.com/Monkestation/Monkestation2.0/pull/1885, bc /tg/ apparently had a "proper" fix.

Their fix does not seem to be working. So I've un-reverted #1885, which did in fact seem to work.

## Changelog
:cl:
fix: Actually, hopefully, probably fixed runaway ruin anomalies this time. Again.
/:cl:
