### PR TITLE
Curator music QoL

### DIFF
--- a/monkestation/code/modules/cargo/crates/service.dm
+++ b/monkestation/code/modules/cargo/crates/service.dm
@@ -40,8 +40,12 @@
 	name = "Bulk Cassette Crate"
 	desc = "In the unlikely event all your cassettes are the same, or the likely event youve run out of songs to play, this crate is here to help you, contains 10 Approved Cassettes for use in the DJ Station."
 	cost = CARGO_CRATE_VALUE * 4
-	contains = list(/obj/item/device/cassette_tape/random = 10)
+	//contains = list(/obj/item/device/cassette_tape/random = 10)
 	crate_name = "cassette crate"
+
+/datum/supply_pack/service/cassettes/fill(obj/structure/closet/crate/our_crate)
+	for(var/id in unique_random_tapes(10))
+		new /obj/item/device/cassette_tape(our_crate, id)
 
 /datum/supply_pack/service/blankcassettes
 	name = "Blank Cassettes Crate"

--- a/monkestation/code/modules/cassettes/cassette_db/subsystem.dm
+++ b/monkestation/code/modules/cassettes/cassette_db/subsystem.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(cassette_storage)
 	name = "Cassette Storage"
 	flags = SS_NO_FIRE
-	runlevels = RUNLEVEL_LOBBY|RUNLEVELS_DEFAULT
+	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
 	var/list/cassette_datums = list()
 
 
@@ -18,3 +18,13 @@ SUBSYSTEM_DEF(cassette_storage)
 			qdel(new_data)
 			continue
 		cassette_datums += new_data
+
+/datum/controller/subsystem/cassette_storage/proc/get_cassettes_by_ckey(user_ckey) as /list
+	RETURN_TYPE(/list)
+	. = list()
+	if(!user_ckey)
+		return
+	user_ckey = ckey(user_ckey)
+	for(var/datum/cassette_data/tape as anything in SScassette_storage.cassette_datums)
+		if(ckey(tape.cassette_author_ckey) == user_ckey)
+			. += tape


### PR DESCRIPTION

## About The Pull Request

Whenever a curator joins - if the player has any approved cassettes, up to 3 of them will be spawned in their cassette rack.

Also, this makes it so bulk cassette crates won't contain duplicates.

## Why It's Good For The Game

I wanna play my own tapes without relying on crate rng or admins using Spawn-Mixtape.

## Changelog
:cl:
add: Curators will now spawn with some of the tapes they've had approved (if any) in their cassette rack.
qol: Bulk cassette crates will no longer contain duplicates tapes.
/:cl:
