### PR TITLE
Adds config options to disable sunlight, weather, and storytellers to speed up local init

### DIFF
--- a/code/controllers/configuration/entries/monkestation.dm
+++ b/code/controllers/configuration/entries/monkestation.dm
@@ -30,3 +30,9 @@
 /datum/config_entry/flag/looc_enabled
 
 /datum/config_entry/flag/log_storyteller
+
+/datum/config_entry/flag/disable_sunlight_visuals
+
+/datum/config_entry/flag/disable_particle_weather
+
+/datum/config_entry/flag/disable_storyteller

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -144,7 +144,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	if(SSlighting.initialized)
 		// Space tiles should never have lighting objects
 		//monkestation addition start
-		if(SSoutdoor_effects.initialized)
+		if(SSoutdoor_effects.enabled)
 			outdoor_effect = old_outdoor_effect
 			get_sky_and_weather_states()
 

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -144,7 +144,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 	if(SSlighting.initialized)
 		// Space tiles should never have lighting objects
 		//monkestation addition start
-		if(SSoutdoor_effects.enabled)
+		if(SSoutdoor_effects.initialized && SSoutdoor_effects.enabled)
 			outdoor_effect = old_outdoor_effect
 			get_sky_and_weather_states()
 

--- a/monkestation/code/modules/outdoors/code/_onclick/hud/fullscreen.dm
+++ b/monkestation/code/modules/outdoors/code/_onclick/hud/fullscreen.dm
@@ -15,6 +15,8 @@
 
 /atom/movable/screen/fullscreen/lighting_backdrop/sunlight/Initialize()
 	. = ..()
+	if(!SSoutdoor_effects.enabled)
+		return
 	SSoutdoor_effects.sunlighting_planes |= src
 	color = SSoutdoor_effects.last_color
 
@@ -23,11 +25,8 @@
 		if(SSmapping.level_trait(z, ZTRAIT_DAYCYCLE))
 			daylight = TRUE
 			continue
-	if(!daylight)
-		SSoutdoor_effects.transition_sunlight_color(src, 1)
-	else
-		SSoutdoor_effects.transition_sunlight_color(src)
+	SSoutdoor_effects.transition_sunlight_color(src, !daylight)
 
 /atom/movable/screen/fullscreen/lighting_backdrop/sunlight/Destroy()
-	. = ..()
 	SSoutdoor_effects.sunlighting_planes -= src
+	return ..()

--- a/monkestation/code/modules/outdoors/code/_onclick/hud/rendering/plane_master.dm
+++ b/monkestation/code/modules/outdoors/code/_onclick/hud/rendering/plane_master.dm
@@ -31,7 +31,8 @@
 /atom/movable/screen/plane_master/weather_effect/Initialize()
 	. = ..()
 	//filters += filter(type="alpha", render_source=WEATHER_RENDER_TARGET)
-	SSoutdoor_effects.weather_planes_need_vis |= src
+	if(SSoutdoor_effects.enabled)
+		SSoutdoor_effects.weather_planes_need_vis |= src
 
 /atom/movable/screen/plane_master/weather_effect/Destroy()
 	. = ..()

--- a/monkestation/code/modules/outdoors/code/admin_commands.dm
+++ b/monkestation/code/modules/outdoors/code/admin_commands.dm
@@ -6,6 +6,10 @@
 	if(!holder)
 		return
 
+	if(!SSparticle_weather.enabled)
+		to_chat(src, span_warning("Particle weather is currently disabled!"), type = MESSAGE_TYPE_ADMINLOG)
+		return
+
 	var/weather_type = input("Choose a weather", "Weather")  as null|anything in sort_list(subtypesof(/datum/particle_weather), /proc/cmp_typepaths_asc)
 	if(!weather_type)
 		return

--- a/monkestation/code/modules/outdoors/code/controllers/subsystem/outdoors_effects.dm
+++ b/monkestation/code/modules/outdoors/code/controllers/subsystem/outdoors_effects.dm
@@ -98,6 +98,7 @@ SUBSYSTEM_DEF(outdoor_effects)
 	                                                   new /datum/time_of_day/midnight())
 	var/next_day = FALSE // Resets when station_time is less than the next start time.
 	var/current_color
+	var/enabled = TRUE // Micro-optimization to avoid having to check config or bitflags
 
 /datum/controller/subsystem/outdoor_effects/stat_entry(msg)
 	msg = "W:[GLOB.SUNLIGHT_QUEUE_WORK.len]|U:[GLOB.SUNLIGHT_QUEUE_UPDATE.len]|C:[GLOB.SUNLIGHT_QUEUE_CORNER.len]"
@@ -111,6 +112,9 @@ SUBSYSTEM_DEF(outdoor_effects)
 				GLOB.SUNLIGHT_QUEUE_WORK += T
 
 /datum/controller/subsystem/outdoor_effects/Initialize(timeofday)
+	if(CONFIG_GET(flag/disable_sunlight_visuals))
+		disable()
+		return SS_INIT_NO_NEED
 	if(SSmapping.config.map_name == "Oshan Station")
 		for(var/datum/time_of_day/listed_time as anything in time_cycle_steps)
 			qdel(listed_time)
@@ -140,6 +144,15 @@ SUBSYSTEM_DEF(outdoor_effects)
 			listed_time.color = GLOB.starlight_color
 
 	return SS_INIT_SUCCESS
+
+/// Disables the subsystem, cleaning up its vars and preventing it from firing.
+/datum/controller/subsystem/outdoor_effects/proc/disable()
+	enabled = FALSE
+	flags |= SS_NO_FIRE
+	QDEL_LIST(time_cycle_steps)
+	QDEL_NULL(current_step_datum)
+	QDEL_NULL(next_step_datum)
+	weather_light_affecting_event = null
 
 /datum/controller/subsystem/outdoor_effects/proc/InitializeTurfs(list/targets)
 	for (var/z in (SSmapping.levels_by_trait(ZTRAIT_DAYCYCLE) + SSmapping.levels_by_trait(ZTRAIT_STARLIGHT)))
@@ -188,6 +201,8 @@ SUBSYSTEM_DEF(outdoor_effects)
 
 /* set sunlight color + add weather effect to clients */
 /datum/controller/subsystem/outdoor_effects/fire(resumed, init_tick_checks)
+	if(!enabled)
+		return
 	MC_SPLIT_TICK_INIT(3)
 	if(!init_tick_checks)
 		MC_SPLIT_TICK
@@ -280,6 +295,8 @@ SUBSYSTEM_DEF(outdoor_effects)
 
 //Transition from our last color to our current color (i.e if it is going from daylight (white) to sunset (red), we transition to red in the first hour of sunset)
 /datum/controller/subsystem/outdoor_effects/proc/transition_sunlight_color(atom/movable/screen/fullscreen/lighting_backdrop/sunlight/SP, time_given)
+	if(!enabled)
+		return
 	/* transistion in an hour or time diff from now to our next step, whichever is smaller */
 	if(!next_step_datum)
 		get_time_of_day()

--- a/monkestation/code/modules/outdoors/code/datum/particle_weathers/_particle_weather.dm
+++ b/monkestation/code/modules/outdoors/code/datum/particle_weathers/_particle_weather.dm
@@ -67,10 +67,11 @@ GLOBAL_LIST_EMPTY(siren_objects)
 				else
 					playsound_z(SSmapping.levels_by_trait(ZTRAIT_ECLIPSE), pick(sound_effects), 50, _mixer_channel = CHANNEL_WEATHER)
 		if(GLE_STAGE_THIRD)
-			color_animating = SSoutdoor_effects.current_color
+			if(SSoutdoor_effects.enabled)
+				color_animating = SSoutdoor_effects.current_color
 			animate_flags = CIRCULAR_EASING | EASE_IN
 
-	if(color_animating)
+	if(color_animating && SSoutdoor_effects.enabled)
 		for(var/atom/movable/screen/fullscreen/lighting_backdrop/sunlight/plane in SSoutdoor_effects.sunlighting_planes)
 			animate(plane, color = color_animating, easing = animate_flags, time = duration)
 
@@ -82,9 +83,10 @@ GLOBAL_LIST_EMPTY(siren_objects)
 		sleep(duration)
 
 	else if(stage > max_stages)
-		SSoutdoor_effects.weather_light_affecting_event = null
-		for(var/atom/movable/screen/fullscreen/lighting_backdrop/sunlight/plane in SSoutdoor_effects.sunlighting_planes)
-			SSoutdoor_effects.transition_sunlight_color(plane)
+		if(SSoutdoor_effects.enabled)
+			SSoutdoor_effects.weather_light_affecting_event = null
+			for(var/atom/movable/screen/fullscreen/lighting_backdrop/sunlight/plane in SSoutdoor_effects.sunlighting_planes)
+				SSoutdoor_effects.transition_sunlight_color(plane)
 		qdel(src)
 		return
 

--- a/monkestation/code/modules/replays/subsystem/replay.dm
+++ b/monkestation/code/modules/replays/subsystem/replay.dm
@@ -68,11 +68,10 @@ SUBSYSTEM_DEF(demo)
 /datum/controller/subsystem/demo/Initialize()
 	if(!CONFIG_GET(flag/demos_enabled))
 		flags |= SS_NO_FIRE
-		can_fire = FALSE
 		marked_dirty.Cut()
 		marked_new.Cut()
 		marked_turfs.Cut()
-		return SS_INIT_SUCCESS
+		return SS_INIT_NO_NEED
 
 	var/rounder = file("[GLOB.demo_directory]/round_number.txt")
 	fdel(rounder)

--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -189,6 +189,9 @@ SUBSYSTEM_DEF(gamemode)
 		event_pools[event.track] += event //Add it to the categorized event pools
 
 	load_roundstart_data()
+	if(CONFIG_GET(flag/disable_storyteller)) // we're just gonna disable firing but still initialize, so we don't have any weird runtimes
+		flags |= SS_NO_FIRE
+		return SS_INIT_NO_NEED
 	return SS_INIT_SUCCESS
 
 


### PR DESCRIPTION
… 
## About The Pull Request

This adds 3 new config options: `DISABLE_PARTICLE_WEATHER`, `DISABLE_SUNLIGHT_VISUALS`, and `DISABLE_STORYTELLER`.

These do exactly what they say - they don't bother initializing the subsystems and disable the subsystems from firing.

## Why It's Good For The Game

Shaves a whole 10 seconds off init time when testing locally on Runtime Station (from 40 secs down to 30 secs for me)

## Changelog

No player-facing changes (this adds **server-side** config options)