### PR TITLE
Traitor Assistants can buy clone army kit.

### DIFF
--- a/monkestation/code/modules/uplink/uplink_items/job.dm
+++ b/monkestation/code/modules/uplink/uplink_items/job.dm
@@ -18,7 +18,7 @@
 	progression_minimum = 5 MINUTES
 	cost = 20
 	item = /obj/item/storage/box/clonearmy
-	restricted_roles = list(JOB_GENETICIST, JOB_RESEARCH_DIRECTOR, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER) // Experimental cloners were traditionally bought by cargo.
+	restricted_roles = list(JOB_GENETICIST, JOB_RESEARCH_DIRECTOR, JOB_MEDICAL_DOCTOR, JOB_CHIEF_MEDICAL_OFFICER, JOB_CARGO_TECHNICIAN, JOB_QUARTERMASTER, JOB_ASSISTANT) // Experimental cloners were traditionally bought by cargo.
 
 ///I know this probably isn't the right place to put it, but I don't know where I should put it, and I can move it later.
 /obj/item/disk/clonearmy


### PR DESCRIPTION

## About The Pull Request
Assistant traitors can now buy the clone army kit.
## Why It's Good For The Game
It's thematic for assistants to have numbers, and clone army kit gives them those numbers.
## Changelog
:cl:
add: Traitor Assistants can buy syndicate clone army kit. (Greytide station wide.)
/:cl:
