### PR TITLE
Adds gas miners to icebox

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -2491,7 +2491,9 @@
 /area/station/medical/treatment_center)
 "aRj" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/miner/carbon_dioxide,
+/obj/machinery/atmospherics/miner/carbon_dioxide{
+	desc = "Gasses mined from the ground below flow out through this massive vent."
+	},
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "aRl" = (
@@ -9815,6 +9817,7 @@
 /obj/effect/turf_decal/trimline/dark_red/arrow_ccw{
 	dir = 1
 	},
+/obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "cXZ" = (
@@ -15962,7 +15965,9 @@
 /area/station/command/heads_quarters/hop)
 "eWj" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
-/obj/machinery/atmospherics/miner/plasma,
+/obj/machinery/atmospherics/miner/plasma{
+	desc = "Gasses mined from the ground below flow out through this massive vent."
+	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "eWn" = (
@@ -16016,7 +16021,9 @@
 /area/station/command/bridge)
 "eWQ" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/miner/nitrogen,
+/obj/machinery/atmospherics/miner/nitrogen{
+	desc = "Gasses mined from the ground below  flow out through this massive vent."
+	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
 "eWT" = (
@@ -16162,7 +16169,9 @@
 /area/station/service/hydroponics)
 "eZc" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/machinery/atmospherics/miner/n2o,
+/obj/machinery/atmospherics/miner/n2o{
+	desc = "Gasses mined from the ground below flow out through this massive vent."
+	},
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "eZi" = (
@@ -60109,7 +60118,9 @@
 /area/station/engineering/storage_shared)
 "tln" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/miner/oxygen,
+/obj/machinery/atmospherics/miner/oxygen{
+	desc = "Gasses mined from the ground below flow out through this massive vent."
+	},
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "tlo" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -2491,6 +2491,7 @@
 /area/station/medical/treatment_center)
 "aRj" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "aRl" = (
@@ -15961,6 +15962,7 @@
 /area/station/command/heads_quarters/hop)
 "eWj" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/atmospherics/miner/plasma,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "eWn" = (
@@ -16014,6 +16016,7 @@
 /area/station/command/bridge)
 "eWQ" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/miner/nitrogen,
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
 "eWT" = (
@@ -16159,6 +16162,7 @@
 /area/station/service/hydroponics)
 "eZc" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "eZi" = (
@@ -54876,8 +54880,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
-	name = "Plasma to Pure";
-	piping_layer = 4
+	name = "Plasma to Pure"
 	},
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
@@ -60106,6 +60109,7 @@
 /area/station/engineering/storage_shared)
 "tln" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/miner/oxygen,
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "tlo" = (


### PR DESCRIPTION

## About The Pull Request
### Simply adds renewable gas to atmos
## Why It's Good For The Game
A entire job being limited kinda sucks, specially when it can cause effects on the station if you run our of air,
## Changelog
:cl:
add: Gas miners to atmospherics on IceBox
