### PR TITLE
Russian Hunter Fix

### DIFF
--- a/code/modules/antagonists/fugitive/hunters/hunter_outfits.dm
+++ b/code/modules/antagonists/fugitive/hunters/hunter_outfits.dm
@@ -71,6 +71,7 @@
 		var/obj/item/card/id/equipped_card = equip_to.wear_id
 		equipped_card.assignment = "Russian Bounty Hunter"
 		equipped_card.registered_name = equip_to.real_name
+		equipped_card.access = list(ACCESS_BOUNTY_HUNTER)
 		equipped_card.update_label()
 		equipped_card.update_icon()
 


### PR DESCRIPTION

## About The Pull Request

Because of how fucking stupid Russian Bounty Hunters have their ID cards built when spawned, we have to forcibly add the BOUNTY HUNTER access list to their IDs cards during post equip! It's fucking stupid!

## Why It's Good For The Game

Hunters won't be locked down.

## Changelog
:cl:
fix: fixes the cyka blyat id cards.
/:cl:
