### PR TITLE
Fixes the Ashen Forge traitor faction not rolling

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -172,7 +172,6 @@ GLOBAL_LIST_INIT(hijack_employers, list(
 	"Gone Postal",
 	"Tiger Cooperative Fanatic",
 	"Waffle Corporation Terrorist",
-	"The Ashen Forge Member",
 ))
 
 ///employers who hire agents to do a task and escape... or martyrdom. whatever
@@ -186,7 +185,6 @@ GLOBAL_LIST_INIT(normal_employers, list(
 	"Legal Trouble",
 	"MI13",
 	"Waffle Corporation",
-	"The Ashen Forge Member",
 ))
 
 ///employers for malfunctioning ais. they do not have sides, unlike traitors.


### PR DESCRIPTION

## About The Pull Request

Issue was this piece of code right here:
```dm
	if(istype(ending_objective, /datum/objective/hijack))
		possible_employers -= GLOB.normal_employers
	else //escape or martyrdom
		possible_employers -= GLOB.hijack_employers
```

Ashen Forge was in both the normal and hijack employers list, *so it'd always be removed from the possibilities*.

<details>
<summary>Proof that it works</summary>

![2024-08-18 (1724039098) ~ Code](https://github.com/user-attachments/assets/3a53d146-d4cb-45d2-ad1f-1b9dc538760e)
![2024-08-18 (1724039153) ~ dreamseeker](https://github.com/user-attachments/assets/2f10cebe-6518-445b-9134-5c3d7f829680)

</details>

## Changelog
:cl:
fix: The Ashen Forge traitor faction can now actually roll.
/:cl:
