### PR TITLE
Fix overlay lighting messing up alert overlays

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1503,3 +1503,10 @@ GLOBAL_LIST_EMPTY(icon_dimensions)
 		var/icon/my_icon = icon(icon_path)
 		GLOB.icon_dimensions[icon_path] = list("width" = my_icon.Width(), "height" = my_icon.Height())
 	return GLOB.icon_dimensions[icon_path]
+
+/proc/strip_appearance_underlays(mutable_appearance/appearance)
+	var/base_plane = PLANE_TO_TRUE(appearance.plane)
+	for(var/mutable_appearance/underlay as anything in appearance.underlays)
+		if(PLANE_TO_TRUE(underlay.plane) != base_plane)
+			appearance.underlays -= underlay
+	return appearance

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -55,7 +55,7 @@
 		master_appearance.pixel_x = new_master.base_pixel_x
 		master_appearance.pixel_y = new_master.base_pixel_y
 		master_appearance.pixel_z = 0 /* new_master.base_pixel_z */
-		thealert.add_overlay(master_appearance)
+		thealert.add_overlay(strip_appearance_underlays(master_appearance))
 		thealert.icon_state = "template" // We'll set the icon to the client's ui pref in reorganize_alerts()
 		thealert.master = new_master
 	else

--- a/monkestation/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/monkestation/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -17,13 +17,15 @@
 			continue
 		var/sac_name = trimtext(target_mind.name || living_target.real_name || living_target.name)
 		living_targets[sac_name] = living_target
-		var/mutable_appearance/target_appearance = new
-		target_appearance.appearance = living_target.appearance
-		target_appearance.setDir(SOUTH)
-		target_appearance.pixel_x = 0
-		target_appearance.pixel_y = 0
-		target_appearance.pixel_z = 0
-		targets_to_choose[sac_name] = target_appearance
+		var/mutable_appearance/target_appearance = new(living_target)
+		target_appearance.appearance_flags = KEEP_TOGETHER
+		target_appearance.layer = FLOAT_LAYER
+		target_appearance.plane = FLOAT_PLANE
+		target_appearance.dir = SOUTH
+		target_appearance.pixel_x = living_target.base_pixel_x
+		target_appearance.pixel_y = living_target.base_pixel_y
+		target_appearance.pixel_z = 0 /* living_target.base_pixel_z */
+		targets_to_choose[sac_name] = strip_appearance_underlays(target_appearance)
 
 	// If we don't have a last tracked name, open a radial to set one.
 	// If we DO have a last tracked name, we skip the radial if they right click the action.


### PR DESCRIPTION

## About The Pull Request

Port of my own PR: https://github.com/tgstation/tgstation/pull/87362 

## Changelog
:cl:
fix: Fix overlay lighting (such as lanterns) messing up alert overlays, i.e the rod of asclepius alert, and the living heart selection.
/:cl:
