### PR TITLE
Give all genes proper seed extractor icons

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -3,7 +3,7 @@
 	/// The name of the gene.
 	var/name
 	/// The font awesome icon name representing the gene in the seed extractor UI
-	var/icon = "dna"
+	var/icon = FA_ICON_DNA
 	/// Flags that determine if a gene can be modified.
 	var/mutability_flags
 
@@ -271,7 +271,7 @@
 /// Allows the plant to be squashed when thrown or slipped on, leaving a colored mess and trash type item behind.
 /datum/plant_gene/trait/squash
 	name = "Liquid Contents"
-	icon = "droplet"
+	icon = FA_ICON_DROPLET
 	description = "It may burst open from the internal pressure on impact."
 	trait_ids = THROW_IMPACT_ID | REAGENT_TRANSFER_ID | ATTACK_SELF_ID
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
@@ -327,7 +327,7 @@
 /datum/plant_gene/trait/slip
 	name = "Slippery Skin"
 	description = "Watch your step around this."
-	icon = "person-falling"
+	icon = FA_ICON_PERSON_FALLING
 	rate = 1.6
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
@@ -361,7 +361,7 @@
 /datum/plant_gene/trait/cell_charge
 	name = "Electrical Activity"
 	description = "It can electrocute on interaction or recharge batteries when eaten."
-	icon = "bolt"
+	icon = FA_ICON_BOLT
 	rate = 0.2
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 	var/prob_mult = 2
@@ -430,7 +430,7 @@
  */
 /datum/plant_gene/trait/glow
 	name = "Bioluminescence"
-	icon = "lightbulb"
+	icon = FA_ICON_LIGHTBULB
 	rate = 0.03
 	description = "It emits a soft glow."
 	trait_ids = GLOW_ID
@@ -459,7 +459,7 @@
  */
 /datum/plant_gene/trait/glow/shadow
 	name = "Shadow Emission"
-	icon = "lightbulb-o"
+	icon = FA_ICON_MOON
 	rate = 0.04
 	glow_color = "#AAD84B"
 
@@ -510,7 +510,7 @@
 /datum/plant_gene/trait/teleport
 	name = "Bluespace Activity"
 	description = "It causes people to teleport on interaction."
-	icon = "right-left"
+	icon = FA_ICON_RIGHT_LEFT
 	rate = 0.1
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
@@ -575,7 +575,7 @@
 /datum/plant_gene/trait/maxchem
 	name = "Densified Chemicals"
 	description = "The reagent volume is doubled, halving the plant yield instead."
-	icon = "flask-vial"
+	icon = FA_ICON_FLASK_VIAL
 	rate = 2
 	trait_flags = TRAIT_HALVES_YIELD
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
@@ -596,7 +596,7 @@
 /datum/plant_gene/trait/repeated_harvest
 	name = "Perennial Growth"
 	description = "It may be harvested multiple times from the same plant."
-	icon = "cubes-stacked"
+	icon = FA_ICON_CUBES_STACKED
 	/// Don't allow replica pods to be multi harvested, please.
 	seed_blacklist = list(/obj/item/seeds/replicapod)
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
@@ -609,7 +609,7 @@
 /datum/plant_gene/trait/battery
 	name = "Capacitive Cell Production"
 	description = "It can work like a power cell when wired properly."
-	icon = "car-battery"
+	icon = FA_ICON_CAR_BATTERY
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 	/// The number of cables needed to make a battery.
 	var/cables_needed_per_battery = 5
@@ -689,7 +689,7 @@
 /datum/plant_gene/trait/stinging
 	name = "Hypodermic Prickles"
 	description = "It stings, passing some reagents in the process."
-	icon = "syringe"
+	icon = FA_ICON_SYRINGE
 	trait_ids = REAGENT_TRANSFER_ID
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
@@ -728,7 +728,7 @@
 /datum/plant_gene/trait/smoke
 	name = "Gaseous Decomposition"
 	description = "It can be smashed to turn its Liquid Contents into smoke."
-	icon = "cloud"
+	icon = FA_ICON_CLOUD
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
 /datum/plant_gene/trait/smoke/on_new_plant(obj/item/our_plant, newloc)
@@ -761,7 +761,7 @@
 /datum/plant_gene/trait/fire_resistance
 	name = "Fire Resistance"
 	description = "Makes the seeds, plant and produce fireproof."
-	icon = "fire"
+	icon = FA_ICON_FIRE
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
 /datum/plant_gene/trait/fire_resistance/on_new_seed(obj/item/seeds/new_seed)
@@ -784,7 +784,7 @@
 /datum/plant_gene/trait/invasive
 	name = "Invasive Spreading"
 	description = "It attempts to spread around if not contained."
-	icon = "virus"
+	icon = FA_ICON_VIRUS
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
 /datum/plant_gene/trait/invasive/on_new_seed(obj/item/seeds/new_seed)
@@ -850,7 +850,7 @@
 /datum/plant_gene/trait/brewing
 	name = "Auto-Distilling Composition"
 	description = "Its nutriments undergo fermentation."
-	icon = "wine-glass"
+	icon = FA_ICON_WINE_GLASS
 	trait_ids = CONTENTS_CHANGE_ID
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
@@ -862,7 +862,7 @@
 /datum/plant_gene/trait/juicing
 	name = "Auto-Juicing Composition"
 	description = "Its nutriments turn into juice."
-	icon = "glass-water"
+	icon = FA_ICON_GLASS_WATER
 	trait_ids = CONTENTS_CHANGE_ID
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
@@ -874,7 +874,7 @@
 /datum/plant_gene/trait/plant_laughter
 	name = "Hallucinatory Feedback"
 	description = "Makes sounds when people slip on it."
-	icon = "face-laugh-squint"
+	icon = FA_ICON_FACE_LAUGH_SQUINT
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 	/// Sounds that play when this trait triggers
 	var/list/sounds = list('sound/items/SitcomLaugh1.ogg', 'sound/items/SitcomLaugh2.ogg', 'sound/items/SitcomLaugh3.ogg')
@@ -910,7 +910,7 @@
 /datum/plant_gene/trait/eyes
 	name = "Oculary Mimicry"
 	description = "It will watch after you."
-	icon = "eye"
+	icon = FA_ICON_EYE
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 	/// Our googly eyes appearance.
 	var/mutable_appearance/googly
@@ -928,7 +928,7 @@
 /datum/plant_gene/trait/sticky
 	name = "Prickly Adhesion"
 	description = "It sticks to people when thrown, also passing reagents if stingy."
-	icon = "bandage"
+	icon = FA_ICON_BANDAGE
 	trait_ids = THROW_IMPACT_ID
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
@@ -952,7 +952,7 @@
 /datum/plant_gene/trait/chem_heating
 	name = "Exothermic Activity"
 	description = "It consumes nutriments to heat up other reagents, halving the yield."
-	icon = "temperatyre-arrow-up"
+	icon = FA_ICON_TEMPERATURE_ARROW_UP
 	trait_ids = TEMP_CHANGE_ID
 	trait_flags = TRAIT_HALVES_YIELD
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
@@ -964,7 +964,7 @@
 /datum/plant_gene/trait/chem_cooling
 	name = "Endothermic Activity"
 	description = "It consumes nutriments to cool down other reagents, halving the yield."
-	icon = "temperature-arrow-down"
+	icon = FA_ICON_TEMPERATURE_ARROW_DOWN
 	trait_ids = TEMP_CHANGE_ID
 	trait_flags = TRAIT_HALVES_YIELD
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
@@ -985,7 +985,7 @@
 /datum/plant_gene/trait/preserved
 	name = "Natural Insecticide"
 	description = "It does not attract ants or decompose."
-	icon = "bug-slash"
+	icon = FA_ICON_BUG_SLASH
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
 /datum/plant_gene/trait/preserved/on_new_plant(obj/item/our_plant, newloc)
@@ -1000,7 +1000,7 @@
 /datum/plant_gene/trait/carnivory
 	name = "Obligate Carnivory"
 	description = "Pests have positive effect on the plant health."
-	icon = "spider"
+	icon = FA_ICON_SPIDER
 
 /// Plant type traits. Incompatible with one another.
 /datum/plant_gene/trait/plant_type
@@ -1012,15 +1012,15 @@
 /datum/plant_gene/trait/plant_type/weed_hardy
 	name = "Weed Adaptation"
 	description = "It is a weed that needs no nutrients and doesn't suffer from other weeds."
-	icon = "seedling"
+	icon = FA_ICON_SEEDLING
 
 /// Mushrooms need less light and have a minimum yield.
 /datum/plant_gene/trait/plant_type/fungal_metabolism
 	name = "Fungal Vitality"
 	description = "It is a mushroom that needs no water, less light and can't be overtaken by weeds."
-	icon = "droplet-slash"
+	icon = FA_ICON_DROPLET_SLASH
 
 /// Currently unused and does nothing. Appears in strange seeds.
 /datum/plant_gene/trait/plant_type/alien_properties
-	name ="?????"
-	icon = "reddit-alien"
+	name = "?????"
+	icon = FA_ICON_QUESTION

--- a/monkestation/code/modules/hydroponics/plant_genes.dm
+++ b/monkestation/code/modules/hydroponics/plant_genes.dm
@@ -6,11 +6,13 @@
 /datum/plant_gene/trait/seedless
 	name = "Seedless"
 	description = "The plant is unable to produce seeds"
+	icon = FA_ICON_STRIKETHROUGH
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
 /datum/plant_gene/trait/noreact
 	name = "Catalytic Inhibitor Serum"
 	description = "This genetic trait enables the plant to produce a serum that effectively halts chemical reactions within its tissues."
+	icon = FA_ICON_LAYER_GROUP
 	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_GRAFTABLE
 
 /datum/plant_gene/trait/noreact/on_new_plant(obj/item/our_plant, newloc)


### PR DESCRIPTION

## About The Pull Request

This makes all the `/datum/plant_gene` icons use the fontawesome defines rather than strings, and gives icons to a few genes that didn't have proper icons (seedless, catalytic inhibitor, the useless strange seeds gene_

![2024-09-25 (1727318109) ~ dreamseeker](https://github.com/user-attachments/assets/9344bdb6-68f4-49fc-9604-ddfdf90e60a0)
![2024-09-25 (1727318115) ~ dreamseeker](https://github.com/user-attachments/assets/71be006f-1a63-41b4-bfa3-9651b36b331c)


## Changelog
:cl:
fix: Ensured some of the plant genes had proper icons in the Seed Extractor UI.
/:cl:
