### PR TITLE
Make the storyteller matter even after the 85minute mark

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -93,7 +93,7 @@
 	if(roundstart && ((SSticker.round_start_time && world.time - SSticker.round_start_time >= 2 MINUTES) || (SSgamemode.ran_roundstart && !fake_check)))
 		return FALSE
 	if(istype(src, /datum/round_event_control/antagonist/solo/from_ghosts) && (SSautotransfer.starttime + 85 MINUTES <= world.time))
-		return TRUE // we allow all ghost roles to run at this point and dont care about other checks
+		return FALSE // we allow all ghost roles to run at this point and dont care about other checks
 //monkestation edit end
 	if(occurrences >= max_occurrences)
 		return FALSE


### PR DESCRIPTION
## About The Pull Request

There was a variable set to true that removed all checks for antag to spawn after the 85 minute, I've set it to false

## Why It's Good For The Game

Actually make long rounds not go into the shitter instantly by the gazillion antag and actually make the storyteller matter

## Changelog

set a variable to false in  _event_.dm to actually let the storyteller still matter even after the 85 minute mark

:cl:

code: _event_.dm got a variable set to false instead of true, stopping the gazillion antag roll after the 85 minute mark.

/:cl: