### PR TITLE
Prybar is now bulky

### DIFF
--- a/monkestation/code/modules/blueshift/items/tools.dm
+++ b/monkestation/code/modules/blueshift/items/tools.dm
@@ -93,7 +93,7 @@
 		return FALSE
 	return TRUE
 
-// Just a completely normal crowbar except it's bulky sized and can force doors like jaws of life can
+// Just a completely normal crowbar except it's bulky sized and can force doors like jaws of life can.
 
 /obj/item/crowbar/large/doorforcer
 	name = "prybar"

--- a/monkestation/code/modules/blueshift/items/tools.dm
+++ b/monkestation/code/modules/blueshift/items/tools.dm
@@ -93,7 +93,7 @@
 		return FALSE
 	return TRUE
 
-// Just a completely normal crowbar except its normal sized and can force doors like jaws of life can
+// Just a completely normal crowbar except it's bulky sized and can force doors like jaws of life can
 
 /obj/item/crowbar/large/doorforcer
 	name = "prybar"
@@ -102,6 +102,7 @@
 	icon = 'monkestation/code/modules/blueshift/icons/tools.dmi'
 	icon_state = "prybar"
 	toolspeed = 1.3
+	w_class = WEIGHT_CLASS_BULKY
 	force_opens = TRUE
 	custom_materials = list(
 		/datum/material/iron = SHEET_MATERIAL_AMOUNT * 1.75,


### PR DESCRIPTION

## About The Pull Request
The prybar is now bulky, so you can't carry it in your bag. (You can still wear it on your waist slot.)

## Why It's Good For The Game
The prybar is an easy to get AA card. This makes it at least harder to carry with you.

## Changelog
:cl:
balance: Prybar is now bulky.
/:cl:
