### PR TITLE
Buffs the wheelchair's speed to be on par with 1.0

### DIFF
--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -8,7 +8,7 @@
 	armor_type = /datum/armor/ridden_wheelchair
 	density = FALSE //Thought I couldn't fix this one easily, phew
 	/// Run speed delay is multiplied with this for vehicle move delay.
-	var/delay_multiplier = 6.7
+	var/delay_multiplier = 3
 	/// This variable is used to specify which overlay icon is used for the wheelchair, ensures wheelchair can cover your legs
 	var/overlay_icon = "wheelchair_overlay"
 	var/image/wheels_overlay


### PR DESCRIPTION

## About The Pull Request
Increases the wheelchair speed to the one we had on 1.0
## Why It's Good For The Game
wheelchairs are currently awfully slow. There's a reason why nobody plays paraplegic characters anymore. Although I'm unsure how to add a unbuckle timer this should significantly improve the gameplay and enjoyability for paraplegic characters

## Changelog
:cl:
balance: All wheelchairs have received a brand new set of wheels! They should roll around much faster than before.
/:cl:
