### PR TITLE
Update Peacekeeper Cyborgs transformation message

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -760,7 +760,7 @@
 
 /obj/item/robot_model/peacekeeper/do_transform_animation()
 	..()
-	to_chat(loc, "<span class='userdanger'>Under ASIMOV, you are an enforcer of the PEACE and preventer of HUMAN HARM. \
+	to_chat(loc, "<span class='userdanger'>You are an Enforcer and Upholder of your active lawset. \
 	You are not a security member and you are expected to follow orders and prevent harm above all else. Space law means nothing to you.</span>")
 
 /obj/item/robot_model/security


### PR DESCRIPTION

## About The Pull Request
Removes mention of Asimovs when peacekeeper cyborgs transform.
## Why It's Good For The Game
Peacekeeper Borgs when transforming get a giant text blurb saying they now uphold Asimovs. Not only is our default lawset not Asimov but there's a weird variety of goals and laws that can fall outside the blurb of Asimov and Human harm.

And it keeps the second half as the reminder that they shouldn't care about spacelaw, which is useful reminder for the borg. They ain't cops. Unless they are RoboCop laws. Then they are I guess)
## Changelog
:cl:
fix: Made Peacekeeper Cyborg transformation message more broad.
:cl:
