### PR TITLE
Reduces stage 1 hunger nutrition drain

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/stage1.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/stage1.dm
@@ -167,7 +167,7 @@
 
 /datum/symptom/wendigo_warning/activate(mob/living/mob)
 	to_chat(mob, span_warning("[pick(host_messages)]"))
-	mob.adjust_nutrition(-25)
+	mob.adjust_nutrition(-10)
 
 
 /datum/symptom/cult_hallucination


### PR DESCRIPTION

## About The Pull Request
Reduces the stage 1 hunger nutrition drain from 25 to 10
## Why It's Good For The Game
See #3000, while this symptom isn't as awful at nuking your hunger, it still causes the same issues. Reducing the nutrition drain will hopefully still make it a nuisance, without it forcing players to constantly be hungry.
## Changelog
:cl:
balance: Reduced the stage 1 hunger symptom nutrition drain from 25 to 10
/:cl:
