### PR TITLE
Remove sentient disease from midround antags preferences

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/sentientdisease.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/sentientdisease.ts
@@ -1,3 +1,4 @@
+/* Monkestation edit : sentient disease doesnt exist or work in current codebase
 import { Antagonist, Category } from '../base';
 import { multiline } from 'common/string';
 
@@ -14,3 +15,4 @@ const SentientDisease: Antagonist = {
 };
 
 export default SentientDisease;
+*/


### PR DESCRIPTION

## About The Pull Request
Removes sentient disease as a option in the midround preferences

Good job pathologists
## Why It's Good For The Game
The weight has been set to 0
It doesnt work Ive been told under new pathology
I have seen no interest in bringing it back so far.

So leave the code and dissuade confusion for players by not giving them the illusion of its existence.
If we want it back
Simply just uncode block/revert this edit. simple enough
## Changelog
:cl:
del: Removed sentient disease from showing in antag preferences 
/:cl:
