### PR TITLE
Allow numbers in names, give palsmamen, arachnids, and flies hair

### DIFF
--- a/code/modules/client/preferences/names.dm
+++ b/code/modules/client/preferences/names.dm
@@ -38,7 +38,7 @@
 	// The `_` makes it first in ABC order.
 	group = "_real_name"
 	savefile_key = "real_name"
-	allow_numbers = TRUE
+	allow_numbers = TRUE // Monkestation addition
 
 /datum/preference/name/real_name/apply_to_human(mob/living/carbon/human/target, value)
 	target.real_name = value
@@ -72,7 +72,7 @@
 	explanation = "Backup human name"
 	group = "backup_human"
 	savefile_key = "human_name"
-	allow_numbers = TRUE
+	allow_numbers = TRUE // Monkestation addition
 
 /datum/preference/name/backup_human/create_informed_default_value(datum/preferences/preferences)
 	var/gender = preferences.read_preference(/datum/preference/choiced/gender)
@@ -85,7 +85,7 @@
 	explanation = "Clown name"
 	group = "fun"
 	relevant_job = /datum/job/clown
-	allow_numbers = TRUE
+	allow_numbers = TRUE // Monkestation addition
 
 /datum/preference/name/clown/create_default_value()
 	return pick(GLOB.clown_names)
@@ -96,7 +96,7 @@
 	explanation = "Mime name"
 	group = "fun"
 	relevant_job = /datum/job/mime
-	allow_numbers = TRUE
+	allow_numbers = TRUE // Monkestation addition
 
 /datum/preference/name/mime/create_default_value()
 	return pick(GLOB.mime_names)

--- a/code/modules/client/preferences/names.dm
+++ b/code/modules/client/preferences/names.dm
@@ -38,6 +38,7 @@
 	// The `_` makes it first in ABC order.
 	group = "_real_name"
 	savefile_key = "real_name"
+	allow_numbers = TRUE
 
 /datum/preference/name/real_name/apply_to_human(mob/living/carbon/human/target, value)
 	target.real_name = value
@@ -71,6 +72,7 @@
 	explanation = "Backup human name"
 	group = "backup_human"
 	savefile_key = "human_name"
+	allow_numbers = TRUE
 
 /datum/preference/name/backup_human/create_informed_default_value(datum/preferences/preferences)
 	var/gender = preferences.read_preference(/datum/preference/choiced/gender)
@@ -83,6 +85,7 @@
 	explanation = "Clown name"
 	group = "fun"
 	relevant_job = /datum/job/clown
+	allow_numbers = TRUE
 
 /datum/preference/name/clown/create_default_value()
 	return pick(GLOB.clown_names)
@@ -93,6 +96,7 @@
 	explanation = "Mime name"
 	group = "fun"
 	relevant_job = /datum/job/mime
+	allow_numbers = TRUE
 
 /datum/preference/name/mime/create_default_value()
 	return pick(GLOB.mime_names)

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -310,7 +310,7 @@
 	limb_id = SPECIES_FLYPERSON
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
-	head_flags = HEAD_EYESPRITES | HEAD_DEBRAIN
+	head_flags = HEAD_EYESPRITES | HEAD_DEBRAIN | HEAD_HAIR
 
 /obj/item/bodypart/chest/fly
 	limb_id = SPECIES_FLYPERSON

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -310,8 +310,12 @@
 	limb_id = SPECIES_FLYPERSON
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
+//MONKESTATION ADDITION START
+	/*
+	head_flags = HEAD_EYESPRITES | HEAD_DEBRAIN
+*/
 	head_flags = HEAD_EYESPRITES | HEAD_DEBRAIN | HEAD_HAIR
-
+//MONKESTATION ADDITION END
 /obj/item/bodypart/chest/fly
 	limb_id = SPECIES_FLYPERSON
 	is_dimorphic = TRUE

--- a/code/modules/surgery/bodyparts/species_parts/plasmaman_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/plasmaman_bodyparts.dm
@@ -7,8 +7,12 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	dmg_overlay_type = null
+//MONKESTATION ADDITION START
+/*
+	head_flags = HEAD_EYESPRITES
+*/
 	head_flags = HEAD_EYESPRITES | HEAD_HAIR
-
+// MONKESTATION ADDITION END
 /obj/item/bodypart/chest/plasmaman
 	icon = 'icons/mob/species/plasmaman/bodyparts.dmi'
 	icon_state = "plasmaman_chest"

--- a/code/modules/surgery/bodyparts/species_parts/plasmaman_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/plasmaman_bodyparts.dm
@@ -7,7 +7,7 @@
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
 	dmg_overlay_type = null
-	head_flags = HEAD_EYESPRITES
+	head_flags = HEAD_EYESPRITES | HEAD_HAIR
 
 /obj/item/bodypart/chest/plasmaman
 	icon = 'icons/mob/species/plasmaman/bodyparts.dmi'

--- a/monkestation/code/modules/surgery/bodyparts/arachnid_bodyparts.dm
+++ b/monkestation/code/modules/surgery/bodyparts/arachnid_bodyparts.dm
@@ -2,7 +2,7 @@
 	icon_greyscale = 'monkestation/icons/mob/species/arachnid/bodyparts.dmi'
 	limb_id = SPECIES_ARACHNIDS
 	is_dimorphic = FALSE
-	head_flags = HEAD_EYESPRITES | HEAD_EYEHOLES | HEAD_DEBRAIN | HEAD_EYECOLOR
+	head_flags = HEAD_EYESPRITES | HEAD_EYEHOLES | HEAD_DEBRAIN | HEAD_EYECOLOR | HEAD_HAIR
 	palette = /datum/color_palette/generic_colors
 	palette_key = MUTANT_COLOR
 


### PR DESCRIPTION

## About The Pull Request
Gives Plasma men, Fly people and arachnids, the option to have hair.

Allows numbers in names

## Why It's Good For The Game
To quote https://github.com/Monkestation/Monkestation2.0/pull/1213 
"hair is hair. In an age where you can have chemicals that can rapidly transform your body, you can have hair"
Skeletons can already have hair, why not these guys. Just player freedom

Numbers in names should've been done a LONG time ago. Lets people have way more freedom, we already have and allow III and stuff in names, no reason not to let real numbers

## Changelog

:cl:
add: You can now have numbers in your characters name
add: Plasma men, Arachnids, and fly people can have hair
/:cl:

