### PR TITLE
Adding Research Director's skillchip to the Research Director's Locker

### DIFF
--- a/code/game/objects/items/storage/boxes/job_boxes.dm
+++ b/code/game/objects/items/storage/boxes/job_boxes.dm
@@ -292,6 +292,7 @@
 	desc = "Contains spares of every science job skillchip."
 
 /obj/item/storage/box/skillchips/science/PopulateContents()
+	new/obj/item/skillchip/job/research_director(src)
 	new/obj/item/skillchip/job/roboticist(src)
 	new/obj/item/skillchip/job/roboticist(src)
 	new/obj/item/skillchip/cyberjacker(src)


### PR DESCRIPTION

## About The Pull Request

Adds a spare copy of the Research Director's R.D.S.P.L.X. skill chip into the Science skill chip box inside the Research Director's Locker.
## Why It's Good For The Game
In the instance of RNG 'blessing' the station with a looping rod there's very little that can be done. You need a R.D.S.P.L.X. skill chip to be able to deal with the threat. Issue is these only naturally spawn inside a Research Director. A head position that often isn't filled. And no way to signal one is needed via the HOP's console unlike other jobs. The station will be stuck with permanent spacing/dead zone, sometimes being in a critical position. (I've had a looping rod through my AI Core and PSU as AI before.) 

By adding the chip and keeping it to the RD's locker it means only the Research Director. Captain, and acting captain, can easily access it.  And even still they have to visit the library to get it installed. 

In conclusion, shuttle being called over a destructive threat with no preventive measures because no one decided to play a specific head of staff doesn't feel good for anyone in the round.
## Changelog
:cl:
add: Adds R.D.S.P.L.X. skill chip to the science skill chip box. 
:cl:
