### PR TITLE
Some minor map adjustments

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -5254,7 +5254,6 @@
 "bbG" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted,
-/obj/machinery/station_map/engineering,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "bbH" = (
@@ -7405,6 +7404,7 @@
 "bwg" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad/secure,
+/obj/machinery/station_map/engineering/directional/north,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "bwi" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -10101,6 +10101,7 @@
 /obj/effect/turf_decal/trimline/dark_green/line{
 	dir = 4
 	},
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pathology)
 "dMH" = (
@@ -10177,6 +10178,7 @@
 /obj/effect/turf_decal/trimline/dark_green/corner{
 	dir = 4
 	},
+/obj/machinery/camera/directional/south,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pathology)
 "dOw" = (
@@ -10372,6 +10374,7 @@
 /obj/effect/turf_decal/trimline/dark_green/line{
 	dir = 5
 	},
+/obj/machinery/camera/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pathology)
 "dRA" = (
@@ -19086,6 +19089,7 @@
 /obj/effect/turf_decal/trimline/dark_green/line{
 	dir = 9
 	},
+/obj/machinery/camera/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/pathology)
 "gYO" = (
@@ -30215,7 +30219,6 @@
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
 	},
-/obj/structure/window/spawner/directional/east,
 /obj/machinery/door/window/right/directional/south{
 	name = "Corpse Arrivals"
 	},
@@ -38927,6 +38930,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "nGp" = (
@@ -49530,6 +49534,13 @@
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
+"rvC" = (
+/obj/effect/turf_decal/trimline/dark_green/line{
+	dir = 4
+	},
+/obj/machinery/camera/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/station/medical/pathology)
 "rvE" = (
 /turf/closed/wall,
 /area/station/medical/pharmacy)
@@ -50118,6 +50129,7 @@
 /obj/structure/table/glass,
 /obj/item/reagent_containers/cup/beaker,
 /obj/item/reagent_containers/dropper,
+/obj/machinery/camera/directional/west,
 /turf/open/floor/iron/white/diagonal,
 /area/station/medical/pathology)
 "rEO" = (
@@ -54719,6 +54731,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
+/obj/machinery/camera/directional/east,
 /turf/open/floor/wood/large,
 /area/station/medical/pathology)
 "tgy" = (
@@ -84025,7 +84038,7 @@ gqk
 naX
 gqk
 gqk
-gqk
+rvC
 xjH
 kvX
 xoV

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -9858,6 +9858,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
+"cWn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/service/hydroponics/garden)
 "cWu" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -18592,6 +18597,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "fFq" = (
@@ -21102,6 +21108,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
+"gsB" = (
+/obj/machinery/duct,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/garden)
 "gsK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -38070,6 +38080,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "lpQ" = (
@@ -39958,6 +39969,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/directional/east,
+/obj/structure/sink/kitchen/directional/north,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "lRt" = (
@@ -41091,6 +41103,7 @@
 	dir = 5
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "miF" = (
@@ -43481,6 +43494,7 @@
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "mWg" = (
@@ -47244,6 +47258,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "oeq" = (
@@ -49591,6 +49606,10 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"oPT" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/stairs/left,
+/area/station/service/hydroponics/garden)
 "oPZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -49987,6 +50006,7 @@
 /area/station/command/heads_quarters/qm)
 "oWO" = (
 /obj/machinery/growing/tray,
+/obj/machinery/duct,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "oWQ" = (
@@ -50805,6 +50825,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "pju" = (
@@ -51796,6 +51817,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "pBZ" = (
@@ -58611,6 +58633,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "rwB" = (
@@ -60686,6 +60709,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light/directional/west,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "sbR" = (
@@ -63795,6 +63819,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/landmark/navigate_destination,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "tan" = (
@@ -80091,6 +80116,8 @@
 /obj/effect/spawner/random/food_or_drink/seed,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/south,
+/obj/machinery/duct,
+/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "xLC" = (
@@ -111046,7 +111073,7 @@ wUT
 aud
 bvU
 rOj
-aKk
+gsB
 lRn
 tGd
 cwk
@@ -111558,7 +111585,7 @@ bJS
 bJS
 bJS
 neU
-bJS
+cWn
 tGd
 tGd
 tGd
@@ -111815,7 +111842,7 @@ nhC
 nhC
 bJS
 alc
-pKo
+oPT
 sbO
 mis
 tGd

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -9858,11 +9858,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"cWn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/duct,
-/turf/open/floor/plating,
-/area/station/service/hydroponics/garden)
 "cWu" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -21108,10 +21103,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
-"gsB" = (
-/obj/machinery/duct,
-/turf/open/floor/grass,
-/area/station/service/hydroponics/garden)
 "gsK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -21485,6 +21476,10 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/plating,
 /area/station/security/brig/entrance)
+"gyI" = (
+/obj/machinery/duct,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/garden)
 "gyL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -29395,6 +29390,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness)
+"iQp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/station/service/hydroponics/garden)
 "iQq" = (
 /turf/open/floor/iron/stairs/medium{
 	dir = 1
@@ -49606,10 +49606,6 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"oPT" = (
-/obj/machinery/duct,
-/turf/open/floor/iron/stairs/left,
-/area/station/service/hydroponics/garden)
 "oPZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -63852,6 +63848,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"taO" = (
+/obj/machinery/duct,
+/turf/open/floor/iron/stairs/left,
+/area/station/service/hydroponics/garden)
 "taQ" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/reagent_containers/syringe,
@@ -80116,8 +80116,6 @@
 /obj/effect/spawner/random/food_or_drink/seed,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera/autoname/directional/south,
-/obj/machinery/duct,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "xLC" = (
@@ -111073,7 +111071,7 @@ wUT
 aud
 bvU
 rOj
-gsB
+gyI
 lRn
 tGd
 cwk
@@ -111585,7 +111583,7 @@ bJS
 bJS
 bJS
 neU
-cWn
+iQp
 tGd
 tGd
 tGd
@@ -111842,7 +111840,7 @@ nhC
 nhC
 bJS
 alc
-oPT
+taO
 sbO
 mis
 tGd


### PR DESCRIPTION

## About The Pull Request
Fixes some various issues with the maps, and small issues I had with the maps. I have the maps. Including missing cams. weird object placement, and missing objects.
## Why It's Good For The Game
Meta morgue chute is blocked meaning you cant retireve any bodies sent through it. Not good.
Upside holomap on blueshift while funny shoudl be adjusted. 
Meta virology has no cams. This means war crime virus's can't be inspected ahead of time. New cameras are placed that leave the backroom off cams.
Added a sink to Theseus Garden so plants stopped dying. (Nearest was four rooms away in bathrooms.)
## Changelog
:cl:
add: Camera system to meta virology
add: Added sink to Theseus's garden
fix: Adjusted the windows of meta morgue chute to not block the chute.
fix: Fixed upside engi map in blueshift's bridge so the captain pilots the ship in the right direction
/:cl:
