### PR TITLE
Fixes players being unable to switch back to the default title for Brig Physician after selecting an alternate title

### DIFF
--- a/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
+++ b/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
@@ -70,6 +70,7 @@
 
 /datum/job/brig_physician
 	alt_titles = list(
+		"Brig Physician",
 		"Jail Doctor",
 		"Brig Orderly",
 		"Prison Medic",


### PR DESCRIPTION
## About The Pull Request

Adds "Brig Physician" as a selectable title for Brig Physician.

## Why It's Good For The Game

Fixes players being unable to change the title for Brig Physician back to the default one after selecting a different title.

## Changelog


:cl:
fix: Fixes players being unable to switch back to the default title for Brig Physician after selecting an alternate title.
/:cl: