### PR TITLE
Adds various botany circuit boards to Tech Storage

### DIFF
--- a/code/game/objects/effects/spawners/random/techstorage.dm
+++ b/code/game/objects/effects/spawners/random/techstorage.dm
@@ -44,6 +44,15 @@
 		/obj/item/circuitboard/machine/chem_dispenser/drinks,
 		/obj/item/circuitboard/machine/chem_dispenser/drinks/beer,
 		/obj/item/circuitboard/computer/slot_machine,
+		// monkestation start: botany stuff
+		/obj/item/circuitboard/machine/composters,
+		/obj/item/circuitboard/machine/plantgenes,
+		/obj/item/circuitboard/machine/biogenerator,
+		/obj/item/circuitboard/machine/hydroponics,
+		/obj/item/circuitboard/machine/seed_extractor,
+		/obj/item/circuitboard/machine/chicken_grinder,
+		/obj/item/circuitboard/machine/feed_machine,
+		// monkestation end
 	)
 
 /obj/effect/spawner/random/techstorage/rnd_all

--- a/monkestation/code/modules/ranching/circuits.dm
+++ b/monkestation/code/modules/ranching/circuits.dm
@@ -21,6 +21,7 @@
 	name = "feed machine (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
 	greyscale_colors = CIRCUIT_COLOR_SERVICE
+	build_path = /obj/machinery/feed_machine
 	req_components = list(
 		/datum/stock_part/matter_bin = 3,
 		/datum/stock_part/manipulator = 1)


### PR DESCRIPTION

## About The Pull Request

This adds the following boards to the service rack in tech storage:
- Composter
- Plant DNA Manipulator
- Biogenerator
- Hydroponics Tray
- Seed Extractor
- Chicken Grinder
- Chicken Feed Producer

## Why It's Good For The Game

Better to be able to have spares and build these easier. Some of these can't even be printed yet - but that's something I'll handle in a followup PR.

## Changelog
:cl:
add: Added various botany circuit boards to Tech Storage.
/:cl:
