### PR TITLE
Replace `/proc/trim_reduced` with the native BYOND `trimtext`

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -309,24 +309,6 @@
 			return copytext(text, 1, i + 1)
 	return ""
 
-//Returns a string with reserved characters and spaces after the first and last letters removed
-//Like trim(), but very slightly faster. worth it for niche usecases
-/proc/trim_reduced(text)
-	var/starting_coord = 1
-	var/text_len = length(text)
-	for (var/i in 1 to text_len)
-		if (text2ascii(text, i) > 32)
-			starting_coord = i
-			break
-
-	for (var/i = text_len, i >= starting_coord, i--)
-		if (text2ascii(text, i) > 32)
-			return copytext(text, starting_coord, i + 1)
-
-	if(starting_coord > 1)
-		return copytext(text, starting_coord)
-	return ""
-
 /**
  * Truncate a string to the given length
  *
@@ -347,7 +329,7 @@
 /proc/trim(text, max_length)
 	if(max_length)
 		text = copytext_char(text, 1, max_length)
-	return trim_reduced(text)
+	return trimtext(text)
 
 //Returns a string with the first element of the string capitalized.
 /proc/capitalize(t)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -114,6 +114,9 @@
 /proc/_text2num(T)
 	return text2num(T)
 
+/proc/_trimtext(Text)
+	return trimtext(Text)
+
 /proc/_ohearers(Dist, Center = usr)
 	return ohearers(Dist, Center)
 

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -131,9 +131,6 @@
 	newfriend.turf_blacklist = turf_blacklist?.Copy()
 	return newfriend
 
-//text trimming (both directions) helper macro
-#define TRIM_TEXT(text) (trim_reduced(text))
-
 /**
  * Helper and recommened way to load a map file
  * - dmm_file: The path to the map file
@@ -844,7 +841,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 			if(member_string[length(member_string)] == "}")
 				variables_start = findtext(member_string, "{")
 
-			var/path_text = TRIM_TEXT(copytext(member_string, 1, variables_start))
+			var/path_text = trimtext(copytext(member_string, 1, variables_start))
 			var/atom_def = text2path(path_text) //path definition, e.g /obj/foo/bar
 
 			if(!ispath(atom_def, /atom)) // Skip the item if the path does not exist.  Fix your crap, mappers!
@@ -1016,7 +1013,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 
 		// check if this is a simple variable (as in list(var1, var2)) or an associative one (as in list(var1="foo",var2=7))
 		var/equal_position = findtext(text,"=",old_position, position)
-		var/trim_left = TRIM_TEXT(copytext(text,old_position,(equal_position ? equal_position : position)))
+		var/trim_left = trimtext(copytext(text,old_position,(equal_position ? equal_position : position)))
 		var/left_constant = parse_constant(trim_left)
 		if(position)
 			old_position = position + length(text[position])
@@ -1026,7 +1023,7 @@ GLOBAL_LIST_EMPTY(map_model_default)
 		if(equal_position && !isnum(left_constant))
 			// Associative var, so do the association.
 			// Note that numbers cannot be keys - the RHS is dropped if so.
-			var/trim_right = TRIM_TEXT(copytext(text, equal_position + length(text[equal_position]), position))
+			var/trim_right = trimtext(copytext(text, equal_position + length(text[equal_position]), position))
 			var/right_constant = parse_constant(trim_right)
 			.[left_constant] = right_constant
 		else  // simple var
@@ -1082,5 +1079,4 @@ GLOBAL_LIST_EMPTY(map_model_default)
 #undef MAP_DMM
 #undef MAP_TGM
 #undef MAP_UNKNOWN
-#undef TRIM_TEXT
 #undef MAPLOADING_CHECK_TICK


### PR DESCRIPTION
## About The Pull Request

Port of my upstream PR, https://github.com/tgstation/tgstation/pull/87317

BYOND added a native `trimtext` proc in 515, which as far as I know, does the same thing as the `trim_reduced` proc - trims whitespace off both ends of a string, but `trimtext` should be faster, as it's a builtin rather than implemented in DM.

Also, added a global `_trimtext` proc, for use from SDQL2 or Lua, as it's a builtin and can't be `call()`'d.

## Why It's Good For The Game

Micro-optimizations my beloved - especially since I imagine this proc is called quite a lot, even if it doesn't really have a performance impact anyways, but it can't hurt.

## Changelog
:cl:
refactor: Refactored some text helper procs to use BYOND's native text trimming proc.
admin: Added a _trimtext proc, for use with SDQL2 or Lua scripting.
/:cl:
