### PR TITLE
Move plant dna disks to roundstart tech

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -139,6 +139,7 @@
 		"universal_scanner",
 		"voice_analyzer",
 		"watering_can",
+		"diskplantgene", // monkestation edit: move to roundstart tech
 	)
 
 /datum/techweb_node/mmi
@@ -1507,7 +1508,7 @@
 	description = "Botanical tools"
 	prereq_ids = list("biotech")
 	design_ids = list(
-		"diskplantgene",
+		/* "diskplantgene", */ // monkestation edit: move to roundstart tech
 		"biogenerator",
 		"flora_gun",
 		"gene_shears",


### PR DESCRIPTION

## About The Pull Request

This moves the plant dna disks from Botanical Engineering to roundstart tech.

## Why It's Good For The Game

They spawn in botany lockers roundstart anyways... _but not all maps have the same amount!_ Some have 3-4 boxes, some only have 2... 

## Changelog
:cl:
qol: Moved the plant dna disk design from Botanical Engineering to roundstart tech.
/:cl:
