### PR TITLE
Actually adds to the plush refill canister to maint loot

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -286,6 +286,10 @@ GLOBAL_LIST_INIT(uncommon_loot, list(//uncommon: useful items
 		/obj/item/instrument/violin/golden = 2,
 		) = 2,
 
+	list(//MONKESTATION ADDITION: misc
+		/obj/item/vending_refill/plushvendor = 1,
+		) = 2,
+
 	list(//fakeout items, keep this list at low relative weight
 		/obj/item/clothing/shoes/jackboots = 1,
 		/obj/item/dice/d20 = 1, //To balance out the stealth die of fates in oddities


### PR DESCRIPTION
## About The Pull Request
See title.
## Why It's Good For The Game
Oops.
## Changelog

:cl:
fix: Plush refill canister is actually in maint loot now.
:cl:
