### PR TITLE
Wheelchair Re-Balance so that's like 1.0 again

### DIFF
--- a/code/datums/components/riding/riding_vehicle.dm
+++ b/code/datums/components/riding/riding_vehicle.dm
@@ -258,13 +258,13 @@
 
 // special messaging for those without arms
 /datum/component/riding/vehicle/wheelchair/hand/driver_move(obj/vehicle/vehicle_parent, mob/living/user, direction)
-	var/delay_multiplier = 6.7 // magic number from wheelchair code
+	var/delay_multiplier = 4 // magic number from wheelchair code //MONKESTATION EDIT
 	vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * delay_multiplier) / clamp(user.usable_hands, 1, 2)
 	return ..()
 
 /datum/component/riding/vehicle/wheelchair/motorized/driver_move(obj/vehicle/vehicle_parent, mob/living/user, direction)
 	var/speed = 1 // Should never be under 1
-	var/delay_multiplier = 6.7 // magic number from wheelchair code
+	var/delay_multiplier = 4 // magic number from wheelchair code //MONKESTATION EDIT
 
 	var/obj/vehicle/ridden/wheelchair/motorized/our_chair = parent
 	for(var/datum/stock_part/manipulator/manipulator in our_chair.component_parts)

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -61,7 +61,7 @@
 	if(usr == buckled_mob)
 		..()
 	else
-		if(do_after(usr, 3 SECONDS))
+		if(do_after(usr, 2 SECONDS))
 			..()
 //MONKESTATION ADDITION END
 

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "wheelchair"
 	layer = OBJ_LAYER
-	max_integrity = 100
+	max_integrity = 40 //MONKESTATION EDIT
 	armor_type = /datum/armor/ridden_wheelchair
 	density = FALSE //Thought I couldn't fix this one easily, phew
 	/// Run speed delay is multiplied with this for vehicle move delay.
@@ -56,6 +56,15 @@
 	. = ..()
 	update_appearance()
 
+//MONKESTATION ADDITION START
+/obj/vehicle/ridden/wheelchair/unbuckle_mob(mob/living/buckled_mob, force = FALSE, can_fall = TRUE)
+	if(usr == buckled_mob)
+		..()
+	else
+		if(do_after(usr, 3 SECONDS))
+			..()
+//MONKESTATION ADDITION END
+
 /obj/vehicle/ridden/wheelchair/wrench_act(mob/living/user, obj/item/I) //Attackby should stop it attacking the wheelchair after moving away during decon
 	..()
 	to_chat(user, span_notice("You begin to detach the wheels..."))
@@ -87,7 +96,7 @@
 	desc = "Damn, must've been through a lot."
 	icon_state = "gold_wheelchair"
 	overlay_icon = "gold_wheelchair_overlay"
-	max_integrity = 200
+	max_integrity = 90 //MONKESTATION EDIT
 	armor_type = /datum/armor/wheelchair_gold
 	custom_materials = list(/datum/material/gold = SHEET_MATERIAL_AMOUNT*5)
 	foldabletype = /obj/item/wheelchair/gold

--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/vehicles.dmi'
 	icon_state = "wheelchair"
 	layer = OBJ_LAYER
-	max_integrity = 40 //MONKESTATION EDIT
+	max_integrity = 50 //MONKESTATION EDIT
 	armor_type = /datum/armor/ridden_wheelchair
 	density = FALSE //Thought I couldn't fix this one easily, phew
 	/// Run speed delay is multiplied with this for vehicle move delay.
@@ -55,15 +55,6 @@
 /obj/vehicle/ridden/wheelchair/post_unbuckle_mob()
 	. = ..()
 	update_appearance()
-
-//MONKESTATION ADDITION START
-/obj/vehicle/ridden/wheelchair/unbuckle_mob(mob/living/buckled_mob, force = FALSE, can_fall = TRUE)
-	if(usr == buckled_mob)
-		..()
-	else
-		if(do_after(usr, 2 SECONDS))
-			..()
-//MONKESTATION ADDITION END
 
 /obj/vehicle/ridden/wheelchair/wrench_act(mob/living/user, obj/item/I) //Attackby should stop it attacking the wheelchair after moving away during decon
 	..()

--- a/monkestation/code/modules/vehicles/wheelchair.dm
+++ b/monkestation/code/modules/vehicles/wheelchair.dm
@@ -1,0 +1,7 @@
+//modular modification of 'code\modules\vehicles\wheelchair.dm' so that there is a do_after
+/obj/vehicle/ridden/wheelchair/unbuckle_mob(mob/living/buckled_mob, force = FALSE, can_fall = TRUE)
+	if(usr == buckled_mob)
+		. = ..()
+	else
+		if(do_after(usr, 1 SECONDS))
+			. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7580,6 +7580,7 @@
 #include "monkestation\code\modules\uplink\uplink_items\species.dm"
 #include "monkestation\code\modules\uplink\uplink_items\weapons.dm"
 #include "monkestation\code\modules\vehicles\monkey_ball.dm"
+#include "monkestation\code\modules\vehicles\wheelchair.dm"
 #include "monkestation\code\modules\vehicles\mecha\mecha_actions.dm"
 #include "monkestation\code\modules\vehicles\mecha\equipment\tools\other_tools.dm"
 #include "monkestation\code\modules\vending\megaseed.dm"


### PR DESCRIPTION

## About The Pull Request
This PR does several things to make them feel somewhat as they were on Monke 1.0 such as, make them faster, have a do after when someone tries to take you out of the chair, and to balance those two changes out halfs the health of the chair.

https://github.com/user-attachments/assets/0d263ec5-7d63-4cf5-b308-ac7903356372

## Why It's Good For The Game
Makes being a paraplegic something that's actually worth doing, as all of our old paraplegic from 1.0 no longer play or just don't use the trait but they REALLY want to do to how fucking slow the chairs are. I belive this change will make the chairs something that's more fun to use.

if you think it's to powerful, remember 3 toolbox hits and the chair is gone


## Changelog
:cl:
balance: rebalanced the wheelchairs to be similar to as they were in monke 1.0!
/:cl:
