### PR TITLE
Assault operative improvements

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -19695,7 +19695,10 @@
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
 "cvB" = (
-/obj/machinery/armament_station/assault_operatives,
+/obj/structure/signboard{
+	locked = 1;
+	sign_text = "Your armament points is effectively your uplink, use it in-hand!"
+	},
 /turf/open/floor/iron/smooth_large,
 /area/cruiser_dock)
 "cvJ" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -20738,10 +20738,8 @@
 /area/centcom/central_command_areas/adminroom)
 "gwo" = (
 /obj/structure/closet/cardboard,
-/mob/living/basic/bot/medbot{
-	faction = list("Syndicate");
-	name = "Kahn";
-	radio_channel = "Syndicate"
+/mob/living/basic/bot/medbot/nukie/assop{
+	name = "Kahn"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)

--- a/_maps/shuttles/nova/goldeneye_cruiser.dmm
+++ b/_maps/shuttles/nova/goldeneye_cruiser.dmm
@@ -348,6 +348,7 @@
 	dir = 4
 	},
 /obj/structure/chair/stool/directional/west,
+/obj/effect/spawner/random/entertainment/plushie,
 /turf/open/floor/iron/dark/diagonal,
 /area/shuttle/syndicate/cruiser/brig)
 "pE" = (
@@ -560,7 +561,9 @@
 /area/shuttle/syndicate/cruiser/hallway)
 "Bx" = (
 /obj/effect/turf_decal/bot_white,
-/obj/structure/tank_holder,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/brig)
 "CH" = (
@@ -880,12 +883,10 @@
 /area/shuttle/syndicate/cruiser/brig)
 "Ud" = (
 /obj/structure/closet/crate/medical,
-/mob/living/basic/bot/medbot{
-	faction = list("Syndicate");
-	name = "James T. Kirk";
-	radio_channel = "Syndicate"
-	},
 /obj/effect/turf_decal/bot_white,
+/mob/living/basic/bot/medbot/nukie/assop{
+	name = "James T. Kirk"
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/hallway)
 "Vm" = (

--- a/_maps/shuttles/nova/goldeneye_cruiser.dmm
+++ b/_maps/shuttles/nova/goldeneye_cruiser.dmm
@@ -483,7 +483,7 @@
 "wb" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/bot,
-/obj/machinery/defibrillator_mount/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/medical)
 "ws" = (
@@ -945,7 +945,6 @@
 "ZC" = (
 /obj/structure/rack/shelf,
 /obj/effect/turf_decal/bot_white,
-/obj/item/defibrillator/loaded,
 /obj/item/storage/backpack/duffelbag/syndie/surgery,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/medical)

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -295,7 +295,7 @@ GLOBAL_LIST_INIT(book_types, typecacheof(list(
 #define is_bartender_job(job_type) (istype(job_type, /datum/job/bartender))
 #define is_captain_job(job_type) (istype(job_type, /datum/job/captain))
 #define is_chaplain_job(job_type) (istype(job_type, /datum/job/chaplain))
-#define is_clown_job(job_type) (istype(job_type, /datum/job/clown))
+#define is_clown_job(job_type) (istype(job_type, /datum/job/clown) || istype(job_type, /datum/job/yellowclown))
 #define is_detective_job(job_type) (istype(job_type, /datum/job/detective))
 #define is_scientist_job(job_type) (istype(job_type, /datum/job/scientist))
 #define is_security_officer_job(job_type) (istype(job_type, /datum/job/security_officer))

--- a/code/__DEFINES/~monkestation/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/~monkestation/dcs/signals/signals_global.dm
@@ -1,0 +1,2 @@
+/// Sent whenever a new goldeneye key is spawned: (obj/item/goldeneye_key)
+#define COMSIG_GLOB_GOLDENEYE_KEY_CREATED "!goldeneye_key_created"

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -22,9 +22,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/defibrillator_mount, 28)
 
 /obj/machinery/defibrillator_mount/loaded/Initialize(mapload) //loaded subtype for mapping use
 	. = ..()
-	defib = new/obj/item/defibrillator/loaded(src)
+	defib = new /obj/item/defibrillator/loaded(src)
 
-MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/defibrillator_mount, 28)
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/defibrillator_mount/loaded, 28)
 
 /obj/machinery/defibrillator_mount/Destroy()
 	if(defib)

--- a/monkestation/code/modules/assault_ops/code/antagonist.dm
+++ b/monkestation/code/modules/assault_ops/code/antagonist.dm
@@ -11,6 +11,7 @@
 	antag_moodlet = /datum/mood_event/focused
 	show_to_ghosts = TRUE
 	hijack_speed = 2
+	remove_from_manifest = TRUE
 
 	preview_outfit = /datum/outfit/assaultops_preview
 	/// In the preview icon, the operatives who are behind the leader

--- a/monkestation/code/modules/assault_ops/code/antagonist.dm
+++ b/monkestation/code/modules/assault_ops/code/antagonist.dm
@@ -30,15 +30,28 @@
 	Use your pinpointer to locate these after you have extracted the GoldenEye key from the head of staff. It will be sent in by droppod. \
 	You must then upload the key to the GoldenEye upload terminal on this GoldenEye station. After you have completed your mission, \
 	The GoldenEye defence network will fall, and we will gain access to Nanotrasen's military systems. Good luck agent."
-	/// A link to our internal pinpointer.
-	var/datum/status_effect/goldeneye_pinpointer/pinpointer
+	/// A link to our team monitor, used to track keycards.
+	var/datum/component/team_monitor/monitor
 
 /datum/antagonist/assault_operative/Destroy()
-	QDEL_NULL(pinpointer)
+	UnregisterSignal(SSdcs, COMSIG_GLOB_GOLDENEYE_KEY_CREATED)
+	QDEL_NULL(monitor)
 	return ..()
 
 /datum/antagonist/assault_operative/apply_innate_effects(mob/living/mob_override)
-	add_team_hud(mob_override || owner.current, /datum/antagonist/assault_operative)
+	var/mob/living/target = mob_override || owner.current
+	monitor = target.AddComponent(/datum/component/team_monitor, "goldeneye_key")
+	for(var/obj/item/goldeneye_key/keycard as anything in SSgoldeneye.goldeneye_keys)
+		if(QDELETED(keycard))
+			continue
+		monitor.add_to_tracking_network(keycard.beacon)
+	monitor.show_hud(target)
+	add_team_hud(target, /datum/antagonist/assault_operative)
+
+/datum/antagonist/assault_operative/remove_innate_effects(mob/living/mob_override)
+	var/mob/living/target = mob_override || owner.current
+	monitor?.hide_hud(target)
+	QDEL_NULL(monitor)
 
 /datum/antagonist/assault_operative/get_team()
 	return assault_team
@@ -51,6 +64,7 @@
 
 /datum/antagonist/assault_operative/on_gain()
 	. = ..()
+	RegisterSignal(SSdcs, COMSIG_GLOB_GOLDENEYE_KEY_CREATED, PROC_REF(on_goldeneye_key_created))
 	equip_operative()
 	forge_objectives()
 	if(send_to_spawnpoint)
@@ -78,30 +92,18 @@
 
 // UI systems
 /datum/antagonist/assault_operative/ui_data(mob/user)
-	var/list/data = list()
+	return list(
+		"uploaded_keys" = SSgoldeneye.uploaded_keys,
+		"available_targets" = get_available_targets(),
+		"extracted_targets" = get_extracted_targets(),
+		"goldeneye_keys" = get_goldeneye_keys(),
+	)
 
-	data["required_keys"] = SSgoldeneye.required_keys
-
-	data["uploaded_keys"] = SSgoldeneye.uploaded_keys
-
-	data["available_targets"] = get_available_targets()
-	data["extracted_targets"] = get_extracted_targets()
-
-	data["goldeneye_keys"] = get_goldeneye_keys()
-
-	data["objectives"] = get_objectives()
-	return data
-
-/datum/antagonist/assault_operative/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
-	. = ..()
-	if(.)
-		return
-	switch(action)
-		if("track_key")
-			var/obj/item/goldeneye_key/selected_key = locate(params["key_ref"]) in SSgoldeneye.goldeneye_keys
-			if(!selected_key)
-				return
-			pinpointer.set_target(selected_key)
+/datum/antagonist/assault_operative/ui_static_data(mob/user)
+	return list(
+		"required_keys" = SSgoldeneye.required_keys,
+		"objectives" = get_objectives(),
+	)
 
 /datum/antagonist/assault_operative/proc/get_available_targets()
 	var/list/available_targets_data = list()
@@ -124,18 +126,19 @@
 	return extracted_targets_data
 
 /datum/antagonist/assault_operative/proc/get_goldeneye_keys()
-	var/list/goldeneye_keys = list()
-	for(var/obj/item/goldeneye_key/iterating_key in SSgoldeneye.goldeneye_keys)
-		var/turf/location = get_turf(iterating_key)
-		goldeneye_keys += list(list(
+	. = list()
+	for(var/obj/item/goldeneye_key/keycard as anything in SSgoldeneye.goldeneye_keys)
+		if(QDELETED(keycard))
+			continue
+		var/turf/location = get_turf(keycard)
+		. += list(list(
+			"name" = keycard.goldeneye_tag,
+			"color" = keycard.beacon_color,
 			"coord_x" = location.x,
 			"coord_y" = location.y,
 			"coord_z" = location.z,
-			"selected" = pinpointer?.target == iterating_key,
-			"name" = iterating_key.goldeneye_tag,
-			"ref" = REF(iterating_key),
+			"ref" = REF(keycard),
 		))
-	return goldeneye_keys
 
 
 /datum/antagonist/assault_operative/forge_objectives()
@@ -162,6 +165,7 @@
 		to_chat(human_target, span_userdanger("You are now a human!"))
 
 	for(var/obj/item/item in human_target.get_equipped_items(TRUE))
+		human_target.dropItemToGround(item, force = TRUE, silent = TRUE)
 		qdel(item)
 
 	var/obj/item/organ/internal/brain/human_brain = human_target.get_organ_slot(BRAIN)
@@ -169,7 +173,8 @@
 	human_target.equipOutfit(assault_operative_default_outfit)
 	human_target.regenerate_icons()
 
-	pinpointer = human_target.apply_status_effect(/datum/status_effect/goldeneye_pinpointer)
+	if(!human_target.has_language(/datum/language/common, TRUE))
+		human_target.grant_language(/datum/language/common, TRUE, TRUE, LANGUAGE_MIND)
 
 	return TRUE
 
@@ -197,6 +202,10 @@
 	final_icon.Blend(disky, ICON_OVERLAY)
 
 	return finish_preview_icon(final_icon)
+
+/datum/antagonist/assault_operative/proc/on_goldeneye_key_created(datum/source, obj/item/goldeneye_key/key)
+	SIGNAL_HANDLER
+	monitor?.add_to_tracking_network(key.beacon)
 
 /**
  * ASSAULT OPERATIVE TEAM DATUM

--- a/monkestation/code/modules/assault_ops/code/assault_op_vendor.dm
+++ b/monkestation/code/modules/assault_ops/code/assault_op_vendor.dm
@@ -1,14 +1,7 @@
-// VENDOR
-/obj/machinery/armament_station/assault_operatives
-	name = "Military Grade Armament Station"
-
-	// required_access = list(ACCESS_SYNDICATE) TESTING
-
-	armament_type = /datum/armament_entry/assault_operatives
-
 // POINTS CARDS
 
 /obj/item/armament_points_card/assaultops
+	desc = "A points card that can be used to acquire weapons and tools for your mission."
 	points = 50
 	armament_type = /datum/armament_entry/assault_operatives
 	access = list(ACCESS_SYNDICATE)

--- a/monkestation/code/modules/assault_ops/code/interrogator.dm
+++ b/monkestation/code/modules/assault_ops/code/interrogator.dm
@@ -218,8 +218,6 @@
 	SSgoldeneye.extract_mind(human_occupant.mind)
 	var/obj/structure/closet/supplypod/pod = new
 	new /obj/effect/pod_landingzone(landingzone, pod, new_key)
-	for(var/datum/status_effect/goldeneye_pinpointer/iterating_pinpointer in GLOB.goldeneye_pinpointers)
-		iterating_pinpointer.set_target(new_key)
 
 	notify_ghosts("GoldenEye key launched!",
 		source = new_key,

--- a/monkestation/code/modules/assault_ops/code/interrogator.dm
+++ b/monkestation/code/modules/assault_ops/code/interrogator.dm
@@ -17,7 +17,7 @@
  */
 /obj/machinery/interrogator
 	name = "In-TERROR-gator"
-	desc = "A morraly corrupt piece of machinery used to extract the human mind into a GoldenEye authentication key. The process is said to be one of the most painful experiences someone can endure. Alt+click to start the process."
+	desc = "A morraly corrupt piece of machinery used to extract the human mind into a GoldenEye authentication key. The process is said to be one of the most painful experiences someone can endure. Alt + Click to start the process."
 	icon = 'monkestation/code/modules/assault_ops/icons/goldeneye.dmi'
 	icon_state = "interrogator_open"
 	state_open = FALSE
@@ -32,9 +32,31 @@
 	/// The human occupant currently inside. Used for easier referencing later on.
 	var/mob/living/carbon/human/human_occupant
 
+/obj/machinery/interrogator/Initialize(mapload)
+	. = ..()
+	register_context()
+
+/obj/machinery/interrogator/Destroy()
+	if(timer_id)
+		deltimer(timer_id)
+		timer_id = null
+	human_occupant = null
+	return ..()
+
+/obj/machinery/interrogator/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	if(!processing)
+		if(check_requirements())
+			context[SCREENTIP_CONTEXT_ALT_LMB] = "Begin Extraction"
+		if(!locked)
+			context[SCREENTIP_CONTEXT_LMB] = state_open ? "Close Door" : "Open Door"
+	else
+		context[SCREENTIP_CONTEXT_ALT_LMB] = "Cancel Extraction"
+	return CONTEXTUAL_SCREENTIP_SET
+
 /obj/machinery/interrogator/examine(mob/user)
 	. = ..()
 	. += "It requies a direct link to a Nanotrasen defence network, stay near a Nanotrasen comms sat!"
+	. += span_info(span_italics("If a target has committed suicide, their body can be still be used to instantly extract the keycard."))
 
 /obj/machinery/interrogator/AltClick(mob/user)
 	. = ..()
@@ -64,13 +86,6 @@
 	else
 		icon_state = state_open ? "interrogator_open" : "interrogator_closed"
 
-/obj/machinery/interrogator/Destroy()
-	if(timer_id)
-		deltimer(timer_id)
-		timer_id = null
-	human_occupant = null
-	return ..()
-
 /obj/machinery/interrogator/container_resist_act(mob/living/user)
 	if(!locked)
 		open_machine()
@@ -97,7 +112,7 @@
 		return FALSE
 	if(!is_station_level(z))
 		return FALSE
-	if(human_occupant.stat == DEAD)
+	if(human_occupant.stat == DEAD && !HAS_TRAIT(human_occupant, TRAIT_SUICIDED))
 		return FALSE
 	return TRUE
 
@@ -115,15 +130,25 @@
 		balloon_alert_to_viewers("invalid target DNA!")
 		return
 	human_occupant = occupant
-	if(human_occupant.stat == DEAD)
+	if(human_occupant.stat == DEAD && !HAS_TRAIT(human_occupant, TRAIT_SUICIDED))
 		balloon_alert_to_viewers("occupant is dead!")
 		return
 	if(!SSgoldeneye.check_goldeneye_target(human_occupant.mind)) // Preventing abuse by method of duplication.
 		balloon_alert_to_viewers("no GoldenEye data!")
 		playsound(src, 'sound/machines/scanbuzz.ogg', 100)
 		return
+	if(handle_victim_suicide(human_occupant))
+		return
 
 	start_extract()
+
+/obj/machinery/interrogator/proc/handle_victim_suicide(mob/living/carbon/human/victim)
+	if(!HAS_TRAIT(victim, TRAIT_SUICIDED))
+		return FALSE
+	say("Extraction completed instantly due to target's mental state. A key is being sent aboard! Crew will shortly detect the keycard!")
+	send_keycard()
+	addtimer(CALLBACK(src, PROC_REF(announce_creation)), ALERT_CREW_TIME)
+	return TRUE
 
 /obj/machinery/interrogator/proc/start_extract()
 	to_chat(human_occupant, span_userdanger("You feel dread wash over you as you hear the door on [src] lock!"))

--- a/monkestation/code/modules/assault_ops/code/sunbeam.dm
+++ b/monkestation/code/modules/assault_ops/code/sunbeam.dm
@@ -51,6 +51,8 @@
 	if(obliteration_range_flatten_override)
 		obliteration_range_flatten = obliteration_range_flatten_override
 
+	SSpoints_of_interest.make_point_of_interest(src)
+
 	START_PROCESSING(SSfastprocess, src)
 	update_appearance()
 	if(scale_x || scale_y)

--- a/monkestation/code/modules/assault_ops/code/sunbeam.dm
+++ b/monkestation/code/modules/assault_ops/code/sunbeam.dm
@@ -66,6 +66,7 @@
 	soundloop = new(src, TRUE)
 
 /obj/effect/sunbeam/Destroy(force)
+	target_atom = null
 	QDEL_NULL(soundloop)
 	return ..()
 
@@ -77,7 +78,7 @@
 		. += beam_overlay
 
 /obj/effect/sunbeam/process(seconds_per_tick)
-	if(target_atom && COOLDOWN_FINISHED(src, movement_delay))
+	if(!QDELETED(target_atom) && COOLDOWN_FINISHED(src, movement_delay))
 		step_towards(src, target_atom)
 		COOLDOWN_START(src, movement_delay, movement_cooldown)
 

--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/components/team_monitor.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/components/team_monitor.dm
@@ -602,5 +602,6 @@ GLOBAL_LIST_EMPTY(tracker_beacons)
 	icon = 'monkestation/icons/mob/hud.dmi'
 	icon_state = "hud_arrow"
 	screen_loc = ui_team_finder
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 #undef ALT_APPEARENCE_ID

--- a/monkestation/code/modules/mob/living/basic/bots/medbot/medbot.dm
+++ b/monkestation/code/modules/mob/living/basic/bots/medbot/medbot.dm
@@ -1,3 +1,21 @@
+/mob/living/basic/bot/medbot/nukie
+	bot_mode_flags = parent_type::bot_mode_flags & ~(BOT_MODE_REMOTE_ENABLED) // Prevent nukie/assop medibots from outing them via remote control
+
+// Assault op medibot shares the nukie subtype, but gets rid of the custom description/behavior,
+// so we don't have to duplicate code to related to the syndicate radio channel.
+/mob/living/basic/bot/medbot/nukie/assop
+	desc = /mob/living/basic/bot/medbot::desc
+	skin = "advanced"
+
+/mob/living/basic/bot/medbot/nukie/assop/nuke_disarm()
+	return
+
+/mob/living/basic/bot/medbot/nukie/assop/nuke_arm()
+	return
+
+/mob/living/basic/bot/medbot/nukie/assop/nuke_detonate()
+	return
+
 /mob/living/basic/bot/medbot/proc/link_techweb(datum/techweb/techweb)
 	if(QDELETED(techweb))
 		return FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -472,6 +472,7 @@
 #include "code\__DEFINES\~monkestation\dcs\signals\signals_carbon.dm"
 #include "code\__DEFINES\~monkestation\dcs\signals\signals_element.dm"
 #include "code\__DEFINES\~monkestation\dcs\signals\signals_food.dm"
+#include "code\__DEFINES\~monkestation\dcs\signals\signals_global.dm"
 #include "code\__DEFINES\~monkestation\dcs\signals\signals_guns.dm"
 #include "code\__DEFINES\~monkestation\dcs\signals\signals_item.dm"
 #include "code\__DEFINES\~monkestation\dcs\signals\signals_object.dm"

--- a/tgui/packages/tgui/interfaces/AntagInfoAssaultops.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoAssaultops.tsx
@@ -32,12 +32,12 @@ type ExtractedTargets = {
 };
 
 type GoldeneyeKeys = {
+  name: string;
+  color: string;
   coord_x: number;
   coord_y: number;
   coord_z: number;
-  name: string;
   ref: string;
-  selected: BooleanLike;
 };
 
 type Info = {
@@ -138,7 +138,7 @@ export const AntagInfoAssaultops = (props) => {
 };
 
 const TargetPrintout = (props) => {
-  const { act, data } = useBackend<Info>();
+  const { data } = useBackend<Info>();
   const { available_targets, extracted_targets } = data;
   return (
     <Section>
@@ -213,34 +213,18 @@ const KeyPrintout = (props) => {
                   <Button
                     width="100%"
                     textAlign="center"
-                    color="yellow"
-                    disabled={key.selected}
+                    color={key.color || 'yellow'}
                     key={key.name}
                     icon="key"
                     content={
-                      key.selected
-                        ? key.name +
-                          ' (' +
-                          key.coord_x +
-                          ', ' +
-                          key.coord_y +
-                          ', ' +
-                          key.coord_z +
-                          ')' +
-                          ' (Tracking)'
-                        : key.name +
-                          ' (' +
-                          key.coord_x +
-                          ', ' +
-                          key.coord_y +
-                          ', ' +
-                          key.coord_z +
-                          ')'
-                    }
-                    onClick={() =>
-                      act('track_key', {
-                        key_ref: key.ref,
-                      })
+                      key.name +
+                      ' (' +
+                      key.coord_x +
+                      ', ' +
+                      key.coord_y +
+                      ', ' +
+                      key.coord_z +
+                      ')'
                     }
                   />
                 </Stack.Item>


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/087588f9-9109-4d3e-8ceb-84ebced7a24b)

![2024-10-23 (1729714027) ~ dreamseeker](https://github.com/user-attachments/assets/e00b107c-16e3-40b8-90d5-6549d0260e31)

## Why It's Good For The Game

Prevents confusion about the armament vendor (it used to have shared limits, it does not anymore), and just some other qol changes.

## Changelog
:cl:
del: Get rid of the armament vendor machine at the assault ops base, replacing it with a signboard telling them to use their card in-hand instead.
qol: The ICARUS sunbeam is now a point of interest in the ghost orbit menu.
qol: The In-TERROR-gator now works on suicided targets, instantly extracting their keycard.
qol: Added screentips to the In-TERROR-gator.
fix: Nukie and assault operative medibots now have remote control disabled by default, preventing them from being outed by the AI bot control or the BotKeeper app.
qol: Pre-loaded the defib into the wall mount on the GoldenEye cruiser.
fix: Roundstart assault operatives are now removed from the crew manifest.
add: Replaced the assault operative keycard pinpointer HUD with arrows on their screen.
balance: GoldenEye keycards are now stationloving, similar to the nuke disk.
add: Added an arcade machine to the GoldenEye Cruiser's prison.
/:cl:
