### PR TITLE
Fix speech artifacts EXCLUSIVELY making dead/mute mobs speak

### DIFF
--- a/monkestation/code/modules/art_sci_overrides/faults/say.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/say.dm
@@ -11,6 +11,7 @@
 
 	for(var/mob/living/living in viewers(rand(7, 10), center_turf))
 		if(living.stat != CONSCIOUS || !living.can_speak())
-			var/speak_over_radio = prob(10) ? "; " : ""
-			var/forced_message = pick_list_replacements(ARTIFACT_FILE, "speech_artifact")
-			living.say(speak_over_radio + forced_message, forced = "artifact ([src])")
+			continue
+		var/speak_over_radio = prob(10) ? "; " : ""
+		var/forced_message = pick_list_replacements(ARTIFACT_FILE, "speech_artifact")
+		living.say(speak_over_radio + forced_message, forced = "artifact ([src])")


### PR DESCRIPTION

## Changelog
:cl:
fix: Fixed speech artifacts EXCLUSIVELY making dead/mute mobs speak.
/:cl:
