### PR TITLE
Removing IPC Organs from medbay's bounty pool

### DIFF
--- a/code/modules/cargo/bounties/medical.dm
+++ b/code/modules/cargo/bounties/medical.dm
@@ -4,6 +4,7 @@
 	reward = CARGO_CRATE_VALUE * 5
 	wanted_types = list(
 		/obj/item/organ/internal/heart = TRUE,
+		/obj/item/organ/internal/heart/synth = FALSE,
 		/obj/item/organ/internal/heart/cybernetic = FALSE,
 		/obj/item/organ/internal/heart/cybernetic/tier2 = TRUE,
 		/obj/item/organ/internal/heart/cybernetic/tier3 = TRUE,
@@ -16,6 +17,7 @@
 	required_count = 3
 	wanted_types = list(
 		/obj/item/organ/internal/lungs = TRUE,
+		/obj/item/organ/internal/lungs/synth = FALSE,
 		/obj/item/organ/internal/lungs/cybernetic = FALSE,
 		/obj/item/organ/internal/lungs/cybernetic/tier2 = TRUE,
 		/obj/item/organ/internal/lungs/cybernetic/tier3 = TRUE,
@@ -34,6 +36,7 @@
 	required_count = 3
 	wanted_types = list(
 		/obj/item/organ/internal/ears = TRUE,
+		/obj/item/organ/internal/ears/synth = FALSE,
 		/obj/item/organ/internal/ears/cybernetic = FALSE,
 		/obj/item/organ/internal/ears/cybernetic/upgraded = TRUE,
 	)
@@ -45,6 +48,7 @@
 	required_count = 3
 	wanted_types = list(
 		/obj/item/organ/internal/liver = TRUE,
+		/obj/item/organ/internal/liver/synth = FALSE,
 		/obj/item/organ/internal/liver/cybernetic = FALSE,
 		/obj/item/organ/internal/liver/cybernetic/tier2 = TRUE,
 		/obj/item/organ/internal/liver/cybernetic/tier3 = TRUE,
@@ -57,6 +61,7 @@
 	required_count = 3
 	wanted_types = list(
 		/obj/item/organ/internal/eyes = TRUE,
+		/obj/item/organ/internal/eyes/synth = FALSE,
 		/obj/item/organ/internal/eyes/robotic = FALSE,
 	)
 


### PR DESCRIPTION

## About The Pull Request
Central had a strange influx of IPC organs scamming their clients who specifically requested, 'No cybernetic organs.' and 'only upgraded ones'. We've updated the sensors of the bounty board to address this.
## Why It's Good For The Game
Medbay on a single stack of iron and glass can make a lot of money very quickly with very little effort through bounties. As most of the IPC organs cost 1k iron and glass. 

While it is my first nerf I do think it is a healthy one as with this removed it incentivises the alternatives. Either making an organ harvester or a limb grower. (Both machines giving benefits for the whole of Medbay outside of just bounties.) or getting their hands dirty in the morgue if they want a early bounty.
## Changelog
:cl:
balance: Removes IPC organ smuggling from the Medbays bounty pool.
/:cl:
