### PR TITLE
fix: only admin ghosts can make living mobs chug

### DIFF
--- a/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -106,6 +106,9 @@
 	if(!isliving(over))
 		return
 
+	if(!isliving(usr) && !check_rights(R_FUN)) // monkestation edit: a bug? nah, its a feature!
+		return
+
 	if(!spillable)
 		return
 


### PR DESCRIPTION

## About The Pull Request
So, chugging. Best thing ever. You can even make other players chug drinks as long as you're standing next to them! Great feature. HOWEVER. That applies to ghosts too.

and I thought "hm, its pretty funny though!" so I made it a feature! It checks if you have the `R_FUN` right.

## Why It's Good For The Game

You don't want a bunch of non-admin ghosts making players chug things do you?

## Changelog
:cl:
admin: restricted making players chug as ghost a "FUN" only feature.
/:cl:
