### PR TITLE
A/S maintnece has no grid connection

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -3759,6 +3759,7 @@
 	},
 /obj/effect/mapping_helpers/broken_floor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "bfG" = (
@@ -62205,6 +62206,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "sBm" = (


### PR DESCRIPTION
## About The Pull Request
Connects the A/S maintence APC being unconnected to the grid
## Why It's Good For The Game
Depowering station do be bad.
I even made this ms paint+Comic sans visual of the issue!
![nowires](https://github.com/user-attachments/assets/a4a31b17-c0ff-400d-aa3a-0168725bfc9f)
## Changelog
:cl:
fix: fixed A/S maintenance APC being unconnected on Theseus.
/:cl:
