### PR TITLE
The heretic living heart now uses appearance cloning instead of getFlatIcon

### DIFF
--- a/monkestation/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/monkestation/code/modules/antagonists/heretic/heretic_antag.dm
@@ -29,7 +29,7 @@
 		return FALSE
 	var/datum/weakref/target_ref = WEAKREF(target_mind)
 	LAZYOR(all_sac_targets, target_ref)
-	LAZYSET(current_sac_targets, target_ref, getFlatIcon(target_body, defdir = SOUTH))
+	LAZYSET(current_sac_targets, target_ref, TRUE)
 	return TRUE
 
 /**

--- a/monkestation/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/monkestation/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -17,7 +17,13 @@
 			continue
 		var/sac_name = trimtext(target_mind.name || living_target.real_name || living_target.name)
 		living_targets[sac_name] = living_target
-		targets_to_choose[sac_name] = heretic_datum.current_sac_targets[target_ref]
+		var/mutable_appearance/target_appearance = new
+		target_appearance.appearance = living_target.appearance
+		target_appearance.setDir(SOUTH)
+		target_appearance.pixel_x = 0
+		target_appearance.pixel_y = 0
+		target_appearance.pixel_z = 0
+		targets_to_choose[sac_name] = target_appearance
 
 	// If we don't have a last tracked name, open a radial to set one.
 	// If we DO have a last tracked name, we skip the radial if they right click the action.


### PR DESCRIPTION
## About The Pull Request

this gets rid of the getFlatIcon used in the living heart (used to display the target's appearance in the radial menu), and instead uses appearance cloning.

this allows us to ensure the target always appears to be facing south without pixel offsets, with very little performance impact.

https://github.com/user-attachments/assets/9ad31048-2872-4b90-9b37-dbc9925f04a6

## Why It's Good For The Game

means that the appearance of the target will always be up-to-date whenever living heart is used, and it's far more performant.

## Changelog
:cl:
qol: The heretic living heart now displays up-to-date appearances of its targets when used.
/:cl:
