### PR TITLE
Removes FOV from the bio hood

### DIFF
--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -13,10 +13,11 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION
 
-/obj/item/clothing/head/bio_hood/Initialize(mapload)
-	. = ..()
-	if(flags_inv & HIDEFACE)
-		AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
+// MONKESTATION REMOVAL
+//obj/item/clothing/head/bio_hood/Initialize(mapload)
+	//. = ..()
+	//if(flags_inv & HIDEFACE)
+	//	AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
 
 /datum/armor/head_bio_hood
 	bio = 100

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -13,11 +13,6 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION
 
-/obj/item/clothing/head/bio_hood/Initialize(mapload)
-	. = ..()
-	if(flags_inv & HIDEFACE)
-		AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
-
 /datum/armor/head_bio_hood
 	bio = 100
 	fire = 30

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -13,6 +13,11 @@
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION
 
+/obj/item/clothing/head/bio_hood/Initialize(mapload)
+	. = ..()
+	if(flags_inv & HIDEFACE)
+		AddComponent(/datum/component/clothing_fov_visor, FOV_90_DEGREES)
+
 /datum/armor/head_bio_hood
 	bio = 100
 	fire = 30


### PR DESCRIPTION
## About The Pull Request

Removes the FOV from the bio hood

## Why It's Good For The Game

A while back a bunch of the TG FOV changes were ported so stuff like gas masks and certain helmets would restrict your view to 90 degrees in front. The bio hood is the last of those items to have it's FOV effect removed. I feel like it is currently unnecessary for the bio hood to have such a restriction. Also fla tout doesn't make sense, space helmets and gas masks don't block your view why would a bio hood block it.

## Changelog
:cl:
qol: Removed the FOV restriction from bio hoods.
/:cl:
