### PR TITLE
Tunnel Vision Quirk

### DIFF
--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -218,7 +218,7 @@
 	name = "Tunnel Vision"
 	desc = "You spent too long scoped in. You cant see behind you!"
 	value = -2
-	icon = FA_ICON_EXCLAMATION
+	icon = FA_ICON_QUESTION
 	gain_text = span_notice("You have trouble focusing on what you left behind.")
 	lose_text = span_notice("You feel paranoid, constantly checking your back...")
 	medical_record_text = "Patient had trouble noticing people walking up from behind during the examination."

--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -218,7 +218,7 @@
 	name = "Tunnel Vision"
 	desc = "You spent too long scoped in. You cant see behind you!"
 	value = -2
-	icon = FA_ICON_EYE_SLASH
+	icon = FA_ICON_EXCLAMATION
 	gain_text = span_notice("You have trouble focusing on what you left behind.")
 	lose_text = span_notice("You feel paranoid, constantly checking your back...")
 	medical_record_text = "Patient had trouble noticing people walking up from behind during the examination."

--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -214,3 +214,16 @@
 	if(isipc(quirk_holder)) //monkestation addition
 		to_chat(quirk_holder, span_boldnotice("Your chassis feels frail."))
 
+/datum/quirk/tunnel_vision
+	name = "Tunnel Vision"
+	desc = "You spent too long scoped in. You cant see behind you!"
+	value = -2
+	icon = FA_ICON_EYE_SLASH
+	gain_text = span_notice("You have trouble focusing on what you left behind.")
+	lose_text = span_notice("You feel paranoid, constantly checking your back...")
+	medical_record_text = "Patient had trouble noticing people walking up from behind during the examination."
+/datum/quirk/tunnel_vision/add()
+	quirk_holder.add_fov_trait("tunnel vision quirk", FOV_90_DEGREES)
+
+/datum/quirk/tunnel_vision/remove()
+	quirk_holder.remove_fov_trait("tunnel vision quirk", FOV_90_DEGREES)

--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -222,8 +222,21 @@
 	gain_text = span_notice("You have trouble focusing on what you left behind.")
 	lose_text = span_notice("You feel paranoid, constantly checking your back...")
 	medical_record_text = "Patient had trouble noticing people walking up from behind during the examination."
-/datum/quirk/tunnel_vision/add()
-	quirk_holder.add_fov_trait("tunnel vision quirk", FOV_90_DEGREES)
 
+/datum/quirk/tunnel_vision/add_unique(client/client_source)
+	var/range_name = client_source?.prefs.read_preference(/datum/preference/choiced/tunnel_vision_fov) || "Minor (90 Degrees)"
+	var/fov_range
+	switch(range_name)
+		if ("Severe (270 Degrees)")
+			fov_range = FOV_270_DEGREES
+		if ("Moderate (180 Degrees)")
+			fov_range = FOV_180_DEGREES
+		else
+			fov_range = FOV_90_DEGREES
+	quirk_holder.add_fov_trait("tunnel vision quirk", fov_range)
+/*
+/datum/quirk/tunnel_vision/add()
+	quirk_holder.add_fov_trait("tunnel vision quirk", fov_range)
+*/
 /datum/quirk/tunnel_vision/remove()
-	quirk_holder.remove_fov_trait("tunnel vision quirk", FOV_90_DEGREES)
+	quirk_holder.remove_fov_trait("tunnel vision quirk")

--- a/monkestation/code/modules/client/preferences/tunnel_vision.dm
+++ b/monkestation/code/modules/client/preferences/tunnel_vision.dm
@@ -1,0 +1,18 @@
+GLOBAL_LIST_INIT(tunnel_vision_fovs, list("Minor (90 Degrees)","Moderate (180 Degrees)","Severe (270 Degrees)"))
+
+/datum/preference/choiced/tunnel_vision_fov
+	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
+	savefile_key = "tunnel_vision_fov"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/choiced/tunnel_vision_fov/init_possible_values()
+	return GLOB.tunnel_vision_fovs
+
+/datum/preference/choiced/tunnel_vision_fov/is_accessible(datum/preferences/preferences)
+	if (!..(preferences))
+		return FALSE
+
+	return "Tunnel Vision" in preferences.all_quirks
+
+/datum/preference/choiced/tunnel_vision_fov/apply_to_human(mob/living/carbon/human/target, value)
+	return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6682,6 +6682,7 @@
 #include "monkestation\code\modules\client\preferences\prude.dm"
 #include "monkestation\code\modules\client\preferences\runechat.dm"
 #include "monkestation\code\modules\client\preferences\sounds.dm"
+#include "monkestation\code\modules\client\preferences\tunnel_vision.dm"
 #include "monkestation\code\modules\client\preferences\alt_jobs\_job.dm"
 #include "monkestation\code\modules\client\preferences\alt_jobs\titles.dm"
 #include "monkestation\code\modules\client\preferences\species_features\arachnid.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/tunnel_vision.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/tunnel_vision.tsx
@@ -1,0 +1,6 @@
+import { FeatureChoiced, FeatureDropdownInput } from '../base';
+
+export const tunnel_vision_fov: FeatureChoiced = {
+  name: 'Tunnel Vision FOV',
+  component: FeatureDropdownInput,
+};


### PR DESCRIPTION
## About The Pull Request
Adds in a new -2 quirk, Tunnel Vision, it prevents you from looking behind you as if you were wearing a biohood. Permanently.
![image](https://github.com/user-attachments/assets/0418ff4a-2e33-48e4-9203-5da152b5cd0f)
This image has a moth behind you, but you cant tell because the POV has the tunnel vision quirk.
**Update:** PRs been updated to have a extra choice on just how big the range of tunnel vision is. the above image still is valid of a showcase of 90 degrees FOV.
## Why It's Good For The Game
Adds in a new way to challenge yourself, or to open an extra roleplay opportunity by being someone super oblivious, or a Metal Gear guard.
## Changelog
:cl: Tractor Mann
add: Added a new quirk, Tunnel Vision! (-2) using it will add FOV, preventing you from seeing behind you! You can pick a range of 90-180-270 Degrees to not see people in.
del: Removed herobrine.
/:cl:
