### PR TITLE
Adds a new chemical recipe to create Space Cleaner from watered down Urine

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -395,6 +395,12 @@
 	rate_up_lim = 40
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE
 
+/datum/chemical_reaction/piss_cleaner
+	results = list(/datum/reagent/space_cleaner = 2)
+	required_reagents = list(/datum/reagent/ammonia/urine = 2, /datum/reagent/water = 1)
+	rate_up_lim = 40
+	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_UNIQUE
+
 /datum/chemical_reaction/plantbgone
 	results = list(/datum/reagent/toxin/plantbgone = 5)
 	required_reagents = list(/datum/reagent/toxin = 1, /datum/reagent/water = 4)


### PR DESCRIPTION
## About The Pull Request

Adds in a new chemical reaction converting 2u of Urine and 1u of Water into Space Cleaner at the request of Pooba.

## Why It's Good For The Game

Piss Cleaner Real. Also due to current major TMs related to organ changes, the original concept of Janitors pissing straight up space cleaner is delayed until said TM(s) are fullmerged.

Also, Space Cleaner is just equal parts Ammonia and Water in-game, so having a recipe like this isn't too far-fetched.

## Changelog

:cl: Meowosers
add: Space Cleaner can now be made with Urine and Water
/:cl: