### PR TITLE
Nuclear operatives Gun Kit Cost Fix

### DIFF
--- a/monkestation/code/modules/blueshift/items/gunset.dm
+++ b/monkestation/code/modules/blueshift/items/gunset.dm
@@ -39,7 +39,7 @@
 /obj/item/storage/toolbox/guncase/m90gl
 	name = "m-90gl gun case"
 	weapon_to_spawn = /obj/item/gun/ballistic/automatic/m90
-	extra_to_spawn = /obj/item/ammo_box/magazine/m223
+	extra_to_spawn = /obj/item/ammo_box/magazine/m556
 
 /obj/item/storage/toolbox/guncase/m90gl/PopulateContents()
 	new weapon_to_spawn (src)

--- a/monkestation/code/modules/blueshift/uplinks/kits.dm
+++ b/monkestation/code/modules/blueshift/uplinks/kits.dm
@@ -13,6 +13,7 @@
 	desc = "A small, easily concealable handgun that uses 10mm auto rounds in 8-round magazines and is compatible \
 			with suppressors. Comes with three spare magazines."
 	item = /obj/item/storage/toolbox/guncase/clandestine
+	cost = 8
 
 /datum/uplink_item/weapon_kits/high_cost/carbine
 	name = "M-90gl Carbine Case (Hard)"
@@ -20,17 +21,20 @@
 		with a 40mm underbarrel grenade launcher. Use secondary-fire to fire the grenade launcher. Comes with two spare magazines \
 		and a box of 40mm rubber slugs."
 	item = /obj/item/storage/toolbox/guncase/m90gl
+	cost = 18
 
 /datum/uplink_item/weapon_kits/medium_cost/rawketlawnchair
 	name = "Dardo-RE Rocket Propelled Grenade Launcher (Hard)"
 	desc = "A reusable rocket propelled grenade launcher preloaded with a low-yield 84mm HE round. \
 		Guaranteed to send your target out with a bang or your money back! Comes with a bouquet of additional rockets!"
+	cost = 16
 	item = /obj/item/storage/toolbox/guncase/rocketlauncher
 
 /datum/uplink_item/weapon_kits/medium_cost/revolvercase
 	name = "Syndicate Revolver Case (Moderate)"
 	desc = "Waffle Co.'s modernized Syndicate revolver. Fires 7 brutal rounds of .357 Magnum. \
 		A classic operative weapon, brought to the modern era. Comes with 3 additional speedloaders of .357."
+	cost = 14
 	item = /obj/item/storage/toolbox/guncase/revolver
 
 /datum/uplink_item/weapon_kits/medium_cost/cqc
@@ -38,4 +42,5 @@
 	desc = "Contains a manual that instructs you in the ways of CQC, or Close Quarters Combat. Comes with a stealth implant, a pack of smokes and a snazzy bandana (use it with the hat stabilizers in your MODsuit)."
 	item = /obj/item/storage/toolbox/guncase/cqc
 	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
+	cost = 16
 	surplus = 0


### PR DESCRIPTION

## About The Pull Request

Added costs for the nukeops kits from blueshift
fixed ammo provided with m-90Gl kit

## Why It's Good For The Game

nukeops can no longer buy 500 rocket launchers and also have CQC

## Changelog

:cl:
add: costs to blueshift nukeops gun kits
fix: m90GL provides correct toploading ammo magazines
/:cl:

