### PR TITLE
Wumpas now fully respect the "squeak" mixer channel

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -689,7 +689,7 @@
 	if(user && iscarbon(user))
 		SEND_SIGNAL(user, COMSIG_CARBON_ITEM_DROPPED, src)
 	if(!silent)
-		playsound(src, drop_sound, DROP_SOUND_VOLUME, ignore_walls = FALSE)
+		playsound(src, drop_sound, DROP_SOUND_VOLUME, ignore_walls = FALSE, mixer_channel = drop_mixer_channel) // monkestation edit: sound mixer
 	user?.update_equipment_speed_mods()
 
 /// called just as an item is picked up (loc is not yet changed)
@@ -755,9 +755,9 @@
 	item_flags |= IN_INVENTORY
 	if(!initial)
 		if(equip_sound && (slot_flags & slot))
-			playsound(src, equip_sound, EQUIP_SOUND_VOLUME, TRUE, ignore_walls = FALSE)
+			playsound(src, equip_sound, EQUIP_SOUND_VOLUME, TRUE, ignore_walls = FALSE, mixer_channel = equip_mixer_channel) // monkestation: sound mixer
 		else if(slot & ITEM_SLOT_HANDS)
-			playsound(src, pickup_sound, PICKUP_SOUND_VOLUME, ignore_walls = FALSE)
+			playsound(src, pickup_sound, PICKUP_SOUND_VOLUME, ignore_walls = FALSE, mixer_channel = pickup_mixer_channel) // monkestation: sound mixer
 	user.update_equipment_speed_mods()
 
 /// Gives one of our item actions to a mob, when equipped to a certain slot
@@ -862,7 +862,7 @@
 			playsound(hit_atom, 'sound/weapons/throwtap.ogg', 1, volume, -1)
 
 	else
-		playsound(src, drop_sound, YEET_SOUND_VOLUME, ignore_walls = FALSE)
+		playsound(src, drop_sound, YEET_SOUND_VOLUME, ignore_walls = FALSE, mixer_channel = drop_mixer_channel) // monkestation edit: sound mixer
 	return hit_atom.hitby(src, 0, itempush, throwingdatum=throwingdatum)
 
 /obj/item/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback, force, gentle = FALSE, quickstart = TRUE)

--- a/monkestation/code/game/objects/items.dm
+++ b/monkestation/code/game/objects/items.dm
@@ -1,3 +1,11 @@
+/obj/item
+	/// If specified, the pickup sound will use this mixer channel.
+	var/pickup_mixer_channel
+	/// If specified, the drop sound will use this mixer channel.
+	var/drop_mixer_channel
+	/// If specified, the equip sound will use this mixer channel.
+	var/equip_mixer_channel
+
 /obj/item/proc/adjust_weight_class(amt, min_weight = WEIGHT_CLASS_TINY, max_weight = WEIGHT_CLASS_GIGANTIC)
 	if(!amt || !isnum(amt))
 		stack_trace("Attempted to adjust weight class by an invalid value ([amt])")

--- a/monkestation/code/game/objects/items.dm
+++ b/monkestation/code/game/objects/items.dm
@@ -1,10 +1,10 @@
 /obj/item
 	/// If specified, the pickup sound will use this mixer channel.
-	var/pickup_mixer_channel
+	var/pickup_mixer_channel = CHANNEL_SOUND_EFFECTS
 	/// If specified, the drop sound will use this mixer channel.
-	var/drop_mixer_channel
+	var/drop_mixer_channel = CHANNEL_SOUND_EFFECTS
 	/// If specified, the equip sound will use this mixer channel.
-	var/equip_mixer_channel
+	var/equip_mixer_channel = CHANNEL_SOUND_EFFECTS
 
 /obj/item/proc/adjust_weight_class(amt, min_weight = WEIGHT_CLASS_TINY, max_weight = WEIGHT_CLASS_GIGANTIC)
 	if(!amt || !isnum(amt))

--- a/monkestation/code/modules/donator/code/item/misc.dm
+++ b/monkestation/code/modules/donator/code/item/misc.dm
@@ -3,27 +3,37 @@
 	desc = span_bold("What in the god-dam?...")
 	icon = 'monkestation/code/modules/donator/icons/obj/misc.dmi'
 	icon_state = "wumpa"
-	var/datum/looping_sound/wumpa/sounds
-	var/shutup = FALSE
 	pickup_sound = 'monkestation/code/modules/donator/sounds/woah_3.ogg'
 	drop_sound = 'monkestation/code/modules/donator/sounds/woah_1.ogg'
-	var/squeak_override = list('monkestation/code/modules/donator/sounds/woah_1.ogg' = 33,
-	'monkestation/code/modules/donator/sounds/woah_2.ogg'=33,
-	'monkestation/code/modules/donator/sounds/woah_3.ogg'=33,
-	'monkestation/code/modules/donator/sounds/woahwoah.ogg' = 1)
+	pickup_mixer_channel = CHANNEL_SQUEAK
+	drop_mixer_channel = CHANNEL_SQUEAK
+	var/datum/looping_sound/wumpa/sound_loop
+	var/shutup = FALSE
+	var/static/list/squeak_override = list(
+		'monkestation/code/modules/donator/sounds/woah_1.ogg'   = 33,
+		'monkestation/code/modules/donator/sounds/woah_2.ogg'   = 33,
+		'monkestation/code/modules/donator/sounds/woah_3.ogg'   = 33,
+		'monkestation/code/modules/donator/sounds/woahwoah.ogg' = 1,
+	)
+
 /obj/item/donator/wumpa/Initialize(mapload)
 	. = ..()
-	sounds = new /datum/looping_sound/wumpa(src,TRUE,FALSE,FALSE,CHANNEL_JUKEBOX)
-	AddComponent(/datum/component/squeak,squeak_override)
+	sound_loop = new /datum/looping_sound/wumpa(src, TRUE, FALSE, FALSE, CHANNEL_JUKEBOX)
+	AddComponent(/datum/component/squeak, squeak_override)
+
+/obj/item/donator/wumpa/Destroy(force)
+	QDEL_NULL(sound_loop)
+	return ..()
+
 /obj/item/donator/wumpa/attack_self(mob/user, modifiers)
 	. = ..()
-	shutup=!shutup
+	shutup = !shutup
 	if(shutup)
-		user.visible_message("[src] shuts up.")
-		sounds.stop()
+		user.visible_message(span_notice("[src] shuts up."))
+		sound_loop.stop()
 	else
-		user.visible_message("[src] continues its jolly melody.")
-		sounds.start(src)
+		user.visible_message(span_notice("[src] continues its jolly melody."))
+		sound_loop.start(src)
 
 
 /datum/looping_sound/wumpa


### PR DESCRIPTION
## Changelog
:cl:
fix: Fixed a hard delete related to wumpas.
sound: The sound from picking up / dropping a wumpa now respects the "squeak" mixer channel, as stepping on it and such already does.
/:cl:
