### PR TITLE
Cosmic Fields now block projectiles shot by someone with a star mark

### DIFF
--- a/monkestation/code/game/objects/effects/forcefields.dm
+++ b/monkestation/code/game/objects/effects/forcefields.dm
@@ -1,0 +1,8 @@
+/obj/effect/forcefield/cosmic_field/CanAllowThrough(atom/movable/mover, border_dir)
+	if(isprojectile(mover))
+		var/obj/projectile/projectile = mover
+		if(isliving(projectile.firer))
+			var/mob/living/living_firer = projectile.firer
+			if(living_firer.has_status_effect(/datum/status_effect/star_mark))
+				return FALSE
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5856,6 +5856,7 @@
 #include "monkestation\code\game\machinery\trains\train_network.dm"
 #include "monkestation\code\game\objects\items.dm"
 #include "monkestation\code\game\objects\effects\countdown.dm"
+#include "monkestation\code\game\objects\effects\forcefields.dm"
 #include "monkestation\code\game\objects\effects\glowshroom.dm"
 #include "monkestation\code\game\objects\effects\landmark.dm"
 #include "monkestation\code\game\objects\effects\sprint_dust.dm"


### PR DESCRIPTION

## About The Pull Request

This makes it so projectiles can't go through cosmic fields, if they were shot by someone with a star mark.

## Why It's Good For The Game

Cosmic path is kinda based around area denial/control, but it's kinda useless when you just get magdumped anyways.

## Changelog
:cl:
balance: Cosmic Fields now block projectiles, if they were shot by someone with a star mark.
/:cl:
