### PR TITLE
Fix the endless kitchen fire alarms on Box and Delta

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -21967,7 +21967,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/freezer{
 	name = "Coldroom"
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -32304,7 +32304,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/open/floor/iron/freezer,


### PR DESCRIPTION

## About The Pull Request

So, turns out the issue was, these two maps have firelocks in the kitchen cold room doors, while all other maps don't. The firelocks trigger due to the cold air, leading to firelock hell.

## Why It's Good For The Game

Fixes an annoying bug.

## Changelog
:cl:
fix: Fixed the endless kitchen fire alarms on Box and Delta.
/:cl:
