### PR TITLE
Improves Icebox Station's kitchen

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -129,9 +129,6 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/chair{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red/full,
 /turf/open/floor/iron/large,
 /area/station/service/kitchen/diner)
@@ -747,11 +744,14 @@
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
 "aon" = (
-/obj/machinery/deepfryer,
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/structure/sign/poster/contraband/moffuchis_pizza/directional/east,
 /obj/machinery/camera/directional/east{
 	c_tag = "Service Kitchen"
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
@@ -1796,12 +1796,14 @@
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "aEU" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "kitchencounter";
+	name = "Kitchen Counter Shutters"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/item/food/snowcones/rainbow,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "aFg" = (
@@ -1951,10 +1953,11 @@
 /area/station/command/meeting_room)
 "aHZ" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/table,
+/obj/item/knife/kitchen{
+	pixel_y = 2
 	},
-/obj/effect/landmark/start/cook,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "aIe" = (
@@ -3440,7 +3443,7 @@
 "beT" = (
 /obj/structure/table/glass,
 /obj/item/cultivator,
-/turf/open/floor/plating,
+/turf/open/floor/wood/parquet,
 /area/station/maintenance/starboard/fore)
 "beZ" = (
 /turf/closed/indestructible/riveted{
@@ -8480,9 +8483,8 @@
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
 "cDw" = (
-/obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/glass{
-	name = "Maintenance"
+	name = "Personal Garden"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
 /obj/effect/mapping_helpers/airlock/unres,
@@ -9138,6 +9140,7 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/light/directional/south,
 /obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/item/reagent_containers/condiment/enzyme,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "cMv" = (
@@ -13230,14 +13233,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
-"ecZ" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/machinery/reagentgrinder{
-	pixel_y = 9
-	},
-/turf/open/floor/iron/kitchen/diagonal,
-/area/station/service/kitchen)
 "edd" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -13561,7 +13556,7 @@
 /area/station/security/execution/transfer)
 "eie" = (
 /obj/machinery/light/small/directional/north,
-/turf/open/floor/plating,
+/turf/open/floor/wood/parquet,
 /area/station/maintenance/starboard/fore)
 "eig" = (
 /obj/structure/rack,
@@ -13698,12 +13693,19 @@
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "eke" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/structure/closet/mini_fridge{
-	name = "mini-fridge"
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 8;
+	id = "kitchencounter";
+	name = "Kitchen Counter Shutters"
 	},
-/obj/item/reagent_containers/condiment/milk,
+/obj/machinery/door/firedoor,
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3
+	},
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "ekq" = (
@@ -15330,13 +15332,13 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/mine/mechbay)
 "eLT" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north{
 	dir = 8;
 	name = "Hydroponics Desk";
 	req_access = list("hydroponics")
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/biogenerator,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "eLW" = (
@@ -15794,12 +15796,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "eUw" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/item/storage/bag/tray,
-/obj/item/knife/kitchen{
-	pixel_y = 2
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "kitchencounter";
+	name = "Kitchen Counter Shutters"
 	},
+/obj/machinery/door/firedoor,
+/obj/item/holosign_creator/robot_seat/restaurant,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "eUD" = (
@@ -17337,6 +17341,7 @@
 	req_access = list("kitchen")
 	},
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/machinery/holopad,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "ftN" = (
@@ -18594,8 +18599,6 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/clothing/head/fedora,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen/diner)
@@ -18877,12 +18880,13 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/structure/sign/poster/random/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Service Diner North"
+	},
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets{
+	pixel_y = 8
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen/diner)
@@ -19525,10 +19529,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
 "ggD" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/red/full,
+/obj/structure/table,
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 3
+	},
 /turf/open/floor/iron/large,
 /area/station/service/kitchen/diner)
 "ggG" = (
@@ -23131,7 +23139,7 @@
 "hrt" = (
 /obj/structure/table/glass,
 /obj/item/shovel/spade,
-/turf/open/floor/plating,
+/turf/open/floor/wood/parquet,
 /area/station/maintenance/starboard/fore)
 "hrJ" = (
 /obj/effect/spawner/structure/window,
@@ -29473,10 +29481,8 @@
 /area/station/hallway/primary/central)
 "jwv" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
+/obj/structure/table,
+/obj/item/kitchen/spoon/soup_ladle,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "jwx" = (
@@ -30629,7 +30635,7 @@
 /area/station/maintenance/aft/lesser)
 "jQo" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/machinery/grill,
+/obj/structure/table,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "jQt" = (
@@ -31200,15 +31206,11 @@
 /turf/open/floor/iron,
 /area/mine/eva)
 "jZt" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/item/plate,
-/obj/item/reagent_containers/condiment/enzyme{
-	pixel_x = -7;
-	pixel_y = 6
+/obj/structure/chair{
+	dir = 4
 	},
-/turf/open/floor/iron/kitchen/diagonal,
-/area/station/service/kitchen)
+/turf/open/floor/iron/white/smooth_large,
+/area/station/service/kitchen/diner)
 "jZB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -32643,10 +32645,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
 "kvs" = (
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "kitchencounter";
+	name = "Kitchen Counter Shutters"
 	},
+/obj/machinery/door/firedoor,
+/obj/item/food/snowcones/rainbow,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "kvA" = (
@@ -33489,7 +33495,7 @@
 "kKl" = (
 /obj/structure/table/glass,
 /obj/item/plant_analyzer,
-/turf/open/floor/plating,
+/turf/open/floor/wood/parquet,
 /area/station/maintenance/starboard/fore)
 "kKv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33795,13 +33801,13 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "kPe" = (
-/obj/machinery/growing/tray,
-/obj/effect/turf_decal/siding/wideplating/dark{
-	dir = 1
+/obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 5
 	},
-/obj/item/seeds/watermelon,
-/turf/open/floor/grass,
-/area/station/maintenance/starboard/fore)
+/turf/open/floor/iron/kitchen/diagonal,
+/area/station/service/kitchen)
 "kPg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35957,14 +35963,10 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/tools)
 "lxf" = (
-/obj/structure/table,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 3
-	},
 /obj/effect/turf_decal/tile/red/full,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/iron/large,
 /area/station/service/kitchen/diner)
 "lxj" = (
@@ -37604,8 +37606,9 @@
 /area/station/hallway/primary/starboard)
 "lZv" = (
 /obj/structure/table/glass,
-/obj/item/seeds/bamboo,
-/turf/open/floor/plating,
+/obj/effect/spawner/random/food_or_drink/seed,
+/obj/effect/spawner/random/food_or_drink/seed,
+/turf/open/floor/wood/parquet,
 /area/station/maintenance/starboard/fore)
 "lZQ" = (
 /obj/machinery/airalarm/directional/west,
@@ -39699,7 +39702,7 @@
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 1
 	},
-/obj/item/seeds/berry,
+/obj/effect/spawner/random/food_or_drink/seed,
 /turf/open/floor/grass,
 /area/station/maintenance/starboard/fore)
 "mKq" = (
@@ -39910,7 +39913,9 @@
 /area/station/medical/chemistry)
 "mOz" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/machinery/stove,
+/obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/cake_ingredients,
+/obj/item/food/dough,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "mOA" = (
@@ -42161,7 +42166,7 @@
 "nwI" = (
 /obj/item/reagent_containers/cup/bucket,
 /obj/structure/sink/directional/east,
-/turf/open/floor/plating,
+/turf/open/floor/wood/parquet,
 /area/station/maintenance/starboard/fore)
 "nwT" = (
 /turf/closed/wall,
@@ -43828,8 +43833,8 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "nTI" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/table,
 /obj/machinery/processor{
 	pixel_y = 6
 	},
@@ -48465,11 +48470,8 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/machinery/newscaster/directional/north,
-/obj/effect/landmark/start/hangover,
+/obj/machinery/restaurant_portal/restaurant,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen/diner)
 "ptx" = (
@@ -50465,11 +50467,9 @@
 /turf/open/floor/iron,
 /area/station/service/janitor)
 "pYI" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "pYT" = (
@@ -50770,10 +50770,10 @@
 /turf/open/floor/iron,
 /area/station/security/processing)
 "qfe" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
+/obj/structure/table,
 /obj/item/book/manual/chef_recipes,
-/obj/item/holosign_creator/robot_seat/restaurant,
+/obj/item/reagent_containers/cup/rag,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "qfh" = (
@@ -52195,20 +52195,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "qDZ" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/item/reagent_containers/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/item/reagent_containers/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/effect/spawner/random/food_or_drink/cake_ingredients,
-/obj/item/food/piedough,
-/obj/item/kitchen/spoon/soup_ladle,
-/obj/item/reagent_containers/cup/soup_pot,
-/turf/open/floor/iron/kitchen/diagonal,
-/area/station/service/kitchen)
+/turf/open/floor/wood/parquet,
+/area/station/maintenance/starboard/fore)
 "qEa" = (
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
@@ -52452,9 +52440,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "qIv" = (
-/obj/machinery/icecream_vat,
 /obj/effect/turf_decal/tile/brown/diagonal_edge,
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/machinery/icecream_vat,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "qIB" = (
@@ -58637,9 +58625,6 @@
 "sIC" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
-	},
-/obj/structure/chair{
-	dir = 8
 	},
 /obj/structure/sign/poster/random/directional/north,
 /obj/machinery/light/directional/north,
@@ -64938,8 +64923,10 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/machinery/restaurant_portal/restaurant,
 /obj/effect/turf_decal/tile/red/full,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron/large,
 /area/station/service/kitchen/diner)
 "uOL" = (
@@ -67877,10 +67864,7 @@
 /area/station/service/chapel/office)
 "vMq" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/holopad,
+/obj/effect/landmark/start/cook,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "vMA" = (
@@ -67904,8 +67888,8 @@
 /area/station/hallway/primary/central)
 "vMR" = (
 /obj/structure/table/glass,
-/obj/item/seeds/glowshroom,
-/turf/open/floor/plating,
+/obj/item/seeds/tomato,
+/turf/open/floor/wood/parquet,
 /area/station/maintenance/starboard/fore)
 "vND" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -68714,11 +68698,10 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/effect/spawner/random/food_or_drink/donkpockets{
-	pixel_y = 8
-	},
 /obj/machinery/light/directional/north,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/service/kitchen/diner)
 "wbN" = (
@@ -69669,10 +69652,11 @@
 /turf/open/floor/iron/dark,
 /area/mine/storage)
 "wqZ" = (
-/obj/machinery/deepfryer,
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/machinery/light/directional/east,
 /obj/machinery/firealarm/directional/east,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/deepfryer,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
 "wrc" = (
@@ -70873,7 +70857,7 @@
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
@@ -71999,9 +71983,6 @@
 /area/station/commons/fitness)
 "xbn" = (
 /obj/effect/turf_decal/tile/neutral/diagonal_edge,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/kitchen/diagonal,
 /area/station/service/kitchen)
@@ -72639,11 +72620,19 @@
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
 "xlv" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	dir = 1;
+	id = "kitchencounter";
+	name = "Kitchen Counter Shutters"
 	},
-/turf/open/floor/iron/white/smooth_large,
-/area/station/service/kitchen/diner)
+/obj/machinery/door/firedoor,
+/obj/structure/closet/mini_fridge{
+	name = "mini-fridge"
+	},
+/obj/item/reagent_containers/condiment/milk,
+/turf/open/floor/iron/kitchen/diagonal,
+/area/station/service/kitchen)
 "xlx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -244349,7 +244338,7 @@ fgE
 shh
 mdZ
 uOH
-rDF
+jZt
 rSK
 rBt
 gyr
@@ -244610,8 +244599,8 @@ ggD
 pNV
 cpY
 pxF
-iYi
-iYi
+eke
+aEU
 iYi
 iYi
 ifw
@@ -244865,7 +244854,7 @@ mdZ
 wbB
 lxf
 eBa
-qZB
+eUw
 ftM
 gtw
 gtw
@@ -245120,11 +245109,11 @@ cnf
 vLQ
 mdZ
 acx
-xlv
+rDF
 oDm
 qZB
 gtw
-xHi
+kPe
 aHZ
 jwv
 pYI
@@ -245377,14 +245366,14 @@ kQX
 tGZ
 mdZ
 ptp
-ggD
+sHB
 ifg
 qZB
 gtw
 jQo
 vMq
-eUw
-jZt
+gtw
+gtw
 fkk
 cMs
 cpY
@@ -245634,14 +245623,14 @@ rrx
 nIr
 mdZ
 fRJ
-lxf
+sHB
 son
-qZB
+kvs
 gtw
-kpf
+qfe
 xbn
-qDZ
-eke
+xHi
+kpf
 fkk
 bpG
 onv
@@ -245891,14 +245880,14 @@ mKh
 kKL
 kKL
 sIC
-xlv
+rDF
 iXH
-qZB
+xlv
 oEh
 mOz
-kvs
-qfe
-ecZ
+gtw
+xHi
+kpf
 fkk
 qIv
 onv
@@ -246153,7 +246142,7 @@ son
 tCl
 eDx
 fkk
-aEU
+fMP
 fMP
 fMP
 oyV
@@ -246929,7 +246918,7 @@ kKL
 kKl
 beT
 nwI
-kPe
+mKi
 kKL
 veJ
 vwO
@@ -247184,8 +247173,8 @@ kKL
 cSQ
 kKL
 eie
-lli
-lli
+qDZ
+qDZ
 mKi
 kKL
 rjP
@@ -247440,9 +247429,9 @@ fRP
 kKL
 cSQ
 cDw
-lli
-lli
-lli
+qDZ
+qDZ
+qDZ
 mkj
 kKL
 cwO


### PR DESCRIPTION
## About The Pull Request

"Majorly" improves Ice Box Station's lackluster kitchen. 
- Reformats the main kitchen area
- Removes the grill
-  Makes the airlock for the small garden behind the Kitchen no longer abandoned
- Replaces most of the seed spawns in said garden with random seed spawners
- Puts a Biogenerator on the front desk of Botany
- Shifts around the tables at the top of the diner to make the Restaurant Portal slightly easier to use (PLEASE FIX THIS DAMNED THING)
- Upgrades the Stove into a second Range
- Removes one of the unneeded Deep Fryers
- Adds a couple Snowcones to the serving table (Get it, because it's Icebox)

## Why It's Good For The Game

Ice Box's previous kitchen was a major pain. It wasn't a BAD design, but it felt a bit annoying. Stoves have VERY little use compared to Ranges, so having one was just a waste of space. The Grill also never came with fuel and is designed to be a cargo purchase item. For some reason a Mini-fridge was placed right in the middle of the tables as well. This version should be a lot less clunky.
![image](https://github.com/user-attachments/assets/14d05142-38b4-436a-97d6-1d0d3eeec9c6)

## Changelog
:cl: Meowosers
add: Placed a Biogenerator on the front desk of Icebox Station's Hydroponics
qol: Rearranged Icebox Station's Kitchen
/:cl:
