### PR TITLE
Give medbay borer crate orders

### DIFF
--- a/monkestation/code/modules/cargo/crates/medical.dm
+++ b/monkestation/code/modules/cargo/crates/medical.dm
@@ -65,3 +65,11 @@
 	contraband = TRUE
 	contains = list(/obj/item/reagent_containers/pill/maintenance = 10)
 	crate_name = "experimental medicine crate"
+
+/datum/supply_pack/medical/borer_cage
+	name = "Borer cage"
+	desc = "A troublesome brain worm dumping one to many unprescribed drugs into your patients? Well this crate if for you!"
+	cost = CARGO_CRATE_VALUE * 10
+	contraband = TRUE
+	contains = list(/obj/item/cortical_cage)
+	crate_name = "anti-borer crate"


### PR DESCRIPTION

## About The Pull Request
Makes it so medbay can order borer crates through their express order console.
## Why It's Good For The Game
Currently Borer crates are orderable via the security express console. This, makes no sense. In all my hours of playing I have not once seen security order this nor care about the threat borers poses. And if they do, they dont go to security for it removed. They go to medical. 

In addition, with how dive worms. the problematic ones, work they end up in medical typically with all the bodies trying to implant the impowered eggs. 

This gives medical a tool to actually take care of the borer. As even when removed from a host via surgery they then have to chase and hunt the borer who hides under everything. 
## Changelog
:cl:
add: Adds borer cages as a medical express order.
/:cl:
