### PR TITLE
Don't delete wings whenever regenerating organs

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -478,7 +478,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		// External organ checking. We need to check the external organs owned by the carbon itself,
 		// because we want to also remove ones not shared by its species.
 		// This should be done even if species was not changed.
-		if(external_organ in external_organs)
+		if((external_organ in external_organs) || istype(external_organ, /obj/item/organ/external/wings/functional)) // monkestation edit: don't delete wings
 			continue // Don't remove external organs this species is supposed to have.
 
 		external_organ.Remove(organ_holder)


### PR DESCRIPTION
vampires can once again have wings now without losing them during torpor!

## Changelog
:cl:
fix: Organ regeneration/healing stuff no longer deletes your wings, if you obtained any.
/:cl:
