### PR TITLE
Moves the Radio frequency to the reserved range

### DIFF
--- a/code/__DEFINES/radio.dm
+++ b/code/__DEFINES/radio.dm
@@ -75,6 +75,7 @@
 #define FREQ_MEDICAL 1355 // Medical comms frequency, soft blue
 #define FREQ_ENGINEERING 1357 // Engineering comms frequency, orange
 #define FREQ_SECURITY 1359 // Security comms frequency, red
+#define FREQ_RADIO 1361 //monkestation edit
 
 #define FREQ_HOLOGRID_SOLUTION 1433
 #define FREQ_STATUS_DISPLAYS 1435
@@ -83,7 +84,6 @@
 // Only the 1441 to 1489 range is freely available for general conversation.
 // This represents 1/8th of the available spectrum.
 
-#define FREQ_RADIO 1443 //monkestation edit
 #define FREQ_AI_PRIVATE 1447 // AI private comms frequency, magenta
 #define FREQ_PRESSURE_PLATE 1447
 #define FREQ_ELECTROPACK 1449


### PR DESCRIPTION

## About The Pull Request

This moves the Radio frequency from 144.3 to 136.1, in the reserved range - meaning headsets/intercoms/etc cannot be set to manually broadcast to it, only the curator's mic can broadcast to it by default.

## Why It's Good For The Game

Stops people from being annoying by (mass) hotmicing to the radio channel, and well, so you can't just get special fancy color that everyone can hear just from setting a frequency

## Changelog
:cl:
qol: The curator's radio channel frequency is now reserved, and can only be broadcast to by the radio booth's mic.
/:cl:
