### PR TITLE
Admin Modsuit No Rads

### DIFF
--- a/code/modules/mod/mod_types.dm
+++ b/code/modules/mod/mod_types.dm
@@ -508,6 +508,7 @@
 		/obj/item/mod/module/magboot/advanced,
 		/obj/item/mod/module/jetpack/advanced,
 		/obj/item/mod/module/anomaly_locked/kinesis/plus,
+		/obj/item/mod/module/rad_protection, // monkestation edit
 	)
 	default_pins = list(
 		/obj/item/mod/module/stealth/ninja,


### PR DESCRIPTION

## About The Pull Request

For the times we are doing projects and people are COOKIN'.
## Why It's Good For The Game

The admin modsuit should've been immune to radiation from the start. This fixes that problem.
## Changelog
:cl:
qol: admin mods now have anti rad built it. it's shrimple.
/:cl:
