### PR TITLE
Nosferatu vampires are no longer hurt by pressure/temperature while ventcrawling

### DIFF
--- a/code/modules/antagonists/abductor/equipment/glands/ventcrawl.dm
+++ b/code/modules/antagonists/abductor/equipment/glands/ventcrawl.dm
@@ -9,22 +9,12 @@
 
 /obj/item/organ/internal/heart/gland/ventcrawling/on_insert(mob/living/carbon/organ_owner, special)
 	. = ..()
-	RegisterSignal(organ_owner, SIGNAL_ADDTRAIT(TRAIT_MOVE_VENTCRAWLING), PROC_REF(give_pipe_resistance))
-	RegisterSignal(organ_owner, SIGNAL_REMOVETRAIT(TRAIT_MOVE_VENTCRAWLING), PROC_REF(take_pipe_resistance))
+	organ_owner.AddComponentFrom(REF(src), /datum/component/vent_safety)
 
 /obj/item/organ/internal/heart/gland/ventcrawling/on_remove(mob/living/carbon/organ_owner, special)
 	. = ..()
-	UnregisterSignal(organ_owner, list(SIGNAL_ADDTRAIT(TRAIT_MOVE_VENTCRAWLING), SIGNAL_REMOVETRAIT(TRAIT_MOVE_VENTCRAWLING)))
-	REMOVE_TRAITS_IN(organ_owner, ABDUCTOR_GLAND_VENTCRAWLING_TRAIT)
+	organ_owner.RemoveComponentSource(REF(src), /datum/component/vent_safety)
 
 /obj/item/organ/internal/heart/gland/ventcrawling/activate()
 	to_chat(owner, span_notice("You feel very stretchy."))
 	ADD_TRAIT(owner, TRAIT_VENTCRAWLER_ALWAYS, ABDUCTOR_GLAND_TRAIT)
-
-/obj/item/organ/internal/heart/gland/ventcrawling/proc/give_pipe_resistance()
-	SIGNAL_HANDLER
-	owner.add_traits(list(TRAIT_RESISTHIGHPRESSURE, TRAIT_RESISTLOWPRESSURE, TRAIT_RESISTHEAT, TRAIT_RESISTCOLD, TRAIT_NOBREATH), ABDUCTOR_GLAND_VENTCRAWLING_TRAIT)
-
-/obj/item/organ/internal/heart/gland/ventcrawling/proc/take_pipe_resistance()
-	SIGNAL_HANDLER
-	REMOVE_TRAITS_IN(owner, ABDUCTOR_GLAND_VENTCRAWLING_TRAIT)

--- a/monkestation/code/datums/components/vent_safety.dm
+++ b/monkestation/code/datums/components/vent_safety.dm
@@ -1,0 +1,31 @@
+/// A simple component that grants full pressure and temperature immunity while ventcrawling.
+/datum/component/vent_safety
+	dupe_mode = COMPONENT_DUPE_SOURCES
+	/// A list of traits to grant while inside of a vent.
+	var/static/list/traits_to_give = list(
+		TRAIT_RESISTHIGHPRESSURE,
+		TRAIT_RESISTLOWPRESSURE,
+		TRAIT_RESISTHEAT,
+		TRAIT_RESISTCOLD,
+		TRAIT_NOBREATH,
+	)
+
+/datum/component/vent_safety/Initialize()
+	if(!isliving(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/vent_safety/RegisterWithParent()
+	RegisterSignal(parent, SIGNAL_ADDTRAIT(TRAIT_MOVE_VENTCRAWLING), PROC_REF(give_pipe_resistance))
+	RegisterSignal(parent, SIGNAL_REMOVETRAIT(TRAIT_MOVE_VENTCRAWLING), PROC_REF(take_pipe_resistance))
+
+/datum/component/vent_safety/UnregisterFromParent()
+	UnregisterSignal(parent, list(SIGNAL_ADDTRAIT(TRAIT_MOVE_VENTCRAWLING), SIGNAL_REMOVETRAIT(TRAIT_MOVE_VENTCRAWLING)))
+	take_pipe_resistance()
+
+/datum/component/vent_safety/proc/give_pipe_resistance(mob/living/source)
+	SIGNAL_HANDLER
+	parent.add_traits(traits_to_give, REF(src))
+
+/datum/component/vent_safety/proc/take_pipe_resistance(mob/living/source)
+	SIGNAL_HANDLER
+	parent.remove_traits(traits_to_give, REF(src))

--- a/monkestation/code/modules/bloodsuckers/clans/nosferatu.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/nosferatu.dm
@@ -18,6 +18,7 @@
 	if(!bloodsuckerdatum.owner.current.has_quirk(/datum/quirk/badback))
 		bloodsuckerdatum.owner.current.add_quirk(/datum/quirk/badback)
 	bloodsuckerdatum.owner.current.add_traits(list(TRAIT_VENTCRAWLER_ALWAYS, TRAIT_DISFIGURED), BLOODSUCKER_TRAIT)
+	bloodsuckerdatum.owner.current.AddComponentFrom(REF(src), /datum/component/vent_safety)
 
 /datum/bloodsucker_clan/nosferatu/Destroy(force)
 	for(var/datum/action/cooldown/bloodsucker/power in bloodsuckerdatum.powers)
@@ -25,6 +26,7 @@
 	bloodsuckerdatum.give_starting_powers()
 	bloodsuckerdatum.owner.current.remove_quirk(/datum/quirk/badback)
 	bloodsuckerdatum.owner.current.remove_traits(list(TRAIT_VENTCRAWLER_ALWAYS, TRAIT_DISFIGURED), BLOODSUCKER_TRAIT)
+	bloodsuckerdatum.owner.current.RemoveComponentSource(REF(src), /datum/component/vent_safety)
 	return ..()
 
 /datum/bloodsucker_clan/nosferatu/handle_clan_life(datum/antagonist/bloodsucker/source)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5778,6 +5778,7 @@
 #include "monkestation\code\datums\components\turf_checker_complex.dm"
 #include "monkestation\code\datums\components\turf_healing.dm"
 #include "monkestation\code\datums\components\uplink.dm"
+#include "monkestation\code\datums\components\vent_safety.dm"
 #include "monkestation\code\datums\components\wound_converter.dm"
 #include "monkestation\code\datums\diseases\advance\symptoms\clockwork.dm"
 #include "monkestation\code\datums\elements\area_locked.dm"


### PR DESCRIPTION
## About The Pull Request

Same as with abductees with ventcrawl gland. I refactored it into a component (`/datum/component/vent_safety`). which applies pressure/temp immunity traits while inside of vents.

## Why It's Good For The Game

people with the abductor ventcrawl gland already get this, and it kinda sucks having your main "gimmick" fucked over because atmos did the bare minimum of optimization

## Changelog
:cl:
qol: Nosferatu vampires are no longer hurt by pressure/temperature while ventcrawling.
/:cl:
