### PR TITLE
Fix reviving ooze that had a mind put back into it after first failed revival

### DIFF
--- a/monkestation/code/modules/smithing/oozelings/body/organs.dm
+++ b/monkestation/code/modules/smithing/oozelings/body/organs.dm
@@ -229,7 +229,6 @@
 /obj/item/organ/internal/brain/slime/proc/rebuild_body(mob/user, nugget = TRUE)
 	if(rebuilt)
 		return
-	rebuilt = TRUE
 	set_organ_damage(-maxHealth) // heals the brain fully
 
 	if(gps_active) // making sure the gps signal is removed if it's active on revival
@@ -249,6 +248,7 @@
 		return TRUE
 	var/mob/living/carbon/human/new_body = new /mob/living/carbon/human(drop_location())
 
+	rebuilt = TRUE
 	brainmob.client?.prefs?.safe_transfer_prefs_to(new_body)
 	new_body.underwear = "Nude"
 	new_body.undershirt = "Nude"


### PR DESCRIPTION

## About The Pull Request
This moves `rebuilt = TRUE` to AFTER the checks for revivability. fixes an edge case where if you try to revive an oozeling core that has no mind, that was in CentCom, then returns to its core, and revive again, it wouldn't actually revive them because `rebuilt` was set to TRUE last time a revival was attempted but failed.

## Why It's Good For The Game

## Changelog

:cl:
fix: oozeling revival bug involving going to CC and returning to corpse
/:cl:
