### PR TITLE
[Non-Modular][Test-Merge-First] Makes heretics target each other because I got killed once by a dynamic duo

### DIFF
--- a/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -218,9 +218,7 @@
 		balloon_message = "they're dead, " + balloon_message
 
 //Monke Edit begin
-	var/datum/mind/target_mob = tracked_mob.mind
-	var/datum/antagonist/heretic/valuable_target = target_mob.has_antag_datum(/datum/antagonist/heretic)
-	if(valuable_target)
+	if(IS_HERETIC(tracked_mob))
 		balloon_message = "A fellow Mansus follower... " + balloon_message
 //Monke Edit End
 

--- a/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -217,4 +217,9 @@
 	if(tracked_mob.stat == DEAD)
 		balloon_message = "they're dead, " + balloon_message
 
+	var/datum/mind/target_mob = tracked_mob.mind
+	var/datum/antagonist/heretic/valuable_target = target_mob.has_antag_datum(/datum/antagonist/heretic)
+	if(valuable_target)
+		balloon_message = "A fellow Mansus follower... " + balloon_message
+
 	return balloon_message

--- a/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -217,9 +217,11 @@
 	if(tracked_mob.stat == DEAD)
 		balloon_message = "they're dead, " + balloon_message
 
+//Monke Edit begin
 	var/datum/mind/target_mob = tracked_mob.mind
 	var/datum/antagonist/heretic/valuable_target = target_mob.has_antag_datum(/datum/antagonist/heretic)
 	if(valuable_target)
 		balloon_message = "A fellow Mansus follower... " + balloon_message
+//Monke Edit End
 
 	return balloon_message

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -206,10 +206,16 @@
 
 	var/feedback = "Your patrons accept your offer"
 	var/sac_department_flag = sacrifice.mind?.assigned_role?.departments_bitflags | sacrifice.last_mind?.assigned_role?.departments_bitflags
+	var/datum/antagonist/heretic/target_heretic = IS_HERETIC(sacrifice)
 	if(sac_department_flag & DEPARTMENT_BITFLAG_COMMAND)
 		heretic_datum.knowledge_points++
 		heretic_datum.high_value_sacrifices++
 		feedback += " <i>graciously</i>"
+
+	if(target_heretic)
+		heretic_datum.knowledge_points += 2
+		heretic_datum.high_value_sacrifices++
+		feedback += " <i>maliciously</i>"
 
 	to_chat(user, span_hypnophrase("[feedback]."))
 	heretic_datum.total_sacrifices++

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -151,6 +151,15 @@
 			valid_targets -= department_mind
 			break
 
+///Monke Edit begin - Heretics now always get another heretic as a sacrifice target (if there is one)
+	for(var/datum/mind/heretic_mind as anything in shuffle(valid_targets))
+		var/datum/antagonist/heretic/heretic_sac = heretic_mind.has_antag_datum(/datum/antagonist/heretic)
+		if(heretic_sac)
+			final_targets += heretic_mind
+			valid_targets -= heretic_mind
+			break
+///Monke Edit end
+
 	// Now grab completely random targets until we'll full
 	var/target_sanity = 0
 	while(length(final_targets) < num_targets_to_generate && length(valid_targets) > num_targets_to_generate && target_sanity < 25)

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -215,7 +215,7 @@
 		feedback += " <i>graciously</i>"
 
 //Monke edit - give heretics extra points for saccing heretics
-	if(target_heretic)
+	if(IS_HERETIC(sacrifice))
 		heretic_datum.knowledge_points += 2
 		heretic_datum.high_value_sacrifices++
 		feedback += " <i>maliciously</i>"

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -152,7 +152,7 @@
 			break
 
 ///Monke Edit begin - Heretics now always get another heretic as a sacrifice target (if there is one)
-	for(var/mob/living/heretic_mind as anything in shuffle(valid_targets))
+	for(var/datum/mind/heretic_mind as anything in shuffle(valid_targets))
 		var/datum/antagonist/heretic/heretic_sac = heretic_mind.has_antag_datum(/datum/antagonist/heretic)
 		if(heretic_sac)
 			final_targets += heretic_mind

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -206,16 +206,20 @@
 
 	var/feedback = "Your patrons accept your offer"
 	var/sac_department_flag = sacrifice.mind?.assigned_role?.departments_bitflags | sacrifice.last_mind?.assigned_role?.departments_bitflags
+	//Monke edit begin
 	var/datum/antagonist/heretic/target_heretic = IS_HERETIC(sacrifice)
+	//Monke edit end
 	if(sac_department_flag & DEPARTMENT_BITFLAG_COMMAND)
 		heretic_datum.knowledge_points++
 		heretic_datum.high_value_sacrifices++
 		feedback += " <i>graciously</i>"
 
+//Monke edit - give heretics extra points for saccing heretics
 	if(target_heretic)
 		heretic_datum.knowledge_points += 2
 		heretic_datum.high_value_sacrifices++
 		feedback += " <i>maliciously</i>"
+//Monke edit end
 
 	to_chat(user, span_hypnophrase("[feedback]."))
 	heretic_datum.total_sacrifices++

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -152,8 +152,9 @@
 			break
 
 ///Monke Edit begin - Heretics now always get another heretic as a sacrifice target (if there is one)
-	for(var/datum/mind/heretic_mind as anything in shuffle(valid_targets))
-		if(IS_HERETIC(heretic_mind))
+	for(var/mob/living/heretic_mind as anything in shuffle(valid_targets))
+		var/datum/antagonist/heretic/heretic_sac = heretic_mind.has_antag_datum(/datum/antagonist/heretic)
+		if(heretic_sac)
 			final_targets += heretic_mind
 			valid_targets -= heretic_mind
 			break

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -153,8 +153,7 @@
 
 ///Monke Edit begin - Heretics now always get another heretic as a sacrifice target (if there is one)
 	for(var/datum/mind/heretic_mind as anything in shuffle(valid_targets))
-		var/datum/antagonist/heretic/heretic_sac = heretic_mind.has_antag_datum(/datum/antagonist/heretic)
-		if(heretic_sac)
+		if(IS_HERETIC(heretic_mind))
 			final_targets += heretic_mind
 			valid_targets -= heretic_mind
 			break

--- a/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -205,9 +205,6 @@
 
 	var/feedback = "Your patrons accept your offer"
 	var/sac_department_flag = sacrifice.mind?.assigned_role?.departments_bitflags | sacrifice.last_mind?.assigned_role?.departments_bitflags
-	//Monke edit begin
-	var/datum/antagonist/heretic/target_heretic = IS_HERETIC(sacrifice)
-	//Monke edit end
 	if(sac_department_flag & DEPARTMENT_BITFLAG_COMMAND)
 		heretic_datum.knowledge_points++
 		heretic_datum.high_value_sacrifices++


### PR DESCRIPTION

## About The Pull Request
Adds a new guaranteed target to heretics heart target picker - a fellow heretic
## Why It's Good For The Game
Among us
## Proof of Testing
I don't have a screen shot or video, but on local host I did debug-spawn-full-crew and gave 1 heretic, then spammed heretic on another over and over and it always included the first one
Test merge for now please because Story teller is broke:tm: on my local host and won't fire heretics without active clients so I can't check if it will pick heretics spawning at the same time because I have no friends
## Changelog
:cl:
balance: Heretics get other heretics as a target (Only one)
/:cl:
