### PR TITLE
Adds a confirmation prompt for ghost critter spawn points

### DIFF
--- a/monkestation/code/modules/ghost_critters/ghost_critter_spawnpoint.dm
+++ b/monkestation/code/modules/ghost_critters/ghost_critter_spawnpoint.dm
@@ -53,5 +53,9 @@
 	if(ghost.client.ghost_critter_cooldown > world.time)
 		return
 
+	var/confirm_critter = tgui_alert(usr, "Would you like to spawn as a ghost critter? This will make you unrevivable.", "Ghost critter confirmation", list("Yes", "No"))
+	if(!confirm_critter || confirm_critter == "No")
+		return
+
 	ghost.client.try_critter_spawn(src)
 	qdel(ghost)


### PR DESCRIPTION

## About The Pull Request
Adds a confirmation prompt for ghost critter spawn points
## Why It's Good For The Game
Helps to prevent accidently going dnr by misclicking the spawn points
## Changelog
:cl:
qol: Ghost critter spawn points now have a confirmation prompt before making you a critter
/:cl:
