### PR TITLE
Chasm.dm MMI Purgatory Patch

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -160,6 +160,10 @@
 
 	// send to oblivion
 	dropped_thing.visible_message(span_boldwarning("[dropped_thing] falls into [parent]!"), span_userdanger("[oblivion_message]"))
+	if(iscyborg(dropped_thing)) // If they are a robot with out this then they glitch out and get stuck in a Chasm Purgatory. Patch job to fix it, probably can be implemented better, but this'll work for now - Amy
+		dropped_thing.visible_message(span_userdanger("Your internal anti-suffering measures kick in, intiating an internal shutdown."))
+		var/mob/living/silicon/robot/S = dropped_thing
+		qdel(S.mmi)
 	if (isliving(dropped_thing))
 		var/mob/living/falling_mob = dropped_thing
 		ADD_TRAIT(falling_mob, TRAIT_NO_TRANSFORM, REF(src))


### PR DESCRIPTION
Updates the Chasm.dm with a small code patch to delete the MMI when a borg falls in.

## About The Pull Request

Small PR to fix up the issue of cyborgs falling into chasms being stuck in a purgatory with their MMI undestroyed at the bottom of the chasm until an ash storm comes by and finishes them off.

## Why It's Good For The Game

helps make the death to the chasm be a far smoother experience for borgs and keeps them from, well, being stuck in a purgatory.

## Changelog
:cl:
Fix: chasm.dm not properly Qdel-ing the cyborg's MMI when they fall in.
/:cl:
