### PR TITLE
Fix florida man antag token spawning

### DIFF
--- a/monkestation/code/modules/antagonists/florida_man/_florida_man.dm
+++ b/monkestation/code/modules/antagonists/florida_man/_florida_man.dm
@@ -58,7 +58,6 @@
 		floridan.fully_replace_character_name(newname = "Tony Brony")
 
 /datum/antagonist/florida_man/antag_token(datum/mind/hosts_mind, mob/spender)
-	. = ..()
 	if(isobserver(spender))
 		var/mob/living/carbon/human/new_mob = spender.change_mob_type(/mob/living/carbon/human, delete_old_mob = TRUE)
 		new_mob.equipOutfit(/datum/outfit/florida_man_three)


### PR DESCRIPTION
well i guess `SHOULD_CALL_PARENT(FALSE)` doesn't do jack shit

Fixes https://github.com/Monkestation/Monkestation2.0/issues/2813

## Changelog
:cl:
fix: Antag tokening for Florida Man as ghost no longer spawns a duplicate random human.
/:cl:
