### PR TITLE
2 Change color of tooltips text to improve QoL

### DIFF
--- a/tgui/packages/tgui/styles/components/Tooltip.scss
+++ b/tgui/packages/tgui/styles/components/Tooltip.scss
@@ -6,7 +6,7 @@
 @use '../base.scss';
 @use '../functions.scss' as *;
 
-$color: #ffffff !default;
+$color: #c90000 !default;
 $background-color: #000000 !default;
 $border-radius: base.$border-radius !default;
 
@@ -15,6 +15,7 @@ $border-radius: base.$border-radius !default;
   padding: 0.5em 0.75em;
   pointer-events: none;
   text-align: left;
+  font-weight: bold;
   transition: opacity 150ms ease-out;
   background-color: $background-color;
   color: $color;


### PR DESCRIPTION
Linked to issues https://github.com/UnionRolistes/Monkestation2.0-ur/issues/2

## About The Pull Request
- The aim of this change is to make the game easier to read and more comfortable for players, by highlighting the tooltips text, in particular with red and bold text.

## Why It's Good For The Game
it's a simple change that brings direct benefits to all users. 

## Changelog

:cl:
qol: Change tooltips color to dark red (c90000) and bold
:cl:

@Mortifia