### PR TITLE
Drops the odds of self respiration messages being sent to chat

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/stage4.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/stage4.dm
@@ -447,7 +447,8 @@
 	mob.losebreath = max(0, mob.losebreath - multiplier)
 	mob.adjustOxyLoss(-2 * multiplier)
 	if(multiplier >= 4)
-		to_chat(mob, span_notice("[pick("Your lungs feel great.", "You realize you haven't been breathing.", "You don't feel the need to breathe.")]"))
+		if(prob(2.5))
+			to_chat(mob, span_notice("[pick("Your lungs feel great.", "You realize you haven't been breathing.", "You don't feel the need to breathe.")]"))
 		if(breathing)
 			breathing = FALSE
 			ADD_TRAIT(mob, TRAIT_NOBREATH, type)


### PR DESCRIPTION

## About The Pull Request
Was just looking in discord and saw an issue being reported that the self respiration messages were being spammed in the chat window. There is now a 2.5% chance per symptom activation rather than 100%
## Why It's Good For The Game
These messages were being sent so often that the game was lagging apparently, I hope this mitigates this
## Changelog
:cl:
fix: self respiration messages should no longer spam chat as often
/:cl:
