### PR TITLE
More 516 prep (rename `caller` vars)

### DIFF
--- a/code/__HELPERS/paths/jps.dm
+++ b/code/__HELPERS/paths/jps.dm
@@ -56,7 +56,7 @@
 
 /datum/pathfind/jps
 	/// The movable we are pathing
-	var/atom/movable/caller
+	var/atom/movable/requester
 	/// The turf we're trying to path to (note that this won't track a moving target)
 	var/turf/end
 	/// The open list/stack we pop nodes out from (TODO: make this a normal list and macro-ize the heap operations to reduce proc overhead)
@@ -73,9 +73,9 @@
 	///Defines how we handle diagonal moves. See __DEFINES/path.dm
 	var/diagonal_handling = DIAGONAL_REMOVE_CLUNKY
 
-/datum/pathfind/jps/proc/setup(atom/movable/caller, list/access, max_distance, simulated_only, avoid, list/datum/callback/on_finish, atom/goal, mintargetdist, skip_first, diagonal_handling)
-	src.caller = caller
-	src.pass_info = new(caller, access)
+/datum/pathfind/jps/proc/setup(atom/movable/requester, list/access, max_distance, simulated_only, avoid, list/datum/callback/on_finish, atom/goal, mintargetdist, skip_first, diagonal_handling)
+	src.requester = requester
+	src.pass_info = new(requester, access)
 	src.max_distance = max_distance
 	src.simulated_only = simulated_only
 	src.avoid = avoid
@@ -89,12 +89,12 @@
 
 /datum/pathfind/jps/Destroy(force)
 	. = ..()
-	caller = null
+	requester = null
 	end = null
 	open = null
 
 /datum/pathfind/jps/start()
-	start = start || get_turf(caller)
+	start = start || get_turf(requester)
 	. = ..()
 	if(!.)
 		return .
@@ -116,7 +116,7 @@
 	. = ..()
 	if(!.)
 		return .
-	if(QDELETED(caller))
+	if(QDELETED(requester))
 		return FALSE
 
 	while(!open.is_empty() && !path)

--- a/code/__HELPERS/paths/path.dm
+++ b/code/__HELPERS/paths/path.dm
@@ -4,7 +4,7 @@
  * It will yield until a path is returned, using magic
  *
  * Arguments:
- * * caller: The movable atom that's trying to find the path
+ * * requester: The movable atom that's trying to find the path
  * * end: What we're trying to path to. It doesn't matter if this is a turf or some other atom, we're gonna just path to the turf it's on anyway
  * * max_distance: The maximum number of steps we can take in a given path to search (default: 30, 0 = infinite)
  * * mintargetdistance: Minimum distance to the target before path returns, could be used to get near a target, but not right to it - for an AI mob with a gun, for example.
@@ -14,16 +14,16 @@
  * * skip_first: Whether or not to delete the first item in the path. This would be done because the first item is the starting tile, which can break movement for some creatures.
  * * diagonal_handling: defines how we handle diagonal moves. see __DEFINES/path.dm
  */
-/proc/get_path_to(atom/movable/caller, atom/end, max_distance = 30, mintargetdist, access=list(), simulated_only = TRUE, turf/exclude, skip_first=TRUE, diagonal_handling=DIAGONAL_REMOVE_CLUNKY)
+/proc/get_path_to(atom/movable/requester, atom/end, max_distance = 30, mintargetdist, access=list(), simulated_only = TRUE, turf/exclude, skip_first=TRUE, diagonal_handling=DIAGONAL_REMOVE_CLUNKY)
 	var/list/hand_around = list()
 	// We're guarenteed that list will be the first list in pathfinding_finished's argset because of how callback handles the arguments list
 	var/datum/callback/await = list(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(pathfinding_finished), hand_around))
-	if(!SSpathfinder.pathfind(caller, end, max_distance, mintargetdist, access, simulated_only, exclude, skip_first, diagonal_handling, await))
+	if(!SSpathfinder.pathfind(requester, end, max_distance, mintargetdist, access, simulated_only, exclude, skip_first, diagonal_handling, await))
 		return list()
 
 	UNTIL(length(hand_around))
 	var/list/return_val = hand_around[1]
-	if(!islist(return_val) || (QDELETED(caller) || QDELETED(end))) // It's trash, just hand back empty to make it easy
+	if(!islist(return_val) || (QDELETED(requester) || QDELETED(end))) // It's trash, just hand back empty to make it easy
 		return list()
 	return return_val
 
@@ -37,7 +37,7 @@
  * It will yield until a path is returned, using magic
  *
  * Arguments:
- * * caller: The movable atom that's trying to find the path
+ * * requester: The movable atom that's trying to find the path
  * * end: What we're trying to path to. It doesn't matter if this is a turf or some other atom, we're gonna just path to the turf it's on anyway
  * * max_distance: The maximum number of steps we can take in a given path to search (default: 30, 0 = infinite)
  * * mintargetdistance: Minimum distance to the target before path returns, could be used to get near a target, but not right to it - for an AI mob with a gun, for example.
@@ -47,29 +47,29 @@
  * * exclude: If we want to avoid a specific turf, like if we're a mulebot who already got blocked by some turf
  * * skip_first: Whether or not to delete the first item in the path. This would be done because the first item is the starting tile, which can break movement for some creatures.
  */
-/proc/get_swarm_path_to(atom/movable/caller, atom/end, max_distance = 30, mintargetdist, age = MAP_REUSE_INSTANT, access = list(), simulated_only = TRUE, turf/exclude, skip_first=TRUE)
+/proc/get_swarm_path_to(atom/movable/requester, atom/end, max_distance = 30, mintargetdist, age = MAP_REUSE_INSTANT, access = list(), simulated_only = TRUE, turf/exclude, skip_first=TRUE)
 	var/list/hand_around = list()
 	// We're guarenteed that list will be the first list in pathfinding_finished's argset because of how callback handles the arguments list
 	var/datum/callback/await = list(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(pathfinding_finished), hand_around))
-	if(!SSpathfinder.swarmed_pathfind(caller, end, max_distance, mintargetdist, age, access, simulated_only, exclude, skip_first, await))
+	if(!SSpathfinder.swarmed_pathfind(requester, end, max_distance, mintargetdist, age, access, simulated_only, exclude, skip_first, await))
 		return list()
 
 	UNTIL(length(hand_around))
 	var/list/return_val = hand_around[1]
-	if(!islist(return_val) || (QDELETED(caller) || QDELETED(end))) // It's trash, just hand back empty to make it easy
+	if(!islist(return_val) || (QDELETED(requester) || QDELETED(end))) // It's trash, just hand back empty to make it easy
 		return list()
 	return return_val
 
-/proc/get_sssp(atom/movable/caller, max_distance = 30, access = list(), simulated_only = TRUE, turf/exclude)
+/proc/get_sssp(atom/movable/requester, max_distance = 30, access = list(), simulated_only = TRUE, turf/exclude)
 	var/list/hand_around = list()
 	// We're guarenteed that list will be the first list in pathfinding_finished's argset because of how callback handles the arguments list
 	var/datum/callback/await = list(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(pathfinding_finished), hand_around))
-	if(!SSpathfinder.build_map(caller, get_turf(caller), max_distance, access, simulated_only, exclude, await))
+	if(!SSpathfinder.build_map(requester, get_turf(requester), max_distance, access, simulated_only, exclude, await))
 		return null
 
 	UNTIL(length(hand_around))
 	var/datum/path_map/return_val = hand_around[1]
-	if(!istype(return_val, /datum/path_map) || (QDELETED(caller))) // It's trash, just hand back null to make it easy
+	if(!istype(return_val, /datum/path_map) || (QDELETED(requester))) // It's trash, just hand back null to make it easy
 		return null
 	return return_val
 
@@ -202,7 +202,7 @@
 	return modified_path
 
 /**
- * For seeing if we can actually move between 2 given turfs while accounting for our access and the caller's pass_flags
+ * For seeing if we can actually move between 2 given turfs while accounting for our access and the requester's pass_flags
  *
  * Assumes destinantion turf is non-dense - check and shortcircuit in code invoking this proc to avoid overhead.
  * Makes some other assumptions, such as assuming that unless declared, non dense objects will not block movement.
@@ -315,7 +315,7 @@
 	/// Let's avoid this
 	var/camera_type
 
-	/// Weakref to the caller used to generate this info
+	/// Weakref to the requester used to generate this info
 	/// Should not use this almost ever, it's for context and to allow for proc chains that
 	/// Require a movable
 	var/datum/weakref/caller_ref = null

--- a/code/__HELPERS/paths/sssp.dm
+++ b/code/__HELPERS/paths/sssp.dm
@@ -201,8 +201,8 @@
 	/// Our current position in the working queue
 	var/working_index
 
-/datum/pathfind/sssp/proc/setup(atom/movable/caller, list/access, turf/center, max_distance, simulated_only, turf/avoid, list/datum/callback/on_finish)
-	src.pass_info = new(caller, access)
+/datum/pathfind/sssp/proc/setup(atom/movable/requester, list/access, turf/center, max_distance, simulated_only, turf/avoid, list/datum/callback/on_finish)
+	src.pass_info = new(requester, access)
 	src.start = center
 	src.max_distance = max_distance
 	src.simulated_only = simulated_only

--- a/code/controllers/subsystem/pathfinder.dm
+++ b/code/controllers/subsystem/pathfinder.dm
@@ -61,9 +61,9 @@ SUBSYSTEM_DEF(pathfinder)
 		currentmaps.len--
 
 /// Initiates a pathfind. Returns true if we're good, FALSE if something's failed
-/datum/controller/subsystem/pathfinder/proc/pathfind(atom/movable/caller, atom/end, max_distance = 30, mintargetdist, access = list(), simulated_only = TRUE, turf/exclude, skip_first = TRUE, diagonal_handling = DIAGONAL_REMOVE_CLUNKY, list/datum/callback/on_finish)
+/datum/controller/subsystem/pathfinder/proc/pathfind(atom/movable/requester, atom/end, max_distance = 30, mintargetdist, access = list(), simulated_only = TRUE, turf/exclude, skip_first = TRUE, diagonal_handling = DIAGONAL_REMOVE_CLUNKY, list/datum/callback/on_finish)
 	var/datum/pathfind/jps/path = new()
-	path.setup(caller, access, max_distance, simulated_only, exclude, on_finish, end, mintargetdist, skip_first, diagonal_handling)
+	path.setup(requester, access, max_distance, simulated_only, exclude, on_finish, end, mintargetdist, skip_first, diagonal_handling)
 	if(path.start())
 		active_pathing += path
 		return TRUE
@@ -71,21 +71,21 @@ SUBSYSTEM_DEF(pathfinder)
 
 /// Initiates a swarmed pathfind. Returns TRUE if we're good, FALSE if something's failed
 /// If a valid pathmap exists for the TARGET turf we'll use that, otherwise we have to build a new one
-/datum/controller/subsystem/pathfinder/proc/swarmed_pathfind(atom/movable/caller, atom/end, max_distance = 30, mintargetdist = 0, age = MAP_REUSE_INSTANT, access = list(), simulated_only = TRUE, turf/exclude, skip_first = TRUE, list/datum/callback/on_finish)
+/datum/controller/subsystem/pathfinder/proc/swarmed_pathfind(atom/movable/requester, atom/end, max_distance = 30, mintargetdist = 0, age = MAP_REUSE_INSTANT, access = list(), simulated_only = TRUE, turf/exclude, skip_first = TRUE, list/datum/callback/on_finish)
 	var/turf/target = get_turf(end)
-	var/datum/can_pass_info/pass_info = new(caller, access)
+	var/datum/can_pass_info/pass_info = new(requester, access)
 	// If there's a map we can use already, use it
 	var/datum/path_map/valid_map = get_valid_map(pass_info, target, simulated_only, exclude, age, include_building = TRUE)
 	if(valid_map && valid_map.expand(max_distance))
-		path_map_passalong(on_finish, get_turf(caller), mintargetdist, skip_first, valid_map)
+		path_map_passalong(on_finish, get_turf(requester), mintargetdist, skip_first, valid_map)
 		return TRUE
 
 	// Otherwise we're gonna make a new one, and turn it into a path for the callbacks passed into us
 	var/list/datum/callback/pass_in = list()
-	pass_in += CALLBACK(GLOBAL_PROC, /proc/path_map_passalong, on_finish, get_turf(caller), mintargetdist, skip_first)
+	pass_in += CALLBACK(GLOBAL_PROC, /proc/path_map_passalong, on_finish, get_turf(requester), mintargetdist, skip_first)
 	// And to allow subsequent calls to reuse the same map, we'll put a placeholder in the cache, and fill it up when the pathing finishes
 	var/datum/path_map/empty = new()
-	empty.pass_info = new(caller, access)
+	empty.pass_info = new(requester, access)
 	empty.start = target
 	empty.pass_space = simulated_only
 	empty.avoid = exclude
@@ -133,9 +133,9 @@ SUBSYSTEM_DEF(pathfinder)
 		source_to_maps[target] -= same_target
 
 /// Initiates a SSSP run. Returns true if we're good, FALSE if something's failed
-/datum/controller/subsystem/pathfinder/proc/build_map(atom/movable/caller, turf/source, max_distance = 30, access = list(), simulated_only = TRUE, turf/exclude, list/datum/callback/on_finish)
+/datum/controller/subsystem/pathfinder/proc/build_map(atom/movable/requester, turf/source, max_distance = 30, access = list(), simulated_only = TRUE, turf/exclude, list/datum/callback/on_finish)
 	var/datum/pathfind/sssp/path = new()
-	path.setup(caller, access, source, max_distance, simulated_only, exclude, on_finish)
+	path.setup(requester, access, source, max_distance, simulated_only, exclude, on_finish)
 	if(path.start())
 		active_pathing += path
 		return TRUE
@@ -160,7 +160,7 @@ SUBSYSTEM_DEF(pathfinder)
 /// Optionally takes a max age to accept (defaults to 0 seconds) and a minimum acceptable range
 /// If include_building is true and we can only find a building path, ew'll use that instead. tho we will wait for it to finish first
 /datum/controller/subsystem/pathfinder/proc/get_valid_map(datum/can_pass_info/pass_info, turf/target, simulated_only = TRUE, turf/exclude, age = MAP_REUSE_INSTANT, min_range = -INFINITY, include_building = FALSE)
-	// Walk all the maps that match our caller's turf OR our target's
+	// Walk all the maps that match our requester's turf OR our target's
 	// Then hold onto em. If their cache time is short we can reuse/expand them, if not we'll have to make a new one
 	var/oldest_time = world.time - age
 	/// Backup return value used if no finished pathmaps are found
@@ -189,7 +189,7 @@ SUBSYSTEM_DEF(pathfinder)
 /// Takes a set of pathfind info, returns all valid pathmaps that would work
 /// Takes an optional minimum range arg
 /datum/controller/subsystem/pathfinder/proc/get_valid_maps(datum/can_pass_info/pass_info, turf/target, simulated_only = TRUE, turf/exclude, age = MAP_REUSE_INSTANT, min_range = -INFINITY, include_building = FALSE)
-	// Walk all the maps that match our caller's turf OR our target's
+	// Walk all the maps that match our requester's turf OR our target's
 	// Then hold onto em. If their cache time is short we can reuse/expand them, if not we'll have to make a new one
 	var/list/valid_maps = list()
 	var/oldest_time = world.time - age

--- a/code/datums/actions/cooldown_action.dm
+++ b/code/datums/actions/cooldown_action.dm
@@ -222,7 +222,7 @@
 	return PreActivate(user)
 
 /// Intercepts client owner clicks to activate the ability
-/datum/action/cooldown/proc/InterceptClickOn(mob/living/caller, params, atom/target)
+/datum/action/cooldown/proc/InterceptClickOn(mob/living/user, params, atom/target)
 	if(!IsAvailable(feedback = TRUE))
 		return FALSE
 	if(!target)
@@ -233,8 +233,8 @@
 
 	// And if we reach here, the action was complete successfully
 	if(unset_after_click)
-		unset_click_ability(caller, refund_cooldown = FALSE)
-	caller.next_click = world.time + click_cd_override
+		unset_click_ability(user, refund_cooldown = FALSE)
+	user.next_click = world.time + click_cd_override
 
 	return TRUE
 

--- a/code/datums/actions/innate_action.dm
+++ b/code/datums/actions/innate_action.dm
@@ -76,17 +76,17 @@
 	on_who.click_intercept = null
 
 /// Handles whenever a mob clicks on something
-/datum/action/innate/proc/InterceptClickOn(mob/living/caller, params, atom/clicked_on)
+/datum/action/innate/proc/InterceptClickOn(mob/living/user, params, atom/clicked_on)
 	if(!IsAvailable(feedback = TRUE))
-		unset_ranged_ability(caller)
+		unset_ranged_ability(user)
 		return FALSE
 	if(!clicked_on)
 		return FALSE
 
-	return do_ability(caller, clicked_on)
+	return do_ability(user, clicked_on)
 
 /// Actually goes through and does the click ability
-/datum/action/innate/proc/do_ability(mob/living/caller, atom/clicked_on)
+/datum/action/innate/proc/do_ability(mob/living/user, atom/clicked_on)
 	return FALSE
 
 /datum/action/innate/Remove(mob/removed_from)

--- a/code/datums/components/plumbing/_plumbing.dm
+++ b/code/datums/components/plumbing/_plumbing.dm
@@ -334,7 +334,7 @@
 		tile_covered = should_hide
 		parent_obj.update_appearance()
 
-/datum/component/plumbing/proc/change_ducting_layer(obj/caller, obj/changer, new_layer = DUCT_LAYER_DEFAULT)
+/datum/component/plumbing/proc/change_ducting_layer(obj/user, obj/changer, new_layer = DUCT_LAYER_DEFAULT)
 	SIGNAL_HANDLER
 	ducting_layer = new_layer
 
@@ -393,7 +393,7 @@
 	demand_connects = NORTH
 	supply_connects = SOUTH
 
-/datum/component/plumbing/manifold/change_ducting_layer(obj/caller, obj/changer, new_layer)
+/datum/component/plumbing/manifold/change_ducting_layer(obj/user, obj/changer, new_layer)
 	return
 
 #define READY 2

--- a/code/datums/holocall.dm
+++ b/code/datums/holocall.dm
@@ -34,10 +34,10 @@
 	///calls from a head of staff autoconnect, if the receiving pad is not secure.
 	var/head_call = FALSE
 
-//creates a holocall made by `caller` from `calling_pad` to `callees`
-/datum/holocall/New(mob/living/caller, obj/machinery/holopad/calling_pad, list/callees, elevated_access = FALSE)
+//creates a holocall made by `caller_user` from `calling_pad` to `callees`
+/datum/holocall/New(mob/living/caller_user, obj/machinery/holopad/calling_pad, list/callees, elevated_access = FALSE)
 	call_start_time = world.time
-	user = caller
+	user = caller_user
 	calling_pad.outgoing_call = src
 	calling_holopad = calling_pad
 	head_call = elevated_access

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -291,9 +291,9 @@ Possible to do for anyone motivated enough:
 	for(var/I in holo_calls)
 		var/datum/holocall/HC = I
 		var/list/call_data = list(
-			caller = HC.user,
-			connected = HC.connected_holopad == src ? TRUE : FALSE,
-			ref = REF(HC)
+			"caller" = HC.user,
+			"connected" = HC.connected_holopad == src ? TRUE : FALSE,
+			"ref" = REF(HC)
 		)
 		data["holo_calls"] += list(call_data)
 	return data

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -708,13 +708,13 @@ DEFINE_BITFIELD(turret_flags, list(
 	remote_controller = null
 	return TRUE
 
-/obj/machinery/porta_turret/proc/InterceptClickOn(mob/living/caller, params, atom/A)
+/obj/machinery/porta_turret/proc/InterceptClickOn(mob/living/user, params, atom/A)
 	if(!manual_control)
 		return FALSE
-	if(!can_interact(caller))
+	if(!can_interact(user))
 		remove_control()
 		return FALSE
-	log_combat(caller,A,"fired with manual turret control at")
+	log_combat(user,A,"fired with manual turret control at")
 	target(A)
 	return TRUE
 

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -743,16 +743,16 @@ GLOBAL_LIST_EMPTY(station_turfs)
  * Returns adjacent turfs to this turf that are reachable, in all cardinal directions
  *
  * Arguments:
- * * caller: The movable, if one exists, being used for mobility checks to see what tiles it can reach
+ * * source: The movable, if one exists, being used for mobility checks to see what tiles it can reach
  * * access: A list that decides if we can gain access to doors that would otherwise block a turf
  * * simulated_only: Do we only worry about turfs with simulated atmos, most notably things that aren't space?
  * * no_id: When true, doors with public access will count as impassible
 */
-/turf/proc/reachableAdjacentTurfs(atom/movable/caller, list/access, simulated_only, no_id = FALSE)
+/turf/proc/reachableAdjacentTurfs(atom/movable/source, list/access, simulated_only, no_id = FALSE)
 	var/static/space_type_cache = typecacheof(/turf/open/space)
 	. = list()
 
-	var/datum/can_pass_info/pass_info = new(caller, access, no_id)
+	var/datum/can_pass_info/pass_info = new(source, access, no_id)
 	for(var/iter_dir in GLOB.cardinals)
 		var/turf/turf_to_check = get_step(src,iter_dir)
 		if(!turf_to_check || (simulated_only && space_type_cache[turf_to_check.type]))

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -226,12 +226,12 @@
 	enable_text = span_cult("You prepare to horrify a target...")
 	disable_text = span_cult("You dispel the magic...")
 
-/datum/action/innate/cult/blood_spell/horror/InterceptClickOn(mob/living/caller, params, atom/clicked_on)
-	var/turf/caller_turf = get_turf(caller)
+/datum/action/innate/cult/blood_spell/horror/InterceptClickOn(mob/living/user, params, atom/clicked_on)
+	var/turf/caller_turf = get_turf(user)
 	if(!isturf(caller_turf))
 		return FALSE
 
-	if(!ishuman(clicked_on) || get_dist(caller, clicked_on) > 7)
+	if(!ishuman(clicked_on) || get_dist(user, clicked_on) > 7)
 		return FALSE
 
 	var/mob/living/carbon/human/human_clicked = clicked_on
@@ -240,23 +240,23 @@
 
 	return ..()
 
-/datum/action/innate/cult/blood_spell/horror/do_ability(mob/living/caller, mob/living/carbon/human/clicked_on)
+/datum/action/innate/cult/blood_spell/horror/do_ability(mob/living/user, mob/living/carbon/human/clicked_on)
 
 	clicked_on.set_hallucinations_if_lower(240 SECONDS)
-	SEND_SOUND(caller, sound('sound/effects/ghost.ogg', FALSE, TRUE, 50))
+	SEND_SOUND(user, sound('sound/effects/ghost.ogg', FALSE, TRUE, 50))
 
 	var/image/sparkle_image = image('icons/effects/cult/effects.dmi', clicked_on, "bloodsparkles", ABOVE_MOB_LAYER)
 	clicked_on.add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/cult, "cult_apoc", sparkle_image, NONE)
 
 	addtimer(CALLBACK(clicked_on, TYPE_PROC_REF(/atom/, remove_alt_appearance), "cult_apoc", TRUE), 4 MINUTES, TIMER_OVERRIDE|TIMER_UNIQUE)
-	to_chat(caller, span_cultbold("[clicked_on] has been cursed with living nightmares!"))
+	to_chat(user, span_cultbold("[clicked_on] has been cursed with living nightmares!"))
 
 	charges--
 	desc = base_desc
 	desc += "<br><b><u>Has [charges] use\s remaining</u></b>."
 	build_all_button_icons()
 	if(charges <= 0)
-		to_chat(caller, span_cult("You have exhausted the spell's power!"))
+		to_chat(user, span_cult("You have exhausted the spell's power!"))
 		qdel(src)
 
 	return TRUE

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -284,8 +284,8 @@
 /datum/action/innate/cult/master/cultmark/IsAvailable(feedback = FALSE)
 	return ..() && COOLDOWN_FINISHED(src, cult_mark_cooldown)
 
-/datum/action/innate/cult/master/cultmark/InterceptClickOn(mob/caller, params, atom/clicked_on)
-	var/turf/caller_turf = get_turf(caller)
+/datum/action/innate/cult/master/cultmark/InterceptClickOn(mob/user, params, atom/clicked_on)
+	var/turf/caller_turf = get_turf(user)
 	if(!isturf(caller_turf))
 		return FALSE
 
@@ -294,8 +294,8 @@
 
 	return ..()
 
-/datum/action/innate/cult/master/cultmark/do_ability(mob/living/caller, atom/clicked_on)
-	var/datum/antagonist/cult/cultist = caller.mind.has_antag_datum(/datum/antagonist/cult, TRUE)
+/datum/action/innate/cult/master/cultmark/do_ability(mob/living/user, atom/clicked_on)
+	var/datum/antagonist/cult/cultist = user.mind.has_antag_datum(/datum/antagonist/cult, TRUE)
 	if(!cultist)
 		CRASH("[type] was casted by someone without a cult antag datum.")
 
@@ -304,17 +304,17 @@
 		CRASH("[type] was casted by a cultist without a cult team datum.")
 
 	if(cult_team.blood_target)
-		to_chat(caller, span_cult("The cult has already designated a target!"))
+		to_chat(user, span_cult("The cult has already designated a target!"))
 		return FALSE
 
-	if(cult_team.set_blood_target(clicked_on, caller, cult_mark_duration))
-		unset_ranged_ability(caller, span_cult("The marking rite is complete! It will last for [DisplayTimeText(cult_mark_duration)] seconds."))
+	if(cult_team.set_blood_target(clicked_on, user, cult_mark_duration))
+		unset_ranged_ability(user, span_cult("The marking rite is complete! It will last for [DisplayTimeText(cult_mark_duration)] seconds."))
 		COOLDOWN_START(src, cult_mark_cooldown, cult_mark_cooldown_duration)
 		build_all_button_icons()
 		addtimer(CALLBACK(src, PROC_REF(build_all_button_icons)), cult_mark_cooldown_duration + 1)
 		return TRUE
 
-	unset_ranged_ability(caller, span_cult("The marking rite failed!"))
+	unset_ranged_ability(user, span_cult("The marking rite failed!"))
 	return TRUE
 
 /datum/action/innate/cult/ghostmark //Ghost version
@@ -414,44 +414,44 @@
 /datum/action/innate/cult/master/pulse/IsAvailable(feedback = FALSE)
 	return ..() && COOLDOWN_FINISHED(src, pulse_cooldown)
 
-/datum/action/innate/cult/master/pulse/InterceptClickOn(mob/living/caller, params, atom/clicked_on)
-	var/turf/caller_turf = get_turf(caller)
+/datum/action/innate/cult/master/pulse/InterceptClickOn(mob/living/user, params, atom/clicked_on)
+	var/turf/caller_turf = get_turf(user)
 	if(!isturf(caller_turf))
 		return FALSE
 
 	if(!(clicked_on in view(7, caller_turf)))
 		return FALSE
 
-	if(clicked_on == caller)
+	if(clicked_on == user)
 		return FALSE
 
 	return ..()
 
-/datum/action/innate/cult/master/pulse/do_ability(mob/living/caller, atom/clicked_on)
+/datum/action/innate/cult/master/pulse/do_ability(mob/living/user, atom/clicked_on)
 	var/atom/throwee = throwee_ref?.resolve()
 
 	if(QDELETED(throwee))
-		to_chat(caller, span_cult("You lost your target!"))
+		to_chat(user, span_cult("You lost your target!"))
 		throwee = null
 		throwee_ref = null
 		return FALSE
 
 	if(throwee)
 		if(get_dist(throwee, clicked_on) >= 16)
-			to_chat(caller, span_cult("You can't teleport [clicked_on.p_them()] that far!"))
+			to_chat(user, span_cult("You can't teleport [clicked_on.p_them()] that far!"))
 			return FALSE
 
 		var/turf/throwee_turf = get_turf(throwee)
 
 		playsound(throwee_turf, 'sound/magic/exit_blood.ogg')
-		new /obj/effect/temp_visual/cult/sparks(throwee_turf, caller.dir)
+		new /obj/effect/temp_visual/cult/sparks(throwee_turf, user.dir)
 		throwee.visible_message(
 			span_warning("A pulse of magic whisks [throwee] away!"),
 			span_cult("A pulse of blood magic whisks you away..."),
 		)
 
 		if(!do_teleport(throwee, clicked_on, channel = TELEPORT_CHANNEL_CULT))
-			to_chat(caller, span_cult("The teleport fails!"))
+			to_chat(user, span_cult("The teleport fails!"))
 			throwee.visible_message(
 				span_warning("...Except they don't go very far"),
 				span_cult("...Except you don't appear to have moved very far."),
@@ -459,15 +459,15 @@
 			return FALSE
 
 		throwee_turf.Beam(clicked_on, icon_state = "sendbeam", time = 0.4 SECONDS)
-		new /obj/effect/temp_visual/cult/sparks(get_turf(clicked_on), caller.dir)
+		new /obj/effect/temp_visual/cult/sparks(get_turf(clicked_on), user.dir)
 		throwee.visible_message(
 			span_warning("[throwee] appears suddenly in a pulse of magic!"),
 			span_cult("...And you appear elsewhere."),
 		)
 
 		COOLDOWN_START(src, pulse_cooldown, pulse_cooldown_duration)
-		to_chat(caller, span_cult("A pulse of blood magic surges through you as you shift [throwee] through time and space."))
-		caller.click_intercept = null
+		to_chat(user, span_cult("A pulse of blood magic surges through you as you shift [throwee] through time and space."))
+		user.click_intercept = null
 		throwee_ref = null
 		build_all_button_icons()
 		addtimer(CALLBACK(src, PROC_REF(build_all_button_icons)), pulse_cooldown_duration + 1)
@@ -479,13 +479,13 @@
 			var/mob/living/living_clicked = clicked_on
 			if(!IS_CULTIST(living_clicked))
 				return FALSE
-			SEND_SOUND(caller, sound('sound/weapons/thudswoosh.ogg'))
-			to_chat(caller, span_cultbold("You reach through the veil with your mind's eye and seize [clicked_on]! <b>Click anywhere nearby to teleport [clicked_on.p_them()]!</b>"))
+			SEND_SOUND(user, sound('sound/weapons/thudswoosh.ogg'))
+			to_chat(user, span_cultbold("You reach through the veil with your mind's eye and seize [clicked_on]! <b>Click anywhere nearby to teleport [clicked_on.p_them()]!</b>"))
 			throwee_ref = WEAKREF(clicked_on)
 			return TRUE
 
 		if(istype(clicked_on, /obj/structure/destructible/cult))
-			to_chat(caller, span_cultbold("You reach through the veil with your mind's eye and lift [clicked_on]! <b>Click anywhere nearby to teleport it!</b>"))
+			to_chat(user, span_cultbold("You reach through the veil with your mind's eye and lift [clicked_on]! <b>Click anywhere nearby to teleport it!</b>"))
 			throwee_ref = WEAKREF(clicked_on)
 			return TRUE
 

--- a/code/modules/antagonists/heretic/magic/furious_steel.dm
+++ b/code/modules/antagonists/heretic/magic/furious_steel.dm
@@ -43,12 +43,12 @@
 
 	unset_click_ability(source, refund_cooldown = TRUE)
 
-/datum/action/cooldown/spell/pointed/projectile/furious_steel/InterceptClickOn(mob/living/caller, params, atom/target)
+/datum/action/cooldown/spell/pointed/projectile/furious_steel/InterceptClickOn(mob/living/user, params, atom/target)
 	// Let the caster prioritize using items like guns over blade casts
-	if(caller.get_active_held_item())
+	if(user.get_active_held_item())
 		return FALSE
 	// Let the caster prioritize melee attacks like punches and shoves over blade casts
-	if(get_dist(caller, target) <= 1)
+	if(get_dist(user, target) <= 1)
 		return FALSE
 
 	return ..()

--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -442,19 +442,19 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	. = ..()
 	desc = "[desc] It has [uses] use\s remaining."
 
-/datum/action/innate/ai/ranged/override_machine/do_ability(mob/living/caller, atom/clicked_on)
-	if(caller.incapacitated())
-		unset_ranged_ability(caller)
+/datum/action/innate/ai/ranged/override_machine/do_ability(mob/living/user, atom/clicked_on)
+	if(user.incapacitated())
+		unset_ranged_ability(user)
 		return FALSE
 	if(!ismachinery(clicked_on))
-		to_chat(caller, span_warning("You can only animate machines!"))
+		to_chat(user, span_warning("You can only animate machines!"))
 		return FALSE
 	var/obj/machinery/clicked_machine = clicked_on
 	if(!clicked_machine.can_be_overridden() || is_type_in_typecache(clicked_machine, GLOB.blacklisted_malf_machines))
-		to_chat(caller, span_warning("That machine can't be overridden!"))
+		to_chat(user, span_warning("That machine can't be overridden!"))
 		return FALSE
 
-	caller.playsound_local(caller, 'sound/misc/interference.ogg', 50, FALSE, use_reverb = FALSE)
+	user.playsound_local(user, 'sound/misc/interference.ogg', 50, FALSE, use_reverb = FALSE)
 	adjust_uses(-1)
 
 	if(uses)
@@ -462,15 +462,15 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 		build_all_button_icons()
 
 	clicked_machine.audible_message(span_userdanger("You hear a loud electrical buzzing sound coming from [clicked_machine]!"))
-	addtimer(CALLBACK(src, PROC_REF(animate_machine), caller, clicked_machine), 5 SECONDS) //kabeep!
-	unset_ranged_ability(caller, span_danger("Sending override signal..."))
+	addtimer(CALLBACK(src, PROC_REF(animate_machine), user, clicked_machine), 5 SECONDS) //kabeep!
+	unset_ranged_ability(user, span_danger("Sending override signal..."))
 	return TRUE
 
-/datum/action/innate/ai/ranged/override_machine/proc/animate_machine(mob/living/caller, obj/machinery/to_animate)
+/datum/action/innate/ai/ranged/override_machine/proc/animate_machine(mob/living/user, obj/machinery/to_animate)
 	if(QDELETED(to_animate))
 		return
 
-	new /mob/living/simple_animal/hostile/mimic/copy/machine(get_turf(to_animate), to_animate, caller, TRUE)
+	new /mob/living/simple_animal/hostile/mimic/copy/machine(get_turf(to_animate), to_animate, user, TRUE)
 
 /// Destroy RCDs: Detonates all non-cyborg RCDs on the station.
 /datum/ai_module/destructive/destroy_rcd
@@ -519,38 +519,38 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	..()
 	desc = "[desc] It has [uses] use\s remaining."
 
-/datum/action/innate/ai/ranged/overload_machine/proc/detonate_machine(mob/living/caller, obj/machinery/to_explode)
+/datum/action/innate/ai/ranged/overload_machine/proc/detonate_machine(mob/living/user, obj/machinery/to_explode)
 	if(QDELETED(to_explode))
 		return
 
 	var/turf/machine_turf = get_turf(to_explode)
-	message_admins("[ADMIN_LOOKUPFLW(caller)] overloaded [to_explode.name] ([to_explode.type]) at [ADMIN_VERBOSEJMP(machine_turf)].")
-	caller.log_message("overloaded [to_explode.name] ([to_explode.type])", LOG_ATTACK)
+	message_admins("[ADMIN_LOOKUPFLW(user)] overloaded [to_explode.name] ([to_explode.type]) at [ADMIN_VERBOSEJMP(machine_turf)].")
+	user.log_message("overloaded [to_explode.name] ([to_explode.type])", LOG_ATTACK)
 	explosion(to_explode, heavy_impact_range = 2, light_impact_range = 3)
 	if(!QDELETED(to_explode)) //to check if the explosion killed it before we try to delete it
 		qdel(to_explode)
 
-/datum/action/innate/ai/ranged/overload_machine/do_ability(mob/living/caller, atom/clicked_on)
-	if(caller.incapacitated())
-		unset_ranged_ability(caller)
+/datum/action/innate/ai/ranged/overload_machine/do_ability(mob/living/user, atom/clicked_on)
+	if(user.incapacitated())
+		unset_ranged_ability(user)
 		return FALSE
 	if(!ismachinery(clicked_on))
-		to_chat(caller, span_warning("You can only overload machines!"))
+		to_chat(user, span_warning("You can only overload machines!"))
 		return FALSE
 	var/obj/machinery/clicked_machine = clicked_on
 	if(is_type_in_typecache(clicked_machine, GLOB.blacklisted_malf_machines))
-		to_chat(caller, span_warning("You cannot overload that device!"))
+		to_chat(user, span_warning("You cannot overload that device!"))
 		return FALSE
 
-	caller.playsound_local(caller, SFX_SPARKS, 50, 0)
+	user.playsound_local(user, SFX_SPARKS, 50, 0)
 	adjust_uses(-1)
 	if(uses)
 		desc = "[initial(desc)] It has [uses] use\s remaining."
 		build_all_button_icons()
 
 	clicked_machine.audible_message(span_userdanger("You hear a loud electrical buzzing sound coming from [clicked_machine]!"))
-	addtimer(CALLBACK(src, PROC_REF(detonate_machine), caller, clicked_machine), 5 SECONDS) //kaboom!
-	unset_ranged_ability(caller, span_danger("Overcharging machine..."))
+	addtimer(CALLBACK(src, PROC_REF(detonate_machine), user, clicked_machine), 5 SECONDS) //kaboom!
+	unset_ranged_ability(user, span_danger("Overcharging machine..."))
 	return TRUE
 
 /// Blackout: Overloads a random number of lights across the station. Three uses.
@@ -1050,7 +1050,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	. = ..()
 	desc = "[desc] It has [uses] use\s remaining."
 
-/datum/action/innate/ai/ranged/emag/do_ability(mob/living/caller, atom/clicked_on)
+/datum/action/innate/ai/ranged/emag/do_ability(mob/living/user, atom/clicked_on)
 
 	// Only things with of or subtyped of any of these types may be remotely emagged
 	var/static/list/compatable_typepaths = list(
@@ -1062,13 +1062,13 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 		/mob/living/silicon,
 	)
 
-	if (!isAI(caller))
+	if (!isAI(user))
 		return FALSE
 
-	var/mob/living/silicon/ai/ai_caller = caller
+	var/mob/living/silicon/ai/ai_caller = user
 
 	if(ai_caller.incapacitated())
-		unset_ranged_ability(caller)
+		unset_ranged_ability(user)
 		return FALSE
 
 	if (!ai_caller.can_see(clicked_on))
@@ -1147,15 +1147,15 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	. = ..()
 	desc = "[desc] It has [uses] use\s remaining."
 
-/datum/action/innate/ai/ranged/core_tilt/do_ability(mob/living/caller, atom/clicked_on)
+/datum/action/innate/ai/ranged/core_tilt/do_ability(mob/living/user, atom/clicked_on)
 
 	if (!COOLDOWN_FINISHED(src, time_til_next_tilt))
-		caller.balloon_alert(caller, "on cooldown!")
+		user.balloon_alert(user, "on cooldown!")
 		return FALSE
 
-	if (!isAI(caller))
+	if (!isAI(user))
 		return FALSE
-	var/mob/living/silicon/ai/ai_caller = caller
+	var/mob/living/silicon/ai/ai_caller = user
 
 	if (ai_caller.incapacitated() || !isturf(ai_caller.loc))
 		return FALSE
@@ -1198,8 +1198,8 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	return ai_caller.fall_and_crush(target, MALF_AI_ROLL_DAMAGE, MALF_AI_ROLL_CRIT_CHANCE, null, paralyze_time, picked_dir, rotation = get_rotation_from_dir(picked_dir))
 
 /// Used in our radial menu, state-checking proc after the radial menu sleeps
-/datum/action/innate/ai/ranged/core_tilt/proc/radial_check(mob/living/silicon/ai/caller)
-	if (QDELETED(caller) || caller.incapacitated() || caller.stat == DEAD)
+/datum/action/innate/ai/ranged/core_tilt/proc/radial_check(mob/living/silicon/ai/user)
+	if (QDELETED(user) || user.incapacitated() || user.stat == DEAD)
 		return FALSE
 
 	if (uses <= 0)
@@ -1240,14 +1240,14 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	. = ..()
 	desc = "[desc] It has [uses] use\s remaining."
 
-/datum/action/innate/ai/ranged/remote_vendor_tilt/do_ability(mob/living/caller, atom/clicked_on)
+/datum/action/innate/ai/ranged/remote_vendor_tilt/do_ability(mob/living/user, atom/clicked_on)
 
-	if (!isAI(caller))
+	if (!isAI(user))
 		return FALSE
-	var/mob/living/silicon/ai/ai_caller = caller
+	var/mob/living/silicon/ai/ai_caller = user
 
 	if(ai_caller.incapacitated())
-		unset_ranged_ability(caller)
+		unset_ranged_ability(user)
 		return FALSE
 
 	if(!isvendor(clicked_on))
@@ -1268,7 +1268,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 		clicked_vendor.balloon_alert(ai_caller, "inoperable!")
 		return FALSE
 
-	var/picked_dir_string = show_radial_menu(ai_caller, clicked_vendor, GLOB.all_radial_directions, custom_check = CALLBACK(src, PROC_REF(radial_check), caller, clicked_vendor))
+	var/picked_dir_string = show_radial_menu(ai_caller, clicked_vendor, GLOB.all_radial_directions, custom_check = CALLBACK(src, PROC_REF(radial_check), user, clicked_vendor))
 	if (isnull(picked_dir_string))
 		return FALSE
 	var/picked_dir = text2dir(picked_dir_string)
@@ -1288,7 +1288,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 		desc = "[initial(desc)] It has [uses] use\s remaining."
 		build_all_button_icons()
 
-	unset_ranged_ability(caller, span_danger("Tilting..."))
+	unset_ranged_ability(user, span_danger("Tilting..."))
 	return TRUE
 
 /datum/action/innate/ai/ranged/remote_vendor_tilt/proc/do_vendor_tilt(obj/machinery/vending/vendor, turf/target)
@@ -1301,8 +1301,8 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	vendor.tilt(target, MALF_VENDOR_TIPPING_CRIT_CHANCE)
 
 /// Used in our radial menu, state-checking proc after the radial menu sleeps
-/datum/action/innate/ai/ranged/remote_vendor_tilt/proc/radial_check(mob/living/silicon/ai/caller, obj/machinery/vending/clicked_vendor)
-	if (QDELETED(caller) || caller.incapacitated() || caller.stat == DEAD)
+/datum/action/innate/ai/ranged/remote_vendor_tilt/proc/radial_check(mob/living/silicon/ai/user, obj/machinery/vending/clicked_vendor)
+	if (QDELETED(user) || user.incapacitated() || user.stat == DEAD)
 		return FALSE
 
 	if (QDELETED(clicked_vendor))
@@ -1311,8 +1311,8 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	if (uses <= 0)
 		return FALSE
 
-	if (!caller.can_see(clicked_vendor))
-		to_chat(caller, span_warning("Lost sight of [clicked_vendor]!"))
+	if (!user.can_see(clicked_vendor))
+		to_chat(user, span_warning("Lost sight of [clicked_vendor]!"))
 		return FALSE
 
 	return TRUE

--- a/code/modules/basketball/referee.dm
+++ b/code/modules/basketball/referee.dm
@@ -14,33 +14,33 @@
 	disable_text = span_cult("You decide it was a bad call...")
 	COOLDOWN_DECLARE(whistle_cooldown_minigame)
 
-/datum/action/innate/timeout/InterceptClickOn(mob/living/caller, params, atom/clicked_on)
-	var/turf/caller_turf = get_turf(caller)
+/datum/action/innate/timeout/InterceptClickOn(mob/living/user, params, atom/clicked_on)
+	var/turf/caller_turf = get_turf(user)
 	if(!isturf(caller_turf))
 		return FALSE
 
-	if(!ishuman(clicked_on) || get_dist(caller, clicked_on) > 7)
+	if(!ishuman(clicked_on) || get_dist(user, clicked_on) > 7)
 		return FALSE
 
-	if(clicked_on == caller) // can't call a foul on yourself
+	if(clicked_on == user) // can't call a foul on yourself
 		return FALSE
 
 	if(!COOLDOWN_FINISHED(src, whistle_cooldown_minigame))
-		caller.balloon_alert(caller, "cant cast for [COOLDOWN_TIMELEFT(src, whistle_cooldown_minigame) *0.1] seconds!")
-		unset_ranged_ability(caller)
+		user.balloon_alert(user, "cant cast for [COOLDOWN_TIMELEFT(src, whistle_cooldown_minigame) *0.1] seconds!")
+		unset_ranged_ability(user)
 		return FALSE
 
 	return ..()
 
-/datum/action/innate/timeout/do_ability(mob/living/caller, mob/living/carbon/human/target)
-	caller.say("FOUL BY [target]!", forced = "whistle")
-	playsound(caller, 'sound/misc/whistle.ogg', 30, FALSE, 4)
+/datum/action/innate/timeout/do_ability(mob/living/user, mob/living/carbon/human/target)
+	user.say("FOUL BY [target]!", forced = "whistle")
+	playsound(user, 'sound/misc/whistle.ogg', 30, FALSE, 4)
 
-	new /obj/effect/timestop(get_turf(target), 0, 5 SECONDS, list(caller), TRUE, TRUE)
+	new /obj/effect/timestop(get_turf(target), 0, 5 SECONDS, list(user), TRUE, TRUE)
 
 	COOLDOWN_START(src, whistle_cooldown_minigame, 1 MINUTES)
-	unset_ranged_ability(caller)
+	unset_ranged_ability(user)
 
-	to_chat(target, span_bold("[caller] has given you a timeout for a foul!"))
-	to_chat(caller, span_bold("You put [target] in a timeout!"))
+	to_chat(target, span_bold("[user] has given you a timeout for a foul!"))
+	to_chat(user, span_bold("You put [target] in a timeout!"))
 	return TRUE

--- a/code/modules/mob/living/basic/bots/_bots.dm
+++ b/code/modules/mob/living/basic/bots/_bots.dm
@@ -793,11 +793,11 @@ GLOBAL_LIST_INIT(command_strings, list(
 	initial_access = access_card.access.Copy()
 
 
-/mob/living/basic/bot/proc/summon_bot(atom/caller, turf/turf_destination, user_access = list(), grant_all_access = FALSE)
-	if(isAI(caller) && !set_ai_caller(caller))
+/mob/living/basic/bot/proc/summon_bot(atom/user, turf/turf_destination, user_access = list(), grant_all_access = FALSE)
+	if(isAI(user) && !set_ai_caller(user))
 		return FALSE
-	bot_reset(bypass_ai_reset = isAI(caller))
-	var/turf/destination = turf_destination ? turf_destination : get_turf(caller)
+	bot_reset(bypass_ai_reset = isAI(user))
+	var/turf/destination = turf_destination ? turf_destination : get_turf(user)
 	ai_controller?.set_blackboard_key(BB_BOT_SUMMON_TARGET, destination)
 	var/list/access_to_grant = grant_all_access ? REGION_ACCESS_ALL_STATION : user_access + initial_access
 	access_card.set_access(access_to_grant)
@@ -805,11 +805,11 @@ GLOBAL_LIST_INIT(command_strings, list(
 	update_bot_mode(new_mode = BOT_SUMMON)
 	return TRUE
 
-/mob/living/basic/bot/proc/set_ai_caller(mob/living/caller)
+/mob/living/basic/bot/proc/set_ai_caller(mob/living/user)
 	var/atom/calling_ai = calling_ai_ref?.resolve()
 	if(!isnull(calling_ai) && calling_ai != src)
 		return FALSE
-	calling_ai_ref = WEAKREF(caller)
+	calling_ai_ref = WEAKREF(user)
 	return TRUE
 
 /mob/living/basic/bot/proc/update_bot_mode(new_mode, update_hud = TRUE)

--- a/code/modules/mob/living/basic/lavaland/brimdemon/brimdemon_ai.dm
+++ b/code/modules/mob/living/basic/lavaland/brimdemon/brimdemon_ai.dm
@@ -31,7 +31,7 @@
 	var/datum/action/cooldown/ability = controller.blackboard[BB_TARGETED_ACTION]
 	if(QDELETED(target) || QDELETED(controller.pawn) || !ability?.IsAvailable())
 		return
-	ability.InterceptClickOn(caller = controller.pawn, target = target)
+	ability.InterceptClickOn(user = controller.pawn, target = target)
 
 /datum/ai_planning_subtree/targeted_mob_ability/brimbeam
 	use_ability_behaviour = /datum/ai_behavior/targeted_mob_ability/brimbeam

--- a/code/modules/mob/living/basic/space_fauna/morph.dm
+++ b/code/modules/mob/living/basic/space_fauna/morph.dm
@@ -147,7 +147,7 @@
 	SIGNAL_HANDLER
 
 	// linters hate this if it's not async for some reason even though nothing blocks
-	INVOKE_ASYNC(disguise_ability, TYPE_PROC_REF(/datum/action/cooldown, InterceptClickOn), caller = source, target = target)
+	INVOKE_ASYNC(disguise_ability, TYPE_PROC_REF(/datum/action/cooldown, InterceptClickOn), user = source, target = target)
 	return COMSIG_MOB_CANCEL_CLICKON
 
 /// Handles the logic for attacking anything.

--- a/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
@@ -277,22 +277,22 @@ Doesn't work on other aliens/AI.*/
 // We do this in InterceptClickOn() instead of Activate()
 // because we use the click parameters for aiming the projectile
 // (or something like that)
-/datum/action/cooldown/alien/acid/neurotoxin/InterceptClickOn(mob/living/caller, params, atom/target)
+/datum/action/cooldown/alien/acid/neurotoxin/InterceptClickOn(mob/living/user, params, atom/target)
 	. = ..()
 	if(!.)
-		unset_click_ability(caller, refund_cooldown = FALSE)
+		unset_click_ability(user, refund_cooldown = FALSE)
 		return FALSE
 
 	var/modifiers = params2list(params)
-	caller.visible_message(
-		span_danger("[caller] spits neurotoxin!"),
+	user.visible_message(
+		span_danger("[user] spits neurotoxin!"),
 		span_alertalien("You spit neurotoxin."),
 	)
-	var/obj/projectile/neurotoxin/neurotoxin = new /obj/projectile/neurotoxin(caller.loc)
-	neurotoxin.preparePixelProjectile(target, caller, modifiers)
-	neurotoxin.firer = caller
+	var/obj/projectile/neurotoxin/neurotoxin = new /obj/projectile/neurotoxin(user.loc)
+	neurotoxin.preparePixelProjectile(target, user, modifiers)
+	neurotoxin.firer = user
 	neurotoxin.fire()
-	caller.newtonian_move(get_dir(target, caller))
+	user.newtonian_move(get_dir(target, user))
 	return TRUE
 
 // Has to return TRUE, otherwise is skipped.

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -661,8 +661,8 @@ Pass a positive integer as an argument to override a bot's default speed.
 	if(mode != BOT_SUMMON && mode != BOT_RESPONDING)
 		access_card.set_access(prev_access)
 
-/mob/living/simple_animal/bot/proc/call_bot(caller, turf/waypoint, message = TRUE)
-	if(isAI(caller) && calling_ai && calling_ai != src) //Prevents an override if another AI is controlling this bot.
+/mob/living/simple_animal/bot/proc/call_bot(user, turf/waypoint, message = TRUE)
+	if(isAI(user) && calling_ai && calling_ai != src) //Prevents an override if another AI is controlling this bot.
 		return FALSE
 
 	bot_reset() //Reset a bot before setting it to call mode.
@@ -671,7 +671,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 	//Easier then building the list ourselves. I'm sorry.
 	var/static/obj/item/card/id/all_access = new /obj/item/card/id/advanced/gold/captains_spare()
 	set_path(get_path_to(src, waypoint, max_distance=200, access = all_access.GetAccess()))
-	calling_ai = caller //Link the AI to the bot!
+	calling_ai = user //Link the AI to the bot!
 	ai_waypoint = waypoint
 
 	if(path?.len) //Ensures that a valid path is calculated!
@@ -681,7 +681,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 		access_card.set_access(REGION_ACCESS_ALL_STATION) //Give the bot all-access while under the AI's command.
 		if(client)
 			reset_access_timer_id = addtimer(CALLBACK (src, PROC_REF(bot_reset)), 60 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_STOPPABLE) //if the bot is player controlled, they get the extra access for a limited time
-			to_chat(src, span_notice("[span_big("Priority waypoint set by [icon2html(calling_ai, src)] <b>[caller]</b>. Proceed to <b>[end_area]</b>.")]<br>[path.len-1] meters to destination. You have been granted additional door access for 60 seconds."))
+			to_chat(src, span_notice("[span_big("Priority waypoint set by [icon2html(calling_ai, src)] <b>[user]</b>. Proceed to <b>[end_area]</b>.")]<br>[path.len-1] meters to destination. You have been granted additional door access for 60 seconds."))
 		if(message)
 			to_chat(calling_ai, span_notice("[icon2html(src, calling_ai)] [name] called to [end_area]. [path.len-1] meters to destination."))
 		pathset = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -335,7 +335,7 @@
 
 	return TRUE
 
-/datum/action/cooldown/globules/InterceptClickOn(mob/living/caller, params, atom/target)
+/datum/action/cooldown/globules/InterceptClickOn(mob/living/user, params, atom/target)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -344,19 +344,19 @@
 	// Well, we need to use the params of the click intercept
 	// for passing into preparePixelProjectile, so we'll handle it here instead.
 	// We just need to make sure Pre-activate and Activate return TRUE so we make it this far
-	caller.visible_message(
-		span_nicegreen("[caller] launches a mending globule!"),
+	user.visible_message(
+		span_nicegreen("[user] launches a mending globule!"),
 		span_notice("You launch a mending globule."),
 	)
 
-	var/mob/living/simple_animal/hostile/ooze/oozy = caller
+	var/mob/living/simple_animal/hostile/ooze/oozy = user
 	if(istype(oozy))
 		oozy.adjust_ooze_nutrition(-5)
 
 	var/modifiers = params2list(params)
-	var/obj/projectile/globule/globule = new(caller.loc)
-	globule.preparePixelProjectile(target, caller, modifiers)
-	globule.def_zone = caller.zone_selected
+	var/obj/projectile/globule/globule = new(user.loc)
+	globule.preparePixelProjectile(target, user, modifiers)
+	globule.def_zone = user.zone_selected
 	globule.fire()
 
 	StartCooldown()

--- a/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
@@ -81,13 +81,13 @@
 	if(refund_cooldown)
 		to_chat(on_who, span_notice("You stop preparing your [on_who == owner ? "":"steed's "]pimp-tentacle."))
 
-/datum/action/cooldown/tentacle_slap/InterceptClickOn(mob/living/caller, params, atom/target)
+/datum/action/cooldown/tentacle_slap/InterceptClickOn(mob/living/user, params, atom/target)
 	// Check if we can slap
 	if(!isliving(target) || target == owner)
 		return FALSE
 
 	if(!owner.Adjacent(target))
-		owner.balloon_alert(caller, "too far!")
+		owner.balloon_alert(user, "too far!")
 		return FALSE
 
 	// Do the slap
@@ -97,8 +97,8 @@
 
 	// Give feedback from the slap.
 	// Additional feedback for if a rider did it
-	if(caller != owner)
-		to_chat(caller, span_notice("You command [owner] to slap [target] with its tentacles."))
+	if(user != owner)
+		to_chat(user, span_notice("You command [owner] to slap [target] with its tentacles."))
 
 	return TRUE
 

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -497,11 +497,11 @@
  * The program calling this proc.
  * The message that the program wishes to display.
  */
-/obj/item/modular_computer/proc/alert_call(datum/computer_file/program/caller, alerttext, sound = 'sound/machines/twobeep_high.ogg')
-	if(!caller || !caller.alert_able || caller.alert_silenced || !alerttext) //Yeah, we're checking alert_able. No, you don't get to make alerts that the user can't silence.
+/obj/item/modular_computer/proc/alert_call(datum/computer_file/program/origin, alerttext, sound = 'sound/machines/twobeep_high.ogg')
+	if(!origin || !origin.alert_able || origin.alert_silenced || !alerttext) //Yeah, we're checking alert_able. No, you don't get to make alerts that the user can't silence.
 		return FALSE
 	playsound(src, sound, 50, TRUE)
-	loc.visible_message(span_notice("[icon2html(src)] [span_notice("The [src] displays a [caller.filedesc] notification: [alerttext]")]"))
+	loc.visible_message(span_notice("[icon2html(src)] [span_notice("The [src] displays a [origin.filedesc] notification: [alerttext]")]"))
 
 /obj/item/modular_computer/proc/ring(ringtone) // bring bring
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_PDA_GLITCHED))

--- a/code/modules/spells/spell_types/pointed/_pointed.dm
+++ b/code/modules/spells/spell_types/pointed/_pointed.dm
@@ -64,7 +64,7 @@
 	build_all_button_icons()
 	return TRUE
 
-/datum/action/cooldown/spell/pointed/InterceptClickOn(mob/living/caller, params, atom/target)
+/datum/action/cooldown/spell/pointed/InterceptClickOn(mob/living/user, params, atom/target)
 
 	var/atom/aim_assist_target
 	if(aim_assist && isturf(target))
@@ -74,7 +74,7 @@
 			// If we didn't find a human, we settle for any living at all
 			aim_assist_target = locate(/mob/living) in target
 
-	return ..(caller, params, aim_assist_target || target)
+	return ..(user, params, aim_assist_target || target)
 
 /datum/action/cooldown/spell/pointed/is_valid_target(atom/cast_on)
 	if(cast_on == owner)

--- a/code/modules/spells/spell_types/pointed/swap.dm
+++ b/code/modules/spells/spell_types/pointed/swap.dm
@@ -35,8 +35,8 @@
 		return FALSE
 	return TRUE
 
-/datum/action/cooldown/spell/pointed/swap/InterceptClickOn(mob/living/caller, params, atom/target)
-	if((caller.istate & ISTATE_SECONDARY))
+/datum/action/cooldown/spell/pointed/swap/InterceptClickOn(mob/living/user, params, atom/target)
+	if((user.istate & ISTATE_SECONDARY))
 		if(!IsAvailable(feedback = TRUE))
 			return FALSE
 		if(!target)

--- a/monkestation/code/modules/antagonists/clock_cult/scriptures/_scripture.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/scriptures/_scripture.dm
@@ -404,7 +404,7 @@ GLOBAL_LIST_EMPTY(clock_scriptures_by_type)
 	return ..()
 
 
-/datum/action/cooldown/spell/pointed/slab/InterceptClickOn(mob/living/caller, params, atom/target)
+/datum/action/cooldown/spell/pointed/slab/InterceptClickOn(mob/living/user, params, atom/target)
 	parent_scripture?.click_on(target)
 
 /// Generate all scriptures in a global assoc of name:ref. Only needs to be done once

--- a/monkestation/code/modules/bloodsuckers/powers/targeted/_base_targeted.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/targeted/_base_targeted.dm
@@ -88,5 +88,5 @@
 	StartCooldown()
 	DeactivatePower()
 
-/datum/action/cooldown/bloodsucker/targeted/InterceptClickOn(mob/living/caller, params, atom/target)
+/datum/action/cooldown/bloodsucker/targeted/InterceptClickOn(mob/living/user, params, atom/target)
 	click_with_power(target)

--- a/monkestation/code/modules/blueshift/benos/beno_types/sentinel.dm
+++ b/monkestation/code/modules/blueshift/benos/beno_types/sentinel.dm
@@ -66,40 +66,40 @@
 	build_all_button_icons()
 	on_who.update_icons()
 
-/datum/action/cooldown/alien/acid/nova/InterceptClickOn(mob/living/caller, params, atom/target)
+/datum/action/cooldown/alien/acid/nova/InterceptClickOn(mob/living/user, params, atom/target)
 	. = ..()
 	if(!.)
-		unset_click_ability(caller, refund_cooldown = FALSE)
+		unset_click_ability(user, refund_cooldown = FALSE)
 		return FALSE
 
-	var/turf/user_turf = caller.loc
-	var/turf/target_turf = get_step(caller, target.dir)
+	var/turf/user_turf = user.loc
+	var/turf/target_turf = get_step(user, target.dir)
 	if(!isturf(target_turf))
 		return FALSE
 
 	var/modifiers = params2list(params)
-	caller.visible_message(
-		span_danger("[caller] spits [projectile_name]!"),
+	user.visible_message(
+		span_danger("[user] spits [projectile_name]!"),
 		span_alertalien("You spit [projectile_name]."),
 	)
 
 	if(acid_projectile)
-		var/obj/projectile/spit_projectile = new acid_projectile(caller.loc)
-		spit_projectile.preparePixelProjectile(target, caller, modifiers)
-		spit_projectile.firer = caller
+		var/obj/projectile/spit_projectile = new acid_projectile(user.loc)
+		spit_projectile.preparePixelProjectile(target, user, modifiers)
+		spit_projectile.firer = user
 		spit_projectile.fire()
-		playsound(caller, spit_sound, 100, TRUE, 5, 0.9)
-		caller.newtonian_move(get_dir(target_turf, user_turf))
+		playsound(user, spit_sound, 100, TRUE, 5, 0.9)
+		user.newtonian_move(get_dir(target_turf, user_turf))
 		return TRUE
 
 	if(acid_casing)
-		var/obj/item/ammo_casing/casing = new acid_casing(caller.loc)
-		playsound(caller, spit_sound, 100, TRUE, 5, 0.9)
-		casing.fire_casing(target, caller, null, null, null, ran_zone(), 0, caller)
-		caller.newtonian_move(get_dir(target_turf, user_turf))
+		var/obj/item/ammo_casing/casing = new acid_casing(user.loc)
+		playsound(user, spit_sound, 100, TRUE, 5, 0.9)
+		casing.fire_casing(target, user, null, null, null, ran_zone(), 0, user)
+		user.newtonian_move(get_dir(target_turf, user_turf))
 		return TRUE
 
-	CRASH("Neither acid_projectile or acid_casing are set on [caller]'s spit attack!")
+	CRASH("Neither acid_projectile or acid_casing are set on [user]'s spit attack!")
 
 /datum/action/cooldown/alien/acid/nova/Activate(atom/target)
 	return TRUE

--- a/monkestation/code/modules/emotes/code/emote.dm
+++ b/monkestation/code/modules/emotes/code/emote.dm
@@ -402,11 +402,11 @@
 	var/mob/living/L = on_who
 	src.Remove(L)
 
-/datum/action/cooldown/spell/pointed/projectile/spit/InterceptClickOn(mob/living/caller, params, atom/target)
-	var/mob/living/spitter = caller
+/datum/action/cooldown/spell/pointed/projectile/spit/InterceptClickOn(mob/living/user, params, atom/target)
+	var/mob/living/spitter = user
 
 	if(ishuman(spitter))
-		var/mob/living/carbon/human/humanoid = caller
+		var/mob/living/carbon/human/humanoid = user
 		if(humanoid.is_mouth_covered())
 			humanoid.audible_message("[emote_spit_msg] in their mask!", deaf_message = span_emote("You see <b>[spitter]</b> spit in their mask."), audible_message_flags = EMOTE_MESSAGE)
 			if(boolPlaySound)
@@ -418,7 +418,7 @@
 					ignore_walls = FALSE,
 					mixer_channel = CHANNEL_MOB_EMOTES,
 				)
-			src.Remove(caller)
+			src.Remove(user)
 			return
 
 	. = ..()
@@ -433,7 +433,7 @@
 			ignore_walls = FALSE,
 			mixer_channel = CHANNEL_MOB_EMOTES,
 		)
-	src.Remove(caller)
+	src.Remove(user)
 
 
 /datum/action/cooldown/spell/pointed/projectile/spit/mime


### PR DESCRIPTION
## About The Pull Request

Caller is a protected/reserved var in 516, and it's used in various places, so let's... fix that:
```
- caller and callee vars

	- The current proc has caller and callee vars that return a reference to
	  the running caller and to the running proc itself, respectively. The
	  returned var is of internal type /callee.

	- /callee has vars src, usr, args, file, line, caller, and all vars that
	  apply to proc prototypes (name, type, desc, category, invisibility).	 
```

yes I did just a find & replace

no I'm not adding `// monkestation edit` next to these edits, /tg/ will end up doing the same thing anyways

## Why It's Good For The Game

so 516 compiles lol

## Changelog

No user-facing changes (only renames variables)