### PR TITLE
keeps people from escaping centcom

### DIFF
--- a/monkestation/code/modules/ghost_players/job_helpers/firing_range_helper.dm
+++ b/monkestation/code/modules/ghost_players/job_helpers/firing_range_helper.dm
@@ -53,6 +53,7 @@
 		/obj/item/gun/magic/wand/safety,
 		/obj/item/gun/medbeam,
 		/obj/item/gun/energy/recharge/kinetic_accelerator/meme,
+		/obj/item/gun/magic/artifact,
 	)
 
 /obj/structure/centcom_item_spawner/gun_and_ammo_creator/spawn_chosen_item(type_to_spawn)

--- a/monkestation/code/modules/ghost_players/job_helpers/food_machine.dm
+++ b/monkestation/code/modules/ghost_players/job_helpers/food_machine.dm
@@ -8,7 +8,6 @@
 
 	icon = 'icons/obj/money_machine.dmi'
 	icon_state = "bogdanoff"
-	blacklisted_types = list(/obj/item/food/grown/kudzupod)
 
 /obj/structure/food_machine/attack_hand(mob/living/user, list/modifiers)
 	. = ..()

--- a/monkestation/code/modules/ghost_players/job_helpers/food_machine.dm
+++ b/monkestation/code/modules/ghost_players/job_helpers/food_machine.dm
@@ -8,7 +8,6 @@
 
 	icon = 'icons/obj/money_machine.dmi'
 	icon_state = "bogdanoff"
-	///typesof() these types will not be able to be spawned
 	blacklisted_types = list(/obj/item/food/grown/kudzupod)
 
 /obj/structure/food_machine/attack_hand(mob/living/user, list/modifiers)


### PR DESCRIPTION
## About The Pull Request

adds like two things to the blacklists

## Why It's Good For The Game

escaping centcom is bad, causing kudzu floods is bad
## Changelog
:cl:
fix: CentCom has updated the blacklists on their equipment teleporters. No more borging yourself, and I WILL get around to removing your ability to kudzu flood sooner or later.
/:cl:
