### PR TITLE
Fix Poly's AI

### DIFF
--- a/code/modules/mob/living/basic/pets/parrot/_parrot.dm
+++ b/code/modules/mob/living/basic/pets/parrot/_parrot.dm
@@ -70,7 +70,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 		/obj/structure/frame/computer,
 	))
 	///items we wont pick up
-	var/static/list/ignore_items = typecacheof(list(/obj/item/radio, /obj/effect/name_tag)) //Monkestation addition: ignore their nametag
+	var/static/list/ignore_items = typecacheof(list(/obj/item/radio, /obj/effect)) //Monkestation addition: ignore their nametag
 
 	/// Food that Poly loves to eat (spoiler alert it's just crackers)
 	var/static/list/edibles = list(

--- a/code/modules/mob/living/basic/pets/parrot/_parrot.dm
+++ b/code/modules/mob/living/basic/pets/parrot/_parrot.dm
@@ -70,7 +70,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 		/obj/structure/frame/computer,
 	))
 	///items we wont pick up
-	var/static/list/ignore_items = typecacheof(list(/obj/item/radio))
+	var/static/list/ignore_items = typecacheof(list(/obj/item/radio, /obj/effect/name_tag)) //Monkestation addition: ignore their nametag
 
 	/// Food that Poly loves to eat (spoiler alert it's just crackers)
 	var/static/list/edibles = list(

--- a/monkestation/code/modules/mob/living/basic/pets/parrot/parrot_ai/parroting_action.dm
+++ b/monkestation/code/modules/mob/living/basic/pets/parrot/parrot_ai/parroting_action.dm
@@ -3,3 +3,4 @@
 
 /datum/ai_behavior/perform_speech/parrot/perform(seconds_per_tick, datum/ai_controller/controller, ...)
 	controller.behavior_cooldowns[src] = world.time + rand(45 SECONDS, 3 MINUTES)
+	. = ..()


### PR DESCRIPTION

## About The Pull Request
Fixes Poly's AI getting stuck in a loop trying to hoard their nametag, and their speech behavior not functioning properly.
## Why It's Good For The Game
Poly's currently in a very buggy state, where they mostly just sit on a tile all shift attempting to hoard their nametag (they can't). Even if that wasn't buggy, #1666 broke their speech behavior in an attempt to reduce their speech spam. This fixes both behaviors, and fixes #3179
## Changelog
:cl:
fix: Fixed Poly getting stuck in a hoarding loop
fix: Fixed Poly being unable to speak
/:cl:
