### PR TITLE
"Get Server Logs" can now jump to a specific round ID

### DIFF
--- a/monkestation/code/game/world.dm
+++ b/monkestation/code/game/world.dm
@@ -7,7 +7,7 @@
 	if(!GLOB.round_id || !SSdbcore.IsConnected())
 		return
 	var/datum/db_query/set_log_directory = SSdbcore.NewQuery({"
-		UPDATE `[format_table_name("round")]`
+		UPDATE [format_table_name("round")]
 		SET
 			`log_directory` = :log_directory
 		WHERE
@@ -15,3 +15,25 @@
 	"}, list("log_directory" = GLOB.log_directory, "round_id" = GLOB.round_id))
 	set_log_directory.Execute()
 	QDEL_NULL(set_log_directory)
+
+/proc/get_log_directory_by_round_id(round_id)
+	if(!isnum(round_id) || round_id <= 0 || !SSdbcore.IsConnected())
+		return
+	var/datum/db_query/query_log_directory = SSdbcore.NewQuery({"
+		SELECT `log_directory`
+		FROM
+			[format_table_name("round")]
+		WHERE
+			`id` = :round_id
+	"}, list("round_id" = round_id))
+	if(!query_log_directory.warn_execute())
+		qdel(query_log_directory)
+		return
+	if(!query_log_directory.NextRow())
+		qdel(query_log_directory)
+		CRASH("Failed to get log directory for round [round_id]")
+	var/log_directory = query_log_directory.item[1]
+	QDEL_NULL(query_log_directory)
+	if(!rustg_file_exists(log_directory))
+		CRASH("Log directory '[log_directory]' for round ID [round_id] doesn't exist!")
+	return log_directory


### PR DESCRIPTION

## About The Pull Request

As a result of https://github.com/Monkestation/Monkestation2.0/pull/3284, this is now easily possible without jank!

Also, added stupid a snowflake bit to the file validation regex to make it possible for `+DEBUG` log fetching to get profiler logs.

## Why It's Good For The Game

Makes getting logs for a specific round ID easy.

## Changelog
:cl:
admin: "Get Server Logs" can now jump to a specific round ID.
admin: "Get Current/Server Logs (Debug)" can now download profiler logs, as users with the permission to use that can use the profiler anyways.
/:cl:
