### PR TITLE
Adding recent jobs as contract targets

### DIFF
--- a/monkestation/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/monkestation/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -71,7 +71,6 @@
 		/datum/job/cook,
 		// Monkestation edit: security assistants & brig docs
 		/datum/job/security_assistant,
-		/datum/job/brig_physician,
 	)
 	alive_bonus = 4
 
@@ -90,6 +89,8 @@
 		/datum/job/detective,
 		/datum/job/security_officer,
 		/datum/job/warden,
+		// Monkestation edit: brig docs
+		/datum/job/brig_physician,
 	)
 	alive_bonus = 5
 

--- a/monkestation/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/monkestation/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -69,7 +69,7 @@
 		/datum/job/paramedic,
 		// Service
 		/datum/job/cook,
-		// Monkestation edit: security assistants & brig docs
+		// Monkestation edit: security assistants
 		/datum/job/security_assistant,
 	)
 	alive_bonus = 4

--- a/monkestation/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/monkestation/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -69,8 +69,9 @@
 		/datum/job/paramedic,
 		// Service
 		/datum/job/cook,
-		// Monkestation edit: security assistants
+		// Monkestation edit: security assistants & brig docs
 		/datum/job/security_assistant,
+		/datum/job/brig_physician,
 	)
 	alive_bonus = 4
 
@@ -100,6 +101,8 @@
 	target_jobs = list(
 		/datum/job/captain,
 		/datum/job/head_of_security,
+		// Monkestation edit: Blueshields
+		/datum/job/blueshield,
 	)
 	alive_bonus = 6
 


### PR DESCRIPTION
## About The Pull Request
"Welcome agent, Nanotrasen has grown, and as such we have new contracts for you."

Adds the recent additions to the NT's roster to contractors kidnapping list. Blueshield and brig physician. 
## Why It's Good For The Game
I hope obviously I dont need to argue the merits of why the additions are good. Certain jobs being exempt of objectives.

But Ill shortly argue the meretis of each postion.
### Blueshield
Captain Level
Blueshields are assumed to be on the level of a Captain and HOS in their innate lethality and difficulty to catch. In addition to their variety and uniqueness of access. Ontop of that I'm sure syndicate would be willing to pay top dollar to interrogate someone from Central Command directly.

### Brig physician
Rare
Brig physicians _should_ be in brig for most if not all of the shift. Which often will have some variety of secoffs and the warden. And while some infirmaries have maint access some really dont. Take blueshift. If your bold enough to break into the brig for one of these medics, you should be compensated for it.
## Changelog
:cl:
add: Adds Blueshields and brig physicians to the kidnapping objectives target lists.
/:cl:
