### PR TITLE
Fixing Delta botany layering issue

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -5787,11 +5787,11 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "bqC" = (
-/obj/machinery/seed_extractor,
 /obj/effect/turf_decal/bot,
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/seed_extractor,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
 "bqF" = (
@@ -50110,14 +50110,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "lPs" = (
-/obj/machinery/biogenerator,
 /obj/effect/turf_decal/bot,
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/biogenerator,
 /obj/structure/railing{
 	dir = 4;
-	layer = 4.1
+	layer = 4.1;
+	pixel_x = 5
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
@@ -55073,7 +55074,9 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "mZA" = (
-/obj/machinery/door/window/left/directional/west,
+/obj/machinery/door/window/left/directional/west{
+	name = "Hydroponics Center"
+	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -61766,19 +61769,21 @@
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
 "oJj" = (
-/obj/structure/reagent_dispensers/watertank/high,
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1;
+	pixel_x = 5
+	},
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
 	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_x = 5
+	},
+/obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/cup/watering_can,
 /obj/item/reagent_containers/cup/watering_can,
-/obj/structure/railing{
-	dir = 4;
-	layer = 4.1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics)
 "oJy" = (
@@ -70630,13 +70635,17 @@
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
 	},
-/obj/machinery/composters,
 /obj/structure/railing{
-	dir = 1
+	dir = 1;
+	pixel_x = -5
 	},
 /obj/structure/railing{
 	dir = 8;
-	layer = 4.1
+	layer = 4.1;
+	pixel_x = -5
+	},
+/obj/machinery/composters{
+	pixel_x = -1
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/hydroponics)
@@ -81018,7 +81027,9 @@
 	pixel_x = 32
 	},
 /obj/structure/table/wood/fancy/blue,
-/obj/machinery/door/window/left/directional/west,
+/obj/machinery/door/window/left/directional/west{
+	name = "Hydroponics Center"
+	},
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
@@ -92157,14 +92168,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "vZo" = (
-/obj/machinery/smartfridge,
 /obj/effect/turf_decal/bot,
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/machinery/smartfridge,
 /obj/structure/railing{
 	dir = 8;
-	layer = 4.1
+	layer = 4.1;
+	pixel_x = -5
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics)
@@ -97705,6 +97717,11 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/railing{
+	dir = 4;
+	layer = 4.1;
+	pixel_x = 5
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "xpr" = (
@@ -100797,7 +100814,10 @@
 "yba" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/window/right/directional/west{
+/obj/machinery/door/window/left/directional/west{
+	name = "Hydroponics Center"
+	},
+/obj/machinery/door/window/left/directional/west{
 	name = "Hydroponics Center"
 	},
 /turf/open/floor/iron/dark,


### PR DESCRIPTION

## About The Pull Request
The railings used to be on a higher layer than the machines in botany. With a bit of layering changes and pixel shifting we can go from Before 
![before](https://github.com/user-attachments/assets/1763fd5a-ff96-4531-a631-b398e70af0c4)
to after
![After](https://github.com/user-attachments/assets/e7e8fde6-492a-42fa-8b10-1b08c797db09)
## Why It's Good For The Game
Was annoying before. This version is much nicer and avoids accidentally clicking on the railings
## Changelog
:cl:
fix: Fix Delta's hydroponics railings to be on a lower layer than the machines
/:cl:
