### PR TITLE
[PORT] playsound() will runtime if you try to pass a list into it

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -106,6 +106,9 @@ GLOBAL_LIST_EMPTY(cached_mixer_channels)
 	if(isarea(source))
 		CRASH("playsound(): source is an area")
 
+	if(islist(soundin))
+		CRASH("playsound(): soundin attempted to pass a list! Consider using pick()")
+
 	var/turf/turf_source = get_turf(source)
 
 	if (!turf_source || !soundin || !vol)


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/86934

Adds an islist() sanity check and runtime to playsound() to prevent client crashing.

## Why It's Good For The Game

avoids a situation like https://github.com/Monkestation/Monkestation2.0/issues/2923 happening again

## Changelog

Not player facing
