### PR TITLE
Lets Ash Walkers use flight potion

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -122,6 +122,7 @@ Lizard subspecies: ASHWALKERS
 	id = SPECIES_LIZARD_ASH
 	mutantlungs = /obj/item/organ/internal/lungs/lavaland
 	mutantbrain = /obj/item/organ/internal/brain/primitive
+	wing_types = list(/obj/item/organ/external/wings/functional/dragon)
 	species_traits = list(
 		MUTCOLORS,
 		MUTCOLORS_SECONDARY,
@@ -130,7 +131,8 @@ Lizard subspecies: ASHWALKERS
 	inherent_traits = list(
 		//TRAIT_LITERATE,
 		TRAIT_VIRUSIMMUNE,
-		TRAIT_HARD_SOLES //MONKESTATION ADDITION
+		TRAIT_HARD_SOLES, //MONKESTATION ADDITION
+		TRAIT_CAN_USE_FLIGHT_POTION,
 	)
 	species_language_holder = /datum/language_holder/lizard/ash
 	/*digitigrade_customization = DIGITIGRADE_FORCED*/ //MONKESTATION REMOVAL: not needed


### PR DESCRIPTION

## About The Pull Request
Title
Fixes https://github.com/Monkestation/Monkestation2.0/issues/1716

## Why It's Good For The Game
Let the lizards fly

## Changelog

:cl:
fix: Ash walkers can now use flight potions
/:cl:

