### PR TITLE
[PORT] slaughter/laughter demon roundend report consume count + you cant bodyslam yourself

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -270,7 +270,6 @@
 	new /obj/effect/dummy/phased_mob(T, spawned)
 
 	spawned.key = C.key
-	spawned.generate_antagonist_status()
 
 /obj/item/antag_spawner/slaughter_demon/laughter
 	name = "vial of tickles"

--- a/code/modules/antagonists/wizard/slaughter_antag.dm
+++ b/code/modules/antagonists/wizard/slaughter_antag.dm
@@ -1,5 +1,6 @@
 /datum/antagonist/slaughter
 	name = "\improper Slaughter Demon"
+	roundend_category = "demons"
 	show_name_in_check_antagonists = TRUE
 	ui_name = "AntagInfoDemon"
 	job_rank = ROLE_ALIEN
@@ -37,6 +38,30 @@
 	data["objectives"] = get_objectives()
 	data["explain_attack"] = TRUE
 	return data
+
+/datum/antagonist/slaughter/roundend_report()
+	var/list/report = list()
+
+	if(!owner)
+		CRASH("Antagonist datum without owner")
+
+	report += printplayer(owner)
+
+	if(objectives.len)
+		report += printobjectives(objectives)
+
+	var/datum/action/cooldown/spell/jaunt/bloodcrawl/slaughter_demon/consume_ability = locate() in owner.current?.actions
+	if(consume_ability?.consume_count > 0)
+		report += span_greentext("The [name] consumed a total of [consume_ability.consume_count] bodies!")
+	else
+		report += span_redtext("The [name] did not consume anyone! Shame!!")
+
+	if(owner.current?.stat != DEAD)
+		report += "<span class='greentext big'>The [name] survived!</span>"
+	else
+		report += "<span class='redtext big'>The [name] was vanquished!</span>"
+
+	return report.Join("<br>")
 
 /datum/antagonist/slaughter/laughter
 	name = "Laughter demon"

--- a/code/modules/events/ghost_role/slaughter_event.dm
+++ b/code/modules/events/ghost_role/slaughter_event.dm
@@ -32,7 +32,6 @@
 	new /obj/effect/dummy/phased_mob(spawn_location, spawned)
 
 	player_mind.transfer_to(spawned)
-	spawned.generate_antagonist_status()
 
 	message_admins("[ADMIN_LOOKUPFLW(spawned)] has been made into a slaughter demon by an event.")
 	spawned.log_message("was spawned as a slaughter demon by an event.", LOG_GAME)

--- a/code/modules/mob/living/basic/space_fauna/demon/demon.dm
+++ b/code/modules/mob/living/basic/space_fauna/demon/demon.dm
@@ -60,8 +60,9 @@
 	return list()
 
 /// Proc that just sets up the demon's antagonism status.
-/mob/living/basic/demon/proc/generate_antagonist_status()
-	if(isnull(antag_type))
+/mob/living/basic/demon/mind_initialize()
+	. = ..()
+	if(isnull(antag_type) || mind.has_antag_datum(antag_type))
 		return // we weren't built for this proc to run
 
 	mind.set_assigned_role(SSjob.GetJobType(/datum/job/slaughter_demon))

--- a/code/modules/mob/living/basic/space_fauna/demon/demon_subtypes.dm
+++ b/code/modules/mob/living/basic/space_fauna/demon/demon_subtypes.dm
@@ -67,7 +67,7 @@
 
 /// Performs the classic slaughter demon bodyslam on the attack_target. Yeets them a screen away.
 /mob/living/basic/demon/slaughter/proc/bodyslam(atom/attack_target)
-	if(!isliving(attack_target))
+	if(!isliving(attack_target) || attack_target == src)
 		return
 
 	if(!Adjacent(attack_target))

--- a/code/modules/spells/spell_types/jaunt/bloodcrawl.dm
+++ b/code/modules/spells/spell_types/jaunt/bloodcrawl.dm
@@ -162,6 +162,8 @@
 		they will be consumed by you, fully healing you."
 	/// The sound played when someone's consumed.
 	var/consume_sound = 'sound/magic/demon_consume.ogg'
+	/// consume count (statistics and stuff)
+	var/consume_count = 0
 
 /datum/action/cooldown/spell/jaunt/bloodcrawl/slaughter_demon/try_enter_jaunt(obj/effect/decal/cleanable/blood, mob/living/jaunter)
 	// Save this before the actual jaunt
@@ -228,6 +230,7 @@
 		victim.investigate_log("has been killed by being consumed by a slaugter demon.", INVESTIGATE_DEATHS)
 	victim.death()
 	on_victim_consumed(victim, jaunter)
+	consume_count++
 
 /**
  * Called when a victim starts to be consumed.


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/82481

## Why It's Good For The Game

> i wanted to brag in OOC about my supreme robust killcount but then i realized theres no way to verify this
> also hurting yourself is stupid

## Changelog
:cl: Absolucy, mc-oofert
qol: Slaughter/laughter demons have a cooler round end report.
qol: You may not bodyslam yourself as a demon
code: Slaughter and laughter demons are given their antag datum when their mind initializes.
/:cl:
