### PR TITLE
Fixes and enables antag tokens for cortical borers

### DIFF
--- a/config/monkestation/antag-tokens.toml
+++ b/config/monkestation/antag-tokens.toml
@@ -1,3 +1,3 @@
-low = ["traitor", "florida_man", "paradox_clone"]
-medium = ["heretic", "bloodsucker"]
+low = ["traitor", "florida_man", "paradox_clone", "cortical_borer"]
+medium = ["heretic", "bloodsucker", "cortical_borer/hivemind"]
 high = ["cult", "rev/head", "wizard", "clock_cultist", "ninja"]

--- a/monkestation/code/modules/antagonists/borers/code/antagonist_stuff/midround_event.dm
+++ b/monkestation/code/modules/antagonists/borers/code/antagonist_stuff/midround_event.dm
@@ -68,8 +68,9 @@
 	for(var/repeating_code in 1 to choosing_number)
 		var/mob/dead/observer/new_borer = pick(candidates)
 		candidates -= new_borer
-		var/turf/vent_turf = get_turf(pick(vents))
-		var/mob/living/basic/cortical_borer/spawned_cb = new /mob/living/basic/cortical_borer(vent_turf)
+		var/vent = pick(vents)
+		var/mob/living/basic/cortical_borer/spawned_cb = new /mob/living/basic/cortical_borer(get_turf(vent))
+		spawned_cb.move_into_vent(vent)
 		spawned_cb.ckey = new_borer.ckey
 		spawned_cb.mind.add_antag_datum(/datum/antagonist/cortical_borer/hivemind)
 		announce_to_ghosts(spawned_cb)

--- a/monkestation/code/modules/antagonists/borers/code/items/borer_spawner.dm
+++ b/monkestation/code/modules/antagonists/borers/code/items/borer_spawner.dm
@@ -89,8 +89,8 @@
 		action = NOTIFY_ORBIT,
 		header = "Someone just got a new friend!"
 	)
-	message_admins("[ADMIN_LOOKUPFLW(new_mob)] has been made into a borer via a traitor item used by [user]")
-	log_game("[key_name(new_mob)] was spawned as a borer by [key_name(user)]")
+	message_admins("[ADMIN_LOOKUPFLW(new_mob)] has been made into a borer via a traitor item used by [user].")
+	log_game("[key_name(new_mob)] was spawned as a borer by [key_name(user)].")
 	visible_message("A borer wriggles out of the [src]!")
 
 	var/obj/item/cortical_cage/empty_cage = new(drop_location())

--- a/monkestation/code/modules/client/verbs.dm
+++ b/monkestation/code/modules/client/verbs.dm
@@ -120,16 +120,18 @@ GLOBAL_LIST_INIT(antag_token_config, load_antag_token_config())
 			/datum/antagonist/rev/head,
 			/datum/antagonist/wizard,
 			/datum/antagonist/clock_cultist,
-			/datum/antagonist/ninja
+			/datum/antagonist/ninja,
 		)),
 		MEDIUM_THREAT = init_antag_list(list(
 			/datum/antagonist/heretic,
-			/datum/antagonist/bloodsucker
+			/datum/antagonist/bloodsucker,
+			/datum/antagonist/cortical_borer/hivemind,
 		)),
 		LOW_THREAT = init_antag_list(list(
 			/datum/antagonist/florida_man,
 			/datum/antagonist/traitor,
-			/datum/antagonist/paradox_clone
+			/datum/antagonist/paradox_clone,
+			/datum/antagonist/cortical_borer,
 		))
 	)
 	var/static/list/toml_keys = list(

--- a/tgui/packages/tgui/interfaces/AntagInfoBorer.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoBorer.tsx
@@ -111,7 +111,7 @@ const MainPage = () => {
           <Stack vertical>
             <Stack.Item textColor="red" fontSize="20px">
               You are a Cortical Borer, a creature that crawls into peoples
-              ear&#39;s to then settle on the brain
+              ears to then settle in the brain.
             </Stack.Item>
             <Stack.Item>
               <ObjectivePrintout />

--- a/tgui/packages/tgui/interfaces/AntagInfoBorer.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoBorer.tsx
@@ -110,8 +110,8 @@ const MainPage = () => {
         <Section scrollable fill>
           <Stack vertical>
             <Stack.Item textColor="red" fontSize="20px">
-              You are a Cortical Borer, a creature that crawls into peoples
-              ears to then settle in the brain.
+              You are a Cortical Borer, a creature that crawls into peoples ears
+              to then settle in the brain.
             </Stack.Item>
             <Stack.Item>
               <ObjectivePrintout />

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/corticalborer.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/corticalborer.ts
@@ -8,7 +8,7 @@ const CorticalBorer: Antagonist = {
     multiline`
     You are a slug that crawls into peoples ears and
     then manipulates them in various ways
-    to make sure your species survives and thrives
+    to make sure your species survives and thrives.
     `,
   ],
   category: Category.Midround,


### PR DESCRIPTION
## About The Pull Request

Adds neutered cortical borers to the low threat token tier and hivequeen cortical borers to the medium threat token tier.
Token tiers were taken from the [antag trading wiki page](https://wiki.monkestation.com/en/antag-trades).

Also fixes some issues with cortical borer spawning, namely that they don't get put in a vent, rather on top of one.
It'd be rather sad if you spawned on top of a random vent only for a crew member to instantly notice you.

Additionally did some spellchecking.
## Why It's Good For The Game

Bugfixes and spellchecks are self explanatory.
As for the tokens, Pooba complained that making someone a borer was an absolute pain in the ass.
So now it should be easy for people to exchange tokens to become one. Just one button press.
## Changelog
:cl:
add: Borers are now available in the antag token menu. (regular and neutered)
fix: Borers now spawn in vents, rather than on top of them.
spellcheck: Fixed some minor typos and whatnot.
/:cl:
