### PR TITLE
Tide viruses now properly exclude external airlocks

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1392,7 +1392,7 @@
 	return ..()
 
 /obj/machinery/door/airlock/proc/prison_open()
-	if(obj_flags & EMAGGED)
+	if((obj_flags & EMAGGED) || is_probably_external_airlock()) // monkestation edit: STOP SPACING ENGI
 		return
 	locked = FALSE
 	open()

--- a/monkestation/code/modules/antagonists/traitor/objectives/tide_bug_department.dm
+++ b/monkestation/code/modules/antagonists/traitor/objectives/tide_bug_department.dm
@@ -169,7 +169,7 @@
 /// any tiles that have likely unsafe atmospheric conditions.
 /obj/machinery/door/airlock/proc/is_probably_external_airlock()
 	. = FALSE
-	if(leads_to_space() || closeOther?.leads_to_space())
+	if(leads_to_space() || closeOther?.leads_to_space() || cyclelinkedairlock?.leads_to_space())
 		return TRUE
 	for(var/obj/machinery/door/airlock/other_door in close_others)
 		if(other_door.leads_to_space())


### PR DESCRIPTION

## About The Pull Request

The logic in https://github.com/Monkestation/Monkestation2.0/pull/2953 was kinda flawed, and would sometimes still space shit - and non-traitor (random event) greytides would still space, which is even more annoying.

## Changelog
:cl:
fix: Tide viruses now properly exclude external airlocks.
/:cl:
