### PR TITLE
Ports DmIcon from Paradise and /tg/

### DIFF
--- a/code/controllers/subsystem/early_assets.dm
+++ b/code/controllers/subsystem/early_assets.dm
@@ -10,10 +10,10 @@ SUBSYSTEM_DEF(early_assets)
 
 /datum/controller/subsystem/early_assets/Initialize()
 	for (var/datum/asset/asset_type as anything in subtypesof(/datum/asset))
-		if (initial(asset_type._abstract) == asset_type)
+		if (asset_type::_abstract == asset_type)
 			continue
 
-		if (!initial(asset_type.early))
+		if (!asset_type::early)
 			continue
 
 		if (!load_asset_datum(asset_type))

--- a/code/modules/asset_cache/assets/icon_ref_map.dm
+++ b/code/modules/asset_cache/assets/icon_ref_map.dm
@@ -1,0 +1,28 @@
+/// Maps icon names to ref values
+/datum/asset/json/icon_ref_map
+	name = "icon_ref_map"
+	early = TRUE
+
+/datum/asset/json/icon_ref_map/generate()
+	var/list/data = list() //"icons/obj/drinks.dmi" => "[0xc000020]"
+
+	//var/start = "0xc000000"
+	var/value = 0
+
+	while(TRUE)
+		value += 1
+		var/ref = "\[0xc[num2text(value,6,16)]\]"
+		var/mystery_meat = locate(ref)
+
+		if(isicon(mystery_meat))
+			if(!isfile(mystery_meat)) // Ignore the runtime icons for now
+				continue
+			var/path = get_icon_dmi_path(mystery_meat) //Try to get the icon path
+			if(path)
+				data[path] = ref
+		else if(mystery_meat)
+			continue; //Some other non-icon resource, ogg/json/whatever
+		else //Out of resources end this, could also try to end this earlier as soon as runtime generated icons appear but eh
+			break;
+
+	return data

--- a/code/modules/hydroponics/seed_extractor.dm
+++ b/code/modules/hydroponics/seed_extractor.dm
@@ -197,7 +197,8 @@
 		piles[seed_id]["refs"] += WEAKREF(to_add)
 	else
 		var/list/seed_data = list()
-		seed_data["icon"] = sanitize_css_class_name("[initial(to_add.icon)][initial(to_add.icon_state)]")
+		seed_data["icon"] = to_add.icon
+		seed_data["icon_state"] = to_add.icon_state
 		seed_data["name"] = capitalize(replacetext(to_add.name,"pack of ", ""));
 		seed_data["lifespan"] = to_add.lifespan
 		seed_data["endurance"] = to_add.endurance
@@ -291,7 +292,14 @@
 				INVOKE_ASYNC(src, TYPE_PROC_REF(/datum, update_static_data_for_all_viewers)) // monkestation edit: lagfixing
 				. = TRUE
 
-/obj/machinery/seed_extractor/ui_assets(mob/user)
-	return list(
-		get_asset_datum(/datum/asset/spritesheet/seeds)
-	)
+/obj/machinery/seed_extractor/perftest/Initialize(mapload, obj/item/seeds/new_seed)
+	. = ..()
+	INVOKE_ASYNC(src, PROC_REF(add_random_seeds))
+
+/obj/machinery/seed_extractor/perftest/proc/add_random_seeds()
+	for(var/i = 1 to 500)
+		add_seed(new /obj/item/seeds/random)
+	var/list/seed_types = subtypesof(/obj/item/seeds)
+	for(var/i = 1 to 250)
+		var/seed_type = pick(seed_types)
+		add_seed(new seed_type)

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -118,6 +118,8 @@
 		/datum/asset/simple/namespaced/fontawesome))
 	flush_queue |= window.send_asset(get_asset_datum(
 		/datum/asset/simple/namespaced/tgfont))
+	flush_queue |= window.send_asset(get_asset_datum(
+		/datum/asset/json/icon_ref_map))
 	for(var/datum/asset/asset in src_object.ui_assets(user))
 		flush_queue |= window.send_asset(asset)
 	if (flush_queue)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3091,6 +3091,7 @@
 #include "code\modules\asset_cache\assets\fontawesome.dm"
 #include "code\modules\asset_cache\assets\genetics.dm"
 #include "code\modules\asset_cache\assets\headers.dm"
+#include "code\modules\asset_cache\assets\icon_ref_map.dm"
 #include "code\modules\asset_cache\assets\inventory.dm"
 #include "code\modules\asset_cache\assets\irv.dm"
 #include "code\modules\asset_cache\assets\jquery.dm"

--- a/tgui/docs/component-reference.md
+++ b/tgui/docs/component-reference.md
@@ -8,51 +8,55 @@ This table of contents must be manually maintained.
 Make sure to add new items to this list if you document new components.
 -->
 
-- [General Concepts](#general-concepts)
-- [`tgui/components`](#tguicomponents)
-  - [`AnimatedNumber`](#animatednumber)
-  - [`BlockQuote`](#blockquote)
-  - [`Box`](#box)
-  - [`Button`](#button)
-  - [`Button.Checkbox`](#buttoncheckbox)
-  - [`Button.Confirm`](#buttonconfirm)
-  - [`Button.Input`](#buttoninput)
-  - [`ByondUi`](#byondui)
-  - [`Collapsible`](#collapsible)
-  - [`ColorBox`](#colorbox)
-  - [`Dimmer`](#dimmer)
-  - [`Divider`](#divider)
-  - [`Dropdown`](#dropdown)
-  - [`Flex`](#flex)
-  - [`Flex.Item`](#flexitem)
-  - [`Grid`](#grid)
-  - [`Grid.Column`](#gridcolumn)
-  - [`Icon`](#icon)
-  - [`Icon.Stack`](#iconstack)
-  - [`Input`](#input)
-  - [`Knob`](#knob)
-  - [`LabeledControls`](#labeledcontrols)
-  - [`LabeledControls.Item`](#labeledcontrolsitem)
-  - [`LabeledList`](#labeledlist)
-  - [`LabeledList.Item`](#labeledlistitem)
-  - [`LabeledList.Divider`](#labeledlistdivider)
-  - [`Modal`](#modal)
-  - [`NoticeBox`](#noticebox)
-  - [`NumberInput`](#numberinput)
-  - [`ProgressBar`](#progressbar)
-  - [`RoundGauge`](#roundgauge)
-  - [`Section`](#section)
-  - [`Slider`](#slider)
-  - [`Stack`](#stack)
-  - [`Table`](#table)
-  - [`Table.Row`](#tablerow)
-  - [`Table.Cell`](#tablecell)
-  - [`Tabs`](#tabs)
-  - [`Tabs.Tab`](#tabstab)
-  - [`Tooltip`](#tooltip)
-- [`tgui/layouts`](#tguilayouts)
-  - [`Window`](#window)
-  - [`Window.Content`](#windowcontent)
+- [Component Reference](#component-reference)
+  - [General Concepts](#general-concepts)
+  - [`tgui/components`](#tguicomponents)
+    - [`AnimatedNumber`](#animatednumber)
+    - [`BlockQuote`](#blockquote)
+    - [`Box`](#box)
+    - [`Button`](#button)
+    - [`Button.Checkbox`](#buttoncheckbox)
+    - [`Button.Confirm`](#buttonconfirm)
+    - [`Button.Input`](#buttoninput)
+    - [`ByondUi`](#byondui)
+    - [`Collapsible`](#collapsible)
+    - [`ColorBox`](#colorbox)
+    - [`Dimmer`](#dimmer)
+    - [`Divider`](#divider)
+    - [`Dropdown`](#dropdown)
+    - [`Flex`](#flex)
+    - [`Flex.Item`](#flexitem)
+    - [`Grid`](#grid)
+    - [`Grid.Column`](#gridcolumn)
+    - [`Icon`](#icon)
+    - [`Icon.Stack`](#iconstack)
+    - [`ImageButton`](#imagebutton)
+    - [`Input`](#input)
+    - [`Knob`](#knob)
+    - [`LabeledControls`](#labeledcontrols)
+    - [`LabeledControls.Item`](#labeledcontrolsitem)
+    - [`LabeledList`](#labeledlist)
+    - [`LabeledList.Item`](#labeledlistitem)
+    - [`LabeledList.Divider`](#labeledlistdivider)
+    - [`Modal`](#modal)
+    - [`NoticeBox`](#noticebox)
+    - [`NumberInput`](#numberinput)
+    - [`Popper`](#popper)
+    - [`ProgressBar`](#progressbar)
+    - [`RoundGauge`](#roundgauge)
+    - [`Section`](#section)
+    - [`Slider`](#slider)
+    - [`Stack`](#stack)
+    - [`Stack.Item`](#stackitem)
+    - [`Table`](#table)
+    - [`Table.Row`](#tablerow)
+    - [`Table.Cell`](#tablecell)
+    - [`Tabs`](#tabs)
+    - [`Tabs.Tab`](#tabstab)
+    - [`Tooltip`](#tooltip)
+  - [`tgui/layouts`](#tguilayouts)
+    - [`Window`](#window)
+    - [`Window.Content`](#windowcontent)
 
 ## General Concepts
 
@@ -549,6 +553,43 @@ Renders children icons on top of each other in order to make your own icon.
 
 - See inherited props: [Box](#box)
 - `children: Icon` - Icons to stack.
+
+### `ImageButton`
+
+A Robust button is specifically for sticking a picture in it.
+
+**Props:**
+
+- See inherited props: [Box](#box)
+- `asset: string[]` - Asset cache. Example: `asset={`assetname32x32, ${thing.key}`}`
+- `base64: string` - Classic way to put images. Example: `base64={thing.image}`
+- `buttons: any` - Special section for any component, or, content.
+  Quite a small area at the bottom of the image in non-fluid mode.
+  Has a style overrides, best to use [Button](#button) inside.
+- `buttonsAlt: boolean` - Enables alternative buttons layout.
+  With fluid, makes buttons like a humburger.
+  Without, moves it to top, and disables pointer-events.
+- `children: any` - Content under image.
+- `className: string` - Applies a CSS class to the element.
+- `color: string` - Color of the button, but without `transparent`; see [Button](#button)
+- `disabled: boolean` - Makes button disabled and dark red if true.
+  Also disables onClick & onRightClick.
+- `selected: boolean` - Makes button selected and green if true.
+- `dmFallback: any` - Optional. Adds a "stub" when loading DmIcon.
+- `dmIcon: string` - Parameter `icon` of component `DmIcon`.
+- `dmIconState: string` - Parameter `icon_state` of component `DmIcon`.
+  For proper work of `DmIcon` it is necessary that both parameters are filled in!
+- `fluid: boolean` - Changes the layout of the button, making it fill the entire horizontally available space.
+  Allows the use of `title`
+- `imageSize: number` - Parameter responsible for the size of the image, component and standard "stubs".
+  Measured in pixels. `imageSize={64}` = 64px.
+- `imageSrc: string` - Prop `src` of <img>. Example: `imageSrc={resolveAsset(thing.image)}`
+- `onClick: (e) => void` - Called when button is clicked with LMB.
+- `onRightClick: (e) => void` - Called when button is clicked with RMB.
+- `title: string` - Requires `fluid` for work. Bold text with divider betwen content.
+- `tooltip: string` - A fancy, boxy tooltip, which appears when hovering
+over the button.
+- `tooltipPosition: string` - Position of the tooltip. See [`Popper`](#Popper) for valid options.
 
 ### `Input`
 

--- a/tgui/global.d.ts
+++ b/tgui/global.d.ts
@@ -188,6 +188,11 @@ type ByondType = {
    * Loads a script into the document.
    */
   loadJs(url: string): void;
+
+  /**
+   * Maps icons to their ref
+   */
+  iconRefMap: Record<string, string>;
 };
 
 /**

--- a/tgui/packages/tgui/components/DmIcon.tsx
+++ b/tgui/packages/tgui/components/DmIcon.tsx
@@ -1,0 +1,89 @@
+import { Component, InfernoNode } from 'inferno';
+import { resolveAsset } from '../assets';
+import { fetchRetry } from '../http';
+import { BoxProps } from './Box';
+import { Image } from './Image';
+
+enum Direction {
+  NORTH = 1,
+  SOUTH = 2,
+  EAST = 4,
+  WEST = 8,
+  NORTHEAST = NORTH | EAST,
+  NORTHWEST = NORTH | WEST,
+  SOUTHEAST = SOUTH | EAST,
+  SOUTHWEST = SOUTH | WEST,
+}
+
+type DmIconProps = {
+  /** Required: The path of the icon */
+  icon: string;
+  /** Required: The state of the icon */
+  icon_state: string;
+} & Partial<{
+  /** Facing direction. See direction enum. Default is South */
+  direction: Direction;
+  /** Fallback icon. */
+  fallback: InfernoNode;
+  /** Frame number. Default is 1 */
+  frame: number;
+  /** Movement state. Default is false */
+  movement: any;
+}> &
+  BoxProps;
+
+type DmIconState = {
+  iconRef: string;
+};
+
+let refMap: Record<string, string> | undefined;
+
+export class DmIcon extends Component<DmIconProps, DmIconState> {
+  state: DmIconState = {
+    iconRef: '',
+  };
+
+  async fetchRefMap() {
+    const response = await fetchRetry(resolveAsset('icon_ref_map.json'));
+    const data = await response.json();
+    refMap = data;
+    this.setState({ iconRef: data[this.props.icon] });
+  }
+
+  componentDidMount() {
+    this.updateOrFetchRefMap();
+  }
+
+  componentDidUpdate(prevProps: DmIconProps) {
+    if (prevProps.icon !== this.props.icon) {
+      this.updateOrFetchRefMap();
+    }
+  }
+
+  updateOrFetchRefMap() {
+    if (refMap) {
+      this.setState({ iconRef: refMap[this.props.icon] });
+    } else {
+      this.fetchRefMap();
+    }
+  }
+
+  render() {
+    const {
+      className,
+      direction = Direction.SOUTH,
+      fallback,
+      frame = 1,
+      icon_state,
+      movement = false,
+      ...rest
+    } = this.props;
+    const { iconRef } = this.state;
+
+    const query = `${iconRef}?state=${icon_state}&dir=${direction}&movement=${!!movement}&frame=${frame}`;
+
+    if (!iconRef) return fallback || null;
+
+    return <Image fixErrors src={query} {...rest} />;
+  }
+}

--- a/tgui/packages/tgui/components/Image.tsx
+++ b/tgui/packages/tgui/components/Image.tsx
@@ -1,0 +1,70 @@
+import { Component } from 'inferno';
+import { BoxProps, computeBoxProps } from './Box';
+
+type Props = Partial<{
+  /** True is default, this fixes an ie thing */
+  fixBlur: boolean;
+  /** False by default. Good if you're fetching images on UIs that do not auto update. This will attempt to fix the 'x' icon 5 times. */
+  fixErrors: boolean;
+  /** Fill is default. */
+  objectFit: 'contain' | 'cover';
+}> &
+  IconUnion &
+  BoxProps;
+
+// at least one of these is required
+type IconUnion =
+  | {
+      className?: string;
+      src: string;
+    }
+  | {
+      className: string;
+      src?: string;
+    };
+
+const maxAttempts = 5;
+
+/** Image component. Use this instead of Box as="img". */
+export class Image extends Component<Props> {
+  attempts: number = 0;
+
+  handleError = (event) => {
+    const { fixErrors, src } = this.props;
+    if (fixErrors && this.attempts < maxAttempts) {
+      const imgElement = event.currentTarget;
+
+      setTimeout(() => {
+        imgElement.src = `${src}?attempt=${this.attempts}`;
+        this.attempts++;
+      }, 1000);
+    }
+  };
+
+  render() {
+    const {
+      fixBlur = true,
+      fixErrors = false,
+      objectFit = 'fill',
+      src,
+      ...rest
+    } = this.props;
+
+    /* Remove -ms-interpolation-mode with Byond 516. -webkit-optimize-contrast is better than pixelated */
+    const computedProps = computeBoxProps({
+      style: {
+        '-ms-interpolation-mode': `${fixBlur ? 'nearest-neighbor' : 'auto'}`,
+        'image-rendering': `${fixBlur ? '-webkit-optimize-contrast' : 'auto'}`,
+        'object-fit': `${objectFit}`,
+      },
+      ...rest,
+    });
+
+    /* Use div instead img if used asset, cause img with class leaves white border on 516 */
+    if (computedProps.className) {
+      return <div onError={this.handleError} {...computedProps} />;
+    }
+
+    return <img onError={this.handleError} src={src} {...computedProps} />;
+  }
+}

--- a/tgui/packages/tgui/components/index.jsx
+++ b/tgui/packages/tgui/components/index.jsx
@@ -21,6 +21,8 @@ export { Dropdown } from './Dropdown';
 export { Flex } from './Flex';
 export { FitText } from './FitText';
 export { Grid } from './Grid';
+export { Image } from './Image';
+export { DmIcon } from './DmIcon';
 export { Icon } from './Icon';
 export { ImageButton } from './ImageButton';
 export { InfinitePlane } from './InfinitePlane';

--- a/tgui/packages/tgui/icons.ts
+++ b/tgui/packages/tgui/icons.ts
@@ -1,0 +1,14 @@
+import { resolveAsset } from './assets';
+import { fetchRetry } from './http';
+import { logger } from './logging';
+
+export const loadIconRefMap = function () {
+  if (Byond.iconRefMap && Object.keys(Byond.iconRefMap).length > 0) {
+    return;
+  }
+
+  fetchRetry(resolveAsset('icon_ref_map.json'))
+    .then((res) => res.json())
+    .then((data) => (Byond.iconRefMap = data))
+    .catch((error) => logger.log(error));
+};

--- a/tgui/packages/tgui/index.tsx
+++ b/tgui/packages/tgui/index.tsx
@@ -42,6 +42,7 @@ import { setupGlobalEvents } from './events';
 import { setupHotKeys } from './hotkeys';
 import { setupHotReloading } from 'tgui-dev-server/link/client.cjs';
 import { setGlobalStore } from './backend';
+import { loadIconRefMap } from './icons';
 
 perf.mark('inception', window.performance?.timing?.navigationStart);
 perf.mark('init');
@@ -50,6 +51,7 @@ const store = configureStore();
 
 const renderApp = createRenderer(() => {
   setGlobalStore(store);
+  loadIconRefMap();
 
   const { getRoutedComponent } = require('./routes');
   const Component = getRoutedComponent(store);

--- a/tgui/packages/tgui/interfaces/SeedExtractor.tsx
+++ b/tgui/packages/tgui/interfaces/SeedExtractor.tsx
@@ -1,4 +1,4 @@
-import { BooleanLike, classes } from 'common/react';
+import { BooleanLike } from 'common/react';
 import { createSearch } from 'common/string';
 import { flow } from 'common/fp';
 import { sortBy } from 'common/collections';
@@ -13,6 +13,7 @@ import {
   Table,
   NoticeBox,
   Icon,
+  DmIcon,
 } from '../components';
 import { Window } from '../layouts';
 
@@ -40,6 +41,7 @@ type SeedData = {
   potency: number;
   instability: number;
   icon: string;
+  icon_state: string;
   volume_mod: BooleanLike;
   traits: string[];
   reagents: ReagentData[];
@@ -195,9 +197,13 @@ export const SeedExtractor = (props) => {
                   style={{ 'border-top': '2px solid #222' }}
                 >
                   <Table.Cell collapsing>
-                    <Box
+                    <DmIcon
                       mb={-2}
-                      className={classes(['seeds32x32', item.icon])}
+                      icon={item.icon}
+                      icon_state={item.icon_state}
+                      fallback={<Icon mr={1} name="spinner" spin />}
+                      height={'32px'}
+                      width={'32px'}
                     />
                   </Table.Cell>
                   <Table.Cell py={0.5} px={1}>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/ParadiseSS13/Paradise/pull/26623, which in turn is a partial port of https://github.com/tgstation/tgstation/pull/82533

Currently, only the seed extractor UI has been changed to use this:

![2024-10-13 (1728870421) ~ %pn](https://github.com/user-attachments/assets/f374d31b-a50a-4a86-af81-7d79f9d2e430)

## Why It's Good For The Game

> The most modern, convenient and fastest way to add any image to the TGUI
> So how do I add an image? VERY easy! You just need to pass icon and icon_state of the object to TGUI, and use them in DmIcon or ImageButton
> No need to generate images anymore (Unless they are grayscale or built from overlays).

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Absolucy, Aylong, jlsnow301
refactor: Added a better system of displaying object icons in tgui.
refactor: Botany seed extractors now use aforementioned system to display seed icons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
