### PR TITLE
Reduces time for dragon and blob event

### DIFF
--- a/code/modules/events/ghost_role/blob.dm
+++ b/code/modules/events/ghost_role/blob.dm
@@ -5,7 +5,7 @@
 	max_occurrences = 1
 
 	min_players = 35  //monkie edit: 20 to 35
-	earliest_start = 60 MINUTES //monkie edit: 20 to 90
+	earliest_start = 45 MINUTES //monkie edit: 20 to 45
 	//dynamic_should_hijack = TRUE
 	category = EVENT_CATEGORY_ENTITIES
 	description = "Spawns a new blob overmind."

--- a/code/modules/events/ghost_role/space_dragon.dm
+++ b/code/modules/events/ghost_role/space_dragon.dm
@@ -4,7 +4,7 @@
 	weight = 7
 	max_occurrences = 1
 	min_players = 30 //monke edit: 20 to 30
-	earliest_start = 60 MINUTES //monke edit: 20 to 60
+	earliest_start = 45 MINUTES //monke edit: 20 to 45
 	//dynamic_should_hijack = TRUE
 	category = EVENT_CATEGORY_ENTITIES
 	description = "Spawns a space dragon, which will try to take over the station."


### PR DESCRIPTION

## About The Pull Request
Reduces the minimum time for the space dragon and blob ghost role events from 60 minutes to 45
## Why It's Good For The Game
Request from Kilgor
## Changelog
:cl:
balance: The space dragon and blob ghost role events will now start to appear at 45 minutes, down from 60 minutes.
/:cl:
