### PR TITLE
Adds a missing BP locker to Ourobouros

### DIFF
--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -4889,11 +4889,7 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/healthanalyzer{
-	pixel_y = 10
-	},
-/obj/item/clothing/gloves/latex,
+/obj/structure/closet/secure_closet/brig_physician,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "buK" = (
@@ -69072,6 +69068,10 @@
 	},
 /obj/effect/turf_decal/trimline/red/mid_joiner{
 	dir = 1
+	},
+/obj/item/clothing/gloves/latex,
+/obj/item/healthanalyzer{
+	pixel_y = 10
 	},
 /turf/open/floor/iron/white/smooth_edge{
 	dir = 1


### PR DESCRIPTION
## About The Pull Request
Title, adss a missing brig physician locker to Ourobouros
## Why It's Good For The Game
Map consistancy, fixes #3271
## Changelog
:cl:
add: Ourobouros now has a Brig Physician locker
/:cl:
