### PR TITLE
Makes the confusion symptom tolerable (hopefully)

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/stage3.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/stage3.dm
@@ -106,11 +106,12 @@ GLOBAL_LIST_INIT(disease_hivemind_users, list())
 	stage = 3
 	badness = EFFECT_DANGER_HINDRANCE
 	max_multiplier = 5
-	max_chance = 15
+	symptom_delay_min = 1
+	symptom_delay_max = 5
 
 /datum/symptom/confusion/activate(mob/living/carbon/mob)
-	to_chat(mob, span_notice("You have trouble telling right and left apart all of a sudden."))
-	mob.adjust_confusion(1 SECONDS * multiplier)
+	to_chat(mob, span_warning("You have trouble telling right and left apart all of a sudden!"))
+	mob.adjust_confusion_up_to(1 SECONDS * multiplier, 20 SECONDS)
 
 /datum/symptom/groan
 	name = "Groaning Syndrome"


### PR DESCRIPTION
## About The Pull Request

This nerfs the confusion symptom (Topographical Cretinism), hopefully making it less awful for everyone involved.
- Caps the confusion it can cause to 20 seconds, preventing fully randomized movement
- Adds a cooldown of 1 to 5 seconds to the symptom's activation.

## Why It's Good For The Game

this is perhaps THE worst symptom i've encountered

- the confusion _stacks_
- there's no cooldown for activation, so it can just spam confusion stacks
- if it spreads, it's nigh impossible to cure because _nobody can properly move_

## Changelog
:cl:
balance: The confusion symptom's (Topographical Cretinism) confusion no longer infinitely stacks - it will no longer COMPLETELY randomize your movement.
balance: The confusion symptom can now only activate every 1 to 5 seconds.
/:cl:
