### PR TITLE
Adds a telescopic baton to Blueshield's locker

### DIFF
--- a/monkestation/code/modules/blueshield/closet.dm
+++ b/monkestation/code/modules/blueshield/closet.dm
@@ -27,6 +27,7 @@
 	new /obj/item/grenade/flashbang(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/restraints/handcuffs(src)
+	new /obj/item/melee/baton/telescopic(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/storage/medkit/frontier/stocked(src)
 	new /obj/item/storage/bag/garment/blueshield(src)


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
Gives them a more reliable form of non-lethal detainment that won't encourage blueshields to play like a secoff. Will also help discourage blueshield's from just using lethals on any kind of conflict..
## Changelog
:cl:
balance: Added a telescopic baton to the blueshield's locker
/:cl:
