### PR TITLE
fixes headsets not being consumed by parrots (v2)

### DIFF
--- a/code/modules/mob/living/basic/pets/parrot/parrot_items.dm
+++ b/code/modules/mob/living/basic/pets/parrot/parrot_items.dm
@@ -2,7 +2,7 @@
 	key = STRIPPABLE_ITEM_PARROT_HEADSET
 
 /datum/strippable_item/parrot_headset/get_item(atom/source)
-	var/mob/living/basic/parrot/poly/parrot_source = source
+	var/mob/living/basic/parrot/parrot_source = source
 	return istype(parrot_source) ? parrot_source.ears : null
 
 /datum/strippable_item/parrot_headset/try_equip(atom/source, obj/item/equipping, mob/user)


### PR DESCRIPTION
## About The Pull Request
i thought this got merged already so i deleted the repository and ohno it wasnt merged fuck
https://github.com/tgstation/tgstation/pull/82046

## Why It's Good For The Game
fixes https://github.com/Monkestation/Monkestation2.0/issues/2762
in the random event that you decide to put a headset on a parrot that isnt poly, the headset will completely disappear. its not healthy for parrots to eat electronics

## Changelog
:cl:
fix: If you place a headset on a non-Poly Parrot, you should be able to remove it from the parrot as-expected now rather than having the parrot send it to the shadow realm.
/:cl:
