### PR TITLE
You can now properly deconstruct railings

### DIFF
--- a/code/game/objects/structures/railings.dm
+++ b/code/game/objects/structures/railings.dm
@@ -76,12 +76,14 @@
 /obj/structure/railing/AltClick(mob/user)
 	return ..() // This hotkey is BLACKLISTED since it's used by /datum/component/simple_rotation
 
+/* monkestation edit: replaced in [monkestation\code\modules\blueshift\structures\wooden_fence.dm]
 /obj/structure/railing/wirecutter_act(mob/living/user, obj/item/I)
 	. = ..()
 	to_chat(user, span_warning("You cut apart the railing."))
 	I.play_tool_sound(src, 100)
 	deconstruct()
 	return TRUE
+monkestation end */
 
 /obj/structure/railing/deconstruct(disassembled)
 	if((flags_1 & NODECONSTRUCT_1))

--- a/monkestation/code/modules/blueshift/structures/wooden_fence.dm
+++ b/monkestation/code/modules/blueshift/structures/wooden_fence.dm
@@ -23,9 +23,16 @@
 	)
 	update_appearance()
 
-// previously NO_DECONSTRUCTION
-/obj/structure/railing/wirecutter_act(mob/living/user, obj/item/I)
-	return NONE
+/obj/structure/railing/wirecutter_act(mob/living/user, obj/item/tool)
+	. = ..()
+	if(flags_1 & NODECONSTRUCT_1)
+		return NONE
+	var/deconstruct_time = anchored ? (1.5 SECONDS) : (0.5 SECONDS)
+	if(do_after(user, deconstruct_time, src))
+		user.visible_message(span_info("[user] cuts apart \the [src]."), span_warning("You cut apart \the [src]."))
+		tool.play_tool_sound(src, 50)
+		deconstruct()
+		return TRUE
 
 // Fence gates for the above mentioned fences
 


### PR DESCRIPTION

## About The Pull Request

Kinda silly that you can build them, but you have to whack them repeatedly to get rid of them.

## Changelog
:cl:
fix: Railings can now actually be deconstructed.
/:cl:
