### PR TITLE
Roundstart meteor sats (+ cargo shelf improvements)

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -48770,13 +48770,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/upper)
 "jyn" = (
-/obj/structure/table/reinforced,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	pixel_x = 2;
-	pixel_y = 7
-	},
-/obj/item/stock_parts/cell/high,
+/obj/effect/turf_decal/bot,
+/obj/structure/cargo_shelf/meteor_shield,
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "jyo" = (
@@ -111302,9 +111297,8 @@
 /turf/open/floor/wood,
 /area/station/service/hydroponics/garden/abandoned)
 "vzs" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/east,
+/obj/effect/turf_decal/bot,
+/obj/structure/cargo_shelf/meteor_shield,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "vzx" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -6756,6 +6756,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/structure/cargo_shelf,
 /turf/open/floor/iron,
 /area/station/engineering/storage)
 "cjW" = (
@@ -19682,7 +19683,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/sign/warning/no_smoking/directional/north,
 /turf/open/floor/iron/textured,
 /area/station/engineering/main)
 "gBL" = (
@@ -32513,12 +32513,8 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/structure/rack,
-/obj/item/flashlight,
-/obj/item/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cargo_shelf/meteor_shield/single,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "kOW" = (
@@ -48505,6 +48501,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
+"qeQ" = (
+/obj/structure/sign/warning/no_smoking/directional/north,
+/obj/effect/turf_decal/bot,
+/obj/structure/cargo_shelf/meteor_shield,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "qeZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -99733,7 +99735,7 @@ lfT
 xba
 afJ
 xba
-blv
+qeQ
 gBF
 ahn
 blv

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -59308,15 +59308,14 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "odw" = (
-/obj/item/stack/package_wrap,
-/obj/item/hand_labeler,
-/obj/structure/table/reinforced,
 /obj/machinery/camera/directional/north{
 	c_tag = "Bridge - E.V.A. Fore";
 	name = "command camera"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/newscaster/directional/east,
+/obj/effect/turf_decal/bot,
+/obj/structure/cargo_shelf/meteor_shield/single,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "odI" = (
@@ -65852,7 +65851,8 @@
 	supplies_requestable = 1
 	},
 /obj/structure/sign/poster/official/do_not_question/directional/east,
-/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/box,
+/obj/structure/cargo_shelf/meteor_shield,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "pJo" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4087,6 +4087,7 @@
 	pixel_y = -3
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "bsZ" = (
@@ -28538,7 +28539,7 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/structure/closet/crate/solarpanel_small,
+/obj/structure/cargo_shelf/meteor_shield,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "kcg" = (
@@ -36389,6 +36390,14 @@
 	dir = 1
 	},
 /area/station/security/prison)
+"mQH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/window/spawner/directional/north,
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "mRg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -49244,20 +49253,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
-"rtd" = (
-/obj/machinery/camera/motion/directional/east{
-	c_tag = "E.V.A. Storage"
-	},
-/obj/machinery/requests_console/directional/east{
-	department = "EVA";
-	name = "EVA Requests Console"
-	},
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/ai_monitored/command/storage/eva)
 "rtj" = (
 /obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
@@ -53190,6 +53185,19 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
+"sIU" = (
+/obj/machinery/light/directional/east,
+/obj/machinery/requests_console/directional/east{
+	department = "EVA";
+	name = "EVA Requests Console"
+	},
+/obj/machinery/camera/motion/directional/east{
+	c_tag = "E.V.A. Storage"
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cargo_shelf/meteor_shield/single,
+/turf/open/floor/iron,
+/area/station/ai_monitored/command/storage/eva)
 "sIX" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible/layer2{
 	dir = 9
@@ -67155,6 +67163,7 @@
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/window/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "xFx" = (
@@ -92420,7 +92429,7 @@ qjf
 mXf
 wjQ
 uuv
-wjQ
+mQH
 dLC
 rGm
 gqX
@@ -92932,7 +92941,7 @@ pIm
 uac
 aUK
 aUK
-rtd
+isn
 isn
 uEx
 xBF
@@ -93189,7 +93198,7 @@ tOh
 euj
 rnX
 bsW
-yfL
+sIU
 xFs
 dYb
 gqA

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -11474,6 +11474,7 @@
 	pixel_y = -1
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/item/storage/box/smart_metal_foam,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "dwz" = (
@@ -22562,15 +22563,13 @@
 /turf/open/floor/iron/dark/small,
 /area/station/science/genetics)
 "gLW" = (
-/obj/structure/table,
 /obj/effect/turf_decal/bot_white,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/item/storage/box/smart_metal_foam,
-/obj/item/wrench,
-/obj/item/crowbar,
 /obj/machinery/light/cold/directional/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/box,
+/obj/structure/cargo_shelf/meteor_shield,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
 "gMh" = (
@@ -41047,6 +41046,13 @@
 /obj/structure/sign/warning/yes_smoking/circle/directional/north,
 /turf/open/floor/iron/vaporwave,
 /area/station/maintenance/department/security/upper)
+"mbo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cargo_shelf/meteor_shield,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "mbp" = (
 /obj/structure/chair/comfy{
 	color = "#596479";
@@ -113967,7 +113973,7 @@ qkl
 nCx
 iLD
 tXY
-bzI
+mbo
 vLV
 aFk
 kyJ

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -16,10 +16,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "aau" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
+/obj/effect/turf_decal/bot,
+/obj/structure/cargo_shelf/meteor_shield,
 /turf/open/floor/iron/textured,
 /area/station/engineering/storage_shared)
 "aaA" = (
@@ -15822,7 +15823,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/white/end,
+/obj/effect/turf_decal/bot,
+/obj/structure/cargo_shelf/meteor_shield/single,
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/ai_monitored/command/storage/eva)
 "eCy" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -47559,6 +47559,10 @@
 	pixel_y = -32
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/cargo_shelf/meteor_shield,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/main)
 "odV" = (
@@ -63956,6 +63960,13 @@
 	},
 /turf/open/floor/noslip/tram_plate,
 /area/station/hallway/primary/tram/right)
+"toW" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/cargo_shelf/meteor_shield,
+/turf/open/floor/iron/dark,
+/area/station/command/teleporter)
 "toY" = (
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
@@ -160488,7 +160499,7 @@ uNB
 dfW
 fga
 nTm
-jfn
+toW
 jns
 htx
 pvm

--- a/monkestation/code/game/objects/structures/crates_lockers/crates.dm
+++ b/monkestation/code/game/objects/structures/crates_lockers/crates.dm
@@ -12,3 +12,13 @@
 	open_sound_volume = 25
 	close_sound_volume = 50
 	can_install_electronics = FALSE
+
+/obj/structure/closet/crate/engineering/meteor_shields
+	name = "Hard-Kill Meteor Protection Satellites"
+	desc = "Contains a 5 pack of HK-MPS capsules, which can be deployed into a full meteor defense satellite."
+	var/spawn_amt = 5
+
+/obj/structure/closet/crate/engineering/meteor_shields/PopulateContents()
+	. = ..()
+	for(var/i in 1 to spawn_amt)
+		new /obj/item/meteor_shield_capsule(src)

--- a/monkestation/code/modules/shelves/presets.dm
+++ b/monkestation/code/modules/shelves/presets.dm
@@ -1,0 +1,5 @@
+/obj/structure/cargo_shelf/meteor_shield
+	preload_crates = list(/obj/structure/closet/crate/engineering/meteor_shields = 2)
+
+/obj/structure/cargo_shelf/meteor_shield/single
+	preload_crates = list(/obj/structure/closet/crate/engineering/meteor_shields = 1)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7423,6 +7423,7 @@
 #include "monkestation\code\modules\security\code\holographic_handcuffs.dm"
 #include "monkestation\code\modules\security\code\weapons\lawbringer.dm"
 #include "monkestation\code\modules\security\code\weapons\paco.dm"
+#include "monkestation\code\modules\shelves\presets.dm"
 #include "monkestation\code\modules\shelves\shelf.dm"
 #include "monkestation\code\modules\skyrat_snipes\languages.dm"
 #include "monkestation\code\modules\skyrat_snipes\reagents\drink_reagents.dm"


### PR DESCRIPTION
## About The Pull Request

This adds 2 cargo shelves with crates of meteor sats to each map - one shelf in EVA, one in engineering.

Engi shelf has 2 crates, while the EVA shelf has 1 on single-Z maps, and 2 on multi-Z maps.

Also, this makes it so you can load crates into a cargo shelf by left clicking while pulling a crate, or unload the topmost crate with right click. Plus, allows pre-loading mapped in crates into cargo shelves.

![2024-08-22 (1724373230) ~ dreamseeker](https://github.com/user-attachments/assets/2760a2e0-5c07-4ce9-a1cc-210e62ba777b)

## Why It's Good For The Game

It's good for the station and players if engis actually setup meteor sats - with some roundstart meteor sats, they can do some immediately, which will be helpful against early-round space debris. Plus, it frees the departmental order console for other stuff initially.

Also, cargo shelves being more intuitive to use is always nice.

## Changelog
:cl:
add: Adds two cargo shelves with meteor sat crates to each map - one in EVA, one in engineering.
qol: You can now load crates into a cargo shelf by left clicking while pulling a crate.
qol: You can now unload the topmost crate in a cargo shelf by right clicking.
/:cl:
