### PR TITLE
Include the log directory for rounds in the database

### DIFF
--- a/SQL/database_changelog.md
+++ b/SQL/database_changelog.md
@@ -5,15 +5,31 @@ Make sure to also update `DB_MAJOR_VERSION` and `DB_MINOR_VERSION`, which can be
 The latest database version is 5.24; The query to update the schema revision table is:
 
 ```sql
-INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 24);
+INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 25);
 ```
 or
 
 ```sql
-INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 24);
+INSERT INTO `SS13_schema_revision` (`major`, `minor`) VALUES (5, 25);
 ```
 
 In any query remember to add a prefix to the table names if you use one.
+
+-----------------------------------------------------
+Version 5.25, 8 September 2024, by Absolucy
+Added `log_directory` field to the `round` table.
+```sql
+ALTER TABLE `round`
+	ADD COLUMN `log_directory` VARCHAR(255) NULL AFTER `station_name`;
+
+UPDATE `round`
+SET `log_directory` = CONCAT(
+	'data/logs/',
+	DATE_FORMAT(`initialize_datetime`, '%Y/%m/%d'),
+	'/round-',
+	`id`
+);
+```
 
 -----------------------------------------------------
 Version 5.24, 17 May 2023, by LemonInTheDark

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -494,6 +494,7 @@ CREATE TABLE `round` (
   `shuttle_name` VARCHAR(64) NULL,
   `map_name` VARCHAR(32) NULL,
   `station_name` VARCHAR(80) NULL,
+  `log_directory` VARCHAR(255) NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -492,6 +492,7 @@ CREATE TABLE `SS13_round` (
   `shuttle_name` VARCHAR(64) NULL,
   `map_name` VARCHAR(32) NULL,
   `station_name` VARCHAR(80) NULL,
+  `log_directory` VARCHAR(255) NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -20,7 +20,7 @@
  *
  * make sure you add an update to the schema_version stable in the db changelog
  */
-#define DB_MINOR_VERSION 24
+#define DB_MINOR_VERSION 25
 
 
 //! ## Timing subsystem

--- a/monkestation/code/game/world.dm
+++ b/monkestation/code/game/world.dm
@@ -1,0 +1,17 @@
+/world/SetupLogs()
+	. = ..()
+	set_db_log_directory()
+
+/proc/set_db_log_directory()
+	set waitfor = FALSE
+	if(!GLOB.round_id || !SSdbcore.IsConnected())
+		return
+	var/datum/db_query/set_log_directory = SSdbcore.NewQuery({"
+		UPDATE `[format_table_name("round")]`
+		SET
+			`log_directory` = :log_directory
+		WHERE
+			`id` = :round_id
+	"}, list("log_directory" = GLOB.log_directory, "round_id" = GLOB.round_id))
+	set_log_directory.Execute()
+	QDEL_NULL(set_log_directory)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5846,6 +5846,7 @@
 #include "monkestation\code\datums\wires\particle_accelerator.dm"
 #include "monkestation\code\game\atom.dm"
 #include "monkestation\code\game\sound.dm"
+#include "monkestation\code\game\world.dm"
 #include "monkestation\code\game\area\areas.dm"
 #include "monkestation\code\game\area\areas\station.dm"
 #include "monkestation\code\game\machinery\_machinery.dm"


### PR DESCRIPTION

## About The Pull Request

This logs the log directory for each round in the database. Should make various scripts and functionality easier to implement (i.e directly getting logs for a specific round ID)

***Requires an update to the SQL database!!!***

## SQL Migration

```sql
INSERT INTO `schema_revision` (`major`, `minor`) VALUES (5, 25);

ALTER TABLE `round`
	ADD COLUMN `log_directory` VARCHAR(255) NULL AFTER `station_name`;

UPDATE `round`
SET `log_directory` = CONCAT(
	'data/logs/',
	DATE_FORMAT(`initialize_datetime`, '%Y/%m/%d'),
	'/round-',
	`id`
);
```
This will add the `log_directory` column - and set the log directory for all existing rounds, presuming they use the normal `data/logs/YYYY/mm/dd/round-123` pathing.


## Changelog

No player-facing changes
