### PR TITLE
Anchors ghost critter spawnpoints

### DIFF
--- a/monkestation/code/modules/ghost_critters/ghost_critter_spawnpoint.dm
+++ b/monkestation/code/modules/ghost_critters/ghost_critter_spawnpoint.dm
@@ -31,6 +31,7 @@
 	icon_state = "ghost_spawn"
 
 	density = FALSE
+	anchored = TRUE
 	resistance_flags = INDESTRUCTIBLE
 
 	plane = GHOST_PLANE


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
Prevents the ghost critter spawn points from being dragged around by gravity anomalies
## Changelog
:cl:
fix: Ghost critter spawn points are now anchored.
/:cl:
