### PR TITLE
Give the QM a singular roundstart cargo teleporter in their locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -6,7 +6,7 @@
 /obj/structure/closet/secure_closet/quartermaster/PopulateContents()
 	..()
 	new /obj/item/storage/lockbox/medal/cargo(src)
-///	new /obj/item/radio/headset/heads/qm(src) // Monkestation Edit - QM is not a head. They do not need a command headset.
+///	new /obj/item/radio/headset/heads/qm(src) // monkestation edit - QM is not a head. They do not need a command headset.
 	new /obj/item/megaphone/cargo(src)
 	new /obj/item/tank/internals/emergency_oxygen(src)
 	new /obj/item/universal_scanner(src)
@@ -15,7 +15,8 @@
 	new /obj/item/storage/photo_album/qm(src)
 	new /obj/item/circuitboard/machine/ore_silo(src)
 	new /obj/item/storage/bag/garment/quartermaster(src)
-	new /obj/item/encryptionkey/headset_cargo(src) // Monkestation Edit - An extra encryption key for someone joining Cargyptia
+	new /obj/item/encryptionkey/headset_cargo(src) // monkestation edit - An extra encryption key for someone joining Cargyptia
+	new /obj/item/cargo_teleporter(src) // monkestation edit - singular roundstart cargo teleporter
 
 /obj/structure/closet/secure_closet/quartermaster/populate_contents_immediate()
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

discussed this idea with ook a while back, and the idea to give the QM a roundstart cargo teleporter came up:
![image](https://github.com/user-attachments/assets/a0c00eab-ab18-462b-9740-6f20052ea853)


## Why It's Good For The Game

Might help cargo actually bother to DELIVER stuff...

## Changelog
:cl:
add: The Quartermaster's locker now spawns with a single handheld cargo teleporter at roundstart.
/:cl:
