### PR TITLE
Fixes Nuclear and Assaults operatives having no cyberlink for their cybernetics 

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -530,6 +530,17 @@
 	new /obj/item/autosurgeon/organ/cyberlink_syndicate(src)
 	new /obj/item/autosurgeon/syndicate/laser_arm (src)
 
+/obj/item/storage/box/syndie_kit/nodrop/PopulateContents()
+	new /obj/item/autosurgeon/organ/cyberlink_nt_high(src)
+	new /obj/item/autosurgeon/syndicate/nodrop(src)
+
+/obj/item/storage/box/syndie_kit/anti_stun/PopulateContents()
+	new /obj/item/autosurgeon/organ/cyberlink_nt_high(src)
+	new /obj/item/autosurgeon/syndicate/anti_stun(src)
+
+/obj/item/storage/box/syndie_kit/reviver/PopulateContents()
+	new /obj/item/autosurgeon/organ/cyberlink_nt_high(src)
+	new /obj/item/autosurgeon/syndicate/reviver(src)
 
 /obj/item/storage/box/syndie_kit/centcom_costume/PopulateContents()
 	new /obj/item/clothing/under/rank/centcom/officer(src)

--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -709,7 +709,7 @@
 /datum/uplink_item/implants/antistun
 	name = "CNS Rebooter Implant"
 	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."
-	item = /obj/item/autosurgeon/syndicate/anti_stun
+	item = /obj/item/storage/box/syndie_kit/anti_stun
 	cost = 12
 	surplus = 40 //monkestation edit: from 0 to 40
 	purchasable_from = UPLINK_NUKE_OPS
@@ -735,7 +735,7 @@
 /datum/uplink_item/implants/reviver
 	name = "Reviver Implant"
 	desc = "This implant will attempt to revive and heal you if you lose consciousness. Comes with an autosurgeon."
-	item = /obj/item/autosurgeon/syndicate/reviver
+	item = /obj/item/storage/box/syndie_kit/reviver
 	cost = 8
 	surplus = 30 //monkestation edit: from 0 to 30
 	purchasable_from = UPLINK_NUKE_OPS

--- a/monkestation/code/modules/assault_ops/code/armaments/implants.dm
+++ b/monkestation/code/modules/assault_ops/code/armaments/implants.dm
@@ -44,5 +44,5 @@
 /datum/armament_entry/assault_operatives/implants/nodrop
 	name = "Anti-Drop Implant"
 	description = "When activated forces your hand muscles to tightly grip the object you are holding, preventing you from dropping it involuntarily."
-	item_type = /obj/item/autosurgeon/syndicate/nodrop
+	item_type = /obj/item/storage/box/syndie_kit/nodrop
 	cost = 5

--- a/monkestation/code/modules/cybernetics/augments/internal_implants.dm
+++ b/monkestation/code/modules/cybernetics/augments/internal_implants.dm
@@ -183,8 +183,8 @@
 	var/list/boxed = list(
 		/obj/item/autosurgeon/syndicate/thermal_eyes,
 		/obj/item/autosurgeon/syndicate/xray_eyes,
-		/obj/item/autosurgeon/syndicate/anti_stun,
-		/obj/item/autosurgeon/syndicate/reviver)
+		/obj/item/storage/box/syndie_kit/anti_stun,
+		/obj/item/storage/box/syndie_kit/reviver)
 	var/amount = 5
 
 /obj/item/storage/box/cyber_implants/PopulateContents()


### PR DESCRIPTION

## About The Pull Request
Someone at CYBERSUN seriously missed the memo on the cybernetics software update and had been providing operatives faulty equipment. They had been dealt with.

(Moves antistun, revivers, and antidrops into boxes with cyberlinks 2.0's in uplinks so they can actually function.)
## Why It's Good For The Game
People being able to use the cybernetics they paid for is pretty good change. Currently its a noob trap. If fixed assistants no longer will get a Esword from a single shove in maintence.
## Changelog
:cl:
add: Adds syndicate boxes for revivers, anti-stun, and anti-drop cybernetics with a cyberlink also.
fix: Fixed the Nuclear and Assault Operatives cybernetics by giving them syndicate box bundles instead
/:cl:
