### PR TITLE
Fix Kilo Station Science Atmos Plumbing

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -2787,6 +2787,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "aUv" = (
@@ -27844,6 +27846,8 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "iDq" = (
@@ -53765,6 +53769,17 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
+"qTX" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Biohazard";
+	name = "Emergency Research Blast Door"
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/station/science/research)
 "qTY" = (
 /obj/structure/table,
 /obj/item/surgical_drapes,
@@ -69878,6 +69893,8 @@
 	},
 /obj/effect/landmark/navigate_destination,
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
 "vQf" = (
@@ -114664,7 +114681,7 @@ jBh
 bBF
 sxB
 kBP
-kBP
+qTX
 kBP
 vFY
 ofs


### PR DESCRIPTION

## About The Pull Request
Fixes the atmos in Kilo Station's science department by reattaching it to the central plumbing.

## Why It's Good For The Game
It's hard for the science team to think when they're breathing in their own farts for 2 hours.
Also means the ordnance airlock will start cycling properly.

## Changelog
:cl:
fix: reconnected atmos in kilo station science department
/:cl:
