### PR TITLE
Character Armor

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -29,8 +29,8 @@
 	for(var/obj/item/clothing/clothing_item in covering_clothing)
 		if(clothing_item.body_parts_covered & def_zone.body_part)
 			protection *= (100 - min(clothing_item.get_armor_rating(damage_type), 100)) * 0.01
-	//monkestation edit start
 	protection *= (100 - min(physiology.armor.get_rating(damage_type), 100)) / 100
+	//monkestation edit start
 	protection *= isnull(inherent_armor_rating) ? 1 : (100 - inherent_armor_rating) / 100
 	//end monkeststation edit: now checks src.armor so you can give characters inherent armor without targeting physiology or generating clothing
 	//you can use this with "target.set_armor" and it will work on live creatures

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -25,10 +25,15 @@
 		return 0
 	var/protection = 100
 	var/list/covering_clothing = list(head, wear_mask, wear_suit, w_uniform, back, gloves, shoes, belt, s_store, glasses, ears, wear_id, wear_neck) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)
+	var/inherent_armor_rating = src.armor?.get_rating(damage_type) //monkestation edit, exists for debugger
 	for(var/obj/item/clothing/clothing_item in covering_clothing)
 		if(clothing_item.body_parts_covered & def_zone.body_part)
 			protection *= (100 - min(clothing_item.get_armor_rating(damage_type), 100)) * 0.01
-	protection *= (100 - min(physiology.armor.get_rating(damage_type), 100)) * 0.01
+	//monkestation edit start
+	protection *= (100 - min(physiology.armor.get_rating(damage_type), 100)) / 100
+	protection *= isnull(inherent_armor_rating) ? 1 : (100 - inherent_armor_rating) / 100
+	//end monkeststation edit: now checks src.armor so you can give characters inherent armor without targeting physiology or generating clothing
+	//you can use this with "target.set_armor" and it will work on live creatures
 	return 100 - protection
 
 ///Get all the clothing on a specific body part


### PR DESCRIPTION
you can do the thing
## About The Pull Request
I realized while trying to add armor to martial arts owners that the only two ways of changing a character's armor was with physiology.armor and clothing, unless you count "other" methods.
This change allows you to use "set_armor()" on /carbon/human to give them armor.

Should also fix several random items throughout the codebase, nanites will certainly be affected.
## Why It's Good For The Game
This just fixes a bug that we have had for a LONG time, given the last time this code was touched was 2 years ago.
## Changelog
:cl:
fix: character and inherent armor have been fixed. unknown how many things this will affect, but includes nanite armor
code: modified carbon/human/proc/check_armor() to check src.armor during calculations
code: you can now use "set_armor" on human subtypes
refactor: for people using debuggers, you can watch "inherent_armor_rating" to see the inherent armor stats of a character being damaged.
refactor: uses / 100 instead of * 0.01. No change in function as far as I know
/:cl:
