### PR TITLE
Renames Rule 8 achievement to Rule 3

### DIFF
--- a/code/datums/achievements/misc_achievements.dm
+++ b/code/datums/achievements/misc_achievements.dm
@@ -70,9 +70,9 @@
 	database_id = MEDAL_CLEANBOSS
 
 /datum/award/achievement/misc/rule8
-	name = "Rule 8"
+	name = "Rule 3"
 	desc = "Call an admin this is ILLEGAL!!"
-	database_id = MEDAL_RULE8
+	database_id = MEDAL_RULE8 //blame tg lmao
 	icon = "rule8"
 
 /datum/award/achievement/misc/speed_round


### PR DESCRIPTION

## About The Pull Request

because erp rule is rule 3 here not 8

## Why It's Good For The Game

number good

## Changelog
:cl:
add: The ERP achievement has been updated to reflect current rules naming schemes in-game. This DOES NOT affect back-end code because I'm too lazy to change that.
/:cl:
