### PR TITLE
Frogs no longer destroy your eardrums from the next department over

### DIFF
--- a/code/modules/mob/living/basic/vermin/frog.dm
+++ b/code/modules/mob/living/basic/vermin/frog.dm
@@ -68,12 +68,14 @@
 	AddElement(/datum/element/ai_retaliate)
 	AddElement(/datum/element/swabable, CELL_LINE_TABLE_FROG, CELL_VIRUS_TABLE_GENERIC_MOB, 1, 5)
 
+/* monkestation edit: overriden in [monkestation\code\modules\mob\living\basic\vermin\frog.dm]
 /mob/living/basic/frog/proc/on_entered(datum/source, AM as mob|obj)
 	SIGNAL_HANDLER
 	if(!stat && isliving(AM))
 		var/mob/living/L = AM
 		if(L.mob_size > MOB_SIZE_TINY)
 			playsound(src, stepped_sound, 50, TRUE)
+monkestation end */
 
 /datum/ai_controller/basic_controller/frog
 	blackboard = list(

--- a/monkestation/code/modules/mob/living/basic/vermin/frog.dm
+++ b/monkestation/code/modules/mob/living/basic/vermin/frog.dm
@@ -1,0 +1,26 @@
+#define FROG_VOLUME				50
+#define FROG_NOISE_COOLDOWN		1.5 SECONDS
+#define FROG_FALLOFF_EXPONENT	20 // same as bike horn
+
+/mob/living/basic/frog
+	/// Cooldown for frogs making their frog noise
+	COOLDOWN_DECLARE(frogspam_cooldown)
+
+/mob/living/basic/frog/proc/on_entered(datum/source, mob/living/stepper)
+	SIGNAL_HANDLER
+	if(stat || !isliving(stepper) || stepper.mob_size <= MOB_SIZE_TINY || !COOLDOWN_FINISHED(src, frogspam_cooldown))
+		return
+	playsound(
+		src,
+		stepped_sound,
+		vol = FROG_VOLUME,
+		vary = TRUE,
+		extrarange = MEDIUM_RANGE_SOUND_EXTRARANGE,
+		falloff_exponent = FROG_FALLOFF_EXPONENT,
+		ignore_walls = FALSE // I DO NOT WANT TO HEAR THIS THING FROM THE NEXT DEPARTMENT OVER
+	)
+	COOLDOWN_START(src, frogspam_cooldown, FROG_NOISE_COOLDOWN)
+
+#undef FROG_FALLOFF_EXPONENT
+#undef FROG_NOISE_COOLDOWN
+#undef FROG_VOLUME

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6934,6 +6934,7 @@
 #include "monkestation\code\modules\mob\living\basic\ggg\susflash.dm"
 #include "monkestation\code\modules\mob\living\basic\pets\parrot\parrot_ai\parroting_action.dm"
 #include "monkestation\code\modules\mob\living\basic\space_fauna\fugu_gland.dm"
+#include "monkestation\code\modules\mob\living\basic\vermin\frog.dm"
 #include "monkestation\code\modules\mob\living\basic\vermin\mouse.dm"
 #include "monkestation\code\modules\mob\living\carbon\carbon.dm"
 #include "monkestation\code\modules\mob\living\carbon\carbon_death.dm"


### PR DESCRIPTION
## About The Pull Request

This makes frogs slightly less of a hearing hazard. I know people would complain if I removed the sound entirely, so, I decided to meet in the middle:
- Made the volume fall off more with distance (same as bike horn now)
- Sound no longer goes through walls
- Sound has overall less range
- 1.5 second cooldown between each scream

I'm 100% willing to change this up to get it merged, I just want it even _slightly_ more tolerable than it is now.

## Why It's Good For The Game

Because very few things in this game are worse than hearing HUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUUU repeatedly from the maints several rooms over

## Changelog
:cl:
qol: Frogs no longer scream louder than literal megafauna, and can no longer be heard from several rooms over. They still scream, tho, don't worry.
/:cl:
