### PR TITLE
Cybernetics for Blueshield and Sec Assistant during cybernetic revolution.

### DIFF
--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -211,6 +211,7 @@
 		/datum/job/atmospheric_technician = /obj/item/organ/internal/cyberimp/arm/item_set/atmospherics, // monkestation edit: cybernetics overhaul (useful job stuff)
 		/datum/job/bartender = /obj/item/organ/internal/liver/cybernetic/tier3,
 		/datum/job/bitrunner = /obj/item/organ/internal/eyes/robotic/thermals,
+		/datum/job/blueshield = /obj/item/organ/internal/cyberimp/arm/ammo_counter, // monkestation edit: cybernetics for recently added job
 		/datum/job/botanist = /obj/item/organ/internal/cyberimp/arm/item_set/botany, // monkestation edit: cybernetics overhaul (useful job stuff)
 		/datum/job/captain = /obj/item/organ/internal/heart/cybernetic/tier3,
 		/datum/job/cargo_technician = /obj/item/organ/internal/stomach/cybernetic/tier2,
@@ -236,6 +237,7 @@
 		/datum/job/research_director = /obj/item/organ/internal/cyberimp/bci,
 		/datum/job/roboticist = /obj/item/organ/internal/cyberimp/arm/item_set/connector, // monkestation edit: cybernetics overhaul (useful job stuff)
 		/datum/job/scientist = /obj/item/organ/internal/ears/cybernetic,
+		/datum/job/security_assistant = /obj/item/organ/internal/cyberimp/leg/accelerator, // monkestation edit: cybernetics for recently added job
 		/datum/job/security_officer = /obj/item/organ/internal/cyberimp/arm/item_set/flash,
 		/datum/job/shaft_miner = /obj/item/organ/internal/cyberimp/arm/item_set/mining_drill/diamond, // monkestation edit: cybernetics overhaul (useful job stuff)
 		/datum/job/station_engineer = /obj/item/organ/internal/cyberimp/arm/item_set/toolset,


### PR DESCRIPTION
## About The Pull Request

Gives Blueshield and Security Assistant jobs S.M.A.R.T. Ammo Counters and accelerator cybernetics respectively during a cybernetic revolution. 
## Why It's Good For The Game

Every job no matter how small or big is given something unique during a revolution. Even prisoners and assistants. Currently, Blueshield and Security Assistants get nothing how ever. This helps gives some love to our recent additions, enhancing their current aspects rather than giving new ones with the cybernetics. The accelerator for sec assistants will allow them to keep diving at folks no matter what happens to their gloves. And Blueshield's can watch as their ammo instantly depletes.
## Changelog

:cl:
add: Accelerator Cybernetic for Security Assistants and S.M.A.R.T. Ammo Counters for Blueshields during the Cybernetic Revolution Station Trait.
:cl: