### PR TITLE
IPC damage fix

### DIFF
--- a/monkestation/code/modules/smithing/ipcs/body/base_bodyparts.dm
+++ b/monkestation/code/modules/smithing/ipcs/body/base_bodyparts.dm
@@ -9,6 +9,8 @@
 	biological_state = BIO_ROBOTIC | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 	head_flags = HEAD_HAIR |  HEAD_LIPS | HEAD_EYECOLOR | HEAD_LIPS
+	brute_modifier = 1.2 // Monkestation Edit
+	burn_modifier = 1.2 // Monkestation Edit
 
 	body_damage_coeff = 1.1	//IPC's Head can dismember	//Monkestation Edit
 	max_damage = 40	//Keep in mind that this value is used in the //Monkestation Edit
@@ -26,7 +28,8 @@
 	bodypart_traits = list(TRAIT_LIMBATTACHMENT)
 	body_damage_coeff = 1	//IPC Chest at default	///Monkestation Edit
 	max_damage = 250	//Default: 200 ///Monkestation Edit
-
+	brute_modifier = 1.2 // Monkestation Edit
+	burn_modifier = 1.2 // Monkestation Edit
 
 	dmg_overlay_type = "synth"
 
@@ -39,6 +42,8 @@
 	should_draw_greyscale = FALSE
 	biological_state = BIO_ROBOTIC | BIO_JOINTED | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
+	brute_modifier = 1.2 // Monkestation Edit
+	burn_modifier = 1.2 // Monkestation Edit
 
 	body_damage_coeff = 1.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
 	max_damage = 30	//Monkestation Edit
@@ -54,6 +59,8 @@
 	should_draw_greyscale = FALSE
 	biological_state = BIO_ROBOTIC | BIO_JOINTED | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
+	brute_modifier = 1.2 // Monkestation Edit
+	burn_modifier = 1.2 // Monkestation Edit
 
 	body_damage_coeff = 1.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
 	max_damage = 30	//Monkestation Edit
@@ -69,6 +76,8 @@
 	should_draw_greyscale = FALSE
 	biological_state = BIO_ROBOTIC | BIO_JOINTED | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
+	brute_modifier = 1.2 // Monkestation Edit
+	burn_modifier = 1.2 // Monkestation Edit
 
 	dmg_overlay_type = "synth"
 	step_sounds = list('sound/effects/servostep.ogg')
@@ -82,6 +91,8 @@
 	should_draw_greyscale = FALSE
 	biological_state = BIO_ROBOTIC | BIO_JOINTED | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
+	brute_modifier = 1.2 // Monkestation Edit
+	burn_modifier = 1.2 // Monkestation Edit
 
 	body_damage_coeff = 1.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
 	max_damage = 30	//Monkestation Edit

--- a/monkestation/code/modules/smithing/ipcs/species.dm
+++ b/monkestation/code/modules/smithing/ipcs/species.dm
@@ -67,7 +67,6 @@
 	bodytemp_heat_damage_limit = CELCIUS_TO_KELVIN(450)
 	bodytemp_cold_damage_limit = CELCIUS_TO_KELVIN(-260) //they are practically immune to cold
 
-	brutemod = 1.2
 	coldmod = 1.2
 	heatmod = 2 // TWO TIMES DAMAGE FROM BEING TOO HOT?! WHAT?! No wonder lava is literal instant death for us.
 	siemens_coeff = 1.4 // Not more because some shocks will outright crit you, which is very unfun

--- a/monkestation/code/modules/smithing/ipcs/species.dm
+++ b/monkestation/code/modules/smithing/ipcs/species.dm
@@ -67,7 +67,7 @@
 	bodytemp_heat_damage_limit = CELCIUS_TO_KELVIN(450)
 	bodytemp_cold_damage_limit = CELCIUS_TO_KELVIN(-260) //they are practically immune to cold
 
-	brutemod = 1.5
+	brutemod = 1.2
 	coldmod = 1.2
 	heatmod = 2 // TWO TIMES DAMAGE FROM BEING TOO HOT?! WHAT?! No wonder lava is literal instant death for us.
 	siemens_coeff = 1.4 // Not more because some shocks will outright crit you, which is very unfun


### PR DESCRIPTION

## About The Pull Request
IPCs are intended to take 50% more brute but this is overriden by them being augmented and also being subtype of cyborg parts taking 20% less instead.

Makes them take 1.2(20%) more brute and burn instead, felt 50% is to much, leave that to plasmamen. Its all they have

## Why It's Good For The Game
IPCs are already pretty powerful when it comes to taking damage, their limbs have damage caps and fall off easy acting as a double edged sort of extra health, and have very little wounds. This makes them much better when it comes to combat balance

## Changelog

:cl:
fix: IPCs take 20% more damage not 20% less
/:cl:

