### PR TITLE
Certain jobs now have boosted immune systems

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -512,6 +512,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 	return
 
 /mob/living/carbon/has_dna()
+	RETURN_TYPE(/datum/dna)
 	return dna
 
 /// Returns TRUE if the mob is allowed to mutate via its DNA, or FALSE if otherwise.

--- a/monkestation/code/modules/virology/immune_systems/_immune_system.dm
+++ b/monkestation/code/modules/virology/immune_systems/_immune_system.dm
@@ -1,6 +1,7 @@
 /datum/immune_system
 	var/mob/living/carbon/host = null
 	var/strength = 1
+	var/boost = 1
 	var/overloaded = FALSE
 	var/list/antibodies = list(
 		ANTIGEN_O	= 0,
@@ -18,45 +19,64 @@
 		ANTIGEN_Z	= 0,
 		)
 
-/datum/immune_system/Destroy(force, ...)
-	. = ..()
+/datum/immune_system/Destroy()
 	host = null
 	antibodies = null
+	return ..()
 
-/datum/immune_system/New(mob/living/carbon/source)
+/datum/immune_system/New(mob/living/carbon/host, boost = 1)
 	..()
-	if (!source)
-		del(src)
+	if(QDELETED(host))
+		stack_trace("Attempted to initialize immune system on invalid entity!")
+		qdel(src)
 		return
-	host = source
-
-	for (var/antibody in antibodies)
-		if (antibody in GLOB.rare_antigens)
-			antibodies[antibody] = rand(1,15)
+	src.host = host
+	src.boost = boost
+	for(var/antibody in antibodies)
+		if(antibody in GLOB.rare_antigens)
+			antibodies[antibody] = rand(1, 15) * boost
 			if (prob(5))
-				antibodies[antibody] += 10
-		if (antibody in GLOB.common_antigens)
-			antibodies[antibody] = rand(10,30)
-		if (antibody in GLOB.blood_antigens)
-			antibodies[antibody] = rand(10,20)
-			if(!ismouse(host))
-				if (host.dna && host.dna.blood_type)
-					if (antibody == ANTIGEN_O)
-						antibodies[antibody] += rand(12,15)
-					if (antibody == ANTIGEN_A && findtext(host.dna.blood_type,"A"))
-						antibodies[antibody] += rand(12,15)
-					if (antibody == ANTIGEN_B && findtext(host.dna.blood_type,"B"))
-						antibodies[antibody] += rand(12,15)
-					if (antibody == ANTIGEN_RH && findtext(host.dna.blood_type,"+"))
-						antibodies[antibody] += rand(12,15)
+				antibodies[antibody] += 10 * boost
+		if(antibody in GLOB.common_antigens)
+			antibodies[antibody] = rand(10, 30) * boost
+		if(antibody in GLOB.blood_antigens)
+			antibodies[antibody] = rand(10, 20) * boost
+			var/blood_type = host.has_dna()?.blood_type
+			if(blood_type)
+				switch(antibody)
+					if(ANTIGEN_O)
+						antibodies[antibody] += rand(12, 15) * boost
+					if(ANTIGEN_A)
+						if(findtext(blood_type, "A"))
+							antibodies[antibody] += rand(12, 15) * boost
+					if(ANTIGEN_B)
+						if(findtext(blood_type, "B"))
+							antibodies[antibody] += rand(12, 15) * boost
+					if(ANTIGEN_RH)
+						if(findtext(blood_type, "+"))
+							antibodies[antibody] += rand(12, 15) * boost
+		if(boost > 1)
+			antibodies[antibody] = min(antibodies[antibody], boost)
 
 /datum/immune_system/proc/transfer_to(mob/living/carbon/source)
-	if (!source.immune_system)
+	if(QDELETED(source))
+		CRASH("Attempted to transfer immune system to non-existant mob")
+	if(QDELETED(source.immune_system))
 		source.immune_system = new(source)
 
 	source.immune_system.strength = strength
+	source.immune_system.boost = boost
 	source.immune_system.overloaded = overloaded
 	source.immune_system.antibodies = antibodies.Copy()
+
+/datum/immune_system/proc/change_boost(new_boost = 1)
+	var/old_boost = boost
+	if(new_boost == old_boost)
+		return
+	for(var/antibody in antibodies)
+		antibodies[antibody] /= old_boost
+		antibodies[antibody] *= new_boost
+	boost = new_boost
 
 /datum/immune_system/proc/GetImmunity()
 	return list(strength, antibodies.Copy())
@@ -90,11 +110,11 @@
 	return TRUE
 
 /datum/immune_system/proc/ApplyAntipathogenics(threshold)
-	if (overloaded)
+	if(overloaded)
 		return
 
-	for (var/datum/disease/advanced/disease as anything in host.diseases)
-		for (var/A in disease.antigen)
+	for(var/datum/disease/advanced/disease as anything in host.diseases)
+		for(var/A in disease.antigen)
 			var/tally = 0.5
 			if (isturf(host.loc) && (host.body_position == LYING_DOWN))
 				tally += 0.5
@@ -108,6 +128,8 @@
 						tally += 2//if we're sleeping in a bed, we get up to 4
 			else if(istype(host.loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
 				tally += 2.5
+
+			tally *= boost
 
 			if (antibodies[A] < threshold)
 				antibodies[A] = min(antibodies[A] + tally, threshold)//no overshooting here
@@ -144,6 +166,8 @@
 						tally = max(tally - 1.5, 0.5)
 					else
 						EMPTY_BLOCK_GUARD
+
+			tally *= boost
 
 			if (antibodies[A] < 69)
 				antibodies[A] = min(antibodies[A] + tally * strength, 70)

--- a/monkestation/code/modules/virology/immune_systems/job_boosting.dm
+++ b/monkestation/code/modules/virology/immune_systems/job_boosting.dm
@@ -1,0 +1,26 @@
+/datum/job
+	/// If set, players spawning with this job will start with a boosted immune system.
+	var/boost_immune_system
+
+/datum/job/after_spawn(mob/living/spawned, client/player_client)
+	. = ..()
+	if(!isnull(boost_immune_system))
+		if(QDELETED(spawned.immune_system))
+			spawned.immune_system = new(spawned, boost_immune_system)
+		else
+			spawned.immune_system.change_boost(boost_immune_system)
+
+/datum/job/chief_medical_officer
+	boost_immune_system = 1.7
+
+/datum/job/doctor
+	boost_immune_system = 1.4
+
+/datum/job/paramedic
+	boost_immune_system = 1.4
+
+/datum/job/virologist
+	boost_immune_system = 1.8
+
+/datum/job/janitor
+	boost_immune_system = 2

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7760,6 +7760,7 @@
 #include "monkestation\code\modules\virology\effects\cleanables.dm"
 #include "monkestation\code\modules\virology\effects\pathogen_cloud.dm"
 #include "monkestation\code\modules\virology\immune_systems\_immune_system.dm"
+#include "monkestation\code\modules\virology\immune_systems\job_boosting.dm"
 #include "monkestation\code\modules\virology\items\_base_item_additions.dm"
 #include "monkestation\code\modules\virology\items\antibodyscanner.dm"
 #include "monkestation\code\modules\virology\items\bio_hazard_deployable.dm"


### PR DESCRIPTION

## About The Pull Request

This makes it so an immune system can a permanent "boost" multiplier applied to it - all antigen increases are multiplied by the boost.

Several jobs now start with boosted immune systems:
- **CMO**: 1.7x
- **Medical Doctor, Paramedic**: 1.4x
- **Virologist**: 1.8x
- **Janitor**: 2x

## Why It's Good For The Game

Makes sense that people who work with sick people and/or clean up possibly disease-infested messes would have a beefier immune system compared to your average tider.

## Changelog
:cl:
add: Certain jobs, mostly most medical and the janitor, now have naturally stronger immune systems.
/:cl:
