### PR TITLE
Fix mood resetting when the HUD is toggled

### DIFF
--- a/code/datums/mood.dm
+++ b/code/datums/mood.dm
@@ -518,10 +518,9 @@
 	holder.layer = LOW_MOB_LAYER
 	holder.icon_state = null
 	if(initial(type.mood_change) > 0)
-		holder.icon_state = "hud_good_mood"
+		flick("hud_good_mood", holder)
 	else
-		holder.icon_state = "hud_bad_mood"
-	addtimer(VARSET_CALLBACK(holder, icon_state, null), 19, (TIMER_UNIQUE|TIMER_OVERRIDE))
+		flick("hud_bad_mood", holder)
 //MONKESTATION ADDITION END
 
 #undef MINOR_INSANITY_PEN


### PR DESCRIPTION

## About The Pull Request
Stops the mood icons from reappearing when toggling the ghost hud.
## Why It's Good For The Game
Turns out the code I thought prevented this wasn't working properly. This should do the trick.
## Changelog
:cl:
fix: Mood hud should no longer constantly appear when retoggling ghost hud.
/:cl:
