### PR TITLE
Fixes Poly's AI Freezing

### DIFF
--- a/monkestation/code/modules/mob/living/basic/pets/parrot/parrot_ai/parroting_action.dm
+++ b/monkestation/code/modules/mob/living/basic/pets/parrot/parrot_ai/parroting_action.dm
@@ -1,6 +1,3 @@
-/datum/ai_behavior/perform_speech/parrot
-	action_cooldown = 45 SECONDS // SHUT UP
-
 /datum/ai_behavior/perform_speech/parrot/perform(seconds_per_tick, datum/ai_controller/controller, ...)
 	controller.behavior_cooldowns[src] = world.time + rand(45 SECONDS, 3 MINUTES)
 	. = ..()

--- a/monkestation/code/modules/mob/living/basic/pets/parrot/parrot_ai/parroting_action.dm
+++ b/monkestation/code/modules/mob/living/basic/pets/parrot/parrot_ai/parroting_action.dm
@@ -1,3 +1,3 @@
 /datum/ai_behavior/perform_speech/parrot/perform(seconds_per_tick, datum/ai_controller/controller, ...)
-	controller.behavior_cooldowns[src] = world.time + rand(45 SECONDS, 3 MINUTES)
+	controller.behavior_cooldowns[src] = world.time + rand(45 SECONDS, 3 MINUTES) // Prevents Poly from being too yappy
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Fix Poly freezing up after speaking
## Why It's Good For The Game
Turns out, the active_cooldown var is used to determine time between different actions, meaning that it being set to 45 for Poly speaking means that Poly has to wait 45 seconds before they can perform any other AI tasks, causing them to freeze in place after speaking. This fixes that, without Poly becoming a chatterbox on the comms (that is handled in the behavior cooldown).
## Changelog
:cl:
fix: Fixes Poly freezing up after speaking
/:cl:
