### PR TITLE
[Bounty] Reduces the weight of xeno infestation event

### DIFF
--- a/code/modules/events/ghost_role/alien_infestation.dm
+++ b/code/modules/events/ghost_role/alien_infestation.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/antagonist/solo/from_ghosts/alien_infestation
 	name = "Alien Infestation"
 	typepath = /datum/round_event/antagonist/solo/ghost/alien_infestation
-	weight = 5
+	weight = 2 //monkie edit: 5 to 2
 
 	min_players = 35 //monkie edit: 10 to 35 (tg what the fuck)
 


### PR DESCRIPTION
## About The Pull Request
Title, reduces the weight from 5 to 2
## Why It's Good For The Game
Xenos can be incredibly hard to remove, considering getting rid of them involves killing all and preventing any larva from getting away. This will hopefully reduce how frequently they appear as a late roll event, letting other events have more opportunities to shine.
## Changelog
:cl:
balance: Reduced the weight of the xeno infestation event from 5 to 2
/:cl:
