### PR TITLE
Adds Plague Doctor as a pathologist alt title.

### DIFF
--- a/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
+++ b/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
@@ -351,6 +351,7 @@
 		"Pathologist",
 		"Fish Doctor",
 		"Junior Pathologist",
+		"Plague Doctor",
 	)
 
 /datum/job/warden


### PR DESCRIPTION

## About The Pull Request
Adds plague doctor as an alt pathologist title cause one person asked for it and it was easy.
## Why It's Good For The Game
What is a pathologist but a doctor of the plague?
## Changelog
:cl:
add: Added an alternate job name for pathologist.
/:cl:
