### PR TITLE
Minor QoL and bug fixes for mining

### DIFF
--- a/code/datums/mind/antag.dm
+++ b/code/datums/mind/antag.dm
@@ -215,7 +215,7 @@
 	enslaved_to = WEAKREF(creator)
 
 	current.faction |= creator.faction
-	creator.faction |= current.faction
+	creator.faction |= "[REF(current)]"
 
 	if(creator.mind?.special_role)
 		message_admins("[ADMIN_LOOKUPFLW(current)] has been created by [ADMIN_LOOKUPFLW(creator)], an antagonist.")

--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -95,6 +95,7 @@
 	icon_state = "iceboots"
 	inhand_icon_state = null
 	clothing_traits = list(TRAIT_NO_SLIP_ICE, TRAIT_NO_SLIP_SLIDE)
+	resistance_flags = FIRE_PROOF // Monkestation addition
 
 // A pair of ice boots intended for general crew EVA use - see EVA winter coat for comparison.
 /obj/item/clothing/shoes/winterboots/ice_boots/eva

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -91,6 +91,11 @@
 	///This damage is taken when atmos doesn't fit all the requirements above. Set to 0 to avoid adding the atmos_requirements element.
 	var/unsuitable_atmos_damage = 1
 
+//MONKESTATION EDIT START
+	/// List of weather immunity traits that are then added on Initialize(), see traits.dm.
+	var/list/weather_immunities
+//MONKESTATION EDIT END
+
 	bodytemp_cold_damage_limit = NPC_DEFAULT_MIN_TEMP
 	bodytemp_heat_damage_limit = NPC_DEFAULT_MAX_TEMP
 	///This damage is taken when the body temp is too cold. Set both this and unsuitable_heat_damage to 0 to avoid adding the basic_body_temp_sensitive element.

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -112,6 +112,11 @@
 	if(!real_name)
 		real_name = name
 
+	// MONKESTATION ADDITION START
+	if(length(weather_immunities))
+		add_traits(weather_immunities, ROUNDSTART_TRAIT)
+	//MONKESTATION ADDITION END
+
 	/* MONKESTATION REMOVAL - This is totally valid to create a mob in nullspace, its not valid to move a client onto it, this seems weird.
 	if(!loc)
 		stack_trace("Basic mob being instantiated in nullspace")

--- a/code/modules/mob/living/basic/guardian/guardian.dm
+++ b/code/modules/mob/living/basic/guardian/guardian.dm
@@ -14,6 +14,7 @@
 	basic_mob_flags = DEL_ON_DEATH
 	sentience_type = SENTIENCE_HUMANOID
 	hud_type = /datum/hud/guardian
+	weather_immunities = list(TRAIT_ASHSTORM_IMMUNE) // Monkestation addition
 	faction = list()
 	speed = 0
 	maxHealth = INFINITY // The spirit itself is invincible and passes damage to its host


### PR DESCRIPTION

## About The Pull Request
Makes holoparasites/powerminers ash storm proof
Makes iceboots burn proof
Ports https://github.com/tgstation/tgstation/pull/81274 to fix  https://github.com/Monkestation/Monkestation2.0/issues/3831 and fix https://github.com/Monkestation/Monkestation2.0/issues/2990

## Why It's Good For The Game
Holoparasites in general, and espically powerminers aren't currently ash storm proof meaning even if owner is they still take damage from their holopara just existing, and double damage if not.

Iceboots are a miner item and also very important to icebox mining, yet they aren't burn proof as they should be

Port fixes making a mining mob sentient pacifying all of lavaland letting you walk up to megafaunas and kill them without them fighting back. By sentient potion not giving you that faction, this blanket fixes some other stuff that could be cheesed with gaining factions

## Changelog

:cl:
fix: Making a mob sentient no longer gives you all of their factions.
qol: Miner Iceboots are now fireproof
qol: Holoparasites, guardian spirits, and power miners are now ash storm proof. 
/:cl:

