### PR TITLE
Fixes loadout suits with hoods deleting loadout hats

### DIFF
--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -39,7 +39,11 @@
 /obj/item/clothing/suit/hooded/on_outfit_equip(mob/living/carbon/human/outfit_wearer, visuals_only, item_slot)
 	if(visuals_only)
 		MakeHood()
-	ToggleHood()
+	//monkestation edit start
+	var/datum/outfit/outfit
+	if(outfit.head == null)
+		ToggleHood()
+	//monkestation edit end
 
 /obj/item/clothing/suit/hooded/proc/RemoveHood()
 	src.icon_state = "[initial(icon_state)]"


### PR DESCRIPTION

## About The Pull Request
Fixes various loadout suits with hoods deleting equipped loadout hats, fixes #2748
## Why It's Good For The Game
Bugs bad, also being able to wear your hat of choice with things like winter jackets is good.
## Changelog
:cl:
fix: Fixed character loadout suits with a hood deleting character loadout hats.
/:cl:
