### PR TITLE
Fix the Goldeneye shuttle console becoming a nukie shuttle console when reconstructed

### DIFF
--- a/monkestation/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/monkestation/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -18,7 +18,12 @@
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/nanite_cloud_controller
 
-/obj/item/circuitboard/computer/goldeneye_cruiser
-	name = "Goldeneye Cruiser"
+/obj/item/circuitboard/computer/goldeneye_helm
+	name = "goldeneye cruiser helm"
 	greyscale_colors = CIRCUIT_COLOR_GENERIC
 	build_path = /obj/machinery/computer/shuttle/goldeneye_cruiser
+
+/obj/item/circuitboard/computer/goldeneye_recall
+	name = "goldeneye cruiser recall"
+	greyscale_colors = CIRCUIT_COLOR_GENERIC
+	build_path = /obj/machinery/computer/shuttle/goldeneye_cruiser/recall

--- a/monkestation/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/monkestation/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -17,3 +17,8 @@
 	name = "Nanite Cloud Control (Computer Board)"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/computer/nanite_cloud_controller
+
+/obj/item/circuitboard/computer/goldeneye_cruiser
+	name = "Goldeneye Cruiser"
+	greyscale_colors = CIRCUIT_COLOR_GENERIC
+	build_path = /obj/machinery/computer/shuttle/goldeneye_cruiser

--- a/monkestation/code/modules/assault_ops/code/shuttle.dm
+++ b/monkestation/code/modules/assault_ops/code/shuttle.dm
@@ -3,7 +3,7 @@
 	desc = "The terminal used to control the goldeneye cruiser."
 	shuttleId = "goldeneye_cruiser"
 	possible_destinations = "goldeneye_cruiser_custom;goldeneye_cruiser_dock;syndicate_away;syndicate_z5;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s;syndicate_cruiser_dock;whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland;ferry_away"
-	circuit = /obj/item/circuitboard/computer/syndicate_shuttle
+	circuit = /obj/item/circuitboard/computer/goldeneye_cruiser
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
 	light_color = COLOR_SOFT_RED

--- a/monkestation/code/modules/assault_ops/code/shuttle.dm
+++ b/monkestation/code/modules/assault_ops/code/shuttle.dm
@@ -3,7 +3,7 @@
 	desc = "The terminal used to control the goldeneye cruiser."
 	shuttleId = "goldeneye_cruiser"
 	possible_destinations = "goldeneye_cruiser_custom;goldeneye_cruiser_dock;syndicate_away;syndicate_z5;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s;syndicate_cruiser_dock;whiteship_away;whiteship_home;whiteship_z4;whiteship_lavaland;ferry_away"
-	circuit = /obj/item/circuitboard/computer/goldeneye_cruiser
+	circuit = /obj/item/circuitboard/computer/goldeneye_helm
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
 	light_color = COLOR_SOFT_RED
@@ -22,6 +22,7 @@
 	name = "goldeneye shuttle recall terminal"
 	desc = "Use this if your friends left you behind."
 	possible_destinations = "goldeneye_cruiser_dock"
+	circuit = /obj/item/circuitboard/computer/goldeneye_recall
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/goldeneye_cruiser
 	name = "goldeneye cruiser navigation computer"


### PR DESCRIPTION
## Changelog
:cl:
fix: Fixed the Goldeneye shuttle console becoming a nukie shuttle console when reconstructed.
/:cl:
