### PR TITLE
[Issue fix] BlueShield office on Theseus has command access instead of central.

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -61430,7 +61430,7 @@
 	id_tag = "BSdoor";
 	name = "Blueshield's Office"
 	},
-/obj/effect/mapping_helpers/airlock/access/any/command/general,
+/obj/effect/mapping_helpers/airlock/access/all/admin/general,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/blueshield)
 "soq" = (


### PR DESCRIPTION
## About The Pull Request
[Fixes BlueShield's door access so command keeps their noses out.](https://github.com/Monkestation/Monkestation2.0/issues/3863)
## Why It's Good For The Game
Consistency good
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far-reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
:cl:
fix: Fixed incorrect door access on Theseus's BlueShield's Office.
/:cl:
