### PR TITLE
Give recent jobs latejoin icons

### DIFF
--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -30,10 +30,10 @@ const BASEICONS = {
   Cyborg: 'robot',
   Detective: 'user-secret',
   'Diet Wizard': 'hat-wizard',
-  'Discount Godzilla': 'ticket-alt' //like a movie ticket? IDK theres not many good icons for this.
+  'Discount Godzilla': 'ticket-alt', //like a movie ticket? IDK theres not many good icons for this.
   Geneticist: 'dna',
   Ghost: 'ghost',
-  Gorilla: 'monkey',
+  Gorilla: 'exclamation-triangle',
   'Head of Personnel': 'dog',
   'Head of Security': 'user-shield',
   Janitor: 'soap',
@@ -55,7 +55,7 @@ const BASEICONS = {
   'Security Officer (Science)': 'shield-halved',
   'Security Officer': 'shield-halved',
   'Shaft Miner': 'digging',
-  skeleton: 'skull',
+  Skeleton: 'skull-crossbones',
   'Station Engineer': 'gears',
   'Syndicate Operative': 'dragon',
   Virologist: 'virus',

--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -11,6 +11,7 @@ const BASEICONS = {
   // Really I wanted this to be like heart wings but thats not really an option
   'Brig Physician': 'heart',
   Captain: 'crown',
+  'Candy Salesman': 'cookie-bite',
   'Cargo Technician': 'box',
   'CentCom Commander': 'star',
   'CentCom Head Intern': 'pen-fancy',
@@ -28,7 +29,11 @@ const BASEICONS = {
   'Cyber Police': 'qrcode',
   Cyborg: 'robot',
   Detective: 'user-secret',
+  'Diet Wizard': 'hat-wizard',
+  'Discount Godzilla': 'ticket-alt' //like a movie ticket? IDK theres not many good icons for this.
   Geneticist: 'dna',
+  Ghost: 'ghost',
+  Gorilla: 'monkey',
   'Head of Personnel': 'dog',
   'Head of Security': 'user-shield',
   Janitor: 'soap',
@@ -50,10 +55,12 @@ const BASEICONS = {
   'Security Officer (Science)': 'shield-halved',
   'Security Officer': 'shield-halved',
   'Shaft Miner': 'digging',
+  skeleton: 'skull',
   'Station Engineer': 'gears',
   'Syndicate Operative': 'dragon',
   Virologist: 'virus',
   Warden: 'handcuffs',
+  'Yellow Clown': 'lemon', //yellow lemon.
 } as const;
 
 const ALTTITLES = {
@@ -238,6 +245,10 @@ const ALTTITLES = {
   'Security Operative': BASEICONS['Security Officer'],
   Peacekeeper: BASEICONS['Security Officer'],
   'Security Cadet': BASEICONS['Security Officer'],
+  //Security Assistant - file-invoice-dollar
+  'Hall Monitor': BASEICONS['Security Assistant'],
+  'Assistant Officer': BASEICONS['Security Assistant'],
+  'Professional Snitch': BASEICONS['Security Assistant'],
   // Shaft Miner - digging
   'Union Miner': BASEICONS['Shaft Miner'],
   Excavator: BASEICONS['Shaft Miner'],

--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -6,6 +6,7 @@ const BASEICONS = {
   Bartender: 'cocktail',
   'Bit Avatar': 'code',
   Bitrunner: 'gamepad',
+  Blueshield: 'chess-rook',
   Botanist: 'seedling',
   // Really I wanted this to be like heart wings but thats not really an option
   'Brig Physician': 'heart',
@@ -42,6 +43,7 @@ const BASEICONS = {
   'Research Director': 'user-graduate',
   Roboticist: 'battery-half',
   Scientist: 'flask',
+  'Security Assistant': 'file-invoice-dollar',
   'Security Officer (Cargo)': 'shield-halved',
   'Security Officer (Engineering)': 'shield-halved',
   'Security Officer (Medical)': 'shield-halved',

--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -30,7 +30,7 @@ const BASEICONS = {
   Cyborg: 'robot',
   Detective: 'user-secret',
   'Diet Wizard': 'hat-wizard',
-  'Discount Godzilla': 'ticket-alt', //like a movie ticket? IDK theres not many good icons for this.
+  'Discount Godzilla': 'ticket-alt', // like a movie ticket? IDK theres not many good icons for this.
   Geneticist: 'dna',
   Ghost: 'ghost',
   Gorilla: 'exclamation-triangle',
@@ -60,7 +60,7 @@ const BASEICONS = {
   'Syndicate Operative': 'dragon',
   Virologist: 'virus',
   Warden: 'handcuffs',
-  'Yellow Clown': 'lemon', //yellow lemon.
+  'Yellow Clown': 'lemon', // yellow lemon.
 } as const;
 
 const ALTTITLES = {
@@ -245,7 +245,7 @@ const ALTTITLES = {
   'Security Operative': BASEICONS['Security Officer'],
   Peacekeeper: BASEICONS['Security Officer'],
   'Security Cadet': BASEICONS['Security Officer'],
-  //Security Assistant - file-invoice-dollar
+  // Security Assistant - file-invoice-dollar
   'Hall Monitor': BASEICONS['Security Assistant'],
   'Assistant Officer': BASEICONS['Security Assistant'],
   'Professional Snitch': BASEICONS['Security Assistant'],


### PR DESCRIPTION
## About The Pull Request
Gives blueshield and Secass icons.
Alongside of off spooktober
![bingo](https://github.com/user-attachments/assets/f5308924-5a46-44bf-876d-3d0bcb5166c9)
![spooktober](https://github.com/user-attachments/assets/715b8ea2-d1b4-4520-8b76-15abaa9e18b1)

## Why It's Good For The Game
Is pretty
## Changelog
:cl:
add: Added icons for Blueshield and Secass
add: Added icons for all Spooktober roles
/:cl:
