### PR TITLE
Fills in QM quarters and adds chargers

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -8528,6 +8528,10 @@
 	},
 /turf/open/floor/iron/shuttle/arrivals/airless,
 /area/space/nearstation)
+"bHM" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/iron/smooth_large,
+/area/station/cargo/storage)
 "bHU" = (
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/structure/cable,
@@ -54615,6 +54619,9 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
+/obj/machinery/modular_computer/preset/cargochat/cargo{
+	dir = 4
+	},
 /turf/open/floor/wood/parquet,
 /area/station/cargo/quartermaster)
 "kAG" = (
@@ -118264,6 +118271,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark,
 /area/station/cargo/quartermaster)
 "wPG" = (
@@ -164802,7 +164810,7 @@ iYD
 hRq
 eFn
 gsY
-oTl
+bHM
 sAs
 ipg
 oTl

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -11900,7 +11900,6 @@
 /obj/effect/turf_decal/delivery/white,
 /obj/machinery/light/directional/north,
 /obj/structure/closet/crate/critter,
-/obj/effect/spawner/random/clothing/kittyears_or_rabbitears,
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "dVk" = (
@@ -31381,6 +31380,10 @@
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"kuW" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/station/maintenance/port)
 "kvh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -89677,7 +89680,7 @@ jEi
 dOt
 fUs
 cLZ
-jEi
+kuW
 bnl
 nYd
 vmV

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -34777,7 +34777,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/suit_storage_unit/industrial/loader,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/iron,
 /area/station/cargo/quartermaster)
 "ilG" = (
@@ -42147,13 +42148,11 @@
 "jWq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/north,
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed,
 /obj/machinery/airalarm/directional/north,
-/obj/item/stock_parts/cell/high/empty,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "jWG" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -37,7 +37,7 @@
 /turf/open/floor/grass,
 /area/station/security/prison/safe)
 "aaT" = (
-/obj/effect/spawner/random/structure/crate,
+/obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "abb" = (
@@ -4820,6 +4820,7 @@
 /area/mine/mechbay)
 "bzN" = (
 /obj/machinery/light/small/directional/west,
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "bzQ" = (
@@ -53175,6 +53176,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/light_switch/directional/south,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "qUe" = (
@@ -67273,7 +67275,6 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -162625,7 +162626,7 @@ gjq
 gjq
 gjq
 jpS
-oXo
+aaT
 yef
 baV
 svy
@@ -162882,7 +162883,7 @@ eJf
 eJf
 eJf
 jpS
-aaT
+oXo
 bWV
 fPB
 ljz

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -67946,6 +67946,9 @@
 /obj/machinery/requests_console/auto_name/directional/west,
 /obj/effect/mapping_helpers/requests_console/information,
 /obj/effect/mapping_helpers/requests_console/assistance,
+/obj/machinery/modular_computer/preset/cargochat/cargo{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/station/cargo/quartermaster)
 "uhn" = (
@@ -77643,6 +77646,15 @@
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/paper_bin/carbon{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/pen{
+	pixel_x = -5;
+	pixel_y = 4
 	},
 /turf/open/floor/iron/large,
 /area/station/cargo/quartermaster)

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -3882,6 +3882,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/textured_edge{
 	dir = 1
 	},
@@ -4471,6 +4472,9 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/modular_computer{
+	dir = 4
+	},
 /turf/open/floor/carpet/black,
 /area/station/cargo/quartermaster)
 "boe" = (
@@ -43460,6 +43464,9 @@
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/directional/south,
+/obj/machinery/modular_computer/preset/cargochat{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/quartermaster)
 "mna" = (
@@ -51444,6 +51451,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/quartermaster)
 "ozq" = (


### PR DESCRIPTION

## About The Pull Request
Add borg charging stations into the cargo bays that were missing them, and on delta and icebox, moves the loader modsuit into more accessible areas for the CTs. Along with this i filled in holes for QM quarters after a recent merge

## Why It's Good For The Game
the empty spots looked really off, and this cleans them up along with a few other small problems that i found in multiple maps
## Changelog
:cl:
add: Fluff items to fill in the QM quarters that were empty
qol: adds rechargers to multiple maps in the cargo bay
fix: Moved the mod-suit location to CT areas, on Delta and IceBox
/:cl:
