### PR TITLE
Clicking floor tiles now also closes curator/morgue doors

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -528,6 +528,10 @@
 /obj/machinery/door/morgue
 	icon = 'icons/obj/doors/doormorgue.dmi'
 
+/obj/machinery/door/morgue/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/redirect_attack_hand_from_turf)
+
 /obj/machinery/door/get_dumping_location()
 	return null
 


### PR DESCRIPTION
## About The Pull Request

Port of my own upstream PR, https://github.com/tgstation/tgstation/pull/85994

This makes it so the "morgue doors" (more often seen on the curator's study or chaplain confession booth, tbh) also have `/datum/component/redirect_attack_hand_from_turf`.

## Why It's Good For The Game

Consistency, and just nice to have.

## Changelog
:cl:
qol: Clicking floor tiles now also closes curator/morgue doors, like with normal airlocks.
/:cl:
