### PR TITLE
Removes an extra blueshield locker on blueshift

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -8392,7 +8392,6 @@
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/closet/secure_closet/blueshield,
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/blueshield)
 "bFO" = (


### PR DESCRIPTION

## About The Pull Request
Title, fixes #3438 
## Why It's Good For The Game
Bug bad
## Changelog
:cl:
fix: Fixed the doubled blueshields lockers on blueshift
/:cl:
