### PR TITLE
Comms console can no longer lower the alert from delta/epsilon

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -200,11 +200,18 @@
 					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
 					return
 
+			// monkestation start: prevent lowering alert level from delta
 			var/new_sec_level = SSsecurity_level.text_level_to_number(params["newSecurityLevel"])
+			var/current_sec_level = SSsecurity_level.get_current_level_as_number()
+			if (current_sec_level > SEC_LEVEL_RED)
+				to_chat(usr, span_warning("Alert cannot be manually lowered from the current security level!"))
+				playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, FALSE)
+				return
 			if (new_sec_level != SEC_LEVEL_GREEN && new_sec_level != SEC_LEVEL_BLUE)
 				return
-			if (SSsecurity_level.get_current_level_as_number() == new_sec_level)
+			if (current_sec_level == new_sec_level)
 				return
+			// monkestation end
 
 			SSsecurity_level.set_level(new_sec_level)
 


### PR DESCRIPTION
## Changelog

:cl:
fix: You can no longer lower the alert from delta/epsilon from a comms console (it wouldn't actually do anything to whatever was CAUSING said alert anyways)
/:cl:
