### PR TITLE
Fix a runtime when adding admin verbs

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -275,7 +275,7 @@ GLOBAL_PROTECT(admin_verbs_poll)
 
 		var/rights = holder.rank_flags()
 		add_verb(src, GLOB.admin_verbs_default)
-		add_verb(GLOB.mentor_verbs) //Monkestation Edit
+		add_verb(src, GLOB.mentor_verbs) // monkestation edit: mentors
 		if(rights & R_BUILD)
 			add_verb(src, /client/proc/togglebuildmodeself)
 		if(rights & R_ADMIN)


### PR DESCRIPTION
## Changelog
:cl:
fix: Fixed a runtime relating to granting admins mentor-related verbs.
/:cl:
