### PR TITLE
Halves liquid pump wrench time

### DIFF
--- a/monkestation/code/modules/liquids/liquid_pump.dm
+++ b/monkestation/code/modules/liquids/liquid_pump.dm
@@ -20,7 +20,7 @@
 
 /obj/structure/liquid_pump/wrench_act(mob/living/user, obj/item/I)
 	. = ..()
-	default_unfasten_wrench(user, I, 40)
+	default_unfasten_wrench(user, I, 20)
 	if(!anchored && turned_on)
 		toggle_working()
 	return TRUE


### PR DESCRIPTION

## About The Pull Request
See title.
## Why It's Good For The Game
Constantly moving the liquid pump to fully clean up liquid spills is very painful.

## Changelog

:cl:
balance: Wrenching and unwrenching the liquid pump takes 2 seconds instead of 4.
/:cl:
