### PR TITLE
All janitors now spawn with the keyring

### DIFF
--- a/code/modules/jobs/job_types/janitor.dm
+++ b/code/modules/jobs/job_types/janitor.dm
@@ -41,17 +41,13 @@
 	belt = /obj/item/modular_computer/pda/janitor
 	ears = /obj/item/radio/headset/headset_srv
 	skillchips = list(/obj/item/skillchip/job/janitor)
+	backpack_contents = list(/obj/item/access_key)
 
 /datum/outfit/job/janitor/pre_equip(mob/living/carbon/human/human_equipper, visuals_only)
 	. = ..()
 	if(check_holidays(GARBAGEDAY))
 		backpack_contents += list(/obj/item/gun/ballistic/revolver)
 		r_pocket = /obj/item/ammo_box/a357
-
-	var/static/access_key_given = FALSE
-	if(!access_key_given && !visuals_only)
-		access_key_given = TRUE
-		backpack_contents += list(/obj/item/access_key)
 
 /datum/outfit/job/janitor/get_types_to_preload()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This PR makes it so that all janitors spawn with the keyring in their backpack, instead of just the first one.

## Why It's Good For The Game

Allows multiple janitors to respond to emergency mess calls.
The second (or more) janitors aren't permanently lacking an important tool of the job the whole shift due to them joining after the first janitor.

## Changelog
:cl:
qol: Janitorial has had a budget increase. All janitors are now equipped with keyrings.
/:cl:
