### PR TITLE
Giving Blueshift robotics adjustments

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -25981,6 +25981,10 @@
 	dir = 4
 	},
 /area/station/security/prison/safe)
+"eWk" = (
+/obj/machinery/smartfridge/organ,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics)
 "eWl" = (
 /turf/closed/wall,
 /area/station/maintenance/disposal)
@@ -32456,14 +32460,15 @@
 /area/station/common/night_club/changing_room)
 "gme" = (
 /obj/structure/table,
+/obj/item/wrench,
+/obj/item/crowbar,
+/obj/item/stack/sheet/plasteel/twenty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
-/obj/item/wrench,
-/obj/item/crowbar,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/mineral/plastitanium,
 /area/station/science/robotics/lab)
@@ -219672,7 +219677,7 @@ kky
 aXQ
 rlz
 sXt
-hbU
+eWk
 vXP
 bDH
 uor

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -80736,7 +80736,7 @@
 /area/station/maintenance/starboard/fore)
 "pHX" = (
 /obj/effect/turf_decal/bot_red,
-/obj/structure/frame/machine,
+/obj/machinery/autolathe,
 /turf/open/floor/mineral/plastitanium,
 /area/station/science/robotics/lab)
 "pHY" = (

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -99782,8 +99782,10 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms/room3)
 "tpV" = (
-/obj/machinery/smartfridge/organ,
 /obj/machinery/firealarm/directional/north,
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics)
 "tqc" = (


### PR DESCRIPTION
## About The Pull Request
Replaces the blueshift's robotics empty machine frame with an auto lathe and organ fridge with a morgue.
Adjusts the position of the organ storage and adds a wee bit of plasteel
## Why It's Good For The Game
It brings it more in line with other robotics. Every robotics has an auto lathe and for a reason. Its a key machine in producing a portion of games simple bots. Hygiene and cleanbots both requiring pipe and buckets from an auto lathe or the service lathe. which is a whole z level and station apart and a robo does not have access to. 

While having the option for other machines to be built is interesting in practice rarely if ever a different machine is built if one is built in that place at all.

And the morgue is useful for not having a body lying in robotics all shift after borging an assistant or the like.

Plasteel is a helpful resource letting them finish their early mechs and using the raw materials for construction like nanites.
## Changelog
:cl:
add: Added an auto lathe, morgue, and plasteel to Blueshift's robotics
/:cl:
