### PR TITLE
fix silicon cat screams when they arent cat

### DIFF
--- a/monkestation/code/modules/emotes/code/emote.dm
+++ b/monkestation/code/modules/emotes/code/emote.dm
@@ -141,7 +141,7 @@
 	return ..()
 
 /datum/emote/living/scream/get_sound(mob/living/user)
-	if ((is_cat_enough(user, TRUE) && issilicon(user)) || (is_cat_enough(user, TRUE) && isipc(user)))
+	if ((is_cat_enough(user, TRUE) && issilicon(user)) || (is_cat_enough(user, FALSE) && isipc(user)))
 		return pick(
 			'monkestation/sound/voice/screams/silicon/catscream1.ogg',
 			'monkestation/sound/voice/screams/silicon/catscream2.ogg',


### PR DESCRIPTION

## About The Pull Request
literally just one value change. for IPC's it was just checking if they had the anime trait, then it would let them scream as cat. this fixes that by, telling the is_cat_enough to actually check for cat things.

## Why It's Good For The Game

## Changelog
:cl:
fix: silicons with the anime trait and no cat ears/tail cannot scream like a cat.
/:cl:
