### PR TITLE
Slimes are now guaranteed to mutate if they qualify for a color that hasn't been mutated at all

### DIFF
--- a/monkestation/code/modules/slimecore/slime_color_mutations/_base_color.dm
+++ b/monkestation/code/modules/slimecore/slime_color_mutations/_base_color.dm
@@ -1,5 +1,5 @@
-GLOBAL_LIST_INIT(unlocked_slime_colors, list())
-GLOBAL_LIST_INIT(mutated_slime_colors, list())
+GLOBAL_LIST_EMPTY_TYPED(unlocked_slime_colors, /datum/slime_color)
+GLOBAL_LIST_EMPTY_TYPED(mutated_slime_colors, /datum/slime_color)
 
 /datum/slime_color
 	///the name of the slime color
@@ -18,9 +18,9 @@ GLOBAL_LIST_INIT(mutated_slime_colors, list())
 
 /datum/slime_color/New()
 	. = ..()
-	if(!(type in GLOB.unlocked_slime_colors))
+	if(GLOB.unlocked_slime_colors[type])
 		on_first_unlock()
-		GLOB.unlocked_slime_colors |= type
+		GLOB.unlocked_slime_colors[type] = TRUE
 
 /datum/slime_color/proc/on_first_unlock()
 	return


### PR DESCRIPTION
## Testing Evidence

![image](https://github.com/user-attachments/assets/90b23198-5f16-421e-8a61-18446ccee88b)

## Changelog
:cl:
qol: Slimes are now guaranteed to mutate if they qualify for a color that hasn't been mutated at all. For example - if you feed a slime gauze, and no slimes have mutated into purple previously, it's guaranteed to mutate into a purple the first chance it gets.
/:cl:
