### PR TITLE
Fixes a Longevity Syndrome bug where it doesn't update health

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/stage4.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/stage4.dm
@@ -92,8 +92,8 @@
 		total_healed += heal_amt * 0.2
 	else
 		total_healed += (heal_amt - current_health) * 0.2
-	mob.heal_overall_damage(brute = heal_amt, burn = heal_amt, updating_health = FALSE)
-	mob.adjustCloneLoss(-heal_amt, updating_health = TRUE)
+	mob.heal_overall_damage(brute = heal_amt, burn = heal_amt)
+	mob.adjustCloneLoss(-heal_amt)
 
 /datum/symptom/immortal/deactivate(mob/living/carbon/mob)
 	if(ishuman(mob))


### PR DESCRIPTION

## About The Pull Request

AdjustCloneloss does not update health if it doesn't heal anything.
So while Longevity does heal damage, it doesn't make you feel like it's healing anything.
## Why It's Good For The Game

Bugfix good.
## Changelog
:cl:
fix: Fixed a health update bug with Longevity Syndrome.
/:cl:
