### PR TITLE
Ensure blood volume is restored whenever TRAIT_NOBLOOD is lost

### DIFF
--- a/monkestation/code/modules/mob/living/carbon/human/init_signals.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/init_signals.dm
@@ -1,0 +1,7 @@
+/mob/living/carbon/human/register_init_signals()
+	. = ..()
+	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_NOBLOOD), PROC_REF(on_lose_noblood_trait))
+
+/mob/living/carbon/human/proc/on_lose_noblood_trait(datum/source)
+	SIGNAL_HANDLER
+	blood_volume = clamp(blood_volume, BLOOD_VOLUME_NORMAL, BLOOD_VOLUME_MAXIMUM - 1)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7112,6 +7112,7 @@
 #include "monkestation\code\modules\mob\living\carbon\human\emotes.dm"
 #include "monkestation\code\modules\mob\living\carbon\human\human.dm"
 #include "monkestation\code\modules\mob\living\carbon\human\human_defines.dm"
+#include "monkestation\code\modules\mob\living\carbon\human\init_signals.dm"
 #include "monkestation\code\modules\mob\living\carbon\human\lizard_gags.dm"
 #include "monkestation\code\modules\mob\living\carbon\human\simian_gags.dm"
 #include "monkestation\code\modules\mob\living\carbon\human\worn_overlays.dm"


### PR DESCRIPTION
## Changelog
:cl:
fix: Ensure blood volume is restored to normal levels whenever TRAIT_NOBLOOD is lost.
/:cl:
