### PR TITLE
Makes no-heal challenge less of a pain for medbay

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -164,6 +164,11 @@
 		else
 			render_list += "<span class='alert ml-1'>Subject has been husked.</span>\n"
 
+	// monkestation edit: no-heal challenge
+	if(HAS_TRAIT(target, TRAIT_NO_HEALS))
+		render_list += "<span class='alert ml-1'><b>Subject cannot be healed by any known methods.</b></span>\n"
+	// monkestation end
+
 	if(target.stamina.loss)
 		if(advanced)
 			render_list += "<span class='alert ml-1'>Fatigue level: [target.stamina.loss]%.</span>\n"

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -298,6 +298,15 @@
 			radio.talk_into(src, msg, radio_channel)
 		return
 
+	// monkestation start: kick no-healers out
+	if(HAS_TRAIT(mob_occupant, TRAIT_NO_HEALS))
+		playsound(src, 'sound/machines/cryo_warning.ogg', volume)
+		radio.talk_into(src, "Patient is unable to be healed, ejecting.", radio_channel)
+		set_on(FALSE)
+		open_machine()
+		return
+	// monkerstation end
+
 	patient_dead = FALSE
 
 	if(mob_occupant.get_organic_health() >= mob_occupant.getMaxHealth()) // Don't bother with fully healed people.

--- a/monkestation/code/modules/surgery/healing.dm
+++ b/monkestation/code/modules/surgery/healing.dm
@@ -1,0 +1,4 @@
+/datum/surgery/healing/can_start(mob/user, mob/living/patient)
+	if(HAS_TRAIT(patient, TRAIT_NO_HEALS))
+		return FALSE
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7860,6 +7860,7 @@
 #include "monkestation\code\modules\storytellers\storytellers\vote.dm"
 #include "monkestation\code\modules\storytellers\storytellers\warrior.dm"
 #include "monkestation\code\modules\surgery\blood_filter.dm"
+#include "monkestation\code\modules\surgery\healing.dm"
 #include "monkestation\code\modules\surgery\nif_debonding.dm"
 #include "monkestation\code\modules\surgery\advanced\brainwashing.dm"
 #include "monkestation\code\modules\surgery\bodyparts\arachnid_bodyparts.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![2024-09-16 (1726482065) ~ dreamseeker](https://github.com/user-attachments/assets/a471fabc-bb53-45ba-8307-e1b9a044367f)

## Why It's Good For The Game

Makes it possible to actually KNOW when someone is on the no-heal challenge, without wasting forever trying surgery or leaving them stuck in the cryotube for eternity.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Health Analyzers now tell if someone is incapable of being healed.
qol: Cryotubes will now automatically eject people who are incapable of being healed.
qol: Wound tending surgeries can no longer be started on patients who are incapable of being healed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
