### PR TITLE
Fixes some Android species annoyances

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -25,7 +25,12 @@
 		TRAIT_TOXIMMUNE,
 		TRAIT_NOBLOOD,
 		TRAIT_VIRUSIMMUNE,
-		TRAIT_REVIVES_BY_HEALING, // monkestation edit: making androids closer to IPCs
+		// monkestation edit: making androids closer to IPCs
+		TRAIT_REVIVES_BY_HEALING,
+		TRAIT_NO_DNA_COPY,
+		TRAIT_XENO_IMMUNE,
+		TRAIT_STABLELIVER,
+		// monkestation end
 	)
 
 	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID


### PR DESCRIPTION

## About The Pull Request

- turns out `NOTRANSSTING` isn't checked anywhere haha, `TRAIT_NO_DNA_COPY` should be used for that.
- giving androids the ability to metabolize unintentionally made them vulnerable to liver failure by extension
  - they only have livers and a metabolism in the first place so certain things work (i.e flight potions), it's not central to their not-biology.
- facehuggers targeting them is stupid tbh - they're *guaranteed* to fail the actual impregnation due to the robotic chest, and why would they try to hug a robot anyways?

## Changelog
:cl:
fix: Androids can no longer be transform stung by changelings.
fix: Androids no longer suffer from liver failure.
fix: Facehuggers no longer waste their lives trying to hug androids (who can't host an embryo anyways.)
/:cl:
