### PR TITLE
Removes xenomicrobes from the maint pill reagent pool

### DIFF
--- a/monkestation/code/modules/reagents/misc.dm
+++ b/monkestation/code/modules/reagents/misc.dm
@@ -8,6 +8,9 @@
 /datum/reagent/gondola_mutation_toxin/virtual_domain
 	restricted = TRUE // STOP SHOVING ALL THE WINDOWS AROUND
 
+/datum/reagent/xenomicrobes
+	restricted = TRUE
+
 // Reagents that shouldn't be in the random pool, as they're either completely useless or shouldn't exist on their own.
 /datum/reagent/slime_ooze
 	restricted = TRUE


### PR DESCRIPTION

## About The Pull Request

Fully removes xenomicrobes (the chem that turns you into a xeno hunter) from the maint pill pool, similar to romerol and such.

Done at the request of @ThePooba

## Why It's Good For The Game

CREW XENOS SUCK. also i was offered coins for this.

## Changelog
:cl:
del: Removed xenomicrobes from the maint pill reagent pool.
/:cl:
