### PR TITLE
Hotfix to Covert Modsuits chameleon module

### DIFF
--- a/monkestation/code/modules/assault_ops/code/covert_modsuit.dm
+++ b/monkestation/code/modules/assault_ops/code/covert_modsuit.dm
@@ -18,7 +18,7 @@
 	slowdown_inactive = 0
 	slowdown_active = 0
 	ui_theme = "hackerman"
-	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
+	slot_flags = ITEM_SLOT_BELT // | ITEM_SLOT_BACK
 	inbuilt_modules = list(
 		/obj/item/mod/module/storage/belt,
 		/obj/item/mod/module/chameleon/contractor,


### PR DESCRIPTION

## About The Pull Request
Currently, the convert modsuit's chameleon modules will not function. After a bit of testing, it seems to be an issue with the fact the convert modsuit is the only modsuit in the game (from what Ive seen) equipable on the back and toolbelt. Saying the mod suit is made with a toolbelt storage module hardbuilt into it, its wiser to limit it to the toolbelt slot than backpack. And enabling the chameleon mod. At least until someone more insane than me tackles the chameleon module code.
## Why It's Good For The Game
Assault operatives usually fall flat whenever they go fully loud and proud. Renabling them a more passive stealth option than their prototype stealth mod. And giving synergy to their other purchaseables (Chameleon outfit, storage implants. etc,) Allows for a more stealthy approach while maintaining their modsuits usability without being caught.  
## Changelog
:cl:
fix: Fixed Convert Modsuit's chameleon module by making it equipable belt slot only.
:cl:
