### PR TITLE
[Non-Modular] Makes zauker not immediately disappear in nitrogren because I spilled my gas once then spent 40 minutes making it all again

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reaction_factors.dm
+++ b/code/modules/atmospherics/gasmixtures/reaction_factors.dm
@@ -164,7 +164,7 @@
 /datum/gas_reaction/zauker_decomp/init_factors() //Fixed reaction rate
 	factor = list(
 		/datum/gas/zauker = "Zauker is consumed at 1 reaction rate",
-		/datum/gas/nitrogen = "At least [MINIMUM_MOLE_COUNT] moles of Nitrogen needs to be present for this reaction to occur. Nitrogen is produced at 0.7 reaction rate",
+		/datum/gas/water_vapor = "At least [MINIMUM_MOLE_COUNT] moles of H2O needs to be present for this reaction to occur. H2O is produced at 0.7 reaction rate", //monke edit, changes nitrogen to water_vapor
 		/datum/gas/oxygen = "Oxygen is produced at 0.3 reaction rate",
 		"Energy" = "[ZAUKER_DECOMPOSITION_ENERGY] joules of energy is released per reaction rate",
 	)

--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -929,23 +929,24 @@
  * Zauker Decomposition:
  *
  * Occurs in the presence of nitrogen to prevent zauker floods.
+ * ///Monke edit begin Changes every instance of 'Nitrogen' to 'water_vapor'
  * Exothermic.
  */
 /datum/gas_reaction/zauker_decomp
 	priority_group = PRIORITY_POST_FORMATION
 	name = "Zauker Decomposition"
 	id = "zauker_decomp"
-	desc = "Decomposition of zauker when exposed to nitrogen."
+	desc = "Decomposition of zauker when exposed to H2O."
 
 /datum/gas_reaction/zauker_decomp/init_reqs()
 	requirements = list(
-		/datum/gas/nitrogen = MINIMUM_MOLE_COUNT,
+		/datum/gas/water_vapor = MINIMUM_MOLE_COUNT,
 		/datum/gas/zauker = MINIMUM_MOLE_COUNT,
 	)
 
 /datum/gas_reaction/zauker_decomp/react(datum/gas_mixture/air, datum/holder)
 	var/list/cached_gases = air.gases //this speeds things up because accessing datum vars is slow
-	var/burned_fuel = min(ZAUKER_DECOMPOSITION_MAX_RATE, cached_gases[/datum/gas/nitrogen][MOLES], cached_gases[/datum/gas/zauker][MOLES])
+	var/burned_fuel = min(ZAUKER_DECOMPOSITION_MAX_RATE, cached_gases[/datum/gas/water_vapor][MOLES], cached_gases[/datum/gas/zauker][MOLES])
 	if (burned_fuel <= 0 || cached_gases[/datum/gas/zauker][MOLES] - burned_fuel < 0)
 		return NO_REACTION
 
@@ -953,8 +954,8 @@
 	cached_gases[/datum/gas/zauker][MOLES] -= burned_fuel
 	ASSERT_GAS(/datum/gas/oxygen, air)
 	cached_gases[/datum/gas/oxygen][MOLES] += burned_fuel * 0.3
-	ASSERT_GAS(/datum/gas/nitrogen, air)
-	cached_gases[/datum/gas/nitrogen][MOLES] += burned_fuel * 0.7
+	ASSERT_GAS(/datum/gas/water_vapor, air)
+	cached_gases[/datum/gas/water_vapor][MOLES] += burned_fuel * 0.7
 
 	SET_REACTION_RESULTS(burned_fuel)
 	var/energy_released = ZAUKER_DECOMPOSITION_ENERGY * burned_fuel
@@ -962,7 +963,7 @@
 	if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
 		air.temperature = max((air.temperature * old_heat_capacity + energy_released) / new_heat_capacity, TCMB)
 	return REACTING
-
+///Monke edit end
 
 // Proto-Nitrate
 

--- a/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/atmos_gas_reagents.dm
@@ -131,10 +131,11 @@
 	chemical_flags = REAGENT_NO_RANDOM_RECIPE
 	affected_biotype = MOB_ORGANIC | MOB_MINERAL | MOB_PLANT // "toxic to all living beings"
 	affected_respiration_type = ALL
-
+///monke edit begin, nerfs damage numbers to breathing zauker
 /datum/reagent/zauker/on_mob_life(mob/living/breather, seconds_per_tick, times_fired)
-	breather.adjustBruteLoss(6 * REM * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
-	breather.adjustOxyLoss(1 * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
-	breather.adjustFireLoss(2 * REM * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
-	breather.adjustToxLoss(2 * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
+	breather.adjustBruteLoss(4 * REM * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
+	breather.adjustOxyLoss(0.7 * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype, required_respiration_type = affected_respiration_type)
+	breather.adjustFireLoss(1.5 * REM * seconds_per_tick, FALSE, required_bodytype = affected_bodytype)
+	breather.adjustToxLoss(1.5 * REM * seconds_per_tick, FALSE, required_biotype = affected_biotype)
 	return ..()
+///monke edit end


### PR DESCRIPTION

## About The Pull Request
Changes Zaukers decomposition reaction from nitrogen to water vapor because an admin said it would be funny, also nerfs the damage it deals when breathing it by ~ 30-33%
## Why It's Good For The Game
atmos becomes less unforgiving with this fancy gas + its still easy to get rid of it all if need be as water vapor is very easy to make
## Proof of testing
it compiles and my zauker stayed neatly tucked in its room
![image](https://github.com/Monkestation/Monkestation2.0/assets/39929315/45db7e4e-41f0-4c3a-a859-1b28066cca5d)

## Changelog
:cl:
balance: changed zauker decomp gas and damage
/:cl:
