### PR TITLE
Bugfixes-8-1-2024

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -133,6 +133,8 @@
 #define COMSIG_LIVING_SLAM_TABLE "living_slam_table"
 ///from /obj/item/hand_item/slapper/attack(): (source=mob/living/slapper, mob/living/slapped)
 #define COMSIG_LIVING_SLAP_MOB "living_slap_mob"
+/// from /mob/living/*/UnarmedAttack(), before sending [COMSIG_LIVING_UNARMED_ATTACK]: (mob/living/source, atom/target, proximity, modifiers)
+#define COMSIG_LIVING_EARLY_UNARMED_ATTACK "human_pre_attack_hand"
 ///(NOT on humans) from mob/living/*/UnarmedAttack(): (mob/living/source, atom/target, proximity, modifiers)
 #define COMSIG_LIVING_UNARMED_ATTACK "living_unarmed_attack"
 ///From base of mob/living/MobBump() (mob/living)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -9,6 +9,7 @@
 	else if (secondary_result != SECONDARY_ATTACK_CALL_NORMAL)
 		CRASH("resolve_right_click_attack (probably attack_hand_secondary) did not return a SECONDARY_ATTACK_* define.")
 
+//Checks if mob doesnt have hands blocked, for future TG PR port (see https://github.com/tgstation/tgstation/pull/78991)
 /mob/living/proc/can_unarmed_attack()
 	return !HAS_TRAIT(src, TRAIT_HANDS_BLOCKED)
 
@@ -130,8 +131,10 @@
 #define LIVING_UNARMED_ATTACK_BLOCKED(target_atom) (HAS_TRAIT(src, TRAIT_HANDS_BLOCKED) \
 	|| SEND_SIGNAL(src, COMSIG_LIVING_UNARMED_ATTACK, target_atom, proximity_flag) & COMPONENT_CANCEL_ATTACK_CHAIN)
 
+//Partial port of https://github.com/tgstation/tgstation/pull/78991 to fix some immenent bugs with cleanbots
+//This will eventually be entirely ported
 /mob/living/UnarmedAttack(atom/attack_target, proximity_flag, list/modifiers)
-s	var/sigreturn = SEND_SIGNAL(src, COMSIG_LIVING_EARLY_UNARMED_ATTACK, attack_target, proximity_flag, modifiers)
+	var/sigreturn = SEND_SIGNAL(src, COMSIG_LIVING_EARLY_UNARMED_ATTACK, attack_target, proximity_flag, modifiers)
 	if(sigreturn & COMPONENT_CANCEL_ATTACK_CHAIN)
 		return TRUE
 	if(sigreturn & COMPONENT_SKIP_ATTACK)

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -6,7 +6,8 @@
 	var/datum/action/lung_punch/lungpunch = new/datum/action/lung_punch()
 
 /datum/action/neck_chop
-	name = "Neck Chop - Injures the neck, stopping the victim from speaking for a while."
+	name = "Neck Chop"
+	desc = "Injures the neck, stopping the victim from speaking for a while." //monkestation edit: this was the name before
 	button_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "neckchop"
 
@@ -22,7 +23,8 @@
 		owner.mind.martial_art.streak = "neck_chop"
 
 /datum/action/leg_sweep
-	name = "Leg Sweep - Trips the victim, knocking them down for a brief moment."
+	name = "Leg Sweep"
+	desc = "Trips the victim, knocking them down for a brief moment." //monkestation edit: this was the entire name before
 	button_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "legsweep"
 
@@ -38,7 +40,8 @@
 		owner.mind.martial_art.streak = "leg_sweep"
 
 /datum/action/lung_punch//referred to internally as 'quick choke'
-	name = "Lung Punch - Delivers a strong punch just above the victim's abdomen, constraining the lungs. The victim will be unable to breathe for a short time."
+	name = "Lung Punch"
+	desc = "Delivers a strong punch just above the victim's abdomen, constraining the lungs. The victim will be unable to breathe for a short time." //monkestation edit: this was the entire fucking name before
 	button_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "lungpunch"
 

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
@@ -338,9 +338,11 @@
 
 	visible_message(span_danger("[src] sprays hydrofluoric acid at [target]!"))
 	playsound(src, 'sound/effects/spray2.ogg', 50, TRUE, -6)
+	//START: Monkestation edit (this lets it burn trash a tiny bit faster)
 	if(is_type_in_typecache(target, huntable_trash))
 		target.acid_act(75, 20)
 		return COMPONENT_CANCEL_ATTACK_CHAIN
+	//END: Monkestation edit
 	else
 		target.acid_act(75, 10)
 		return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
@@ -159,7 +159,7 @@
 	)
 
 	grant_actions_by_list(innate_actions)
-	RegisterSignal(src, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, PROC_REF(pre_attack))
+	RegisterSignal(src, COMSIG_LIVING_EARLY_UNARMED_ATTACK, PROC_REF(pre_attack))
 	RegisterSignal(src, COMSIG_ATOM_ATTACKBY, PROC_REF(on_attack_by))
 	update_appearance(UPDATE_ICON)
 
@@ -323,20 +323,27 @@
 	INVOKE_ASYNC(weapon, TYPE_PROC_REF(/obj/item, attack), stabbed_carbon, src)
 	stabbed_carbon.Knockdown(2 SECONDS)
 
-/mob/living/basic/bot/cleanbot/proc/pre_attack(mob/living/source, atom/target)
+/mob/living/basic/bot/cleanbot/proc/pre_attack(mob/living/source, atom/target, proximity, modifiers)
 	SIGNAL_HANDLER
+
+	if(!proximity || !can_unarmed_attack())
+		return NONE
 
 	if(is_type_in_typecache(target, huntable_pests) && !isnull(our_mop))
 		INVOKE_ASYNC(our_mop, TYPE_PROC_REF(/obj/item, melee_attack_chain), src, target)
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
-	if(!iscarbon(target) && !is_type_in_typecache(target, huntable_trash))
-		return
+	if(!(iscarbon(target) && (bot_access_flags & BOT_COVER_EMAGGED)) && !is_type_in_typecache(target, huntable_trash))
+		return NONE
 
 	visible_message(span_danger("[src] sprays hydrofluoric acid at [target]!"))
 	playsound(src, 'sound/effects/spray2.ogg', 50, TRUE, -6)
-	target.acid_act(75, 10)
-	return COMPONENT_CANCEL_ATTACK_CHAIN
+	if(is_type_in_typecache(target, huntable_trash))
+		target.acid_act(75, 20)
+		return COMPONENT_CANCEL_ATTACK_CHAIN
+	else
+		target.acid_act(75, 10)
+		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /mob/living/basic/bot/cleanbot/proc/generate_ai_keys()
 	ai_controller.set_blackboard_key(BB_CLEANABLE_DECALS, cleanable_decals)

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
@@ -68,7 +68,7 @@
 	controller.queue_behavior(/datum/ai_behavior/find_and_set/in_list/clean_targets, BB_CLEAN_TARGET, final_hunt_list)
 
 /datum/ai_behavior/find_and_set/in_list/clean_targets
-	action_cooldown = 1 SECONDS
+	action_cooldown = 2 SECONDS
 
 /datum/ai_behavior/find_and_set/in_list/clean_targets/search_tactic(datum/ai_controller/controller, locate_paths, search_range)
 	var/list/found = typecache_filter_list(oview(search_range, controller.pawn), locate_paths)

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
@@ -68,7 +68,7 @@
 	controller.queue_behavior(/datum/ai_behavior/find_and_set/in_list/clean_targets, BB_CLEAN_TARGET, final_hunt_list)
 
 /datum/ai_behavior/find_and_set/in_list/clean_targets
-	action_cooldown = 2 SECONDS
+	action_cooldown = 2 SECONDS //Monkestation edit
 
 /datum/ai_behavior/find_and_set/in_list/clean_targets/search_tactic(datum/ai_controller/controller, locate_paths, search_range)
 	var/list/found = typecache_filter_list(oview(search_range, controller.pawn), locate_paths)
@@ -118,11 +118,9 @@
 	. = ..()
 	var/mob/living/basic/living_pawn = controller.pawn
 	var/atom/target = controller.blackboard[target_key]
-
 	if(QDELETED(target))
 		finish_action(controller, FALSE, target_key)
 		return
-
 	living_pawn.UnarmedAttack(target, proximity_flag = TRUE)
 	finish_action(controller, TRUE, target_key)
 

--- a/code/modules/reagents/reagent_containers/condiment.dm
+++ b/code/modules/reagents/reagent_containers/condiment.dm
@@ -207,14 +207,19 @@
 	. = ..()
 	var/datum/chemical_reaction/recipe_dough = GLOB.chemical_reactions_list[/datum/chemical_reaction/food/dough]
 	var/datum/chemical_reaction/recipe_cakebatter = GLOB.chemical_reactions_list[/datum/chemical_reaction/food/cakebatter]
+	var/datum/chemical_reaction/recipe_cakebatter_vegan = GLOB.chemical_reactions_list[/datum/chemical_reaction/food/cakebatter/vegan]
 	var/dough_flour_required = recipe_dough.required_reagents[/datum/reagent/consumable/flour]
 	var/dough_water_required = recipe_dough.required_reagents[/datum/reagent/water]
 	var/cakebatter_flour_required = recipe_cakebatter.required_reagents[/datum/reagent/consumable/flour]
 	var/cakebatter_eggyolk_required = recipe_cakebatter.required_reagents[/datum/reagent/consumable/eggyolk]
+	var/cakebatter_eggwhite_required = recipe_cakebatter.required_reagents[/datum/reagent/consumable/eggwhite]
 	var/cakebatter_sugar_required = recipe_cakebatter.required_reagents[/datum/reagent/consumable/sugar]
+	var/cakebatter_soy_required = recipe_cakebatter_vegan.required_reagents[/datum/reagent/consumable/soymilk]
 	. += "<b><i>You retreat inward and recall the teachings of... Making Dough...</i></b>"
 	. += span_notice("[dough_flour_required] flour, [dough_water_required] water makes normal dough. You can make flat dough from it.")
-	. += span_notice("[cakebatter_flour_required] flour, [cakebatter_eggyolk_required] egg yolk (or soy milk), [cakebatter_sugar_required] sugar makes cake dough. You can make pie dough from it.")
+	. += span_notice("[cakebatter_flour_required] flour, [cakebatter_eggyolk_required] egg yolk, [cakebatter_eggwhite_required] egg white, and [cakebatter_sugar_required] sugar makes cake dough.")
+	. += span_notice("Alternatively, a vegan cake is made with: [cakebatter_flour_required] flour, [cakebatter_soy_required] soy milk, and [cakebatter_sugar_required] sugar.")
+	. += span_notice("It can be flattened into pie dough and then cut into pastry base. Once baked, pastry base can be combined with sugar for donuts!")
 
 /obj/item/reagent_containers/condiment/soymilk
 	name = "soy milk"

--- a/monkestation/code/modules/mech_comp/objects/flush.dm
+++ b/monkestation/code/modules/mech_comp/objects/flush.dm
@@ -19,13 +19,12 @@
 	. = ..()
 	if(. == SUCCESSFUL_UNFASTEN)
 		if(anchored)
-			trunk = locate() in src.loc
-			if(trunk)
-				trunk.linked = src
+			trunk_check()
 		else
 			trunk = null
 
 /obj/item/mcobject/flusher/proc/flush(datum/mcmessage/input)
+	trunk_check()
 	if(!trunk || !COOLDOWN_FINISHED(src, flush_cd) || !input?.cmd)
 		return
 	var/count = 0
@@ -56,3 +55,10 @@
 
 	H.vent_gas(loc)
 	qdel(H)
+
+/obj/item/mcobject/flusher/proc/trunk_check()
+	trunk = locate() in src.loc
+	if(trunk)
+		trunk.linked = src
+	else
+		trunk = null

--- a/monkestation/code/modules/surgery/organs/internal/butts.dm
+++ b/monkestation/code/modules/surgery/organs/internal/butts.dm
@@ -147,7 +147,7 @@
 	var/volume = 40
 	var/true_instability = fart_instability
 
-	if(istype(Location, /turf/open/floor/iron/kitchen_coldroom/freezerfloor))
+	if(istype(Location, /turf/open/floor/iron/kitchen_coldroom) || istype(Location, /turf/open/floor/iron/freezer))
 		new /obj/item/stack/sheet/mineral/frozen_fart(Location)
 
 	//TRAIT CHECKS


### PR DESCRIPTION
## About The Pull Request
Fixed Cleanbots being unable to use acid spray on trash and dead rats, they would instead clean forever,
Updated unarmed attack logic to fix this (taken from a TG PR https://github.com/tgstation/tgstation/pull/78991)

Removed LIVING_UNARMED_ATTACK_BLOCKED literally nothing anywhere used this
Removed krav maga gloves name also being its description(why was this a thing for so long )
Can now fart in the freezer on blueshift to make frozen farts
Fixed flushers deleting people if the trunk under it was destroyed
Updated flour bag to show correct recipes for cake batter
Fixes https://github.com/Monkestation/Monkestation2.0/issues/2787
Fixes https://github.com/Monkestation/Monkestation2.0/issues/2754
## Why It's Good For The Game
bugfixes polish and cleaner code
## Changelog

:cl:
fix: Krav Maga gloves now have a tooltip instead of the longest name in the game for its abilities
fix: Farting in blueshifts fridge now makes frozen farts (and every other maps fridge)
fix: Cleaner bots now clean trash and dead rats with acid (Make sure to turn it on!)
fix: Flour bag now displays correct recipes for dough and cake batter
fix: Flushers no longer DELETE YOU if the trunk under it is broken
/:cl:

