### PR TITLE
Fix the icebox magbar being spaced

### DIFF
--- a/_maps/~monkestation/RandomBars/Icebox/Magbar.dmm
+++ b/_maps/~monkestation/RandomBars/Icebox/Magbar.dmm
@@ -941,7 +941,7 @@
 /obj/machinery/vending/boozeomat{
 	layer = 3.1
 	},
-/turf/open/space/basic,
+/turf/open/floor/pod,
 /area/station/service/bar)
 "Gt" = (
 /obj/machinery/door/airlock/maintenance,


### PR DESCRIPTION

## About The Pull Request

only caught this due to mesons lol, it was hidden very well under a door

![image](https://github.com/user-attachments/assets/95a83f91-ad2d-4ebc-853f-a05d18cfc056)


## Changelog
:cl:
fix: Fix the icebox magbar being spaced roundstart.
/:cl:
