### PR TITLE
Fixes bot pathfinding on kilo

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -1853,18 +1853,6 @@
 /obj/machinery/camera/directional/north,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"aDx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=HOP";
-	location = "Security";
-	name = "security navigation beacon"
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/security/brig)
 "aDF" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -69231,6 +69219,15 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/medical/treatment_center)
+"vHR" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=HOP";
+	location = "Security";
+	name = "security navigation beacon"
+	},
+/turf/open/floor/iron,
+/area/station/security/brig)
 "vHS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -102209,7 +102206,7 @@ hyc
 ihl
 hyc
 pUa
-aDx
+dZA
 qOC
 lNf
 eHH
@@ -104008,7 +104005,7 @@ ych
 ych
 ych
 vVt
-aOe
+vHR
 sQa
 cfL
 pRP

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -31577,12 +31577,6 @@
 	},
 /area/station/service/chapel)
 "jIX" = (
-/obj/item/radio/intercom/directional/west{
-	freerange = 1;
-	listening = 0;
-	name = "Common Channel";
-	pixel_y = 4
-	},
 /obj/item/radio/intercom/directional/north{
 	freerange = 1;
 	listening = 0;
@@ -31606,6 +31600,13 @@
 	name = "AI Chamber Lockdown";
 	pixel_x = -24;
 	req_access = list("ai_upload")
+	},
+/obj/item/radio/intercom/directional/west{
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_y = 4;
+	listening = 0
 	},
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai)


### PR DESCRIPTION

## About The Pull Request
I forgot to move a beacon from security, fixed.
## Why It's Good For The Game
Medibots shouldn't be stuck in brig anymore, at least I hope. Their pathfinding is weird.
## Changelog
:cl:
fix: Fixed bot pathfinding in Kilostation
/:cl:
