### PR TITLE
Replaces the drone dispensers on blueshift and ouroboros with pre-loaded ones

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -69519,7 +69519,7 @@
 /area/station/engineering/atmos)
 "nBp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/drone_dispenser,
+/obj/machinery/drone_dispenser/preloaded,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -24082,7 +24082,7 @@
 /turf/open/floor/iron,
 /area/station/security/prison)
 "hjz" = (
-/obj/machinery/drone_dispenser,
+/obj/machinery/drone_dispenser/preloaded,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "hjJ" = (


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
Map consistency.
## Changelog
:cl:
add: Replaced the drone dispensers on blueshift and ouroboros with pre-loaded variants
/:cl:
