### PR TITLE
Add a fallback timer to ensure smoke doesn't far outlive its intended lifetime

### DIFF
--- a/monkestation/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
+++ b/monkestation/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
@@ -1,0 +1,20 @@
+/obj/effect/particle_effect/fluid/smoke
+	/// ID of the fallback timer, used to ensure that the smoke does not far outlive its intended lifetime, in case of subsystem delay or whatnot.
+	var/fallback_timer
+
+/obj/effect/particle_effect/fluid/smoke/Initialize(mapload, datum/fluid_group/group, ...)
+	. = ..()
+	// Ensure that smoke does not live for much longer than 1.5x the length of its lifetime (rounded up to the nearest 2 seconds)
+	var/fallback_time = CEILING(initial(lifetime) * 1.5, 2 SECONDS)
+	fallback_timer = addtimer(CALLBACK(src, PROC_REF(anti_fog_measures)), fallback_time, TIMER_UNIQUE | TIMER_STOPPABLE)
+
+/obj/effect/particle_effect/fluid/smoke/Destroy()
+	if(fallback_timer)
+		deltimer(fallback_timer)
+		fallback_timer = null
+	return ..()
+
+/obj/effect/particle_effect/fluid/smoke/proc/anti_fog_measures()
+	fallback_timer = null
+	if(!QDELETED(src))
+		kill_smoke()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5913,6 +5913,7 @@
 #include "monkestation\code\game\objects\effects\anomalies\anomalies_bioscrambler.dm"
 #include "monkestation\code\game\objects\effects\anomalies\anomalies_dimensional.dm"
 #include "monkestation\code\game\objects\effects\anomalies\anomalies_dimensional_themes.dm"
+#include "monkestation\code\game\objects\effects\effect_system\fluid_spread\effects_smoke.dm"
 #include "monkestation\code\game\objects\effects\random\ai_module.dm"
 #include "monkestation\code\game\objects\effects\spawners\roomspawner.dm"
 #include "monkestation\code\game\objects\effects\spawners\random\fishing.dm"


### PR DESCRIPTION
## Changelog
:cl:
fix: Large amounts of smoke should no longer live for many times its intended lifetime.
/:cl:
