### PR TITLE
Fixes cargo express console being unlockable by entire cargo all the time

### DIFF
--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -6,7 +6,7 @@
 	icon_screen = "supply_express"
 	circuit = /obj/item/circuitboard/computer/cargo/express
 	blockade_warning = "Bluespace instability detected. Delivery impossible."
-	req_access = list(ACCESS_CARGO)
+	req_access = list(ACCESS_QM)
 	is_express = TRUE
 	interface_type = "CargoExpress"
 

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -6,7 +6,7 @@
 	icon_screen = "supply_express"
 	circuit = /obj/item/circuitboard/computer/cargo/express
 	blockade_warning = "Bluespace instability detected. Delivery impossible."
-	req_access = list(ACCESS_QM)
+	req_access = list(ACCESS_QM) //MONKESTATION EDIT
 	is_express = TRUE
 	interface_type = "CargoExpress"
 


### PR DESCRIPTION

## About The Pull Request
Does what the title says, nobody else will be able to open it now with the exception of lowpop where cargo techs get extended access, and well HOP and Captain can access it too.
## Why It's Good For The Game
Says on the console itself, nobody else should be able to unlock it outside of lowpop now. No idea why it wasn't a thing before despite it saying so.

![qmbasado](https://github.com/user-attachments/assets/4506c23e-a069-4cd7-9f99-f01acb6376a7)
## Changelog
:cl:
fix: fixed cargo express being unlockable by entire cargo all the time
/:cl:
