### PR TITLE
Turns off the air conditioning for SMs and telecomms, lowers cold rooms temperatures air alarms

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -620,7 +620,11 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 /obj/machinery/airalarm/proc/set_tlv_cold_room()
 	tlv_collection["temperature"] = new /datum/tlv/cold_room_temperature
 	tlv_collection["pressure"] = new /datum/tlv/cold_room_pressure
-	stop_ac() //monkestation addition: prevents cold rooms from heating up from the air conditioning
+	//monkestation addition start: helps keep cold rooms cold
+	ac_temp_target = COLD_ROOM_TEMP
+	ac_temp_min = COLD_ROOM_TEMP - 5
+	ac_temp_max = COLD_ROOM_TEMP + 5
+	//monkestation addition end
 
 ///Used for air alarm no tlv helper, which removes alarm thresholds
 /obj/machinery/airalarm/proc/set_tlv_no_checks()

--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -620,11 +620,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/airalarm, 27)
 /obj/machinery/airalarm/proc/set_tlv_cold_room()
 	tlv_collection["temperature"] = new /datum/tlv/cold_room_temperature
 	tlv_collection["pressure"] = new /datum/tlv/cold_room_pressure
+	stop_ac() //monkestation addition: prevents cold rooms from heating up from the air conditioning
 
 ///Used for air alarm no tlv helper, which removes alarm thresholds
 /obj/machinery/airalarm/proc/set_tlv_no_checks()
 	tlv_collection["temperature"] = new /datum/tlv/no_checks
 	tlv_collection["pressure"] = new /datum/tlv/no_checks
+	stop_ac() //monkestation addition: prevents air conditioning from trying to heat up telecomms
 
 ///Used for air alarm link helper, which connects air alarm to a sensor with corresponding chamber_id
 /obj/machinery/airalarm/proc/setup_chamber_link()

--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -350,6 +350,7 @@
 		var/area/area = get_area(target)
 		log_mapping("[src] at [AREACOORD(src)] [(area.type)] tried to adjust [target]'s access to engine_access but it's already changed!")
 	target.engine_access = TRUE
+	target.stop_ac() // monkestation addition: prevents the air conditioning from heating up the SM
 
 /obj/effect/mapping_helpers/airalarm/mixingchamber_access
 	name = "airalarm mixingchamber access helper"


### PR DESCRIPTION
## About The Pull Request
Title, makes it so the no check/engine access map tlv helpers turn off the air conditioning of the alarms they are attached to, and the cold room tlv map helper lowers the air conditioning temperatures to keep the kitchen cold room cold.
## Why It's Good For The Game
Telecomms is supposed to be incredibly cold, but the air conditioning is heating up the room to room temperature, same goes for the kitchen, but to a lesser extent.. The kitchen suffers from this the most, due to needing the cold temperature to prevent food from rotting if they aren't in a freezer crate.  This also fixes the air alarm for the cold room always going off. The SM also doesn't need to heat to room temperature, and just messes with engineers.
## Changelog
:cl:
balance: Turned off telecomms and SM air conditioning, and lowered the cold room air conditioning temperature to prevent the rooms from heating up too much.
/:cl:
