### PR TITLE
Looms now auto-stack from adjacent tiles

### DIFF
--- a/code/datums/elements/loomable.dm
+++ b/code/datums/elements/loomable.dm
@@ -76,6 +76,7 @@
 	if(isstack(source))
 		var/obj/item/stack/stack_we_use = source
 		while(stack_we_use.amount >= required_amount)
+			combine_nearby_stacks(user, stack_we_use) // monkestation edit: automatically merge nearby stacks
 			if(!do_after(user, loom_time, target))
 				break
 

--- a/monkestation/code/datums/elements/loomable.dm
+++ b/monkestation/code/datums/elements/loomable.dm
@@ -1,0 +1,6 @@
+/datum/element/loomable/proc/combine_nearby_stacks(atom/target, obj/item/stack/our_stack)
+	for(var/obj/item/stack/nearby_stack as anything in view(1, get_turf(target)))
+		if(our_stack.amount >= our_stack.max_amount)
+			break
+		if(our_stack.can_merge(nearby_stack, inhand = TRUE))
+			nearby_stack.merge(our_stack)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5843,6 +5843,7 @@
 #include "monkestation\code\datums\diseases\advance\symptoms\clockwork.dm"
 #include "monkestation\code\datums\elements\area_locked.dm"
 #include "monkestation\code\datums\elements\basic_eating.dm"
+#include "monkestation\code\datums\elements\loomable.dm"
 #include "monkestation\code\datums\elements\trash_if_empty.dm"
 #include "monkestation\code\datums\elements\uncompressed_storage.dm"
 #include "monkestation\code\datums\ert\moff_inspectors.dm"


### PR DESCRIPTION

## About The Pull Request

_note: I sped up the looming time in the GIF via varedit for the sake of demonstrating the feature quickly, this PR does not change that_

![2024-09-16 (1726502754) ~ dreamseeker](https://github.com/user-attachments/assets/55c6e3c3-d91e-4b51-a01e-2e982352cda0)

## Why It's Good For The Game

Saves people from spam-clicking to accomplish the same thing, as spam-clicking is prolly not good for the whole "avoiding carpal tunnel" thing tbh.

## Changelog
:cl:
qol: Looms will now "refill" your stack while you're spinning if you have more stacks adjacent to you on the floor.
/:cl:
