### PR TITLE
Bogseo and trappiste ammo box changes

### DIFF
--- a/monkestation/code/modules/blueshift/items/ammo.dm
+++ b/monkestation/code/modules/blueshift/items/ammo.dm
@@ -662,7 +662,7 @@
 
 /obj/item/ammo_box/c585trappiste
 	name = "ammo box (.585 Trappiste lethal)"
-	desc = "A box of .585 Trappiste pistol rounds, holds twelve cartridges."
+	desc = "A box of .585 Trappiste pistol rounds, holds thirty-two cartridges."
 
 	icon = 'monkestation/code/modules/blueshift/icons/obj/company_and_or_faction_based/trappiste_fabriek/ammo.dmi'
 	icon_state = "585box"
@@ -673,7 +673,7 @@
 
 	caliber = CALIBER_585TRAPPISTE
 	ammo_type = /obj/item/ammo_casing/c585trappiste
-	max_ammo = 12
+	max_ammo = 32
 
 // .585 Trappiste equivalent to a rubber bullet
 
@@ -700,7 +700,7 @@
 
 /obj/item/ammo_box/c585trappiste/incapacitator
 	name = "ammo box (.585 Trappiste flathead)"
-	desc = "A box of .585 Trappiste pistol rounds, holds twelve cartridges. The blue stripe indicates that it should hold less lethal rounds."
+	desc = "A box of .585 Trappiste pistol rounds, holds thirty-two cartridges. The blue stripe indicates that it should hold less lethal rounds."
 
 	icon_state = "585box_disabler"
 
@@ -728,7 +728,7 @@
 
 /obj/item/ammo_box/c585trappiste/hollowpoint
 	name = "ammo box (.585 Trappiste hollowhead)"
-	desc = "A box of .585 Trappiste pistol rounds, holds twelve cartridges. The purple stripe indicates that it should hold hollowpoint-like rounds."
+	desc = "A box of .585 Trappiste pistol rounds, holds 32 cartridges. The purple stripe indicates that it should hold hollowpoint-like rounds."
 
 	icon_state = "585box_shrapnel"
 

--- a/monkestation/code/modules/blueshift/items/company_guns.dm
+++ b/monkestation/code/modules/blueshift/items/company_guns.dm
@@ -394,7 +394,7 @@
 
 /obj/item/gun/ballistic/automatic/xhihao_smg
 	name = "\improper Bogseo Submachine Gun"
-	desc = "A weapon that could hardly be called a 'sub' machinegun, firing the monstrous .585 cartridge. \
+	desc = "A weapon that could hardly be called a 'sub' machinegun, firing the .27-54 cartridge. \
 		It provides enough kick to bruise a shoulder pretty bad if used without protection."
 
 	icon = 'monkestation/code/modules/blueshift/icons/obj/company_and_or_faction_based/xhihao_light_arms/guns32x.dmi'
@@ -412,7 +412,7 @@
 	weapon_weight = WEAPON_HEAVY
 	slot_flags = ITEM_SLOT_SUITSTORE | ITEM_SLOT_BELT
 
-	accepted_magazine_type = /obj/item/ammo_box/magazine/c585trappiste_pistol
+	accepted_magazine_type = /obj/item/ammo_box/magazine/miecz
 
 	fire_sound = 'monkestation/code/modules/blueshift/sounds/smg_heavy.ogg'
 	can_suppress = TRUE

--- a/monkestation/code/modules/blueshift/items/gunset.dm
+++ b/monkestation/code/modules/blueshift/items/gunset.dm
@@ -260,15 +260,15 @@
 	name = "\improper Xhihao 'Bogseo' gunset"
 
 	weapon_to_spawn = /obj/item/gun/ballistic/automatic/xhihao_smg/no_mag
-	extra_to_spawn = /obj/item/ammo_box/magazine/c585trappiste_pistol
+	extra_to_spawn = /obj/item/ammo_box/magazine/miecz
 
 /obj/item/storage/toolbox/guncase/skyrat/xhihao_large_case/bogseo/PopulateContents()
 	new weapon_to_spawn (src)
 
 	generate_items_inside(list(
-		/obj/item/ammo_box/c585trappiste/incapacitator = 1,
-		/obj/item/ammo_box/c585trappiste = 1,
-		/obj/item/ammo_box/magazine/c585trappiste_pistol/spawns_empty = 3,
+		/obj/item/ammo_box/c27_54cesarzowa/rubber = 2,
+		/obj/item/ammo_box/c27_54cesarzowa = 1,
+		/obj/item/ammo_box/magazine/miecz/spawns_empty = 3,
 	), src)
 
 // Base yellow with symbol trappiste case


### PR DESCRIPTION

## About The Pull Request
Changes the Bogseo to use .27-54 Cesarzowa piercing bullets instead of trappiste bullets, changes the trappiste ammo boxes to containt 32 rounds (from 12) The blueshield Bogseo set comes with 1 ammo box of ap rounds, and 2 boxes of rubber rounds, enough ammo to fill up all their mags.
## Why It's Good For The Game
The trappiste ammo box changes are so they can fill up 2 mags worth in a single box, which is how much they were supposed to fill before they hade their magazine size increased. The Bogseo changes are due to the weapon currently being too strong, due to being able to put someone into hard crit very quickly. Changing the ammo will help reduce the strength of the Bogseo without completely killing it. The starting ammo was changed to make sure that all 3 mags can be filled
## Changelog
:cl:
balance: The Bogseo now uses .27-54 Cesarzowa rounds, instead of .585 trappiste rounds
balance: The Bogseo smg gunset for the Blueshield now comes with 1 box of .27-54 Cesarzowa piercing bullets, and 2 boxes of the rubber variant.
balance: The trappiste ammo boxes now contain 32 rounds
/:cl:
