### PR TITLE
Yellow clown Bridge access (Station trait)

### DIFF
--- a/monkestation/code/modules/jobs/job_types/yellowclown.dm
+++ b/monkestation/code/modules/jobs/job_types/yellowclown.dm
@@ -56,6 +56,13 @@
 		bladder = new/obj/item/organ/internal/bladder/clown
 		bladder.Insert(spawned)
 
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_CLOWN_BRIDGE))
+		var/obj/item/card/id/card = spawned.get_idcard(hand_first = FALSE)
+		if(card)
+			card.add_access(list(ACCESS_COMMAND), mode = FORCE_ADD_ALL)
+			card.desc += "\n<b>You can see the word \"<span class='honk'>BRIDGE</span>\" hastily scribbled over it in crayon, and nobody knows why the system recognizes this as valid.</b>"
+			to_chat(player_client, span_boldnotice("The <span class='honk'>Clown Planet</span> has given all clowns access to a specific weakness in airlock ID scanners, resulting in all clowns having <b>bridge access</b>! Honk!"))
+
 /datum/outfit/job/yellowclown
 	name = "Yellow Clown"
 	jobtype = /datum/job/yellowclown


### PR DESCRIPTION

## About The Pull Request
The dastardly clowns have multiplied. And have shared techniques amongst each other.

Gives yellow clown bridge access during corresponding station trait 
## Why It's Good For The Game
Is also clown

Let the clowns put aside their rivalry and pie the cap and BlueShield at the same time
Truely the team up we didn't need. And most certainly didn't deserve.
## Changelog
:cl:
add: Gives yellow clown bridge access during Clown Bridge Access station trait.
/:cl:
