### PR TITLE
Only admins with +ADMIN override deadchat viewing restrictions

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -455,12 +455,12 @@ GLOBAL_LIST_EMPTY(species_list)
 			toggles = prefs.toggles
 			ignoring = prefs.ignoring
 		if(admin_only)
-			if (!M.client?.holder)
+			if (!M.client?.holder?.check_for_rights(R_ADMIN)) // monkestation edit: only include admins with the +ADMIN permission
 				return
 			else
 				message += span_deadsay(" (This is viewable to admins only).")
 		var/override = FALSE
-		if(M.client?.holder && (chat_toggles & CHAT_DEAD))
+		if(M.client?.holder?.check_for_rights(R_ADMIN) && (chat_toggles & CHAT_DEAD)) // monkestation edit: only include admins with the +ADMIN permission
 			override = TRUE
 		if(HAS_TRAIT(M, TRAIT_SIXTHSENSE) && message_type == DEADCHAT_REGULAR)
 			override = TRUE

--- a/code/__HELPERS/~monkestation-helpers/clients.dm
+++ b/code/__HELPERS/~monkestation-helpers/clients.dm
@@ -14,3 +14,9 @@
 	log_admin("[key_name(usr)] kicked [key_name(to_kick)].")
 	message_admins(span_adminnotice("[key_name_admin(usr)] kicked [key_name_admin(to_kick)]."))
 	qdel(to_kick)
+
+/// When passed a mob, client, or mind, returns their admin holder, if they have one.
+/proc/get_admin_holder(doohickey) as /datum/admins
+	RETURN_TYPE(/datum/admins)
+	var/client/client = CLIENT_FROM_VAR(doohickey)
+	return client?.holder


### PR DESCRIPTION

## About The Pull Request

This makes it so the "admins can hear deadchat while alive or in lobby" thing only applies to admins who actually have the `+ADMIN` permission.

## Changelog

No user-facing changes
