### PR TITLE
Adding powercord as a printable cybernetic

### DIFF
--- a/monkestation/code/modules/research/designs/mechfabricator_designs.dm
+++ b/monkestation/code/modules/research/designs/mechfabricator_designs.dm
@@ -82,3 +82,16 @@
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_MISC
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
+/datum/design/power_cord
+	name = "power cord implant"
+	desc = "An internal power cord hooked up to a battery. Useful if you run on volts."
+	id = "power_cord"
+	build_type = MECHFAB
+	construction_time = 15 SECONDS
+	materials = list(/datum/material/iron = 2500, /datum/material/glass = 2000)
+	build_path = /obj/item/organ/internal/cyberimp/arm/item_set/power_cord
+	category = list(
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_MISC
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL

--- a/monkestation/code/modules/research/techweb/all_nodes.dm
+++ b/monkestation/code/modules/research/techweb/all_nodes.dm
@@ -220,6 +220,7 @@
 		"ipc_arm_left",
 		"ipc_arm_right",
 		"ipc_leg_left",
-		"ipc_leg_right"
+		"ipc_leg_right",
+		"power_cord"
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)


### PR DESCRIPTION

## About The Pull Request
Adds the IPCs power cable cybernetic to the IPC repair tech and becomes printable in the associated lathes
## Why It's Good For The Game
Despite being a cybernetic the power cable is more of a organ for IPC's. And while we can replace their left limb we cant replace the power cable. This should help when the wizard causes takes too much inspiration from the name 'Monkestation' and gives the crew the ability to create gorillas.
## Changelog
:cl:
add: Adds powercable cybernetics as a researchable and printable technology
/:cl:
