### PR TITLE
Unarmed attacks with carp jaws now uses the bite attack effect

### DIFF
--- a/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/carp_organs.dm
@@ -61,6 +61,7 @@
 	head.unarmed_damage_low = 10
 	head.unarmed_damage_high = 15
 	head.unarmed_stun_threshold = 15
+	head.unarmed_attack_effect = ATTACK_EFFECT_BITE
 
 /obj/item/organ/internal/tongue/carp/on_remove(mob/living/carbon/tongue_owner)
 	. = ..()
@@ -75,6 +76,7 @@
 	head.unarmed_damage_low = initial(head.unarmed_damage_low)
 	head.unarmed_damage_high = initial(head.unarmed_damage_high)
 	head.unarmed_stun_threshold = initial(head.unarmed_stun_threshold)
+	head.unarmed_attack_effect = initial(head.unarmed_attack_effect)
 
 /obj/item/organ/internal/tongue/carp/on_life(seconds_per_tick, times_fired)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Port of my own upstream PR, https://github.com/tgstation/tgstation/pull/85959

The carp organ set gives your head 10-15 unarmed damage, alongside making you attack with your head... Which is, well, you're biting them with your carp jaws. So, let's make it actually use the bite effect.

## Why It's Good For The Game

Makes more sense - if you're biting using carp jaws, then the effect should be a bite.

## Changelog
:cl:
qol: Unarmed attacks with carp jaws now uses a bite effect rather than a punch effect.
/:cl:
