### PR TITLE
Private therapy on Theseus 

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -54864,10 +54864,6 @@
 	},
 /area/station/service/chapel)
 "qsO" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Psychiatrist Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	invisibility = 101
@@ -54877,6 +54873,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/door/airlock/medical{
+	name = "Psychiatrist Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/medical/psychology,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "qsS" = (


### PR DESCRIPTION

## About The Pull Request
Removes the glass airlock and adjusts the airlock access to psychologist rather than medical. So they may (murder their patients)  give counseling to patients and privacy without being in eyesight of the main medical area.
## Why It's Good For The Game
Jokes aside about psychologists murdering all their patients at one point or another some good and frankly personal rp comes from the phycologists room and not everyone wants to do therapy in front of bone saws fighting off the incursion of revenants
## Changelog
:cl:
add: Adjusts psychologists' primary door to a solid airlock and their access.
/:cl:
