### PR TITLE
Changes the Bioterror Grenade into a Large Grenade Casing

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -625,7 +625,10 @@
 	desc = "Tiger Cooperative chemical foam grenade. Causes temporary irration, blindness, confusion, mutism, and mutations to carbon based life forms. Contains additional spore toxin."
 	stage = GRENADE_READY
 
+// MONKESTATION EDIT START
+// MONKESTATION EDIT ORIGINAL /obj/item/grenade/chem_grenade/bioterrorfoam/Initialize(mapload)
 /obj/item/grenade/chem_grenade/large/bioterrorfoam/Initialize(mapload)
+// MONKESTATION EDIT END
 	. = ..()
 	var/obj/item/reagent_containers/cup/beaker/bluespace/beaker_one = new(src)
 	var/obj/item/reagent_containers/cup/beaker/bluespace/beaker_two = new(src)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -617,12 +617,15 @@
 	beakers += beaker_one
 	beakers += beaker_two
 
-/obj/item/grenade/chem_grenade/bioterrorfoam
+// MONKESTATION EDIT START
+// MONKESTATION EDIT ORIGINAL /obj/item/grenade/chem_grenade/bioterrorfoam
+/obj/item/grenade/chem_grenade/large/bioterrorfoam
+// MONKESTATION EDIT END
 	name = "Bio terror foam grenade"
 	desc = "Tiger Cooperative chemical foam grenade. Causes temporary irration, blindness, confusion, mutism, and mutations to carbon based life forms. Contains additional spore toxin."
 	stage = GRENADE_READY
 
-/obj/item/grenade/chem_grenade/bioterrorfoam/Initialize(mapload)
+/obj/item/grenade/chem_grenade/large/bioterrorfoam/Initialize(mapload)
 	. = ..()
 	var/obj/item/reagent_containers/cup/beaker/bluespace/beaker_one = new(src)
 	var/obj/item/reagent_containers/cup/beaker/bluespace/beaker_two = new(src)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -712,7 +712,10 @@
 	new /obj/item/gun/ballistic/automatic/c20r/toy(src)
 	new /obj/item/storage/box/syringes(src)
 	new /obj/item/ammo_box/foambox/riot(src)
-	new /obj/item/grenade/chem_grenade/bioterrorfoam(src)
+	// MONKESTATION EDIT START
+	// MONKESTATION EDIT ORIGINAL new /obj/item/grenade/chem_grenade/bioterrorfoam(src)
+	new /obj/item/grenade/chem_grenade/large/bioterrorfoam(src)
+	// MONKESTATION EDIT END
 	if(prob(5))
 		new /obj/item/food/pizza/pineapple(src)
 

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -224,7 +224,10 @@
 			new /obj/item/megaphone(src) // 0 tc
 			new /obj/item/grenade/clusterbuster/random(src) // 10 tc?
 			new /obj/item/grenade/clusterbuster/random(src) // 10 tc?
-			new /obj/item/grenade/chem_grenade/bioterrorfoam(src) // 5 tc
+			// MONKESTATION EDIT START
+			// MONKESTATION EDIT ORIGINAL new /obj/item/grenade/chem_grenade/bioterrorfoam(src)
+			new /obj/item/grenade/chem_grenade/large/bioterrorfoam(src) // 5 tc
+			// MONKESTATION EDIT END
 			new /obj/item/assembly/signaler(src) // 0 tc
 			new /obj/item/assembly/signaler(src) // 0 tc
 			new /obj/item/assembly/signaler(src) // 0 tc

--- a/monkestation/code/modules/assault_ops/code/armaments/explosives.dm
+++ b/monkestation/code/modules/assault_ops/code/armaments/explosives.dm
@@ -8,7 +8,10 @@
 	cost = 3
 
 /datum/armament_entry/assault_operatives/explosives/bioterror
-	item_type = /obj/item/grenade/chem_grenade/bioterrorfoam
+	// MONKESTATION EDIT START
+	// MONKESTATION EDIT ORIGINAL item_type = /obj/item/grenade/chem_grenade/bioterrorfoam
+	item_type = /obj/item/grenade/chem_grenade/large/bioterrorfoam
+	// MONKESTATION EDIT END
 	cost = 1
 
 /datum/armament_entry/assault_operatives/explosives/minibomb

--- a/monkestation/code/modules/assault_ops/code/armaments/explosives.dm
+++ b/monkestation/code/modules/assault_ops/code/armaments/explosives.dm
@@ -8,10 +8,7 @@
 	cost = 3
 
 /datum/armament_entry/assault_operatives/explosives/bioterror
-	// MONKESTATION EDIT START
-	// MONKESTATION EDIT ORIGINAL item_type = /obj/item/grenade/chem_grenade/bioterrorfoam
 	item_type = /obj/item/grenade/chem_grenade/large/bioterrorfoam
-	// MONKESTATION EDIT END
 	cost = 1
 
 /datum/armament_entry/assault_operatives/explosives/minibomb


### PR DESCRIPTION
## About The Pull Request

This PR changes the Bioterror foam grenade's casing from a regular grenade casing to a large grenade casing. The Bioterror foam grenade uses two bluespace beakers to hold its reagents, but regular grenade casings cannot use bluespace beakers due to their size limits. This has created issues for kits like the Mad Scientist Syndi-Special, which encourages deconstructing and modifying chemical grenades with remote signalers. The change to a large grenade casing resolves this issue.

## Why It's Good For The Game

This change ensures that the Bioterror foam grenade can be fully deconstructed and modified, as intended by kits like the Mad Scientist Syndi-Special Kit, which gives you 4 remote signalers and the bioterror foam grenade. Players will now be able to add remote signalers or any other modifications without running into problems caused by the regular grenade casing.

## Changelog

:cl:
fix: The Bioterror foam grenade now uses a large grenade casing to fit its bluespace beakers.
/:cl: