### PR TITLE
NO MORE DEEPFRIED MODS! HOORAY!

### DIFF
--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -11,6 +11,7 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	/obj/item/delivery,
 	/obj/item/his_grace,
 	/obj/item/bodybag/bluespace,
+	/obj/item/mod/control,
 )))
 
 /obj/machinery/deepfryer


### PR DESCRIPTION
yeah!
## About The Pull Request
fixes #915 (how did I even come up with that)
## Why It's Good For The Game
Prevents you from going to MODsuit AI-induced lobby screen (aside from other weirdness)
## Changelog
:cl:
fix: Modsuits are no longer deepfriable
/:cl:
