### PR TITLE
Fish Protection Program: the Blueshift aquarium is now reinforced

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -7474,7 +7474,7 @@
 "bwW" = (
 /obj/structure/flora/bush/jungle/b/style_2,
 /obj/structure/flora/bush/flowers_pp,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "bwY" = (
@@ -19625,7 +19625,7 @@
 "dKI" = (
 /obj/structure/flora/bush/jungle/b/style_2,
 /obj/structure/flora/bush/flowers_pp/style_3,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "dKK" = (
@@ -34127,7 +34127,7 @@
 "gBx" = (
 /obj/structure/flora/bush/jungle,
 /obj/structure/flora/bush/flowers_yw/style_3,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "gBz" = (
@@ -38475,7 +38475,7 @@
 "hwe" = (
 /obj/structure/flora/bush/jungle/a/style_2,
 /obj/structure/flora/bush/flowers_yw/style_2,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "hwi" = (
@@ -45125,7 +45125,7 @@
 "iMf" = (
 /obj/structure/flora/bush/jungle/c/style_3,
 /obj/structure/flora/bush/flowers_br,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "iMj" = (
@@ -45984,7 +45984,7 @@
 "iWF" = (
 /obj/structure/flora/bush/jungle/c/style_3,
 /obj/structure/flora/bush/flowers_yw/style_3,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "iWJ" = (
@@ -49924,7 +49924,7 @@
 "jJh" = (
 /obj/structure/flora/bush/jungle/c/style_3,
 /obj/structure/flora/bush/flowers_pp/style_3,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "jJi" = (
@@ -53172,7 +53172,7 @@
 "knr" = (
 /obj/structure/flora/bush/jungle/a,
 /obj/structure/flora/bush/flowers_br/style_3,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "knt" = (
@@ -55037,7 +55037,7 @@
 "kER" = (
 /obj/structure/flora/bush/jungle/a/style_3,
 /obj/structure/flora/bush/flowers_br/style_2,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "kFd" = (
@@ -64372,6 +64372,9 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
+"mzu" = (
+/turf/closed/wall/r_wall,
+/area/station/hallway/primary/upper)
 "mzv" = (
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
@@ -66564,7 +66567,7 @@
 "mVh" = (
 /obj/structure/flora/bush/jungle/b,
 /obj/structure/flora/bush/flowers_yw,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "mVi" = (
@@ -78122,7 +78125,7 @@
 "pit" = (
 /obj/structure/flora/bush/jungle/c,
 /obj/structure/flora/bush/flowers_pp/style_2,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "piw" = (
@@ -85343,7 +85346,7 @@
 "qDe" = (
 /obj/structure/flora/bush/jungle/a/style_2,
 /obj/structure/flora/bush/flowers_yw/style_3,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "qDf" = (
@@ -93411,7 +93414,7 @@
 "sgt" = (
 /obj/structure/flora/bush/jungle/b,
 /obj/structure/flora/bush/flowers_br,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "sgv" = (
@@ -104398,6 +104401,16 @@
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/carpet,
 /area/station/service/library/lounge)
+"ukH" = (
+/obj/structure/sign/directions/command{
+	dir = 1;
+	pixel_y = 3
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = -3
+	},
+/turf/closed/wall/r_wall,
+/area/station/hallway/primary/upper)
 "ukI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -114329,7 +114342,7 @@
 "wdN" = (
 /obj/structure/flora/bush/jungle/b/style_2,
 /obj/structure/flora/bush/flowers_br/style_3,
-/obj/structure/window/fulltile,
+/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
 /area/station/hallway/primary/upper)
 "wdS" = (
@@ -221844,11 +221857,11 @@ pQF
 tYT
 tYT
 tYT
-pKz
+mzu
 mVh
 iMf
 gBx
-pQF
+ukH
 qJk
 qJk
 lcX
@@ -222105,7 +222118,7 @@ bwW
 wfr
 cMo
 tiA
-pKz
+mzu
 coT
 gST
 lcX
@@ -223133,7 +223146,7 @@ pit
 mMJ
 xtV
 eUH
-pKz
+mzu
 ugc
 uol
 lcX
@@ -223386,11 +223399,11 @@ pQF
 akt
 akt
 akt
-pKz
+mzu
 iWF
 knr
 dKI
-pQF
+ukH
 wiK
 wiK
 lcX


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![image](https://github.com/user-attachments/assets/0e40c27b-2c93-4f8d-95f8-655ca7c168eb)

This changes the Blueshift aquarium to use reinforced walls and windows.

## Why It's Good For The Game

If you want to flood the station, you should have to put a bit of effort into it!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: As part of an agreement with the Church of Carp'Sie, the windows and walls for the aquarium on Blueshift-model stations has been reinforced.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
