### PR TITLE
Prickly Adhesion Damage Nerf

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -930,7 +930,7 @@
 	description = "It sticks to people when thrown, also passing reagents if stingy."
 	icon = FA_ICON_BANDAGE
 	trait_ids = THROW_IMPACT_ID
-	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
+	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_GRAFTABLE
 
 /datum/plant_gene/trait/sticky/on_new_plant(obj/item/our_plant, newloc)
 	. = ..()

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -930,7 +930,7 @@
 	description = "It sticks to people when thrown, also passing reagents if stingy."
 	icon = FA_ICON_BANDAGE
 	trait_ids = THROW_IMPACT_ID
-	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_GRAFTABLE
+	mutability_flags = PLANT_GENE_REMOVABLE | PLANT_GENE_MUTATABLE | PLANT_GENE_GRAFTABLE
 
 /datum/plant_gene/trait/sticky/on_new_plant(obj/item/our_plant, newloc)
 	. = ..()
@@ -943,7 +943,7 @@
 	else
 		our_plant.embedding = EMBED_HARMLESS
 	our_plant.updateEmbedding()
-	our_plant.throwforce = qp_sigmoid(1000, 100, our_seed.potency)
+	our_plant.throwforce = qp_sigmoid(1000, 50, our_seed.potency)
 
 /**
  * This trait automatically heats up the plant's chemical contents when harvested.


### PR DESCRIPTION
## About The Pull Request

Nerfs Prickly Adhesion damage by half

## Why It's Good For The Game

Some players are unhappy about the strength of this trait, and i agree. I started a discussion on Discord about a potential nerf, and the majority voted to reduce its current damage by half.

:cl:
balance: Prickly Adhesion damage halved
/:cl:
