### PR TITLE
Adding the Atmos Holofan to Engiborg

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -390,6 +390,7 @@
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/iron/base/cyborg,
 		/obj/item/stack/cable_coil,
+		/obj/item/holosign_creator/atmos,
 	)
 	radio_channels = list(RADIO_CHANNEL_ENGINEERING)
 	emag_modules = list(


### PR DESCRIPTION

## About The Pull Request

Started the round with no engineers and needed to get into the supermatter room to extinguish it without leaking all the N2, plasma and what have you? Need a fast way to fix the latest prison breach? Look no further! Introducing: The engiborg holofan!

## Why It's Good For The Game

Yes I know engiborgs are overpowered, yes this will not make people pick them less, in fact, it could do the opposite. HOWEVER, this is an incredibly useful tool for an engineer/atmosian and if engiborgs are to do any real fixing of the station, this tool is severely needed.

## Changelog
:cl: manray
add: atmos holofan to engiborg's default toolkit
/:cl:
