### PR TITLE
You can now search for reagents in the seed extractor

### DIFF
--- a/tgui/packages/tgui/interfaces/SeedExtractor.tsx
+++ b/tgui/packages/tgui/interfaces/SeedExtractor.tsx
@@ -60,7 +60,7 @@ export const SeedExtractor = (props) => {
   const [searchText, setSearchText] = useLocalState('searchText', '');
   const [sortField, setSortField] = useLocalState('sortField', 'name');
   const [action, toggleAction] = useLocalState('action', true);
-  const search = createSearch(searchText, (item: SeedData) => item.name);
+  const search = createSearch(searchText, createSearchableString);
   const seeds_filtered =
     searchText.length > 0 ? data.seeds.filter(search) : data.seeds;
   const seeds = flow([
@@ -374,3 +374,11 @@ const TraitTooltip = (props) => {
     </Tooltip>
   );
 };
+
+function createSearchableString(seedData: SeedData): string {
+  const reagentNames = seedData.reagents.map((reagent) => reagent.name).join(' ');
+  
+  const searchableString = `${seedData.name} ${reagentNames}`;
+  
+  return searchableString;
+}

--- a/tgui/packages/tgui/interfaces/SeedExtractor.tsx
+++ b/tgui/packages/tgui/interfaces/SeedExtractor.tsx
@@ -375,10 +375,11 @@ const TraitTooltip = (props) => {
   );
 };
 
-function createSearchableString(seedData: SeedData): string {
-  const reagentNames = seedData.reagents.map((reagent) => reagent.name).join(' ');
-  
+const createSearchableString = (seedData: SeedData): string => {
+  const reagentNames = seedData.reagents
+    .map((reagent) => reagent.name)
+    .join(' ');
   const searchableString = `${seedData.name} ${reagentNames}`;
-  
+
   return searchableString;
-}
+};


### PR DESCRIPTION

## About The Pull Request

You can now use the search bar of the seed extractor to filter seeds by reagents

## Why It's Good For The Game

Makes it easier and less annoying to sort through big amount of seeds

## Changelog

:cl:
qol: You can now search for reagents in the seed extractor
/:cl:

