### PR TITLE
Fixes bot launch pad and stationary medbot sprite

### DIFF
--- a/code/game/machinery/botlaunchpad.dm
+++ b/code/game/machinery/botlaunchpad.dm
@@ -1,11 +1,11 @@
 /obj/machinery/botpad
-	name = "Bot pad"
+	name = "orbital bot pad"
 	desc = "A lighter version of the orbital mech pad modified to launch bots. Requires linking to a remote to function."
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "botpad"
 	circuit = /obj/item/circuitboard/machine/botpad
 	// ID of the console, used for linking up
-	var/id = "botlauncher"
+	// var/id = "botlauncher" MONKESTATION removal
 	var/obj/item/botpad_remote/connected_remote
 	var/datum/weakref/launched_bot // we need this to recall the bot
 
@@ -44,6 +44,9 @@
 			user.balloon_alert(user, "too many bots on the pad!")
 			return
 		possible_bot = robot  // We don't change the launched_bot var here because we are not sure if there is another bot on the pad.
+	if(QDELETED(possible_bot)) //MONKESTATION addition
+		user.balloon_alert(user, "no bots detected on the pad!")
+		return
 	launched_bot = WEAKREF(possible_bot)
 	podspawn(list(
 		"target" = get_turf(src),
@@ -56,15 +59,15 @@
 /obj/machinery/botpad/proc/recall(mob/living/user)
 	var/atom/our_bot = launched_bot?.resolve()
 	if(isnull(our_bot))
-		user.balloon_alert(user, "no bots detected on the pad!")
+		user.balloon_alert(user, "no bot to send back to the pad!")
 		return
 	user.balloon_alert(user, "bot sent back to pad")
 	if(isbasicbot(our_bot))
 		var/mob/living/basic/bot/basic_bot = our_bot
-		basic_bot.summon_bot(src)
-		return
-	var/mob/living/simple_animal/bot/simple_bot = our_bot
-	simple_bot.call_bot(src,  get_turf(src))
+		basic_bot.summon_bot(user, get_turf(src))
+	else
+		var/mob/living/simple_animal/bot/simple_bot = our_bot
+		simple_bot.call_bot(user, get_turf(src))
 
 /obj/structure/closet/supplypod/botpod
 	style = STYLE_SEETHROUGH

--- a/code/game/objects/items/botpad_remote.dm
+++ b/code/game/objects/items/botpad_remote.dm
@@ -1,12 +1,12 @@
 /obj/item/botpad_remote
-	name = "Bot pad controller"
-	desc = "Use this device to control the connected bot pad."
-	desc_controls = "Left-click for launch, right-click for recall."
+	name = "orbital bot pad controller"
+	desc = "Use this device to control the connected orbital bot pad."
+	desc_controls = "Use in hand to launch, right-click to recall back to the pad."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "botpad_controller"
 	w_class = WEIGHT_CLASS_SMALL
 	// ID of the remote, used for linking up
-	var/id = "botlauncher"
+	// var/id = "botlauncher" MONKESTATION removal
 	var/obj/machinery/botpad/connected_botpad
 
 /obj/item/botpad_remote/Destroy()
@@ -39,7 +39,7 @@
 		else if(!connected_botpad && istype(buffered_remote, /obj/machinery/botpad))
 			connected_botpad = buffered_remote
 			connected_botpad.connected_remote = src
-			connected_botpad.id = id
+			// connected_botpad.id = id MONKESTATION REMOVAL
 			multitool.buffer = null
 			to_chat(user, span_notice("You connect the controller to the pad with data from the [multitool.name]'s buffer."))
 		else
@@ -52,7 +52,9 @@
 	if(connected_botpad.panel_open)
 		user?.balloon_alert(user, "close the panel!")
 		return
+/* MONKESTATION REMOVAL START
 	if(!(locate(/mob/living/simple_animal/bot) in get_turf(connected_botpad)))
 		user?.balloon_alert(user, "no bots detected on the pad!")
 		return
+	MONKESTATION REMOVAL END */
 	connected_botpad.launch(user)

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -1040,7 +1040,7 @@
 	req_components = list()
 
 /obj/item/circuitboard/machine/botpad
-	name = "Bot launchpad"
+	name = "Bot Orbital Pad"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/botpad
 	req_components = list()

--- a/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -163,7 +163,7 @@
 		icon_state = "[base_icon_state]a"
 		return
 	if(mode == BOT_HEALING)
-		icon_state = "[base_icon_state]s[medical_mode_flags & MEDBOT_STATIONARY_MODE]"
+		icon_state = "[base_icon_state]s[medical_mode_flags & MEDBOT_STATIONARY_MODE ? 1 : 0]"
 		return
 	icon_state = "[base_icon_state][medical_mode_flags & MEDBOT_STATIONARY_MODE ? 2 : 1]" //Bot has yellow light to indicate stationary mode.
 


### PR DESCRIPTION

## About The Pull Request
Fixes runtimes and broken behavior with the bot launch pad, and comments out some unused code. Fixes stationary medbot disappearing while healing.
## Why It's Good For The Game
Bug fix good. Commented out the unused `id` variable since it could be used in the future, but currently has no purpose.

## Changelog

:cl:
fix: Bot launch pad fixed and renamed to "orbital bot pad".
fix: Stationary medbot healing sprite fixed.
/:cl:
