### PR TITLE
Abductors Can Now Send Plushies Through Their Telepad

### DIFF
--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -17,14 +17,17 @@
 		target.forceMove(get_turf(src))
 
 /obj/machinery/abductor/pad/proc/Send()
-	if(teleport_target == null)
-		teleport_target = GLOB.teleportlocs[pick(GLOB.teleportlocs)]
-	flick("alien-pad", src)
-	for(var/mob/living/target in loc)
-		target.forceMove(teleport_target)
-		new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
-		to_chat(target, span_warning("The instability of the warp leaves you disoriented!"))
-		target.Stun(60)
+    if(teleport_target == null)
+        teleport_target = GLOB.teleportlocs[pick(GLOB.teleportlocs)]
+    flick("alien-pad", src)
+    for(var/atom/movable/target in loc)
+        if(isliving(target) || istype(target, /obj/item/toy/plush))
+            target.forceMove(teleport_target)
+            new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
+            if(isliving(target))
+                var/mob/living/L = target
+                to_chat(L, span_warning("The instability of the warp leaves you disoriented!"))
+                L.Stun(60)
 
 /obj/machinery/abductor/pad/proc/Retrieve(mob/living/target)
 	flick("alien-pad", src)
@@ -41,10 +44,11 @@
 	addtimer(CALLBACK(src, PROC_REF(doMobToLoc), place, target), 80)
 
 /obj/machinery/abductor/pad/proc/doPadToLoc(place)
-	flick("alien-pad", src)
-	for(var/mob/living/target in get_turf(src))
-		target.forceMove(place)
-		new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
+    flick("alien-pad", src)
+    for(var/atom/movable/target in get_turf(src))
+        if(isliving(target) || istype(target, /obj/item/toy/plush))
+            target.forceMove(place)
+            new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
 
 /obj/machinery/abductor/pad/proc/PadToLoc(place)
 	new /obj/effect/temp_visual/teleport_abductor(place)

--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -16,6 +16,7 @@
 	if(!target.buckled)
 		target.forceMove(get_turf(src))
 
+// Monkestation Edit
 /obj/machinery/abductor/pad/proc/Send()
     if(teleport_target == null)
         teleport_target = GLOB.teleportlocs[pick(GLOB.teleportlocs)]
@@ -43,7 +44,8 @@
 	new /obj/effect/temp_visual/teleport_abductor(place)
 	addtimer(CALLBACK(src, PROC_REF(doMobToLoc), place, target), 80)
 
-/obj/machinery/abductor/pad/proc/doPadToLoc(place)
+// Monkestation Edit
+/obj/machinery/abductor/pad/proc/doPadToLoc(place)  
     flick("alien-pad", src)
     for(var/atom/movable/target in get_turf(src))
         if(isliving(target) || istype(target, /obj/item/toy/plush))

--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -18,17 +18,17 @@
 
 // Monkestation Edit
 /obj/machinery/abductor/pad/proc/Send()
-    if(teleport_target == null)
-        teleport_target = GLOB.teleportlocs[pick(GLOB.teleportlocs)]
-    flick("alien-pad", src)
-    for(var/atom/movable/target in loc)
-        if(isliving(target) || istype(target, /obj/item/toy/plush))
-            target.forceMove(teleport_target)
-            new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
-            if(isliving(target))
-                var/mob/living/L = target
-                to_chat(L, span_warning("The instability of the warp leaves you disoriented!"))
-                L.Stun(60)
+   	if(teleport_target == null)
+    		teleport_target = GLOB.teleportlocs[pick(GLOB.teleportlocs)]
+   	flick("alien-pad", src)
+   	for(var/atom/movable/target in loc)
+    	if(isliving(target) || istype(target, /obj/item/toy/plush))
+   		target.forceMove(teleport_target)
+  	        new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
+   	        if(isliving(target))
+  	        	var/mob/living/L = target
+ 	        	to_chat(L, span_warning("The instability of the warp leaves you disoriented!"))
+ 	        	L.Stun(60)
 
 /obj/machinery/abductor/pad/proc/Retrieve(mob/living/target)
 	flick("alien-pad", src)
@@ -46,11 +46,11 @@
 
 // Monkestation Edit
 /obj/machinery/abductor/pad/proc/doPadToLoc(place)  
-    flick("alien-pad", src)
-    for(var/atom/movable/target in get_turf(src))
-        if(isliving(target) || istype(target, /obj/item/toy/plush))
-            target.forceMove(place)
-            new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
+ 	flick("alien-pad", src)
+	for(var/atom/movable/target in get_turf(src))
+ 	if(isliving(target) || istype(target, /obj/item/toy/plush))
+  	        target.forceMove(place)
+   	        new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
 
 /obj/machinery/abductor/pad/proc/PadToLoc(place)
 	new /obj/effect/temp_visual/teleport_abductor(place)

--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -22,13 +22,13 @@
     		teleport_target = GLOB.teleportlocs[pick(GLOB.teleportlocs)]
    	flick("alien-pad", src)
    	for(var/atom/movable/target in loc)
-    	if(isliving(target) || istype(target, /obj/item/toy/plush))
-   		target.forceMove(teleport_target)
-  	        new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
-   	        if(isliving(target))
-  	        	var/mob/living/L = target
- 	        	to_chat(L, span_warning("The instability of the warp leaves you disoriented!"))
- 	        	L.Stun(60)
+    		if(isliving(target) || istype(target, /obj/item/toy/plush))
+   			target.forceMove(teleport_target)
+  			new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
+   	        	if(isliving(target))
+  	        		var/mob/living/abductedTarget = target
+ 	        		to_chat(abductedTarget, span_warning("The instability of the warp leaves you disoriented!"))
+ 	        		abductedTarget.Stun(60)
 
 /obj/machinery/abductor/pad/proc/Retrieve(mob/living/target)
 	flick("alien-pad", src)

--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -16,7 +16,6 @@
 	if(!target.buckled)
 		target.forceMove(get_turf(src))
 
-
 /obj/machinery/abductor/pad/proc/Send()
 	if(teleport_target == null)
 		teleport_target = GLOB.teleportlocs[pick(GLOB.teleportlocs)]
@@ -45,7 +44,6 @@
 /obj/machinery/abductor/pad/proc/MobToLoc(place,mob/living/target)
 	new /obj/effect/temp_visual/teleport_abductor(place)
 	addtimer(CALLBACK(src, PROC_REF(doMobToLoc), place, target), 80)
-
 
 /obj/machinery/abductor/pad/proc/doPadToLoc(place)  
 	flick("alien-pad", src)

--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -16,7 +16,7 @@
 	if(!target.buckled)
 		target.forceMove(get_turf(src))
 
-// Monkestation Edit
+// Monkestation Edit Start
 /obj/machinery/abductor/pad/proc/Send()
 	if(teleport_target == null)
 		teleport_target = GLOB.teleportlocs[pick(GLOB.teleportlocs)]
@@ -29,6 +29,7 @@
 				var/mob/living/abductedTarget = target
 				to_chat(abductedTarget, span_warning("The instability of the warp leaves you disoriented!"))
 				abductedTarget.Stun(60)
+// Monkestation Edit End
 
 /obj/machinery/abductor/pad/proc/Retrieve(mob/living/target)
 	flick("alien-pad", src)
@@ -44,13 +45,14 @@
 	new /obj/effect/temp_visual/teleport_abductor(place)
 	addtimer(CALLBACK(src, PROC_REF(doMobToLoc), place, target), 80)
 
-// Monkestation Edit
+// Monkestation Edit Start
 /obj/machinery/abductor/pad/proc/doPadToLoc(place)  
 	flick("alien-pad", src)
 	for(var/atom/movable/target in get_turf(src))
 		if(isliving(target) || istype(target, /obj/item/toy/plush))
 			target.forceMove(place)
 			new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
+// Monkestation Edit End
 
 /obj/machinery/abductor/pad/proc/PadToLoc(place)
 	new /obj/effect/temp_visual/teleport_abductor(place)

--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -48,9 +48,9 @@
 /obj/machinery/abductor/pad/proc/doPadToLoc(place)  
  	flick("alien-pad", src)
 	for(var/atom/movable/target in get_turf(src))
- 	if(isliving(target) || istype(target, /obj/item/toy/plush))
-  	        target.forceMove(place)
-   	        new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
+ 		if(isliving(target) || istype(target, /obj/item/toy/plush))
+  	        	target.forceMove(place)
+   	        	new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
 
 /obj/machinery/abductor/pad/proc/PadToLoc(place)
 	new /obj/effect/temp_visual/teleport_abductor(place)

--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -16,11 +16,12 @@
 	if(!target.buckled)
 		target.forceMove(get_turf(src))
 
-// Monkestation Edit Start
+
 /obj/machinery/abductor/pad/proc/Send()
 	if(teleport_target == null)
 		teleport_target = GLOB.teleportlocs[pick(GLOB.teleportlocs)]
 	flick("alien-pad", src)
+// Monkestation Edit Start
 	for(var/atom/movable/target in loc)
 		if(isliving(target) || istype(target, /obj/item/toy/plush))
 			target.forceMove(teleport_target)
@@ -45,9 +46,10 @@
 	new /obj/effect/temp_visual/teleport_abductor(place)
 	addtimer(CALLBACK(src, PROC_REF(doMobToLoc), place, target), 80)
 
-// Monkestation Edit Start
+
 /obj/machinery/abductor/pad/proc/doPadToLoc(place)  
 	flick("alien-pad", src)
+// Monkestation Edit Start
 	for(var/atom/movable/target in get_turf(src))
 		if(isliving(target) || istype(target, /obj/item/toy/plush))
 			target.forceMove(place)

--- a/code/modules/antagonists/abductor/machinery/pad.dm
+++ b/code/modules/antagonists/abductor/machinery/pad.dm
@@ -18,17 +18,17 @@
 
 // Monkestation Edit
 /obj/machinery/abductor/pad/proc/Send()
-   	if(teleport_target == null)
-    		teleport_target = GLOB.teleportlocs[pick(GLOB.teleportlocs)]
-   	flick("alien-pad", src)
-   	for(var/atom/movable/target in loc)
-    		if(isliving(target) || istype(target, /obj/item/toy/plush))
-   			target.forceMove(teleport_target)
-  			new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
-   	        	if(isliving(target))
-  	        		var/mob/living/abductedTarget = target
- 	        		to_chat(abductedTarget, span_warning("The instability of the warp leaves you disoriented!"))
- 	        		abductedTarget.Stun(60)
+	if(teleport_target == null)
+		teleport_target = GLOB.teleportlocs[pick(GLOB.teleportlocs)]
+	flick("alien-pad", src)
+	for(var/atom/movable/target in loc)
+		if(isliving(target) || istype(target, /obj/item/toy/plush))
+			target.forceMove(teleport_target)
+			new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
+			if(isliving(target))
+				var/mob/living/abductedTarget = target
+				to_chat(abductedTarget, span_warning("The instability of the warp leaves you disoriented!"))
+				abductedTarget.Stun(60)
 
 /obj/machinery/abductor/pad/proc/Retrieve(mob/living/target)
 	flick("alien-pad", src)
@@ -46,11 +46,11 @@
 
 // Monkestation Edit
 /obj/machinery/abductor/pad/proc/doPadToLoc(place)  
- 	flick("alien-pad", src)
+	flick("alien-pad", src)
 	for(var/atom/movable/target in get_turf(src))
- 		if(isliving(target) || istype(target, /obj/item/toy/plush))
-  	        	target.forceMove(place)
-   	        	new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
+		if(isliving(target) || istype(target, /obj/item/toy/plush))
+			target.forceMove(place)
+			new /obj/effect/temp_visual/dir_setting/ninja(get_turf(target), target.dir)
 
 /obj/machinery/abductor/pad/proc/PadToLoc(place)
 	new /obj/effect/temp_visual/teleport_abductor(place)


### PR DESCRIPTION
## About The Pull Request

This pull request adds the ability for Abductor telepads to send plushies. Previously, the telepad could only teleport living targets, but now plushies can be teleported as well. This change allows Abductors to pull off fake-outs to scare crewmembers or set up humorous gags around the station, similar to how space cows are sometimes sent to confuse people.

## Why It's Good For The Game

This change adds a fun and lighthearted feature to the game by giving Abductors a little more versatility in how they interact with crewmembers. Whether it's used for a little bit of mischief or comedic relief, this is a wholesome tool added to the Abductors' toolkit without affecting balance.

**Demonstration:**

https://github.com/user-attachments/assets/f2809abb-93f7-40d9-b110-efc9c01bd49c


**What a Fake-Out Example Could Look Like:**
![idea](https://github.com/user-attachments/assets/6bb7313b-ca03-407d-9853-69416729bd07)


## Changelog

:cl:
add: Abductor telepads can now send plushies, adding more opportunities for fun interactions.
/:cl:
