### PR TITLE
[Bounty] Fixes box station jungle bar creating chasms

### DIFF
--- a/_maps/~monkestation/RandomBars/Box/vietmoth_bar.dmm
+++ b/_maps/~monkestation/RandomBars/Box/vietmoth_bar.dmm
@@ -52,7 +52,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/misc/dirt/jungle,
+/turf/open/misc/dirt/station,
 /area/station/service/theater)
 "gM" = (
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -76,7 +76,7 @@
 /turf/open/floor/grass,
 /area/station/commons/lounge)
 "jB" = (
-/turf/open/misc/dirt/jungle,
+/turf/open/misc/dirt/station,
 /area/station/service/theater)
 "jK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -374,7 +374,7 @@
 /area/station/commons/lounge)
 "Mu" = (
 /obj/machinery/light/directional/east,
-/turf/open/misc/dirt/jungle,
+/turf/open/misc/dirt/station,
 /area/station/service/theater)
 "MI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -388,11 +388,11 @@
 	name = "service camera"
 	},
 /obj/machinery/airalarm/directional/south,
-/turf/open/misc/dirt/jungle,
+/turf/open/misc/dirt/station,
 /area/station/service/theater)
 "Ol" = (
 /obj/item/radio/intercom/directional/south,
-/turf/open/misc/dirt/jungle,
+/turf/open/misc/dirt/station,
 /area/station/service/theater)
 "Oz" = (
 /obj/structure/chair/wood{


### PR DESCRIPTION
## About The Pull Request
Fixes the box station jungle bar having dirt floors that create chasms
## Why It's Good For The Game
Stationside chasms in a public, frequently visited area is bad.
## Changelog
:cl:
fix: Fixed one of the bars in box station having flooring that can create chasms
/:cl:
