### PR TITLE
fixes quartermaster doors being named mining lobby

### DIFF
--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -40516,7 +40516,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/mining{
-	name = "Mining Lobby"
+	name = "Quatermaster's Office"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -46373,7 +46373,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
-	name = "Mining Lobby"
+	name = "Quatermaster's Ouarters"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/supply/qm,
 /obj/effect/turf_decal/siding/wood/end,


### PR DESCRIPTION

## About The Pull Request
Simple name fixes, doors are now quartermaster's office and quartermaster's quarters, 😆 
## Why It's Good For The Game
Inconsistencies suck.
## Changelog
:cl:
fix: fixed quartermasters doors.
/:cl:
