### PR TITLE
Tribal claw buff

### DIFF
--- a/monkestation/code/modules/martial_arts/tribal_claw.dm
+++ b/monkestation/code/modules/martial_arts/tribal_claw.dm
@@ -101,7 +101,7 @@ If the target is T3 grabbed or sleeping, instead deal 60 damage with a weeping a
 				break
 
 	if((defender.health <= defender.crit_threshold || (attacker.pulling == defender && attacker.grab_state >= GRAB_NECK) || defender.IsSleeping()) && !is_jugcut) {
-		log_combat(attacker, defender, "jugular gored (Tribal Claw)", name)
+		log_combat(attacker, defender, "strong jugular cut (Tribal Claw)", name)
 		defender.apply_damage(60, BRUTE, BODY_ZONE_HEAD, def_check)
 		defender.visible_message(span_warning("[attacker] tears out [defender]'s throat with their tail!"), \
 						span_userdanger("[attacker] tears out your throat with their tail!"))
@@ -159,6 +159,6 @@ If the target is T3 grabbed or sleeping, instead deal 60 damage with a weeping a
 	to_chat(usr, "<b><i>You retreat inward and recall the teachings of the Tribal Claw...</i></b>")
 
 	to_chat(usr, span_notice("Tail Sweep</span>: Disarm Harm. Pushes everyone around you away and knocks them down."))
-	to_chat(usr, span_notice("Face Scratch</span>: Harm Harm. Damages your defender's head and confuses them for a short time."))
-	to_chat(usr, span_notice("Jugular Cut</span>: Harm Disarm. Causes your defender to rapidly lose blood, works only if you grab your defender by their neck, if they are sleeping, or in critical condition."))
-	to_chat(usr, span_notice("Tail Grab</span>: Disarm Disarm Grab. Grabs your defender by their neck and makes them unable to talk for a short time."))
+	to_chat(usr, span_notice("Face Scratch</span>: Harm Harm. Damages your target's head and confuses them for a short time."))
+	to_chat(usr, span_notice("Jugular Cut</span>: Harm Disarm. Causes your target to rapidly lose blood, works only if you grab your target by their neck, if they are sleeping, or in critical condition."))
+	to_chat(usr, span_notice("Tail Grab</span>: Disarm Disarm Grab. Grabs your target by their neck and makes them unable to talk for a short time."))

--- a/monkestation/code/modules/martial_arts/tribal_claw.dm
+++ b/monkestation/code/modules/martial_arts/tribal_claw.dm
@@ -10,99 +10,144 @@
 	id = MARTIALART_TRIBALCLAW
 	allow_temp_override = FALSE
 	help_verb = /mob/living/carbon/human/proc/tribal_claw_help
+	var/list/tribal_traits = list(TRAIT_HARDLY_WOUNDED, TRAIT_HARD_SOLES)
 
-/datum/martial_art/tribal_claw/proc/check_streak(mob/living/carbon/human/attacker, mob/living/carbon/human/target)
+	smashes_tables = TRUE //:3
+
+	block_chance = 60  //you can use throw mode to block melee attacks... sometimes
+	//originally wanted to do inverse correlation but it donbt work :pensive:
+
+/datum/armor/scales
+	melee = 20
+	bullet = 20
+	laser = 20
+	wound = 20
+
+/datum/martial_art/tribal_claw/teach(mob/living/carbon/human/target, make_temporary = FALSE)
+	. = ..()
+	if(!.)
+		return
+	target.add_traits(tribal_traits)
+	target.set_armor(target.get_armor().add_other_armor(/datum/armor/scales))
+
+/datum/martial_art/tribal_claw/on_remove(mob/living/carbon/human/target)
+	target.set_armor(target.get_armor().subtract_other_armor(/datum/armor/scales))
+	REMOVE_TRAITS_IN(target, tribal_traits)
+	. = ..()
+
+/datum/martial_art/tribal_claw/proc/check_streak(mob/living/carbon/human/attacker, mob/living/carbon/human/defender)
 	if(findtext(streak,TAIL_SWEEP_COMBO))
 		streak = ""
-		tailSweep(attacker,target)
+		tailSweep(attacker,defender)
 		return TRUE
 	if(findtext(streak,FACE_SCRATCH_COMBO))
 		streak = ""
-		faceScratch(attacker,target)
+		faceScratch(attacker,defender)
 		return TRUE
 	if(findtext(streak,JUGULAR_CUT_COMBO))
 		streak = ""
-		jugularCut(attacker,target)
+		jugularCut(attacker,defender)
 		return TRUE
 	if(findtext(streak,TAIL_GRAB_COMBO))
 		streak = ""
-		tailGrab(attacker,target)
+		tailGrab(attacker,defender)
 		return TRUE
 	return FALSE
 
 //Tail Sweep, triggers an effect similar to Alien Queen's tail sweep but only affects stuff 1 tile next to you, basically 3x3.
-/datum/martial_art/tribal_claw/proc/tailSweep(mob/living/carbon/human/attacker, mob/living/carbon/human/target)
+/datum/martial_art/tribal_claw/proc/tailSweep(mob/living/carbon/human/attacker, mob/living/carbon/human/defender)
 	if(attacker == current_target)
 		return
-	log_combat(attacker, target, "tail sweeped(Tribal Claw)", name)
-	target.visible_message(span_warning("[attacker] sweeps [target]'s legs with their tail!"), \
-						span_userdanger("[attacker] sweeps your legs with their tail!"))
+	log_combat(attacker, defender, "tail sweeped(Tribal Claw)", name)
+	defender.visible_message(span_warning("[attacker] sweeps [defender] off their legs with their tail!"), \
+						span_userdanger("[attacker] sweeps you off your legs with their tail!"))
 	var/static/datum/action/cooldown/spell/aoe/repulse/martial/lizard/tail_sweep = new
 	tail_sweep.cast(attacker)
 
-//Face Scratch, deals 10 brute to head(reduced by armor), blurs the target's vision and gives them the confused effect for a short time.
-/datum/martial_art/tribal_claw/proc/faceScratch(mob/living/carbon/human/attacker, mob/living/carbon/human/target)
-	var/def_check = target.getarmor(BODY_ZONE_HEAD, MELEE)
-	log_combat(attacker, target, "face scratched (Tribal Claw)", name)
-	target.visible_message(span_warning("[attacker] scratches [target]'s face with their claws!"), \
+//Face Scratch, deals 30 brute to head(reduced by armor), blurs the defender's vision and gives them the confused effect for a short time.
+/datum/martial_art/tribal_claw/proc/faceScratch(mob/living/carbon/human/attacker, mob/living/carbon/human/defender)
+	var/def_check = defender.getarmor(BODY_ZONE_HEAD, MELEE)
+	log_combat(attacker, defender, "face scratched (Tribal Claw)", name)
+	defender.visible_message(span_warning("[attacker] scratches [defender]'s face with their claws!"), \
 						span_userdanger("[attacker] scratches your face with their claws!"))
-	target.apply_damage(10, BRUTE, BODY_ZONE_HEAD, def_check)
-	target.adjust_confusion(5 SECONDS)
-	target.adjust_eye_blur(5 SECONDS)
-	attacker.do_attack_animation(target, ATTACK_EFFECT_CLAW)
-	playsound(get_turf(target), 'sound/weapons/slash.ogg', 50, 1, -1)
+	defender.apply_damage(30, BRUTE, BODY_ZONE_HEAD, def_check)
+	defender.adjust_confusion(5 SECONDS)
+	defender.adjust_eye_blur(5 SECONDS)
+	attacker.do_attack_animation(defender, ATTACK_EFFECT_CLAW)
+	playsound(get_turf(defender), 'sound/weapons/slash.ogg', 50, 1, -1)
 
 /*
-Jugular Cut, can only be done if the target is in crit, being held in a tier 3 grab by the user or if they are sleeping.
-Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect similar to throat slicing someone with a sharp item.
+Jugular Cut
+Deals 15 damage to the target plus 10 seconds of oxygen loss and 10 oxyloss, with an open laceration
+If the target is T3 grabbed or sleeping, instead deal 60 damage with a weeping avulsion alongside the previous.
 */
-//LIES!! TG completely FUCKED throat slitting and it's EXTREMELY DIFFICULT to replicate. This absolutely sucked to code.
+/datum/martial_art/tribal_claw/proc/jugularCut(mob/living/carbon/attacker, mob/living/carbon/defender)
+	var/def_check = defender.getarmor(BODY_ZONE_HEAD, MELEE)
+	var/obj/item/bodypart/head = defender.get_bodypart(BODY_ZONE_HEAD)
 
+	var/wound_type = /datum/wound/slash/flesh/severe
+	var/critical_wound_type = /datum/wound/slash/flesh/critical
+	var/datum/wound/slash/flesh/laceration = new wound_type()
+	var/datum/wound/slash/flesh/jugcut = new critical_wound_type()
+	var/is_jugcut = FALSE
 
-/datum/martial_art/tribal_claw/proc/jugularCut(mob/living/carbon/attacker, mob/living/carbon/target)
-	var/def_check = target.getarmor(BODY_ZONE_HEAD, MELEE)
-	var/wound_type = /datum/wound/slash/flesh/critical
-	var/obj/item/bodypart/head = target.get_bodypart(BODY_ZONE_HEAD)
-	var/datum/wound/slash/flesh/jugcut = new wound_type()
+	log_combat(attacker, defender, "jugular cut (Tribal Claw)", name)
 
-	if((target.health <= target.crit_threshold || (attacker.pulling == target && attacker.grab_state >= GRAB_NECK) || target.IsSleeping()))
-		log_combat(attacker, target, "jugular cut (Tribal Claw)", name)
-		target.visible_message(span_warning("[attacker] cuts [target]'s jugular vein with their claws!"), \
-							span_userdanger("[attacker] cuts your jugular vein!"))
-		target.apply_damage(15, BRUTE, BODY_ZONE_HEAD, def_check)
+	//balance feature, prevents damage bonus
+	if(LAZYLEN(head?.wounds) > 0)
+		for(var/i in head.wounds)
+			if (i == critical_wound_type)
+				is_jugcut = TRUE
+				break
+
+	if((defender.health <= defender.crit_threshold || (attacker.pulling == defender && attacker.grab_state >= GRAB_NECK) || defender.IsSleeping()) && !is_jugcut) {
+		log_combat(attacker, defender, "jugular gored (Tribal Claw)", name)
+		defender.apply_damage(60, BRUTE, BODY_ZONE_HEAD, def_check)
+		defender.visible_message(span_warning("[attacker] tears out [defender]'s throat with their tail!"), \
+						span_userdanger("[attacker] tears out your throat with their tail!"))
 		jugcut.apply_wound(head)
-		attacker.do_attack_animation(target, ATTACK_EFFECT_CLAW)
-		playsound(get_turf(target), 'sound/weapons/slash.ogg', 50, 1, -1)
-	else
-		//the original code says that this should be a basic attack instead, but not quite sure I could get that to work without fanangling
-		return MARTIAL_ATTACK_FAIL
+		playsound(get_turf(defender), 'sound/effects/wounds/splatter.ogg')
+	} else {
+		defender.apply_damage(15, BRUTE, BODY_ZONE_HEAD, def_check)
+		defender.visible_message(span_warning("[attacker] cuts [defender]'s jugular vein with their claws!"), \
+						span_userdanger("[attacker] cuts your jugular vein!"))
+		laceration.apply_wound(head)
+	}
+	//aditional effects
+	//this should improve lethality
+	if(defender.losebreath <= 50)
+		defender.losebreath = clamp(defender.losebreath + 10, 0, 50)
+	defender.adjustOxyLoss(10)
+	attacker.do_attack_animation(defender, ATTACK_EFFECT_CLAW)
+	playsound(get_turf(defender), 'sound/weapons/slash.ogg', 50, 1, -1)
 
 
-//Tail Grab, instantly puts your target in a T3 grab and makes them unable to talk for a short time.
-/datum/martial_art/tribal_claw/proc/tailGrab(mob/living/carbon/human/attacker, mob/living/carbon/human/target)
-	log_combat(attacker, target, "tail grabbed (Tribal Claw)", name)
-	target.visible_message(span_warning("[attacker] grabs [target] with their tail!"), \
+
+//Tail Grab, instantly puts your defender in a T3 grab and makes them unable to talk for a short time.
+/datum/martial_art/tribal_claw/proc/tailGrab(mob/living/carbon/human/attacker, mob/living/carbon/human/defender)
+	log_combat(attacker, defender, "tail grabbed (Tribal Claw)", name)
+	defender.visible_message(span_warning("[attacker] grabs [defender] with their tail!"), \
 						span_userdanger("[attacker] grabs you with their tail!6</span>"))
-	target.grabbedby(attacker, 1)
-	target.Knockdown(5) //Without knockdown target still stands up while T3 grabbed.
+	defender.grabbedby(attacker, 1)
+	defender.Knockdown(5) //Without knockdown defender still stands up while T3 grabbed.
 	attacker.setGrabState(GRAB_NECK)
-	target.adjust_silence_up_to(10 SECONDS, 10 SECONDS)
+	defender.adjust_silence_up_to(10 SECONDS, 10 SECONDS)
 
-/datum/martial_art/tribal_claw/harm_act(mob/living/carbon/human/attacker, mob/living/carbon/human/target)
-	add_to_streak("H",target)
-	if(check_streak(attacker,target))
+/datum/martial_art/tribal_claw/harm_act(mob/living/carbon/human/attacker, mob/living/carbon/human/defender)
+	add_to_streak("H",defender)
+	if(check_streak(attacker,defender))
 		return TRUE
 	return FALSE
 
-/datum/martial_art/tribal_claw/disarm_act(mob/living/carbon/human/attacker, mob/living/carbon/human/target)
-	add_to_streak("D",target)
-	if(check_streak(attacker,target))
+/datum/martial_art/tribal_claw/disarm_act(mob/living/carbon/human/attacker, mob/living/carbon/human/defender)
+	add_to_streak("D",defender)
+	if(check_streak(attacker,defender))
 		return TRUE
 	return FALSE
 
-/datum/martial_art/tribal_claw/grab_act(mob/living/carbon/human/attacker, mob/living/carbon/human/target)
-	add_to_streak("G",target)
-	if(check_streak(attacker,target))
+/datum/martial_art/tribal_claw/grab_act(mob/living/carbon/human/attacker, mob/living/carbon/human/defender)
+	add_to_streak("G",defender)
+	if(check_streak(attacker,defender))
 		return TRUE
 	return FALSE
 
@@ -114,6 +159,6 @@ Deals 15 brute to head(reduced by armor) and causes a rapid bleeding effect simi
 	to_chat(usr, "<b><i>You retreat inward and recall the teachings of the Tribal Claw...</i></b>")
 
 	to_chat(usr, span_notice("Tail Sweep</span>: Disarm Harm. Pushes everyone around you away and knocks them down."))
-	to_chat(usr, span_notice("Face Scratch</span>: Harm Harm. Damages your target's head and confuses them for a short time."))
-	to_chat(usr, span_notice("Jugular Cut</span>: Harm Disarm. Causes your target to rapidly lose blood, works only if you grab your target by their neck, if they are sleeping, or in critical condition."))
-	to_chat(usr, span_notice("Tail Grab</span>: Disarm Disarm Grab. Grabs your target by their neck and makes them unable to talk for a short time."))
+	to_chat(usr, span_notice("Face Scratch</span>: Harm Harm. Damages your defender's head and confuses them for a short time."))
+	to_chat(usr, span_notice("Jugular Cut</span>: Harm Disarm. Causes your defender to rapidly lose blood, works only if you grab your defender by their neck, if they are sleeping, or in critical condition."))
+	to_chat(usr, span_notice("Tail Grab</span>: Disarm Disarm Grab. Grabs your defender by their neck and makes them unable to talk for a short time."))

--- a/monkestation/code/modules/uplink/uplink_items/species.dm
+++ b/monkestation/code/modules/uplink/uplink_items/species.dm
@@ -26,6 +26,6 @@
 /datum/uplink_item/species_restricted/tribal_claw_scroll
 	name = "Silver-Scale Scroll"
 	desc = "A scroll with ancient heritage. It can teach the user the secrets of Tribal Claw, an offensive martial art reliant on one's claws and tail."
-	cost = 7
+	cost = 10
 	item = /obj/item/book/granter/martial/tribal_claw
 	restricted_species = list(SPECIES_LIZARD)


### PR DESCRIPTION
finally
## About The Pull Request
secretly an ided pr.....

When I was testing TC on live I found that it was kind of horrifically weak, so I have improved its damage output and made it a bit more faithful to the original.
## Why It's Good For The Game
Tribal claw was an extremely weak martial art with very very little redeeming factors besides its ability to stunlock with tail sweep, which also did no damage. Sleeping carp and CQC can both do better.
## Changelog
:cl:
balance: tribal claw rebalance
balance: Tribal Claw now costs 10 TC, an increase of 3.
balance: Tribal Claw now gives you 20% armor against melee, bullets, and lasers, as well as giving you wound resistance.
balance: Tribal Claw now gives Hard Soles (run on glass my pretties)
balance: Tribal Claw now has a 60% block chance against melee when in throw mode.
balance: Face Scratch now deals 30 damage instead of 10 as well as its original effects
balance: Jugular Cut now deals 10 oxygen damage and causes breath loss for 10 seconds per combo hit, capping out at 50 seconds.
balance: Jugular Cut has a strong attack on sleeping or neck grabbed targets, which deals 60 damage and a Weeping Avulsion.
balance: Jugular Cut has a weak attack on standing targets for 15 damage, but only does a Open Laceration
code: minor code fixes in Tribal Claw
/:cl:
