### PR TITLE
Fixes the lavaland clown prefab by adding a normal floor underneath the airlock.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -333,7 +333,7 @@
 /area/ruin/powered/clownplanet)
 "bZ" = (
 /obj/machinery/door/airlock/bananium,
-/turf/open/indestructible/honk,
+/turf/open/floor/carpet,
 /area/ruin/powered/clownplanet)
 "ca" = (
 /obj/item/bikehorn,


### PR DESCRIPTION

## About The Pull Request
Fixes #1467.
## Why It's Good For The Game
Supposedly this change was made on tg a long while back and just never made it here.
## Changelog
:cl:
fix: adds a normal floor tile underneath a certain airlock in a certain lavaland ruin.
/:cl:
