### PR TITLE
Makes T2 and T3 Manips give the chem dispenser additional chems

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -88,7 +88,7 @@
 		/datum/reagent/medicine/mine_salve,
 		/datum/reagent/medicine/morphine,
 		/datum/reagent/drug/space_drugs,
-		/datum/reagent/toxin
+		/datum/reagent/australium
 	)
 
 	var/list/recording_recipe

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -80,7 +80,8 @@
 
 	var/list/upgrade_reagents3 = list(
 		/datum/reagent/medicine/mine_salve,
-		/datum/reagent/toxin
+		/datum/reagent/toxin,
+		/datum/reagent/saltpetre
 	)
 	
 	var/list/emagged_reagents = list(

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -65,15 +65,24 @@
 		/datum/reagent/fuel,
 		/datum/reagent/silver,
 	)
-	//these become available once the manipulator has been upgraded to tier 4 (femto)
+	//These become available once upgraded. (Monkestation Edit)
 	var/list/upgrade_reagents = list(
-		/datum/reagent/acetone,
-		/datum/reagent/ammonia,
-		/datum/reagent/ash,
-		/datum/reagent/diethylamine,
 		/datum/reagent/fuel/oil,
-		/datum/reagent/saltpetre
+		/datum/reagent/ammonia,
+		/datum/reagent/ash
 	)
+
+	var/list/upgrade_reagents2 = list(
+		/datum/reagent/acetone,
+		/datum/reagent/phenol,
+		/datum/reagent/diethylamine
+	)
+
+	var/list/upgrade_reagents3 = list(
+		/datum/reagent/medicine/mine_salve,
+		/datum/reagent/toxin
+	)
+	
 	var/list/emagged_reagents = list(
 		/datum/reagent/toxin/carpotoxin,
 		/datum/reagent/medicine/mine_salve,
@@ -428,12 +437,13 @@
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
 		recharge_amount *= capacitor.tier
 		parts_rating += capacitor.tier
-	for(var/datum/stock_part/manipulator/manipulator in component_parts)
-		if (manipulator.tier > 3)
+	for(var/datum/stock_part/manipulator/manipulator in component_parts) // Monkestation Edit
+		if (manipulator.tier > 1)
 			dispensable_reagents |= upgrade_reagents
-		else
-			dispensable_reagents -= upgrade_reagents
-		parts_rating += manipulator.tier
+		if (manipulator.tier > 2)
+			dispensable_reagents |= upgrade_reagents2
+		if (manipulator.tier > 3)
+			dispensable_reagents |= upgrade_reagents3
 	powerefficiency = round(newpowereff, 0.01)
 
 /obj/machinery/chem_dispenser/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)


### PR DESCRIPTION
## About The Pull Request
Adds additional Chems to the T2 manip and T3 manip versions of the Chem Dispenser

T2: Adds Oil, Ash and Ammonia
T3: Adds Acetone, Phenol, Diethylaime
T4 Adds Toxin, Miner's salve, Saltpetre
Emagged Change: Toxin replaced with Austrailium (unless better replacement found, was suggested)

## Why It's Good For The Game
makes mid-game upgrade feel better
## Changelog
:cl:
qol: Chemical Dispenser now actually upgrades with manipulators instead of a dump at T4 and adds a few more
/:cl:
