### PR TITLE
Gothic coats and brushes for monkeshop

### DIFF
--- a/monkestation/code/modules/clothing/neck/cloaks.dm
+++ b/monkestation/code/modules/clothing/neck/cloaks.dm
@@ -165,7 +165,7 @@
 	item_cost = 20000
 
 /obj/item/clothing/neck/linjacket
-	name = "oranate coat"
+	name = "ornate coat"
 	desc = "You'll hold this weight."
 	icon = 'monkestation/icons/obj/clothing/necks.dmi'
 	worn_icon = 'monkestation/icons/mob/clothing/neck.dmi'

--- a/monkestation/code/modules/loadouts/items/pocket.dm
+++ b/monkestation/code/modules/loadouts/items/pocket.dm
@@ -166,6 +166,13 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 	name = "Cannabis Rollie"
 	item_path = /obj/item/clothing/mask/cigarette/rollie/cannabis
 
+/datum/loadout_item/pocket_items/brush
+	name = "Hairbrush"
+	item_path = /obj/item/hairbrush
+
+/datum/loadout_item/pocket_items/comb
+	name = "Comb"
+	item_path = /obj/item/hairbrush/comb
 /*
 *	DONATOR
 */

--- a/monkestation/code/modules/loadouts/items/suits.dm
+++ b/monkestation/code/modules/loadouts/items/suits.dm
@@ -143,7 +143,8 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 
 /datum/loadout_item/suit/gothcoat
 	name = "Gothic Coat"
-	/obj/item/clothing/suit/costume/gothcoat
+	item_path = /obj/item/clothing/suit/costume/gothcoat
+
 /*
 *	COSTUMES
 */

--- a/monkestation/code/modules/loadouts/items/suits.dm
+++ b/monkestation/code/modules/loadouts/items/suits.dm
@@ -141,6 +141,9 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	name = "Ethereal Raincoat"
 	item_path = /obj/item/clothing/suit/hooded/ethereal_raincoat
 
+/datum/loadout_item/suit/gothcoat
+	name = "Gothic Coat"
+	/obj/item/clothing/suit/costume/gothcoat
 /*
 *	COSTUMES
 */

--- a/monkestation/code/modules/store/store_items/pocket.dm
+++ b/monkestation/code/modules/store/store_items/pocket.dm
@@ -118,3 +118,13 @@ GLOBAL_LIST_INIT(store_pockets, generate_store_items(/datum/store_item/pocket))
 /datum/store_item/pocket/pet_beacon
 	name = "Pet Delivery Beacon"
 	item_path = /obj/item/choice_beacon/pet
+
+/datum/store_item/pocket/brush
+	name = "Hairbrush"
+	item_path = /obj/item/hairbrush
+	item_cost = 5000
+
+/datum/store_item/pocket/comb
+	name = "Comb"
+	item_path = /obj/item/hairbrush/comb
+	item_cost = 5000

--- a/monkestation/code/modules/store/store_items/suits.dm
+++ b/monkestation/code/modules/store/store_items/suits.dm
@@ -404,6 +404,11 @@ GLOBAL_LIST_INIT(store_suits, generate_store_items(/datum/store_item/suit))
 	item_path = /obj/item/clothing/suit/mothcoat
 	item_cost = 5000
 
+/datum/store_item/suit/gothcoat
+	name = "Gothic Coat"
+	item_path = /obj/item/clothing/suit/costume/gothcoat
+	item_cost = 5000
+
 /*
 *	VARSITY JACKET
 */


### PR DESCRIPTION
## About The Pull Request
Adds the brush, gothic coat, and comb to the monkeshop, ideally.
## Why It's Good For The Game
### Who wants this?
Uhm, me. Maybe a few others.
### Why do we want it?
Hair is a key part of identity, so give us the tool to emote and take care of it!
And Im a sucker for the gothic coat. (A lot of mimes wear it too weirdly from what I've seen)
### Is there a precedent?
Several items of the gothic set are already in the monkey shop, but not the gothic coat. and visually distinct & pretty neat lookin. 
There's actually a tactical hairbrush already in the shop. But its Donator only. So let the donators flex hard on us peasants with their advanced hairbrushes. 
### Is this a personal pull with little benefit to the overall gameplay?
I
Uhm


### My finally tactic
**Guilt tripping**
See this?
This is Charlie
![guilt trip](https://github.com/user-attachments/assets/ef3d2346-68fc-4ff3-8cf7-63e24235efd8)
This is a happy Charlie.
It would be a shame if something happened 
## Changelog
:cl:
add: Adds hairbrush, comb, and the gothic coat to the Monke shop
spellcheck: Fixes the name of ornate coat
/:cl: