### PR TITLE
[PORT] Fixes the biogenerator displaying item costs that were being divided by the machine's efficiency twice

### DIFF
--- a/tgui/packages/tgui/interfaces/Biogenerator.tsx
+++ b/tgui/packages/tgui/interfaces/Biogenerator.tsx
@@ -229,11 +229,7 @@ const ItemList = (props) => {
         <Button
           fluid
           align="right"
-          content={
-            parseFloat(
-              ((item.cost * item.amount) / props.efficiency).toFixed(2),
-            ) + ' BIO'
-          }
+          content={parseFloat((item.cost * item.amount).toFixed(2)) + ' BIO'}
           disabled={item.disabled}
           onClick={() =>
             act('create', {


### PR DESCRIPTION
Port of https://github.com/tgstation/tgstation/pull/74939

## Changelog
:cl: GoldenAlpharex
fix: Biogenerators now display the accurate price of their products after having been upgraded, as they no longer visually apply the efficiency discount twice.
/:cl:
