### PR TITLE
Meteor Shield QoL: debris drifting, reliability improvements

### DIFF
--- a/monkestation/code/modules/holomaps/machinery.dm
+++ b/monkestation/code/modules/holomaps/machinery.dm
@@ -262,6 +262,20 @@
 	if(length(z_transitions))
 		legend += z_transitions
 
+	if(length(GLOB.meteor_shielded_turfs))
+		var/icon/canvas = icon(HOLOMAP_ICON, "blank")
+		var/z_has_coverage = FALSE
+		for(var/turf/open/shielded_turf as anything in GLOB.meteor_shielded_turfs)
+			if(shielded_turf?.z != current_z_level)
+				continue
+			var/offset_x = HOLOMAP_CENTER_X + shielded_turf.x
+			var/offset_y = HOLOMAP_CENTER_Y + shielded_turf.y
+			var/color = ((offset_x ^ offset_y) % 2 == 0) ? HOLOMAP_AREACOLOR_SHIELD_1 : HOLOMAP_AREACOLOR_SHIELD_2
+			canvas.DrawBox(color, offset_x, offset_y)
+			z_has_coverage = TRUE
+		if(z_has_coverage)
+			legend["Meteor Shield"] = list("icon" = image('monkestation/code/modules/holomaps/icons/8x8.dmi', icon_state = "meteor_shield"), "markers" = list(image(canvas)))
+
 	return legend
 
 /obj/machinery/station_map/engineering
@@ -293,20 +307,6 @@
 
 	if(length(fire_alarms))
 		extra_overlays["Fire Alarms"] = list("icon" = image('monkestation/code/modules/holomaps/icons/8x8.dmi', icon_state = "fire_marker"), "markers" = fire_alarms)
-
-	if(length(GLOB.meteor_shielded_turfs))
-		var/icon/canvas = icon(HOLOMAP_ICON, "blank")
-		var/z_has_coverage = FALSE
-		for(var/turf/open/shielded_turf as anything in GLOB.meteor_shielded_turfs)
-			if(shielded_turf?.z != current_z_level)
-				continue
-			var/offset_x = HOLOMAP_CENTER_X + shielded_turf.x
-			var/offset_y = HOLOMAP_CENTER_Y + shielded_turf.y
-			var/color = ((offset_x ^ offset_y) % 2 == 0) ? HOLOMAP_AREACOLOR_SHIELD_1 : HOLOMAP_AREACOLOR_SHIELD_2
-			canvas.DrawBox(color, offset_x, offset_y)
-			z_has_coverage = TRUE
-		if(z_has_coverage)
-			extra_overlays["Meteor Shield"] = list("icon" = image('monkestation/code/modules/holomaps/icons/8x8.dmi', icon_state = "meteor_shield"), "markers" = list(image(canvas)))
 
 	/*
 	var/list/air_alarms = list()

--- a/monkestation/code/modules/meteor_shield/meteor_shield_field.dm
+++ b/monkestation/code/modules/meteor_shield/meteor_shield_field.dm
@@ -3,24 +3,22 @@ GLOBAL_LIST_EMPTY_TYPED(meteor_shield_fields, /datum/proximity_monitor/advanced/
 /// A proximity monitor field that marks openspace turfs within as being covered by a meteor shield.
 /datum/proximity_monitor/advanced/meteor_shield
 	edge_is_a_field = TRUE
-	var/obj/machinery/satellite/meteor_shield/proxied_host
+	var/obj/machinery/satellite/meteor_shield/true_host
 
-/datum/proximity_monitor/advanced/meteor_shield/New(atom/_host, range, _ignore_if_not_on_turf, proxied_host)
+/datum/proximity_monitor/advanced/meteor_shield/New(atom/_host, range, _ignore_if_not_on_turf, obj/machinery/satellite/meteor_shield/proxied_host)
 	GLOB.meteor_shield_fields += src
-	if(proxied_host)
-		src.proxied_host = proxied_host
+	true_host = proxied_host || _host
 	return ..()
 
 /datum/proximity_monitor/advanced/meteor_shield/Destroy()
 	GLOB.meteor_shield_fields -= src
-	proxied_host = null
+	true_host = null
 	return ..()
 
 /datum/proximity_monitor/advanced/meteor_shield/setup_field_turf(turf/open/target)
 	if(!isgroundlessturf(target))
 		return
-	var/obj/machinery/satellite/meteor_shield/host_sat = proxied_host || host
-	if(host_sat.check_los(get_turf(host_sat), target))
+	if(true_host.check_los(get_turf(true_host), target))
 		ADD_TRAIT(target, TRAIT_COVERED_BY_METEOR_SHIELD, REF(src))
 		target.AddElement(/datum/element/meteor_shield_coverage)
 
@@ -31,3 +29,9 @@ GLOBAL_LIST_EMPTY_TYPED(meteor_shield_fields, /datum/proximity_monitor/advanced/
 	. = ..()
 	if(.)
 		recalculate_field(full_recalc = TRUE)
+
+/datum/proximity_monitor/advanced/meteor_shield/field_turf_crossed(atom/movable/thingymajig, turf/old_location, turf/new_location)
+	true_host.meteor_act(thingymajig)
+
+/datum/proximity_monitor/advanced/meteor_shield/field_turf_uncrossed(atom/movable/thingymajig, turf/old_location, turf/new_location)
+	true_host.meteor_act(thingymajig)

--- a/monkestation/code/modules/meteor_shield/meteor_shield_proxy.dm
+++ b/monkestation/code/modules/meteor_shield/meteor_shield_proxy.dm
@@ -1,6 +1,6 @@
 /obj/effect/abstract/meteor_shield_proxy
 	invisibility = INVISIBILITY_ABSTRACT
-	/// The meteor shield sat this is proxying - any HasProximity calls will be forwarded to it.
+	/// The meteor shield sat this is proxying - it will received all our meteor_acts
 	var/obj/machinery/satellite/meteor_shield/parent
 	/// Our proximity monitor.
 	var/datum/proximity_monitor/advanced/meteor_shield/monitor
@@ -23,9 +23,6 @@
 		UnregisterSignal(parent, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_Z_CHANGED, COMSIG_QDELETING))
 	parent = null
 	return ..()
-
-/obj/effect/abstract/meteor_shield_proxy/HasProximity(obj/effect/meteor/meteor)
-	parent.HasProximity(meteor)
 
 /obj/effect/abstract/meteor_shield_proxy/proc/on_parent_moved()
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request

![image](https://github.com/user-attachments/assets/17d7ab1b-188f-42d5-b768-d62924252e66)

## Changelog
:cl:
fix: Meteor shields should zap meteors even more reliably now.
qol: The debris from a zapped meteor now drifts, rather than staying in one spot where it was zapped.
/:cl:
