### PR TITLE
Port /tg/ polling improvements

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -883,11 +883,11 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	if(!. || isnull(poll))
 		return
 	var/list/modifiers = params2list(params)
-	if(LAZYACCESS(modifiers, ALT_CLICK) && poll.ignoring_category)
+	if(LAZYACCESS(modifiers, ALT_CLICK))
 		set_never_round()
 		return
-	if(LAZYACCESS(modifiers, CTRL_CLICK) && poll.jump_to_me)
-		jump_to_pic_source()
+	if(LAZYACCESS(modifiers, CTRL_CLICK))
+		jump_to_jump_target()
 		return
 	handle_sign_up()
 
@@ -899,6 +899,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	update_signed_up_overlay()
 
 /atom/movable/screen/alert/poll_alert/proc/set_never_round()
+	if(!poll?.ignoring_category)
+		return
 	if(!(owner.ckey in GLOB.poll_ignore[poll.ignoring_category]))
 		poll.do_never_for_this_round(owner)
 		color = "red"
@@ -907,7 +909,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	poll.undo_never_for_this_round(owner)
 	color = initial(color)
 
-/atom/movable/screen/alert/poll_alert/proc/jump_to_pic_source()
+/atom/movable/screen/alert/poll_alert/proc/jump_to_jump_target()
 	if(!poll?.jump_to_me || !isobserver(owner))
 		return
 	var/turf/target_turf = get_turf(poll.jump_to_me)
@@ -921,7 +923,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	if(href_list["signup"])
 		handle_sign_up()
 	if(href_list["jump"])
-		jump_to_pic_source()
+		jump_to_jump_target()
 		return
 
 /atom/movable/screen/alert/poll_alert/proc/update_signed_up_overlay()
@@ -932,7 +934,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/poll_alert/proc/update_candidates_number_overlay()
 	cut_overlay(candidates_num_overlay)
-	if(!length(poll.signed_up))
+	if(!length(poll.signed_up) || !poll.show_candidate_amount)
 		return
 	candidates_num_overlay = new
 	candidates_num_overlay.maptext = MAPTEXT("<span style='text-align: right; color: aqua'>[length(poll.signed_up)]</span>")

--- a/code/controllers/subsystem/polling.dm
+++ b/code/controllers/subsystem/polling.dm
@@ -2,7 +2,7 @@ SUBSYSTEM_DEF(polling)
 	name = "Polling"
 	flags = SS_BACKGROUND | SS_NO_INIT
 	wait = 1 SECONDS
-	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+	runlevels = RUNLEVEL_GAME
 	/// List of polls currently ongoing, to be checked on next fire()
 	var/list/datum/candidate_poll/currently_polling
 	/// Number of polls performed since the start
@@ -27,10 +27,14 @@ SUBSYSTEM_DEF(polling)
  * * ignore_category: Optional, A poll category. If a candidate has this category in their ignore list, they won't be polled.
  * * flash_window: If TRUE, the candidate's window will flash when they're polled.
  * * list/group: A list of candidates to poll.
- * * pic_source: Optional, An /atom or an /image to display on the poll alert.
+ * * alert_pic: Optional, An /atom or an /image to display on the poll alert.
+ * * jump_target: An /atom to teleport/jump to, if alert_pic is an /atom defaults to that.
  * * role_name_text: Optional, A string to display in logging / the (default) question. If null, the role name will be used.
  * * list/custom_response_messages: Optional, A list of strings to use as responses to the poll. If null, the default responses will be used. see __DEFINES/polls.dm for valid keys to use.
  * * start_signed_up: If TRUE, all candidates will start signed up for the poll, making it opt-out rather than opt-in.
+ * * amount_to_pick: Lets you pick candidates and return a single mob or list of mobs that were chosen.
+ * * chat_text_border_icon: Object or path to make an icon of to decorate the chat announcement.
+ * * announce_chosen: Whether we should announce the chosen candidates in chat. This is ignored unless amount_to_pick is greater than 0.
  *
  * Returns a list of all mobs who signed up for the poll.
  */
@@ -42,18 +46,22 @@ SUBSYSTEM_DEF(polling)
 	ignore_category = null,
 	flash_window = TRUE,
 	list/group = null,
-	pic_source,
+	alert_pic,
+	jump_target,
 	role_name_text,
 	list/custom_response_messages,
-	start_signed_up = FALSE
+	start_signed_up = FALSE,
+	amount_to_pick = 0,
+	chat_text_border_icon,
+	announce_chosen = TRUE,
+	show_candidate_amount = TRUE,
 )
-	RETURN_TYPE(/list/mob)
-	if(group.len == 0)
-		return list()
+	if(length(group) == 0)
+		return
 	if(role && !role_name_text)
 		role_name_text = role
 	if(role_name_text && !question)
-		question = "Do you want to play as [full_capitalize(role_name_text)]?"
+		question = "Do you want to play as [span_notice(role_name_text)]?"
 	if(!question)
 		question = "Do you want to play as a special role?"
 	log_game("Polling candidates [role_name_text ? "for [role_name_text]" : "\"[question]\""] for [DisplayTimeText(poll_time)] seconds")
@@ -61,9 +69,11 @@ SUBSYSTEM_DEF(polling)
 	// Start firing
 	total_polls++
 
-	var/jumpable = isatom(pic_source) ? pic_source : null
+	if(isnull(jump_target) && isatom(alert_pic))
+		jump_target = alert_pic
 
-	var/datum/candidate_poll/new_poll = new(role_name_text, question, poll_time, ignore_category, jumpable, custom_response_messages)
+	var/datum/candidate_poll/new_poll = new(role_name_text, question, poll_time, ignore_category, jump_target, custom_response_messages)
+	new_poll.show_candidate_amount = show_candidate_amount
 	LAZYADD(currently_polling, new_poll)
 
 	var/category = "[new_poll.poll_key]_poll_alert"
@@ -71,13 +81,12 @@ SUBSYSTEM_DEF(polling)
 	for(var/mob/candidate_mob as anything in group)
 		if(!candidate_mob.client)
 			continue
-		// Universal opt-out for all players if it's for a role.
+		// Universal opt-out for all players.
 		if(!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles))
 			continue
 		// Opt-out for admins whom are currently adminned.
-		if(!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin) && candidate_mob.client.holder)
+		if((!candidate_mob.client.prefs.read_preference(/datum/preference/toggle/ghost_roles_as_admin)) && candidate_mob.client.holder)
 			continue
-		// Eligibility check (checks jobbans, prefs, and ignore categories)
 		if(!is_eligible(candidate_mob, role, check_jobban, ignore_category))
 			continue
 
@@ -121,96 +130,155 @@ SUBSYSTEM_DEF(polling)
 			if((candidate_mob in other_poll.signed_up) && new_poll.sign_up(candidate_mob, TRUE))
 				break
 
+		// Image to display
 		var/image/poll_image
-		if(pic_source)
-			if(isatom(pic_source))
-				var/atom/the_pic_source = pic_source
-				var/old_layer = the_pic_source.layer
-				var/old_plane = the_pic_source.plane
-				the_pic_source.plane = poll_alert_button.plane
-				the_pic_source.layer = FLOAT_LAYER
-				poll_alert_button.add_overlay(the_pic_source)
-				the_pic_source.layer = old_layer
-				the_pic_source.plane = old_plane
-			else if(ispath(pic_source, /datum/antagonist))
-				var/datum/antagonist/antagonist = new pic_source
-				poll_image = antagonist.render_poll_preview() || image('icons/effects/effects.dmi', icon_state = "static", layer = FLOAT_LAYER)
-				qdel(antagonist)
-			else
-				poll_image = image(pic_source, layer = FLOAT_LAYER)
+		if(ispath(alert_pic, /atom) || isatom(alert_pic))
+			poll_image = new /mutable_appearance(alert_pic)
+			poll_image.pixel_z = 0
+		else if(ispath(alert_pic, /datum/antagonist))
+			var/datum/antagonist/antagonist = new alert_pic
+			poll_image = antagonist.render_poll_preview() || image('icons/effects/effects.dmi', icon_state = "static", layer = FLOAT_LAYER)
+			QDEL_NULL(antagonist)
+		else if(!isnull(alert_pic))
+			poll_image = alert_pic
 		else
-			// Just use a generic image
-			poll_image = image('icons/effects/effects.dmi', icon_state = "static", layer = FLOAT_LAYER)
+			poll_image = image('icons/effects/effects.dmi', icon_state = "static")
 
 		if(poll_image)
+			poll_image.layer = FLOAT_LAYER
 			poll_image.plane = poll_alert_button.plane
 			poll_alert_button.add_overlay(poll_image)
 
 		// Chat message
 		var/act_jump = ""
-		if(isatom(pic_source) && isobserver(candidate_mob))
-			act_jump = "<a href='?src=[REF(poll_alert_button)];jump=1'>\[Teleport\]</a>"
-		var/act_signup = "<a href='?src=[REF(poll_alert_button)];signup=1'>\[[start_signed_up ? "Opt out" : "Sign Up"]\]</a>"
+		var/custom_link_style_start = "<style>a:visited{color:Crimson !important}</style>"
+		var/custom_link_style_end = "style='color:DodgerBlue;font-weight:bold;-dm-text-outline: 1px black'"
+		if(isatom(alert_pic) && isobserver(candidate_mob))
+			act_jump = "[custom_link_style_start]<a href='?src=[REF(poll_alert_button)];jump=1'[custom_link_style_end]>\[Teleport\]</a>"
+		var/act_signup = "[custom_link_style_start]<a href='?src=[REF(poll_alert_button)];signup=1'[custom_link_style_end]>\[[start_signed_up ? "Opt out" : "Sign Up"]\]</a>"
 		var/act_never = ""
 		if(ignore_category)
-			act_never = "<a href='?src=[REF(poll_alert_button)];never=1'>\[Never For This Round\]</a>"
+			act_never = "[custom_link_style_start]<a href='?src=[REF(poll_alert_button)];never=1'[custom_link_style_end]>\[Never For This Round\]</a>"
 
-		if(!duplicate_message_check(alert_poll) && candidate_mob.client) //Only notify people once. They'll notice if there are multiple and we don't want to spam people.
-			SEND_SOUND(candidate_mob.client, sound('monkestation/sound/effects/prompt.ogg', volume = candidate_mob.client.prefs.channel_volume["[CHANNEL_SOUND_EFFECTS]"])) // monkestation edit: prompt sound
-			to_chat(candidate_mob, span_boldnotice(examine_block("Now looking for candidates [role_name_text ? "to play as \an [role_name_text]." : "\"[question]\""] [act_jump] [act_signup] [act_never]")))
+		if(!duplicate_message_check(alert_poll)) //Only notify people once. They'll notice if there are multiple and we don't want to spam people.
+			SEND_SOUND(candidate_mob, sound('monkestation/sound/effects/prompt.ogg', volume = candidate_mob.client?.prefs?.channel_volume["[CHANNEL_SOUND_EFFECTS]"])) // monkestation edit: prompt sound
+			var/surrounding_icon
+			if(chat_text_border_icon)
+				var/image/surrounding_image
+				if(!ispath(chat_text_border_icon))
+					var/mutable_appearance/border_image = chat_text_border_icon
+					surrounding_image = border_image
+				else if(ispath(chat_text_border_icon, /datum/antagonist))
+					var/datum/antagonist/antagonist = new chat_text_border_icon
+					surrounding_image = antagonist.render_poll_preview()
+					QDEL_NULL(antagonist)
+				else
+					surrounding_image = image(chat_text_border_icon)
+				surrounding_icon = icon2html(surrounding_image, candidate_mob, extra_classes = "bigicon")
+			var/final_message =  examine_block("<span style='text-align:center;display:block'>[surrounding_icon] <span style='font-size:1.2em'>[span_ooc(question)]</span> [surrounding_icon]\n[act_jump]      [act_signup]      [act_never]</span>")
+			to_chat(candidate_mob, final_message)
 
 		// Start processing it so it updates visually the timer
 		START_PROCESSING(SSprocessing, poll_alert_button)
 
 	// Sleep until the time is up
 	UNTIL(new_poll.finished)
-	return new_poll.signed_up
+	if(!(amount_to_pick > 0))
+		return new_poll.signed_up
+	for(var/pick in 1 to amount_to_pick)
+		new_poll.chosen_candidates += pick_n_take(new_poll.signed_up)
+	if(announce_chosen)
+		new_poll.announce_chosen(group)
+	if(new_poll.chosen_candidates.len == 1)
+		var/chosen_one = pick(new_poll.chosen_candidates)
+		return chosen_one
+	return new_poll.chosen_candidates
 
-/datum/controller/subsystem/polling/proc/poll_ghost_candidates(question, role, check_jobban, poll_time = 30 SECONDS, ignore_category = null, flashwindow = TRUE, pic_source, role_name_text)
+/datum/controller/subsystem/polling/proc/poll_ghost_candidates(
+	question,
+	role,
+	check_jobban,
+	poll_time = 30 SECONDS,
+	ignore_category = null,
+	flashwindow = TRUE,
+	alert_pic,
+	jump_target,
+	role_name_text,
+	list/custom_response_messages,
+	start_signed_up = FALSE,
+	amount_to_pick = 0,
+	chat_text_border_icon,
+	announce_chosen = TRUE,
+	show_candidate_amount = TRUE,
+) as /list
+	RETURN_TYPE(/list)
 	var/list/candidates = list()
 	if(!(GLOB.ghost_role_flags & GHOSTROLE_STATION_SENTIENCE))
-		return candidates
-
+		return
 	for(var/mob/dead/observer/ghost_player in GLOB.player_list)
 		candidates += ghost_player
 
-	return poll_candidates(question, role, check_jobban, poll_time, ignore_category, flashwindow, candidates, pic_source, role_name_text)
+#ifdef TESTING
+	for(var/mob/dude in GLOB.player_list)
+		candidates |= dude
+#endif
 
-/datum/controller/subsystem/polling/proc/poll_ghost_candidates_for_mob(question, role, check_jobban, poll_time = 30 SECONDS, mob/target_mob, ignore_category = null, flashwindow = TRUE, pic_source, role_name_text)
-	var/static/list/mob/currently_polling_mobs = list()
+	return poll_candidates(question, role, check_jobban, poll_time, ignore_category, flashwindow, candidates, alert_pic, jump_target, role_name_text, custom_response_messages, start_signed_up, amount_to_pick, chat_text_border_icon, announce_chosen, show_candidate_amount)
 
-	if(!isnull(target_mob) && !ismob(target_mob))
-		stack_trace("attempted to use a non-mob as the target mob ([target_mob] | [target_mob.type])")
+/datum/controller/subsystem/polling/proc/poll_ghosts_for_target(
+	question,
+	role,
+	check_jobban,
+	poll_time = 30 SECONDS,
+	atom/movable/checked_target,
+	ignore_category = null,
+	flashwindow = TRUE,
+	alert_pic,
+	jump_target,
+	role_name_text,
+	list/custom_response_messages,
+	start_signed_up = FALSE,
+	chat_text_border_icon,
+	announce_chosen = TRUE,
+	show_candidate_amount = TRUE,
+) as /mob/dead/observer
+	RETURN_TYPE(/mob/dead/observer)
+	var/static/list/atom/movable/currently_polling_targets = list()
+	if(currently_polling_targets.Find(checked_target))
+		return
+	currently_polling_targets += checked_target
+	var/mob/chosen_one = poll_ghost_candidates(question, role, check_jobban, poll_time, ignore_category, flashwindow, alert_pic, jump_target, role_name_text, custom_response_messages, start_signed_up, amount_to_pick = 1, chat_text_border_icon = chat_text_border_icon, announce_chosen = announce_chosen, show_candidate_amount = show_candidate_amount)
+	currently_polling_targets -= checked_target
+	if(!checked_target || QDELETED(checked_target) || !checked_target.loc)
+		return null
+	return chosen_one
 
-	if(currently_polling_mobs.Find(target_mob))
+/datum/controller/subsystem/polling/proc/poll_ghosts_for_targets(
+	question,
+	role,
+	check_jobban,
+	poll_time = 30 SECONDS,
+	list/checked_targets,
+	ignore_category = null,
+	flashwindow = TRUE,
+	alert_pic,
+	jump_target,
+	role_name_text,
+	list/custom_response_messages,
+	start_signed_up = FALSE,
+	chat_text_border_icon,
+	show_candidate_amount = TRUE,
+) as /list
+	RETURN_TYPE(/list)
+	var/list/candidate_list = poll_ghost_candidates(question, role, check_jobban, poll_time, ignore_category, flashwindow, alert_pic, jump_target, role_name_text, custom_response_messages, start_signed_up, chat_text_border_icon = chat_text_border_icon, show_candidate_amount = show_candidate_amount)
+	for(var/atom/movable/potential_target as anything in checked_targets)
+		if(QDELETED(potential_target) || !potential_target.loc)
+			checked_targets -= potential_target
+	if(!length(checked_targets))
 		return list()
-
-	if(!pic_source && target_mob)
-		pic_source = target_mob
-
-	currently_polling_mobs += target_mob
-
-	var/list/possible_candidates = poll_ghost_candidates(question, role, check_jobban, poll_time, ignore_category, flashwindow, pic_source, role_name_text)
-
-	currently_polling_mobs -= target_mob
-	if(!target_mob || QDELETED(target_mob) || !target_mob.loc)
-		return list()
-
-	return possible_candidates
-
-/datum/controller/subsystem/polling/proc/poll_ghost_candidates_for_mobs(question, role, check_jobban, poll_time = 30 SECONDS, list/mobs, ignore_category = null, flashwindow = TRUE, pic_source, role_name_text)
-	var/list/candidate_list = poll_ghost_candidates(question, role, check_jobban, poll_time, ignore_category, flashwindow, pic_source, role_name_text)
-
-	for(var/mob/potential_mob as anything in mobs)
-		if(QDELETED(potential_mob) || !potential_mob.loc)
-			mobs -= potential_mob
-
-	if(!length(mobs))
-		return list()
-
 	return candidate_list
 
-/datum/controller/subsystem/polling/proc/is_eligible(mob/potential_candidate, role, check_jobban, the_ignore_category)
+/datum/controller/subsystem/polling/proc/is_eligible(mob/potential_candidate, role, check_jobban, the_ignore_category) as num
 	if(isnull(potential_candidate.key) || isnull(potential_candidate.client))
 		return FALSE
 	if(the_ignore_category)
@@ -223,8 +291,6 @@ SUBSYSTEM_DEF(polling)
 		if(potential_candidate.client && potential_candidate.client.get_remaining_days(required_time) > 0)
 			return FALSE
 
-	if(isnull(check_jobban) || !isnull(role))
-		check_jobban = role
 	if(check_jobban)
 		if(is_banned_from(potential_candidate.ckey, list(check_jobban, ROLE_SYNDICATE)))
 			return FALSE
@@ -258,13 +324,14 @@ SUBSYSTEM_DEF(polling)
 	return ..()
 
 ///Is there a multiple of the given event type running right now?
-/datum/controller/subsystem/polling/proc/duplicate_message_check(datum/candidate_poll/poll_to_check)
+/datum/controller/subsystem/polling/proc/duplicate_message_check(datum/candidate_poll/poll_to_check) as num
 	for(var/datum/candidate_poll/running_poll as anything in currently_polling)
 		if((running_poll.poll_key == poll_to_check.poll_key && running_poll != poll_to_check) && running_poll.time_left() > 0)
 			return TRUE
 	return FALSE
 
-/datum/controller/subsystem/polling/proc/get_next_poll_to_finish()
+/datum/controller/subsystem/polling/proc/get_next_poll_to_finish() as /datum/candidate_poll
+	RETURN_TYPE(/datum/candidate_poll)
 	var/lowest_time_left = INFINITY
 	var/next_poll_to_finish
 	for(var/datum/candidate_poll/poll as anything in currently_polling)

--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -52,7 +52,7 @@
 		check_jobban = ROLE_PAI,
 		poll_time = 10 SECONDS,
 		ignore_category = POLL_IGNORE_IMAGINARYFRIEND,
-		pic_source = owner,
+		alert_pic = owner,
 		role_name_text = "imaginary friend"
 	)
 	if(LAZYLEN(candidates))

--- a/code/datums/components/spirit_holding.dm
+++ b/code/datums/components/spirit_holding.dm
@@ -62,7 +62,7 @@
 		check_jobban = ROLE_PAI,
 		poll_time = 10 SECONDS,
 		ignore_category = POLL_IGNORE_POSSESSED_BLADE,
-		pic_source = parent,
+		alert_pic = parent,
 		role_name_text = "possessed blade",
 	)
 	if(!LAZYLEN(candidates))

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -125,7 +125,7 @@
 		return
 
 	mode.log_dynamic_and_announce("Polling [possible_volunteers.len] players to apply for the [name] ruleset.")
-	candidates = SSpolling.poll_ghost_candidates("Looking for volunteers to become [antag_flag] for [name]", check_jobban = antag_flag_override, role = antag_flag || antag_flag_override, poll_time = 30 SECONDS, pic_source = /obj/structure/sign/poster/contraband/syndicate_recruitment, role_name_text = antag_flag)
+	candidates = SSpolling.poll_ghost_candidates("Looking for volunteers to become [antag_flag] for [name]", check_jobban = antag_flag_override, role = antag_flag || antag_flag_override, poll_time = 30 SECONDS, alert_pic = /obj/structure/sign/poster/contraband/syndicate_recruitment, role_name_text = antag_flag)
 
 	if(!candidates || candidates.len <= 0)
 		mode.log_dynamic_and_announce("The ruleset [name] received no applications.")

--- a/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
+++ b/code/game/objects/effects/anomalies/anomalies_ectoplasm.dm
@@ -179,7 +179,7 @@
 		candidate_list += GLOB.current_observers_list
 		candidate_list += GLOB.dead_player_list
 
-	var/list/candidates = SSpolling.poll_candidates("Would you like to participate in a spooky ghost swarm? (Warning: you will not be able to return to your body!)", check_jobban = ROLE_SENTIENCE, poll_time = 10 SECONDS, group = candidate_list, pic_source = src, role_name_text = "ghost swarm")
+	var/list/candidates = SSpolling.poll_candidates("Would you like to participate in a spooky ghost swarm? (Warning: you will not be able to return to your body!)", check_jobban = ROLE_SENTIENCE, poll_time = 10 SECONDS, group = candidate_list, alert_pic = src, role_name_text = "ghost swarm")
 	for(var/mob/dead/observer/candidate_ghost as anything in candidates)
 		var/mob/living/basic/ghost/swarm/new_ghost = new(get_turf(src))
 		ghosts_spawned += new_ghost

--- a/code/game/objects/effects/anomalies/anomalies_pyroclastic.dm
+++ b/code/game/objects/effects/anomalies/anomalies_pyroclastic.dm
@@ -33,21 +33,10 @@
 	pyro.maximum_survivable_temperature = INFINITY
 	pyro.apply_temperature_requirements()
 
-	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates_for_mob(
-		"Do you want to play as a pyroclastic anomaly slime?",
-		check_jobban = ROLE_SENTIENCE,
-		role = ROLE_SENTIENCE,
-		poll_time = 10 SECONDS,
-		target_mob = pyro,
-		ignore_category = POLL_IGNORE_PYROSLIME,
-		pic_source = pyro,
-		role_name_text = "pyroclastic anomaly slime"
-	)
-	if(!LAZYLEN(candidates))
+	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(check_jobban = ROLE_SENTIENCE, poll_time = 10 SECONDS, checked_target = pyro, ignore_category = POLL_IGNORE_PYROSLIME, alert_pic = pyro, role_name_text = "pyroclastic anomaly slime")
+	if(isnull(chosen_one))
 		return
-
-	var/mob/dead/observer/chosen = pick(candidates)
-	pyro.key = chosen.key
+	pyro.key = chosen_one.key
 	pyro.mind.special_role = ROLE_PYROCLASTIC_SLIME
 	pyro.mind.add_antag_datum(/datum/antagonist/pyro_slime)
 	pyro.log_message("was made into a slime by pyroclastic anomaly", LOG_GAME)

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -442,11 +442,10 @@
 			var/mob/living/carbon/human/human_servant = new(drop_location())
 			do_smoke(0, holder = src, location = drop_location())
 
-			var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates_for_mob("Do you want to play as [user.real_name]'s Servant?", check_jobban = ROLE_WIZARD, role = ROLE_WIZARD, poll_time = 5 SECONDS, target_mob = human_servant, pic_source = user, role_name_text = "dice servant")
-			if(LAZYLEN(candidates))
-				var/mob/dead/observer/candidate = pick(candidates)
-				message_admins("[ADMIN_LOOKUPFLW(candidate)] was spawned as Dice Servant")
-				human_servant.key = candidate.key
+			var/mob/chosen_one = SSpolling.poll_ghosts_for_target("Do you want to play as [span_danger("[user.real_name]'s")] [span_notice("Servant")]?", check_jobban = ROLE_WIZARD, role = ROLE_WIZARD, poll_time = 5 SECONDS, checked_target = human_servant, alert_pic = user, role_name_text = "dice servant")
+			if(chosen_one)
+				message_admins("[ADMIN_LOOKUPFLW(chosen_one)] was spawned as Dice Servant")
+				human_servant.key = chosen_one.key
 
 			human_servant.equipOutfit(/datum/outfit/butler)
 			var/datum/mind/servant_mind = new /datum/mind()

--- a/code/modules/admin/fun_balloon.dm
+++ b/code/modules/admin/fun_balloon.dm
@@ -87,16 +87,17 @@
 		if (!possessable.ckey && possessable.stat == CONSCIOUS) // Only assign ghosts to living, non-occupied mobs!
 			bodies += possessable
 
-	var/question = "Would you like to be [group_name]?"
-	var/list/candidates = SSpolling.poll_ghost_candidates_for_mobs(
-		question,
+	var/list/candidates = SSpolling.poll_ghosts_for_targets(
+		question = "Would you like to be [span_notice(group_name)]?",
 		role = ROLE_SENTIENCE,
+		check_jobban = ROLE_SENTIENCE,
 		poll_time = 10 SECONDS,
-		mobs = bodies,
+		checked_targets = bodies,
 		ignore_category = POLL_IGNORE_SHUTTLE_DENIZENS,
-		pic_source = src,
-		role_name_text = group_name || "sentience fun balloon"
+		alert_pic = src,
+		role_name_text = "sentience fun balloon",
 	)
+
 	while(LAZYLEN(candidates) && LAZYLEN(bodies))
 		var/mob/dead/observer/C = pick_n_take(candidates)
 		var/mob/living/body = pick_n_take(bodies)

--- a/code/modules/admin/verbs/ert.dm
+++ b/code/modules/admin/verbs/ert.dm
@@ -141,7 +141,7 @@
 		var/list/spawnpoints = GLOB.emergencyresponseteamspawn
 		var/index = 0
 
-		var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates("Do you wish to be considered for [ertemplate.polldesc]?", check_jobban = "deathsquad", pic_source = /obj/item/card/id/advanced/centcom/ert, role_name_text = "emergency response team")
+		var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates("Do you wish to be considered for [ertemplate.polldesc]?", check_jobban = "deathsquad", alert_pic = /obj/item/card/id/advanced/centcom/ert, role_name_text = "emergency response team")
 		var/teamSpawned = FALSE
 
 		// This list will take priority over spawnpoints if not empty

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -401,7 +401,7 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 				var/list/candidates = list()
 
 				if (prefs["offerghosts"]["value"] == "Yes")
-					candidates = SSpolling.poll_ghost_candidates(replacetext(prefs["ghostpoll"]["value"], "%TYPE%", initial(pathToSpawn.name)), check_jobban = ROLE_TRAITOR, pic_source = pathToSpawn, role_name_text = "portal storm")
+					candidates = SSpolling.poll_ghost_candidates(replacetext(prefs["ghostpoll"]["value"], "%TYPE%", initial(pathToSpawn.name)), check_jobban = ROLE_TRAITOR, alert_pic = pathToSpawn, role_name_text = "portal storm")
 
 				if (prefs["playersonly"]["value"] == "Yes" && length(candidates) < prefs["minplayers"]["value"])
 					message_admins("Not enough players signed up to create a portal storm, the minimum was [prefs["minplayers"]["value"]] and the number of signups [length(candidates)]")
@@ -547,7 +547,7 @@ GLOBAL_DATUM(everyone_a_traitor, /datum/everyone_is_a_traitor_controller)
 			if(teamsize <= 0)
 				return FALSE
 
-			candidates = SSpolling.poll_ghost_candidates("Do you wish to be considered for a Nanotrasen emergency response drone?", check_jobban = ROLE_DRONE, pic_source = /mob/living/basic/drone/classic, role_name_text = "nanotrasen emergency response drone")
+			candidates = SSpolling.poll_ghost_candidates("Do you wish to be considered for a Nanotrasen emergency response drone?", check_jobban = ROLE_DRONE, alert_pic = /mob/living/basic/drone/classic, role_name_text = "nanotrasen emergency response drone")
 
 			if(length(candidates) == 0)
 				return FALSE

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -286,20 +286,15 @@ GLOBAL_LIST_EMPTY(antagonists)
 /datum/antagonist/proc/replace_banned_player()
 	set waitfor = FALSE
 
-	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates_for_mob(
-		"Do you want to play as a [name]?",
-		check_jobban = job_rank || "[name]",
-		role = job_rank,
-		poll_time = 5 SECONDS,
-		target_mob = owner.current,
-		role_name_text = name
-	)
-	if(LAZYLEN(candidates))
-		var/mob/dead/observer/C = pick(candidates)
+	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(check_jobban = job_rank, role = job_rank, poll_time = 5 SECONDS, checked_target = owner.current, alert_pic = owner.current, role_name_text = name)
+	if(chosen_one)
 		to_chat(owner, "Your mob has been taken over by a ghost! Appeal your job ban if you want to avoid this in the future!")
-		message_admins("[key_name_admin(C)] has taken control of ([key_name_admin(owner)]) to replace a jobbanned player.")
+		message_admins("[key_name_admin(chosen_one)] has taken control of ([key_name_admin(owner)]) to replace antagonist banned player.")
+		log_game("[key_name(chosen_one)] has taken control of ([key_name(owner)]) to replace antagonist banned player.")
 		owner.current.ghostize(FALSE)
-		owner.current.key = C.key
+		owner.current.key = chosen_one.key
+	else
+		log_game("Couldn't find antagonist ban replacement for ([key_name(owner)]).")
 
 /**
  * Called by the remove_antag_datum() and remove_all_antag_datums() mind procs for the antag datum to handle its own removal and deletion.

--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -55,16 +55,15 @@
 /obj/item/antag_spawner/contract/proc/poll_for_student(mob/living/carbon/human/teacher, apprentice_school)
 	balloon_alert(teacher, "contacting apprentice...")
 	polling = TRUE
-	var/list/candidates = SSpolling.poll_ghost_candidates_for_mob("Do you want to play as a wizard's [apprentice_school] apprentice?", check_jobban = ROLE_WIZARD, role = ROLE_WIZARD, poll_time = 15 SECONDS, target_mob = src, pic_source = teacher, role_name_text = "wizard apprentice")
+	var/mob/chosen_one = SSpolling.poll_ghosts_for_target("Do you want to play as [span_danger("[teacher]'s")] [span_notice("[apprentice_school] apprentice")]?", check_jobban = ROLE_WIZARD, role = ROLE_WIZARD, poll_time = 15 SECONDS, checked_target = src, alert_pic = /obj/item/clothing/head/wizard/red, jump_target = src, role_name_text = "wizard apprentice", chat_text_border_icon = /obj/item/clothing/head/wizard/red)
 	polling = FALSE
-	if(!LAZYLEN(candidates))
+	if(isnull(chosen_one))
 		to_chat(teacher, span_warning("Unable to reach your apprentice! You can either attack the spellbook with the contract to refund your points, or wait and try again later."))
 		return
 	if(QDELETED(src) || used)
 		return
 	used = TRUE
-	var/mob/dead/observer/student = pick(candidates)
-	spawn_antag(student.client, get_turf(src), apprentice_school, teacher.mind)
+	spawn_antag(chosen_one.client, get_turf(src), apprentice_school, teacher.mind)
 
 /obj/item/antag_spawner/contract/spawn_antag(client/C, turf/T, kind, datum/mind/user)
 	new /obj/effect/particle_effect/fluid/smoke(T)
@@ -134,13 +133,12 @@
 		return
 
 	to_chat(user, span_notice("You activate [src] and wait for confirmation."))
-	var/list/nuke_candidates = SSpolling.poll_ghost_candidates("Do you want to play as a syndicate [borg_to_spawn ? "[lowertext(borg_to_spawn)] cyborg":"operative"]?", check_jobban = ROLE_OPERATIVE, role = ROLE_OPERATIVE, poll_time = 15 SECONDS, ignore_category = POLL_IGNORE_SYNDICATE, pic_source = src, role_name_text = "syndicate [borg_to_spawn ? "[borg_to_spawn] cyborg":"operative"]")
-	if(LAZYLEN(nuke_candidates))
+	var/mob/chosen_one = SSpolling.poll_ghost_candidates("Do you want to play as a reinforcement [special_role_name]?", check_jobban = ROLE_OPERATIVE, role = ROLE_OPERATIVE, poll_time = 15 SECONDS, ignore_category = POLL_IGNORE_SYNDICATE, alert_pic = src, role_name_text = special_role_name, amount_to_pick = 1)
+	if(chosen_one)
 		if(QDELETED(src) || !check_usability(user))
 			return
 		used = TRUE
-		var/mob/dead/observer/G = pick(nuke_candidates)
-		spawn_antag(G.client, get_turf(src), "nukeop", user.mind)
+		spawn_antag(chosen_one.client, get_turf(src), "nukeop", user.mind)
 		do_sparks(4, TRUE, src)
 		qdel(src)
 	else
@@ -253,20 +251,13 @@
 		return
 	if(used)
 		return
-	var/list/candidates = SSpolling.poll_ghost_candidates(
-		"Do you want to play as a [initial(demon_type.name)]?",
-		check_jobban = ROLE_SLAUGHTER_DEMON,
-		poll_time = 5 SECONDS,
-		pic_source = demon_type,
-		role_name_text = initial(demon_type.name)
-	)
-	if(LAZYLEN(candidates))
+	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(check_jobban = ROLE_ALIEN, role = ROLE_ALIEN, poll_time = 5 SECONDS, checked_target = src, alert_pic = demon_type, jump_target = src, role_name_text = initial(demon_type.name))
+	if(chosen_one)
 		if(used || QDELETED(src))
 			return
 		used = TRUE
-		var/mob/dead/observer/summoned = pick(candidates)
-		user.log_message("has summoned forth the [initial(demon_type.name)] (played by [key_name(summoned)]) using a [name].", LOG_GAME) // has to be here before we create antag otherwise we can't get the ckey of the demon
-		spawn_antag(summoned.client, get_turf(src), initial(demon_type.name), user.mind)
+		user.log_message("has summoned forth the [initial(demon_type.name)] (played by [key_name(chosen_one)]) using a [name].", LOG_GAME) // has to be here before we create antag otherwise we can't get the ckey of the demon
+		spawn_antag(chosen_one.client, get_turf(src), initial(demon_type.name), user.mind)
 		to_chat(user, shatter_msg)
 		to_chat(user, veil_msg)
 		playsound(user.loc, 'sound/effects/glassbr1.ogg', 100, TRUE)

--- a/code/modules/antagonists/blob/powers.dm
+++ b/code/modules/antagonists/blob/powers.dm
@@ -199,7 +199,7 @@
 		check_jobban = ROLE_BLOB,
 		role = ROLE_BLOB,
 		poll_time = 5 SECONDS,
-		pic_source = /mob/living/basic/blob_minion/blobbernaut/minion,
+		alert_pic = /mob/living/basic/blob_minion/blobbernaut/minion,
 		role_name_text = "blobbernaut"
 	)
 

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -143,7 +143,7 @@
 		question = "[span_notice(nominee.name)] seeks to lead your cult, do you support [nominee.p_them()]?",
 		poll_time = 30 SECONDS,
 		group = asked_cultists,
-		pic_source = nominee,
+		alert_pic = nominee,
 		role_name_text = "cult master nomination",
 		custom_response_messages = list(
 			POLL_RESPONSE_SIGNUP = "You have pledged your allegience to [nominee].",

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -672,35 +672,36 @@ structure_check() searches for nearby cultist structures required for the invoca
 		. += "<b>Sacrifices unrewarded:</b> [LAZYLEN(GLOB.sacrificed) - sacrifices_used]"
 
 /obj/effect/rune/raise_dead/invoke(list/invokers)
-	var/turf/T = get_turf(src)
-	var/mob/living/mob_to_revive
-	var/list/potential_revive_mobs = list()
-	var/mob/living/user = invokers[1]
 	if(rune_in_use)
 		return
 	rune_in_use = TRUE
-	for(var/mob/living/M in T.contents)
-		if(IS_CULTIST(M) && (M.stat == DEAD || !M.client || M.client.is_afk()))
-			potential_revive_mobs |= M
+	var/mob/living/mob_to_revive
+	var/list/potential_revive_mobs = list()
+	var/mob/living/user = invokers[1]
+
+	for(var/mob/living/target in loc)
+		if(IS_CULTIST(target) && (target.stat == DEAD || isnull(target.client) || target.client.is_afk()))
+			potential_revive_mobs += target
+
 	if(!length(potential_revive_mobs))
-		to_chat(user, "<span class='cult italic'>There are no dead cultists on the rune!</span>")
+		to_chat(user, span_cultitalic("There are no dead cultists on the rune!"))
 		log_game("Raise Dead rune activated by [user] at [COORD(src)] failed - no cultists to revive.")
 		fail_invoke()
 		return
-	if(length(potential_revive_mobs) > 1)
+
+	if(length(potential_revive_mobs) > 1 && user.mind)
 		mob_to_revive = tgui_input_list(user, "Cultist to revive", "Revive Cultist", potential_revive_mobs)
 		if(isnull(mob_to_revive))
 			return
 	else
 		mob_to_revive = potential_revive_mobs[1]
+
 	if(QDELETED(src) || !validness_checks(mob_to_revive, user))
 		fail_invoke()
 		return
-	if(user.name == "Herbert West")
-		invocation = "To life, to life, I bring them!"
-	else
-		invocation = initial(invocation)
-	..()
+
+	invocation = (user.name == "Herbert West") ? "To life, to life, I bring them!" : initial(invocation)
+
 	if(mob_to_revive.stat == DEAD)
 		var/diff = LAZYLEN(GLOB.sacrificed) - SOULS_TO_REVIVE - sacrifices_used
 		if(diff < 0)
@@ -712,28 +713,21 @@ structure_check() searches for nearby cultist structures required for the invoca
 
 	if(!mob_to_revive.client || mob_to_revive.client.is_afk())
 		set waitfor = FALSE
-		var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates_for_mob(
-			"Do you want to play as a [mob_to_revive.real_name], an inactive blood cultist?",
-			check_jobban = ROLE_CULTIST,
-			role = ROLE_CULTIST,
-			poll_time = 5 SECONDS,
-			target_mob = mob_to_revive,
-			role_name_text = "blood cultist"
-		)
-		if(LAZYLEN(candidates))
-			var/mob/dead/observer/C = pick(candidates)
+		var/mob/chosen_one = SSpolling.poll_ghosts_for_target("Do you want to play as [span_danger(mob_to_revive.real_name)], an [span_notice("inactive blood cultist")]?", check_jobban = ROLE_CULTIST, role = ROLE_CULTIST, poll_time = 5 SECONDS, checked_target = mob_to_revive, alert_pic = mob_to_revive, role_name_text = "inactive cultist")
+		if(chosen_one)
 			to_chat(mob_to_revive.mind, "Your physical form has been taken over by another soul due to your inactivity! Ahelp if you wish to regain your form.")
-			message_admins("[key_name_admin(C)] has taken control of ([key_name_admin(mob_to_revive)]) to replace an AFK player.")
+			message_admins("[key_name_admin(chosen_one)] has taken control of ([key_name_admin(mob_to_revive)]) to replace an AFK player.")
 			mob_to_revive.ghostize(FALSE)
-			mob_to_revive.key = C.key
+			mob_to_revive.key = chosen_one.key
 		else
 			fail_invoke()
 			return
 	SEND_SOUND(mob_to_revive, 'sound/ambience/antag/bloodcult/bloodcult_gain.ogg')
 	to_chat(mob_to_revive, span_cultlarge("\"PASNAR SAVRAE YAM'TOTH. Arise.\""))
 	mob_to_revive.visible_message(span_warning("[mob_to_revive] draws in a huge breath, red light shining from [mob_to_revive.p_their()] eyes."), \
-								  span_cultlarge("You awaken suddenly from the void. You're alive!"))
+		span_cultlarge("You awaken suddenly from the void. You're alive!"))
 	rune_in_use = FALSE
+	return ..()
 
 /obj/effect/rune/raise_dead/proc/validness_checks(mob/living/target_mob, mob/living/user)
 	var/turf/T = get_turf(src)

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -168,22 +168,13 @@
 
 	if(!soon_to_be_ghoul.mind || !soon_to_be_ghoul.client)
 		message_admins("[ADMIN_LOOKUPFLW(user)] is creating a voiceless dead of a body with no player.")
-		var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates_for_mob(
-			"Do you want to play as a [soon_to_be_ghoul.real_name], a voiceless dead?",
-			check_jobban = ROLE_HERETIC,
-			role = ROLE_HERETIC,
-			poll_time = 5 SECONDS,
-			target_mob = soon_to_be_ghoul,
-			role_name_text = "voiceless dead"
-		)
-		if(!LAZYLEN(candidates))
+		var/mob/chosen_one = SSpolling.poll_ghosts_for_target("Do you want to play as [span_danger(soon_to_be_ghoul.real_name)], a [span_notice("voiceless dead")]?", check_jobban = ROLE_HERETIC, role = ROLE_HERETIC, poll_time = 5 SECONDS, checked_target = soon_to_be_ghoul, alert_pic = mutable_appearance('icons/mob/species/human/human.dmi', "husk"), jump_target = soon_to_be_ghoul, role_name_text = "voiceless dead")
+		if(isnull(chosen_one))
 			loc.balloon_alert(user, "ritual failed, no ghosts!")
 			return FALSE
-
-		var/mob/dead/observer/chosen_candidate = pick(candidates)
-		message_admins("[key_name_admin(chosen_candidate)] has taken control of ([key_name_admin(soon_to_be_ghoul)]) to replace an AFK player.")
+		message_admins("[key_name_admin(chosen_one)] has taken control of ([key_name_admin(soon_to_be_ghoul)]) to replace an AFK player.")
 		soon_to_be_ghoul.ghostize(FALSE)
-		soon_to_be_ghoul.key = chosen_candidate.key
+		soon_to_be_ghoul.key = chosen_one.key
 
 	selected_atoms -= soon_to_be_ghoul
 	make_ghoul(user, soon_to_be_ghoul)

--- a/code/modules/antagonists/heretic/structures/knock_final.dm
+++ b/code/modules/antagonists/heretic/structures/knock_final.dm
@@ -43,7 +43,7 @@
 		check_jobban = ROLE_SENTIENCE,
 		poll_time = 10 SECONDS,
 		ignore_category = POLL_IGNORE_HERETIC_MONSTER,
-		pic_source = src,
+		alert_pic = src,
 		role_name_text = "eldritch monster"
 	)
 	while(LAZYLEN(candidates))

--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -85,7 +85,7 @@
 	if(chosen_gang.paid_off)
 		return
 
-	var/list/candidates = SSpolling.poll_ghost_candidates("Do you wish to be considered for a pirate crew of [chosen_gang.name]?", check_jobban = ROLE_SPACE_PIRATE, pic_source = /obj/item/claymore/cutlass, role_name_text = "pirate crew")
+	var/list/candidates = SSpolling.poll_ghost_candidates("Do you wish to be considered for a pirate crew of [chosen_gang.name]?", check_jobban = ROLE_SPACE_PIRATE, alert_pic = /obj/item/claymore/cutlass, role_name_text = "pirate crew")
 	shuffle_inplace(candidates)
 
 	var/template_key = "pirate_[chosen_gang.ship_template_id]"

--- a/code/modules/bitrunning/event.dm
+++ b/code/modules/bitrunning/event.dm
@@ -127,7 +127,7 @@
 		check_jobban = ROLE_PAI,
 		poll_time = 7.5 SECONDS,
 		ignore_category = POLL_IGNORE_SPLITPERSONALITY,
-		pic_source = /datum/antagonist/cyber_police,
+		alert_pic = /datum/antagonist/cyber_police,
 		role_name_text = role_name
 	)
 

--- a/code/modules/clothing/head/mind_monkey_helmet.dm
+++ b/code/modules/clothing/head/mind_monkey_helmet.dm
@@ -47,26 +47,18 @@
 	playsound(src, 'sound/machines/ping.ogg', 30, TRUE)
 	RegisterSignal(magnification, COMSIG_SPECIES_LOSS, PROC_REF(make_fall_off))
 	polling = TRUE
-	var/list/candidates = SSpolling.poll_ghost_candidates_for_mob(
-		"Do you want to play as a mind magnified monkey?",
-		check_jobban = ROLE_MONKEY_HELMET,
-		poll_time = 5 SECONDS,
-		target_mob = magnification,
-		ignore_category = POLL_IGNORE_MONKEY_HELMET,
-		role_name_text = "mind-magnified monkey"
-	)
+	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(check_jobban = ROLE_MONKEY_HELMET, poll_time = 5 SECONDS, checked_target = magnification, ignore_category = POLL_IGNORE_MONKEY_HELMET, alert_pic = magnification, role_name_text = "mind-magnified monkey")
 	polling = FALSE
 	if(!magnification)
 		return
-	if(!length(candidates))
+	if(isnull(chosen_one))
 		UnregisterSignal(magnification, COMSIG_SPECIES_LOSS)
 		magnification = null
 		visible_message(span_notice("[src] falls silent and drops on the floor. Maybe you should try again later?"))
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 30, TRUE)
 		user.dropItemToGround(src)
 		return
-	var/mob/picked = pick(candidates)
-	magnification.key = picked.key
+	magnification.key = chosen_one.key
 	playsound(src, 'sound/machines/microwave/microwave-end.ogg', 100, FALSE)
 	to_chat(magnification, span_notice("You're a mind magnified monkey! Protect your helmet with your life- if you lose it, your sentience goes with it!"))
 	var/policy = get_policy(ROLE_MONKEY_HELMET)

--- a/code/modules/events/ghost_role/abductor.dm
+++ b/code/modules/events/ghost_role/abductor.dm
@@ -14,7 +14,7 @@
 	fakeable = FALSE //Nothing to fake here
 
 /datum/round_event/ghost_role/abductor/spawn_role()
-	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_ABDUCTOR, role = ROLE_ABDUCTOR, pic_source = /obj/item/melee/baton/abductor, role_name_text = role_name)
+	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_ABDUCTOR, role = ROLE_ABDUCTOR, alert_pic = /obj/item/melee/baton/abductor, role_name_text = role_name)
 
 	if(length(candidates) < 2)
 		return NOT_ENOUGH_PLAYERS

--- a/code/modules/events/ghost_role/alien_infestation.dm
+++ b/code/modules/events/ghost_role/alien_infestation.dm
@@ -67,7 +67,7 @@
 			role = antag_flag,
 			poll_time = 20 SECONDS,
 			group = candidates,
-			pic_source = antag_datum,
+			alert_pic = antag_datum,
 			role_name_text = lowertext(cast_control.name),
 		)
 

--- a/code/modules/events/ghost_role/blob.dm
+++ b/code/modules/events/ghost_role/blob.dm
@@ -33,7 +33,7 @@
 	blob_icon.Blend("#9ACD32", ICON_MULTIPLY)
 	blob_icon.Blend(icon('icons/mob/nonhuman-player/blob.dmi', "blob_core_overlay"), ICON_OVERLAY)
 	var/image/blob_image = image(blob_icon)
-	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_BLOB, role = ROLE_BLOB, pic_source = blob_image, role_name_text = role_name)
+	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_BLOB, role = ROLE_BLOB, alert_pic = blob_image, role_name_text = role_name)
 	if(!length(candidates))
 		return NOT_ENOUGH_PLAYERS
 	var/mob/dead/observer/new_blob = pick(candidates)

--- a/code/modules/events/ghost_role/changeling_event.dm
+++ b/code/modules/events/ghost_role/changeling_event.dm
@@ -21,7 +21,7 @@
 	fakeable = FALSE
 
 /datum/round_event/ghost_role/changeling/spawn_role()
-	var/list/mob/dead/observer/candidate = SSpolling.poll_ghost_candidates(check_jobban = ROLE_CHANGELING, role = ROLE_CHANGELING_MIDROUND, pic_source = /obj/item/melee/arm_blade, role_name_text = role_name)
+	var/list/mob/dead/observer/candidate = SSpolling.poll_ghost_candidates(check_jobban = ROLE_CHANGELING, role = ROLE_CHANGELING_MIDROUND, alert_pic = /obj/item/melee/arm_blade, role_name_text = role_name)
 
 	if(!candidate.len)
 		return NOT_ENOUGH_PLAYERS

--- a/code/modules/events/ghost_role/fugitive_event.dm
+++ b/code/modules/events/ghost_role/fugitive_event.dm
@@ -20,7 +20,7 @@
 	if(isnull(landing_turf))
 		return MAP_ERROR
 	var/list/possible_backstories = list()
-	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_FUGITIVE, role = ROLE_FUGITIVE, pic_source = /obj/item/card/id/advanced/prisoner)
+	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_FUGITIVE, role = ROLE_FUGITIVE, alert_pic = /obj/item/card/id/advanced/prisoner)
 
 	if(!length(candidates))
 		return NOT_ENOUGH_PLAYERS

--- a/code/modules/events/ghost_role/morph_event.dm
+++ b/code/modules/events/ghost_role/morph_event.dm
@@ -13,7 +13,7 @@
 	role_name = "morphling"
 
 /datum/round_event/ghost_role/morph/spawn_role()
-	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_MORPH, pic_source = /mob/living/basic/morph, role_name_text = "morph")
+	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_MORPH, alert_pic = /mob/living/basic/morph, role_name_text = "morph")
 	if(!length(candidates))
 		return NOT_ENOUGH_PLAYERS
 

--- a/code/modules/events/ghost_role/nightmare.dm
+++ b/code/modules/events/ghost_role/nightmare.dm
@@ -20,7 +20,7 @@
 		role = ROLE_NIGHTMARE,
 		check_jobban = ROLE_NIGHTMARE,
 		poll_time = 20 SECONDS,
-		pic_source = /datum/antagonist/nightmare,
+		alert_pic = /datum/antagonist/nightmare,
 		role_name_text = "nightmare"
 	)
 	if(!length(candidates))

--- a/code/modules/events/ghost_role/operative.dm
+++ b/code/modules/events/ghost_role/operative.dm
@@ -12,7 +12,7 @@
 	fakeable = FALSE
 
 /datum/round_event/ghost_role/operative/spawn_role()
-	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_OPERATIVE, role = ROLE_LONE_OPERATIVE, pic_source = /obj/machinery/nuclearbomb)
+	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_OPERATIVE, role = ROLE_LONE_OPERATIVE, alert_pic = /obj/machinery/nuclearbomb)
 	if(!length(candidates))
 		return NOT_ENOUGH_PLAYERS
 

--- a/code/modules/events/ghost_role/revenant_event.dm
+++ b/code/modules/events/ghost_role/revenant_event.dm
@@ -29,7 +29,7 @@
 			message_admins("Event attempted to spawn a revenant, but there were only [deadMobs]/[REVENANT_SPAWN_THRESHOLD] dead mobs.")
 			return WAITING_FOR_SOMETHING
 
-	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_REVENANT, role = ROLE_REVENANT, pic_source = /mob/living/basic/revenant)
+	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_REVENANT, role = ROLE_REVENANT, alert_pic = /mob/living/basic/revenant)
 	if(!length(candidates))
 		return NOT_ENOUGH_PLAYERS
 

--- a/code/modules/events/ghost_role/sentience.dm
+++ b/code/modules/events/ghost_role/sentience.dm
@@ -53,7 +53,7 @@ GLOBAL_LIST_INIT(high_priority_sentience, typecacheof(list(
 	candidates = SSpolling.poll_ghost_candidates(
 		"Would you like to be a random animal?",
 		role = ROLE_SENTIENCE,
-		pic_source = /obj/item/slimepotion/slime/sentience,
+		alert_pic = /obj/item/slimepotion/slime/sentience,
 		role_name_text = role_name
 	)
 

--- a/code/modules/events/ghost_role/sentient_disease.dm
+++ b/code/modules/events/ghost_role/sentient_disease.dm
@@ -14,7 +14,7 @@
 	role_name = "sentient disease"
 
 /datum/round_event/ghost_role/sentient_disease/spawn_role()
-	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_SENTIENT_DISEASE, role = ROLE_SENTIENT_DISEASE, pic_source = /obj/structure/sign/warning/biohazard, role_name_text = role_name)
+	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_SENTIENT_DISEASE, role = ROLE_SENTIENT_DISEASE, alert_pic = /obj/structure/sign/warning/biohazard, role_name_text = role_name)
 	if(!length(candidates))
 		return NOT_ENOUGH_PLAYERS
 

--- a/code/modules/events/ghost_role/slaughter_event.dm
+++ b/code/modules/events/ghost_role/slaughter_event.dm
@@ -16,7 +16,7 @@
 	role_name = "slaughter demon"
 
 /datum/round_event/ghost_role/slaughter/spawn_role()
-	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_SLAUGHTER_DEMON, pic_source = /mob/living/basic/demon/slaughter, role_name_text = role_name)
+	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_SLAUGHTER_DEMON, alert_pic = /mob/living/basic/demon/slaughter, role_name_text = role_name)
 	if(!length(candidates))
 		return NOT_ENOUGH_PLAYERS
 

--- a/code/modules/events/ghost_role/space_dragon.dm
+++ b/code/modules/events/ghost_role/space_dragon.dm
@@ -20,7 +20,7 @@
 	priority_announce("A large organic energy flux has been recorded near [station_name()], please stand by.", "Lifesign Alert")
 
 /datum/round_event/ghost_role/space_dragon/spawn_role()
-	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_SPACE_DRAGON, role = ROLE_SPACE_DRAGON, pic_source = /mob/living/basic/space_dragon)
+	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_SPACE_DRAGON, role = ROLE_SPACE_DRAGON, alert_pic = /mob/living/basic/space_dragon)
 	if(!length(candidates))
 		return NOT_ENOUGH_PLAYERS
 

--- a/code/modules/events/ghost_role/space_ninja.dm
+++ b/code/modules/events/ghost_role/space_ninja.dm
@@ -19,7 +19,7 @@
 		return MAP_ERROR
 
 	//selecting a candidate player
-	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_NINJA, role = ROLE_NINJA, pic_source = /obj/item/energy_katana)
+	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_NINJA, role = ROLE_NINJA, alert_pic = /obj/item/energy_katana)
 	if(!length(candidates))
 		return NOT_ENOUGH_PLAYERS
 

--- a/code/modules/events/holiday/xmas.dm
+++ b/code/modules/events/holiday/xmas.dm
@@ -84,7 +84,7 @@
 	priority_announce("Santa is coming to town!", "Unknown Transmission")
 
 /datum/round_event/santa/start()
-	var/list/candidates = SSpolling.poll_ghost_candidates("Santa is coming to town! Do you want to be Santa?", poll_time = 15 SECONDS, pic_source = /obj/item/clothing/head/costume/santa, role_name_text = "santa")
+	var/list/candidates = SSpolling.poll_ghost_candidates("Santa is coming to town! Do you want to be Santa?", poll_time = 15 SECONDS, alert_pic = /obj/item/clothing/head/costume/santa, role_name_text = "santa")
 	if(LAZYLEN(candidates))
 		var/mob/dead/observer/C = pick(candidates)
 		santa = new /mob/living/carbon/human(pick(GLOB.blobstart))

--- a/code/modules/events/wizard/imposter.dm
+++ b/code/modules/events/wizard/imposter.dm
@@ -13,27 +13,24 @@
 		if(!ishuman(M.current))
 			continue
 		var/mob/living/carbon/human/W = M.current
-		var/list/candidates = SSpolling.poll_ghost_candidates("Would you like to be an imposter wizard?", check_jobban = ROLE_WIZARD, pic_source = /obj/item/clothing/head/wizard, role_name_text = "imposter wizard")
-		if(!length(candidates))
+		var/mob/chosen_one = SSpolling.poll_ghost_candidates("Would you like to be an [span_notice("imposter wizard")]?", check_jobban = ROLE_WIZARD, alert_pic = /obj/item/clothing/head/wizard, jump_target = W, role_name_text = "imposter wizard", amount_to_pick = 1)
+		if(isnull(chosen_one))
 			return //Sad Trombone
-		var/mob/dead/observer/C = pick(candidates)
-
 		new /obj/effect/particle_effect/fluid/smoke(W.loc)
-
 		var/mob/living/carbon/human/I = new /mob/living/carbon/human(W.loc)
 		W.dna.transfer_identity(I, transfer_SE=1)
 		I.real_name = I.dna.real_name
 		I.name = I.dna.real_name
 		I.updateappearance(mutcolor_update=1)
 		I.domutcheck()
-		I.key = C.key
+		I.key = chosen_one.key
 		var/datum/antagonist/wizard/master = M.has_antag_datum(/datum/antagonist/wizard)
 		if(!master.wiz_team)
 			master.create_wiz_team()
 		var/datum/antagonist/wizard/apprentice/imposter/imposter = new()
 		imposter.master = M
 		imposter.wiz_team = master.wiz_team
-		master.wiz_team.add_member(I.mind)
+		master.wiz_team.add_member(imposter)
 		I.mind.add_antag_datum(imposter)
 		I.mind.special_role = "imposter"
 		I.log_message("is an imposter!", LOG_ATTACK, color="red") //?

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -428,7 +428,7 @@
 		check_jobban = ROLE_PAI,
 		poll_time = 10 SECONDS,
 		ignore_category = POLL_IGNORE_POSSESSED_BLADE,
-		pic_source = src,
+		alert_pic = src,
 		role_name_text = "soul scythe"
 	)
 	if(LAZYLEN(candidates))

--- a/code/modules/mob/living/basic/guardian/guardian_creator.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_creator.dm
@@ -98,7 +98,7 @@ GLOBAL_LIST_INIT(guardian_radial_images, setup_guardian_radial())
 		check_jobban = ROLE_PAI,
 		poll_time = 10 SECONDS,
 		ignore_category = POLL_IGNORE_HOLOPARASITE,
-		pic_source = guardian_path,
+		alert_pic = guardian_path,
 		role_name_text = "guardian spirit"
 	)
 	if(LAZYLEN(candidates))

--- a/code/modules/mob/living/basic/guardian/guardian_verbs.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_verbs.dm
@@ -166,27 +166,18 @@
 		return FALSE
 
 	to_chat(owner, span_holoparasite("You attempt to reset <font color=\"[chosen_guardian.guardian_colour]\">[span_bold(chosen_guardian.real_name)]</font>'s personality..."))
-	var/list/mob/dead/observer/ghost_candidates = SSpolling.poll_ghost_candidates_for_mob(
-		"Do you want to play as [owner.real_name]'s [chosen_guardian.theme.name]?",
-		check_jobban = ROLE_PAI,
-		poll_time = 10 SECONDS,
-		target_mob = owner,
-		ignore_category = POLL_IGNORE_HOLOPARASITE,
-		role_name_text = chosen_guardian.theme.name
-	)
-	if (!LAZYLEN(ghost_candidates))
+	var/mob/chosen_one = SSpolling.poll_ghost_candidates("Do you want to play as [span_danger("[owner.real_name]'s")] [span_notice(chosen_guardian.theme.name)]?", check_jobban = ROLE_PAI, poll_time = 10 SECONDS, alert_pic = chosen_guardian, jump_target = owner, role_name_text = chosen_guardian.theme.name, amount_to_pick = 1)
+	if(isnull(chosen_one))
 		to_chat(owner, span_holoparasite("Your attempt to reset the personality of \
 			<font color=\"[chosen_guardian.guardian_colour]\">[span_bold(chosen_guardian.real_name)]</font> appears to have failed... \
 			Looks like you're stuck with it for now."))
 		StartCooldown()
 		return FALSE
-
-	var/mob/dead/observer/candidate = pick(ghost_candidates)
 	to_chat(chosen_guardian, span_holoparasite("Your user reset you, and your body was taken over by a ghost. Looks like they weren't happy with your performance."))
 	to_chat(owner, span_boldholoparasite("The personality of <font color=\"[chosen_guardian.guardian_colour]\">[chosen_guardian.theme.name]</font> has been successfully reset."))
-	message_admins("[key_name_admin(candidate)] has taken control of ([ADMIN_LOOKUPFLW(chosen_guardian)])")
+	message_admins("[key_name_admin(chosen_one)] has taken control of ([ADMIN_LOOKUPFLW(chosen_guardian)])")
 	chosen_guardian.ghostize(FALSE)
-	chosen_guardian.key = candidate.key
+	chosen_guardian.key = chosen_one.key
 	COOLDOWN_START(chosen_guardian, resetting_cooldown, 5 MINUTES)
 	chosen_guardian.guardian_rename() //give it a new color and name, to show it's a new person
 	chosen_guardian.guardian_recolour()

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat.dm
@@ -62,6 +62,7 @@
 		poll_ignore_key = POLL_IGNORE_REGAL_RAT,\
 		assumed_control_message = "You are an independent, invasive force on the station! Hoard coins, trash, cheese, and the like from the safety of darkness!",\
 		after_assumed_control = CALLBACK(src, PROC_REF(became_player_controlled)),\
+		poll_chat_border_icon = /obj/item/food/cheese/wedge,\
 	)
 
 	var/datum/action/cooldown/mob_cooldown/domain/domain = new(src)

--- a/code/modules/mob/living/basic/space_fauna/revenant/revenant_items.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/revenant_items.dm
@@ -86,21 +86,11 @@
 /// Handles giving the revenant a new client to control it
 /obj/item/ectoplasm/revenant/proc/get_new_user()
 	message_admins("The new revenant's old client either could not be found or is in a new, living mob - grabbing a random candidate instead...")
-	var/list/candidates = SSpolling.poll_ghost_candidates_for_mob("Do you want to be [revenant.name] (reforming)?", check_jobban = ROLE_REVENANT, role = ROLE_REVENANT, poll_time = 5 SECONDS, target_mob = revenant, pic_source = revenant)
-
-	if(!LAZYLEN(candidates))
+	var/mob/chosen_one = SSpolling.poll_ghosts_for_target("Do you want to be [span_notice(revenant.name)] (reforming)?", check_jobban = ROLE_REVENANT, role = ROLE_REVENANT, poll_time = 5 SECONDS, checked_target = revenant, alert_pic = revenant, role_name_text = "reforming revenant", chat_text_border_icon = revenant)
+	if(isnull(chosen_one))
 		message_admins("No candidates were found for the new revenant.")
 		inert = TRUE
 		visible_message(span_revenwarning("[src] settles down and seems lifeless."))
 		qdel(revenant)
 		return null
-
-	var/mob/dead/observer/potential_client = pick(candidates)
-	if(isnull(potential_client))
-		qdel(revenant)
-		message_admins("No candidate was found for the new revenant. Oh well!")
-		inert = TRUE
-		visible_message(span_revenwarning("[src] settles down and seems lifeless."))
-		return null
-
-	return potential_client
+	return chosen_one

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -97,7 +97,7 @@
 		check_jobban = ROLE_ALIEN,
 		poll_time = 10 SECONDS,
 		ignore_category = POLL_IGNORE_ALIEN_LARVA,
-		pic_source = /mob/living/carbon/alien/larva,
+		alert_pic = /mob/living/carbon/alien/larva,
 		role_name_text = "alien larva"
 	)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -2599,18 +2599,9 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	if(isnull(guardian_client))
 		return
 	else if(guardian_client == "Poll Ghosts")
-		var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates_for_mob(
-			"Do you want to play as an admin created Guardian Spirit of [real_name]?",
-			check_jobban = ROLE_PAI,
-			poll_time = 10 SECONDS,
-			target_mob = src,
-			ignore_category = POLL_IGNORE_HOLOPARASITE,
-			pic_source = /mob/living/basic/guardian,
-			role_name_text = "guardian spirit"
-		)
-		if(LAZYLEN(candidates))
-			var/mob/dead/observer/candidate = pick(candidates)
-			guardian_client = candidate.client
+		var/mob/chosen_one = SSpolling.poll_ghost_candidates("Do you want to play as an admin created [span_notice("Guardian Spirit")] of [span_danger(real_name)]?", check_jobban = ROLE_PAI, poll_time = 10 SECONDS, ignore_category = POLL_IGNORE_HOLOPARASITE, alert_pic = mutable_appearance('icons/mob/nonhuman-player/guardian.dmi', "magicexample"), jump_target = src, role_name_text = "guardian spirit", amount_to_pick = 1)
+		if(chosen_one)
+			guardian_client = chosen_one.client
 		else
 			tgui_alert(admin, "No ghost candidates.", "Guardian Controller")
 			return
@@ -2623,7 +2614,7 @@ GLOBAL_LIST_EMPTY(fire_appearances)
 	if(picked_theme == "Random")
 		picked_theme = null //holopara code handles not having a theme by giving a random one
 	var/picked_name = tgui_input_text(admin, "Name the guardian, leave empty to let player name it.", "Guardian Controller")
-	var/picked_color = tgui_color_picker(admin, "Set the guardian's color, cancel to let player set it.", "Guardian Controller", "#ffffff")
+	var/picked_color = input(admin, "Set the guardian's color, cancel to let player set it.", "Guardian Controller", "#ffffff") as color|null
 	if(tgui_alert(admin, "Confirm creation.", "Guardian Controller", list("Yes", "No")) != "Yes")
 		return
 	var/mob/living/basic/guardian/summoned_guardian = new picked_type(src, picked_theme)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -190,18 +190,10 @@ While using this makes the system rely on OnFire, it still gives options for tim
 				addtimer(CALLBACK(src, PROC_REF(spawn_elite)), 30)
 				return
 			visible_message(span_boldwarning("Something within [src] stirs..."))
-			var/list/candidates = SSpolling.poll_ghost_candidates_for_mob(
-				"Do you want to play as a lavaland elite?",
-				role = ROLE_SENTIENCE,
-				poll_time = 5 SECONDS,
-				target_mob = src,
-				ignore_category = POLL_IGNORE_LAVALAND_ELITE,
-				pic_source = src,
-				role_name_text = "lavaland elite"
-			)
-			if(length(candidates))
+			var/mob/chosen_one = SSpolling.poll_ghosts_for_target(check_jobban = ROLE_SENTIENCE, role = ROLE_SENTIENCE, poll_time = 5 SECONDS, checked_target = src, ignore_category = POLL_IGNORE_LAVALAND_ELITE, alert_pic = src, role_name_text = "lavaland elite")
+			if(chosen_one)
 				audible_message(span_boldwarning("The stirring sounds increase in volume!"))
-				elitemind = pick(candidates)
+				elitemind = chosen_one
 				elitemind.playsound_local(get_turf(elitemind), 'sound/effects/magic.ogg', 40, 0)
 				to_chat(elitemind, "<b>You have been chosen to play as a Lavaland Elite.\nIn a few seconds, you will be summoned on Lavaland as a monster to fight your activator, in a fight to the death.\n\
 					Your attacks can be switched using the buttons on the top left of the HUD, and used by clicking on targets or tiles similar to a gun.\n\

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -362,14 +362,13 @@
 			var/datum/antagonist/A = M.mind.has_antag_datum(/datum/antagonist/)
 			if(A)
 				poll_message = "[poll_message] Status: [A.name]."
-	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates_for_mob(poll_message, check_jobban = ROLE_PAI, poll_time = 10 SECONDS, target_mob = M, pic_source = M, role_name_text = "ghost control")
+	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(poll_message, check_jobban = ROLE_PAI, poll_time = 10 SECONDS, checked_target = M, alert_pic = M, role_name_text = "ghost control")
 
-	if(LAZYLEN(candidates))
-		var/mob/dead/observer/C = pick(candidates)
+	if(chosen_one)
 		to_chat(M, "Your mob has been taken over by a ghost!")
-		message_admins("[key_name_admin(C)] has taken control of ([ADMIN_LOOKUPFLW(M)])")
+		message_admins("[key_name_admin(chosen_one)] has taken control of ([ADMIN_LOOKUPFLW(M)])")
 		M.ghostize(FALSE)
-		M.key = C.key
+		M.key = chosen_one.key
 		M.client?.init_verbs()
 		return TRUE
 	else

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -183,11 +183,10 @@
 	to_chat(src, "<b>You are job banned from cyborg! Appeal your job ban if you want to avoid this in the future!</b>")
 	ghostize(FALSE)
 
-	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates_for_mob("Do you want to play as [src]?", check_jobban = JOB_CYBORG, poll_time = 5 SECONDS, target_mob = src, pic_source = src, role_name_text = "cyborg")
-	if(LAZYLEN(candidates))
-		var/mob/dead/observer/chosen_candidate = pick(candidates)
-		message_admins("[key_name_admin(chosen_candidate)] has taken control of ([key_name_admin(src)]) to replace a jobbanned player.")
-		key = chosen_candidate.key
+	var/mob/chosen_one = SSpolling.poll_ghosts_for_target("Do you want to play as [span_notice(name)]?", check_jobban = JOB_CYBORG, poll_time = 5 SECONDS, checked_target = src, alert_pic = src, role_name_text = "cyborg")
+	if(chosen_one)
+		message_admins("[key_name_admin(chosen_one)] has taken control of ([key_name_admin(src)]) to replace a jobbanned player.")
+		key = chosen_one.key
 
 //human -> alien
 /mob/living/carbon/human/proc/Alienize()

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -393,24 +393,23 @@
 
 /obj/projectile/magic/wipe/proc/possession_test(mob/living/carbon/target)
 	var/datum/brain_trauma/special/imaginary_friend/trapped_owner/trauma = target.gain_trauma(/datum/brain_trauma/special/imaginary_friend/trapped_owner)
-	var/poll_message = "Do you want to play as [target.real_name]?"
+	var/poll_message = "Do you want to play as [span_danger(target.real_name)]?"
 	if(target.mind)
-		poll_message = "[poll_message] Job:[target.mind.assigned_role.title]."
+		poll_message = "[poll_message] Job:[span_notice(target.mind.assigned_role.title)]."
 	if(target.mind && target.mind.special_role)
-		poll_message = "[poll_message] Status:[target.mind.special_role]."
+		poll_message = "[poll_message] Status:[span_boldnotice(target.mind.special_role)]."
 	else if(target.mind)
 		var/datum/antagonist/A = target.mind.has_antag_datum(/datum/antagonist/)
 		if(A)
-			poll_message = "[poll_message] Status:[A.name]."
-	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates_for_mob(poll_message, check_jobban = ROLE_PAI, poll_time = 10 SECONDS, target_mob = target, pic_source = target, role_name_text = "bolt of possession")
+			poll_message = "[poll_message] Status:[span_boldnotice(A.name)]."
+	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(poll_message, check_jobban = ROLE_PAI, poll_time = 10 SECONDS, checked_target = target, alert_pic = target, role_name_text = "bolt of possession")
 	if(target.stat == DEAD)//boo.
 		return
-	if(LAZYLEN(candidates))
-		var/mob/dead/observer/ghost = pick(candidates)
+	if(chosen_one)
 		to_chat(target, span_boldnotice("You have been noticed by a ghost and it has possessed you!"))
 		var/oldkey = target.key
 		target.ghostize(FALSE)
-		target.key = ghost.key
+		target.key = chosen_one.key
 		trauma.friend.key = oldkey
 		trauma.friend.reset_perspective(null)
 		trauma.friend.Show()

--- a/code/modules/religion/sparring/sparring_datum.dm
+++ b/code/modules/religion/sparring/sparring_datum.dm
@@ -301,4 +301,4 @@
 				return
 			to_chat(loser, span_userdanger("You've lost ownership over your soul to [winner]!"))
 			var/obj/item/soulstone/anybody/chaplain/sparring/shard = new(shard_turf)
-			shard.capture_soul(loser, winner, forced = TRUE)
+			INVOKE_ASYNC(shard, TYPE_PROC_REF(/obj/item/soulstone, capture_soul), loser, winner, forced = TRUE)

--- a/code/modules/shuttle/battlecruiser_starfury.dm
+++ b/code/modules/shuttle/battlecruiser_starfury.dm
@@ -135,7 +135,7 @@
  */
 /proc/summon_battlecruiser(datum/team/battlecruiser/team)
 
-	var/list/candidates = SSpolling.poll_ghost_candidates("Do you wish to be considered for battlecruiser crew?", check_jobban = ROLE_TRAITOR, pic_source = /obj/machinery/sleeper/syndie, role_name_text = "battlecruiser crew")
+	var/list/candidates = SSpolling.poll_ghost_candidates("Do you wish to be considered for battlecruiser crew?", check_jobban = ROLE_TRAITOR, alert_pic = /obj/machinery/sleeper/syndie, role_name_text = "battlecruiser crew")
 	shuffle_inplace(candidates)
 
 	var/datum/map_template/ship = SSmapping.map_templates["battlecruiser_starfury.dmm"]

--- a/code/modules/shuttle/shuttle_events/player_controlled.dm
+++ b/code/modules/shuttle/shuttle_events/player_controlled.dm
@@ -21,7 +21,7 @@
 		ghost_alert_string + " (Warning: you will not be able to return to your body!)",
 		check_jobban = role_type,
 		poll_time = 10 SECONDS,
-		pic_source = spawn_type,
+		alert_pic = spawn_type,
 		role_name_text = "shot at shuttle"
 	)
 	var/mob/dead/observer/candidate = length(candidates) ? pick(candidates) : null

--- a/monkestation/code/game/machinery/exp_cloner.dm
+++ b/monkestation/code/game/machinery/exp_cloner.dm
@@ -90,17 +90,16 @@
 		role_text = "defective clone"
 		poll_text = "Do you want to play as [clonename]'s defective clone?"
 
-	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates_for_mob(
+	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(
 		poll_text,
 		poll_time = 10 SECONDS,
-		target_mob = clonee,
+		checked_target = clonee,
 		ignore_category = POLL_IGNORE_DEFECTIVECLONE,
-		pic_source = get_clone_preview(clonee.dna) || clonee,
+		alert_pic = get_clone_preview(clonee.dna) || clonee,
 		role_name_text = role_text
 	)
-	if(LAZYLEN(candidates))
-		var/mob/dead/observer/candidate = pick(candidates)
-		clonee.key = candidate.key
+	if(chosen_one)
+		clonee.key = chosen_one.key
 
 	if(grab_ghost_when == CLONER_FRESH_CLONE)
 		clonee.grab_ghost()

--- a/monkestation/code/modules/antagonists/borers/code/antagonist_stuff/midround_event.dm
+++ b/monkestation/code/modules/antagonists/borers/code/antagonist_stuff/midround_event.dm
@@ -56,7 +56,7 @@
 	var/list/candidates = SSpolling.poll_ghost_candidates(
 		role = ROLE_CORTICAL_BORER,
 		ignore_category = POLL_IGNORE_CORTICAL_BORER,
-		pic_source = /mob/living/basic/cortical_borer,
+		alert_pic = /mob/living/basic/cortical_borer,
 	)
 
 	if(!length(candidates))

--- a/monkestation/code/modules/antagonists/borers/code/items/borer_spawner.dm
+++ b/monkestation/code/modules/antagonists/borers/code/items/borer_spawner.dm
@@ -51,7 +51,7 @@
 		role = ROLE_CORTICAL_BORER,
 		poll_time = polling_time,
 		ignore_category = POLL_IGNORE_CORTICAL_BORER,
-		pic_source = /mob/living/basic/cortical_borer/neutered,
+		alert_pic = /mob/living/basic/cortical_borer/neutered,
 	)
 	if(QDELETED(src)) // prevent shenanigans with refunds
 		return

--- a/monkestation/code/modules/antagonists/borers/code/items/empowered_egg.dm
+++ b/monkestation/code/modules/antagonists/borers/code/items/empowered_egg.dm
@@ -47,7 +47,7 @@
 		role = ROLE_CORTICAL_BORER,
 		poll_time = 10 SECONDS,
 		ignore_category = POLL_IGNORE_CORTICAL_BORER,
-		pic_source = /mob/living/basic/cortical_borer/empowered,
+		alert_pic = /mob/living/basic/cortical_borer/empowered,
 	)
 	if(!length(candidates))
 		var/obj/effect/mob_spawn/ghost_role/borer_egg/empowered/borer_egg = new(owner.drop_location())

--- a/monkestation/code/modules/antagonists/brother/actions/gear.dm
+++ b/monkestation/code/modules/antagonists/brother/actions/gear.dm
@@ -56,7 +56,7 @@
 	var/list/agreed = SSpolling.poll_candidates(
 		"[owner.mind.name || owner.real_name] wishes to choose [chosen_gear.name] as your team's gear. Do you agree?",
 		group = to_poll,
-		pic_source = chosen_gear.preview(),
+		alert_pic = chosen_gear.preview(),
 		role_name_text = "Blood Brother Gear",
 		custom_response_messages = list(
 			POLL_RESPONSE_SIGNUP = "You have agreed to choose [chosen_gear.name] as your team's gear.",

--- a/monkestation/code/modules/antagonists/clock_cult/scriptures/preservation/summon_marauder.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/scriptures/preservation/summon_marauder.dm
@@ -29,7 +29,7 @@
 		role = ROLE_CLOCK_CULTIST,
 		poll_time = 10 SECONDS,
 		ignore_category = POLL_IGNORE_CONSTRUCT,
-		pic_source = /mob/living/basic/clockwork_marauder,
+		alert_pic = /mob/living/basic/clockwork_marauder,
 		role_name_text = "clockwork marauder"
 	)
 	if(length(candidates))

--- a/monkestation/code/modules/antagonists/clock_cult/structures/eminence_beacon.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/structures/eminence_beacon.dm
@@ -47,7 +47,7 @@
 			check_jobban = ROLE_CLOCK_CULTIST,
 			role = ROLE_CLOCK_CULTIST,
 			poll_time = 10 SECONDS,
-			pic_source = /mob/living/eminence,
+			alert_pic = /mob/living/eminence,
 			role_name_text = "eminence"
 		)
 		if(length(candidates))

--- a/monkestation/code/modules/antagonists/clock_cult/structures/sigil/sigil_vitality.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/structures/sigil/sigil_vitality.dm
@@ -46,25 +46,23 @@
 
 		if(affected_mob.stat != DEAD && (!affected_mob.client || affected_mob.client.is_afk()))
 			set waitfor = FALSE
-			var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates_for_mob(
+			var/mob/chosen_one = SSpolling.poll_ghosts_for_target(
 				"Do you want to play as a [affected_mob.real_name], an inactive clock cultist?",
-				check_jobban = ROLE_CLOCK_CULTIST,
 				role = ROLE_CLOCK_CULTIST,
 				poll_time = 5 SECONDS,
-				target_mob = affected_mob,
-				pic_source = affected_mob,
+				checked_target = affected_mob,
+				alert_pic = affected_mob,
 				role_name_text = "clock cultist"
 			)
-			if(LAZYLEN(candidates))
-				var/mob/dead/observer/candidate = pick(candidates)
-				to_chat(affected_mob.mind, "Your physical form has been taken over by another soul due to your inactivity! Ahelp if you wish to regain your form.")
-				message_admins("[key_name_admin(candidate)] has taken control of ([key_name_admin(affected_mob)]) to replace an AFK player.")
-				affected_mob.ghostize(FALSE)
-				affected_mob.key = candidate.key
-				revived = TRUE
-			else
+			if(isnull(chosen_one))
 				visible_message(span_warning("\The [src] fails to revive [affected_mob]!"))
 				fail_invocation()
+			else
+				to_chat(affected_mob.mind, "Your physical form has been taken over by another soul due to your inactivity! Ahelp if you wish to regain your form.")
+				message_admins("[key_name_admin(chosen_one)] has taken control of ([key_name_admin(affected_mob)]) to replace an AFK player.")
+				affected_mob.ghostize(FALSE)
+				affected_mob.key = chosen_one.key
+				revived = TRUE
 		if(revived)
 			SEND_SOUND(affected_mob, 'sound/magic/clockwork/scripture_tier_up.ogg')
 			to_chat(affected_mob, span_bigbrass("\"[text2ratvar("MY LIGHT SHINES THROUGH YOU, YOUR SERVITUDE IS NOT FINISHED.")]\""))

--- a/monkestation/code/modules/antagonists/contractor/datums/contractor_items.dm
+++ b/monkestation/code/modules/antagonists/contractor/datums/contractor_items.dm
@@ -92,7 +92,7 @@
 		role = ROLE_TRAITOR,
 		poll_time = 10 SECONDS,
 		ignore_category = POLL_IGNORE_CONTRACTOR_SUPPORT,
-		pic_source = user,
+		alert_pic = user,
 		role_name_text = "contractor support unit",
 	)
 

--- a/monkestation/code/modules/antagonists/florida_man/florida_events.dm
+++ b/monkestation/code/modules/antagonists/florida_man/florida_events.dm
@@ -30,7 +30,7 @@
 		"Do you want to play as Florida Man?",
 		role = ROLE_FLORIDA_MAN,
 		poll_time = 20 SECONDS,
-		pic_source = /datum/antagonist/florida_man,
+		alert_pic = /datum/antagonist/florida_man,
 		role_name_text = "florida man"
 	)
 	var/turf/spawn_loc = find_safe_turf()//Used for the Drop Pod type of spawn

--- a/monkestation/code/modules/antagonists/slasher/ghost_role.dm
+++ b/monkestation/code/modules/antagonists/slasher/ghost_role.dm
@@ -18,7 +18,7 @@
 		role = ROLE_SLASHER,
 		check_jobban = ROLE_SLASHER,
 		poll_time = 20 SECONDS,
-		pic_source = /datum/antagonist/slasher,
+		alert_pic = /datum/antagonist/slasher,
 		role_name_text = "slasher"
 	)
 	var/turf/spawn_loc = find_safe_turf()//Used for the Drop Pod type of spawn

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_guardian.dm
@@ -37,7 +37,7 @@
 			check_jobban = ROLE_PAI,
 			poll_time = 10 SECONDS,
 			ignore_category = POLL_IGNORE_HOLOPARASITE,
-			pic_source = guardian_path,
+			alert_pic = guardian_path,
 			role_name_text = "guardian spirit",
 		)
 		if(LAZYLEN(candidates))

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_shaded.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_shaded.dm
@@ -21,6 +21,7 @@
 		var/datum/antagonist/shaded_bloodsucker/shaded_datum = shades.mind.has_antag_datum(/datum/antagonist/shaded_bloodsucker)
 		shaded_datum.objectives = bloodsuckerdatum.objectives
 
+/*
 /obj/item/soulstone/bloodsucker/get_ghost_to_replace_shade(mob/living/carbon/victim, mob/user)
 	var/mob/dead/observer/chosen_ghost = victim.get_ghost(FALSE, TRUE)
 	if(QDELETED(chosen_ghost?.client))
@@ -29,3 +30,4 @@
 	victim.unequip_everything()
 	init_shade(victim, user, shade_controller = chosen_ghost)
 	return TRUE
+*/

--- a/monkestation/code/modules/bloodsuckers/clans/malkavian.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/malkavian.dm
@@ -52,7 +52,7 @@
 
 /datum/bloodsucker_clan/malkavian/on_final_death(datum/antagonist/bloodsucker/source)
 	var/obj/item/soulstone/bloodsucker/stone = new /obj/item/soulstone/bloodsucker(get_turf(bloodsuckerdatum.owner.current))
-	stone.capture_soul(bloodsuckerdatum.owner.current, forced = TRUE, bloodsuckerdatum = bloodsuckerdatum)
+	INVOKE_ASYNC(stone, TYPE_PROC_REF(/obj/item/soulstone/bloodsucker, capture_soul), bloodsuckerdatum.owner.current, forced = TRUE, bloodsuckerdatum = bloodsuckerdatum)
 	return DONT_DUST
 
 /datum/bloodsucker_clan/malkavian/proc/on_bloodsucker_broke_masquerade(datum/antagonist/bloodsucker/masquerade_breaker)

--- a/monkestation/code/modules/events/ghost_role/drifting_contractor.dm
+++ b/monkestation/code/modules/events/ghost_role/drifting_contractor.dm
@@ -21,7 +21,7 @@
 		check_jobban = ROLE_DRIFTING_CONTRACTOR,
 		role = ROLE_DRIFTING_CONTRACTOR,
 		poll_time = 20 SECONDS,
-		pic_source = /datum/antagonist/traitor/contractor,
+		alert_pic = /datum/antagonist/traitor/contractor,
 		role_name_text = "drifting contractor"
 	)
 	if(!length(candidates))

--- a/monkestation/code/modules/storytellers/converted_events/_base_event.dm
+++ b/monkestation/code/modules/storytellers/converted_events/_base_event.dm
@@ -252,8 +252,10 @@
 					role = antag_flag,
 					poll_time = 20 SECONDS,
 					group = list(picked_mob),
-					pic_source = antag_datum,
+					alert_pic = antag_datum,
 					role_name_text = lowertext(cast_control.name),
+					chat_text_border_icon = antag_datum,
+					show_candidate_amount = FALSE,
 				)
 		else
 			if(!length(weighted_candidates))
@@ -319,7 +321,7 @@
 			role = antag_flag,
 			poll_time = 20 SECONDS,
 			group = candidates,
-			pic_source = antag_datum,
+			alert_pic = antag_datum,
 			role_name_text = lowertext(cast_control.name),
 		)
 

--- a/monkestation/code/modules/storytellers/converted_events/solo/ghosts/paradox_clone.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/ghosts/paradox_clone.dm
@@ -46,8 +46,9 @@
 			"Would you like to be a paradox clone?",
 			check_jobban = ROLE_PARADOX_CLONE,
 			poll_time = 20 SECONDS,
-			pic_source = /datum/antagonist/paradox_clone,
+			alert_pic = /datum/antagonist/paradox_clone,
 			role_name_text = "paradox clone",
+			chat_text_border_icon = /datum/antagonist/paradox_clone,
 		)
 
 	var/list/weighted_candidates = return_antag_rep_weight(candidates)

--- a/monkestation/code/modules/virology/disease/plague_rat/event.dm
+++ b/monkestation/code/modules/virology/disease/plague_rat/event.dm
@@ -17,18 +17,12 @@
 	role_name = "Plague Rat"
 
 /datum/round_event/ghost_role/plague_rat/spawn_role()
-	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_PLAGUERAT, role = ROLE_PLAGUERAT, pic_source = /mob/living/basic/mouse/plague)
+	var/list/candidates = SSpolling.poll_ghost_candidates(check_jobban = ROLE_PLAGUERAT, role = ROLE_PLAGUERAT, alert_pic = /mob/living/basic/mouse/plague, amount_to_pick = 4)
 	if(!length(candidates))
 		return NOT_ENOUGH_PLAYERS
 
-	for(var/i = 1 to 4)
-
-		var/mob/dead/selected = pick_n_take(candidates)
-		if(!selected)
-			break
-
+	for(var/mob/dead/selected in candidates)
 		var/key = selected.key
-
 		var/mob/living/basic/mouse/plague/dragon = new
 		dragon.key = key
 		dragon.mind.special_role = ROLE_PLAGUERAT

--- a/monkestation/code/modules/virology/disease/symtoms/restricted/stage1.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/restricted/stage1.dm
@@ -54,20 +54,20 @@
 /datum/symptom/transformation/proc/replace_banned_player(mob/living/new_mob, mob/living/affected_mob) // This can run well after the mob has been transferred, so need a handle on the new mob to kill it if needed.
 	set waitfor = FALSE
 
-	var/list/mob/dead/observer/candidates = SSpolling.poll_ghost_candidates_for_mob("Do you want to play as [affected_mob.real_name]?", check_jobban = bantype, role = bantype, poll_time = 5 SECONDS, target_mob = affected_mob, pic_source = affected_mob, role_name_text = "transformation victim")
-	if(LAZYLEN(candidates))
-		var/mob/dead/observer/C = pick(candidates)
-		to_chat(affected_mob, span_userdanger("Your mob has been taken over by a ghost! Appeal your job ban if you want to avoid this in the future!"))
-		message_admins("[key_name_admin(C)] has taken control of ([key_name_admin(affected_mob)]) to replace a jobbanned player.")
-		affected_mob.ghostize(FALSE)
-		affected_mob.key = C.key
-	else
+	var/mob/dead/observer/chosen_one = SSpolling.poll_ghosts_for_target("Do you want to play as [affected_mob.real_name]?", check_jobban = bantype, role = bantype, poll_time = 5 SECONDS, checked_target = affected_mob, alert_pic = affected_mob, role_name_text = "transformation victim")
+	if(isnull(chosen_one))
 		to_chat(new_mob, span_userdanger("Your mob has been claimed by death! Appeal your job ban if you want to avoid this in the future!"))
 		new_mob.investigate_log("has been killed because there was no one to replace them as a job-banned player.", INVESTIGATE_DEATHS)
 		new_mob.death()
 		if (!QDELETED(new_mob))
 			new_mob.ghostize(can_reenter_corpse = FALSE)
 			new_mob.key = null
+		return
+	to_chat(affected_mob, span_userdanger("Your mob has been taken over by a ghost! Appeal your job ban if you want to avoid this in the future!"))
+	message_admins("[key_name_admin(chosen_one)] has taken control of ([key_name_admin(affected_mob)]) to replace a jobbanned player.")
+	affected_mob.ghostize(FALSE)
+	affected_mob.key = chosen_one.key
+
 
 /datum/symptom/transformation/robot
 	name = "Robotic Transformation"


### PR DESCRIPTION

## About The Pull Request

![2024-08-17 (1723874416) ~ dreamseeker](https://github.com/user-attachments/assets/af90a600-b24d-4171-88d5-9e38cf1a2414)

Ports the following PRs from /tg/:
- https://github.com/tgstation/tgstation/pull/81748
- https://github.com/tgstation/tgstation/pull/82009

## Changelog
:cl: Absolucy, 13spacemen, Melbert
code: Poll alerts support small border pictures in the chat message.
code: Poll alert alert picture and jump target do not have to be the same.
qol: Slime intelligence potions ask the user for a reason, this will be shown to ghosts.
fix: Fixes polling for things causing said things to have their planes and layers screwed up (causing random objects or mobs to appear above runechat and blindness, for example)
/:cl:
