### PR TITLE
[Bounty] Blueshield Beacon addition + More QOL

### DIFF
--- a/monkestation/code/modules/blueshield/closet.dm
+++ b/monkestation/code/modules/blueshield/closet.dm
@@ -29,8 +29,6 @@
 /obj/structure/closet/secure_closet/blueshield/New()
 	..()
 	new /obj/item/storage/briefcase/secure(src)
-	new /obj/item/storage/belt/security/blueshield(src)
-	new /obj/item/melee/baton/telescopic(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/storage/medkit/frontier/stocked(src)
 	new /obj/item/storage/bag/garment/blueshield(src)

--- a/monkestation/code/modules/blueshield/gun.dm
+++ b/monkestation/code/modules/blueshield/gun.dm
@@ -13,6 +13,7 @@
 	desc = "A lightly overtuned version of NT's Hellfire Laser rifle, scratches showing its age and the fact it has definitely been owned before. This one is more energy efficient without sacrificing damage."
 	icon_state = "hellgun"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/hellfire/blueshield)
+
 // Blueshields custom takbok revolver.
 /obj/item/gun/ballistic/revolver/takbok/blueshield
 	name = "unmarked takbok revolver" //Give it a unique prefix compared hellfire's 'modified' to stand out
@@ -50,22 +51,24 @@
 
 //Weapon beacon
 /obj/item/choice_beacon/blueshield
-	name = "gunset beacon"
+	name = "armament beacon"
 	desc = "A single use beacon to deliver a gunset of your choice. Please only call this in your office"
 	company_source = "Sol Defense Contracting"
 	company_message = span_bold("Supply Pod incoming, please stand by.")
 
 /obj/item/choice_beacon/blueshield/generate_display_names()
 	var/static/list/selectable_gun_types = list(
-		"Unmarked Takbok Revolver Set" = /obj/item/storage/toolbox/guncase/skyrat/pistol/trappiste_small_case/takbok/blueshield,
+		"Unmarked Takbok Revolver Gunset" = /obj/item/storage/toolbox/guncase/skyrat/pistol/trappiste_small_case/takbok/blueshield,
 		"Custom Hellfire Laser Rifle" = /obj/item/gun/energy/laser/hellgun/blueshield,
 		"Bogseo Submachinegun Gunset" = /obj/item/storage/toolbox/guncase/skyrat/xhihao_large_case/bogseo,
 		"Tech-9" = /obj/item/storage/toolbox/guncase/skyrat/pistol/tech_9,
+		"C.H.R.O.M.A.T.A. Mantis Blade Cyberset" = /obj/item/storage/box/mantis_blade,
 	)
 
 	return selectable_gun_types
 
 /obj/item/storage/toolbox/guncase/skyrat/pistol/tech_9
+	name = "Tech-9 Gunset"
 	desc = "A thick yellow gun case with foam inserts laid out to fit a weapon, magazines, and gear securely. The five square grid of Tech-9 is displayed prominently on the top."
 
 	icon = 'monkestation/code/modules/blueshift/icons/obj/gunsets.dmi'
@@ -92,3 +95,13 @@
 
 /obj/item/gun/ballistic/automatic/pistol/tech_9/no_mag
 	spawnwithmagazine = FALSE
+
+/obj/item/storage/box/mantis_blade
+	name = "C.H.R.O.M.A.T.A. Mantis Blades Cyberset"
+	desc = "A box full essentials for C.H.R.O.M.A.T.A. Blades quick implentation and installation. A deadly and a very personal weapon."
+	icon_state = "cyber_implants"
+
+/obj/item/storage/box/mantis_blade/PopulateContents()
+	new /obj/item/autosurgeon/organ/cyberlink_terragov(src)
+	new /obj/item/autosurgeon/organ/mantis_blade(src)
+	new /obj/item/autosurgeon/organ/mantis_blade/l(src)

--- a/monkestation/code/modules/blueshield/job.dm
+++ b/monkestation/code/modules/blueshield/job.dm
@@ -59,6 +59,7 @@
 	implants = list(/obj/item/implant/mindshield)
 	backpack_contents = list(
 		/obj/item/choice_beacon/blueshield = 1,
+		/obj/item/melee/baton/telescopic = 1,
 	)
 	backpack = /obj/item/storage/backpack/blueshield
 	satchel = /obj/item/storage/backpack/satchel/blueshield
@@ -66,9 +67,9 @@
 
 	head = /obj/item/clothing/head/beret/blueshield
 	box = /obj/item/storage/box/survival/security
-	belt = /obj/item/modular_computer/pda/blueshield
+	belt = /obj/item/storage/belt/security/blueshield
 	l_pocket = /obj/item/sensor_device/blueshield
-
+	r_pocket = /obj/item/modular_computer/pda/blueshield
 	id_trim = /datum/id_trim/job/blueshield
 
 /datum/outfit/plasmaman/blueshield

--- a/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/weapons.dm
+++ b/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/weapons.dm
@@ -88,6 +88,9 @@
 	items_to_create = list(/obj/item/mantis_blade/chromata)
 	encode_info = AUGMENT_TG_LEVEL
 
+/obj/item/organ/internal/cyberimp/arm/item_set/mantis/l
+	zone = BODY_ZONE_L_ARM
+
 /obj/item/organ/internal/cyberimp/arm/item_set/syndie_mantis
 	name = "A.R.A.S.A.K.A. mantis blade implants"
 	desc = "Modernized mantis blade designed coined by Tiger operatives, much sharper blade with energy actuators makes it a much deadlier weapon."
@@ -210,3 +213,4 @@
 	demolition_mod = 1.25
 	usesound = 'sound/weapons/drill.ogg'
 	hitsound = 'sound/weapons/drill.ogg'
+

--- a/monkestation/code/modules/cybernetics/implant_items/autosurgeons.dm
+++ b/monkestation/code/modules/cybernetics/implant_items/autosurgeons.dm
@@ -4,6 +4,13 @@
 /obj/item/autosurgeon/organ/syndicate/esword
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/esword
 
+/obj/item/autosurgeon/organ/mantis_blade
+	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/mantis
+	uses = 1
+
+/obj/item/autosurgeon/organ/mantis_blade/l
+	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/mantis/l
+
 /obj/item/autosurgeon/organ/syndicate/syndie_mantis
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/syndie_mantis
 
@@ -142,3 +149,4 @@
 
 /obj/item/autosurgeon/organ/chemvat
 	starting_organ = /obj/item/organ/internal/cyberimp/chest/chemvat
+


### PR DESCRIPTION
## About The Pull Request

- [The bounty part ](https://discord.com/channels/748354466335686736/1300083207190085634/1300083207190085634)
Gives Blueshield a new option. C.H.R.O.M.O.T.A. Mantis Blades Cyberset. A box full of single use autosurgerons to use the cybernetic. (I'll touch on the Pros and cons of this in the next section.)
![snippet](https://github.com/user-attachments/assets/50257d35-10ef-4d48-bc60-49f567414733)

- Why did we leave that again?
Moves Blueshields belt and telebaton from their locker into their spawn loadout.

- Misc. changes
 Random small things relating to blueshields relating to items name changes and desciption additions.
## Why It's Good For The Game

### C.H.R.O.M.O.T.A. Mantis Blades Cyberset. The good the bad and the other of choosing it.
### Pros:

- The blades give a inbuilt power crowbar if both are deployed. Meaning they have a soft AA akin to the CE if they take this. Being able to open any unbolted door in 5 seconds. I'll note while abusable if a bluey is using it to access places they should not be. (I.E. A head isnt in danger in that area or casual tiding.) This should be a breach of SOP for them. Hopefully much more common with the NT Representative's arrival. 

- Melee prowess. In combat, it gives a melee option comparable to the captain's Sabre. Having more chance to bleed/lacerate and bypass block chances as each blade attacks at the same time with half damage. But having zero block chance. This means any hit against them is going to go through. As carrying a shield severely cripples the effectiveness.

### Cons:

- Disarm? More like Delimb. As the blades implanted DIRECTLY into their arms. They can't be disarmed of their dedicated weapon mid-combat. While normal Blueshield's have the magnetic harness in their modsuit to help prevent this you can still steal their weapon or toss it into the void of space. This means they have some lethality as long as they live.

- Oh god emp's. Emp's become a hard counter to blueshields because by taking a Terran CyberLink they will be hard stunned for 10 seconds if light emp. 20 seconds if hard EMP. If they get EMP'd with no support, from anyone else they will get massacred.

Current antagonists with inbuilt ways to emp's include, 

1. Traitors - Emp grenades and Implanter Kit (2 TC) 
2. Assault Operative - Emp grenade (2 points)
3. Changeling - Dissonant Shriek (1 point)
4. Nuclear operatives 
5. Heretics - "Flesh Stalker (Midtier research summon. Personally its the easiest one to make.)
6. Wizards - Disable Tech (1 magic point)
7. Drifting contractors - Same as traitors
8. Revenants - EMP is half their kit honestly.
9. Blob - There's a form that emits emp's constantly.
10. Borer - I'm pretty sure theres a chemical that causes an EMP and they could potentially make it within the blood as a reaction chamber.

This means 10/32 antagonists gain a hard counter to BlueShield. Usually at cheap prices. Honestly, that total number is smaller as plenty of antagonists they have no right or shouldn't really be dealing with command, and by proxy blueshields watchful gaze. Such as cyber police, plague rats, or fugitives.

- Bringing a knife to a gunfight. By taking this they forgo all range options natively. Meaning if you fight them with a gun their only option is to chase after you with their mod suit module reducing the damage of bullets some.

- Compatibility. As they have a TERRAN cyberlink they have to go through extra hassle and hurdles to be able to use low grade cybernetics. Not a major one but still notable.

### Predressed
With recent changes to insure there is no way to increase blueshield job slots either manually or with random events. We can insure there is one blueshield and order things around that. All of the security starts with their belt, and all of command starts with their baton. So, so should Blueshield. The frontier medkit gets left in locker as CMO's still have to pick up their medical supplies from their locker.
## Changelog
:cl:
add: Added C.H.R.O.M.A.T.A Mantis Blades to Blueshield's armament beacon.
qol: Moved Blueshield's Belt and baton from their locker to their backpack.
spellcheck: Renamed and applied descriptions to various Blueshield items. 
/:cl:
