### PR TITLE
Botany plant reagent genes no longer take all the plant volume if there are other reagents

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -335,39 +335,40 @@
 		total_reagents += reagents_add[rid] * potency_rate
 	if(IS_EDIBLE(T) || istype(T, /obj/item/grown))
 		var/obj/item/food/grown/grown_edible = T
-		var/grown_edible_volume = grown_edible.reagents.maximum_volume
-		var/fitting_proportion = min(1/total_reagents, 1)
-		for(var/rid in reagents_add)
-			var/amount = max(1, round(grown_edible_volume * potency_rate * reagents_add[rid] * fitting_proportion, 1)) //the plant will always have at least 1u of each of the reagents in its reagent production traits
-			var/list/data
-			if(rid == /datum/reagent/blood) // Hack to make blood in plants always O-
-				data = list("blood_type" = /datum/blood_type/crew/human/o_minus)
-			if(istype(grown_edible) && (rid == /datum/reagent/consumable/nutriment || rid == /datum/reagent/consumable/nutriment/vitamin))
-				data = grown_edible.tastes // apple tastes of apple.
-			T.reagents.add_reagent(rid, amount, data)
+		if(total_reagents > 0)
+			var/grown_edible_volume = grown_edible.reagents ? grown_edible.reagents.maximum_volume : 0
+			var/fitting_proportion = min(1/total_reagents, 1)
+			for(var/rid in reagents_add)
+				var/amount = max(1, round(grown_edible_volume * potency_rate * reagents_add[rid] * fitting_proportion, 1)) //the plant will always have at least 1u of each of the reagents in its reagent production traits
+				var/list/data
+				if(rid == /datum/reagent/blood) // Hack to make blood in plants always O-
+					data = list("blood_type" = /datum/blood_type/crew/human/o_minus)
+				if(istype(grown_edible) && (rid == /datum/reagent/consumable/nutriment || rid == /datum/reagent/consumable/nutriment/vitamin))
+					data = grown_edible.tastes // apple tastes of apple.
+				T.reagents.add_reagent(rid, amount, data)
 
-		//Handles the juicing trait, swaps nutriment and vitamins for that species various juices if they exist. Mutually exclusive with distilling.
-		if(get_gene(/datum/plant_gene/trait/juicing) && grown_edible.juice_results)
-			grown_edible.on_juice()
-			grown_edible.reagents.add_reagent_list(grown_edible.juice_results)
+			//Handles the juicing trait, swaps nutriment and vitamins for that species various juices if they exist. Mutually exclusive with distilling.
+			if(get_gene(/datum/plant_gene/trait/juicing) && grown_edible.juice_results)
+				grown_edible.on_juice()
+				grown_edible.reagents.add_reagent_list(grown_edible.juice_results)
 
-		/// The number of nutriments we have inside of our plant, for use in our heating / cooling genes
-		var/num_nutriment = T.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment)
+			/// The number of nutriments we have inside of our plant, for use in our heating / cooling genes
+			var/num_nutriment = T.reagents.get_reagent_amount(/datum/reagent/consumable/nutriment)
 
-		// Heats up the plant's contents by 25 kelvin per 1 unit of nutriment. Mutually exclusive with cooling.
-		if(get_gene(/datum/plant_gene/trait/chem_heating))
-			T.visible_message(span_notice("[T] releases freezing air, consuming its nutriments to heat its contents."))
-			T.reagents.remove_all_type(/datum/reagent/consumable/nutriment, num_nutriment, strict = TRUE)
-			T.reagents.chem_temp = min(1000, (T.reagents.chem_temp + num_nutriment * 25))
-			T.reagents.handle_reactions()
-			playsound(T.loc, 'sound/effects/wounds/sizzle2.ogg', 5)
-		// Cools down the plant's contents by 5 kelvin per 1 unit of nutriment. Mutually exclusive with heating.
-		else if(get_gene(/datum/plant_gene/trait/chem_cooling))
-			T.visible_message(span_notice("[T] releases a blast of hot air, consuming its nutriments to cool its contents."))
-			T.reagents.remove_all_type(/datum/reagent/consumable/nutriment, num_nutriment, strict = TRUE)
-			T.reagents.chem_temp = max(3, (T.reagents.chem_temp + num_nutriment * -5))
-			T.reagents.handle_reactions()
-			playsound(T.loc, 'sound/effects/space_wind.ogg', 50)
+			// Heats up the plant's contents by 25 kelvin per 1 unit of nutriment. Mutually exclusive with cooling.
+			if(get_gene(/datum/plant_gene/trait/chem_heating))
+				T.visible_message(span_notice("[T] releases freezing air, consuming its nutriments to heat its contents."))
+				T.reagents.remove_all_type(/datum/reagent/consumable/nutriment, num_nutriment, strict = TRUE)
+				T.reagents.chem_temp = min(1000, (T.reagents.chem_temp + num_nutriment * 25))
+				T.reagents.handle_reactions()
+				playsound(T.loc, 'sound/effects/wounds/sizzle2.ogg', 5)
+			// Cools down the plant's contents by 5 kelvin per 1 unit of nutriment. Mutually exclusive with heating.
+			else if(get_gene(/datum/plant_gene/trait/chem_cooling))
+				T.visible_message(span_notice("[T] releases a blast of hot air, consuming its nutriments to cool its contents."))
+				T.reagents.remove_all_type(/datum/reagent/consumable/nutriment, num_nutriment, strict = TRUE)
+				T.reagents.chem_temp = max(3, (T.reagents.chem_temp + num_nutriment * -5))
+				T.reagents.handle_reactions()
+				playsound(T.loc, 'sound/effects/space_wind.ogg', 50)
 
 /// Setters procs ///
 

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -329,17 +329,16 @@
 /obj/item/seeds/proc/prepare_result(obj/item/T)
 	if(!T.reagents)
 		CRASH("[T] has no reagents.")
-	var/reagent_max = 0
+	var/total_reagents = 0
+	var/potency_rate = potency/100
 	for(var/rid in reagents_add)
-		reagent_max += reagents_add[rid]
+		total_reagents += reagents_add[rid] * potency_rate
 	if(IS_EDIBLE(T) || istype(T, /obj/item/grown))
 		var/obj/item/food/grown/grown_edible = T
+		var/grown_edible_volume = grown_edible.reagents ? grown_edible.reagents.maximum_volume : 0
+		var/fitting_proportion = min(1/total_reagents, 1)
 		for(var/rid in reagents_add)
-			var/reagent_overflow_mod = reagents_add[rid]
-			if(reagent_max > 1)
-				reagent_overflow_mod = (reagents_add[rid]/ reagent_max)
-			var/edible_vol = grown_edible.reagents ? grown_edible.reagents.maximum_volume : 0
-			var/amount = max(1, round((edible_vol)*(potency/100) * reagent_overflow_mod, 1)) //the plant will always have at least 1u of each of the reagents in its reagent production traits
+			var/amount = max(1, round(grown_edible_volume * potency_rate * reagents_add[rid] * fitting_proportion, 1)) //the plant will always have at least 1u of each of the reagents in its reagent production traits
 			var/list/data
 			if(rid == /datum/reagent/blood) // Hack to make blood in plants always O-
 				data = list("blood_type" = /datum/blood_type/crew/human/o_minus)

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -335,7 +335,7 @@
 		total_reagents += reagents_add[rid] * potency_rate
 	if(IS_EDIBLE(T) || istype(T, /obj/item/grown))
 		var/obj/item/food/grown/grown_edible = T
-		var/grown_edible_volume = grown_edible.reagents ? grown_edible.reagents.maximum_volume : 0
+		var/grown_edible_volume = grown_edible.reagents.maximum_volume
 		var/fitting_proportion = min(1/total_reagents, 1)
 		for(var/rid in reagents_add)
 			var/amount = max(1, round(grown_edible_volume * potency_rate * reagents_add[rid] * fitting_proportion, 1)) //the plant will always have at least 1u of each of the reagents in its reagent production traits


### PR DESCRIPTION
## About The Pull Request

Fixes a bug where in certain scenarios, reagents couldn't be added to the plant due to others occupying all available space. The code has been improved to ensure that all reagents now fill proportionally based on available space and reagent rates.
## Why It's Good For The Game

Fixes an undesired behavior of plant reagents
## Changelog
:cl:
fix: Plant reagent genes no longer take all the plant volume if there are other reagents
/:cl:
