### PR TITLE
Paramedic Arm Implant. Modifications to Combat Cybernetics Implant. Removal of Chemical Arm Implant

### DIFF
--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -215,7 +215,7 @@
 		/datum/job/captain = /obj/item/organ/internal/heart/cybernetic/tier3,
 		/datum/job/cargo_technician = /obj/item/organ/internal/stomach/cybernetic/tier2,
 		/datum/job/chaplain = /obj/item/organ/internal/cyberimp/brain/anti_drop,
-		/datum/job/chemist = /obj/item/organ/internal/cyberimp/arm/item_set/chemical, // monkestation edit: cybernetics overhaul (useful job stuff)
+		/datum/job/chemist = /obj/item/organ/internal/liver/cybernetic/tier3,
 		/datum/job/chief_engineer = /obj/item/organ/internal/cyberimp/chest/thrusters,
 		/datum/job/chief_medical_officer = /obj/item/organ/internal/cyberimp/brain/linked_surgery/perfect/nt, // monkestation edit: cybernetics overhaul (couldn't think of anything else that was good for cmo)
 		/datum/job/clown = /obj/item/organ/internal/cyberimp/chest/knockout, // monkestation edit: cybernetics overhaul (honk!!! it's the clown mech fist shrunken down after all)
@@ -229,7 +229,7 @@
 		/datum/job/janitor = /obj/item/organ/internal/cyberimp/arm/item_set/janitor, // monkestation edit: cybernetics overhaul (useful job stuff)
 		/datum/job/lawyer = /obj/item/organ/internal/heart/cybernetic/tier2,
 		/datum/job/mime = /obj/item/organ/internal/tongue/robot, //...
-		/datum/job/paramedic = /obj/item/organ/internal/cyberimp/arm/item_set/medibeam, // monkestation edit: cybernetics overhaul (on-site healing / assistance)
+		/datum/job/paramedic = /obj/item/organ/internal/cyberimp/arm/item_set/paramedic, // monkestation edit: cybernetics overhaul (on-site healing / assistance)
 		/datum/job/prisoner = /obj/item/organ/internal/eyes/robotic/shield,
 		/datum/job/psychologist = /obj/item/organ/internal/ears/cybernetic/upgraded,
 		/datum/job/quartermaster = /obj/item/organ/internal/stomach/cybernetic/tier3,

--- a/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
+++ b/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
@@ -120,7 +120,7 @@
 		/obj/item/sensor_device,
 		/obj/item/gun/medbeam
 	)
-	encode_info = AUGMENT_NT_LOWLEVEL
+	encode_info = AUGMENT_NT_HIGHLEVEL
 
 /obj/item/organ/internal/cyberimp/arm/item_set/atmospherics
 	name = "atmospherics toolset implant"

--- a/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
+++ b/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
@@ -112,14 +112,13 @@
 		if(located)
 			located.forceMove(drop_location())
 
-/obj/item/organ/internal/cyberimp/arm/item_set/chemical
-	name = "chemical toolset implant"
-	desc = "A set of chemical tools hidden behind a concealed panel on the user's arm."
+/obj/item/organ/internal/cyberimp/arm/item_set/paramedic
+	name = "paramedic toolset implant"
+	desc = "A set of rescue tools hidden behind a concealed panel on the user's arm."
 	items_to_create = list(
-		/obj/item/reagent_containers/cup/beaker,
-		/obj/item/reagent_containers/cup/beaker,
-		/obj/item/reagent_containers/cup/beaker,
-		/obj/item/reagent_containers/dropper
+		/obj/item/roller/robo,
+		/obj/item/sensor_device,
+		/obj/item/gun/medbeam
 	)
 	encode_info = AUGMENT_NT_LOWLEVEL
 
@@ -135,11 +134,11 @@
 	encode_info = AUGMENT_NT_LOWLEVEL
 
 /obj/item/organ/internal/cyberimp/arm/item_set/combat
-	name = "combat cybernetics implant"
+	name = "officer toolset implant"
 	desc = "A powerful cybernetic implant that contains combat modules built into the user's arm."
 	items_to_create = list(
-		/obj/item/gun/medbeam,
-		/obj/item/borg/stun,
+		/obj/item/reagent_containers/spray/pepper,
+		/obj/item/melee/baton,
 		/obj/item/assembly/flash/armimplant,
 	)
 	encode_info = AUGMENT_TG_LEVEL

--- a/monkestation/code/modules/cybernetics/designs/item_sets.dm
+++ b/monkestation/code/modules/cybernetics/designs/item_sets.dm
@@ -7,7 +7,7 @@
 	materials = list(/datum/material/iron = 2500, /datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/silver =HALF_SHEET_MATERIAL_AMOUNT * 1.5)
 	build_path = /obj/item/organ/internal/cyberimp/arm/item_set/botany
 	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_TOOLS
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
@@ -33,20 +33,20 @@
 	materials = list(/datum/material/iron = 2500, /datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/silver =HALF_SHEET_MATERIAL_AMOUNT * 1.5)
 	build_path = /obj/item/organ/internal/cyberimp/arm/item_set/atmospherics
 	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_TOOLS
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-/datum/design/itemset_chemical
-	name = "Chemical Arm Implant"
-	desc =   "A set of chemical tools hidden behind a concealed panel on the user's arm."
-	id = "ci-set-chemical"
+/datum/design/itemset_paramedic
+	name = "Paramedic Arm Implant"
+	desc =   "A set of rescue tools hidden behind a concealed panel on the user's arm."
+	id = "ci-set-paramedic"
 	build_type = PROTOLATHE | MECHFAB
 	construction_time = 3 SECONDS
 	materials = list(/datum/material/iron = 2500, /datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/silver =HALF_SHEET_MATERIAL_AMOUNT * 1.5)
-	build_path = /obj/item/organ/internal/cyberimp/arm/item_set/chemical
+	build_path = /obj/item/organ/internal/cyberimp/arm/item_set/paramedic
 	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_TOOLS
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
@@ -59,7 +59,7 @@
 	materials = list(/datum/material/iron = 2500, /datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/silver =HALF_SHEET_MATERIAL_AMOUNT * 1.5)
 	build_path = /obj/item/organ/internal/cyberimp/arm/item_set/detective
 	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_TOOLS
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
@@ -72,7 +72,7 @@
 	materials = list(/datum/material/iron = 2500, /datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/silver =HALF_SHEET_MATERIAL_AMOUNT * 1.5)
 	build_path = /obj/item/organ/internal/cyberimp/arm/item_set/janitor
 	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_TOOLS
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
@@ -85,7 +85,7 @@
 	materials = list(/datum/material/iron = 2500, /datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/silver =HALF_SHEET_MATERIAL_AMOUNT * 1.5)
 	build_path = /obj/item/organ/internal/cyberimp/arm/item_set/cook
 	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_TOOLS
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
@@ -98,7 +98,7 @@
 	materials = list(/datum/material/iron = 2500, /datum/material/glass =HALF_SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/silver =HALF_SHEET_MATERIAL_AMOUNT * 1.5)
 	build_path = /obj/item/organ/internal/cyberimp/arm/item_set/mining_drill
 	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_TOOLS
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 

--- a/monkestation/code/modules/cybernetics/designs/security.dm
+++ b/monkestation/code/modules/cybernetics/designs/security.dm
@@ -12,7 +12,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
 /datum/design/security_itemset
-	name = "combat cybernetics implant"
+	name = "Officer Arm Implant"
 	desc =  "A powerful cybernetic implant that contains combat modules built into the user's arm."
 	id = "ci-set-combat"
 	build_type = PROTOLATHE

--- a/monkestation/code/modules/cybernetics/tech_nodes.dm
+++ b/monkestation/code/modules/cybernetics/tech_nodes.dm
@@ -24,7 +24,7 @@
 		"ci-set-cook",
 		"ci-set-janitor",
 		"ci-set-detective",
-		"ci-set-chemical",
+		"ci-set-paramedic",
 		"ci-set-atmospherics",
 		"ci-set-connector",
 		"ci-set-botany",


### PR DESCRIPTION

## About The Pull Request

Replaces the Chemical Arm Implant with the Paramedic Arm Implant for a number of reasons. 

The Chemical Arm Implant was rarely ever seen outside of roundstart cybernetics, and even then it was not very good compared to every other arm toolset. The Paramedic Arm Implant aims to move the Medbeam that the Combat Cybernetics Implant had to Medbay, where it belongs. 

This PR also modifies the Combat Cybernetics Implant, renaming it to Officer Arm Implant to be more in line with other arm implants and avoid confusion with the research of a similar name. It also replaces the Borg stun baton with a standard baton usually seen with the Detective, and replaces the slot that the Medibeam used with a canister of Pepperspray.

Paramedic Arm Implant:
Medibeam
Roller Bed Dock
Handheld Crew Monitor

Officer Arm Implant:
Standard Baton
Pepperspray
Photon Projector
## Why It's Good For The Game

The Chemical Arm implant was pretty much never used, and was fundamentally flawed since you can't pour from a beaker in your hand to one in your arm. I replaced the Roundstart Cybernetic that the Chemist usually got with a Tier 3 Cybernetic Liver that the Bartender gets for its toxin filtering.

It also made absolutely zero sense for Security of all departments to have access to the Medibeam, and especially for it to be included alongside two combat items.
## Changelog
:cl: Meowosers
add: Adds a Paramedic Arm Implant with rescue tools
del: Removes the Chemical Arm Implant due to lack of function and use
qol: The Combat Cybernetics Implant has been renamed to the Officer Arm Implant. You're welcome RND
balance: The Officer Arm Implant is now less healing focused, and should be better suited for combat
/:cl:
