### PR TITLE
Updates storyteller with blueshield

### DIFF
--- a/monkestation/code/modules/storytellers/converted_events/solo/bloodcult.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/bloodcult.dm
@@ -26,6 +26,7 @@
 		JOB_SECURITY_ASSISTANT,
 		JOB_WARDEN,
 		JOB_CHAPLAIN,
+		JOB_BLUESHIELD,
 	)
 	required_enemies = 5
 	base_antags = 2

--- a/monkestation/code/modules/storytellers/converted_events/solo/bloodsuckers.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/bloodsuckers.dm
@@ -15,6 +15,7 @@
 		JOB_SECURITY_ASSISTANT,
 		JOB_WARDEN,
 		JOB_BRIG_PHYSICIAN,
+		JOB_BLUESHIELD,
 	)
 	restricted_roles = list(
 		JOB_AI,

--- a/monkestation/code/modules/storytellers/converted_events/solo/brother.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/brother.dm
@@ -16,6 +16,7 @@
 		JOB_SECURITY_ASSISTANT,
 		JOB_WARDEN,
 		JOB_BRIG_PHYSICIAN,
+		JOB_BLUESHIELD,
 	)
 	restricted_roles = list(
 		JOB_AI,
@@ -28,6 +29,7 @@
 		JOB_WARDEN,
 		JOB_SECURITY_OFFICER,
 		JOB_SECURITY_ASSISTANT,
+		JOB_BLUESHIELD,
 	)
 	required_enemies = 1
 	weight = 12

--- a/monkestation/code/modules/storytellers/converted_events/solo/changeling.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/changeling.dm
@@ -15,6 +15,7 @@
 		JOB_SECURITY_ASSISTANT,
 		JOB_WARDEN,
 		JOB_BRIG_PHYSICIAN,
+		JOB_BLUESHIELD,
 	)
 	restricted_roles = list(
 		JOB_AI,

--- a/monkestation/code/modules/storytellers/converted_events/solo/clockwork_cult.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/clockwork_cult.dm
@@ -17,6 +17,7 @@
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
 		JOB_BRIG_PHYSICIAN,
+		JOB_BLUESHIELD,
 	)
 	enemy_roles = list(
 		JOB_CAPTAIN,
@@ -26,6 +27,7 @@
 		JOB_SECURITY_ASSISTANT,
 		JOB_WARDEN,
 		JOB_CHAPLAIN,
+		JOB_BLUESHIELD,
 	)
 	required_enemies = 5
 	base_antags = 4

--- a/monkestation/code/modules/storytellers/converted_events/solo/clown_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/clown_operative.dm
@@ -19,6 +19,7 @@
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
 		JOB_BRIG_PHYSICIAN,
+		JOB_BLUESHIELD,
 	)
 	base_antags = 3
 	maximum_antags = 5
@@ -31,6 +32,7 @@
 		JOB_SECURITY_OFFICER,
 		JOB_SECURITY_ASSISTANT,
 		JOB_WARDEN,
+		JOB_BLUESHIELD,
 	)
 	required_enemies = 5
 	// I give up, just there should be enough heads with 35 players...

--- a/monkestation/code/modules/storytellers/converted_events/solo/heretic.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/heretic.dm
@@ -16,6 +16,7 @@
 		JOB_SECURITY_ASSISTANT,
 		JOB_WARDEN,
 		JOB_BRIG_PHYSICIAN,
+		JOB_BLUESHIELD,
 	)
 	restricted_roles = list(
 		JOB_AI,

--- a/monkestation/code/modules/storytellers/converted_events/solo/malf.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/malf.dm
@@ -13,6 +13,7 @@
 		JOB_SECURITY_ASSISTANT,
 		JOB_WARDEN,
 		JOB_BRIG_PHYSICIAN,
+		JOB_BLUESHIELD,
 	)
 	shared_occurence_type = SHARED_HIGH_THREAT
 	maximum_antags = 1

--- a/monkestation/code/modules/storytellers/converted_events/solo/monsterhunter.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/monsterhunter.dm
@@ -19,6 +19,7 @@
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
 		JOB_BRIG_PHYSICIAN,
+		JOB_BLUESHIELD,
 	)
 	restricted_roles = list(
 		JOB_AI,

--- a/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
@@ -19,6 +19,7 @@
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
 		JOB_BRIG_PHYSICIAN,
+		JOB_BLUESHIELD,
 	)
 	base_antags = 3
 	maximum_antags = 5
@@ -31,6 +32,7 @@
 		JOB_SECURITY_OFFICER,
 		JOB_SECURITY_ASSISTANT,
 		JOB_WARDEN,
+		JOB_BLUESHIELD,
 	)
 	required_enemies = 5
 	// I give up, just there should be enough heads with 35 players...

--- a/monkestation/code/modules/storytellers/converted_events/solo/obsessed.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/obsessed.dm
@@ -16,6 +16,7 @@
 		JOB_AI,
 		JOB_CYBORG,
 		ROLE_POSITRONIC_BRAIN,
+		JOB_BLUESHIELD,
 	)
 	weight = 6
 	max_occurrences = 3

--- a/monkestation/code/modules/storytellers/converted_events/solo/revolutionary.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/revolutionary.dm
@@ -19,6 +19,7 @@
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
 		JOB_BRIG_PHYSICIAN,
+		JOB_BLUESHIELD,
 	)
 	base_antags = 2
 	enemy_roles = list(
@@ -28,6 +29,7 @@
 		JOB_SECURITY_OFFICER,
 		JOB_SECURITY_ASSISTANT,
 		JOB_WARDEN,
+		JOB_BLUESHIELD,
 	)
 	required_enemies = 6
 	// I give up, just there should be enough heads with 35 players...

--- a/monkestation/code/modules/storytellers/converted_events/solo/traitor.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/traitor.dm
@@ -15,6 +15,7 @@
 		JOB_WARDEN,
 		JOB_SECURITY_ASSISTANT,
 		JOB_BRIG_PHYSICIAN,
+		JOB_BLUESHIELD,
 	)
 	restricted_roles = list(
 		JOB_AI,

--- a/monkestation/code/modules/storytellers/converted_events/solo/wizard.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/wizard.dm
@@ -8,6 +8,7 @@
 	restricted_roles = list(
 		JOB_CAPTAIN,
 		JOB_HEAD_OF_SECURITY,
+		JOB_BLUESHIELD
 	) // Just to be sure that a wizard getting picked won't ever imply a Captain or HoS not getting drafted
 	maximum_antags = 1
 	enemy_roles = list(
@@ -18,6 +19,7 @@
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
 		JOB_CHAPLAIN,
+		JOB_BLUESHIELD,
 	)
 	required_enemies = 5
 	roundstart = TRUE


### PR DESCRIPTION

## About The Pull Request
Updates the various storyteller events to include blueshields, mostly to prevent them from being antagonists.
## Why It's Good For The Game
Blueshields are not meant to roll things like blood brother and changeling.
## Changelog
:cl:
fix: Blueshields can no longer roll antag/be converted to antags.
/:cl:
