### PR TITLE
[PORT] Fixes DNA Infuser missing from techfab, tech storage

### DIFF
--- a/code/game/objects/effects/spawners/random/techstorage.dm
+++ b/code/game/objects/effects/spawners/random/techstorage.dm
@@ -63,6 +63,7 @@
 		/obj/item/circuitboard/machine/nanite_program_hub,
 		/obj/item/circuitboard/computer/scan_consolenew,
 		/obj/item/circuitboard/machine/dnascanner,
+		/obj/item/circuitboard/machine/dna_infuser,
 	)
 
 /obj/effect/spawner/random/techstorage/security_all

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -472,6 +472,16 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
 
+/datum/design/board/dnainfuser
+	name = "DNA Infuser Board"
+	desc = "The circuit board for a DNA Infuser."
+	id = "dnainfuser"
+	build_path = /obj/item/circuitboard/machine/dna_infuser
+	category = list(
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_GENETICS
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+
 /datum/design/board/scan_console
 	name = "DNA Console Board"
 	desc = "Allows for the construction of circuit boards used to build a new DNA console."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1286,6 +1286,7 @@
 	prereq_ids = list("biotech")
 	design_ids = list(
 		"dna_disk",
+		"dnainfuser",
 		"dnascanner",
 		"scan_console",
 	)


### PR DESCRIPTION

## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/77348

## Changelog
:cl: Absolucy, Vekter
fix: Fixed the DNA Infuser's circuit board missing from the techfab and tech storage.
/:cl:
