### PR TITLE
Nerfs flesh spiders by removing their venom

### DIFF
--- a/code/modules/mob/living/basic/space_fauna/changeling/flesh_spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/changeling/flesh_spider.dm
@@ -47,7 +47,7 @@
 	ADD_TRAIT(src, TRAIT_WEB_SURFER, INNATE_TRAIT)
 	AddElement(/datum/element/cliff_walking)
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_CLAW)
-	AddElement(/datum/element/venomous, /datum/reagent/toxin/hunterspider, 5)
+	/*AddElement(/datum/element/venomous, /datum/reagent/toxin/hunterspider, 5)*/ //MONKESTATION REMOVAL
 	AddElement(/datum/element/web_walker, /datum/movespeed_modifier/fast_web)
 	AddElement(/datum/element/nerfed_pulling, GLOB.typecache_general_bad_things_to_easily_move)
 	AddElement(/datum/element/prevent_attacking_of_types, GLOB.typecache_general_bad_hostile_attack_targets, "this tastes awful!")
@@ -58,7 +58,7 @@
 	)
 	AddComponent(\
 		/datum/component/regenerator,\
-		regeneration_delay = 4 SECONDS,\
+		regeneration_delay = 6 SECONDS,\
 		health_per_second = maxHealth / 6,\
 		outline_colour = COLOR_PINK,\
 	)

--- a/code/modules/mob/living/basic/space_fauna/changeling/flesh_spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/changeling/flesh_spider.dm
@@ -58,8 +58,8 @@
 	)
 	AddComponent(\
 		/datum/component/regenerator,\
-		regeneration_delay = 6 SECONDS,\
-		health_per_second = maxHealth / 6,\
+		regeneration_delay = 10 SECONDS,\
+		health_per_second = maxHealth / 3,\
 		outline_colour = COLOR_PINK,\
 	)
 


### PR DESCRIPTION
## About The Pull Request
Deleted flesh spider venom (wanted to replace it with something less op but I can't find anything fitting) and increased their regeneration delay to 10 seconds so you actually have to run away from danger instead of fucking around.
## Why It's Good For The Game
Flesh spiders are meant to be a distraction from the real threat (the changeling), not a round ending monster given how easy it is to get them, you just need 3 bodies which really isn't a lot for the damage this ability will cause. They still deal 15-20 brute damage which is enough to distract people (as they should be).
## Changelog
:cl:
balance: Deleted venom from flesh spiders
balance: Increased flesh spider regeneration delay to 10 seconds
balance: Lowered their health regen to 3hp/s
/:cl:
