### PR TITLE
Adds Grant All and Remove All buttons to ID consoles and agent IDs

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1532,31 +1532,37 @@
 
 	switch(action)
 		if("mod_access")
-			var/access_type = params["access_target"]
-			var/try_wildcard = params["access_wildcard"]
-			if(access_type in access)
-				remove_access(list(access_type))
-				LOG_ID_ACCESS_CHANGE(usr, src, "removed [SSid_access.get_access_desc(access_type)]")
+			// monkestation start: allow multiple access edits at once
+			var/list/id_actions = params["actions"]
+			if(!islist(id_actions) || !length(id_actions))
 				return TRUE
+			for(var/list/id_action in id_actions)
+				var/access_type = id_action["access_target"]
+				var/try_wildcard = id_action["access_wildcard"]
+				if(access_type in access)
+					remove_access(list(access_type))
+					LOG_ID_ACCESS_CHANGE(usr, src, "removed [SSid_access.get_access_desc(access_type)]")
+					continue
 
-			if(!(access_type in target_card.access))
-				to_chat(usr, span_notice("ID error: ID card rejected your attempted access modification."))
-				LOG_ID_ACCESS_CHANGE(usr, src, "failed to add [SSid_access.get_access_desc(access_type)][try_wildcard ? " with wildcard [try_wildcard]" : ""]")
-				return TRUE
+				if(!(access_type in target_card.access))
+					to_chat(usr, span_notice("ID error: ID card rejected your attempted access modification."))
+					LOG_ID_ACCESS_CHANGE(usr, src, "failed to add [SSid_access.get_access_desc(access_type)][try_wildcard ? " with wildcard [try_wildcard]" : ""]")
+					return TRUE
 
-			if(!can_add_wildcards(list(access_type), try_wildcard))
-				to_chat(usr, span_notice("ID error: ID card rejected your attempted access modification."))
-				LOG_ID_ACCESS_CHANGE(usr, src, "failed to add [SSid_access.get_access_desc(access_type)][try_wildcard ? " with wildcard [try_wildcard]" : ""]")
-				return TRUE
+				if(!can_add_wildcards(list(access_type), try_wildcard))
+					to_chat(usr, span_notice("ID error: ID card rejected your attempted access modification."))
+					LOG_ID_ACCESS_CHANGE(usr, src, "failed to add [SSid_access.get_access_desc(access_type)][try_wildcard ? " with wildcard [try_wildcard]" : ""]")
+					return TRUE
 
-			if(!add_access(list(access_type), try_wildcard))
-				to_chat(usr, span_notice("ID error: ID card rejected your attempted access modification."))
-				LOG_ID_ACCESS_CHANGE(usr, src, "failed to add [SSid_access.get_access_desc(access_type)][try_wildcard ? " with wildcard [try_wildcard]" : ""]")
-				return TRUE
+				if(!add_access(list(access_type), try_wildcard))
+					to_chat(usr, span_notice("ID error: ID card rejected your attempted access modification."))
+					LOG_ID_ACCESS_CHANGE(usr, src, "failed to add [SSid_access.get_access_desc(access_type)][try_wildcard ? " with wildcard [try_wildcard]" : ""]")
+					return TRUE
 
-			if(access_type in ACCESS_ALERT_ADMINS)
-				message_admins("[ADMIN_LOOKUPFLW(usr)] just added [SSid_access.get_access_desc(access_type)] to an ID card [ADMIN_VV(src)] [(registered_name) ? "belonging to [registered_name]." : "with no registered name."]")
-			LOG_ID_ACCESS_CHANGE(usr, src, "added [SSid_access.get_access_desc(access_type)]")
+				if(access_type in ACCESS_ALERT_ADMINS)
+					message_admins("[ADMIN_LOOKUPFLW(usr)] just added [SSid_access.get_access_desc(access_type)] to an ID card [ADMIN_VV(src)] [(registered_name) ? "belonging to [registered_name]." : "with no registered name."]")
+				LOG_ID_ACCESS_CHANGE(usr, src, "added [SSid_access.get_access_desc(access_type)]")
+			// monkestation end
 			return TRUE
 
 /obj/item/card/id/advanced/chameleon/attack_self(mob/user)

--- a/tgui/packages/tgui/interfaces/ChameleonCard.jsx
+++ b/tgui/packages/tgui/interfaces/ChameleonCard.jsx
@@ -58,10 +58,16 @@ export const ChameleonCard = (props) => {
           showBasic={!!showBasic}
           accessMod={(ref, wildcard) =>
             act('mod_access', {
-              access_target: ref,
-              access_wildcard: wildcard,
+              actions: [{ access_target: ref, access_wildcard: wildcard }],
             })
           }
+          multiAccessMod={(actions) => {
+            act('mod_access', {
+              actions: actions.map(([ref, wildcard]) => {
+                return { access_target: ref, access_wildcard: wildcard };
+              }),
+            });
+          }}
         />
       </Window.Content>
     </Window>

--- a/tgui/packages/tgui/interfaces/NtosCard.jsx
+++ b/tgui/packages/tgui/interfaces/NtosCard.jsx
@@ -85,10 +85,18 @@ export const NtosCardContent = (props) => {
                 }
                 accessMod={(ref, wildcard) =>
                   act('PRG_access', {
-                    access_target: ref,
-                    access_wildcard: wildcard,
+                    actions: [
+                      { access_target: ref, access_wildcard: wildcard },
+                    ],
                   })
                 }
+                multiAccessMod={(actions) => {
+                  act('PRG_access', {
+                    actions: actions.map(([ref, wildcard]) => {
+                      return { access_target: ref, access_wildcard: wildcard };
+                    }),
+                  });
+                }}
               />
             </Box>
           )}


### PR DESCRIPTION

## About The Pull Request

This adds "Grant All" and "Remove All" buttons to the ID access editing UIs for NTOS (HoP console / PDA) and the agent ID.

They work exactly how you think they would - they just save you some clicks.

![2024-08-30 (1724998376) ~ dreamseeker](https://github.com/user-attachments/assets/8ed9fcd5-80eb-4c58-9c53-d1d46737151b)

## Why It's Good For The Game

_sounds of rapid clicking at hopline and impatient shoving during warops_

## Changelog
:cl:
add: Added Grant All and Remove All buttons to ID consoles and agent IDs.
/:cl:
