### PR TITLE
Hopefully fix cleaner slime deadlocks?

### DIFF
--- a/code/__DEFINES/~monkestation/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/~monkestation/dcs/signals/signals_mob/signals_mob_main.dm
@@ -25,3 +25,6 @@
 #define COMSIG_MOBSTACKER_DESTROY "mobstack_destroy_stack"
 
 #define COMSIG_SLIME_REGEN_CALC "slime_regen_calc"
+
+#define COMSIG_MOB_PICKED_UP "mob_picked_up"
+#define COMSIG_MOB_DROPPED "mob_dropped"

--- a/code/modules/mob/living/inhand_holder.dm
+++ b/code/modules/mob/living/inhand_holder.dm
@@ -67,6 +67,7 @@
 			qdel(src)
 		return FALSE
 	var/mob/living/released_mob = held_mob
+	SEND_SIGNAL(released_mob, COMSIG_MOB_DROPPED, loc, src) // monkestation edit: COMSIG_MOB_DROPPED
 	held_mob = null // stops the held mob from being release()'d twice.
 	if(isliving(loc))
 		var/mob/living/L = loc

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1787,6 +1787,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	var/obj/item/clothing/head/mob_holder/holder = new(get_turf(src), src, held_state, head_icon, held_lh, held_rh, worn_slot_flags)
 	user.visible_message(span_warning("[user] scoops up [src]!"))
 	user.put_in_hands(holder)
+	SEND_SIGNAL(src, COMSIG_MOB_PICKED_UP, user, holder) // monkestation edit: COMSIG_MOB_PICKED_UP
 
 /mob/living/proc/set_name()
 	numba = rand(1, 1000)

--- a/monkestation/code/modules/slimecore/mobs/_base_slime.dm
+++ b/monkestation/code/modules/slimecore/mobs/_base_slime.dm
@@ -232,6 +232,7 @@
 		new_planning_subtree |= add_or_replace_tree(/datum/ai_planning_subtree/flee_target)
 
 	if(slime_flags & CLEANER_SLIME)
+		ai_controller.clear_blackboard_key(BB_CLEAN_TARGET)
 		new_planning_subtree |= add_or_replace_tree(/datum/ai_planning_subtree/cleaning_subtree_slime)
 
 	if(!(slime_flags & PASSIVE_SLIME))


### PR DESCRIPTION

## Changelog
:cl:
fix: Hopefully fixed cleaner slimes getting stuck on some faraway target whenever you move them.
/:cl:
