### PR TITLE
Soulless (a new quirk)

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -318,21 +318,6 @@
 		update_appearance()
 
 /obj/machinery/door/airlock/bumpopen(mob/living/user)
-	// MONKESTATION ADDITION START
-	if(user.has_quirk(/datum/quirk/soullessdoor))
-		if(ishuman(user) && prob(95) && density)
-			var/mob/living/carbon/human/H = user
-			if(Adjacent(user))
-				playsound(src, 'sound/effects/bang.ogg', 25, TRUE, mixer_channel = CHANNEL_SOUND_EFFECTS)
-				if(!istype(H.head, /obj/item/clothing/head/helmet))
-					H.visible_message(span_danger("[user] headbutts the airlock."), span_userdanger("You headbutt the airlock!"))
-					H.Paralyze(1)
-					H.apply_damage(10, BRUTE, BODY_ZONE_HEAD)
-					H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
-				else
-					visible_message(span_danger("[user] headbutts the airlock. Good thing [user.p_theyre()] wearing a helmet."))
-		return
-	// MONKESTATION ADDITION END
 	if(!hasPower())
 		return
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -318,6 +318,21 @@
 		update_appearance()
 
 /obj/machinery/door/airlock/bumpopen(mob/living/user)
+	// MONKESTATION ADDITION START
+	if(user.has_quirk(/datum/quirk/soullessdoor))
+		if(ishuman(user) && prob(95) && density)
+			var/mob/living/carbon/human/H = user
+			if(Adjacent(user))
+				playsound(src, 'sound/effects/bang.ogg', 25, TRUE, mixer_channel = CHANNEL_SOUND_EFFECTS)
+				if(!istype(H.head, /obj/item/clothing/head/helmet))
+					H.visible_message(span_danger("[user] headbutts the airlock."), span_userdanger("You headbutt the airlock!"))
+					H.Paralyze(1)
+					H.apply_damage(10, BRUTE, BODY_ZONE_HEAD)
+					H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
+				else
+					visible_message(span_danger("[user] headbutts the airlock. Good thing [user.p_theyre()] wearing a helmet."))
+		return
+	// MONKESTATION ADDITION END
 	if(!hasPower())
 		return
 

--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -240,3 +240,11 @@
 */
 /datum/quirk/tunnel_vision/remove()
 	quirk_holder.remove_fov_trait("tunnel vision quirk")
+
+/datum/quirk/soullessdoor
+	name = "Soulless"
+	desc = "How come the door cameras can't see me!"
+	value = -1
+	icon = FA_ICON_GHOST
+	gain_text = span_notice("You have trouble with the doors not opening when you approach.")
+	lose_text = span_notice("You feel like the doors can see you again.. what.")

--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -255,15 +255,15 @@
 /datum/quirk/soullessdoor/remove()
 	UnregisterSignal(quirk_holder, COMSIG_CARBON_BUMPED_AIRLOCK_OPEN)
 
-/datum/quirk/soullessdoor/proc/on_bump(mob/living/carbon/user)
-	if(ishuman(user) && prob(95) && density)
-		if(Adjacent(user))
+/datum/quirk/soullessdoor/proc/on_bump(mob/living/carbon/user, /obj/machinery/door/airlock/bumped)
+	if(bumped.density && ishuman(user) && prob(95))
+		if(bumped.Adjacent(user))
 			playsound(src, 'sound/effects/bang.ogg', 25, TRUE, mixer_channel = CHANNEL_SOUND_EFFECTS)
 			if(!istype(user.head, /obj/item/clothing/head/helmet))
-				user.visible_message(span_danger("[user] headbutts the airlock."), span_userdanger("You headbutt the airlock!"))
+				user.visible_message(span_danger("[user] headbutts \the [bumped]."), span_userdanger("You headbutt \the [bumped]!"))
 				user.Paralyze(1)
 				user.apply_damage(10, BRUTE, BODY_ZONE_HEAD)
 				user.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
 			else
-				visible_message(span_danger("[user] headbutts the airlock. Good thing [user.p_theyre()] wearing a helmet."))
+				visible_message(span_danger("[user] headbutts \the [bumped]. Good thing [user.p_theyre()] wearing a helmet."))
 	return STOP_BUMP

--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -248,3 +248,22 @@
 	icon = FA_ICON_GHOST
 	gain_text = span_notice("You have trouble with the doors not opening when you approach.")
 	lose_text = span_notice("You feel like the doors can see you again.. what.")
+
+/datum/quirk/soullessdoor/add()
+	RegisterSignal(quirk_holder, COMSIG_CARBON_BUMPED_AIRLOCK_OPEN, PROF_REF(on_bump))
+
+/datum/quirk/soullessdoor/remove()
+	UnregisterSignal(quirk_holder, COMSIG_CARBON_BUMPED_AIRLOCK_OPEN)
+
+/datum/quirk/soullessdoor/proc/on_bump(/mob/living/carbon/user)
+	if(ishuman(user) && prob(95) && density)
+		if(Adjacent(user))
+			playsound(src, 'sound/effects/bang.ogg', 25, TRUE, mixer_channel = CHANNEL_SOUND_EFFECTS)
+			if(!istype(user.head, /obj/item/clothing/head/helmet))
+				user.visible_message(span_danger("[user] headbutts the airlock."), span_userdanger("You headbutt the airlock!"))
+				user.Paralyze(1)
+				user.apply_damage(10, BRUTE, BODY_ZONE_HEAD)
+				user.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
+			else
+				visible_message(span_danger("[user] headbutts the airlock. Good thing [user.p_theyre()] wearing a helmet."))
+	return STOP_BUMP

--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -250,7 +250,7 @@
 	lose_text = span_notice("You feel like the doors can see you again.. what.")
 
 /datum/quirk/soullessdoor/add()
-	RegisterSignal(quirk_holder, COMSIG_CARBON_BUMPED_AIRLOCK_OPEN, PROF_REF(on_bump))
+	RegisterSignal(quirk_holder, COMSIG_CARBON_BUMPED_AIRLOCK_OPEN, PROC_REF(on_bump))
 
 /datum/quirk/soullessdoor/remove()
 	UnregisterSignal(quirk_holder, COMSIG_CARBON_BUMPED_AIRLOCK_OPEN)

--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -244,7 +244,7 @@
 /datum/quirk/soullessdoor
 	name = "Soulless"
 	desc = "How come the door cameras can't see me!"
-	value = -1
+	value = -2
 	icon = FA_ICON_GHOST
 	gain_text = span_notice("You have trouble with the doors not opening when you approach.")
 	lose_text = span_notice("You feel like the doors can see you again.. what.")

--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -255,7 +255,7 @@
 /datum/quirk/soullessdoor/remove()
 	UnregisterSignal(quirk_holder, COMSIG_CARBON_BUMPED_AIRLOCK_OPEN)
 
-/datum/quirk/soullessdoor/proc/on_bump(/mob/living/carbon/user)
+/datum/quirk/soullessdoor/proc/on_bump(mob/living/carbon/user)
 	if(ishuman(user) && prob(95) && density)
 		if(Adjacent(user))
 			playsound(src, 'sound/effects/bang.ogg', 25, TRUE, mixer_channel = CHANNEL_SOUND_EFFECTS)


### PR DESCRIPTION

## About The Pull Request
add's a new quirk called Soulless, this quirk makes it so that when you bump into doors you don't open them but rather headbutt them. you can avoid the damage from headbutting into the door by wearing a helmet, but why would you wear a helmet- what are you lame?.
## Why It's Good For The Game
it's a funny trait and ook really wanted it.

video clip for your enjoyment
https://youtu.be/Qw38qcQq1po?si=omIULUjI4b__WABy&t=89 
## Changelog
:cl:
add: Added new quirk called "Soulless" makes doors not notice you when you bump into them, you have to intentionaly click on them to open them.
/:cl:
