### PR TITLE
Fixes the round-start report always being greenshift

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -334,7 +334,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 		if(ruleset.weight <= 0 || ruleset.cost <= 0)
 			continue
 		min_threat = min(ruleset.cost, min_threat)
-	var/greenshift = GLOB.dynamic_forced_extended || (threat_level < min_threat && shown_threat < min_threat) //if both shown and real threat are below any ruleset, its extended time
+	var/greenshift = SSgamemode.storyteller.disable_distribution //|| (threat_level < min_threat && shown_threat < min_threat) //if both shown and real threat are below any ruleset, its extended time //monkestation edit: Makes it so greenshift is based on the storyteller
 
 	generate_station_goals(greenshift)
 	. += generate_station_goal_report()


### PR DESCRIPTION

## About The Pull Request
Title, fixes the round-start security announcement always being greenshift. It will now only be greenshift if the storyteller distribution is disabled (means only the ghost storyteller will naturally have this)
## Why It's Good For The Game
Dynamic isn't used here, so greenshift being based on the storyteller rather than the unused dynamic threat level is better.
## Changelog
:cl:
fix: The round-start status summary will only be green-shift if the current storyteller is Ghost
/:cl:
