### PR TITLE
Fixes a null runtime with liquids

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1331,17 +1331,20 @@
 		SSexplosions.med_mov_atom += killthis
 	SEND_SIGNAL(src, COMSIG_AIRLOCK_CLOSE, forced)
 
+	// monkestation edit: liquids
 	var/turf/open/open_turf = get_turf(src)
-	if(open_turf.liquids)
+	if(!QDELETED(open_turf.liquids))
 		var/datum/liquid_group/turfs_group = open_turf.liquids.liquid_group
-		turfs_group.remove_from_group(open_turf)
-		qdel(open_turf.liquids)
-		turfs_group.try_split(open_turf)
-		for(var/dir in GLOB.cardinals)
-			var/turf/open/direction_turf = get_step(open_turf, dir)
-			if(!isopenturf(direction_turf) || !direction_turf.liquids)
-				continue
-			turfs_group.check_edges(direction_turf)
+		if(!QDELETED(turfs_group))
+			turfs_group.remove_from_group(open_turf)
+			turfs_group.try_split(open_turf)
+			for(var/dir in GLOB.cardinals)
+				var/turf/open/direction_turf = get_step(open_turf, dir)
+				if(!isopenturf(direction_turf) || QDELING(direction_turf) || QDELETED(direction_turf.liquids))
+					continue
+				turfs_group.check_edges(direction_turf)
+		QDEL_NULL(open_turf.liquids)
+	// monkestation end
 
 	operating = TRUE
 	update_icon(ALL, AIRLOCK_CLOSING, 1)


### PR DESCRIPTION
## Changelog
:cl:
fix: Fixed a runtime error relating to airlocks closing and liquids.
/:cl:
