### PR TITLE
Add "Holy Effect" option to "Select Equipment" menu

### DIFF
--- a/monkestation/code/modules/admin/verbs/selectequipment.dm
+++ b/monkestation/code/modules/admin/verbs/selectequipment.dm
@@ -1,0 +1,7 @@
+/datum/select_equipment/ui_act(action, params)
+	. = ..()
+	if (.)
+		switch(action)
+			if("applyoutfit")
+				if(params["holyEffect"])
+					new /obj/effect/holy(target_mob.loc)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5904,6 +5904,7 @@
 #include "monkestation\code\modules\admin\smites\where_are_your_fingers.dm"
 #include "monkestation\code\modules\admin\verbs\getlogs.dm"
 #include "monkestation\code\modules\admin\verbs\kick_player_by_ckey.dm"
+#include "monkestation\code\modules\admin\verbs\selectequipment.dm"
 #include "monkestation\code\modules\admin\verbs\spawn_mixtape.dm"
 #include "monkestation\code\modules\aesthetics\airlock\airlock.dm"
 #include "monkestation\code\modules\aesthetics\items\clothing.dm"

--- a/tgui/packages/tgui/interfaces/SelectEquipment.jsx
+++ b/tgui/packages/tgui/interfaces/SelectEquipment.jsx
@@ -166,6 +166,7 @@ const OutfitDisplay = (props) => {
 
 const CurrentlySelectedDisplay = (props) => {
   const { act, data } = useBackend();
+  const [holyEffect, setHolyEffect] = useLocalState('holyEffect', false);
   const { current_outfit } = data;
   const { entry } = props;
   return (
@@ -199,6 +200,13 @@ const CurrentlySelectedDisplay = (props) => {
         </Box>
       </Stack.Item>
       <Stack.Item>
+        <Button.Checkbox
+          checked={holyEffect}
+          onClick={() => setHolyEffect(!holyEffect)}
+          content="Holy Effect"
+        />
+      </Stack.Item>
+      <Stack.Item>
         <Button
           mr={0.8}
           lineHeight={2}
@@ -206,6 +214,7 @@ const CurrentlySelectedDisplay = (props) => {
           onClick={() =>
             act('applyoutfit', {
               path: current_outfit,
+              holyEffect,
             })
           }
         >


### PR DESCRIPTION
## About The Pull Request
Adds a checkbox to play a holy effect when you select your equipment. Usually would be used when your target is a ghost and you want a fancy sound to play if you're spawning in.

## Why It's Good For The Game

## Changelog

:cl:
admin: "Select Equipment" now has an option to do "Holy Effect"
/:cl:


https://github.com/user-attachments/assets/9fa6bab0-9609-4fbb-97c4-b3e67991ca46


https://github.com/user-attachments/assets/05e92b27-c08e-47f2-a7a9-4f8d1cde7c6b

