### PR TITLE
Fixes sentient slimes getting taken over by AI when splitting/vaccumed

### DIFF
--- a/monkestation/code/modules/slimecore/components/mob_stacker.dm
+++ b/monkestation/code/modules/slimecore/components/mob_stacker.dm
@@ -40,7 +40,7 @@
 	for(var/mob/living/dude as anything in stacked_mobs)
 		if(isbasicmob(dude))
 			var/mob/living/basic/basic = dude
-			basic.ai_controller?.set_ai_status(AI_STATUS_ON)
+			basic.ai_controller?.reset_ai_status()
 		REMOVE_TRAIT(dude, TRAIT_IN_STACK, "mob_stack")
 		UnregisterSignal(dude, COMSIG_ATOM_JOIN_STACK)
 		UnregisterSignal(dude, COMSIG_LIVING_SET_BUCKLED)

--- a/monkestation/code/modules/slimecore/items/vacuum_pack.dm
+++ b/monkestation/code/modules/slimecore/items/vacuum_pack.dm
@@ -411,8 +411,7 @@
 	if(istype(spewed, /mob/living/basic/slime))
 		var/mob/living/basic/slime/slime = spewed
 		slime.slime_flags &= ~STORED_SLIME
-		if(slime.ai_controller)
-			slime.ai_controller.set_ai_status(AI_STATUS_ON)
+		slime.ai_controller?.reset_ai_status()
 		if(VACUUM_PACK_UPGRADE_STASIS in pack.upgrades)
 			REMOVE_TRAIT(slime, TRAIT_SLIME_STASIS, "vacuum_pack_stasis")
 

--- a/monkestation/code/modules/slimecore/mobs/_base_slime.dm
+++ b/monkestation/code/modules/slimecore/mobs/_base_slime.dm
@@ -360,7 +360,7 @@
 	SEND_SIGNAL(src, COMSIG_MOB_ADJUST_HUNGER, -200)
 
 	slime_flags &= ~SPLITTING_SLIME
-	ai_controller.set_ai_status(AI_STATUS_ON)
+	ai_controller.reset_ai_status()
 
 	var/mob/living/basic/slime/new_slime = new(loc, current_color.type, TRUE)
 	new_slime.mutation_chance = mutation_chance
@@ -412,7 +412,7 @@
 	change_color(mutating_into)
 
 	slime_flags &= ~MUTATING_SLIME
-	ai_controller.set_ai_status(AI_STATUS_ON)
+	ai_controller.reset_ai_status()
 
 
 /mob/living/basic/slime/proc/pick_mutation(random = FALSE)


### PR DESCRIPTION
## About The Pull Request

Don't do `ai_controller.set_ai_status(AI_STATUS_ON)` - do `ai_controller.reset_ai_status()` instead, as it'll check to make sure the controller *should* be on in the first place.

Fixes https://github.com/Monkestation/Monkestation2.0/issues/1680
Fixes https://github.com/Monkestation/Monkestation2.0/issues/2328
Fixes https://github.com/Monkestation/Monkestation2.0/issues/3545

## Changelog
:cl:
fix: Fixes sentient slimes getting taken over by AI when splitting/vaccumed.
/:cl:
