### PR TITLE
[PORT] Transfer TGchat notifications to the top

### DIFF
--- a/tgui/packages/tgui-panel/reconnect.tsx
+++ b/tgui/packages/tgui-panel/reconnect.tsx
@@ -27,13 +27,14 @@ export const ReconnectButton = () => {
       </Button>
       <Button
         color="white"
+        icon="power-off"
+        tooltip="Relaunch game"
+        tooltipPosition="bottom-end"
         onClick={() => {
           location.href = `byond://${url}`;
           Byond.command('.quit');
         }}
-      >
-        Relaunch game
-      </Button>
+      />
     </>
   );
 };

--- a/tgui/packages/tgui-panel/styles/components/Notifications.scss
+++ b/tgui/packages/tgui-panel/styles/components/Notifications.scss
@@ -5,7 +5,7 @@
 
 .Notifications {
   position: absolute;
-  bottom: 1em;
+  top: 1em;
   left: 1em;
   right: 2em;
 }


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/85084

Right now the notifications are not conveniently located, as when the server is initialised, it is quite problematic to communicate OOC
Actually this inconvenience I would like to solve

Also reconnect/restart buttons have been slightly modified

## Why It's Good For The Game

Now you can discuss the last round without waiting for the server to fully initialise

## Changelog
:cl: Absolucy, Aylong
qol: Chat notifications are now at the top.
/:cl:
