### PR TITLE
Fix lavaland temperature, hopefully?

### DIFF
--- a/code/datums/atmosphere/planetary.dm
+++ b/code/datums/atmosphere/planetary.dm
@@ -23,7 +23,7 @@
 	maximum_pressure = LAVALAND_EQUIPMENT_EFFECT_PRESSURE - 1
 
 	minimum_temp = BODYTEMP_COLD_DAMAGE_LIMIT + 1
-	maximum_temp = 350
+	maximum_temp = BODYTEMP_HEAT_DAMAGE_LIMIT - 5
 
 /datum/atmosphere/icemoon
 	id = ICEMOON_DEFAULT_ATMOS


### PR DESCRIPTION

## About The Pull Request
Changes lavaland max temperature to body heat limit - 5 in a attempt to fix people burning to death for existing on lavaland

currently should probably only be TM'd since I haven't tested how well this works just supposed to be a quick temp fix until I read up on new temp code

## Why It's Good For The Game
Currently people die for existing on lavaland if it rolls a high temp, makes mining unplayable

## Changelog

:cl:
fix: fixes lavaland max temperature
/:cl:

