### PR TITLE
[FIX] - Fixes Heart Worms being able to round remove the entire crew.

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/restricted/stage4.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/restricted/stage4.dm
@@ -5,7 +5,7 @@
 	max_multiplier = 5
 	chance = 6
 	var/sound = FALSE
-	badness = EFFECT_DANGER_DEADLY
+	badness = EFFECT_DANGER_DEADLaaY
 
 /datum/symptom/heart_failure/activate(mob/living/carbon/affected_mob)
 	. = ..()
@@ -13,7 +13,7 @@
 		affected_mob.death()
 		return FALSE
 
-	if(!affected_mob.can_heartattack())
+	if(!affected_mob.can_heartattack() && !HAS_TRAIT(affected_mob, TRAIT_STABLEHEART)) //This was so stupid. We had 9 people round removed with no fix other than admins because of this.
 		affected_mob.death()
 		return FALSE
 

--- a/monkestation/code/modules/virology/disease/symtoms/restricted/stage4.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/restricted/stage4.dm
@@ -5,7 +5,7 @@
 	max_multiplier = 5
 	chance = 6
 	var/sound = FALSE
-	badness = EFFECT_DANGER_DEADLaaY
+	badness = EFFECT_DANGER_DEADLY
 
 /datum/symptom/heart_failure/activate(mob/living/carbon/affected_mob)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Fixes Heart Worms permakilling people on penthrite and with vein muscles.

Why was this even a thing? Just calling mob.death() instead of doing progressive damage, or anything else. This was lazy code that round removed so many people on RID 7547.

For reference; (this is an edit) the code itself gives you penthrite as a "last ditch warning to get defibbed", thus the symptom almost always caused this issue by itself.

You are just cooked at the moment; there is no alternative other than death.

## Why It's Good For The Game
what the fuck?

Fixes a critical bug that allowed you to round remove people as botany with extreme ease and very little ways to fix it. If you broke the Cloner and broke the ore silo and research servers (no way to make new cloners); you could essentially, kill the entire crew in 1-2 840u melons with gaseous decomposition.

Or as chemist with the rapid chemical syringe gun (traitor item).

This was an extremely low effort way to grief, and an even more low effort way to accidentally grief.

fixes a critical bug
## Changelog
:cl:
fix: Heart Worms now respects penthrite and vein muscle threading. Like it was supposed to (indicated by its own code)
fix: Heart Worms now no longer instantly kills you if you have CE_STABLEHEART or for some reason are immune to heart attacks WITH stableheart.
/:cl:
