### PR TITLE
Razorwire Spool Nerf

### DIFF
--- a/monkestation/code/modules/blueshift/armaments/deforest_medical.dm
+++ b/monkestation/code/modules/blueshift/armaments/deforest_medical.dm
@@ -215,6 +215,7 @@
 /datum/armament_entry/company_import/deforest/cyber_implants/razorwire
 	name = "Razorwire Spool Implant"
 	item_type = /obj/item/organ/internal/cyberimp/arm/item_set/razorwire
+	cost = CARGO_CRATE_VALUE * 4
 // Modsuit Modules from the medical category, here instead of in Nakamura because nobody buys from this company
 
 /datum/armament_entry/company_import/deforest/medical_modules

--- a/monkestation/code/modules/cybernetics/implant_items/weapons/razorwire_spool.dm
+++ b/monkestation/code/modules/cybernetics/implant_items/weapons/razorwire_spool.dm
@@ -10,7 +10,7 @@
 	inhand_icon_state = "razorwire"
 	w_class = WEIGHT_CLASS_BULKY
 	sharpness = SHARP_EDGED
-	force = 12
+	force = 15
 	demolition_mod = 0.25 // This thing sucks at destroying stuff
 	wound_bonus = -10 // Very weak against armor.
 	bare_wound_bonus = 25

--- a/monkestation/code/modules/cybernetics/implant_items/weapons/razorwire_spool.dm
+++ b/monkestation/code/modules/cybernetics/implant_items/weapons/razorwire_spool.dm
@@ -10,10 +10,10 @@
 	inhand_icon_state = "razorwire"
 	w_class = WEIGHT_CLASS_BULKY
 	sharpness = SHARP_EDGED
-	force = 18
+	force = 12
 	demolition_mod = 0.25 // This thing sucks at destroying stuff
-	wound_bonus = 10
-	bare_wound_bonus = 20
+	wound_bonus = -10 // Very weak against armor.
+	bare_wound_bonus = 25
 	weak_against_armour = TRUE
 	reach = 2
 	hitsound = 'sound/weapons/whip.ogg'


### PR DESCRIPTION
## About The Pull Request
-Changes razorwire spool damage from 18 to 15.
-Changes razorwire spool wound_bonus from 10 to -10. (It's supposed to be bad against armor.)
-Changes razorwire spool bare wound_bonus from 20 to 25.
-Changes razorwire spool price (from company import) from 300 to 800.

## Why It's Good For The Game
The razorwire is amazingly strong. It's an undroppable 18 brute weapon, that can attack from two tiles away, can tether opponents, and is very good at dealing devastating bleeding wounds. And all you have to do to get is is do a few bounties. This seems more like something you'd get from an uplink, than something any crewmember can buy and implant in their arm "just in case."
## Changelog
:cl:
balance: Razorwhile Spool Nerfed.
/:cl:
