### PR TITLE
Increases the maximum amount of changeling stored dna strings from 6 to 60.

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -28,7 +28,7 @@
 	/// The original profile of this changeling.
 	var/datum/changeling_profile/first_profile = null
 	/// How many DNA strands the changeling can store for transformation.
-	var/dna_max = 6
+	var/dna_max = 60
 	/// The amount of DNA gained. Includes DNA sting.
 	var/absorbed_count = 0
 	/// The amount of DMA gained using absorb, not DNA sting. Start with one (your original DNA)

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -28,7 +28,7 @@
 	/// The original profile of this changeling.
 	var/datum/changeling_profile/first_profile = null
 	/// How many DNA strands the changeling can store for transformation.
-	var/dna_max = 60
+	var/dna_max = 60 //Monkestation edit: 6 => 60
 	/// The amount of DNA gained. Includes DNA sting.
 	var/absorbed_count = 0
 	/// The amount of DMA gained using absorb, not DNA sting. Start with one (your original DNA)


### PR DESCRIPTION

## About The Pull Request
Currently once a changeling dna stings 6 people, they lose their ability to shift back into their original body, this is completely Un-telegraphed to the unsuspecting changeling, who now has lost the form that they have the most gear for. Fully tested.

## Why It's Good For The Game
Stealth/bodyshifting changeling is very fun, however it has a massive problem of the fact that you can only do it with 5 people before you lose your original form, which sucks. The ability to be whoever you wanna be whenever you want is one of the main(ideally) tools for changeling, and having that just get messed up whenever they reach an invisible limit sucks.

## Changelog
:cl:
balance: Changelings can now store up to 60 different dna strands!
/:cl:
