### PR TITLE
Reduces the amount of scrubbers in the overflow event

### DIFF
--- a/code/modules/events/scrubber_overflow.dm
+++ b/code/modules/events/scrubber_overflow.dm
@@ -16,7 +16,7 @@
 	/// Amount of reagents ejected from each scrubber
 	var/reagents_amount = 50
 	/// Probability of an individual scrubber overflowing
-	var/overflow_probability = 50
+	var/overflow_probability = 20 //monkestation edit: 20 down from 50
 	/// Specific reagent to force all scrubbers to use, null for random reagent choice
 	var/datum/reagent/forced_reagent_type
 	/// A list of scrubbers that will have reagents ejected from them


### PR DESCRIPTION

## About The Pull Request
Reduces the amount of scrubbers that will spew out fluids in the overflow event, from about half of them, to 20% of them.
## Why It's Good For The Game
Currently, the event floods the station with slipping hazards. While the foam went away rather quickly, the fluids take much longer to drain, and can be rather tedious to clean all of it as a janitor. Reducing the amount of scrubbers that the overflow event effects will still create some work for janitors, while not covering the entire station in various puddles.
## Changelog
:cl:
balance: rReduced the amount of scrubbers affected by the overflow event down from 50% to 20%
/:cl:
