### PR TITLE
Fixes sandstone stool deconstructing into iron

### DIFF
--- a/monkestation/code/game/objects/structures/beds_chairs/chair.dm
+++ b/monkestation/code/game/objects/structures/beds_chairs/chair.dm
@@ -6,6 +6,7 @@
 	icon_state = "stool"
 	resistance_flags = FIRE_PROOF
 	can_buckle = FALSE
+	buildstacktype = /obj/item/stack/sheet/mineral/sandstone
 	buildstackamount = 1
 	item_chair = /obj/item/chair/stool/sandstone
 


### PR DESCRIPTION

## About The Pull Request
Fixes #3203 , although someone should review it and see if that's all I needed to do or if I fucked up somewhere, i'm a mapper and not so good at coding 👍 
## Why It's Good For The Game
Consistency.
## Changelog
:cl:
fix: sandstone stools now deconstruct properly into sandstone bricks.
/:cl:
