### PR TITLE
[Code Bounty] Buffs syndicate bible

### DIFF
--- a/code/modules/library/bibles.dm
+++ b/code/modules/library/bibles.dm
@@ -319,6 +319,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list(
 	name = "Syndicate Tome"
 	desc = "A very ominous tome resembling a bible."
 	icon_state ="ebook"
+	slot_flags = ITEM_SLOT_BELT
 	item_flags = NO_BLOOD_ON_ITEM
 	throw_speed = 2
 	throw_range = 7

--- a/code/modules/library/bibles.dm
+++ b/code/modules/library/bibles.dm
@@ -319,7 +319,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list(
 	name = "Syndicate Tome"
 	desc = "A very ominous tome resembling a bible."
 	icon_state ="ebook"
-	slot_flags = ITEM_SLOT_BELT
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_POCKETS
 	item_flags = NO_BLOOD_ON_ITEM
 	throw_speed = 2
 	throw_range = 7


### PR DESCRIPTION

## About The Pull Request

Allows you to wear syndicate bible in pocket and belt slot, anti magic works from both

## Why It's Good For The Game
Currently syndicate bible is pretty bad, it is barely better than a holy melon for 5 TC.
It requires you to give up a hand slot and carry a item in hand that gives you away as a traitor.
your name is also shown on the bible so just by inspecting it people know its yours even if not on you. 
Most magic antags like cult and heretic are melee focus'd as well, meaning they will most likely shove you over dropping the bible or just have the advantage in melee already. While you although countering their magic only have one hand.

## Changelog

:cl:
balance: syndicate bible can now provide anti-magic from pocket and belt
/:cl:

