### PR TITLE
Nukeops uplink organization and Other bugfixes

### DIFF
--- a/code/datums/elements/bane.dm
+++ b/code/datums/elements/bane.dm
@@ -61,6 +61,8 @@
 		return is_species(living_target, target_type)
 
 /datum/element/bane/proc/do_bane(datum/element_owner, mob/living/bane_applier, mob/living/baned_target, hit_zone)
+	if(!check_biotype_path(bane_applier, baned_target)) // monkestation edit: added check that is present on tg master but wasnt here
+		return
 	var/force_boosted
 	var/applied_dam_type
 

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -375,6 +375,7 @@
 		/obj/item/storage/box/evilmeds = 1,
 		/obj/item/reagent_containers/medigel/sterilizine = 1,
 		/obj/item/clothing/glasses/hud/health/night/science = 1,
+		/obj/item/organ/internal/cyberimp/cyberlink/nt_high = 1, //Monkestation edti: unable to use the hacked surgery toolset without this
 	)
 	generate_items_inside(items_inside,src)
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -149,13 +149,13 @@
 
 /obj/item/gun/ballistic/automatic/m90
 	name = "\improper M-90gl Carbine"
-	desc = "A three-round burst .223 toploading carbine, designated 'M-90gl'. Has an attached underbarrel grenade launcher."
+	desc = "A three-round burst 5.56 toploading carbine, designated 'M-90gl'. Has an attached underbarrel grenade launcher."
 	desc_controls = "Right-click to use grenade launcher."
 	icon_state = "m90"
 	w_class = WEIGHT_CLASS_BULKY
 	inhand_icon_state = "m90"
 	selector_switch_icon = TRUE
-	accepted_magazine_type = /obj/item/ammo_box/magazine/m223
+	accepted_magazine_type = /obj/item/ammo_box/magazine/m556
 	can_suppress = FALSE
 	var/obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel
 	burst_size = 3

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -149,13 +149,13 @@
 
 /obj/item/gun/ballistic/automatic/m90
 	name = "\improper M-90gl Carbine"
-	desc = "A three-round burst 5.56 toploading carbine, designated 'M-90gl'. Has an attached underbarrel grenade launcher."
+	desc = "A three-round burst 5.56 toploading carbine, designated 'M-90gl'. Has an attached underbarrel grenade launcher." //monkestation edit: reverted back from .223 to original 556 as ported from nova
 	desc_controls = "Right-click to use grenade launcher."
 	icon_state = "m90"
 	w_class = WEIGHT_CLASS_BULKY
 	inhand_icon_state = "m90"
 	selector_switch_icon = TRUE
-	accepted_magazine_type = /obj/item/ammo_box/magazine/m556
+	accepted_magazine_type = /obj/item/ammo_box/magazine/m556 //monkestation edit: reverted back from .223 to original 556 as ported from nova
 	can_suppress = FALSE
 	var/obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel
 	burst_size = 3

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -1,18 +1,3 @@
-/datum/uplink_item/bundles_tc/bulldog
-	name = "Bulldog bundle"
-	desc = "Lean and mean: Optimized for people that want to get up close and personal. Contains the popular \
-			Bulldog shotgun, two 12g buckshot drums, and a pair of Thermal imaging goggles."
-	item = /obj/item/storage/backpack/duffelbag/syndie/bulldogbundle
-	cost = 13 // normally 16
-	purchasable_from = UPLINK_NUKE_OPS
-
-/datum/uplink_item/bundles_tc/c20r
-	name = "C-20r bundle"
-	desc = "Old Faithful: The classic C-20r, bundled with two magazines and a suppressor at discount price."
-	item = /obj/item/storage/backpack/duffelbag/syndie/c20rbundle
-	cost = 14 // normally 16
-	purchasable_from = UPLINK_NUKE_OPS
-
 /datum/uplink_item/bundles_tc/cyber_implants
 	name = "Cybernetic Implants Bundle"
 	desc = "A random selection of cybernetic implants. Guaranteed 5 high quality implants. Comes with an autosurgeon."

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -1,3 +1,4 @@
+//Monkestation edit: Bulldog and c20r moved to uplink kits
 /datum/uplink_item/bundles_tc/cyber_implants
 	name = "Cybernetic Implants Bundle"
 	desc = "A random selection of cybernetic implants. Guaranteed 5 high quality implants. Comes with an autosurgeon."

--- a/monkestation/code/modules/blueshift/items/gunset.dm
+++ b/monkestation/code/modules/blueshift/items/gunset.dm
@@ -79,6 +79,10 @@
 	new weapon_to_spawn (src)
 	new extra_to_spawn (src)
 	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate (src)
+	new /obj/item/clothing/mask/bandana/skull (src) // the bandana intended for this doesnt exist anymore so the best i can do is an eypatch and a skull bandana
+	new /obj/item/clothing/glasses/thermal/eyepatch (src) //hngh colonel im trying to sneak around...
+	new /obj/item/toy/plush/snakeplushie (src)
+
 
 /*
 *	GUNSET BOXES

--- a/monkestation/code/modules/blueshift/uplinks/kits.dm
+++ b/monkestation/code/modules/blueshift/uplinks/kits.dm
@@ -13,15 +13,30 @@
 	desc = "A small, easily concealable handgun that uses 10mm auto rounds in 8-round magazines and is compatible \
 			with suppressors. Comes with three spare magazines."
 	item = /obj/item/storage/toolbox/guncase/clandestine
-	cost = 8
+	cost = 7 //this stuff is lying around the base to begin with so its not worth much
 
-/datum/uplink_item/weapon_kits/high_cost/carbine
+/datum/uplink_item/weapon_kits/medium_cost/carbine
 	name = "M-90gl Carbine Case (Hard)"
 	desc = "A fully-loaded, specialized three-round burst carbine that fires .223 ammunition from a 30 round magazine \
 		with a 40mm underbarrel grenade launcher. Use secondary-fire to fire the grenade launcher. Comes with two spare magazines \
 		and a box of 40mm rubber slugs."
 	item = /obj/item/storage/toolbox/guncase/m90gl
-	cost = 18
+	cost = 14
+
+/datum/uplink_item/weapon_kits/medium_cost/bulldog
+	name = "Bulldog bundle (Easy)"
+	desc = "Lean and mean: Optimized for people that want to get up close and personal. Contains the popular \
+			Bulldog shotgun, two 12g buckshot drums, and a pair of Thermal imaging goggles."
+	item = /obj/item/storage/backpack/duffelbag/syndie/bulldogbundle
+	cost = 13 // normally 16
+	purchasable_from = UPLINK_NUKE_OPS
+
+/datum/uplink_item/weapon_kits/medium_cost/c20r
+	name = "C-20r bundle (Easy)"
+	desc = "Old Faithful: The classic C-20r, bundled with two magazines and a suppressor at discount price."
+	item = /obj/item/storage/backpack/duffelbag/syndie/c20rbundle
+	cost = 14 // normally 16
+	purchasable_from = UPLINK_NUKE_OPS
 
 /datum/uplink_item/weapon_kits/medium_cost/rawketlawnchair
 	name = "Dardo-RE Rocket Propelled Grenade Launcher (Hard)"
@@ -33,14 +48,20 @@
 /datum/uplink_item/weapon_kits/medium_cost/revolvercase
 	name = "Syndicate Revolver Case (Moderate)"
 	desc = "Waffle Co.'s modernized Syndicate revolver. Fires 7 brutal rounds of .357 Magnum. \
-		A classic operative weapon, brought to the modern era. Comes with 3 additional speedloaders of .357."
-	cost = 14
+		A classic operative weapon, brought to the modern era. Comes with 3 additional speedloaders of .357. Try not to miss."
+	cost = 15
 	item = /obj/item/storage/toolbox/guncase/revolver
 
-/datum/uplink_item/weapon_kits/medium_cost/cqc
+/datum/uplink_item/weapon_kits/high_cost/sword_and_board
+	name = "Energy sword and shield combo box (Moderate)"
+	desc = "An Energy Shield and sword combo, popular amongst agents that like to get shot in the back."
+	cost = 20
+	item = /obj/item/storage/toolbox/guncase/sword_and_board
+
+/datum/uplink_item/weapon_kits/high_cost/cqc
 	name = "CQC Equipment Case (Very Hard)"
-	desc = "Contains a manual that instructs you in the ways of CQC, or Close Quarters Combat. Comes with a stealth implant, a pack of smokes and a snazzy bandana (use it with the hat stabilizers in your MODsuit)."
+	desc = "Contains a manual that instructs you in the ways of CQC, or Close Quarters Combat. Comes with a stealth implant, a pack of smokes and a discount bandana and a thermal eyepatch."
 	item = /obj/item/storage/toolbox/guncase/cqc
 	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
-	cost = 16
+	cost = 18
 	surplus = 0

--- a/monkestation/code/modules/blueshift/uplinks/kits.dm
+++ b/monkestation/code/modules/blueshift/uplinks/kits.dm
@@ -55,7 +55,7 @@
 /datum/uplink_item/weapon_kits/high_cost/sword_and_board
 	name = "Energy sword and shield combo box (Moderate)"
 	desc = "An Energy Shield and sword combo, popular amongst agents that like to get shot in the back."
-	cost = 20
+	cost = 18
 	item = /obj/item/storage/toolbox/guncase/sword_and_board
 
 /datum/uplink_item/weapon_kits/high_cost/cqc
@@ -63,5 +63,5 @@
 	desc = "Contains a manual that instructs you in the ways of CQC, or Close Quarters Combat. Comes with a stealth implant, a pack of smokes and a discount bandana and a thermal eyepatch."
 	item = /obj/item/storage/toolbox/guncase/cqc
 	purchasable_from = UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS
-	cost = 18
+	cost = 15
 	surplus = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is a PR to fix some TC costs for nukeops and some bundle edits/bugfixes to make them usable
also moved around some bundles to weaponkits to make it cleaner and open up the "bundles" category for more gimmicky nukeops things in the future

ALSO fixed nullrod bane on anymob

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nullrod bane was really stinky
Some incorrect ammo, unusable implants, missing items, incorrect costs fixed
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Nullrod no longer banes for 270 damage on EVERYTHING
fix: Premium combat medical kit now comes with a Cyberlink for your hacked surgery tool (nukeops)
fix: the m-90GL now uses 5.56 instead of .223 which was not purchaseable (nukeops)
fix: the bandana that was in the CQC kit was lost to time and has been replaced with a skull bandana, an thermal eyepatch, and snake plushie (+2 tc cost increase) (nukeops)
fix: some bundles moved into weapon kits (nukeops)
add: Energy sword and Board kit enabled in weapon kits (nukeops, 20tc)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
