### PR TITLE
[Bounty] Adds Blueshield Alt Titles

### DIFF
--- a/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
+++ b/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
@@ -370,3 +370,13 @@
 		"Brig Governor",
 		"Jailer",
 	)
+
+/datum/job/blueshield
+	alt_titles = list(
+		"Blueshield",
+		"Corporate Henchman",
+		"Bodyguard",
+		"Revolutionary Repellent",
+		"Heavily Armed Butler",
+		"Honor Guard",
+	)


### PR DESCRIPTION

## About The Pull Request
Title, gives blueshield alt titles of Corporate Henchman, Bodyguard, Revolutionary Repellent, Heavily Armed Butler, and Honor Guard
## Why It's Good For The Game
Makes Blueshield more consistent with other jobs
## Changelog
:cl:
add: Gives the Blueshield 5 new alt titles
/:cl:
