### PR TITLE
Curator's PDA no longer disables ringer by default

### DIFF
--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -379,10 +379,12 @@
 		/datum/computer_file/program/newscaster,
 	)
 
+/* monkestation removal: don't force ringer off by default
 /obj/item/modular_computer/pda/curator/Initialize(mapload)
 	. = ..()
 	for(var/datum/computer_file/program/messenger/msg in stored_files)
 		msg.alert_silenced = TRUE
+monkestation end */
 
 /**
  * No Department


### PR DESCRIPTION

## About The Pull Request

Self-explanatory.

## Why It's Good For The Game

I KEEP MISSING PDA MESSAGES BC OF THE DISABLED RINGER. You can turn it off in like 2 seconds tops if you really want it off!

## Changelog
:cl:
qol: The curator's PDA no longer disables ringer by default.
/:cl:
