### PR TITLE
Humans Use Mutant Colors

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -6,12 +6,12 @@
 		HAIR,
 		FACEHAIR,
 		LIPS,
+		MUTCOLORS,
 	)
 	inherent_traits = list(
 		TRAIT_CAN_USE_FLIGHT_POTION,
 	)
 	mutant_bodyparts = list("wings" = "None")
-	use_skintones = TRUE
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = GROSS | RAW | CLOTH | BUGS | GORE
 	liked_food = JUNKFOOD | FRIED


### PR DESCRIPTION
## About The Pull Request

Changes humans from using default skin tones to using mutant colors. Doesn't remove the functionality of skin tones because that would break like everything ever.

## Why It's Good For The Game

Many a character creation ruined because the creator is stuck using like 8 different skin tones... This fixes that! And if you still want to use normal skin tones, nothings stopping you, just set it via mutant colors. Easy win.

Additionally, I've looked into alternative ways of adding custom skin colors for humans and I don't think there are any. With the current way that species traits work, this seems to be the only way unless somebody removes species traits like https://github.com/tgstation/tgstation/pull/76297 does.

## Changelog
:cl:
add: Humans now use mutant colors.
/:cl:
