### PR TITLE
Add "Server Memory Stats" debug verb

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -261,6 +261,7 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/log_viewer_new,
 	/client/proc/getserverlogs_debug,
 	/client/proc/getcurrentlogs_debug,
+	/client/proc/server_memory_stats,
 	)
 GLOBAL_LIST_INIT(admin_verbs_possess, list(/proc/possess, /proc/release))
 GLOBAL_PROTECT(admin_verbs_possess)

--- a/monkestation/code/modules/factory_type_beat/debug.dm
+++ b/monkestation/code/modules/factory_type_beat/debug.dm
@@ -33,17 +33,46 @@
 		WRITE_FILE(F, "[i]\t[counts[i]]\n")
 #endif
 
+#ifndef OPENDREAM
 ///these procs don't work on od
 SUBSYSTEM_DEF(memory_stats)
 	name = "Mem Stats"
 	init_order = INIT_ORDER_AIR
 	priority = FIRE_PRIORITY_AIR
 	wait = 5 MINUTES
-	flags = SS_NO_INIT | SS_BACKGROUND
+	flags = SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 
+/datum/controller/subsystem/memory_stats/Initialize()
+	if(world.system_type != MS_WINDOWS || !rustg_file_exists("memorystats.dll"))
+		flags |= SS_NO_FIRE
+	// Technically this isn't really as much of an initialization as it is "just disabling itself if it won't work", so no reason to actually print any output
+	return SS_INIT_NO_NEED
+
 /datum/controller/subsystem/memory_stats/fire(resumed)
-	if(world.system_type == MS_WINDOWS)
-		var/memory_summary = call_ext("memorystats", "get_memory_stats")()
-		if(memory_summary)
-			rustg_file_write(memory_summary, "data/mem_stat/[GLOB.round_id]-memstat.txt")
+	var/memory_summary = get_memory_stats()
+	if(memory_summary)
+		rustg_file_write(memory_summary, "data/mem_stat/[GLOB.round_id]-memstat.txt")
+
+/datum/controller/subsystem/memory_stats/proc/get_memory_stats()
+	if(world.system_type != MS_WINDOWS || !rustg_file_exists("memorystats.dll"))
+		return
+	return trimtext(call_ext("memorystats", "get_memory_stats")())
+#endif
+
+/client/proc/server_memory_stats()
+	set name = "Server Memory Stats"
+	set category = "Debug"
+	set desc = "Print various statistics about the server's current memory usage (does not work on OpenDream)"
+
+	if(!check_rights(R_DEBUG))
+		return
+#ifndef OPENDREAM
+	var/result = span_danger("Error fetching memory statistics!")
+	var/memory_stats = SSmemory_stats.get_memory_stats()
+	if(memory_stats)
+		result = memory_stats
+#else
+	var/result = span_danger("Memory statistics not supported on OpenDream, sorry!")
+#endif
+	to_chat(src, examine_block(result), avoid_highlighting = TRUE, type = MESSAGE_TYPE_DEBUG, confidential = TRUE)


### PR DESCRIPTION

## About The Pull Request

Cleaned up the code for `SSmemory_stats` a bit, and added a new verb, "Server Memory Stats", that prints the memory summary to your chat. Only usable with `+DEBUG` perms, tho.

![2024-09-09 (1725927030) ~ dreamseeker](https://github.com/user-attachments/assets/5dfcb8fa-0b10-4807-82b1-a1fa3401369a)

Also, made it so that OpenDream won't bother compiling `SSmemory_stats` at all - and the subsystem will disable firing during init if it's either not on Windows, or if `memorystats.dll` doesn't exist.

Running the verb on OpenDream will just return "Memory statistics not supported on OpenDream, sorry!"

## Changelog
:cl:
admin: Added a debug verb for admins to output the server's current memory usage summary to their chat.
/:cl:
