### PR TITLE
Gives Guardman Helmet Armor

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -144,6 +144,12 @@
 	inhand_icon_state = "blueshift_helmet"
 	custom_premium_price = PAYCHECK_COMMAND
 
+/obj/item/clothing/head/helmet/guardmanhelmet
+	name = "guardman's helmet"
+	desc = "Keeps your brain intact when fighting heretics"
+	icon = 'monkestation/icons/obj/clothing/hats.dmi'
+	worn_icon = 'monkestation/icons/mob/clothing/head.dmi'
+	icon_state = "guardman_helmet"
 
 /obj/item/clothing/head/helmet/toggleable
 	dog_fashion = null

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -35,7 +35,7 @@
 		/obj/item/storage/belt/holster/energy = 4,
 		/obj/item/clothing/head/helmet/civilprotection_helmet = 1, //monkestation edit
 		/obj/item/clothing/suit/armor/civilprotection_vest = 1, //monkestation edit
-		/obj/item/clothing/head/guardmanhelmet = 1, //monkestation edit: Guardman
+		/obj/item/clothing/head/helmet/guardmanhelmet = 1, //monkestation edit: Guardman
 		/obj/item/clothing/under/guardmanuniform = 1, //monkestation edit: Guardman
 		/obj/item/clothing/suit/armor/guardmanvest = 1, //monkestation edit: Guardman
 		/obj/item/citationinator = 3 // monkestation edit: security assistants


### PR DESCRIPTION

## About The Pull Request
Gives Guardman Helmet from sectech vender armor. Makes a second armored version and puts it there.
Fixes https://github.com/Monkestation/Monkestation2.0/issues/1510

## Why It's Good For The Game
fixes bug/oversight, gives sec 'drip' without costing armor

## Changelog

:cl:
fix: Security's Guardman Helmet now armored
/:cl: