### PR TITLE
[Fix/bounty] Make nuclear reinforcement use ROLE_OPERATIVE_MIDROUND preferences

### DIFF
--- a/code/modules/antagonists/_common/antag_spawner.dm
+++ b/code/modules/antagonists/_common/antag_spawner.dm
@@ -133,7 +133,7 @@
 		return
 
 	to_chat(user, span_notice("You activate [src] and wait for confirmation."))
-	var/mob/chosen_one = SSpolling.poll_ghost_candidates("Do you want to play as a reinforcement [special_role_name]?", check_jobban = ROLE_OPERATIVE, role = ROLE_OPERATIVE, poll_time = 15 SECONDS, ignore_category = POLL_IGNORE_SYNDICATE, alert_pic = src, role_name_text = special_role_name, amount_to_pick = 1)
+	var/mob/chosen_one = SSpolling.poll_ghost_candidates("Do you want to play as a reinforcement [special_role_name]?", check_jobban = ROLE_OPERATIVE, role = ROLE_OPERATIVE_MIDROUND, poll_time = 15 SECONDS, ignore_category = POLL_IGNORE_SYNDICATE, alert_pic = src, role_name_text = special_role_name, amount_to_pick = 1)
 	if(chosen_one)
 		if(QDELETED(src) || !check_usability(user))
 			return


### PR DESCRIPTION

## About The Pull Request
Makes nuclear reinforcements and cyborgs call open [ROLE_OPERATIVE_MIDROUND](https://discord.com/channels/748354466335686736/1296976787863244852/1296976787863244852) pref and not ROLE_OPERATIVE. 
## Why It's Good For The Game
These are ghost roles and midround. Not round start. 
This doesn't affect team datum or makes the ship target the Borgs.
Thankfully.
## Changelog
:cl:
fix: Makes Nuclear reinforcements call upon Midround nukie preferences rather than round start.
/:cl:
