### PR TITLE
DNA Infusions now transfer skillchips

### DIFF
--- a/code/game/machinery/dna_infuser/dna_infuser.dm
+++ b/code/game/machinery/dna_infuser/dna_infuser.dm
@@ -134,7 +134,25 @@
 		return FALSE
 	// Valid organ successfully picked.
 	new_organ = new new_organ()
+	// monkestation start: ensure skillchips don't get nuked
+	var/list/skillchips
+	if(ispath(new_organ, /obj/item/organ/internal/brain))
+		skillchips = target.clone_skillchip_list()
+		target.destroy_all_skillchips(silent = TRUE)
+	// monkestation end
 	new_organ.replace_into(target)
+	// monkestation start: ensure skillchips don't get nuked
+	if(skillchips)
+		for(var/chip in skillchips)
+			var/chip_type = chip["type"]
+			if(!ispath(chip_type, /obj/item/skillchip))
+				continue
+			var/obj/item/skillchip/skillchip = new chip_type(target)
+			if(target.implant_skillchip(skillchip, force = TRUE))
+				qdel(skillchip)
+				continue
+			skillchip.set_metadata(chip)
+	// monkestation end
 	check_tier_progression(target)
 
 /// Picks a random mutated organ from the infuser entry which is also compatible with the target mob.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so, if a dna infusion gives you a new brain, it will transfer any skillchips to the new brain.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: DNA Infusions now transfer skillchips.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
