### PR TITLE
Fix constant runtimes/breakage with symptom varients

### DIFF
--- a/monkestation/code/modules/virology/disease/symptom_varients/base.dm
+++ b/monkestation/code/modules/virology/disease/symptom_varients/base.dm
@@ -20,7 +20,14 @@
 	setup_varient()
 	host_symptom.update_name()
 
-/datum/symptom_varient/proc/set_disease_parent(datum/disease/attached)
+/datum/symptom_varient/Destroy(force)
+	if(host_symptom)
+		UnregisterSignal(host_symptom, list(COMSIG_SYMPTOM_ATTACH, COMSIG_SYMPTOM_DETACH, COMSIG_SYMPTOM_TRIGGER))
+		host_symptom = null
+	host_disease = null
+	return ..()
+
+/datum/symptom_varient/proc/set_disease_parent(datum/source, datum/disease/attached)
 	SIGNAL_HANDLER
 
 	UnregisterSignal(host_symptom, COMSIG_SYMPTOM_ATTACH)

--- a/monkestation/code/modules/virology/disease/symptom_varients/bluespace.dm
+++ b/monkestation/code/modules/virology/disease/symptom_varients/bluespace.dm
@@ -17,13 +17,12 @@ GLOBAL_LIST_INIT(bluespace_varient_list, list())
 	bluespace_id = last_bluespace_id
 
 /datum/symptom_varient/bluespace/Destroy(force)
-	. = ..()
 	GLOB.bluespace_varient_list -= src
+	return ..()
 
 /datum/symptom_varient/bluespace/setup_varient()
 	. = ..()
 	RegisterSignal(host_symptom, COMSIG_SYMPTOM_TRIGGER, PROC_REF(propagate))
-
 
 /datum/symptom_varient/bluespace/proc/propagate()
 	for(var/datum/symptom_varient/bluespace/bluespace as anything in GLOB.bluespace_varient_list)

--- a/monkestation/code/modules/virology/disease/symptom_varients/recursive.dm
+++ b/monkestation/code/modules/virology/disease/symptom_varients/recursive.dm
@@ -5,10 +5,10 @@
 	cooldown_time = 15 SECONDS
 
 /datum/symptom_varient/recursive/Destroy(force)
-	. = ..()
 	UnregisterSignal(host_symptom, COMSIG_SYMPTOM_TRIGGER)
+	return ..()
 
-/datum/symptom_varient/recursive/set_disease_parent(datum/disease/attached)
+/datum/symptom_varient/recursive/set_disease_parent(datum/source, datum/disease/attached)
 	. = ..()
 	RegisterSignal(host_symptom, COMSIG_SYMPTOM_TRIGGER, PROC_REF(start_chain))
 

--- a/monkestation/code/modules/virology/disease/symptom_varients/reflexive.dm
+++ b/monkestation/code/modules/virology/disease/symptom_varients/reflexive.dm
@@ -7,12 +7,12 @@
 	var/mob/living/host_mob
 
 /datum/symptom_varient/reflexive/Destroy(force)
-	. = ..()
 	if(host_mob)
 		UnregisterSignal(host_mob, COMSIG_CARBON_TAKE_BRUTE_DAMAGE)
 		host_mob = null
+	return ..()
 
-/datum/symptom_varient/reflexive/set_disease_parent(datum/disease/attached)
+/datum/symptom_varient/reflexive/set_disease_parent(datum/source, datum/disease/attached)
 	. = ..()
 	if(attached.return_parent())
 		host_mob = attached.return_parent()

--- a/monkestation/code/modules/virology/disease/symptom_varients/routine.dm
+++ b/monkestation/code/modules/virology/disease/symptom_varients/routine.dm
@@ -9,7 +9,7 @@
 	. = ..()
 	STOP_PROCESSING(SSobj, src)
 
-/datum/symptom_varient/routine/set_disease_parent(datum/disease/attached)
+/datum/symptom_varient/routine/set_disease_parent(datum/source, datum/disease/attached)
 	. = ..()
 	START_PROCESSING(SSobj, src)
 

--- a/monkestation/code/modules/virology/disease/symptom_varients/strengthen.dm
+++ b/monkestation/code/modules/virology/disease/symptom_varients/strengthen.dm
@@ -8,7 +8,7 @@
 	. = ..()
 	UnregisterSignal(host_symptom, COMSIG_SYMPTOM_TRIGGER)
 
-/datum/symptom_varient/strength/set_disease_parent(datum/disease/attached)
+/datum/symptom_varient/strength/set_disease_parent(datum/source, datum/disease/attached)
 	. = ..()
 	RegisterSignal(host_symptom, COMSIG_SYMPTOM_TRIGGER, PROC_REF(increase_strength))
 


### PR DESCRIPTION
also added some stuff to avoid hard deletes

## Changelog
:cl:
fix: Fix constant errors related to pathology symptom varients.
/:cl:
