### PR TITLE
Curator's radio is now lossless

### DIFF
--- a/monkestation/code/modules/cassettes/machines/radio_mic.dm
+++ b/monkestation/code/modules/cassettes/machines/radio_mic.dm
@@ -8,6 +8,8 @@
 	radio_host = TRUE
 	command = TRUE
 
+	lossless = TRUE
+
 	density = TRUE
 	anchored = TRUE
 	resistance_flags = INDESTRUCTIBLE


### PR DESCRIPTION

## About The Pull Request

This marks the curator booth radio as "lossless" - meaning exospheric anomalies / broken processors will not affect it.

## Why It's Good For The Game

Allows for there to still be a source of communication/information during exo anomalies. Also because the podcast NEVER STOPS, baybee!

## Changelog
:cl:
qol: The curator booth's radio is now lossless - it is unaffected by exospheric anomalies.
/:cl:
