### PR TITLE
Nearby messages as ghost are bold

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -73,6 +73,7 @@
 #define SPAN_TAPE_RECORDER "tape_recorder"
 #define SPAN_HELIUM "small"
 #define SPAN_SOAPBOX "soapbox"
+#define SPAN_BOLD "bold" // monkestation addition
 
 //bitflag #defines for return value of the radio() proc.
 #define ITALICS (1<<0)

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -62,6 +62,10 @@
 	// Create map text prior to modifying message for goonchat
 	if (client?.prefs.read_preference(/datum/preference/toggle/enable_runechat) && (client.prefs.read_preference(/datum/preference/toggle/enable_runechat_non_mobs) || ismob(speaker)))
 		create_chat_message(speaker, message_language, raw_message, spans)
+	// monkestation start: bold messages for ghosts when they're nearby
+	if((client?.prefs.chat_toggles & CHAT_GHOSTEARS) && in_view_range(src, speaker))
+		spans |= SPAN_BOLD
+	// monkestation end
 	// Recompose the message, because it's scrambled by default
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mods)
 	to_chat(src,


### PR DESCRIPTION
## Changelog
:cl:
qol: When "hear all messages" is on as a ghost, messages from within your view range will be bolded.
/:cl:
