### PR TITLE
Fixs the heart attack disease not progressing to deadly.

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/restricted/stage4.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/restricted/stage4.dm
@@ -3,6 +3,8 @@
 	desc = "If left untreated the subject will die!"
 	restricted = TRUE
 	max_multiplier = 5
+	chance = 20
+	max_chance = 20
 	var/sound = FALSE
 	badness = EFFECT_DANGER_DEADLY
 
@@ -51,6 +53,7 @@
 			affected_mob.set_heartattack(TRUE)
 			affected_mob.reagents.add_reagent(/datum/reagent/medicine/c2/penthrite, 3) // To give the victim a final chance to shock their heart before losing consciousness
 			return FALSE
+	multiplier_tweak(0.1)
 
 /datum/symptom/catapult_sneeze
 	name = "Sneezing?"


### PR DESCRIPTION

## About The Pull Request
Fixes the disease granted by the random heart attack event (Myocardial Infarction, AKA heart worms) not progressing to the later stages, making it effectively do nothing.
## Why It's Good For The Game
Having the random heart attack event actually work is good, cause right now it's a waste of storyteller points.
## Changelog
:cl:
fix: Fixed the disease from the random heart attack event not progressing into later stages.
/:cl:
