### PR TITLE
[Code bounty] Moves surgery tools in robotics into trays and insure a spare health scanner

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -16919,24 +16919,11 @@
 /area/station/commons/dorms/room8)
 "djt" = (
 /obj/structure/table,
-/obj/item/surgical_drapes{
-	pixel_x = 7;
-	pixel_y = -2
-	},
-/obj/item/circular_saw{
-	pixel_y = 12
-	},
-/obj/item/healthanalyzer{
-	pixel_x = -4;
-	pixel_y = -3
-	},
-/obj/item/scalpel{
-	pixel_y = 19
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/white,
 /area/station/science/robotics)
 "djv" = (
@@ -119739,21 +119726,16 @@
 /area/station/cargo/warehouse)
 "xej" = (
 /obj/structure/table,
-/obj/item/retractor,
-/obj/item/hemostat{
-	pixel_x = -9;
-	pixel_y = -2
-	},
-/obj/item/cautery{
-	pixel_x = -5;
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
 /obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 14;
-	pixel_y = -1
+	pixel_x = 9;
+	pixel_y = 4
+	},
+/obj/item/healthanalyzer{
+	pixel_x = -4;
+	pixel_y = 4
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics)

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -55997,6 +55997,10 @@
 	dir = 4
 	},
 /obj/structure/table,
+/obj/item/healthanalyzer{
+	pixel_x = -1;
+	pixel_y = 6
+	},
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -67936,11 +67936,10 @@
 /area/station/security/detectives_office)
 "qgR" = (
 /obj/structure/table/reinforced,
-/obj/item/retractor,
-/obj/item/hemostat,
 /obj/structure/window/reinforced/spawner/directional/north{
 	pixel_y = 2
 	},
+/obj/item/healthanalyzer,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "qgU" = (
@@ -86720,14 +86719,10 @@
 /area/station/security/lockers)
 "uHW" = (
 /obj/structure/table/reinforced,
-/obj/item/scalpel{
-	pixel_y = 8
-	},
-/obj/item/circular_saw,
-/obj/item/cautery,
 /obj/structure/sign/departments/medbay/alt/directional/south,
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/status_display/evac/directional/east,
+/obj/item/surgery_tray,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
 "uHZ" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1372,11 +1372,8 @@
 /area/station/hallway/primary/port)
 "awK" = (
 /obj/structure/table,
-/obj/item/hemostat,
-/obj/item/cautery{
-	pixel_x = 4
-	},
 /obj/item/radio/intercom/directional/north,
+/obj/item/razor,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "axc" = (
@@ -27112,11 +27109,8 @@
 /area/station/hallway/primary/central)
 "iII" = (
 /obj/structure/table,
-/obj/item/circular_saw,
-/obj/item/scalpel{
-	pixel_y = 12
-	},
 /obj/machinery/light/directional/north,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "iIW" = (
@@ -33063,7 +33057,7 @@
 /area/mine/laborcamp)
 "kBT" = (
 /obj/structure/table,
-/obj/item/retractor,
+/obj/item/healthanalyzer,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "kBV" = (
@@ -68000,8 +67994,6 @@
 "vPE" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/latex,
-/obj/item/surgical_drapes,
-/obj/item/razor,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -31715,12 +31715,10 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/fore)
 "jJW" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-18"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/machinery/medipen_refiller,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/medbay/lobby)
 "jKj" = (
@@ -42301,9 +42299,6 @@
 /area/space/nearstation)
 "nij" = (
 /obj/structure/table,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/clothing/mask/surgical,
 /obj/item/mmi,
 /obj/item/mmi,
 /obj/item/mmi,
@@ -46107,9 +46102,6 @@
 /area/station/security/courtroom)
 "oyX" = (
 /obj/structure/table,
-/obj/item/surgical_drapes,
-/obj/item/retractor,
-/obj/item/cautery,
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north{
 	pixel_y = 1
@@ -46117,6 +46109,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
+/obj/item/surgery_tray,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "oyY" = (
@@ -75231,17 +75224,16 @@
 /area/station/medical/medbay/central)
 "xvh" = (
 /obj/structure/table,
-/obj/item/circular_saw,
-/obj/item/scalpel{
-	pixel_y = 16
-	},
-/obj/item/hemostat,
 /obj/structure/window/reinforced/spawner/directional/north{
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
 	},
+/obj/item/clothing/gloves/latex,
+/obj/item/healthanalyzer,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/suit/apron/surgical,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "xvj" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -25370,11 +25370,8 @@
 /area/station/commons/fitness/recreation)
 "iYO" = (
 /obj/structure/table,
-/obj/item/circular_saw,
-/obj/item/scalpel{
-	pixel_y = 16
-	},
 /obj/effect/turf_decal/tile/purple/half/contrasted,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "iYP" = (
@@ -47029,8 +47026,6 @@
 "qBr" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/table,
-/obj/item/surgical_drapes,
-/obj/item/cautery,
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -68598,10 +68593,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "yeS" = (
-/obj/item/retractor,
-/obj/item/hemostat{
-	pixel_x = -10
-	},
 /obj/machinery/light/small/directional/south,
 /obj/structure/table,
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted,

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -51837,6 +51837,7 @@
 /obj/item/mmi{
 	pixel_y = -5
 	},
+/obj/item/healthanalyzer,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "oEk" = (


### PR DESCRIPTION

## About The Pull Request
This changes it so every robotics has either a tray or surgical duffel bag if it had one already. And a spare health sensor near the operating table.

Also adds a missing medipen refiller to kilo.
Attempt at a code bounty for https://discord.com/channels/748354466335686736/1283085097817604139
## Why It's Good For The Game
Loose tools often lead to lost tools. Which can be annoying, doubly so when only some are missing and not all. This helps the surgical side of robotics stay more in uniform as per the request.
## Changelog
:cl:
add: adds missing medipen refiller to Kilo
qol: Ensures all surgical tools in robotics are in a container of some sort.
/:cl:
