### PR TITLE
Add Justice Injections to Metastation

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -6618,7 +6618,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/vg_decals/numbers/two,
 /obj/machinery/door/window/brigdoor/security/cell/right/directional/west{
-	name = "Cell 2"
+	name = "Cell 2";
+	id = "Cell 2"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
@@ -17227,7 +17228,8 @@
 	dir = 8
 	},
 /obj/machinery/door/window/brigdoor/security/cell/right/directional/west{
-	name = "Cell 1"
+	name = "Cell 1";
+	id = "Cell 1"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
@@ -40119,7 +40121,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/vg_decals/numbers/three,
 /obj/machinery/door/window/brigdoor/security/cell/right/directional/west{
-	name = "Cell 3"
+	name = "Cell 3";
+	id = "Cell 3"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
@@ -55422,7 +55425,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/vg_decals/numbers/five,
 /obj/machinery/door/window/brigdoor/security/cell/right/directional/east{
-	name = "Cell 5"
+	name = "Cell 5";
+	id = "Cell 5"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -73522,7 +73526,8 @@
 	dir = 4
 	},
 /obj/machinery/door/window/brigdoor/security/cell/right/directional/east{
-	name = "Cell 4"
+	name = "Cell 4";
+	id = "Cell 4"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -108933,7 +108938,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/vg_decals/numbers/six,
 /obj/machinery/door/window/brigdoor/security/cell/right/directional/east{
-	name = "Cell 6"
+	name = "Cell 6";
+	id = "Cell 6"
 	},
 /turf/open/floor/iron/dark/side{
 	dir = 4

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -51617,9 +51617,16 @@
 /area/station/science/ordnance/testlab)
 "rXB" = (
 /obj/structure/table,
-/obj/item/flashlight/lamp,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/storage/backpack/duffelbag/sec/surgery{
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = 5
+	},
+/obj/item/clothing/mask/balaclava,
+/obj/item/flashlight/lamp,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "rXF" = (
@@ -64412,16 +64419,11 @@
 /area/station/service/cafeteria)
 "wAp" = (
 /obj/item/radio/intercom/directional/west,
-/obj/structure/table,
-/obj/item/storage/backpack/duffelbag/sec/surgery{
-	pixel_y = 5
-	},
-/obj/item/clothing/mask/balaclava,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/red/half/contrasted,
+/obj/structure/closet/secure_closet/injection{
+	name = "justice injections locker"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "wAA" = (


### PR DESCRIPTION
## About The Pull Request

Title says it all!
## Why It's Good For The Game

Brings map parity to Metastation, the only one that doesnt have a Justice/Education Injection locker.

This will also fix an issue that was identified in the middle of generating this PR regarding the cells on Blueshift. The timers now work. Behold.

![image](https://github.com/user-attachments/assets/ce0598db-4a8e-49a4-8388-d61158b45559)

## Changelog
:cl:
add: Metastation now has a justice/education injection locker.
fix: Cell timers for all cells in jail not work on Blueshift.
/:cl:
