### PR TITLE
Heavily slows down heart worms

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/restricted/stage4.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/restricted/stage4.dm
@@ -3,8 +3,7 @@
 	desc = "If left untreated the subject will die!"
 	restricted = TRUE
 	max_multiplier = 5
-	chance = 20
-	max_chance = 20
+	chance = 6
 	var/sound = FALSE
 	badness = EFFECT_DANGER_DEADLY
 


### PR DESCRIPTION

## About The Pull Request
Title, reduces the chance on heart worms from 20% to 6%
## Why It's Good For The Game
Heart worms are progressing way too fast, and are causing people to get insta-killed after being revived from a defib.. It doesn't help that the normal cures for heart worms are not functioning at the moment. This will hopefully give whoever contracts this disease a fighting chance.
## Changelog
:cl:
balance: Heavily slowed the progression of heart worms
/:cl:
