### PR TITLE
Adds a new 4th objective to bloodsuckers that always rolls 1 of 2 things because I got bored after objective rushing and have nothing else to do

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
@@ -498,3 +498,14 @@
 			gourmand_objective.owner = owner
 			gourmand_objective.objective_name = "Optional Objective"
 			objectives += gourmand_objective
+
+	// Objective 2: Stake your claim, or rise in power
+	switch(rand(1, 2))
+		if(1)  //Stake claim objective
+			var/datum/objective/bloodsucker/kingofthehill/stakeclaim_obj = new
+			stakeclaim_obj.owner = owner
+			objectives += stakeclaim_obj
+		if(2) //Rise in power objective
+			var/datum/objective/bloodsucker/control/rise_obj = new
+			rise_obj.owner = owner
+			objectives += rise_obj

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_objectives.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_objectives.dm
@@ -88,6 +88,13 @@
 
 //////////////////////////////////////////////////////////////////////////////////////
 
+/datum/objective/bloodsucker/kingofthehill
+	name = "stakeyourclaim"
+	explanation_text = "Turn your department into your lair, welcome your kind with open arms and defend your claim"
+
+/datum/objective/bloodsucker/control
+	name = "riseinpower"
+	explanation_text = "Ascend the ranks and plant yourself as the leader of the station, you know better than they do and they would be wise to follow your instruction."
 
 /// Vassalize a certain person / people
 /datum/objective/bloodsucker/conversion


### PR DESCRIPTION

## About The Pull Request
Adds two new objectives, of which you will always get 1
Control: Plant yourself as the station leader
Stake(get it?) your claim: Turn your department into your lair, cooperate with other blood suckers to keep it as such
## Why It's Good For The Game
More objectives that have no win condition so if a player can't think of what to do, the game gives them a bit of direction on what to try.
## Proof of Testing
![image](https://github.com/Monkestation/Monkestation2.0/assets/39929315/07c83f47-6be6-48e2-beb7-90082c585906)

## Changelog
:cl:
add: adds 2 new objectives to bloodsuckers
/:cl:
