### PR TITLE
Clean up some more roundstart active turfs

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_asteroid.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_asteroid.dmm
@@ -12,7 +12,7 @@
 /obj/item/clothing/shoes/bronze,
 /obj/item/clothing/head/costume/bronze,
 /turf/open/floor/bronze{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/icemoon/surface)
 "m" = (
@@ -20,12 +20,12 @@
 	name = "empowered bronze spear"
 	},
 /turf/open/floor/bronze{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/icemoon/surface)
 "o" = (
 /turf/open/floor/bronze{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/icemoon/surface)
 "A" = (
@@ -66,7 +66,7 @@
 "L" = (
 /mob/living/simple_animal/hostile/megafauna/clockwork_defender,
 /turf/open/floor/bronze{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/icemoon/surface)
 "M" = (
@@ -95,7 +95,7 @@
 	},
 /obj/item/pen,
 /turf/open/floor/bronze{
-	initial_gas_mix = "LAVALAND_ATMOS"
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/icemoon/surface)
 

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
@@ -15,7 +15,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "an" = (
 /turf/open/floor/engine/n2,
@@ -28,13 +28,13 @@
 "aq" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/disk/holodisk/ruin/snowengieruin,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "ar" = (
 /obj/effect/mob_spawn/corpse/human/assistant,
 /obj/item/construction/rcd,
 /obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "as" = (
 /obj/machinery/modular_computer/preset/civilian{
@@ -46,14 +46,14 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/mapping_helpers/apc/no_charge,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "au" = (
 /obj/machinery/rnd/production/circuit_imprinter/offstation,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "av" = (
 /obj/structure/cable,
@@ -78,14 +78,14 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/rcd_ammo,
 /obj/item/rcd_ammo,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "az" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "aA" = (
 /obj/machinery/rnd/production/protolathe/department/engineering/no_tax,
@@ -96,7 +96,7 @@
 	dir = 1
 	},
 /obj/item/rcd_upgrade/frames,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "aC" = (
 /turf/open/floor/engine/o2,
@@ -114,10 +114,6 @@
 /obj/item/toy/snowball,
 /turf/open/misc/snow/actually_safe,
 /area/ruin/planetengi)
-"aF" = (
-/obj/structure/cable,
-/turf/open/floor/catwalk_floor/iron,
-/area/ruin/planetengi)
 "aG" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/engine/n2,
@@ -127,15 +123,15 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "aI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "aJ" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "aK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
@@ -170,12 +166,12 @@
 /area/ruin/planetengi)
 "aV" = (
 /obj/machinery/autolathe,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "aW" = (
 /obj/item/clothing/under/rank/engineering/chief_engineer,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "aX" = (
 /obj/structure/flora/rock/icy/style_random,
@@ -191,14 +187,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/ruin/planetengi)
-"bd" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "be" = (
 /obj/machinery/atmospherics/components/binary/pump,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bi" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
@@ -234,39 +227,39 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/engineering,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "br" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/structure/sign/poster/official/build/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bx" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/o2{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "by" = (
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bz" = (
 /obj/machinery/door/firedoor/heavy,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bA" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
@@ -275,7 +268,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bB" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
@@ -284,7 +277,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bD" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -297,7 +290,7 @@
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -306,52 +299,47 @@
 /obj/effect/turf_decal/trimline/blue/warning{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bI" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /obj/structure/tank_dispenser,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bL" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bR" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bS" = (
 /obj/structure/table,
 /obj/item/flashlight{
 	pixel_y = 4
 	},
-/turf/open/floor/iron,
-/area/ruin/planetengi)
-"bT" = (
-/turf/open/floor/iron/corner{
-	dir = 4
-	},
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bU" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -366,26 +354,26 @@
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "bZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "ca" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -396,35 +384,35 @@
 /area/ruin/planetengi)
 "cb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cd" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "ce" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 6
 	},
-/turf/open/floor/iron/corner,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cf" = (
 /obj/machinery/atmospherics/components/trinary/filter/flipped{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "ch" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -438,7 +426,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cj" = (
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
@@ -446,15 +434,13 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "ck" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 4
 	},
-/turf/open/floor/iron/corner{
-	dir = 8
-	},
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cl" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -466,35 +452,35 @@
 "cm" = (
 /obj/item/book/manual/wiki/atmospherics,
 /obj/structure/table,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cn" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cp" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cs" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "ct" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /obj/structure/cable,
-/turf/open/floor/engine,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cu" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -504,7 +490,7 @@
 /area/icemoon/surface/outdoors/nospawn)
 "cx" = (
 /obj/item/pipe_dispenser,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cD" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -522,7 +508,7 @@
 	name = "Engineering Access"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/engineering,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cG" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -530,11 +516,11 @@
 /area/ruin/planetengi)
 "cI" = (
 /obj/item/modular_computer/pda/clear,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cJ" = (
 /obj/item/modular_computer/pda/engineering,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cL" = (
 /obj/effect/decal/remains/human,
@@ -542,13 +528,7 @@
 /obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
-/area/ruin/planetengi)
-"cN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/iron/corner{
-	dir = 1
-	},
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cO" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -560,7 +540,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cQ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -569,19 +549,19 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4{
 	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cR" = (
 /obj/machinery/atmospherics/components/binary/pump/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cS" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cU" = (
 /turf/open/floor/iron/icemoon,
@@ -593,37 +573,37 @@
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cW" = (
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cX" = (
 /obj/structure/cable,
 /obj/machinery/power/emitter/welded{
 	dir = 1
 	},
-/turf/open/floor/catwalk_floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cY" = (
 /obj/item/stack/sheet/plasmarglass,
 /obj/item/card/id/advanced/engioutpost,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "db" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "de" = (
 /turf/template_noop,
@@ -633,35 +613,35 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/official/pda_ad/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "dg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "dh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "di" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "dj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "dk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "dl" = (
 /obj/effect/mob_spawn/corpse/human/engineer/mod,
@@ -705,7 +685,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/closed,
 /obj/item/shard,
-/turf/open/floor/plating,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "du" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -813,7 +793,7 @@
 /area/ruin/planetengi)
 "yF" = (
 /mob/living/basic/construct/proteon,
-/turf/open/floor/iron,
+/turf/open/floor/iron/icemoon,
 /area/ruin/planetengi)
 "Ai" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -896,7 +876,7 @@ aG
 ba
 br
 cg
-bd
+cU
 by
 bR
 cP
@@ -958,7 +938,7 @@ do
 do
 do
 aH
-bd
+cU
 bc
 cm
 bS
@@ -1002,7 +982,7 @@ cE
 bF
 bc
 yF
-bd
+cU
 cx
 cR
 dh
@@ -1066,7 +1046,7 @@ bG
 bV
 ce
 cs
-bT
+cU
 cV
 bG
 do
@@ -1083,13 +1063,13 @@ ay
 aq
 aV
 cG
-bd
+cU
 bW
 cf
 bA
 cJ
 cW
-bd
+cU
 cG
 cU
 kS
@@ -1101,7 +1081,7 @@ Ai
 do
 av
 az
-aF
+aJ
 aW
 bq
 aJ
@@ -1110,7 +1090,7 @@ ci
 ct
 cL
 cX
-bd
+cU
 cF
 cU
 GG
@@ -1123,7 +1103,7 @@ do
 aw
 am
 ar
-bd
+cU
 cG
 bH
 bZ
@@ -1150,7 +1130,7 @@ bI
 bZ
 ck
 cu
-cN
+cn
 cg
 dk
 dt

--- a/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_plasma_facility.dmm
@@ -51,7 +51,9 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/edge,
+/turf/open/floor/iron/edge{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "aT" = (
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -61,7 +63,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "aY" = (
 /obj/effect/turf_decal/siding/wood/corner,
@@ -73,7 +77,7 @@
 	name = "Bunk A"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "aZ" = (
 /obj/structure/railing{
@@ -114,7 +118,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/operations)
 "bv" = (
 /obj/effect/decal/cleanable/dirt,
@@ -122,7 +126,9 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/edge,
+/turf/open/floor/iron/edge{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "bD" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -135,7 +141,9 @@
 	pixel_y = 7
 	},
 /obj/effect/decal/cleanable/blood/tracks,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/white/smooth_large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "bM" = (
 /obj/structure/cable,
@@ -143,7 +151,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "bT" = (
 /obj/machinery/atmospherics/components/binary/valve{
@@ -160,11 +170,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/warm/directional/south,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "cb" = (
 /obj/machinery/light/small/broken/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "cn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -179,7 +191,9 @@
 /obj/item/stack/sheet/iron,
 /obj/item/stack/sheet/iron,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "cL" = (
 /obj/structure/table,
@@ -211,7 +225,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "dr" = (
 /obj/structure/lattice,
@@ -225,7 +241,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/built/directional/east,
 /obj/effect/turf_decal/tile/brown/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/operations)
 "dB" = (
 /mob/living/simple_animal/hostile/asteroid/polarbear{
@@ -239,7 +257,9 @@
 /obj/effect/decal/cleanable/glass,
 /obj/item/stock_parts/capacitor,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "dO" = (
 /obj/structure/railing/corner{
@@ -261,7 +281,9 @@
 	},
 /obj/effect/decal/cleanable/plasma,
 /obj/effect/decal/cleanable/blood,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/white/smooth_large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "dR" = (
 /obj/structure/lattice/catwalk,
@@ -296,7 +318,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/broken/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "ea" = (
 /obj/effect/decal/cleanable/dirt,
@@ -312,7 +336,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "eD" = (
 /turf/closed/wall/ice,
@@ -325,14 +351,16 @@
 /obj/structure/table,
 /obj/item/plate,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "eT" = (
 /obj/structure/table/reinforced,
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil/five,
 /obj/item/circuitboard/machine/microwave,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/plasma_facility/commons)
 "eX" = (
 /obj/structure/bonfire,
@@ -381,7 +409,7 @@
 /area/icemoon/underground/explored)
 "gj" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "gk" = (
 /obj/structure/lattice/catwalk,
@@ -418,14 +446,16 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/built/directional/north,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "gH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "gR" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
@@ -446,7 +476,9 @@
 	pixel_y = -2
 	},
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/white/smooth_large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "hc" = (
 /obj/structure/rack,
@@ -489,7 +521,9 @@
 /obj/item/cigbutt/cigarbutt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "hR" = (
 /turf/closed/wall/ice,
@@ -517,7 +551,8 @@
 	},
 /obj/effect/turf_decal/tile/brown/anticorner,
 /turf/open/floor/iron/corner{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "ia" = (
@@ -542,7 +577,7 @@
 "if" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken/directional/south,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "ii" = (
 /obj/structure/fence/corner{
@@ -571,7 +606,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/plasma_facility/commons)
 "im" = (
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -613,7 +648,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/brown/full,
-/turf/open/floor/iron/large,
+/turf/open/floor/iron/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "js" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -667,7 +704,8 @@
 	dir = 4
 	},
 /turf/open/floor/iron/corner{
-	dir = 4
+	dir = 4;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "kG" = (
@@ -683,7 +721,9 @@
 /obj/structure/mirror/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/blacklight/directional/south,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "lf" = (
 /obj/structure/fluff/tram_rail,
@@ -736,7 +776,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "lW" = (
 /obj/structure/cable,
@@ -744,7 +786,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "lX" = (
 /obj/structure/table/reinforced,
@@ -783,7 +827,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "mN" = (
 /obj/structure/cable,
@@ -797,7 +841,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple/half,
-/turf/open/floor/iron/textured_half,
+/turf/open/floor/iron/textured_half{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/operations)
 "ng" = (
 /obj/structure/grille/broken,
@@ -827,7 +873,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "no" = (
 /obj/structure/transit_tube/station/reverse,
@@ -845,7 +893,8 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/edge{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "ns" = (
@@ -854,7 +903,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown/full,
-/turf/open/floor/iron/large,
+/turf/open/floor/iron/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "nu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -863,7 +914,9 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/edge,
+/turf/open/floor/iron/edge{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "nz" = (
 /obj/machinery/door/airlock/hatch{
@@ -905,7 +958,7 @@
 	dir = 1;
 	pixel_y = -7
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/plasma_facility/commons)
 "oA" = (
 /obj/effect/turf_decal/box/corners{
@@ -922,7 +975,9 @@
 	pixel_y = 3
 	},
 /obj/item/knife/combat/survival,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "oF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -949,7 +1004,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron/textured_large,
+/turf/open/floor/iron/textured_large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "oW" = (
 /obj/structure/lattice/catwalk,
@@ -977,7 +1034,8 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/edge{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "pl" = (
@@ -988,7 +1046,9 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/edge,
+/turf/open/floor/iron/edge{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "pt" = (
 /obj/structure/table,
@@ -998,7 +1058,9 @@
 	},
 /obj/item/flashlight/lantern,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "pw" = (
 /obj/effect/turf_decal/bot_white{
@@ -1006,11 +1068,13 @@
 	},
 /obj/structure/ore_box,
 /obj/effect/turf_decal/tile/brown/full,
-/turf/open/floor/iron/textured_large,
+/turf/open/floor/iron/textured_large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "pC" = (
 /obj/machinery/space_heater/improvised_chem_heater,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "pE" = (
 /obj/structure/bed/maint,
@@ -1065,7 +1129,9 @@
 /obj/item/wallframe/apc,
 /obj/item/electronics/apc,
 /obj/item/stack/cable_coil/five,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "qW" = (
 /turf/closed/wall,
@@ -1108,7 +1174,8 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/edge{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "rW" = (
@@ -1128,12 +1195,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/disk/design_disk/modkit_disc/resonator_blast,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "su" = (
 /obj/structure/chair/stool/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "sJ" = (
 /obj/structure/rack,
@@ -1165,14 +1236,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "sY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "tf" = (
 /obj/structure/grille/broken,
@@ -1251,7 +1324,9 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/edge,
+/turf/open/floor/iron/edge{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "ux" = (
 /obj/structure/transit_tube/horizontal,
@@ -1319,7 +1394,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron/dark/side{
-	dir = 8
+	dir = 8;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/operations)
 "wm" = (
@@ -1337,13 +1413,17 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "wF" = (
 /obj/structure/frame,
 /obj/item/stack/cable_coil/five,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "wQ" = (
 /obj/structure/table/reinforced,
@@ -1360,7 +1440,7 @@
 	pixel_y = -3
 	},
 /obj/machinery/light/small/broken/directional/east,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/plasma_facility/commons)
 "xd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1369,7 +1449,9 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/edge,
+/turf/open/floor/iron/edge{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "xV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1389,7 +1471,7 @@
 /obj/item/food/grown/eggplant,
 /obj/item/food/grown/tomato,
 /obj/effect/decal/cleanable/food/flour,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/plasma_facility/commons)
 "yv" = (
 /obj/machinery/light_switch/directional/south,
@@ -1397,7 +1479,9 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/edge,
+/turf/open/floor/iron/edge{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "yG" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
@@ -1413,7 +1497,9 @@
 /area/ruin/plasma_facility/operations)
 "zk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "zD" = (
 /obj/structure/fluff/tram_rail/end{
@@ -1437,7 +1523,8 @@
 	dir = 4
 	},
 /turf/open/floor/iron/edge{
-	dir = 4
+	dir = 4;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "zU" = (
@@ -1472,7 +1559,9 @@
 	name = "Utilities Room"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/iron/smooth_half,
+/turf/open/floor/iron/smooth_half{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/operations)
 "An" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1482,7 +1571,8 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/edge{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "Au" = (
@@ -1493,7 +1583,9 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/edge,
+/turf/open/floor/iron/edge{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "AG" = (
 /turf/open/genturf,
@@ -1535,7 +1627,7 @@
 /area/ruin/plasma_facility/operations)
 "BJ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "BM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1546,7 +1638,8 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/edge{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "BQ" = (
@@ -1571,7 +1664,9 @@
 	name = "Processing Control"
 	},
 /obj/effect/turf_decal/tile/brown/full,
-/turf/open/floor/iron/textured_half,
+/turf/open/floor/iron/textured_half{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/operations)
 "Cb" = (
 /obj/structure/lattice/catwalk,
@@ -1585,7 +1680,7 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "Co" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -1595,7 +1690,9 @@
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/skeleton/plasmaminer,
 /obj/effect/turf_decal/tile/brown/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/operations)
 "CA" = (
 /obj/item/chair/plastic,
@@ -1626,7 +1723,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/east,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "CX" = (
 /obj/structure/fence/door{
@@ -1655,7 +1754,9 @@
 "DN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "DR" = (
 /obj/machinery/light/small/broken/directional/north,
@@ -1744,7 +1845,9 @@
 	},
 /obj/machinery/shower/directional/north,
 /obj/structure/curtain,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "Gb" = (
 /obj/machinery/power/port_gen/pacman,
@@ -1754,7 +1857,9 @@
 "Gd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "Go" = (
 /obj/effect/decal/cleanable/glass,
@@ -1788,7 +1893,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "Hv" = (
 /obj/structure/table,
@@ -1802,7 +1909,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "HC" = (
 /obj/structure/lattice/catwalk,
@@ -1861,7 +1968,9 @@
 	icon_state = "applebush"
 	},
 /obj/effect/turf_decal/tile/brown/full,
-/turf/open/floor/iron/large,
+/turf/open/floor/iron/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "IU" = (
 /obj/structure/chair/sofa/right/brown{
@@ -1908,7 +2017,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron/dark/textured_half,
+/turf/open/floor/iron/dark/textured_half{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "Ju" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
@@ -1939,7 +2050,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "JD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -1947,7 +2060,9 @@
 	},
 /obj/machinery/light/small/broken/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "JQ" = (
 /obj/structure/fence/end{
@@ -1966,7 +2081,7 @@
 	pixel_y = 7
 	},
 /obj/item/chair/wood,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/plasma_facility/commons)
 "Kd" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -1980,7 +2095,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mob_spawn/corpse/human/miner/explorer,
 /obj/machinery/light/small/blacklight/directional/south,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "Km" = (
 /obj/structure/girder,
@@ -2016,7 +2133,7 @@
 	pixel_x = 11;
 	pixel_y = 8
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/plasma_facility/commons)
 "Kx" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
@@ -2038,7 +2155,7 @@
 	name = "Bathroom"
 	},
 /obj/effect/mapping_helpers/airlock/abandoned,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/plasma_facility/commons)
 "KP" = (
 /obj/structure/fence/door/opened{
@@ -2097,11 +2214,13 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "LY" = (
 /obj/machinery/light/small/built/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "LZ" = (
 /obj/structure/flora/rock/icy/style_random,
@@ -2110,7 +2229,9 @@
 "Mc" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/tile/brown/full,
-/turf/open/floor/iron/large,
+/turf/open/floor/iron/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "Mi" = (
 /obj/structure/lattice/catwalk,
@@ -2150,10 +2271,6 @@
 	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/operations)
-"MU" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/ruin/plasma_facility/commons)
 "MW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -2192,7 +2309,9 @@
 	},
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/turf_decal/tile/green/full,
-/turf/open/floor/iron/white/textured_half,
+/turf/open/floor/iron/white/textured_half{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "Nm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -2201,7 +2320,8 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/edge{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "No" = (
@@ -2238,7 +2358,8 @@
 	dir = 4
 	},
 /turf/open/floor/iron/edge{
-	dir = 8
+	dir = 8;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "NC" = (
@@ -2261,7 +2382,9 @@
 /obj/item/shard,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/skeleton/plasmaminer/jackhammer,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "Or" = (
 /obj/machinery/atmospherics/components/tank/plasma,
@@ -2291,7 +2414,9 @@
 /mob/living/basic/skeleton/plasmaminer/jackhammer,
 /obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "OF" = (
 /obj/effect/decal/cleanable/glass,
@@ -2321,7 +2446,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "Pt" = (
 /obj/machinery/conveyor{
@@ -2350,7 +2477,9 @@
 	pixel_y = -7
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "Py" = (
 /obj/effect/turf_decal/box/corners{
@@ -2373,7 +2502,8 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/edge{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "PE" = (
@@ -2406,7 +2536,9 @@
 /obj/item/clothing/glasses/thermal/eyepatch{
 	pixel_y = 8
 	},
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "PQ" = (
 /obj/structure/flora/tree/dead/style_random,
@@ -2416,7 +2548,7 @@
 /obj/structure/girder,
 /obj/item/stack/sheet/iron,
 /obj/item/stack/sheet/iron,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "PS" = (
 /obj/structure/lattice/catwalk,
@@ -2433,7 +2565,9 @@
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/suit_storage_unit,
 /obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron/textured_large,
+/turf/open/floor/iron/textured_large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "Qh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2474,7 +2608,9 @@
 /obj/machinery/computer/order_console/mining,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/broken/directional/west,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "QM" = (
 /obj/structure/fence/cut/medium{
@@ -2484,7 +2620,9 @@
 /area/icemoon/underground/explored)
 "QQ" = (
 /obj/structure/dresser,
-/turf/open/floor/iron/grimy,
+/turf/open/floor/iron/grimy{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "QY" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -2524,7 +2662,8 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/edge{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "RM" = (
@@ -2569,7 +2708,7 @@
 /obj/machinery/door/airlock/wood{
 	name = "Bunk B"
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/plasma_facility/commons)
 "SR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2582,7 +2721,8 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/edge{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "TD" = (
@@ -2592,7 +2732,7 @@
 	pixel_x = -6;
 	pixel_y = 11
 	},
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/plasma_facility/commons)
 "TE" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2614,7 +2754,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "TY" = (
 /obj/structure/closet/crate,
@@ -2654,14 +2796,16 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/turf/open/floor/iron/edge,
+/turf/open/floor/iron/edge{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "VS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/hatch{
 	name = "Maintenance"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/operations)
 "VT" = (
 /obj/item/chair/wood,
@@ -2671,7 +2815,7 @@
 /obj/structure/windoor_assembly,
 /obj/effect/decal/cleanable/glass,
 /obj/item/bikehorn/rubberducky,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "Wd" = (
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -2687,7 +2831,9 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
 "Wu" = (
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "Wx" = (
 /obj/effect/turf_decal/siding/wood/corner,
@@ -2701,7 +2847,9 @@
 /obj/machinery/door/airlock/public{
 	name = "Commons Area"
 	},
-/turf/open/floor/iron/dark/textured_half,
+/turf/open/floor/iron/dark/textured_half{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "WC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2718,7 +2866,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/iron/corner,
+/turf/open/floor/iron/corner{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "WU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2726,7 +2876,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/tile/brown/opposingcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/operations)
 "Xh" = (
 /obj/structure/cable,
@@ -2772,7 +2924,9 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/toilet,
 /obj/structure/curtain,
-/turf/open/floor/iron/freezer,
+/turf/open/floor/iron/freezer{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "XT" = (
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -2789,7 +2943,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "XW" = (
 /obj/effect/turf_decal/bot_white{
@@ -2798,7 +2952,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/pickaxe,
 /obj/effect/turf_decal/tile/brown/full,
-/turf/open/floor/iron/textured_large,
+/turf/open/floor/iron/textured_large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "Yk" = (
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -2825,13 +2981,15 @@
 /obj/effect/turf_decal/caution,
 /obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/tile/neutral/full,
-/turf/open/floor/iron/textured_large,
+/turf/open/floor/iron/textured_large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "YI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
+/turf/open/floor/plating/icemoon,
 /area/ruin/plasma_facility/commons)
 "YN" = (
 /obj/structure/fence/end,
@@ -2865,7 +3023,8 @@
 	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/edge{
-	dir = 1
+	dir = 1;
+	initial_gas_mix = "ICEMOON_ATMOS"
 	},
 /area/ruin/plasma_facility/commons)
 "Zp" = (
@@ -2908,21 +3067,25 @@
 	pixel_x = 10;
 	pixel_y = -2
 	},
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "ZA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/stone,
+/turf/open/floor/stone/icemoon,
 /area/ruin/plasma_facility/commons)
 "ZB" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "ZC" = (
 /obj/effect/decal/cleanable/glass,
@@ -2931,7 +3094,9 @@
 /area/icemoon/underground/explored)
 "ZH" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/wood/large,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 "ZN" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/middle{
@@ -2948,7 +3113,9 @@
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/turf/open/floor/iron/white/smooth_large,
+/turf/open/floor/iron/white/smooth_large{
+	initial_gas_mix = "ICEMOON_ATMOS"
+	},
 /area/ruin/plasma_facility/commons)
 
 (1,1,1) = {"
@@ -3452,7 +3619,7 @@ zk
 Jy
 Gd
 QJ
-MU
+Km
 qW
 rF
 bM

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_mookvillage.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_mookvillage.dmm
@@ -56,7 +56,7 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "aB" = (
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/lavaland,
 /area/lavaland/surface/outdoors)
 "aC" = (
 /obj/structure/sign/nanotrasen,
@@ -86,13 +86,17 @@
 /obj/structure/table/wood/shuttle_bar,
 /obj/item/hatchet/wooden,
 /obj/item/storage/belt/champion,
-/turf/open/floor/holofloor/wood,
+/turf/open/floor/holofloor/wood{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
 /area/lavaland/surface/outdoors)
 "aL" = (
 /obj/item/flashlight/lantern{
 	on = 1
 	},
-/turf/open/floor/holofloor/wood,
+/turf/open/floor/holofloor/wood{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
 /area/lavaland/surface/outdoors)
 "aM" = (
 /obj/structure/chair/pew/right{
@@ -101,7 +105,9 @@
 /turf/open/misc/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "aN" = (
-/turf/open/floor/holofloor/wood,
+/turf/open/floor/holofloor/wood{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
 /area/lavaland/surface/outdoors)
 "aP" = (
 /mob/living/basic/mining/mook/worker,
@@ -110,15 +116,19 @@
 "aR" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/nanotrasen,
-/turf/open/floor/holofloor/wood,
+/turf/open/floor/holofloor/wood{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
 /area/lavaland/surface/outdoors)
 "aT" = (
 /obj/structure/flora/tree/jungle/style_5,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/lavaland,
 /area/lavaland/surface/outdoors)
 "aU" = (
 /obj/structure/table/wood/shuttle_bar,
-/turf/open/floor/holofloor/wood,
+/turf/open/floor/holofloor/wood{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
 /area/lavaland/surface/outdoors)
 "aV" = (
 /obj/structure/chair/pew{
@@ -128,7 +138,7 @@
 /area/lavaland/surface/outdoors)
 "aX" = (
 /obj/structure/flora/grass/jungle/b,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/lavaland,
 /area/lavaland/surface/outdoors)
 "aY" = (
 /obj/structure/chair/pew/left{
@@ -139,25 +149,35 @@
 "eN" = (
 /obj/structure/table/wood/shuttle_bar,
 /obj/item/flashlight/flare/candle/infinite,
-/turf/open/floor/holofloor/wood,
+/turf/open/floor/holofloor/wood{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
 /area/lavaland/surface/outdoors)
 "hi" = (
-/turf/open/floor/carpet/lone,
+/turf/open/floor/carpet/lone{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
 /area/lavaland/surface/outdoors)
 "sk" = (
 /obj/structure/bed/maint,
-/turf/open/floor/holofloor/wood,
+/turf/open/floor/holofloor/wood{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
 /area/lavaland/surface/outdoors)
 "xb" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
-/turf/open/floor/holofloor/wood,
+/turf/open/floor/holofloor/wood{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
 /area/lavaland/surface/outdoors)
 "xv" = (
 /obj/item/fishing_rod,
 /obj/structure/bed/maint,
-/turf/open/floor/holofloor/wood,
+/turf/open/floor/holofloor/wood{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
 /area/lavaland/surface/outdoors)
 "Br" = (
 /obj/structure/ore_container/material_stand,
@@ -167,15 +187,19 @@
 /obj/structure/closet/cabinet,
 /obj/item/food/grown/banana,
 /obj/item/food/meat/slab/goliath,
-/turf/open/floor/holofloor/wood,
+/turf/open/floor/holofloor/wood{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
 /area/lavaland/surface/outdoors)
 "Mn" = (
 /obj/structure/flora/tree/jungle/style_3,
-/turf/open/misc/grass/jungle,
+/turf/open/misc/grass/lavaland,
 /area/lavaland/surface/outdoors)
 "WL" = (
 /obj/structure/chair/wood,
-/turf/open/floor/holofloor/wood,
+/turf/open/floor/holofloor/wood{
+	initial_gas_mix = "LAVALAND_ATMOS"
+	},
 /area/lavaland/surface/outdoors)
 
 (1,1,1) = {"

--- a/_maps/~monkestation/RandomEngines/TramStation/singularity.dmm
+++ b/_maps/~monkestation/RandomEngines/TramStation/singularity.dmm
@@ -77,7 +77,7 @@
 /area/station/engineering/supermatter/room)
 "kr" = (
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "lq" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -218,7 +218,7 @@
 "wX" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "xd" = (
 /obj/machinery/power/energy_accumulator/tesla_coil,
@@ -368,7 +368,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /obj/structure/cable/layer1,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "Pp" = (
 /obj/structure/cable,


### PR DESCRIPTION

## About The Pull Request

This cleans up some roundstart active turfs - mostly icemoon ruins, but also some lavaland ruins, and the Tramstation singularity.

## Why It's Good For The Game

Less wasted processing time during init is good.

## Changelog
:cl:
fix: Cleaned up some more roundstart active turfs, leading to slightly better init times.
/:cl:
