### PR TITLE
Decreases cortical borer evolution rate and makes it use delta time

### DIFF
--- a/monkestation/code/modules/antagonists/borers/code/mobs/cortical_borer.dm
+++ b/monkestation/code/modules/antagonists/borers/code/mobs/cortical_borer.dm
@@ -139,7 +139,7 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 	/// How old the borer is, starting from zero. Goes up only when inside a host and resets when a stat point is gained. This is in seconds.
 	var/maturity_age = 0
 	/// Whether a chem point has been granted for this maturity level. Resets when a stat point is gained.
-	var/chem_point_gained = FALSE // Technically if seconds_per_tick is like 5 this can fail at the max maturity speed but w h a t e v e r .
+	var/chem_point_gained = FALSE // Technically if delta_time is like 5 this can fail at the max maturity speed but w h a t e v e r .
 
 	/// How many times you've levelled up over all
 	var/level = 0
@@ -314,6 +314,7 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 
 /mob/living/basic/cortical_borer/Life(seconds_per_tick, times_fired)
 	. = ..()
+
 	//can only do stuff when we are inside a LIVING human
 	if(!inside_human() || human_host?.stat == DEAD)
 		return
@@ -343,7 +344,7 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 			adjustBruteLoss(maxHealth * -health_regen * seconds_per_tick)
 
 	//this is so they can evolve
-	mature(seconds_per_tick)
+	mature()
 
 //if it doesnt have a ckey, let ghosts have it
 /mob/living/basic/cortical_borer/attack_ghost(mob/dead/observer/user)
@@ -483,26 +484,28 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 	return
 
 /// Called on Life() for the borer to age a bit
-/mob/living/basic/cortical_borer/proc/mature(seconds_per_tick)
+/mob/living/basic/cortical_borer/proc/mature()
 	. = TRUE
+
 	if(upgrade_flags & BORER_STEALTH_MODE)
 		return FALSE
-	maturity_age += seconds_per_tick
+
+	maturity_age += DELTA_WORLD_TIME(SSmobs)
 
 	/**
 	 * In the beginning you start out with the following generation:
-	 * Evolution point per 40 seconds
-	 * Chemical point per 20 seconds
+	 * Evolution point per 60 seconds
+	 * Chemical point per 30 seconds
 	 */
 
 	//20:40, 15:30, 10:20, 5:10
-	var/maturity_threshold = 20
+	var/maturity_threshold = 30
 	if(GLOB.successful_egg_number >= GLOB.objective_egg_borer_number)
-		maturity_threshold -= 2
-	if(length(GLOB.willing_hosts) >= GLOB.objective_willing_hosts)
-		maturity_threshold -= 10
-	if(GLOB.successful_blood_chem >= GLOB.objective_blood_borer)
 		maturity_threshold -= 3
+	if(length(GLOB.willing_hosts) >= GLOB.objective_willing_hosts)
+		maturity_threshold -= 15
+	if(GLOB.successful_blood_chem >= GLOB.objective_blood_borer)
+		maturity_threshold -= 4.5
 
 	if(!chem_point_gained && maturity_age >= maturity_threshold)
 		if(chemical_evolution < limited_borer) //you can only have a default of 10 at a time


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns out making it use the intended 40 second time made it extremely fast compared to before.
My guess is that the original didn't work properly. I've confirmed this works through varedit.
This also edits it to use delta time so it should actually be immune to lag now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix good, also 60 billion evolution point borers bad.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Borers now evolve slower again.
fix: Borer maturity (not regen or such) is now actually lag immune.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
