### PR TITLE
[PORT] Fixes void cloak not making suit store slot items unstrippable

### DIFF
--- a/code/modules/antagonists/heretic/items/heretic_armor.dm
+++ b/code/modules/antagonists/heretic/items/heretic_armor.dm
@@ -108,12 +108,12 @@
 	. = ..()
 	UnregisterSignal(user, list(COMSIG_MOB_UNEQUIPPED_ITEM, COMSIG_MOB_EQUIPPED_ITEM))
 
-/obj/item/clothing/suit/hooded/cultrobes/void/proc/hide_item(obj/item/item, slot)
+/obj/item/clothing/suit/hooded/cultrobes/void/proc/hide_item(datum/source, obj/item/item, slot)
 	SIGNAL_HANDLER
 	if(slot & ITEM_SLOT_SUITSTORE)
 		ADD_TRAIT(item, TRAIT_NO_STRIP, REF(src)) // i'd use examine hide but its a flag and yeah
 
-/obj/item/clothing/suit/hooded/cultrobes/void/proc/show_item(obj/item/item, slot)
+/obj/item/clothing/suit/hooded/cultrobes/void/proc/show_item(datum/source, obj/item/item, slot)
 	SIGNAL_HANDLER
 	REMOVE_TRAIT(item, TRAIT_NO_STRIP, REF(src))
 


### PR DESCRIPTION
Port of https://github.com/tgstation/tgstation/pull/78841

## Changelog
:cl: Absolucy, AnturK
fix: Fixes void cloak not making suit store slot items unstrippable.
/:cl:
