### PR TITLE
The Blueshields headset

### DIFF
--- a/monkestation/code/modules/blueshield/closet.dm
+++ b/monkestation/code/modules/blueshield/closet.dm
@@ -34,3 +34,5 @@
 	new /obj/item/storage/bag/garment/blueshield(src)
 	new /obj/item/mod/control/pre_equipped/blueshield(src)
 	new /obj/item/sensor_device/blueshield(src)
+	new /obj/item/radio/headset/headset_bs(src)
+	new /obj/item/radio/headset/headset_bs/alt(src)

--- a/monkestation/code/modules/blueshield/clothing.dm
+++ b/monkestation/code/modules/blueshield/clothing.dm
@@ -209,6 +209,7 @@
 	keyslot2 = /obj/item/encryptionkey/headset_cent
 
 /obj/item/radio/headset/headset_bs/alt
+	name = "\proper the blueshield's bowman headset"
 	icon_state = "bshield_headset_alt"
 	worn_icon_state = "bshield_headset_alt"
 

--- a/monkestation/code/modules/blueshield/clothing.dm
+++ b/monkestation/code/modules/blueshield/clothing.dm
@@ -201,6 +201,7 @@
 
 /obj/item/radio/headset/headset_bs
 	name = "\proper the blueshield's headset"
+	desc = "The headset of the guy who keeps the administration alive."
 	icon = 'monkestation/code/modules/blueshield/icons/radio.dmi'
 	worn_icon = 'monkestation/code/modules/blueshift/icons/mob/clothing/ears.dmi'
 	icon_state = "bshield_headset"
@@ -210,6 +211,7 @@
 
 /obj/item/radio/headset/headset_bs/alt
 	name = "\proper the blueshield's bowman headset"
+	desc = "The headset of the guy who keeps the administration alive. Protects your ears from flashbangs."
 	icon_state = "bshield_headset_alt"
 	worn_icon_state = "bshield_headset_alt"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds both versions of the Blueshield's headset to their locker, and updates their descriptions/name
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The extra headsets are good for two main reasons. One, recovery. If looted after being robusted by John Tider while protecting CE because they refused to give them a toolbelt. It gives them the ability to get a new headset without begging the HOS or Captain for one of theirs.

The second, PAI's, Lots of Command likes to give their PAI's their radio access so they can help out with more of the secretary work and chime in. This makes it possible to get radio encryption keys for the robot helpers. 
(Also breaking into BlueShield's room and directly threatening them over **_their private radio channel_** is quite the power move.) 

And the name and description changes are just nice flavors bringing it in line with the other command headsets.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Blueshield's headset and Blueshield's bowman headset added to their private locker
fix: Changed the Blueshield alt head set name to a bowman headset and added descriptions to both.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
