### PR TITLE
Blood Brother bans now properly prevent conversion

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -49,7 +49,7 @@
 	return ..()
 
 /datum/antagonist/brother/proc/on_mob_successful_flashed_carbon(mob/living/source, mob/living/carbon/flashed, obj/item/assembly/flash/flash)
-	SIGNAL_HANDLER
+	//SIGNAL_HANDLER
 
 	if (flashed.stat == DEAD)
 		return
@@ -63,13 +63,11 @@
 		flashed.balloon_alert(source, "[flashed.p_their()] mind is vacant!")
 		return
 
-	/*
-	// monkestation edit: allow people to opt-out of BB
-	if(!(ROLE_BROTHER in flashed.client?.prefs?.be_special) || is_banned_from(flashed.ckey, list(ROLE_BROTHER, ROLE_SYNDICATE)))
-		flashed.balloon_alert(source, "unwilling to play role!")
+	// monkestation edit: dont try to convert banned people
+	if(is_banned_from(flashed.ckey, list(ROLE_BROTHER, ROLE_SYNDICATE)))
+		flashed.balloon_alert(source, "cannot become brother!")
 		return
 	// monkestation end
-	*/
 
 	for(var/datum/objective/brother_objective as anything in source.mind.get_all_objectives())
 		// If the objective has a target, are we flashing them?

--- a/monkestation/code/modules/blueshift/items/soul_catcher.dm
+++ b/monkestation/code/modules/blueshift/items/soul_catcher.dm
@@ -114,7 +114,7 @@
 /mob/living/carbon/human/examine_more(mob/user)
 	. = ..()
 	if(user.mind?.has_antag_datum(/datum/antagonist/brother) && !(ROLE_BROTHER in client?.prefs?.be_special))
-		. += span_orange("[p_They()] do[p_es()] not seem to be too fond of brotherly connections.")
+		. += span_userdanger("[p_They()] do[p_es()] not seem to be too fond of brotherly connections.")
 
 /obj/item/disk/nifsoft_uploader/soulcatcher
 	name = "Soulcatcher"


### PR DESCRIPTION

## About The Pull Request

According to Dexee, this seems to be the behavior that's expected by admins at the moment, but this functionality was just nuked whenever the "opt-out via prefs" was removed, rather than just removing the prefs check and leaving the ban check.

## Changelog
:cl:
fix: Blood Brother bans now properly prevent conversion.
/:cl:
