### PR TITLE
[PORT] Ash Ascension spells have high transparency

### DIFF
--- a/code/modules/antagonists/heretic/magic/ash_ascension.dm
+++ b/code/modules/antagonists/heretic/magic/ash_ascension.dm
@@ -53,7 +53,8 @@
 		return
 
 	for(var/turf/nearby_turf as anything in RANGE_TURFS(1, owner))
-		new /obj/effect/hotspot(nearby_turf)
+		var/obj/effect/hotspot/flame_tile = locate(nearby_turf) || new(nearby_turf)
+		flame_tile.alpha = 125
 		nearby_turf.hotspot_expose(750, 25 * seconds_per_tick, 1)
 		for(var/mob/living/fried_living in nearby_turf.contents - owner)
 			fried_living.apply_damage(2.5 * seconds_per_tick, BURN)
@@ -86,7 +87,8 @@
 /datum/action/cooldown/spell/fire_cascade/proc/fire_cascade(atom/centre, flame_radius = 1)
 	for(var/i in 0 to flame_radius)
 		for(var/turf/nearby_turf as anything in spiral_range_turfs(i + 1, centre))
-			new /obj/effect/hotspot(nearby_turf)
+			var/obj/effect/hotspot/flame_tile = locate(nearby_turf) || new(nearby_turf)
+			flame_tile.alpha = 125
 			nearby_turf.hotspot_expose(750, 50, 1)
 			for(var/mob/living/fried_living in nearby_turf.contents - owner)
 				fried_living.apply_damage(5, BURN)


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/83662

## Why It's Good For The Game

I want to see the fucking game.

## Changelog
:cl: Absolucy, carlarctg
qol: Ash Ascension spells have high transparency
/:cl:
