### PR TITLE
[BOUNTY] Adds a surgery to permanently remove a NIF

### DIFF
--- a/monkestation/code/modules/blueshift/nifsoft/_base.dm
+++ b/monkestation/code/modules/blueshift/nifsoft/_base.dm
@@ -516,23 +516,19 @@ GLOBAL_LIST_INIT(purchasable_nifsofts, list(
 
 	if(remove_nif)
 		qdel(installed_nif)
-		persistence.nif_path = null
-		persistence.nif_examine_text = null
+		remove_nif_data(persistence)
 		return
 
 	if(!installed_nif || (installed_nif && !installed_nif.nif_persistence) || (installed_nif.durability <= 0)) // If you have a NIF on file but leave the round without one installed, you only take a durability loss instead of losing the implant.
 		if(persistence.nif_path)
 			if(persistence.nif_durability <= 0) //There is one round to repair the NIF after it breaks, otherwise it will be lost.
-				persistence.nif_path = null
-				persistence.nif_examine_text = null
-				persistence.nif_durability = null
+				remove_nif_data(persistence)
 				return
 
 			persistence.nif_durability = max((persistence.nif_durability - LOSS_WITH_NIF_UNINSTALLED), 0)
 			return
 
-		persistence.nif_path = null
-		persistence.nif_examine_text = null
+		remove_nif_data(persistence)
 		return
 
 	persistence.nif_path = installed_nif.type
@@ -555,6 +551,18 @@ GLOBAL_LIST_INIT(purchasable_nifsofts, list(
 		persistent_nifsoft_paths += "&[(nifsoft.type)]"
 
 	persistence.persistent_nifsofts = persistent_nifsoft_paths
+
+/// Removes the NIF data for an individual user. JFC turn this into a self-contained datum later PLEASE.
+/mob/living/carbon/human/proc/remove_nif_data(datum/modular_persistence/persistence)
+	persistence.nif_path = null
+	persistence.nif_durability = null
+	persistence.nif_examine_text = null
+	persistence.nif_is_calibrated = null
+	persistence.nif_soulcatcher_rooms = null
+	persistence.nif_theme = null
+	persistence.stored_rewards_points = null
+	persistence.soul_poem_nifsoft_message = null
+	persistence.soul_poem_nifsoft_name = null
 
 /// Loads the NIF data for an individual user.
 /mob/living/carbon/human/proc/load_nif_data(datum/modular_persistence/persistence)

--- a/monkestation/code/modules/surgery/nif_debonding.dm
+++ b/monkestation/code/modules/surgery/nif_debonding.dm
@@ -35,7 +35,8 @@
 
 /datum/surgery_step/debond_nif/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(tgui_alert(target, "Would you like to have your NIF debonded from you by [user]?", "NIF Debonding", list("Yes", "No"), timeout = 5 SECONDS) != "Yes")
-		target?.balloon_alert(user, "unwilling!")
+		if(user && target)
+			target.balloon_alert(user, "unwilling!")
 		return SURGERY_STEP_FAIL
 
 	display_results(

--- a/monkestation/code/modules/surgery/nif_debonding.dm
+++ b/monkestation/code/modules/surgery/nif_debonding.dm
@@ -35,7 +35,7 @@
 
 /datum/surgery_step/debond_nif/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(tgui_alert(target, "Would you like to have your NIF debonded from you by [user]?", "NIF Debonding", list("Yes", "No"), timeout = 5 SECONDS) != "Yes")
-		target.balloon_alert(user, "unwilling!")
+		target?.balloon_alert(user, "unwilling!")
 		return SURGERY_STEP_FAIL
 
 	display_results(

--- a/monkestation/code/modules/surgery/nif_debonding.dm
+++ b/monkestation/code/modules/surgery/nif_debonding.dm
@@ -35,7 +35,7 @@
 
 /datum/surgery_step/debond_nif/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(tgui_alert(target, "Would you like to have your NIF debonded from you by [user]?", "NIF Debonding", list("Yes", "No"), timeout = 5 SECONDS) != "Yes")
-		user.balloon_alert(user, "unwilling!")
+		target.balloon_alert(user, "unwilling!")
 		return SURGERY_STEP_FAIL
 
 	display_results(

--- a/monkestation/code/modules/surgery/nif_debonding.dm
+++ b/monkestation/code/modules/surgery/nif_debonding.dm
@@ -1,0 +1,95 @@
+/datum/surgery/nif_debonding
+	name = "NIF debonding"
+	desc = "Permanently removes a bonded NIF from the patient. Requires the patient to mentally prepare for debonding."
+	possible_locs = list(BODY_ZONE_HEAD)
+	steps = list(
+		/datum/surgery_step/incise,
+		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/saw,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/incise,
+		/datum/surgery_step/debond_nif,
+		/datum/surgery_step/close,
+	)
+
+/datum/surgery/nif_debonding/can_start(mob/user, mob/living/patient)
+	if(!..())
+		return FALSE
+
+	var/obj/item/organ/internal/cyberimp/brain/nif/nif = patient.get_organ_slot(ORGAN_SLOT_BRAIN_NIF)
+
+	return nif?.is_calibrated && patient.stat != DEAD && patient.get_organ_slot(ORGAN_SLOT_BRAIN)
+
+/datum/surgery_step/debond_nif
+	name = "debond NIF (scalpel)"
+	time = 5 SECONDS
+	preop_sound = 'sound/surgery/scalpel1.ogg'
+	success_sound = 'sound/surgery/scalpel2.ogg'
+	implements = list(
+		TOOL_SCALPEL = 100,
+		/obj/item/melee/energy/sword = 75,
+		/obj/item/knife = 65,
+		/obj/item/shard = 45,
+		/obj/item = 30,
+	)
+
+/datum/surgery_step/debond_nif/preop(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(tgui_alert(target, "Would you like to have your NIF debonded from you by [user]?", "NIF Debonding", list("Yes", "No"), timeout = 5 SECONDS) != "Yes")
+		user.balloon_alert(user, "unwilling!")
+		return SURGERY_STEP_FAIL
+
+	display_results(
+		user,
+		target,
+		span_notice("You begin to <i>carefully</i> cut the threads of the NIF in [target]..."),
+		span_notice("[user] begins to <i>carefully</i> cut the threads of the NIF in [target]."),
+		span_notice("[user] begins to <i>carefully</i> cut something in [target]'s head."),
+	)
+	display_pain(target, "You feel painful zaps in your head!")
+
+/datum/surgery_step/debond_nif/success(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results)
+	if(target.stat == DEAD)
+		to_chat(user, span_warning("They need to be alive to perform this surgery!"))
+		return FALSE
+
+	var/obj/item/organ/internal/brain/brain = target.get_organ_slot(ORGAN_SLOT_BRAIN)
+	if(!istype(brain))
+		to_chat(user, span_warning("They need a brain, dingus!"))
+		return FALSE
+
+	var/obj/item/organ/internal/cyberimp/brain/nif/nif = target.get_organ_slot(ORGAN_SLOT_BRAIN_NIF)
+	if(!nif)
+		to_chat(user, span_warning("They need an NIF, dingus!"))
+		return FALSE
+
+	if(!brain.modular_persistence)
+		to_chat(user, span_cultlarge("The ethereal forces of reality forbid debonding the NIF! Okay seriously, tell an admin lmao."))
+		CRASH("[user.ckey] attempted NIF debonding for [target.ckey], but no modular persistence datum was found. This shouldn't happen.")
+
+	nif.Remove(target)
+	user.put_in_hands(nif)
+
+	target.save_nif_data(brain.modular_persistence, remove_nif = TRUE)
+	target.save_individual_persistence()
+
+	return ..()
+
+/datum/surgery_step/debond_nif/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery, fail_prob)
+	display_results(
+		user,
+		target,
+		span_notice("You mess up, damaging the NIF and brain!"),
+		span_notice("[user] messes up, damaging the NIF and brain!"),
+		span_notice("[user] messes up!"),
+	)
+	display_pain(user, "You feel a horrible spike of pain in your head!")
+
+	target.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(30, 50))
+
+	var/obj/item/organ/internal/cyberimp/brain/nif/nif = target.get_organ_slot(ORGAN_SLOT_BRAIN_NIF)
+	nif?.adjust_durability(-rand(10, 20))
+
+	return FALSE
+
+/datum/surgery_step/debond_nif/tool_check(mob/user, obj/item/tool)
+	return implement_type != /obj/item || tool.get_sharpness() > 0

--- a/monkestation/code/modules/surgery/nif_debonding.dm
+++ b/monkestation/code/modules/surgery/nif_debonding.dm
@@ -18,7 +18,7 @@
 
 	var/obj/item/organ/internal/cyberimp/brain/nif/nif = patient.get_organ_slot(ORGAN_SLOT_BRAIN_NIF)
 
-	return nif?.is_calibrated && patient.stat != DEAD && patient.get_organ_slot(ORGAN_SLOT_BRAIN)
+	return nif?.is_calibrated && patient.stat != DEAD && patient.client && patient.get_organ_slot(ORGAN_SLOT_BRAIN)
 
 /datum/surgery_step/debond_nif
 	name = "debond NIF (scalpel)"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7584,6 +7584,7 @@
 #include "monkestation\code\modules\storytellers\storytellers\vote.dm"
 #include "monkestation\code\modules\storytellers\storytellers\warrior.dm"
 #include "monkestation\code\modules\surgery\blood_filter.dm"
+#include "monkestation\code\modules\surgery\nif_debonding.dm"
 #include "monkestation\code\modules\surgery\advanced\brainwashing.dm"
 #include "monkestation\code\modules\surgery\bodyparts\arachnid_bodyparts.dm"
 #include "monkestation\code\modules\surgery\bodyparts\clockwork_bodyparts.dm"


### PR DESCRIPTION

## About The Pull Request

Adds a surgery called "NIF debonding" that removes a NIF and it's persistence from the patient.
The debonding step alerts the patient and if they don't accept, the step fails.
## Why It's Good For The Game

As it turns out, adding an item that permanently bonds itself to your character and only has downsides as of now is bad.
Specifically because of the whole "not warning you before bonding" thing. Yep. There's no warning for it. Fun.
## Changelog
:cl:
add: You can now permanently remove NIFs through a surgery on the head called "NIF debonding", but it requires OOC consent.
/:cl:
