### PR TITLE
Fixes blahsucker/ashtongue conflict, adds a new unit test

### DIFF
--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -141,6 +141,7 @@
 #include "json_savefile_importing.dm"
 #include "keybinding_init.dm"
 #include "knockoff_component.dm"
+#include "language_key_conflicts.dm"
 #include "leash.dm"
 #include "lesserform.dm"
 #include "limbsanity.dm"

--- a/code/modules/unit_tests/language_key_conflicts.dm
+++ b/code/modules/unit_tests/language_key_conflicts.dm
@@ -1,0 +1,15 @@
+/// This test ensures that multiple languages aren't mapped to the same prefix key.
+/datum/unit_test/language_key_conflicts
+
+/datum/unit_test/language_key_conflicts/Run()
+	var/list/used_keys = list()
+	for(var/datum/language/language as anything in subtypesof(/datum/language))
+		var/name = language::name
+		var/key = language::key
+		if(!key)
+			continue
+		if(used_keys[key])
+			var/datum/language/conflicting_language = used_keys[key]
+			TEST_FAIL("[name] ([language]) uses the '[key]' prefix, which is also used by [conflicting_language::name] ([conflicting_language])!")
+		else
+			used_keys[key] = language

--- a/monkestation/code/modules/blueshift/items/armor/ash_walker.dm
+++ b/monkestation/code/modules/blueshift/items/armor/ash_walker.dm
@@ -345,7 +345,7 @@
 /datum/language/ashtongue
 	name = "Ashtongue"
 	desc = "A language derived from Draconic, altered and morphed into a strange tongue by the enigmatic will of the Necropolis, a half-successful attempt at patterning its own alien communication methods onto mundane races. It's become nigh-incomprehensible to speakers of the original language."
-	key = "l"
+	key = "a"
 	flags = TONGUELESS_SPEECH
 	space_chance = 70
 	syllables = list(


### PR DESCRIPTION

## About The Pull Request

Changes Ashtongue to use `,a` - and adds a new unit test to ensure no two languages have the same key.

## Changelog
:cl:
fix: The Blah-Sucker and Ashtongue languages no longer conflict over the ",l" prefix, as Ashtongue now uses ",a"
/:cl:
