### PR TITLE
Fixes cortical borer Life() and objective name issues

### DIFF
--- a/monkestation/code/modules/antagonists/borers/code/antagonist_stuff/antagonist_datum.dm
+++ b/monkestation/code/modules/antagonists/borers/code/antagonist_stuff/antagonist_datum.dm
@@ -61,13 +61,13 @@
 
 /datum/antagonist/cortical_borer/hivemind/forge_objectives()
 	var/datum/objective/custom/borer_objective_produce_eggs = new
-	borer_objective_produce_eggs.explanation_text = "we require [GLOB.objective_egg_borer_number] different borers to produce [GLOB.objective_egg_egg_number] eggs to make sure our hive can spread widelly for increasing our chances of survival"
+	borer_objective_produce_eggs.explanation_text = "We require [GLOB.objective_egg_borer_number] different borers to produce [GLOB.objective_egg_egg_number] eggs to spread widely in order to increase our chances of survival."
 
 	var/datum/objective/custom/borer_objective_willing_hosts = new
-	borer_objective_willing_hosts.explanation_text = "we require any amount of the borers to get [GLOB.objective_willing_hosts] willing host's trust to ensure our survival"
+	borer_objective_willing_hosts.explanation_text = "We require [GLOB.objective_willing_hosts] willing hosts to create a backbone for our continued survival, should our prey attempt to exterminate us."
 
 	var/datum/objective/custom/borer_objective_learn_chemicals = new
-	borer_objective_learn_chemicals.explanation_text = "we require any amount of the borers to learn [GLOB.objective_blood_borer] chemicals from blood to aquire further chemical insight"
+	borer_objective_learn_chemicals.explanation_text = "We need to learn [GLOB.objective_blood_borer] chemicals from the bloodstreams of our hosts to acquire further chemical insight."
 
 	objectives += borer_objective_produce_eggs
 	objectives += borer_objective_willing_hosts

--- a/monkestation/code/modules/antagonists/borers/code/evolution/evolution_symbiote.dm
+++ b/monkestation/code/modules/antagonists/borers/code/evolution/evolution_symbiote.dm
@@ -23,7 +23,7 @@
 /datum/borer_evolution/symbiote/chem_per_level/on_evolve(mob/living/basic/cortical_borer/cortical_owner)
 	. = ..()
 	cortical_owner.chem_storage_per_level += 10
-	cortical_owner.chem_regen_per_level += 0.5
+	cortical_owner.chem_regen_per_level += 0.25
 	cortical_owner.recalculate_stats()
 
 // T3 + T2 Path

--- a/monkestation/code/modules/antagonists/borers/code/mobs/cortical_borer.dm
+++ b/monkestation/code/modules/antagonists/borers/code/mobs/cortical_borer.dm
@@ -136,10 +136,10 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 	var/list/blacklisted_chemicals = list()
 
 
-	/// How old the borer is, starting from zero. Goes up only when inside a host
+	/// How old the borer is, starting from zero. Goes up only when inside a host and resets when a stat point is gained. This is in seconds.
 	var/maturity_age = 0
-	/// Just a little "timer" to compare to world.time
-	var/timed_maturity = 0
+	/// Whether a chem point has been granted for this maturity level. Resets when a stat point is gained.
+	var/chem_point_gained = FALSE // Technically if seconds_per_tick is like 5 this can fail at the max maturity speed but w h a t e v e r .
 
 	/// How many times you've levelled up over all
 	var/level = 0
@@ -154,7 +154,7 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 	/// How many chemical points the borer has
 	var/chemical_storage = 50
 	/// How fast chemicals are gained. Goes up only when inside a host
-	var/chemical_regen = 1
+	var/chemical_regen = 0.5
 
 	/// How much health you gain per level
 	var/health_per_level = 2.5
@@ -164,7 +164,7 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 	/// How much more chemical storage you gain per level
 	var/chem_storage_per_level = 20
 	/// Chemical regen you gain per level
-	var/chem_regen_per_level = 1
+	var/chem_regen_per_level = 0.5
 
 	/// The list of actions that the borer has
 	var/list/datum/action/cooldown/borer/known_abilities = list(
@@ -320,7 +320,7 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 
 	//there needs to be a negative to having a borer
 	if(prob(5 * host_harm_multiplier * ((upgrade_flags & BORER_STEALTH_MODE) ? 0.1 : 1)) && human_host.getToxLoss() <= (80 * host_harm_multiplier))
-		human_host.adjustToxLoss(5 * host_harm_multiplier, TRUE, TRUE)
+		human_host.adjustToxLoss(2.5 * seconds_per_tick * host_harm_multiplier, TRUE, TRUE)
 
 	human_host.apply_status_effect(/datum/status_effect/grouped/screwy_hud/fake_healthy, type)
 
@@ -335,16 +335,15 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 	//this is regenerating chemical_storage
 	if(chemical_storage < max_chemical_storage)
 		if(!(upgrade_flags & BORER_STEALTH_MODE))
-			chemical_storage = min(chemical_storage + chemical_regen, max_chemical_storage)
+			chemical_storage = min(chemical_storage + chemical_regen * seconds_per_tick, max_chemical_storage)
 
 	//this is regenerating health
 	if(health < maxHealth)
 		if(!(upgrade_flags & BORER_STEALTH_MODE))
-			adjustBruteLoss(maxHealth * -health_regen)
+			adjustBruteLoss(maxHealth * -health_regen * seconds_per_tick)
 
 	//this is so they can evolve
-	if(timed_maturity < world.time)
-		mature()
+	mature(seconds_per_tick)
 
 //if it doesnt have a ckey, let ghosts have it
 /mob/living/basic/cortical_borer/attack_ghost(mob/dead/observer/user)
@@ -484,35 +483,34 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 	return
 
 /// Called on Life() for the borer to age a bit
-/mob/living/basic/cortical_borer/proc/mature()
+/mob/living/basic/cortical_borer/proc/mature(seconds_per_tick)
 	. = TRUE
 	if(upgrade_flags & BORER_STEALTH_MODE)
 		return FALSE
-	timed_maturity = world.time + 0.5 SECONDS
-	maturity_age++
+	maturity_age += seconds_per_tick
 
 	/**
-	 * The point values are double what they seem
-	 * So in the beginning you start out with the following generation:
+	 * In the beginning you start out with the following generation:
 	 * Evolution point per 40 seconds
 	 * Chemical point per 20 seconds
 	 */
 
 	//20:40, 15:30, 10:20, 5:10
-	var/maturity_threshold = 2 SECONDS
+	var/maturity_threshold = 20
 	if(GLOB.successful_egg_number >= GLOB.objective_egg_borer_number)
-		maturity_threshold -= 0.2 SECONDS
+		maturity_threshold -= 2
 	if(length(GLOB.willing_hosts) >= GLOB.objective_willing_hosts)
-		maturity_threshold -= 1 SECOND
+		maturity_threshold -= 10
 	if(GLOB.successful_blood_chem >= GLOB.objective_blood_borer)
-		maturity_threshold -= 0.3 SECONDS
+		maturity_threshold -= 3
 
-	if(maturity_age == maturity_threshold)
+	if(!chem_point_gained && maturity_age >= maturity_threshold)
 		if(chemical_evolution < limited_borer) //you can only have a default of 10 at a time
 			chemical_evolution++
 			to_chat(src, span_notice("You gain a chemical evolution point. Spend it to learn a new chemical!"))
 		else
 			to_chat(src, span_warning("You were unable to gain a chemical evolution point due to having the max!"))
+		chem_point_gained = TRUE
 	if(maturity_age >= (maturity_threshold * 2))
 		if(stat_evolution < limited_borer)
 			stat_evolution++
@@ -520,6 +518,7 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 		else
 			to_chat(src, span_warning("You were unable to gain a stat evolution point due to having the max!"))
 		maturity_age = 0
+		chem_point_gained = FALSE
 
 /// Use to recalculate a borer's health and chemical stats when something retroactively affects them
 /mob/living/basic/cortical_borer/proc/recalculate_stats()

--- a/monkestation/code/modules/antagonists/borers/code/mobs/cortical_borer.dm
+++ b/monkestation/code/modules/antagonists/borers/code/mobs/cortical_borer.dm
@@ -159,7 +159,7 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 	/// How much health you gain per level
 	var/health_per_level = 2.5
 	/// How much health regen you gain per level
-	var/health_regen_per_level = 0.02
+	var/health_regen_per_level = 0.002
 
 	/// How much more chemical storage you gain per level
 	var/chem_storage_per_level = 20
@@ -185,8 +185,8 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 	/// What the host gains or loses with the borer
 	var/list/hosts_abilities = list()
 
-	/// Multiplies the current health up to the max health
-	var/health_regen = 1.02
+	/// How much health we regen per second while in a host (scales with max health) CODER NOTE: The value was 10.02 before. Assuming the first health_regen_per_level should be added to this. (0.002 as of now, so 0.102 instead of 0.1)
+	var/health_regen = 0.102
 	/// Holds the chems right before injection
 	var/obj/item/reagent_containers/reagent_holder
 	/// Lust a flavor kind of thing
@@ -340,7 +340,7 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 	//this is regenerating health
 	if(health < maxHealth)
 		if(!(upgrade_flags & BORER_STEALTH_MODE))
-			health = min(health * health_regen, maxHealth)
+			adjustBruteLoss(maxHealth * -health_regen)
 
 	//this is so they can evolve
 	if(timed_maturity < world.time)

--- a/monkestation/code/modules/antagonists/borers/code/mobs/empowered_borer.dm
+++ b/monkestation/code/modules/antagonists/borers/code/mobs/empowered_borer.dm
@@ -6,7 +6,7 @@
 	maxHealth = 150
 	health = 150
 	health_per_level = 15
-	health_regen_per_level = 0.04
+	health_regen_per_level = 0.002
 
 	stat_evolution = 8
 	chemical_evolution = 8

--- a/monkestation/code/modules/antagonists/borers/code/mobs/empowered_borer.dm
+++ b/monkestation/code/modules/antagonists/borers/code/mobs/empowered_borer.dm
@@ -13,5 +13,5 @@
 
 	max_chemical_storage = 250
 	chemical_storage = 250
-	chem_regen_per_level = 1.5
+	chem_regen_per_level = 0.75
 	chem_storage_per_level = 25


### PR DESCRIPTION
## About The Pull Request

Cortical borers are supposed to regenerate while inside of a host.
In-game, you could see your health going up in the stat panel, but your health never *actually* changed.
This is because the code was directly setting the health variable instead of using adjustBruteLoss and this PR fixes that.

Additionally, the way borer healing scaled was genuinely ridiculous. It took at most 4 ticks to get to full.
This is because it scaled based on your existing health. So at 50% health, you went to 100% INSTANTLY.
I call bullshit and thus, this PR lowers it to 10% per second. (getting into a host at low health is the hard part)

Also, adds seconds_per_tick scaling to everything in the borer Life() loop and adjusts values to be in a per second format.

And finally, spellchecks borer objectives and makes the sentences more pleasant to read.
## Why It's Good For The Game

Bugfixes and better objective texts are a no brainer.
## Changelog
:cl:
fix: Cortical borers can regenerate as intended.
fix: Cortical borer life ticks now follow subsystem delays, making them resistant to lag.
spellcheck: Cortical borer objectives are now better worded and have proper spelling and punctuation.
/:cl:
