### PR TITLE
Hides hairs/ears on albative hood

### DIFF
--- a/code/modules/clothing/suits/ablativecoat.dm
+++ b/code/modules/clothing/suits/ablativecoat.dm
@@ -4,6 +4,7 @@
 	worn_icon = 'icons/mob/clothing/head/helmet.dmi'
 	desc = "Hood hopefully belonging to an ablative trenchcoat. Includes a visor for cool-o-vision."
 	icon_state = "ablativehood"
+	flags_inv = HIDEHAIR | HIDEEARS
 	armor_type = /datum/armor/hooded_ablative
 	strip_delay = 30
 	var/hit_reflect_chance = 50


### PR DESCRIPTION

## About The Pull Request
Makes it so the hair and ears dont show when you wear a alba trenchcoat
## Why It's Good For The Game
As pictured that much hair loose isnt that great for reflecting purposes.
Before & After
![albabefore](https://github.com/user-attachments/assets/4186ec1b-4aa5-4b4a-8cb8-bcc0dfcf12b5) ![albaafter](https://github.com/user-attachments/assets/939642d7-002c-499d-8242-170c8a744001)


That and all other hoods hide it, so lets be consistent or whatever.
## Changelog
:cl:
fix: Makes ablative trench coat properly hide hair and ears.
/:cl:
