### PR TITLE
The arrivals and cryopod announcers always work regardless of comms failure

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -180,7 +180,7 @@
 		flags_1 |= PREVENT_CONTENTS_EXPLOSION_1
 	}
 
-	if(HAS_TRAIT(SSstation, STATION_TRAIT_BOTS_GLITCHED))
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_BOTS_GLITCHED) && !SSticker.HasRoundStarted()) // monkestation edit: only glitch roundstart bots
 		randomize_language_if_on_station()
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NEW_MACHINE, src)
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -95,6 +95,9 @@
 	///can we radio host
 	var/radio_host = FALSE
 
+	/// If TRUE, then this message will always be received intact, regardless of exospheric anomalies / processor issues.
+	var/lossless = FALSE
+
 /obj/item/radio/Initialize(mapload)
 	set_wires(new /datum/wires/radio(src))
 	secure_radio_connections = list()
@@ -331,6 +334,10 @@
 		signal.levels = list(0)
 		signal.broadcast()
 		return
+	// monkestation edit: "lossless" var
+	if(lossless)
+		signal.data["compression"] = 0
+	// monkestation end
 
 	// All radios make an attempt to use the subspace system first
 	signal.send_to_receivers()

--- a/code/modules/mob/living/basic/bots/_bots.dm
+++ b/code/modules/mob/living/basic/bots/_bots.dm
@@ -133,7 +133,7 @@ GLOBAL_LIST_INIT(command_strings, list(
 		var/datum/atom_hud/datahud = GLOB.huds[data_hud_type]
 		datahud.show_to(src)
 
-	if(HAS_TRAIT(SSstation, STATION_TRAIT_BOTS_GLITCHED))
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_BOTS_GLITCHED) && !SSticker.HasRoundStarted()) // monkestation edit: only glitch roundstart bots
 		randomize_language_if_on_station()
 
 	if(mapload && is_station_level(z) && (bot_mode_flags & BOT_MODE_GHOST_CONTROLLABLE) && (bot_mode_flags & BOT_MODE_ROUNDSTART_POSSESSION))

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -187,7 +187,7 @@
 		path_hud.add_atom_to_hud(src)
 		path_hud.show_to(src)
 
-	if(HAS_TRAIT(SSstation, STATION_TRAIT_BOTS_GLITCHED))
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_BOTS_GLITCHED) && !SSticker.HasRoundStarted()) // monkestation edit: only glitch roundstart bots
 		randomize_language_if_on_station()
 
 	if(mapload && is_station_level(z) && bot_mode_flags & BOT_MODE_GHOST_CONTROLLABLE && bot_mode_flags & BOT_MODE_ROUNDSTART_POSSESSION)

--- a/monkestation/code/game/machinery/_machinery.dm
+++ b/monkestation/code/game/machinery/_machinery.dm
@@ -1,0 +1,7 @@
+/obj/machinery
+	/// If TRUE, then this will be affected by things such as the "Bot Language Matrix Malfunction" station trait.
+	var/can_language_malfunction = TRUE
+
+/obj/machinery/randomize_language_if_on_station()
+	if(can_language_malfunction)
+		return ..()

--- a/monkestation/code/game/machinery/announcement_system.dm
+++ b/monkestation/code/game/machinery/announcement_system.dm
@@ -1,0 +1,7 @@
+/obj/machinery/announcement_system
+	can_language_malfunction = FALSE
+
+/obj/machinery/announcement_system/Initialize(mapload)
+	. = ..()
+	radio.lossless = TRUE
+	radio.subspace_transmission = FALSE

--- a/monkestation/code/modules/cryopods/_cryopod.dm
+++ b/monkestation/code/modules/cryopods/_cryopod.dm
@@ -35,6 +35,7 @@ GLOBAL_LIST_EMPTY(valid_cryopods)
 	verb_say = "coldly states"
 	verb_ask = "queries"
 	verb_exclaim = "alarms"
+	can_language_malfunction = FALSE
 
 	/// Used for logging people entering cryosleep and important items they are carrying.
 	var/list/frozen_crew = list()
@@ -52,6 +53,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 	. = ..()
 	GLOB.cryopod_computers += src
 	radio = new radio(src)
+	radio.lossless = TRUE
 
 /obj/machinery/computer/cryopod/Destroy()
 	GLOB.cryopod_computers -= src

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5804,6 +5804,8 @@
 #include "monkestation\code\datums\wires\particle_accelerator.dm"
 #include "monkestation\code\game\atom.dm"
 #include "monkestation\code\game\sound.dm"
+#include "monkestation\code\game\machinery\_machinery.dm"
+#include "monkestation\code\game\machinery\announcement_system.dm"
 #include "monkestation\code\game\machinery\cloning.dm"
 #include "monkestation\code\game\machinery\exp_cloner.dm"
 #include "monkestation\code\game\machinery\launch_pad.dm"


### PR DESCRIPTION

## About The Pull Request

This makes it so the arrivals and cryo announcers have the following characteristics:
- They will never have their language scrambled by the "Bot Language Matrix Malfunction" station trait
  -  In addition, any bots/machines built after roundstart will speak normally.
- Their radios will still properly transmit if processors aren't working, such as during an exospheric anomaly.
- Their radios will still properly transmit if telecomms is down, similar to a station bounced radio.

![2024-07-18 (1721339972) ~ %pn](https://github.com/user-attachments/assets/86160e38-312f-4de4-a785-482cc9bb8123)

## Why It's Good For The Game

Avoids large amounts of confusion due to not knowing whenever someone joins or cryos during an inconvenient time.

## Changelog
:cl:
qol: The arrivals and cryopod announcers now always broadcast successfully regardless of whether telecomms is working or not.
qol: Bot Language Matrix Malfunction no longer affects the arrivals and cryopod announcers.
qol: Bot Language Matrix Malfunction no longer affects things built AFTER roundstart bots/machines built after roundstart will speak normally.
/:cl:
