### PR TITLE
Aphid hive exits are now anchored

### DIFF
--- a/_maps/~monkestation/templates/hives.dmm
+++ b/_maps/~monkestation/templates/hives.dmm
@@ -3,7 +3,9 @@
 /turf/closed/indestructible/hive,
 /area/station/hive/four)
 "c" = (
-/obj/structure/hive_exit,
+/obj/structure/hive_exit{
+	anchored = 1
+},
 /turf/closed/indestructible/hive,
 /area/station/hive/one)
 "k" = (
@@ -19,7 +21,9 @@
 /turf/open/indestructible/hive,
 /area/station/hive/four)
 "B" = (
-/obj/structure/hive_exit,
+/obj/structure/hive_exit{
+	anchored = 1
+},
 /turf/closed/indestructible/hive,
 /area/station/hive/four)
 "C" = (
@@ -35,11 +39,15 @@
 /turf/open/indestructible/hive,
 /area/station/hive/three)
 "N" = (
-/obj/structure/hive_exit,
+/obj/structure/hive_exit{
+	anchored = 1
+},
 /turf/closed/indestructible/hive,
 /area/station/hive/two)
 "O" = (
-/obj/structure/hive_exit,
+/obj/structure/hive_exit{
+	anchored = 1
+},
 /turf/closed/indestructible/hive,
 /area/station/hive/three)
 

--- a/_maps/~monkestation/templates/hives.dmm
+++ b/_maps/~monkestation/templates/hives.dmm
@@ -3,9 +3,7 @@
 /turf/closed/indestructible/hive,
 /area/station/hive/four)
 "c" = (
-/obj/structure/hive_exit{
-	anchored = 1
-},
+/obj/structure/hive_exit,
 /turf/closed/indestructible/hive,
 /area/station/hive/one)
 "k" = (
@@ -21,9 +19,7 @@
 /turf/open/indestructible/hive,
 /area/station/hive/four)
 "B" = (
-/obj/structure/hive_exit{
-	anchored = 1
-},
+/obj/structure/hive_exit,
 /turf/closed/indestructible/hive,
 /area/station/hive/four)
 "C" = (
@@ -39,15 +35,11 @@
 /turf/open/indestructible/hive,
 /area/station/hive/three)
 "N" = (
-/obj/structure/hive_exit{
-	anchored = 1
-},
+/obj/structure/hive_exit,
 /turf/closed/indestructible/hive,
 /area/station/hive/two)
 "O" = (
-/obj/structure/hive_exit{
-	anchored = 1
-},
+/obj/structure/hive_exit,
 /turf/closed/indestructible/hive,
 /area/station/hive/three)
 

--- a/monkestation/code/modules/botany/species/apid/hive/hive_object.dm
+++ b/monkestation/code/modules/botany/species/apid/hive/hive_object.dm
@@ -86,6 +86,7 @@ GLOBAL_LIST_INIT(hive_exits, list())
 	icon = 'monkestation/code/modules/botany/icons/apid_sprites.dmi'
 	icon_state = "hive_exit"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	anchored = TRUE
 
 	var/obj/structure/beebox/hive/linked_hive
 

--- a/monkestation/code/modules/botany/species/apid/hive/hive_object.dm
+++ b/monkestation/code/modules/botany/species/apid/hive/hive_object.dm
@@ -87,6 +87,7 @@ GLOBAL_LIST_INIT(hive_exits, list())
 	icon_state = "hive_exit"
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	anchored = TRUE
+	move_resist = INFINITY
 
 	var/obj/structure/beebox/hive/linked_hive
 


### PR DESCRIPTION
## About The Pull Request
Title
Fixes https://github.com/Monkestation/Monkestation2.0/issues/3387

## Why It's Good For The Game
Aphids can no longer rip the teleporting void off their wall. Fixes bug.

## Changelog

:cl:
fix: Apid hive exits are now anchored
/:cl: