### PR TITLE
Probably fixes Kudzu at CC

### DIFF
--- a/monkestation/code/modules/ghost_players/job_helpers/food_machine.dm
+++ b/monkestation/code/modules/ghost_players/job_helpers/food_machine.dm
@@ -8,7 +8,9 @@
 
 	icon = 'icons/obj/money_machine.dmi'
 	icon_state = "bogdanoff"
-
+	blacklisted_items = list(
+		/obj/item/food/grown/kudzupod
+)
 
 /obj/structure/food_machine/attack_hand(mob/living/user, list/modifiers)
 	. = ..()


### PR DESCRIPTION
hope it works
## About The Pull Request
hopefully fixes #3266 without breaking stuff
## Why It's Good For The Game
kudzu outgrowing ghost player are sucks
## Changelog
:cl:
fix: kudzu no longer can be grown at ghost player area through the food ingredient spawner
/:cl:
