### PR TITLE
Adjusts radio radio frequency visuals

### DIFF
--- a/tgui/packages/tgui/constants.ts
+++ b/tgui/packages/tgui/constants.ts
@@ -147,7 +147,7 @@ export const RADIO_CHANNELS = [
   },
   {
     name: 'Radio',
-    freq: 1443,
+    freq: 1361,
     color: '#FFC0CB',
   },
 ] as const;

--- a/tgui/packages/tgui/constants.ts
+++ b/tgui/packages/tgui/constants.ts
@@ -147,7 +147,7 @@ export const RADIO_CHANNELS = [
   },
   {
     name: 'Radio',
-    freq: 1361,
+    freq: 1361, // monkestation edit
     color: '#FFC0CB',
   },
 ] as const;

--- a/tgui/packages/tgui/constants.ts
+++ b/tgui/packages/tgui/constants.ts
@@ -147,7 +147,7 @@ export const RADIO_CHANNELS = [
   },
   {
     name: 'Radio',
-    freq: 1361, // monkestation edit
+    freq: 1361,
     color: '#FFC0CB',
   },
 ] as const;


### PR DESCRIPTION

## About The Pull Request
a followup to pull #3708 that moved radio frquency into the reserve range. The text that showed for it and colour would still show on its old spot on radios. Moves it to the new spot.
## Why It's Good For The Game
You tune into a frequency for a given effect. The effect is not given. Feels bad.
## Changelog
:cl:
fix: Fixed the visuals of radio frequency showing on its old frequency spot.
/:cl:
