### PR TITLE
Speech artifact faults no longer make the dead speak

### DIFF
--- a/code/__DEFINES/~monkestation/text.dm
+++ b/code/__DEFINES/~monkestation/text.dm
@@ -1,0 +1,2 @@
+/// File location for artifact speech lines
+#define ARTIFACT_FILE "artifact.json"

--- a/monkestation/code/modules/art_sci_overrides/faults/say.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/say.dm
@@ -1,21 +1,16 @@
 /datum/artifact_fault/speech
 	name = "Talkative Fault"
 	trigger_chance = 25
-	var/list/speech = list("Hello there.","I see you.","I know what you've done.","So hows your shift?","HELP ARTIFACT IS MAKING ME SPEAK","All is one.","One is all.")
-
 	research_value = 50
 
 /datum/artifact_fault/speech/on_trigger()
-	if(!length(speech))
-		return
-
 	var/center_turf = get_turf(our_artifact.parent)
 
 	if(!center_turf)
 		CRASH("[src] had attempted to trigger, but failed to find the center turf!")
 
-	for(var/mob/living/living in range(rand(7, 10), center_turf))
-		if(prob(10))
-			living.say("; [pick(speech)]")
-		else
-			living.say("[pick(speech)]")
+	for(var/mob/living/living in viewers(rand(7, 10), center_turf))
+		if(living.stat != CONSCIOUS || !living.can_speak())
+			var/speak_over_radio = prob(10) ? "; " : ""
+			var/forced_message = pick_list_replacements(ARTIFACT_FILE, "speech_artifact")
+			living.say(speak_over_radio + forced_message, forced = "artifact ([src])")

--- a/strings/artifact.json
+++ b/strings/artifact.json
@@ -1,0 +1,11 @@
+{
+	"speech_artifact": [
+		"Hello there.",
+		"I see you.",
+		"I know what you've done.",
+		"So hows your shift?",
+		"HELP ARTIFACT IS MAKING ME SPEAK",
+		"All is one.",
+		"One is all."
+	]
+}

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -459,6 +459,7 @@
 #include "code\__DEFINES\~monkestation\span.dm"
 #include "code\__DEFINES\~monkestation\status_effects.dm"
 #include "code\__DEFINES\~monkestation\storytellers.dm"
+#include "code\__DEFINES\~monkestation\text.dm"
 #include "code\__DEFINES\~monkestation\time.dm"
 #include "code\__DEFINES\~monkestation\twitch.dm"
 #include "code\__DEFINES\~monkestation\uplink.dm"


### PR DESCRIPTION
## About The Pull Request

This cleans up speech artifact code a bit, and makes them skip dead mobs and mobs that can't speak anyways.

Also ensures the speech is logged as being forced by an artifact, and moved the actual lines to `strings/artifact.json`

## Why It's Good For The Game

speech artifacts are annoying as-is, let's not let them spam deadchat too.

## Changelog
:cl:
fix: Speech artifact faults no longer make the dead speak.
/:cl:
