### PR TITLE
Name tags now take base pixel_x/y into account

### DIFF
--- a/monkestation/code/modules/ranching/name_tags/name_tag.dm
+++ b/monkestation/code/modules/ranching/name_tags/name_tag.dm
@@ -101,7 +101,8 @@
 	var/bound_width = movable_loc.bound_width || world.icon_size
 	maptext_width = NAME_TAG_WIDTH
 	maptext_height = world.icon_size * 1.5
-	maptext_x = (NAME_TAG_WIDTH - bound_width) * -0.5
+	maptext_x = ((NAME_TAG_WIDTH - bound_width + loc.base_pixel_x) * -0.5)
+	maptext_y = src::maptext_y + loc.base_pixel_y
 	RegisterSignal(loc, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(update_z))
 
 /obj/effect/abstract/name_tag/Destroy(force)

--- a/monkestation/code/modules/ranching/name_tags/name_tag.dm
+++ b/monkestation/code/modules/ranching/name_tags/name_tag.dm
@@ -30,13 +30,11 @@
 	name_tag = new(src)
 	//SET_PLANE_EXPLICIT(name_tag, PLANE_NAME_TAGS, src)
 	update_name_tag()
-	vis_contents += name_tag
 
 /mob/Login()
 	. = ..()
 	if(client && isliving(src) && (!iscyborg(src) && !isaicamera(src) && !isAI(src)))
-		shadow = new()
-		shadow.loc = src
+		shadow = new(src)
 		SET_PLANE_EXPLICIT(shadow, PLANE_NAME_TAGS_BLOCKER, src)
 		client.screen += shadow
 		hud_used.always_visible_inventory += shadow
@@ -50,7 +48,6 @@
 	return ..()
 
 /mob/Destroy()
-	vis_contents -= name_tag
 	QDEL_NULL(name_tag)
 	if(shadow)
 		client?.screen -= shadow
@@ -98,14 +95,18 @@
 	if(!ismovable(loc) || QDELING(loc))
 		return INITIALIZE_HINT_QDEL
 	var/atom/movable/movable_loc = loc
+	movable_loc.vis_contents += src
 	var/bound_width = movable_loc.bound_width || world.icon_size
 	maptext_width = NAME_TAG_WIDTH
 	maptext_height = world.icon_size * 1.5
-	maptext_x = ((NAME_TAG_WIDTH - bound_width + loc.base_pixel_x) * -0.5)
-	maptext_y = src::maptext_y + loc.base_pixel_y
+	maptext_x = ((NAME_TAG_WIDTH - bound_width) * -0.5) - loc.base_pixel_x
+	maptext_y = src::maptext_y - loc.base_pixel_y
 	RegisterSignal(loc, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(update_z))
 
 /obj/effect/abstract/name_tag/Destroy(force)
+	if(ismovable(loc))
+		var/atom/movable/movable_loc = loc
+		movable_loc.vis_contents -= src
 	UnregisterSignal(loc, COMSIG_MOVABLE_Z_CHANGED)
 	return ..()
 


### PR DESCRIPTION
## About This Pull Request

This updates name tags so they'll always be properly offset for mobs with a default base pixel_x\/y value.

### Before

![2024-10-19 (1729367870) ~ dreamseeker](https://github.com/user-attachments/assets/eb38398a-c363-4460-a1f1-362bf4d3a257)

### After

![image](https://github.com/user-attachments/assets/0d2e53ca-cbee-4e9f-accd-c8c8209be8d6)


## Changelog
:cl:
fix: Name tags now take the mob's base offset into account.
/:cl:
