### PR TITLE
Moves secoff Paco spawn to backpack

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -121,13 +121,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 			qdel(spawning.ears)
 		spawning.equip_to_slot_or_del(new ears(spawning),ITEM_SLOT_EARS)
 
-	//monkestation edit start: add dept sec outfits
-	if(suit)
-		for(var/obj/item/gun/ballistic/automatic/pistol/paco/no_mag/stored in spawning.contents)
-			if(spawning.wear_suit)
-				qdel(spawning.wear_suit)
-			spawning.equip_to_slot_or_del(new suit(spawning),ITEM_SLOT_OCLOTHING)
-			spawning.equip_to_slot_or_del(stored,ITEM_SLOT_SUITSTORE)
+	//monkestation edit start: add dept sec outfitsif(suit)
 	if(head)
 		if(spawning.head && !isplasmaman(spawning))
 			qdel(spawning.head)
@@ -224,10 +218,10 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	uniform = /obj/item/clothing/under/rank/security/officer
 	head = /obj/item/clothing/head/helmet/hat/cowboy //monkestation edit: cowboy sec
 	suit = /obj/item/clothing/suit/armor/secduster //monkestation edit: cowboy sec
-	suit_store = /obj/item/gun/ballistic/automatic/pistol/paco/no_mag //monkestation edit: Paco sec
 	backpack_contents = list(
 		/obj/item/evidencebag = 1,
-		/obj/item/ammo_box/magazine/m35/rubber = 2, //monkestation edit: Paco sec
+		/obj/item/ammo_box/magazine/m35/rubber = 2,
+		/obj/item/gun/ballistic/automatic/pistol/paco/no_mag, //monkestation edit: Paco sec
 		)
 	belt = /obj/item/modular_computer/pda/security
 	ears = /obj/item/radio/headset/headset_sec/alt


### PR DESCRIPTION

## About The Pull Request
Moves secoff Paco spawn to backpack to account for loadout
Fixes https://github.com/Monkestation/Monkestation2.0/issues/2424

## Why It's Good For The Game
Lets secoffs have drip and their gun

## Changelog

:cl:
fix: fixed secoffs not getting paco with non standard suit
/:cl:

