### PR TITLE
Give's Blueshield a custom takbok instead of the default one

### DIFF
--- a/monkestation/code/modules/blueshield/gun.dm
+++ b/monkestation/code/modules/blueshield/gun.dm
@@ -15,7 +15,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/hellfire/blueshield)
 // Blueshields custom takbok revolver.
 /obj/item/gun/ballistic/revolver/takbok/blueshield
-	name = "ghost takbok revolver" //Ghost as in its lack of tracibility. Give it a unique prefix compared hellfire's 'modified' to stand out
+	name = "unmarked takbok revolver" //Give it a unique prefix compared hellfire's 'modified' to stand out
 	desc = "A modified revolver resembling that of Trappiste's signature Takbok, notabley lacking any of the company's orginal markings or tracablable identifaction. The custom modifactions allows it to shoot the five .585 Trappiste rounds in its cylinder quicker and with more consistancy."
 
 	//In comparasion to the orginal's fire_delay = 1 second, recoil = 3, and wield_recoil =1.
@@ -30,6 +30,7 @@
 /obj/item/gun/ballistic/revolver/takbok/blueshield/examine_more(mob/user)
 	. = ..()
     //Basically, it is a short continuation story of the original takbok about fans continuing their passion for an idea or project. Still, the original company stopped them despite the innovations they brought. And the ‘C’ is a callback to their inspirational figure ‘Cawgo’
+	. += ""
 	. += "After the production run of the original Takbok \
 		ended in 2523 alongside its popularity, enthusiasts of the sidearm continued\
 		to tinker with the make of the weapon to keep it with modern standards for \
@@ -43,7 +44,7 @@
 // Gunset for the custom Takbok Revolver
 
 /obj/item/storage/toolbox/guncase/skyrat/pistol/trappiste_small_case/takbok/blueshield
-	name = "Ghost 'Takbok' gunset"
+	name = "Unmarked 'Takbok' gunset"
 
 	weapon_to_spawn = /obj/item/gun/ballistic/revolver/takbok/blueshield
 
@@ -56,7 +57,7 @@
 
 /obj/item/choice_beacon/blueshield/generate_display_names()
 	var/static/list/selectable_gun_types = list(
-		"Ghost Takbok Revolver Set" = /obj/item/storage/toolbox/guncase/skyrat/pistol/trappiste_small_case/takbok/blueshield,
+		"Unmarked Takbok Revolver Set" = /obj/item/storage/toolbox/guncase/skyrat/pistol/trappiste_small_case/takbok/blueshield,
 		"Custom Hellfire Laser Rifle" = /obj/item/gun/energy/laser/hellgun/blueshield,
 		"Bogseo Submachinegun Gunset" = /obj/item/storage/toolbox/guncase/skyrat/xhihao_large_case/bogseo,
 		"Tech-9" = /obj/item/storage/toolbox/guncase/skyrat/pistol/tech_9,

--- a/monkestation/code/modules/blueshield/gun.dm
+++ b/monkestation/code/modules/blueshield/gun.dm
@@ -13,7 +13,41 @@
 	desc = "A lightly overtuned version of NT's Hellfire Laser rifle, scratches showing its age and the fact it has definitely been owned before. This one is more energy efficient without sacrificing damage."
 	icon_state = "hellgun"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/hellfire/blueshield)
+// Blueshields custom takbok revolver.
+/obj/item/gun/ballistic/revolver/takbok/blueshield
+	name = "ghost takbok revolver" //Ghost as in its lack of tracibility. Give it a unique prefix compared hellfire's 'modified' to stand out
+	desc = "A modified revolver resembling that of Trappiste's signature Takbok, notabley lacking any of the company's orginal markings or tracablable identifaction. The custom modifactions allows it to shoot the five .585 Trappiste rounds in its cylinder quicker and with more consistancy."
 
+	//In comparasion to the orginal's fire_delay = 1 second, recoil = 3, and wield_recoil =1.
+	fire_delay = 0.8 SECONDS
+	recoil = 1.6
+	wield_recoil = 0.8
+
+/obj/item/gun/ballistic/revolver/takbok/blueshield/give_manufacturer_examine()
+	RemoveElement(/datum/element/manufacturer_examine, COMPANY_TRAPPISTE)
+	AddElement(/datum/element/manufacturer_examine, COMPANY_REMOVED)
+
+/obj/item/gun/ballistic/revolver/takbok/blueshield/examine_more(mob/user)
+	. = ..()
+    //Basically, it is a short continuation story of the original takbok about fans continuing their passion for an idea or project. Still, the original company stopped them despite the innovations they brought. And the ‘C’ is a callback to their inspirational figure ‘Cawgo’
+	. += "After the production run of the original Takbok \
+		ended in 2523 alongside its popularity, enthusiasts of the sidearm continued\
+		to tinker with the make of the weapon to keep it with modern standards for \
+		firearms, despite Trappiste's license on the design. This unusual passion \
+		for the weapon led to variations with few to no identifying marks besides \
+		the occasional 'C' carved into the hilt of the gun. As a consequence of its \
+		production methods, it is unable to be distributed through conventional means \
+		despite the typical assessment of most being an improved model."
+	return .
+
+// Gunset for the custom Takbok Revolver
+
+/obj/item/storage/toolbox/guncase/skyrat/pistol/trappiste_small_case/takbok/blueshield
+	name = "Ghost 'Takbok' gunset"
+
+	weapon_to_spawn = /obj/item/gun/ballistic/revolver/takbok/blueshield
+
+//Weapon beacon
 /obj/item/choice_beacon/blueshield
 	name = "gunset beacon"
 	desc = "A single use beacon to deliver a gunset of your choice. Please only call this in your office"
@@ -22,7 +56,7 @@
 
 /obj/item/choice_beacon/blueshield/generate_display_names()
 	var/static/list/selectable_gun_types = list(
-		"Takbok Revolver Set" = /obj/item/storage/toolbox/guncase/skyrat/pistol/trappiste_small_case/takbok,
+		"Ghost Takbok Revolver Set" = /obj/item/storage/toolbox/guncase/skyrat/pistol/trappiste_small_case/takbok/blueshield,
 		"Custom Hellfire Laser Rifle" = /obj/item/gun/energy/laser/hellgun/blueshield,
 		"Bogseo Submachinegun Gunset" = /obj/item/storage/toolbox/guncase/skyrat/xhihao_large_case/bogseo,
 		"Tech-9" = /obj/item/storage/toolbox/guncase/skyrat/pistol/tech_9,


### PR DESCRIPTION
## About The Pull Request
Adds the "Unmarked Takbok Revolver" to the blueshields supply beacon. It is a variation on the original Takbok Revolver. Its key traits/differences are having 0.2 less delay between shots. Reducing its time to empty the gun from 5 to 4 seconds. And less recoil while braced and unbraced. Respectively reduced by half and a fifth. The recoil differences can be seen [here.](https://youtu.be/P3NwroLjbhs)
## Why It's Good For The Game
Blueshield's weapon beacon has had a lot of changes. Mostly addressing the over-tuned and powerful options. (Boesgo and the Tech-9). And with this I hope to address and give love to what is in my opinion the most unpowered and underused of the four options. The Takbok Revolver.
### Why is it needed?
Compared to the options it doesn't have much going for it. Its greatest benefit is its ammo efficiency. The round start trapiste ammo will last you practically the whole round without visiting cargo or ammo bench once. But its issues? Are much more in comparison.

- Damage, requiring 5 shots, (the whole clip) hitting at fleshy target at CC's firing range worth of distance. Meaning you have to have perfect accuracy on someone completely unarmored over 5 seconds while dealing with...
- The recoil. Recoil strength is Three, which is really noticeable and disruptive when in a firefight. Bracing helps quite a bit but is still noticeable. While having a gun with difficulty to use for a benefit isn't bad design, it cant be strong because of it's...
- Accessibility. Takbok is a really easy gun to get. Costing around 600 credits in imports depending on the shift. Most crew can acquire this gun if they want in under 10 minutes by rushing bounties or getting one good one alongside their starting budget. It is not a restricted item from needing to use a hacked cargo console or even an cargo console instead of the NTR app. Unlike the bosego or the hellfire laser. This means we can't reasonably buff it without an issue where everyone has a blueshield level gun.

### In conclusion?
The takbok revolver needs some love for the BlueShield and I love my revolvers/semi-automatics. But any time I have used it I have felt like 'I could've won' or 'that could've gone differentially if I had chosen one of the better options. So I made it better. 

Hell it's so underused it's not even discussed in our discord or mentioned really unlike the other guns. With the phrase 'takbok' shows up only 5 times at the time of writing this.  One of which was asking about reloading it back when you needed three hands to be able to comfortably reload it. And another mentioning the fact they need to stop buying it.
### How to fix it?
I'm fine with certain options or choices being underpowered in comparison to the others. It's natural and I'm content with it. But I believe if it is going to be less powerful than the rest it should at least feel good to use. I believe my changes address this by first making it-

- Exclusive. By making a variation, in this case, the Unmarked Takbok revolver. We can thus buff it while not giving the Cargoina a busted cheap ballistic they can buy. This allows us to give buffs in a safe conscious without worrying about its outside influences messing things up. 
- The recoil. Can now be dropped to something more reasonable and feels less bad for the guns relative strength. Making in a firefight where both you and your target are usually running around. You can make your shots count on the target with your screen flying around a lot less. Doubly so if you ever need to quick draw the weapon and don't have time to brace it.
- The time to down. As mentioned I'm fine with a gun not having as much brute strength compared to the rest. But the slight buff to its time in-between shots means it serves more of a threat and presence.
## Changelog
:cl:
add: Adds the 'Unmarked Takbok Revolver', a variation of the Trapiste Takbok revolver that has less recoil and fires slightly faster.
add:  Replaces the Takbok revolver in the BlueShield's gun beacon with a new addition, the 'Unmarked Takbok Revolver'
/:cl:
