### PR TITLE
Jaunts/teleports now work at centcom after roundend

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -175,7 +175,7 @@
 		if(T.is_transition_turf())
 			continue // Avoid picking these.
 		var/area/A = T.loc
-		if(!(A.area_flags & NOTELEPORT))
+		if(!(A.area_flags & NOTELEPORT) || (SSticker.current_state == GAME_STATE_FINISHED)) // monkestation edit: allow jaunts to work after roundend
 			posturfs.Add(T)
 	return posturfs
 

--- a/code/game/objects/effects/phased_mob.dm
+++ b/code/game/objects/effects/phased_mob.dm
@@ -84,12 +84,13 @@
 		return
 	var/area/destination_area = newloc.loc
 	movedelay = world.time + movespeed
-	if(newloc.turf_flags & NOJAUNT)
-		to_chat(user, span_warning("Some strange aura is blocking the way."))
-		return
-	if(destination_area.area_flags & NOTELEPORT || SSmapping.level_trait(newloc.z, ZTRAIT_NOPHASE))
-		to_chat(user, span_danger("Some dull, universal force is blocking the way. It's overwhelmingly oppressive force feels dangerous."))
-		return
+	if(SSticker.current_state < GAME_STATE_FINISHED) // monkestation edit: allow jaunts to work after roundend
+		if(newloc.turf_flags & NOJAUNT)
+			to_chat(user, span_warning("Some strange aura is blocking the way."))
+			return
+		if((destination_area.area_flags & NOTELEPORT) || SSmapping.level_trait(newloc.z, ZTRAIT_NOPHASE))
+			to_chat(user, span_danger("Some dull, universal force is blocking the way. It's overwhelmingly oppressive force feels dangerous."))
+			return
 	if (direction == UP || direction == DOWN)
 		newloc = can_z_move(direction, get_turf(src), newloc, ZMOVE_INCAPACITATED_CHECKS | ZMOVE_FEEDBACK | ZMOVE_ALLOW_ANCHORED, user)
 

--- a/code/modules/antagonists/heretic/magic/mirror_walk.dm
+++ b/code/modules/antagonists/heretic/magic/mirror_walk.dm
@@ -144,7 +144,7 @@
 
 		if(isturf(thing))
 			var/turf/turf_thing = thing
-			if(turf_thing.turf_flags & NOJAUNT)
+			if((SSticker.current_state < GAME_STATE_FINISHED) && (turf_thing.turf_flags & NOJAUNT)) // monkestation edit: allow jaunts to work after roundend
 				continue
 			if(turf_thing.flags_ricochet & RICOCHET_SHINY)
 				return thing

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -322,7 +322,7 @@
 /obj/item/warp_cube/attack_self(mob/user)
 	var/turf/current_location = get_turf(user)
 	var/area/current_area = current_location.loc
-	if(!linked || (current_area.area_flags & NOTELEPORT))
+	if(!linked || ((SSticker.current_state < GAME_STATE_FINISHED) && (current_area.area_flags & NOTELEPORT))) // monkestation edit: allow jaunts to work after roundend
 		to_chat(user, span_warning("[src] fizzles uselessly."))
 		return
 	if(teleporting)

--- a/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
+++ b/code/modules/mob/living/basic/space_fauna/revenant/_revenant.dm
@@ -357,7 +357,7 @@
 	if(isnull(step_turf))
 		return TRUE // what? whatever let it happen
 
-	if(step_turf.turf_flags & NOJAUNT)
+	if((SSticker.current_state < GAME_STATE_FINISHED) && (step_turf.turf_flags & NOJAUNT)) // monkestation edit: allow jaunts to work after roundend
 		to_chat(src, span_warning("Some strange aura is blocking the way."))
 		return FALSE
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -260,7 +260,7 @@
 						ghostie.apply_status_effect(/datum/status_effect/revenant/revealed, 2 SECONDS)
 						ghostie.apply_status_effect(/datum/status_effect/incapacitating/paralyzed/revenant, 2 SECONDS)
 					return
-				if(stepTurf.turf_flags & NOJAUNT)
+				if((SSticker.current_state < GAME_STATE_FINISHED) && (stepTurf.turf_flags & NOJAUNT)) // monkestation edit: allow jaunts to work after roundend
 					to_chat(L, span_warning("Some strange aura is blocking the way."))
 					return
 				if(locate(/obj/effect/blessing) in stepTurf)

--- a/code/modules/spells/spell_types/jaunt/_jaunt.dm
+++ b/code/modules/spells/spell_types/jaunt/_jaunt.dm
@@ -37,15 +37,16 @@
 	if(!owner_area || !owner_turf)
 		return FALSE // nullspaced?
 
-	if(owner_area.area_flags & NOTELEPORT)
-		if(feedback)
-			to_chat(owner, span_danger("Some dull, universal force is stopping you from jaunting here."))
-		return FALSE
+	if(SSticker.current_state < GAME_STATE_FINISHED) // monkestation edit: allow jaunts to work after roundend
+		if(owner_area.area_flags & NOTELEPORT)
+			if(feedback)
+				to_chat(owner, span_danger("Some dull, universal force is stopping you from jaunting here."))
+			return FALSE
 
-	if(owner_turf?.turf_flags & NOJAUNT)
-		if(feedback)
-			to_chat(owner, span_danger("An otherwordly force is preventing you from jaunting here."))
-		return FALSE
+		if(owner_turf?.turf_flags & NOJAUNT)
+			if(feedback)
+				to_chat(owner, span_danger("An otherwordly force is preventing you from jaunting here."))
+			return FALSE
 
 	return isliving(owner)
 


### PR DESCRIPTION

## About The Pull Request

This makes it so jaunts/teleports/etc ignore noteleport/nojaunt checks **after** the round has ended - allowing them to work at centcom and such.

## Why It's Good For The Game

Why not? More fun, and it's roundend so balance doesn't really matter.

## Changelog
:cl:
qol: Jaunts/teleports now work at centcom after roundend.
/:cl:
