### PR TITLE
Makes the janitorial cart able to hold 250 units of water

### DIFF
--- a/code/game/objects/structures/janitor.dm
+++ b/code/game/objects/structures/janitor.dm
@@ -80,7 +80,7 @@
 
 /obj/structure/mop_bucket/janitorialcart/Initialize(mapload)
 	. = ..()
-	reagents.maximum_volume *= 2.5
+	reagents.maximum_volume *= 2.5 //monkestation edit
 	GLOB.janitor_devices += src
 
 /obj/structure/mop_bucket/janitorialcart/Destroy()

--- a/code/game/objects/structures/janitor.dm
+++ b/code/game/objects/structures/janitor.dm
@@ -80,6 +80,7 @@
 
 /obj/structure/mop_bucket/janitorialcart/Initialize(mapload)
 	. = ..()
+	reagents.maximum_volume *= 2.5
 	GLOB.janitor_devices += src
 
 /obj/structure/mop_bucket/janitorialcart/Destroy()


### PR DESCRIPTION

## About The Pull Request
Increases the janitorial cart's liquid limit from 100 units to 250 units.

## Why It's Good For The Game
As it stands the janitorial cart holds 100 units of water, which is only 30 more than a bucket. I feel like it should hold substantially more to help with cleaning and because the janitorial cart's mop bucket is so large it feels like it'd make sense to hold more water.

This was originally a PR on TGstation: https://github.com/tgstation/tgstation/pull/83829

I thought it also made sense to have it here.

## Changelog
:cl:
qol: make the cart hold 2.5x more water
/:cl:
