### PR TITLE
Ethereal disco balls now use overlay lighting

### DIFF
--- a/code/game/objects/items/etherealdiscoball.dm
+++ b/code/game/objects/items/etherealdiscoball.dm
@@ -17,6 +17,7 @@
 	icon_state = "ethdisco_head_0"
 	anchored = TRUE
 	density = TRUE
+	light_system = OVERLAY_LIGHT // monkestation edit: use overlay lighting
 	var/TurnedOn = FALSE
 	var/current_color
 	var/TimerID
@@ -47,7 +48,7 @@
 
 /obj/structure/etherealball/proc/TurnOff()
 	TurnedOn = FALSE
-	set_light(0)
+	set_light(0, update = FALSE) // monkestation edit: use overlay lighting
 	remove_atom_colour(TEMPORARY_COLOUR_PRIORITY)
 	update_appearance()
 	if(TimerID)
@@ -56,7 +57,7 @@
 /obj/structure/etherealball/proc/DiscoFever()
 	remove_atom_colour(TEMPORARY_COLOUR_PRIORITY)
 	current_color = "#[random_color()]"
-	set_light(l_outer_range = range, l_power = power, l_color = current_color)
+	set_light(l_outer_range = range, l_power = power, l_color = current_color, update = FALSE) // monkestation edit: use overlay lighting
 	add_atom_colour(current_color, FIXED_COLOUR_PRIORITY)
 	update_appearance()
 	TimerID = addtimer(CALLBACK(src, PROC_REF(DiscoFever)), 5, TIMER_STOPPABLE)  //Call ourselves every 0.5 seconds to change colors


### PR DESCRIPTION

## About The Pull Request

This makes ethereal disco balls use overlay lighting - which is FAR less laggy and intensive on the server.

## Why It's Good For The Game

less lag, yay!

## Changelog
:cl:
fix: Etheral disco balls now lag the server much less
/:cl:
