### PR TITLE
Fixes radio mic being delayed

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -331,8 +331,11 @@
 		signal.levels = list(0)
 		signal.broadcast()
 		return
-	// monkestation edit: "lossless" var
-	if(lossless)
+	// monkestation edit: "lossless" var, radio host stuff
+	if(radio_host)
+		backup_transmission(signal) // just immediately do direct signal transmission
+		return
+	else if(lossless)
 		signal.data["compression"] = 0
 	// monkestation end
 


### PR DESCRIPTION

## About The Pull Request

As a side effect of https://github.com/Monkestation/Monkestation2.0/pull/3708, due to the radio freq not being telecomms, this resulted in the radio mic always needing to use the `backup_transmission`. This fixes that, by just... doing that immediately.

## Changelog
:cl:
fix: Fixed the radio mic being delayed by 2 seconds.
/:cl:
