### PR TITLE
Antag selection weighting fixups

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -342,7 +342,11 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 #define HUNTER_PACK_PSYKER "Psyker Shikaris"
 
 // This flag disables certain checks that presume antagonist datums mean 'baddie'.
-#define FLAG_FAKE_ANTAG (1 << 0)
+#define FLAG_FAKE_ANTAG			(1 << 0)
+// monkestation addition: The storyteller will ignore this antag datum as counting against the antag cap.
+#define FLAG_ANTAG_CAP_IGNORE	(1 << 1)
+// monkestation addition: The storyteller will count everyone on this antag's team as a singular antag instead.
+#define FLAG_ANTAG_CAP_TEAM		(1 << 2)
 
 #define FREEDOM_IMPLANT_CHARGES 4
 

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -342,11 +342,13 @@ GLOBAL_LIST_INIT(human_invader_antagonists, list(
 #define HUNTER_PACK_PSYKER "Psyker Shikaris"
 
 // This flag disables certain checks that presume antagonist datums mean 'baddie'.
-#define FLAG_FAKE_ANTAG			(1 << 0)
+#define FLAG_FAKE_ANTAG					(1 << 0)
+/// monkestation addition: Whether the antagonist can see exploitable info on people they examine.
+#define FLAG_CAN_SEE_EXPOITABLE_INFO	(1 << 1)
 // monkestation addition: The storyteller will ignore this antag datum as counting against the antag cap.
-#define FLAG_ANTAG_CAP_IGNORE	(1 << 1)
+#define FLAG_ANTAG_CAP_IGNORE			(1 << 2)
 // monkestation addition: The storyteller will count everyone on this antag's team as a singular antag instead.
-#define FLAG_ANTAG_CAP_TEAM		(1 << 2)
+#define FLAG_ANTAG_CAP_TEAM				(1 << 3)
 
 #define FREEDOM_IMPLANT_CHARGES 4
 

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -287,7 +287,7 @@ GLOBAL_REAL(Master, /datum/controller/master)
 	if(sleep_offline_after_initializations && CONFIG_GET(flag/resume_after_initializations))
 		world.sleep_offline = FALSE
 	initializations_finished_with_no_players_logged_in = initialized_tod < REALTIMEOFDAY - 10
-	SSgamemode.handle_picking_stroyteller() //monkestation edit
+	SSgamemode.handle_picking_storyteller() //monkestation edit
 
 /**
  * Initialize a given subsystem and handle the results.

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -54,7 +54,7 @@ GLOBAL_LIST_EMPTY(antagonists)
 	/// The typepath for the outfit to show in the preview for the preferences menu.
 	var/preview_outfit
 	/// Flags for antags to turn on or off and check!
-	var/antag_flags = NONE
+	var/antag_flags = FLAG_CAN_SEE_EXPOITABLE_INFO // monkestation edit: allow antags to see exploitable info.
 	/// If true, this antagonist can assign themself a new objective
 	var/can_assign_self_objectives = FALSE
 	/// Default to fill in when entering a custom objective.

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -7,6 +7,7 @@
 	show_in_antagpanel = FALSE //should only show subtypes
 	show_to_ghosts = TRUE
 	suicide_cry = "FOR THE MOTHERSHIP!!" // They can't even talk but y'know
+	antag_flags = FLAG_ANTAG_CAP_TEAM // monkestation addition
 	var/datum/team/abductor_team/team
 	var/sub_role
 	var/outfit

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -7,7 +7,7 @@
 	show_in_antagpanel = FALSE //should only show subtypes
 	show_to_ghosts = TRUE
 	suicide_cry = "FOR THE MOTHERSHIP!!" // They can't even talk but y'know
-	antag_flags = FLAG_ANTAG_CAP_TEAM // monkestation addition
+	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_TEAM // monkestation addition
 	var/datum/team/abductor_team/team
 	var/sub_role
 	var/outfit

--- a/code/modules/antagonists/blob/blob_minion.dm
+++ b/code/modules/antagonists/blob/blob_minion.dm
@@ -4,6 +4,7 @@
 	show_name_in_check_antagonists = TRUE
 	show_to_ghosts = TRUE
 	show_in_antagpanel = FALSE
+	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
 	/// The blob core that this minion is attached to
 	var/datum/weakref/overmind
 

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -8,7 +8,7 @@
 	ui_name = "AntagInfoBrother"
 	suicide_cry = "FOR MY BROTHER!!"
 	antag_moodlet = /datum/mood_event/focused
-	antag_flags = FLAG_ANTAG_CAP_TEAM // monkestation addition
+	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_TEAM // monkestation addition
 	VAR_PRIVATE
 		datum/team/brother_team/team
 

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -8,6 +8,7 @@
 	ui_name = "AntagInfoBrother"
 	suicide_cry = "FOR MY BROTHER!!"
 	antag_moodlet = /datum/mood_event/focused
+	antag_flags = FLAG_ANTAG_CAP_TEAM // monkestation addition
 	VAR_PRIVATE
 		datum/team/brother_team/team
 

--- a/code/modules/antagonists/changeling/fallen_changeling.dm
+++ b/code/modules/antagonists/changeling/fallen_changeling.dm
@@ -6,6 +6,7 @@
 	job_rank = ROLE_CHANGELING
 	antag_moodlet = /datum/mood_event/fallen_changeling
 	antag_hud_name = "changeling"
+	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
 
 /datum/mood_event/fallen_changeling
 	description = "My powers! Where are my powers?!"

--- a/code/modules/antagonists/changeling/fallen_changeling.dm
+++ b/code/modules/antagonists/changeling/fallen_changeling.dm
@@ -6,7 +6,7 @@
 	job_rank = ROLE_CHANGELING
 	antag_moodlet = /datum/mood_event/fallen_changeling
 	antag_hud_name = "changeling"
-	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
+	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_IGNORE // monkestation addition
 
 /datum/mood_event/fallen_changeling
 	description = "My powers! Where are my powers?!"

--- a/code/modules/antagonists/heretic/heretic_monsters.dm
+++ b/code/modules/antagonists/heretic/heretic_monsters.dm
@@ -8,6 +8,7 @@
 	antag_hud_name = "heretic_beast"
 	suicide_cry = "MY MASTER SMILES UPON ME!!"
 	show_in_antagpanel = FALSE
+	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
 	/// Our master (a heretic)'s mind.
 	var/datum/mind/master
 

--- a/code/modules/antagonists/heretic/heretic_monsters.dm
+++ b/code/modules/antagonists/heretic/heretic_monsters.dm
@@ -8,7 +8,7 @@
 	antag_hud_name = "heretic_beast"
 	suicide_cry = "MY MASTER SMILES UPON ME!!"
 	show_in_antagpanel = FALSE
-	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
+	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_IGNORE // monkestation addition
 	/// Our master (a heretic)'s mind.
 	var/datum/mind/master
 

--- a/code/modules/antagonists/magic_servant/servant.dm
+++ b/code/modules/antagonists/magic_servant/servant.dm
@@ -3,7 +3,7 @@
 	show_in_roundend = FALSE
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
-	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
+	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_IGNORE // monkestation addition
 
 /datum/antagonist/magic_servant/proc/setup_master(mob/M)
 	var/datum/objective/O = new("Serve [M.real_name].")

--- a/code/modules/antagonists/magic_servant/servant.dm
+++ b/code/modules/antagonists/magic_servant/servant.dm
@@ -3,6 +3,7 @@
 	show_in_roundend = FALSE
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
+	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
 
 /datum/antagonist/magic_servant/proc/setup_master(mob/M)
 	var/datum/objective/O = new("Serve [M.real_name].")

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -7,6 +7,7 @@
 	show_to_ghosts = TRUE
 	suicide_cry = "FOR ME MATEYS!!"
 	hijack_speed = 2 // That is without doubt the worst pirate I have ever seen.
+	antag_flags = FLAG_ANTAG_CAP_TEAM // monkestation addition
 	var/datum/team/pirate/crew
 
 /datum/antagonist/pirate/greet()

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -7,7 +7,7 @@
 	show_to_ghosts = TRUE
 	suicide_cry = "FOR ME MATEYS!!"
 	hijack_speed = 2 // That is without doubt the worst pirate I have ever seen.
-	antag_flags = FLAG_ANTAG_CAP_TEAM // monkestation addition
+	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_TEAM // monkestation addition
 	var/datum/team/pirate/crew
 
 /datum/antagonist/pirate/greet()

--- a/code/modules/antagonists/pyro_slime/pyro_slime.dm
+++ b/code/modules/antagonists/pyro_slime/pyro_slime.dm
@@ -5,6 +5,7 @@
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
 	show_to_ghosts = TRUE
+	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
 
 /datum/antagonist/pyro_slime/on_gain()
 	forge_objectives()

--- a/code/modules/antagonists/revolution/enemy_of_the_revolution.dm
+++ b/code/modules/antagonists/revolution/enemy_of_the_revolution.dm
@@ -7,6 +7,7 @@
 	name = "\improper Enemy of the Revolution"
 	show_in_antagpanel = FALSE
 	suicide_cry = "FOR NANOTRASEN, NOW AND FOREVER!!"
+	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
 
 /datum/antagonist/enemy_of_the_revolution/forge_objectives()
 	var/datum/objective/survive/survive = new

--- a/code/modules/antagonists/revolution/enemy_of_the_revolution.dm
+++ b/code/modules/antagonists/revolution/enemy_of_the_revolution.dm
@@ -7,7 +7,7 @@
 	name = "\improper Enemy of the Revolution"
 	show_in_antagpanel = FALSE
 	suicide_cry = "FOR NANOTRASEN, NOW AND FOREVER!!"
-	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
+	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_IGNORE // monkestation addition
 
 /datum/antagonist/enemy_of_the_revolution/forge_objectives()
 	var/datum/objective/survive/survive = new

--- a/code/modules/antagonists/sentient_creature/sentient_creature.dm
+++ b/code/modules/antagonists/sentient_creature/sentient_creature.dm
@@ -4,6 +4,7 @@
 	show_in_roundend = FALSE
 	count_against_dynamic_roll_chance = FALSE
 	ui_name = "AntagInfoSentient"
+	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
 
 /datum/antagonist/sentient_creature/get_preview_icon()
 	var/icon/final_icon = icon('icons/mob/simple/pets.dmi', "corgi")

--- a/code/modules/antagonists/space_dragon/space_carp.dm
+++ b/code/modules/antagonists/space_dragon/space_carp.dm
@@ -5,6 +5,7 @@
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
 	show_to_ghosts = TRUE
+	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
 	/// The rift to protect
 	var/datum/weakref/rift
 

--- a/code/modules/antagonists/venus_human_trap/venus_human_trap.dm
+++ b/code/modules/antagonists/venus_human_trap/venus_human_trap.dm
@@ -5,6 +5,7 @@
 	show_in_antagpanel = FALSE
 	show_name_in_check_antagonists = TRUE
 	show_to_ghosts = TRUE
+	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
 
 /datum/antagonist/venus_human_trap/on_gain()
 	forge_objectives()

--- a/code/modules/antagonists/wishgranter/wishgranter.dm
+++ b/code/modules/antagonists/wishgranter/wishgranter.dm
@@ -4,6 +4,7 @@
 	show_name_in_check_antagonists = TRUE
 	hijack_speed = 2 //You literally are here to do nothing else. Might as well be fast about it.
 	suicide_cry = "HAHAHAHAHA!!"
+	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
 
 /datum/antagonist/wishgranter/forge_objectives()
 	var/datum/objective/hijack/hijack = new

--- a/code/modules/antagonists/wishgranter/wishgranter.dm
+++ b/code/modules/antagonists/wishgranter/wishgranter.dm
@@ -4,7 +4,7 @@
 	show_name_in_check_antagonists = TRUE
 	hijack_speed = 2 //You literally are here to do nothing else. Might as well be fast about it.
 	suicide_cry = "HAHAHAHAHA!!"
-	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
+	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_IGNORE // monkestation addition
 
 /datum/antagonist/wishgranter/forge_objectives()
 	var/datum/objective/hijack/hijack = new

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -38,6 +38,7 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 	antag_hud_name = "apprentice"
 	show_in_roundend = FALSE
 	show_name_in_check_antagonists = TRUE
+	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
 	/// The wizard team this wizard minion is part of.
 	var/datum/team/wizard/wiz_team
 

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -38,7 +38,7 @@ GLOBAL_LIST_EMPTY(wizard_spellbook_purchases_by_key)
 	antag_hud_name = "apprentice"
 	show_in_roundend = FALSE
 	show_name_in_check_antagonists = TRUE
-	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
+	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_IGNORE // monkestation addition
 	/// The wizard team this wizard minion is part of.
 	var/datum/team/wizard/wiz_team
 

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -66,6 +66,7 @@
 			return
 		captive_team = new
 		captive_team.progenitor = owner
+		antag_flags |= FLAG_ANTAG_CAP_IGNORE // monkestation edit: first captive xeno does not count against cap
 	else
 		if(!istype(new_team))
 			CRASH("Wrong xeno team type provided to create_team")

--- a/code/modules/bitrunning/antagonists/cyber_police.dm
+++ b/code/modules/bitrunning/antagonists/cyber_police.dm
@@ -10,6 +10,7 @@
 	show_to_ghosts = TRUE
 	suicide_cry = "ALT F4!"
 	ui_name = "AntagInfoCyberAuth"
+	antag_flags = FLAG_ANTAG_CAP_IGNORE // monkestation addition
 
 /datum/antagonist/cyber_police/greet()
 	. = ..()

--- a/code/modules/events/ghost_role/alien_infestation.dm
+++ b/code/modules/events/ghost_role/alien_infestation.dm
@@ -87,25 +87,26 @@
 			if(temp_vent_parent.other_atmos_machines.len > 20)
 				vents += temp_vent
 
-	if(!vents.len)
+	if(!length(vents))
 		message_admins("An event attempted to spawn an alien but no suitable vents were found. Shutting down.")
 		return MAP_ERROR
 
-	for(var/i in 1 to antag_count)
-		if(!length(candidates))
-			break
-
-		var/client/mob_client = pick_n_take_weighted(weighted_candidates)
-		var/mob/candidate = mob_client.mob
-		if(candidate.client) //I hate this
-			candidate.client.prefs.reset_antag_rep()
+	var/selected_count = 0
+	while(length(weighted_candidates) && selected_count < antag_count)
+		var/client/candidate_ckey = pick_n_take_weighted(weighted_candidates)
+		var/client/candidate_client = GLOB.directory[candidate_ckey]
+		if(QDELETED(candidate_client) || QDELETED(candidate_client.mob))
+			continue
+		var/mob/candidate = candidate_client.mob
+		candidate_client.prefs?.reset_antag_rep()
 		if(!candidate.mind)
 			candidate.mind = new /datum/mind(candidate.key)
 
 		var/obj/vent = pick_n_take(vents)
 		var/mob/living/carbon/alien/larva/new_xeno = new(vent.loc)
-		new_xeno.key = candidate.key
+		new_xeno.ckey = candidate_ckey
 		new_xeno.move_into_vent(vent)
+		selected_count++
 
 		message_admins("[ADMIN_LOOKUPFLW(new_xeno)] has been made into an alien by an event.")
 		new_xeno.log_message("was spawned as an alien by an event.", LOG_GAME)

--- a/monkestation/code/__DEFINES/antag_defines.dm
+++ b/monkestation/code/__DEFINES/antag_defines.dm
@@ -1,2 +1,0 @@
-/// Whether the antagonist can see exploitable info on people they examine.
-#define FLAG_CAN_SEE_EXPOITABLE_INFO (1<<1)

--- a/monkestation/code/modules/antagonists/_common/antag_datum.dm
+++ b/monkestation/code/modules/antagonists/_common/antag_datum.dm
@@ -1,6 +1,4 @@
 /datum/antagonist
-	/// Allows antags to check exploitable info
-	antag_flags = FLAG_CAN_SEE_EXPOITABLE_INFO
 	///The list of keys that are valid to see our antag hud/of huds we can see
 	var/list/hud_keys
 	/// If this antagonist should be removed from the crew manifest upon gain.

--- a/monkestation/code/modules/antagonists/clock_cult/antag_datums/clock_cultist.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/antag_datums/clock_cultist.dm
@@ -203,6 +203,7 @@
 
 /datum/antagonist/clock_cultist/eminence
 	name = "Eminence"
+	antag_flags = FLAG_ANTAG_CAP_IGNORE
 	give_slab = FALSE
 	antag_moodlet = null
 	communicate = null

--- a/monkestation/code/modules/antagonists/clock_cult/antag_datums/clock_cultist.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/antag_datums/clock_cultist.dm
@@ -203,7 +203,7 @@
 
 /datum/antagonist/clock_cultist/eminence
 	name = "Eminence"
-	antag_flags = FLAG_ANTAG_CAP_IGNORE
+	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_IGNORE
 	give_slab = FALSE
 	antag_moodlet = null
 	communicate = null

--- a/monkestation/code/modules/antagonists/evil_clone/evil_clone.dm
+++ b/monkestation/code/modules/antagonists/evil_clone/evil_clone.dm
@@ -5,6 +5,7 @@
 	antagpanel_category = "Evil Clones"
 	show_name_in_check_antagonists = TRUE
 	show_to_ghosts = TRUE
+	antag_flags = FLAG_ANTAG_CAP_IGNORE
 
 /datum/antagonist/evil_clone/greet()
 	. = ..()

--- a/monkestation/code/modules/antagonists/evil_clone/evil_clone.dm
+++ b/monkestation/code/modules/antagonists/evil_clone/evil_clone.dm
@@ -5,7 +5,7 @@
 	antagpanel_category = "Evil Clones"
 	show_name_in_check_antagonists = TRUE
 	show_to_ghosts = TRUE
-	antag_flags = FLAG_ANTAG_CAP_IGNORE
+	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_IGNORE
 
 /datum/antagonist/evil_clone/greet()
 	. = ..()

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_shaded.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_shaded.dm
@@ -5,7 +5,7 @@
 	show_in_roundend = FALSE
 	job_rank = ROLE_BLOODSUCKER
 	antag_hud_name = "bloodsucker"
-	antag_flags = FLAG_ANTAG_CAP_IGNORE
+	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_IGNORE
 
 /obj/item/soulstone/bloodsucker
 	theme = THEME_WIZARD

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_shaded.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_shaded.dm
@@ -5,6 +5,7 @@
 	show_in_roundend = FALSE
 	job_rank = ROLE_BLOODSUCKER
 	antag_hud_name = "bloodsucker"
+	antag_flags = FLAG_ANTAG_CAP_IGNORE
 
 /obj/item/soulstone/bloodsucker
 	theme = THEME_WIZARD

--- a/monkestation/code/modules/bloodsuckers/vassals/ex_vassal.dm
+++ b/monkestation/code/modules/bloodsuckers/vassals/ex_vassal.dm
@@ -12,6 +12,7 @@
 	silent = TRUE
 	ui_name = FALSE
 	hud_icon = 'monkestation/icons/bloodsuckers/bloodsucker_icons.dmi'
+	antag_flags = FLAG_ANTAG_CAP_IGNORE
 
 	///The revenge vassal that brought us into the fold.
 	var/datum/antagonist/vassal/revenge/revenge_vassal

--- a/monkestation/code/modules/bloodsuckers/vassals/vassal_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/vassals/vassal_datum.dm
@@ -8,7 +8,7 @@
 	roundend_category = "vassals"
 	antagpanel_category = "Bloodsucker"
 	job_rank = ROLE_BLOODSUCKER
-	antag_flags = FLAG_ANTAG_CAP_IGNORE
+	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_IGNORE
 	antag_hud_name = "vassal"
 	show_in_roundend = FALSE
 	hud_icon = 'monkestation/icons/bloodsuckers/bloodsucker_icons.dmi'

--- a/monkestation/code/modules/bloodsuckers/vassals/vassal_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/vassals/vassal_datum.dm
@@ -8,6 +8,7 @@
 	roundend_category = "vassals"
 	antagpanel_category = "Bloodsucker"
 	job_rank = ROLE_BLOODSUCKER
+	antag_flags = FLAG_ANTAG_CAP_IGNORE
 	antag_hud_name = "vassal"
 	show_in_roundend = FALSE
 	hud_icon = 'monkestation/icons/bloodsuckers/bloodsucker_icons.dmi'

--- a/monkestation/code/modules/storytellers/antag_rep/helper_procs.dm
+++ b/monkestation/code/modules/storytellers/antag_rep/helper_procs.dm
@@ -37,27 +37,21 @@ GLOBAL_LIST_INIT(blessed_ckeys, list(
 ///give it a list of clients and the value aswell if it should be affected by multipliers and let er rip
 /proc/mass_adjust_antag_rep(list/clients, value, mulitplier = TRUE)
 	for(var/client/listed_client as anything in clients)
-		if(!listed_client.prefs || !IS_CLIENT_OR_MOCK(listed_client))
+		if(!IS_CLIENT_OR_MOCK(listed_client) || QDELETED(listed_client) || QDELETED(listed_client.prefs))
 			continue
 		listed_client.prefs.adjust_antag_rep(value, mulitplier)
 
 /proc/return_antag_rep_weight(list/candidates)
-	var/list/returning_list = list()
+	. = list()
 	for(var/anything in candidates)
 		var/client/client_source
 		if(ismob(anything))
 			var/mob/mob = anything
 			client_source = mob.client
-		if(IS_CLIENT_OR_MOCK(anything))
+		else if(IS_CLIENT_OR_MOCK(anything))
 			client_source = anything
-		if(!client_source)
+		if(QDELETED(client_source) || !client_source.ckey)
 			continue
+		.[client_source.ckey] = client_source.prefs?.antag_rep || 10
 
-		returning_list += client_source
-		var/return_value = 10
-		if(client_source.prefs?.antag_rep)
-			return_value = client_source.prefs.antag_rep
-		returning_list[client_source] = return_value
-
-	log_antag_rep("Returned Weighted List of [length(returning_list)]", list("before_weight" = candidates, "after_weight" = returning_list))
-	return returning_list
+	log_antag_rep("Returned Weighted List of [length(.)]", list("before_weight" = candidates, "after_weight" = .))

--- a/monkestation/code/modules/storytellers/converted_events/solo/ghosts/paradox_clone.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/ghosts/paradox_clone.dm
@@ -52,26 +52,24 @@
 		)
 
 	var/list/weighted_candidates = return_antag_rep_weight(candidates)
-
-	for(var/i in 1 to antag_count)
-		if(!length(candidates))
-			break
-
-		var/client/mob_client = pick_n_take(weighted_candidates)
-		var/mob/candidate = mob_client.mob
-
-		if(candidate.client) //I hate this
-			candidate.client.prefs.reset_antag_rep()
-
+	var/selected_count = 0
+	while(length(weighted_candidates) && selected_count < antag_count)
+		var/client/candidate_ckey = pick_n_take_weighted(weighted_candidates)
+		var/client/candidate_client = GLOB.directory[candidate_ckey]
+		if(QDELETED(candidate_client) || QDELETED(candidate_client.mob))
+			continue
+		var/mob/candidate = candidate_client.mob
+		candidate_client.prefs?.reset_antag_rep()
 		if(!candidate.mind)
 			candidate.mind = new /datum/mind(candidate.key)
 
 		clone_victim = find_original()
 		new_human = duplicate_object(clone_victim, pick(possible_spawns))
-		new_human.key = candidate.key
+		new_human.ckey = candidate_ckey
 		new_human.mind.special_role = antag_flag
 		new_human.mind.restricted_roles = restricted_roles
 		setup_minds += new_human.mind
+		selected_count++
 	setup = TRUE
 
 

--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -157,8 +157,6 @@ SUBSYSTEM_DEF(gamemode)
 	var/ran_roundstart = FALSE
 	var/list/triggered_round_events = list()
 
-	var/total_valid_antags = 0
-
 /datum/controller/subsystem/gamemode/Initialize(time, zlevel)
 	// Populate event pools
 	for(var/track in event_tracks)
@@ -233,20 +231,29 @@ SUBSYSTEM_DEF(gamemode)
 	var/cap = FLOOR((total_number / ANTAG_CAP_DENOMINATOR), 1) + ANTAG_CAP_FLAT
 	return cap
 
+/datum/controller/subsystem/gamemode/proc/get_antag_count()
+	. = 0
+	var/list/already_counted = list() // Never count the same mind twice
+	for(var/datum/antagonist/antag as anything in GLOB.antagonists)
+		if(QDELETED(antag) || QDELETED(antag.owner) || already_counted[antag.owner])
+			continue
+		if(!antag.count_against_dynamic_roll_chance || (antag.antag_flags & (FLAG_FAKE_ANTAG | FLAG_ANTAG_CAP_IGNORE)))
+			continue
+		if(antag.antag_flags & FLAG_ANTAG_CAP_TEAM)
+			var/datum/team/antag_team = antag.get_team()
+			if(antag_team)
+				if(already_counted[antag_team])
+					continue
+				already_counted[antag_team] = TRUE
+		var/mob/antag_mob = antag.owner.current
+		if(QDELETED(antag_mob) || !antag_mob.key || antag_mob.stat == DEAD || antag_mob.client?.is_afk())
+			continue
+		already_counted[antag.owner] = TRUE
+		.++
+
 /// Whether events can inject more antagonists into the round
 /datum/controller/subsystem/gamemode/proc/can_inject_antags()
-	total_valid_antags = 0
-	for(var/mob/checked_mob in GLOB.mob_list)
-		if(!checked_mob.mind)
-			continue
-		if(!checked_mob.mind.special_role)
-			continue
-		if(checked_mob.stat == DEAD)
-			continue
-		total_valid_antags++
-
-
-	return (get_antag_cap() > total_valid_antags)
+	return (get_antag_cap() > get_antag_count())
 
 /// Gets candidates for antagonist roles.
 /datum/controller/subsystem/gamemode/proc/get_candidates(be_special, job_ban, observers, ready_newplayers, living_players, required_time, inherit_required_time = TRUE, midround_antag_pref, no_antags = TRUE, list/restricted_roles, list/required_roles)
@@ -869,23 +876,13 @@ SUBSYSTEM_DEF(gamemode)
 /// Panel containing information, variables and controls about the gamemode and scheduled event
 /datum/controller/subsystem/gamemode/proc/admin_panel(mob/user)
 	update_crew_infos()
-	total_valid_antags = 0
-	for(var/mob/checked_mob in GLOB.mob_list)
-		if(!checked_mob.mind)
-			continue
-		if(!checked_mob.mind.special_role)
-			continue
-		if(checked_mob.stat == DEAD)
-			continue
-		total_valid_antags++
-
 	var/round_started = SSticker.HasRoundStarted()
 	var/list/dat = list()
 	dat += "Storyteller: [storyteller ? "[storyteller.name]" : "None"] "
 	dat += " <a href='?src=[REF(src)];panel=main;action=halt_storyteller' [halted_storyteller ? "class='linkOn'" : ""]>HALT Storyteller</a> <a href='?src=[REF(src)];panel=main;action=open_stats'>Event Panel</a> <a href='?src=[REF(src)];panel=main;action=set_storyteller'>Set Storyteller</a> <a href='?src=[REF(src)];panel=main'>Refresh</a>"
 	dat += "<BR><font color='#888888'><i>Storyteller determines points gained, event chances, and is the entity responsible for rolling events.</i></font>"
 	dat += "<BR>Active Players: [active_players]   (Head: [head_crew], Sec: [sec_crew], Eng: [eng_crew], Med: [med_crew])"
-	dat += "<BR>Antagonist Count vs Maximum: [total_valid_antags] / [get_antag_cap()]"
+	dat += "<BR>Antagonist Count vs Maximum: [get_antag_count()] / [get_antag_cap()]"
 	dat += "<HR>"
 	dat += "<a href='?src=[REF(src)];panel=main;action=tab;tab=[GAMEMODE_PANEL_MAIN]' [panel_page == GAMEMODE_PANEL_MAIN ? "class='linkOn'" : ""]>Main</a>"
 	dat += " <a href='?src=[REF(src)];panel=main;action=tab;tab=[GAMEMODE_PANEL_VARIABLES]' [panel_page == GAMEMODE_PANEL_VARIABLES ? "class='linkOn'" : ""]>Variables</a>"

--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -798,7 +798,9 @@ SUBSYSTEM_DEF(gamemode)
 	point_thresholds[EVENT_TRACK_ROLESET] = CONFIG_GET(number/roleset_point_threshold)
 	point_thresholds[EVENT_TRACK_OBJECTIVES] = CONFIG_GET(number/objectives_point_threshold)
 
-/datum/controller/subsystem/gamemode/proc/handle_picking_stroyteller()
+/datum/controller/subsystem/gamemode/proc/handle_picking_storyteller()
+	if(CONFIG_GET(flag/disable_storyteller))
+		return
 	if(length(GLOB.clients) > MAX_POP_FOR_STORYTELLER_VOTE)
 		secret_storyteller = TRUE
 		selected_storyteller = pick_weight(get_valid_storytellers(TRUE))

--- a/monkestation/code/modules/storytellers/storytellers/_storyteller.dm
+++ b/monkestation/code/modules/storytellers/storytellers/_storyteller.dm
@@ -122,7 +122,7 @@
 		var/list/valid_events = list()
 		// Determine which events are valid to pick
 		for(var/datum/round_event_control/event as anything in mode.event_pools[track])
-			var/players_amt = get_active_player_count(alive_check = 1, afk_check = 1, human_check = 1)
+			var/players_amt = get_active_player_count(alive_check = TRUE, afk_check = TRUE, human_check = TRUE)
 			if(event.can_spawn_event(players_amt))
 				if(QDELETED(event))
 					message_admins("[event.name] was deleted!")

--- a/monkestation/code/modules/virology/disease/symtoms/restricted/stage1.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/restricted/stage1.dm
@@ -44,8 +44,9 @@
 				affected_mob.mind.transfer_to(new_mob)
 			else
 				new_mob.key = affected_mob.key
-		if(transformed_antag_datum)
-			new_mob.mind.add_antag_datum(transformed_antag_datum)
+		if(transformed_antag_datum && !QDELETED(new_mob.mind))
+			var/datum/antagonist/given_antag = new_mob.mind.has_antag_datum(transformed_antag_datum) || new_mob.mind.add_antag_datum(transformed_antag_datum)
+			given_antag?.antag_flags |= FLAG_ANTAG_CAP_IGNORE // ensure they don't count against storyteller cap
 		new_mob.name = affected_mob.real_name
 		new_mob.real_name = new_mob.name
 		new_mob.update_name_tag()
@@ -78,6 +79,7 @@
 	name = "Xenomorph Transformation"
 	new_form = /mob/living/carbon/alien/adult/hunter
 	bantype = ROLE_ALIEN
+	transformed_antag_datum = /datum/antagonist/xeno
 
 /datum/symptom/transformation/slime
 	name = "Advanced Mutation Transformation"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5790,7 +5790,6 @@
 #include "interface\fonts\tiny_unicode.dm"
 #include "interface\fonts\vcr_osd_mono.dm"
 #include "monkestation\code\__DEFINES\_module_defines.dm"
-#include "monkestation\code\__DEFINES\antag_defines.dm"
 #include "monkestation\code\__DEFINES\projectile.dm"
 #include "monkestation\code\__DEFINES\signals.dm"
 #include "monkestation\code\__HELPERS\_lists.dm"


### PR DESCRIPTION

## About The Pull Request

I was looking through runtimes on the live server, and noticed stuff with midround antag selection, where pick_weighted would complain because there was like a `"": null` in the middle of the input. Looking at the code, I saw several problems, and borbop brought up this may also be causing client hard deletes. So I rewrote some stuff to be more resilient - like just using ckeys instead of `/client` objects as keys in `return_antag_rep_weight` and improving the code of some of the antag selection loops.

<details>
<summary><h3>Testing Evidence</h3></summary>

![2024-09-19 (1726792008) ~ dreamseeker](https://github.com/user-attachments/assets/de212858-03ca-4091-bc8f-704343a255f8)
![2024-09-19 (1726792304) ~ dreamseeker](https://github.com/user-attachments/assets/528ae71a-4db3-4329-9281-0d12436b28be)

</details>

## Changelog
:cl:
fix: Fixed some logic relating to antag selection (roundstart, midround, and ghost roles), hopefully reducing hard deletes and potential issues.
/:cl:
