### PR TITLE
Changes heart diseases badness level to deadly

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/restricted/stage4.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/restricted/stage4.dm
@@ -4,6 +4,7 @@
 	restricted = TRUE
 	max_multiplier = 5
 	var/sound = FALSE
+	badness = EFFECT_DANGER_DEADLY
 
 /datum/symptom/heart_failure/activate(mob/living/carbon/affected_mob)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
This is showing up as good on medihuds, even though it's not. This should fix that.
## Changelog
:cl:
fix: Heart disease (contracted from the heart attack random event) now has the correct badness level
/:cl:
