### PR TITLE
Allows Science/Xenobio Bags To Carry Crossbreed Extracts

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -502,7 +502,9 @@
 	atom_storage.max_total_storage = 200
 	atom_storage.max_slots = 25
 	atom_storage.set_holdable(list(
+//MONKESTATION EDIT START
 		/obj/item/autoslime,
+//MONKESTATION EDIT END
 		/obj/item/bodypart,
 		/obj/item/food/deadmouse,
 		/obj/item/food/monkeycube,
@@ -513,7 +515,9 @@
 		/obj/item/reagent_containers/cup/bottle,
 		/obj/item/reagent_containers/cup/tube,
 		/obj/item/reagent_containers/syringe,
+//MONKESTATION EDIT START
 		/obj/item/slimecross,
+//MONKESTATION EDIT END
 		/obj/item/slime_extract,
 		/obj/item/swab,
 		/obj/item/stack/biomass // monke: make science bags able to hold biomass cubes

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -502,6 +502,7 @@
 	atom_storage.max_total_storage = 200
 	atom_storage.max_slots = 25
 	atom_storage.set_holdable(list(
+		/obj/item/autoslime,
 		/obj/item/bodypart,
 		/obj/item/food/deadmouse,
 		/obj/item/food/monkeycube,
@@ -512,9 +513,8 @@
 		/obj/item/reagent_containers/cup/bottle,
 		/obj/item/reagent_containers/cup/tube,
 		/obj/item/reagent_containers/syringe,
-		/obj/item/slime_extract,
 		/obj/item/slimecross,
-		/obj/item/autoslime,
+		/obj/item/slime_extract,
 		/obj/item/swab,
 		/obj/item/stack/biomass // monke: make science bags able to hold biomass cubes
 		))

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -513,6 +513,8 @@
 		/obj/item/reagent_containers/cup/tube,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/slime_extract,
+		/obj/item/slimecross,
+		/obj/item/autoslime,
 		/obj/item/swab,
 		/obj/item/stack/biomass // monke: make science bags able to hold biomass cubes
 		))


### PR DESCRIPTION
## About The Pull Request

This pull request updates the Xenobiology/Science Bag to now be capable of carrying slime crossbreed extracts. Previously, the bag could only store regular slime extracts. With this change, xenobiologists can now more efficiently manage and carry both regular and crossbreed extracts, improving efficiency during experiments.

## Why It's Good For The Game

Allowing the Science bag to store crossbreed slime extracts improves quality of life for xenobiologists. The change improves ease of access to all slime extracts, rather than forcing players to store crossbreed extracts elsewhere, as majority of the time Xenobiologists will be carrying their Xenofauna bag rather than their usual backpack. I don't believe this will cause balancing issues because if someone really did want to use crossbreeds as a way to harm someone they can always just store them in their regular backpack. This just makes it easier and quicker for xenobiologists to transport and store Crossbreeds.

## Changelog

:cl:
qol: The Xenobiology/Science Bag can now hold slime crossbreed extracts, allowing for easier management of all slime extracts.
/:cl:
