### PR TITLE
Fix suit sensors not being properly updated when ctrl-clicking

### DIFF
--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -98,6 +98,7 @@
 		to_chat(user, span_notice("You repair the suit sensors on [src] with [cabling]."))
 		cabling.use(1)
 		has_sensor = HAS_SENSORS
+		update_wearer_status()
 		return TRUE
 
 	if(istype(attacking_item, /obj/item/clothing/accessory))
@@ -119,6 +120,7 @@
 		has_sensor = BROKEN_SENSORS
 	else if(damaged_state == CLOTHING_PRISTINE && has_sensor == BROKEN_SENSORS)
 		has_sensor = HAS_SENSORS
+	update_wearer_status()
 	update_appearance()
 
 /obj/item/clothing/under/emp_act(severity)
@@ -140,10 +142,7 @@
 			var/mob/M = loc
 			to_chat(M,span_warning("The sensors on the [src] change rapidly!"))
 
-	if(ishuman(loc))
-		var/mob/living/carbon/human/ooman = loc
-		if(ooman.w_uniform == src)
-			ooman.update_suit_sensors()
+	update_wearer_status()
 
 /obj/item/clothing/under/visual_equipped(mob/user, slot)
 	. = ..()
@@ -162,6 +161,14 @@
 	if((slot & ITEM_SLOT_ICLOTHING) && freshly_laundered)
 		freshly_laundered = FALSE
 		user.add_mood_event("fresh_laundry", /datum/mood_event/fresh_laundry)
+
+/obj/item/clothing/under/proc/update_wearer_status()
+	if(!ishuman(loc))
+		return
+
+	var/mob/living/carbon/human/ooman = loc
+	ooman.update_suit_sensors()
+	ooman.med_hud_set_status()
 
 /mob/living/carbon/human/update_suit_sensors()
 	. = ..()
@@ -314,10 +321,7 @@
 			if(SENSOR_COORDS)
 				to_chat(user_mob, span_notice("Your suit will now report your exact vital lifesigns as well as your coordinate position."))
 
-	if(ishuman(loc))
-		var/mob/living/carbon/human/H = loc
-		if(H.w_uniform == src)
-			H.update_suit_sensors()
+	update_wearer_status()
 
 /obj/item/clothing/under/CtrlClick(mob/user)
 	. = ..()
@@ -328,6 +332,7 @@
 
 	sensor_mode = SENSOR_COORDS
 	balloon_alert(user, "set to tracking")
+	update_wearer_status()
 
 /// Checks if the toggler is allowed to toggle suit sensors currently
 /obj/item/clothing/under/proc/can_toggle_sensors(mob/toggler)


### PR DESCRIPTION

## About The Pull Request

Sloppy port of https://github.com/tgstation/tgstation/pull/86599

## Changelog
:cl: Absolucy, LT3
fix: Ctrl+click on equipped uniforms enables suit sensors as expected.
/:cl:
