### PR TITLE
Heavy bleeder challenge health analyzer warning

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -169,6 +169,11 @@
 		render_list += "<span class='alert ml-1'><b>Subject cannot be healed by any known methods.</b></span>\n"
 	// monkestation end
 
+	// monkestation edit: heavy bleeder challenge
+	if(HAS_TRAIT(target, TRAIT_HEAVY_BLEEDER))
+		render_list += "<span class='alert ml-1'><b>Subject will suffer highly abnormal hemorrhaging from laceration or surgical incension.</b></span>\n"
+	// monkestation end
+
 	if(target.stamina.loss)
 		if(advanced)
 			render_list += "<span class='alert ml-1'>Fatigue level: [target.stamina.loss]%.</span>\n"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A ditto to #3433 
Making if you have the heavy bleeder trait it shows up in a similar fashion on any health scanner. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The only way to know about heavy bleeder is to stay observant. And if you preform a open surgery without a stasis. Especially a long one. You can easily lose all 560 U of blood. And while they may be lucky and be the universal receiver, the coin goes both way and they could be the universal donour. 

It allows medical to be more prepared with patients and treat any blood loss for last unlike the current procedure of doing it last.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Health analyzers now alert if the subject has taken the heavy bleeder trait.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
