### PR TITLE
Proto-kinetic shockwaves can no longer be fired on-station

### DIFF
--- a/monkestation/code/modules/mining/accelerators/shockwave.dm
+++ b/monkestation/code/modules/mining/accelerators/shockwave.dm
@@ -10,7 +10,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/shockwave)
 	can_bayonet = FALSE
 	max_mod_capacity = 60
-	firing_pin = /obj/item/firing_pin/explorer/unremovable
+	pin = /obj/item/firing_pin/explorer/unremovable
 
 /obj/item/ammo_casing/energy/kinetic/shockwave
 	projectile_type = /obj/projectile/kinetic/shockwave

--- a/monkestation/code/modules/mining/accelerators/shockwave.dm
+++ b/monkestation/code/modules/mining/accelerators/shockwave.dm
@@ -10,6 +10,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/shockwave)
 	can_bayonet = FALSE
 	max_mod_capacity = 60
+	firing_pin = /obj/item/firing_pin/explorer/unremovable
 
 /obj/item/ammo_casing/energy/kinetic/shockwave
 	projectile_type = /obj/projectile/kinetic/shockwave
@@ -20,3 +21,6 @@
 /obj/projectile/kinetic/shockwave
 	name = "concussive kinetic force"
 	range = 1
+
+/obj/item/firing_pin/explorer/unremovable
+	pin_removable = FALSE


### PR DESCRIPTION

## About The Pull Request

I'm not really the best person to know how to properly balance this, but "don't let them instakill people on-station" seems like a common sense way to start.

## Changelog
:cl:
balance: Proto-kinetic shockwaves now have an unremovable explorer firing pin, preventing them from being fired on the station.
/:cl:
