### PR TITLE
Makes robotic repairs upgrades actually researchable.

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -922,6 +922,13 @@
 	surgery = /datum/surgery/healing/combo/upgraded/femto
 	id = "surgery_heal_combo_upgrade_femto"
 
+/datum/design/surgery/robot_healing // Apparently this helps the code not scream looking at other examples?
+	name = "Repair Robotic Limbs"
+	desc = "A surgical procedure that provides highly effective repairs and maintenance to robotic limbs."
+	surgery = /datum/surgery/robot_healing
+	id = "surgery_heal_robot_base"
+	research_icon_state = "surgery_chest"
+
 /datum/design/surgery/robot_healing/upgraded
 	name = "Repair Robotic Limbs (Physical) Upgrade"
 	desc = "A surgical procedure that provides highly effective repairs and maintenance to robotic limbs. Is somewhat more efficient when the patient is severely damaged."

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -922,6 +922,20 @@
 	surgery = /datum/surgery/healing/combo/upgraded/femto
 	id = "surgery_heal_combo_upgrade_femto"
 
+/datum/design/surgery/robot_healing/upgraded
+	name = "Repair Robotic Limbs (Physical) Upgrade"
+	desc = "A surgical procedure that provides highly effective repairs and maintenance to robotic limbs. Is somewhat more efficient when the patient is severely damaged."
+	surgery = /datum/surgery/robot_healing/upgraded
+	id = "surgery_heal_robot_upgrade"
+	research_icon_state = "surgery_chest"
+
+/datum/design/surgery/robot_healing/upgraded_2
+	name = "Repair Robotic Limbs (Physical) Upgrade"
+	desc = "A surgical procedure that quickly provides highly effective repairs and maintenance to robotic limbs. Is moderately more efficient when the patient is severely damaged."
+	surgery = /datum/surgery/robot_healing/experimental
+	id = "surgery_heal_robot_upgrade_femto"
+	research_icon_state = "surgery_chest"
+	
 /datum/design/surgery/brainwashing
 	name = "Brainwashing"
 	desc = "A surgical procedure which directly implants a directive into the patient's brain, making it their absolute priority. It can be cleared using a mindshield implant."

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -521,6 +521,7 @@
 	design_ids = list(
 		"surgery_heal_brute_upgrade",
 		"surgery_heal_burn_upgrade",
+		"surgery_heal_robot_upgrade",
 		"surgery_filter_upgrade", // monke edit: improved blood filter surgery
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
@@ -533,7 +534,8 @@
 	prereq_ids = list("imp_wt_surgery")
 	design_ids = list(
 		"surgery_heal_brute_upgrade_femto",
-		"surgery_heal_burn_upgrade_femto",
+		"surgery_heal_burn_upgrade_femto",	
+		"surgery_heal_robot_upgrade_femto",
 		"surgery_heal_combo",
 		"surgery_lobotomy",
 		"surgery_wing_reconstruction",

--- a/monkestation/code/modules/antagonists/clock_cult/machines/clockwork_operating_computer.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/machines/clockwork_operating_computer.dm
@@ -13,6 +13,7 @@
 												/datum/surgery/healing/brute/upgraded/femto,
 												/datum/surgery/healing/burn/upgraded/femto,
 												/datum/surgery/healing/combo/upgraded/femto,
+												/datum/surgery/robot_healing/experimental,
 												/datum/surgery/revival)
 
 /obj/machinery/computer/operating/clockwork/Initialize(mapload)

--- a/monkestation/code/modules/smithing/ipcs/surgeries/robot_brain_healing.dm
+++ b/monkestation/code/modules/smithing/ipcs/surgeries/robot_brain_healing.dm
@@ -26,7 +26,7 @@
 		return TRUE
 
 /datum/surgery_step/fix_robot_brain
-	name = "fix posibrain"
+	name = "fix posibrain (multitool)"
 	implements = list(
 		TOOL_MULTITOOL = 100,
 		TOOL_HEMOSTAT = 35,

--- a/monkestation/code/modules/smithing/ipcs/surgeries/robot_healing.dm
+++ b/monkestation/code/modules/smithing/ipcs/surgeries/robot_healing.dm
@@ -16,7 +16,7 @@
 	possible_locs = list(BODY_ZONE_CHEST)
 	replaced_by = /datum/surgery
 	requires_bodypart_type = BODYTYPE_ROBOTIC
-	surgery_flags = SURGERY_IGNORE_CLOTHES | SURGERY_REQUIRE_RESTING | SURGERY_REQUIRE_LIMB
+	surgery_flags = SURGERY_IGNORE_CLOTHES | SURGERY_REQUIRE_RESTING | SURGERY_REQUIRE_LIMB | SURGERY_SELF_OPERABLE
 
 	/// The step to use in the 4th surgery step.
 	var/healing_step_type


### PR DESCRIPTION

## About The Pull Request
There was code for IPC wound tending upgrades but no actual ability to research it. Strange but this adds the upgrades to research to the standard wound tending research tree. And to associated computers.

Alongside making the surgery able to be preformed on yourself. Bringing it in line with similar surgeries for organics. (Wound tending)
## Why It's Good For The Game
For one from what Ive seen its perfectly healthy code just sitting in the system unused.
The other is that from everything Ive seen robotics/synths feel like they are suppose to have their own surgery system but lack some of the polish to do so. Adding/compelting the most basic form wound tending for them would be a great step to finalizing the IPC surgeries if that's a goal. And Its something Id like to see done (How does one even use a hemostat on metal?)

It also would help define robotics as bit more of doctors for IPC's and something to do outside of building a 50th war mech.  
## Changelog
:cl:
add: Made upgraded robotic wound tending a researchable surgery 
add: Gave Exp. Robotic wound tending part to the clockwork operating terminal
qol: Adjusted IPC brain surgery steps to clarify tools more
/:cl:
