### PR TITLE
fixes malkavians not getting an objective when another vamp breaks the masquerade

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_misc_procs.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_misc_procs.dm
@@ -34,7 +34,7 @@
 	broke_masquerade = TRUE
 	antag_hud_name = "masquerade_broken"
 	add_team_hud(owner.current)
-	SEND_GLOBAL_SIGNAL(COMSIG_BLOODSUCKER_BROKE_MASQUERADE)
+	SEND_GLOBAL_SIGNAL(COMSIG_BLOODSUCKER_BROKE_MASQUERADE, src)
 
 ///This is admin-only of reverting a broken masquerade, sadly it doesn't remove the Malkavian objectives yet.
 /datum/antagonist/bloodsucker/proc/fix_masquerade(mob/admin)

--- a/monkestation/code/modules/bloodsuckers/clans/malkavian.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/malkavian.dm
@@ -55,8 +55,10 @@
 	INVOKE_ASYNC(stone, TYPE_PROC_REF(/obj/item/soulstone/bloodsucker, capture_soul), bloodsuckerdatum.owner.current, forced = TRUE, bloodsuckerdatum = bloodsuckerdatum)
 	return DONT_DUST
 
-/datum/bloodsucker_clan/malkavian/proc/on_bloodsucker_broke_masquerade(datum/antagonist/bloodsucker/masquerade_breaker)
+/datum/bloodsucker_clan/malkavian/proc/on_bloodsucker_broke_masquerade(datum/source, datum/antagonist/bloodsucker/masquerade_breaker)
 	SIGNAL_HANDLER
+	if(masquerade_breaker == bloodsuckerdatum)
+		return
 	to_chat(bloodsuckerdatum.owner.current, span_userdanger("[masquerade_breaker.owner.current] has broken the Masquerade! Ensure [masquerade_breaker.owner.current.p_they()] [masquerade_breaker.owner.current.p_are()] eliminated at all costs!"))
 	var/datum/objective/assassinate/masquerade_objective = new()
 	masquerade_objective.target = masquerade_breaker.owner.current


### PR DESCRIPTION
## About The Pull Request

how has nobody noticed this never working

## Changelog
:cl:
fix: Fixed malkavian bloodsuckers not getting an objective when another bloodsucker breaks the masquerade.
/:cl:
