### PR TITLE
You can no longer accidentally round-remove yourself with a single misclick

### DIFF
--- a/monkestation/code/modules/mining/lavaland/tendril_loot.dm
+++ b/monkestation/code/modules/mining/lavaland/tendril_loot.dm
@@ -1,0 +1,14 @@
+/obj/item/clothing/neck/necklace/memento_mori/attack_hand(mob/user, list/modifiers)
+	if(prevent_accidental_suicide(user))
+		return
+	return ..()
+
+/obj/item/clothing/neck/necklace/memento_mori/MouseDrop(atom/over_object)
+	if(prevent_accidental_suicide(over_object))
+		return
+	return ..()
+
+/obj/item/clothing/neck/necklace/memento_mori/proc/prevent_accidental_suicide(mob/user)
+	if(user == active_owner && tgui_alert(user, "Taking this off will INSTANTLY KILL YOU! Are you really sure you want to take it off?", "Memento Mori", list("Yes", "No")) != "Yes")
+		return TRUE
+	return FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7042,6 +7042,7 @@
 #include "monkestation\code\modules\mining\accelerators\repeater.dm"
 #include "monkestation\code\modules\mining\accelerators\shockwave.dm"
 #include "monkestation\code\modules\mining\accelerators\shotgun.dm"
+#include "monkestation\code\modules\mining\lavaland\tendril_loot.dm"
 #include "monkestation\code\modules\mob\login.dm"
 #include "monkestation\code\modules\mob\mob.dm"
 #include "monkestation\code\modules\mob\mob_defines.dm"


### PR DESCRIPTION
## Changelog
:cl:
qol: Trying to take off your own memento mori will ask you if you're *really* sure first.
/:cl:
