### PR TITLE
Fix SSgarbage metrics not properly counting failed hard deletes

### DIFF
--- a/monkestation/code/modules/metrics/subsystem_analytics/generics.dm
+++ b/monkestation/code/modules/metrics/subsystem_analytics/generics.dm
@@ -12,7 +12,8 @@
 		cust["gcr"] = 0
 	else
 		cust["gcr"] = (gcedlasttick / (delslasttick + gcedlasttick))
-	cust["total_harddels"] = totaldels
+	cust["total_harddels"] = totaldels + length(failed_hard_deletes)
+	cust["total_failed_harddels"] = length(failed_hard_deletes)
 	cust["total_softdels"] = totalgcs
 	var/i = 0
 	for(var/list/L in queues)


### PR DESCRIPTION

## About The Pull Request

`SSgarbage.totaldels` is never incremented due to hard deletes being disabled (except for things that are forcefully hard-deleted, like clients), as failed hard deletes just get added to `SSgarbage.failed_hard_deletes`, so I'm making it account for that in the metrics for `SSgarbage`.

## Changelog

No player-facing changes (this only matters for anyone with Grafana access)
