### PR TITLE
You can no longer cryo someone if their soul is in a soulcatcher

### DIFF
--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -53,7 +53,7 @@
 		return FALSE
 
 	var/area/checkable = get_area(src)
-	if(checkable.area_flags & BLOCK_SUICIDE)
+	if(checkable?.area_flags & BLOCK_SUICIDE)
 		to_chat(src, span_warning("You can't commit suicide here! You can ghost if you'd like."))
 		return FALSE
 

--- a/monkestation/code/modules/cryopods/_cryopod.dm
+++ b/monkestation/code/modules/cryopods/_cryopod.dm
@@ -512,7 +512,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/cryopod, 32)
 		return
 
 	if(target.stat == DEAD)
-		to_chat(user, span_notice("Dead people can not be put into cryo."))
+		to_chat(user, span_warning("Dead people can not be put into cryo."))
+		return
+
+	if(target.GetComponent(/datum/component/previous_body))
+		to_chat(user, span_warning("[src] seems to reject [target]."))
 		return
 
 // Allows admins to enable players to override SSD Time check.


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/3237

## Changelog
:cl:
fix: You can no longer cryo someone if their soul is in a soulcatcher.
/:cl:
