### PR TITLE
Syndicate clones don't get red eyes.

### DIFF
--- a/monkestation/code/game/machinery/exp_cloner.dm
+++ b/monkestation/code/game/machinery/exp_cloner.dm
@@ -139,6 +139,7 @@
 		var/datum/antagonist/evil_clone/antag_object = new
 		antag_object.objectives += new evil_objective()
 		mob_occupant.mind.add_antag_datum(antag_object)
+		mob_occupant.AddElement(/datum/element/cult_eyes, initial_delay = 0 SECONDS) //Only emag/emp/event clones get red eyes, 20 tc clone kit clones don't get red eyes.
 	return TRUE
 
 /obj/machinery/clonepod/experimental/proc/get_clone_preview(datum/dna/clone_dna)

--- a/monkestation/code/game/objects/items/storage/uplink_kits.dm
+++ b/monkestation/code/game/objects/items/storage/uplink_kits.dm
@@ -193,7 +193,7 @@
 			<li>The "DNA data disk" inside is actually a sophisticated device that can be used to hijack an experimental cloner, giving the clones a directive they must follow.</li>\
 			<li>In order to use this disk, use it in your hand, and input your desired directive, before hitting the cloner with the disk. You can input and upload a new objective to replace the old one if you ever feel like it, the disk is infinitely reusable.</li>\
 			<li>The clones will be given basic access, including syndicate, maintenance, genetics, and mineral storage. They will also be given an implanted syndicate radio and automatically taught codespeak. Syndicate turrets and the like will recognize the clones as a member of the syndicate.</li>\
-			<li>Be wary, the clones will have obviously evil red eyes, which will alert anyone who sees them with no eye covering that something is wrong with them. Also, don't try to use this on newer cloning models, Nanotrasen fixed the vulnerability that lets the disk work in their newer models.</li>\
+			<li>Don't try to use this on newer cloning models, Nanotrasen fixed the vulnerability that lets the disk work in their newer models.</li>\
 			<li>When hacked, a cloner will begin to operate slower, and anyone who examines it closely will be able to see that the cloner is malfunctioning.</li>\
 			<li>A tip, any activated mutations in the person being scanned, will be present in the clones produced, allowing you to give the clones some intrinsic powers. Make sure to use activators, not mutators.</li>\
 			</ul>

--- a/monkestation/code/modules/antagonists/evil_clone/evil_clone.dm
+++ b/monkestation/code/modules/antagonists/evil_clone/evil_clone.dm
@@ -11,14 +11,3 @@
 	. = ..()
 	owner.announce_objectives()
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/revolutionary_tide.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
-
-/datum/antagonist/evil_clone/apply_innate_effects(mob/living/mob_override)
-	. = ..()
-	var/mob/living/current = owner.current
-	current.AddElement(/datum/element/cult_eyes, initial_delay = 0 SECONDS)
-
-/datum/antagonist/evil_clone/remove_innate_effects(mob/living/mob_override)
-	. = ..()
-	var/mob/living/current = owner.current
-	if (HAS_TRAIT(current, TRAIT_UNNATURAL_RED_GLOWY_EYES))
-		current.RemoveElement(/datum/element/cult_eyes)

--- a/monkestation/code/modules/uplink/uplink_items/job.dm
+++ b/monkestation/code/modules/uplink/uplink_items/job.dm
@@ -18,7 +18,7 @@
 	progression_minimum = 5 MINUTES
 	cost = 20
 	item = /obj/item/storage/box/clonearmy
-	restricted_roles = list(JOB_GENETICIST, JOB_RESEARCH_DIRECTOR, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER) // Experimental cloners were traditionally bought by cargo.
+	restricted_roles = list(JOB_GENETICIST, JOB_RESEARCH_DIRECTOR, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER, JOB_ASSISTANT) // Experimental cloners were traditionally bought by cargo.
 
 ///I know this probably isn't the right place to put it, but I don't know where I should put it, and I can move it later.
 /obj/item/disk/clonearmy

--- a/monkestation/code/modules/uplink/uplink_items/job.dm
+++ b/monkestation/code/modules/uplink/uplink_items/job.dm
@@ -18,7 +18,7 @@
 	progression_minimum = 5 MINUTES
 	cost = 20
 	item = /obj/item/storage/box/clonearmy
-	restricted_roles = list(JOB_GENETICIST, JOB_RESEARCH_DIRECTOR, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER, JOB_ASSISTANT) // Experimental cloners were traditionally bought by cargo.
+	restricted_roles = list(JOB_GENETICIST, JOB_RESEARCH_DIRECTOR, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER) // Experimental cloners were traditionally bought by cargo.
 
 ///I know this probably isn't the right place to put it, but I don't know where I should put it, and I can move it later.
 /obj/item/disk/clonearmy


### PR DESCRIPTION
## About The Pull Request
Syndicate clones don't get the red eyes.

## Why It's Good For The Game
If you're spending 20 tc for a traitor item, it's nice to have it not immediately out you.

## Changelog
:cl:
balance: Syndicate clone army kit clones don't have red eyes.
/:cl:
