### PR TITLE
[BOUNTY] Restores old default hos trenchcoat

### DIFF
--- a/code/game/objects/items/storage/garment.dm
+++ b/code/game/objects/items/storage/garment.dm
@@ -82,6 +82,7 @@
 	new /obj/item/clothing/suit/armor/hos(src)
 	new /obj/item/clothing/suit/armor/hos/hos_formal(src)
 	new /obj/item/clothing/suit/armor/hos/trenchcoat/winter(src)
+	new /obj/item/clothing/suit/armor/hos/trenchcoat/pimpcoat(src)
 	new /obj/item/clothing/suit/armor/vest/leather(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses/eyepatch(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses/gars/giga(src)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -171,8 +171,10 @@
 /obj/item/clothing/suit/armor/hos/trenchcoat/winter
 	name = "head of security's winter trenchcoat"
 	desc = "A trenchcoat enhanced with a special lightweight kevlar, padded with wool on the collar and inside. You feel strangely lonely wearing this coat."
-	icon_state = "pimpcoat" // monkestation edit
+	icon_state = "hoswinter"
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
+
+///obj/item/clothing/suit/armor/hos/trenchcoat/pimpcoat in monkestation\code\modules\aesthetics\items\clothing.dm
 
 /obj/item/clothing/suit/armor/hos/hos_formal
 	name = "\improper Head of Security's parade jacket"

--- a/monkestation/code/modules/aesthetics/items/clothing.dm
+++ b/monkestation/code/modules/aesthetics/items/clothing.dm
@@ -1,4 +1,6 @@
-/obj/item/clothing/suit/armor/hos/trenchcoat
+/obj/item/clothing/suit/armor/hos/trenchcoat/pimpcoat
+	name = "pink armored trenchcoat"
+	desc = "For when an armored trenchcoat isn't pimped out enough."
 	icon = 'monkestation/code/modules/aesthetics/icons/clothing/suits.dmi'
 	icon_state = "pimpcoat"
 	worn_icon = 'monkestation/code/modules/aesthetics/icons/clothing/worn/suit.dmi'


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/user-attachments/assets/b1e8f071-43d9-4181-9cbb-b34430d7d663)
Makes the old armored trenchcoat (pictured on the left) the default one. Pink armored trenchcoat has been moved to the garment bag. Also fixes the winter coat sprite.
## Why It's Good For The Game
I was offered good monkecoins for this. Also the people demand the change.
## Changelog
:cl:
fix: Restored old HOS trenchcoat sprite. Winter trenchcoat sprite also fixed.
/:cl:
