### PR TITLE
Gives Heads of Staff fountain pens

### DIFF
--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -33,6 +33,8 @@
 	name = "head of personnel PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick/head
 	greyscale_colors = "#374f7e#a52f29#a52f29"
+	inserted_item = /obj/item/pen/fountain
+	stored_paper = 20
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
@@ -47,6 +49,7 @@
 	name = "head of security PDA"
 	greyscale_config = /datum/greyscale_config/tablet/head
 	greyscale_colors = "#EA3232#0000CC"
+	inserted_item = /obj/item/pen/fountain
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
@@ -60,6 +63,7 @@
 	name = "chief engineer PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick/head
 	greyscale_colors = "#D99A2E#69DBF3#FAFAFA"
+	inserted_item = /obj/item/pen/fountain
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,
@@ -75,6 +79,7 @@
 	name = "chief medical officer PDA"
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick/head
 	greyscale_colors = "#FAFAFA#000099#3F96CC"
+	inserted_item = /obj/item/pen/fountain
 	starting_programs = list(
 		/datum/computer_file/program/crew_manifest,
 		/datum/computer_file/program/status,


### PR DESCRIPTION
## About The Pull Request

Gives the heads of staff fountain pens in their PDAs. Also gives HoP 20 sheets of paper in it, like the QM gets.
I would give blueshield fountain pens too but I can't seem to find their PDAs listed in the file. I'll worry about that when the new NT rep comes out if they don't also get a fountain pen.

## Why It's Good For The Game

Fancy people get fancy pens. Also lets them do paperwork if the gravity goes out. The paper means the HoP will always be ready to procure paperwork.

## Changelog


:cl:
change: replaced heads of staff "vanilla" pens with fountain pens
add: gave HoP 20 sheets of paper in their PDA, the same as the QM
/:cl:
