### PR TITLE
Modern Glasses to Loadout

### DIFF
--- a/monkestation/code/modules/loadouts/items/glasses.dm
+++ b/monkestation/code/modules/loadouts/items/glasses.dm
@@ -55,6 +55,10 @@ GLOBAL_LIST_INIT(loadout_glasses, generate_loadout_items(/datum/loadout_item/gla
 	name = "Jamjar Glasses"
 	item_path = /obj/item/clothing/glasses/regular/jamjar
 
+/datum/loadout_item/glasses/prescription_glasses/betterunshit
+    name = "modern glasses"
+    item_path = /obj/item/clothing/glasses/regular/betterunshit
+
 /*
 *	COSMETIC GLASSES
 */

--- a/monkestation/code/modules/store/store_items/glasses.dm
+++ b/monkestation/code/modules/store/store_items/glasses.dm
@@ -20,6 +20,10 @@ GLOBAL_LIST_INIT(store_glasses, generate_store_items(/datum/store_item/glasses))
 	name = "Jamjar Glasses"
 	item_path = /obj/item/clothing/glasses/regular/jamjar
 
+/datum/store_item/glasses/prescription_glasses/betterunshit
+    name = "modern glasses"
+    item_path = /obj/item/clothing/glasses/regular/betterunshit
+
 /*
 *	COSMETIC GLASSES
 */


### PR DESCRIPTION

## About The Pull Request

Adds the Modern Glasses from blueshift to the loadouts menu.

## Why It's Good For The Game

Twas requested, and doesn't harm anything else. Price is the same as the other equivalent glasses. More drip options = good.

## Changelog

Adds modern glasses to store and loadout.

:cl:
add: Added new mechanics or gameplay changes
/:cl: