### PR TITLE
Fixes beanbags

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -19,7 +19,7 @@
 	name = "beanbag slug"
 	icon_state = "pellet"
 	damage = 10
-	stamina = 145 //monkestation edit
+	stamina = 65 //monkestation edit
 	wound_bonus = 20
 	sharpness = NONE
 	embedding = null


### PR DESCRIPTION
## About The Pull Request
Changes beanbag stam damage from 145 to 65
closes https://github.com/Monkestation/Monkestation2.0/issues/3779

## Why It's Good For The Game
I misunderstood stamina and improperly corrected beanbags stam damage, made it 1 shot stam crit people, this returns it to a two shot as intended, fixes bug

## Changelog

:cl:
balance: beanbags now properly two shot stam crit
fix: Beanbags no longer stam crit in one shot
/:cl:

