### PR TITLE
Try to fix looping sounds in the volume mixer (+ wumpa volume mixer fix)

### DIFF
--- a/code/datums/looping_sounds/_looping_sound.dm
+++ b/code/datums/looping_sounds/_looping_sound.dm
@@ -66,7 +66,7 @@
 	set_parent(_parent)
 	direct = _direct
 	skip_starting_sounds = _skip_starting_sounds
-	channel = _channel
+	channel ||= _channel
 
 	if(start_immediately)
 		start()

--- a/monkestation/code/modules/donator/code/item/misc.dm
+++ b/monkestation/code/modules/donator/code/item/misc.dm
@@ -33,4 +33,5 @@
 	extra_range = 3
 	falloff_exponent = 100
 	falloff_distance = 3
+	channel = CHANNEL_SQUEAK
 


### PR DESCRIPTION
## Changelog
:cl:
fix: Wumpas now fully respect the volume mixer's "squeak" channel.
fix: Looping sounds should work properly with the volume mixer now.
/:cl:
