### PR TITLE
de-weirds the bunny wand & adds easter bunny costume to costume vendor

### DIFF
--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -183,6 +183,8 @@
 				/obj/item/clothing/mask/animal/cowmask = 1,
 				/obj/item/clothing/mask/animal/horsehead = 1,
 				/obj/item/clothing/head/lizard = 1,
+				/obj/item/clothing/head/costume/bunnyhead/regular = 1,	
+				/obj/item/clothing/suit/costume/bunnysuit/regular = 1,
 			),
 		),
 		list(

--- a/monkestation/code/modules/bunny_wizard/outfits.dm
+++ b/monkestation/code/modules/bunny_wizard/outfits.dm
@@ -14,9 +14,6 @@
 /datum/outfit/cursed_bunny/post_equip(mob/living/carbon/human/equipped_on, visualsOnly=FALSE)
 	if(visualsOnly)
 		return
-	equipped_on.underwear = "Nude"
-	equipped_on.undershirt = "Nude"
-	equipped_on.socks = "Nude"
 	var/list/no_drops = list()
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_FEET)
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_ICLOTHING)
@@ -25,7 +22,7 @@
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_NECK)
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_GLOVES)
 	for(var/obj/item/trait_needed as anything in no_drops)
-		ADD_TRAIT(trait_needed, TRAIT_NODROP, CURSED_ITEM_TRAIT(trait_needed.type))
+		ADD_TRAIT(trait_needed, CURSED_ITEM_TRAIT(trait_needed.type))
 		trait_needed.name = "cursed " + trait_needed.name
 
 /datum/outfit/cursed_bunny/color
@@ -34,9 +31,6 @@
 /datum/outfit/cursed_bunny/color/post_equip(mob/living/carbon/human/equipped_on, visualsOnly=FALSE)
 	if(visualsOnly)
 		return
-	equipped_on.underwear = "Nude"
-	equipped_on.undershirt = "Nude"
-	equipped_on.socks = "Nude"
 	var/bunny_color = random_color()
 	equipped_on.w_uniform?.greyscale_colors = "#[bunny_color]#[bunny_color]#ffffff#87502e"
 	equipped_on.wear_suit?.greyscale_colors = "#[bunny_color]"
@@ -62,7 +56,7 @@
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_NECK)
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_GLOVES)
 	for(var/obj/item/trait_needed as anything in no_drops)
-		ADD_TRAIT(trait_needed, TRAIT_NODROP, CURSED_ITEM_TRAIT(trait_needed.type))
+		ADD_TRAIT(trait_needed, CURSED_ITEM_TRAIT(trait_needed.type))
 		trait_needed.name = "cursed " + trait_needed.name
 
 /datum/outfit/cursed_bunny/syndicate
@@ -139,7 +133,7 @@
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_HEAD)
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_NECK)
 	for(var/obj/item/trait_needed as anything in no_drops)
-		ADD_TRAIT(trait_needed, TRAIT_NODROP, CURSED_ITEM_TRAIT(trait_needed.type))
+		ADD_TRAIT(trait_needed, CURSED_ITEM_TRAIT(trait_needed.type))
 		trait_needed.name = "cursed " + trait_needed.name
 
 

--- a/monkestation/code/modules/bunny_wizard/outfits.dm
+++ b/monkestation/code/modules/bunny_wizard/outfits.dm
@@ -28,12 +28,8 @@
 /datum/outfit/cursed_bunny/costume
 	name = "Cursed Bunny Costume"
 	uniform = null
-	suit = /obj/item/clothing/suit/costume/bunnysuit{
-	slowdown = 0
-	}
-	head = /obj/item/clothing/head/costume/bunnyhead{
-	slowdown = 0
-	}
+	suit = /obj/item/clothing/suit/costume/bunnysuit/regular
+	head = /obj/item/clothing/head/costume/bunnyhead/regular
 	shoes = /obj/item/clothing/shoes/clown_shoes/clown_jester_shoes
 	neck = null
 	r_hand = /obj/item/food/hotcrossbun

--- a/monkestation/code/modules/bunny_wizard/outfits.dm
+++ b/monkestation/code/modules/bunny_wizard/outfits.dm
@@ -32,7 +32,7 @@
 	slowdown = 0
 	}
 	head = /obj/item/clothing/head/costume/bunnyhead{
-	slowdown = "0"
+	slowdown = 0
 	}
 	shoes = /obj/item/clothing/shoes/clown_shoes/clown_jester_shoes
 	neck = null

--- a/monkestation/code/modules/bunny_wizard/outfits.dm
+++ b/monkestation/code/modules/bunny_wizard/outfits.dm
@@ -22,7 +22,7 @@
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_NECK)
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_GLOVES)
 	for(var/obj/item/trait_needed as anything in no_drops)
-		ADD_TRAIT(trait_needed, TRAIT_NODROP CURSED_ITEM_TRAIT(trait_needed.type))
+		ADD_TRAIT(trait_needed, TRAIT_NODROP, CURSED_ITEM_TRAIT(trait_needed.type))
 		trait_needed.name = "cursed " + trait_needed.name
 
 /datum/outfit/cursed_bunny/costume
@@ -45,7 +45,7 @@ var/list/no_drops = list()
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_NECK)
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_GLOVES)
 	for(var/obj/item/trait_needed as anything in no_drops)
-		ADD_TRAIT(trait_needed, TRAIT_NODROP CURSED_ITEM_TRAIT(trait_needed.type))
+		ADD_TRAIT(trait_needed, TRAIT_NODROP, CURSED_ITEM_TRAIT(trait_needed.type))
 		trait_needed.name = "cursed " + trait_needed.name
 
 
@@ -80,7 +80,7 @@ var/list/no_drops = list()
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_NECK)
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_GLOVES)
 	for(var/obj/item/trait_needed as anything in no_drops)
-		ADD_TRAIT(trait_needed, TRAIT_NODROP CURSED_ITEM_TRAIT(trait_needed.type))
+		ADD_TRAIT(trait_needed, TRAIT_NODROP, CURSED_ITEM_TRAIT(trait_needed.type))
 		trait_needed.name = "cursed " + trait_needed.name
 
 /datum/outfit/cursed_bunny/magician

--- a/monkestation/code/modules/bunny_wizard/outfits.dm
+++ b/monkestation/code/modules/bunny_wizard/outfits.dm
@@ -22,8 +22,32 @@
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_NECK)
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_GLOVES)
 	for(var/obj/item/trait_needed as anything in no_drops)
-		ADD_TRAIT(trait_needed, CURSED_ITEM_TRAIT(trait_needed.type))
+		ADD_TRAIT(trait_needed, TRAIT_NODROP CURSED_ITEM_TRAIT(trait_needed.type))
 		trait_needed.name = "cursed " + trait_needed.name
+
+/datum/outfit/cursed_bunny/costume
+	name = "Cursed Bunny Costume"
+	uniform = null
+	suit = /obj/item/clothing/suit/costume/bunnysuit
+	head = /obj/item/clothing/head/costume/bunnyhead
+	shoes = /obj/item/clothing/shoes/clown_shoes/clown_jester_shoes
+	neck = null
+	r_hand = /obj/item/food/hotcrossbun
+	l_hand = null
+	r_pocket = null
+	l_pocket = /obj/item/food/chocolatebunny
+
+var/list/no_drops = list()
+	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_FEET)
+	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_ICLOTHING)
+	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_OCLOTHING)
+	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_HEAD)
+	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_NECK)
+	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_GLOVES)
+	for(var/obj/item/trait_needed as anything in no_drops)
+		ADD_TRAIT(trait_needed, TRAIT_NODROP CURSED_ITEM_TRAIT(trait_needed.type))
+		trait_needed.name = "cursed " + trait_needed.name
+
 
 /datum/outfit/cursed_bunny/color
 	name = "Cursed Bunny (Random Color)"
@@ -56,48 +80,8 @@
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_NECK)
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_GLOVES)
 	for(var/obj/item/trait_needed as anything in no_drops)
-		ADD_TRAIT(trait_needed, CURSED_ITEM_TRAIT(trait_needed.type))
+		ADD_TRAIT(trait_needed, TRAIT_NODROP CURSED_ITEM_TRAIT(trait_needed.type))
 		trait_needed.name = "cursed " + trait_needed.name
-
-/datum/outfit/cursed_bunny/syndicate
-	name = "Cursed Bunny (Syndicate)"
-	uniform = /obj/item/clothing/under/syndicate/syndibunny
-	suit = /obj/item/clothing/suit/jacket/tailcoat/syndicate
-	head = /obj/item/clothing/head/playbunnyears/syndicate
-	neck = /obj/item/clothing/neck/tie/bunnytie/syndicate/tied
-	r_pocket = /obj/item/toy/cards/deck/syndicate
-
-/datum/outfit/cursed_bunny/british
-	name = "Cursed Bunny (British)"
-	uniform = /obj/item/clothing/under/costume/playbunny/british
-	suit = /obj/item/clothing/suit/jacket/tailcoat/british
-	shoes = /obj/item/clothing/shoes/heels/blue
-	head = /obj/item/clothing/head/playbunnyears/british
-	neck = /obj/item/clothing/neck/tie/bunnytie/blue/tied
-
-/datum/outfit/cursed_bunny/communist
-	name = "Cursed Bunny (Communist)"
-	uniform = /obj/item/clothing/under/costume/playbunny/communist
-	suit = /obj/item/clothing/suit/jacket/tailcoat/communist
-	shoes = /obj/item/clothing/shoes/heels/red
-	head = /obj/item/clothing/head/playbunnyears/communist
-	neck = /obj/item/clothing/neck/tie/bunnytie/communist/tied
-
-/datum/outfit/cursed_bunny/usa
-	name = "Cursed Bunny (USA)"
-	uniform = /obj/item/clothing/under/costume/playbunny/usa
-	suit = /obj/item/clothing/suit/jacket/tailcoat/usa
-	shoes = /obj/item/clothing/shoes/heels/red
-	head = /obj/item/clothing/head/playbunnyears/usa
-	neck = /obj/item/clothing/neck/tie/bunnytie/blue/tied
-
-/datum/outfit/cursed_bunny/centcom
-	name = "Cursed Bunny (Centcom)"
-	uniform = /obj/item/clothing/under/costume/playbunny/centcom
-	suit = /obj/item/clothing/suit/jacket/tailcoat/centcom
-	shoes = /obj/item/clothing/shoes/heels/centcom
-	head = /obj/item/clothing/head/playbunnyears/centcom
-	neck = /obj/item/clothing/neck/tie/bunnytie/centcom/tied
 
 /datum/outfit/cursed_bunny/magician
 	name = "Cursed Bunny (Magician)"

--- a/monkestation/code/modules/bunny_wizard/outfits.dm
+++ b/monkestation/code/modules/bunny_wizard/outfits.dm
@@ -28,8 +28,12 @@
 /datum/outfit/cursed_bunny/costume
 	name = "Cursed Bunny Costume"
 	uniform = null
-	suit = /obj/item/clothing/suit/costume/bunnysuit
-	head = /obj/item/clothing/head/costume/bunnyhead
+	suit = /obj/item/clothing/suit/costume/bunnysuit{
+	slowdown = 0
+	}
+	head = /obj/item/clothing/head/costume/bunnyhead{
+	slowdown = "0"
+	}
 	shoes = /obj/item/clothing/shoes/clown_shoes/clown_jester_shoes
 	neck = null
 	r_hand = /obj/item/food/hotcrossbun

--- a/monkestation/code/modules/bunny_wizard/outfits.dm
+++ b/monkestation/code/modules/bunny_wizard/outfits.dm
@@ -37,12 +37,13 @@
 	r_pocket = null
 	l_pocket = /obj/item/food/chocolatebunny
 
-var/list/no_drops = list()
+/datum/outfit/cursed_bunny/costume/post_equip(mob/living/carbon/human/equipped_on, visualsOnly=FALSE)
+	if(visualsOnly)
+		return
+	var/list/no_drops = list()
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_FEET)
-	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_ICLOTHING)
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_OCLOTHING)
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_HEAD)
-	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_NECK)
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_GLOVES)
 	for(var/obj/item/trait_needed as anything in no_drops)
 		ADD_TRAIT(trait_needed, TRAIT_NODROP, CURSED_ITEM_TRAIT(trait_needed.type))
@@ -117,7 +118,7 @@ var/list/no_drops = list()
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_HEAD)
 	no_drops += equipped_on.get_item_by_slot(ITEM_SLOT_NECK)
 	for(var/obj/item/trait_needed as anything in no_drops)
-		ADD_TRAIT(trait_needed, CURSED_ITEM_TRAIT(trait_needed.type))
+		ADD_TRAIT(trait_needed, TRAIT_NODROP, CURSED_ITEM_TRAIT(trait_needed.type))
 		trait_needed.name = "cursed " + trait_needed.name
 
 

--- a/monkestation/code/modules/bunny_wizard/wizard_items.dm
+++ b/monkestation/code/modules/bunny_wizard/wizard_items.dm
@@ -53,7 +53,7 @@
 
 /datum/spellbook_entry/item/wandbunny
 	name = "Wand of Bunnies"
-	desc = "An artefact that spits bolts of lagomorphic energy which cause the target's appearence and clothing to change. Unlike most wands, it is able to recharge its own power. This magic doesn't effect machines or animals."
+	desc = "An artefact that spits bolts of lagomorphic energy which cause the target's clothing to change. Unlike most wands, it is able to recharge its own power. This magic doesn't effect machines or animals."
 	item_path = /obj/item/gun/magic/wand/bunny
 	category = "Offensive"
 
@@ -72,37 +72,6 @@
 	if(isplasmaman(src))
 		equipOutfit(/datum/outfit/plasmaman/cursed_bunny)
 		return
-	var/bunny_theme = pick_weight(list(
-	"Color" = 43,
-	 pick(list(
-		"British",
-		"Communist",
-		"USA",
-	)) = 30,
-	"Black" = 16,
-	"Centcomm" = 2,
-	"Syndicate" = 2,
-	))
-
-	switch(bunny_theme)
-		if("Color")
-			equipOutfit(/datum/outfit/cursed_bunny/color)
-			return
-		if("British")
-			equipOutfit(/datum/outfit/cursed_bunny/british)
-			return
-		if("Communist")
-			equipOutfit(/datum/outfit/cursed_bunny/communist)
-			return
-		if("USA")
-			equipOutfit(/datum/outfit/cursed_bunny/usa)
-			return
-		if("Black")
-			equipOutfit(/datum/outfit/cursed_bunny)
-			return
-		if("Syndicate")
-			equipOutfit(/datum/outfit/cursed_bunny/syndicate)
-			return
-		if("Centcomm")
-			equipOutfit(/datum/outfit/cursed_bunny/centcom)
-			return
+	else
+		equipOutfit(/datum/outfit/cursed_bunny/costume)
+		return

--- a/monkestation/code/modules/bunny_wizard/wizard_items.dm
+++ b/monkestation/code/modules/bunny_wizard/wizard_items.dm
@@ -61,8 +61,8 @@
 	var/obj/effect/particle_effect/fluid/smoke/exit_poof = new(get_turf(src))
 	exit_poof.lifetime = 2 SECONDS
 	for(var/obj/item/clothing/maybe_cursed as anything in get_equipped_items())
-		if(HAS_TRAIT_FROM(maybe_cursed, CURSED_ITEM_TRAIT(maybe_cursed.type)))
-			REMOVE_TRAIT(maybe_cursed, CURSED_ITEM_TRAIT(maybe_cursed.type)) //Get rid fo their cursed gear for different cursed gear
+		if(HAS_TRAIT_FROM(maybe_cursed, TRAIT_NODROP, CURSED_ITEM_TRAIT(maybe_cursed.type)))
+			REMOVE_TRAIT(maybe_cursed, TRAIT_NODROP, CURSED_ITEM_TRAIT(maybe_cursed.type)) //Get rid fo their cursed gear for different cursed gear
 
 	unequip_everything()
 	to_chat(src, span_notice("Your clothing falls to the floor and you seem to be wearing something different!"))

--- a/monkestation/code/modules/bunny_wizard/wizard_items.dm
+++ b/monkestation/code/modules/bunny_wizard/wizard_items.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/magic/staff/bunny
 	name = "staff of bunnies"
-	desc = "An artefact that spits bolts of lagomorphic energy which cause the target's appearence and clothing to change."
+	desc = "An artefact that spits bolts of lagomorphic energy which cause the target's clothing to change."
 	icon = 'monkestation/icons/obj/guns/magic.dmi'
 	worn_icon = 'monkestation/icons/mob/clothing/back.dmi'
 	lefthand_file = 'monkestation/icons/mob/inhands/weapons/staves_lefthand.dmi'
@@ -61,13 +61,11 @@
 	var/obj/effect/particle_effect/fluid/smoke/exit_poof = new(get_turf(src))
 	exit_poof.lifetime = 2 SECONDS
 	for(var/obj/item/clothing/maybe_cursed as anything in get_equipped_items())
-		if(HAS_TRAIT_FROM(maybe_cursed, TRAIT_NODROP, CURSED_ITEM_TRAIT(maybe_cursed.type)))
-			REMOVE_TRAIT(maybe_cursed, TRAIT_NODROP, CURSED_ITEM_TRAIT(maybe_cursed.type)) //Get rid fo their cursed gear for different cursed gear
+		if(HAS_TRAIT_FROM(maybe_cursed, CURSED_ITEM_TRAIT(maybe_cursed.type)))
+			REMOVE_TRAIT(maybe_cursed, CURSED_ITEM_TRAIT(maybe_cursed.type)) //Get rid fo their cursed gear for different cursed gear
 
 	unequip_everything()
 	to_chat(src, span_notice("Your clothing falls to the floor and you seem to be wearing something different!"))
-	src.physique = FEMALE
-	update_body(is_creating = TRUE) //actually update your body sprite
 	if(IS_WIZARD(src))
 		equipOutfit(/datum/outfit/cursed_bunny/magician)
 		return

--- a/monkestation/code/modules/clothing/head/costume.dm
+++ b/monkestation/code/modules/clothing/head/costume.dm
@@ -129,3 +129,7 @@ BUNNY EARS
 /*
 END OF BUNNY EARS
 */
+
+/obj/item/clothing/head/costume/bunnysuit/regular //the real bunny hat
+	slowdown = 0
+	desc = "Considerably more cute than 'Frank'. It looks old."

--- a/monkestation/code/modules/clothing/head/costume.dm
+++ b/monkestation/code/modules/clothing/head/costume.dm
@@ -130,6 +130,6 @@ BUNNY EARS
 END OF BUNNY EARS
 */
 
-/obj/item/clothing/head/costume/bunnysuit/regular //the real bunny hat
+/obj/item/clothing/head/costume/bunnyhead/regular //the real bunny hat
 	slowdown = 0
 	desc = "Considerably more cute than 'Frank'. It looks old."

--- a/monkestation/code/modules/clothing/suits/costume.dm
+++ b/monkestation/code/modules/clothing/suits/costume.dm
@@ -33,6 +33,10 @@
 	worn_icon_state = "gorilla"
 	flags_inv = HIDEHAIR|HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 
+/obj/item/clothing/head/costume/bunnysuit/regular
+	slowdown = 0
+	desc = "Considerably more cute than 'Frank'. It looks old."
+
 /obj/item/clothing/suit/shipwreckedsuit
 	name = "shipwrecked captain suit"
 	desc = "DISCLAIMER:Not Space Proof. Wearing this suit gives you the luck of a true space captain! Just avoid the space rocks..."

--- a/monkestation/code/modules/clothing/suits/costume.dm
+++ b/monkestation/code/modules/clothing/suits/costume.dm
@@ -33,9 +33,9 @@
 	worn_icon_state = "gorilla"
 	flags_inv = HIDEHAIR|HIDEFACE|HIDEFACIALHAIR|HIDESNOUT
 
-/obj/item/clothing/head/costume/bunnysuit/regular
+/obj/item/clothing/suit/costume/bunnysuit/regular
 	slowdown = 0
-	desc = "Considerably more cute than 'Frank'. It looks old."
+	desc = "Hop Hop Hop! It looks old."
 
 /obj/item/clothing/suit/shipwreckedsuit
 	name = "shipwrecked captain suit"


### PR DESCRIPTION
## About The Pull Request

makes it so the bunny wand a. doesnt remove your underwear and socks, b. doesnt change your body to be feminine, and c. puts you in a goofy rabbit costume instead of a sexual bunny one. also adds an easter bunny costume to the autodrobe, yippee!!
## Why It's Good For The Game

this shit WEIRD!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! i dont want to be sexualized on someone else's whims!!!!!! this kind of shit has no place here, so i'm switching it out for something less creepy.
also costume is cool

## Changelog

:cl:
del: Removes degeneracy from the bunny wand.
add: Adds silly easter costumes to the bunny wand.
add: Adds silly easter costume to the autodrobe.
balance: Plasmamen can now remove the bunny costumes added by the bunny wand because i dont really feel like making easter bunny envirosuits
/:cl:
