### PR TITLE
Making Frontier Satchels actual satchels

### DIFF
--- a/monkestation/code/modules/blueshift/armaments/kaharaman.dm
+++ b/monkestation/code/modules/blueshift/armaments/kaharaman.dm
@@ -97,11 +97,11 @@
 	cost = PAYCHECK_CREW
 
 /datum/armament_entry/company_import/kahraman/storage_equipment/satchel
-	item_type = /obj/item/storage/backpack/industrial/frontier_colonist/satchel
+	item_type = /obj/item/storage/backpack/satchel/eng/frontier_colonist
 	cost = PAYCHECK_CREW
 
 /datum/armament_entry/company_import/kahraman/storage_equipment/messenger
-	item_type = /obj/item/storage/backpack/industrial/frontier_colonist/messenger
+	item_type = /obj/item/storage/backpack/satchel/eng/frontier_colonist/messenger
 	cost = PAYCHECK_CREW
 
 /datum/armament_entry/company_import/kahraman/storage_equipment/belt

--- a/monkestation/code/modules/blueshift/biogenerator/equipment.dm
+++ b/monkestation/code/modules/blueshift/biogenerator/equipment.dm
@@ -61,7 +61,7 @@
 	id = "frontier_satchel"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 100)
-	build_path = /obj/item/storage/backpack/industrial/frontier_colonist/satchel
+	build_path = /obj/item/storage/backpack/satchel/eng/frontier_colonist
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_AKHTER_EQUIPMENT,
@@ -72,7 +72,7 @@
 	id = "frontier_messenger"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 100)
-	build_path = /obj/item/storage/backpack/industrial/frontier_colonist/messenger
+	build_path = /obj/item/storage/backpack/satchel/eng/frontier_colonist/messenger
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_AKHTER_EQUIPMENT,

--- a/monkestation/code/modules/blueshift/clothing/kahraman.dm
+++ b/monkestation/code/modules/blueshift/clothing/kahraman.dm
@@ -17,6 +17,7 @@
 /obj/item/storage/backpack/satchel/eng/frontier_colonist
 	name = "frontier satchel"
 	desc = "A rugged satchel often used by settlers and explorers. Holds less of your equipment than a backpack will."
+	icon = 'monkestation/code/modules/blueshift/icons/clothes/clothing.dmi'
 	icon_state = "satchel"
 	worn_icon = 'monkestation/code/modules/blueshift/icons/clothes/clothing_worn.dmi'
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON

--- a/monkestation/code/modules/blueshift/clothing/kahraman.dm
+++ b/monkestation/code/modules/blueshift/clothing/kahraman.dm
@@ -24,7 +24,7 @@
 	worn_icon_state = "satchel"
 	inhand_icon_state = "backpack"
 
-/obj/item/storage/backpack/industrial/frontier_colonist/Initialize(mapload)
+/obj/item/storage/backpack/satchel/eng/frontier_colonist/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_KAHRAMAN)
 

--- a/monkestation/code/modules/blueshift/clothing/kahraman.dm
+++ b/monkestation/code/modules/blueshift/clothing/kahraman.dm
@@ -14,13 +14,20 @@
 	. = ..()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_KAHRAMAN)
 
-/obj/item/storage/backpack/industrial/frontier_colonist/satchel
+/obj/item/storage/backpack/satchel/eng/frontier_colonist
 	name = "frontier satchel"
 	desc = "A rugged satchel often used by settlers and explorers. Holds less of your equipment than a backpack will."
 	icon_state = "satchel"
+	worn_icon = 'monkestation/code/modules/blueshift/icons/clothes/clothing_worn.dmi'
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	worn_icon_state = "satchel"
+	inhand_icon_state = "backpack"
 
-/obj/item/storage/backpack/industrial/frontier_colonist/messenger
+/obj/item/storage/backpack/industrial/frontier_colonist/Initialize(mapload)
+	. = ..()
+	AddElement(/datum/element/manufacturer_examine, COMPANY_KAHRAMAN)
+
+/obj/item/storage/backpack/satchel/eng/frontier_colonist/messenger
 	name = "frontier messenger bag"
 	desc = "A rugged messenger bag often used by settlers and explorers. Holds less of your equipment than a backpack will."
 	icon_state = "messenger"


### PR DESCRIPTION

## About The Pull Request
Adjusts the Frontier Messenger Bag and Frontier Satchel into subtypes of the engineering satchel intead of the industrial backpack.

## Why It's Good For The Game
They both have the description currently. "Holds less of your equipment than a backpack will…" This is false advertising and I will not stand for it. In addition, its really strange to have a satchel that isn't equipable in the belt slot.

Its also helpful to have an option for a toolbelt backpack as the frontier mod suit eats up the back slot.
## Changelog
:cl:
add: Made frontier satchels and messenger bags actual satchel types
/:cl:
