### PR TITLE
Fixes incorrect access on the Blueshift aux base

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -54697,7 +54697,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
 /turf/open/floor/plating,
 /area/station/construction/mining/aux_base)
 "kzV" = (


### PR DESCRIPTION

## About The Pull Request

The west door required construction access (despite the fact that the area it led to was public access), while the three other doors required aux base access. This makes the west door also just need aux base access.

![image](https://github.com/user-attachments/assets/57dd28b1-0d39-4713-a00c-b52c69b47f4c)


## Why It's Good For The Game

Consistency is good.

## Changelog
:cl:
fix: Fixed a door in the Blueshift aux base requiring construction access instead of aux base access.
/:cl:
