### PR TITLE
Ghost messages are no longer bolded for speakers on another z-level

### DIFF
--- a/code/__HELPERS/view.dm
+++ b/code/__HELPERS/view.dm
@@ -20,8 +20,16 @@
 	view_info[2] *= world.icon_size
 	return view_info
 
-/proc/in_view_range(mob/user, atom/A)
-	var/list/view_range = getviewsize(user.client.view)
+// monkestation edit: make this proc actually work as seemingly intended
+/proc/in_view_range(mob/user, atom/A, require_same_z = FALSE)
+	var/list/view_range = getviewsize(user.client?.view || world.view)
 	var/turf/source = get_turf(user)
 	var/turf/target = get_turf(A)
-	return ISINRANGE(target.x, source.x - view_range[1], source.x + view_range[1]) && ISINRANGE(target.y, source.y - view_range[1], source.y + view_range[1])
+	if(QDELETED(source) || QDELETED(target))
+		return FALSE
+	var/x_range = ceil(view_range[1] * 0.5)
+	var/y_range = ceil(view_range[2] * 0.5)
+	if(require_same_z && source.z != target.z)
+		return FALSE
+	return ISINRANGE(target.x, source.x - x_range, source.x + x_range) && ISINRANGE(target.y, source.y - y_range, source.y + y_range)
+// monkestation end

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -64,7 +64,7 @@
 		create_chat_message(speaker, message_language, raw_message, spans)
 	// monkestation start: bold messages for ghosts when they're nearby
 	var/list/our_spans = spans
-	if((client?.prefs.chat_toggles & CHAT_GHOSTEARS) && in_view_range(src, to_follow))
+	if((client?.prefs.chat_toggles & CHAT_GHOSTEARS) && in_view_range(src, to_follow, TRUE))
 		our_spans = spans.Copy()
 		our_spans |= SPAN_BOLD
 	// monkestation end


### PR DESCRIPTION
## About The Pull Request

`in_view_range` doesn't check z level lol, only x and y

also it wasn't working as intended anyways - view size is edge-to-edge, so it was actually considering the view range *doubled* in calculations

## Changelog
:cl:
fix: Ghost messages are no longer bolded for speakers on another z-level.
/:cl:
