### PR TITLE
[Port] Adds three useful PDA programs to Cyborg's default PDA loadout #86725

### DIFF
--- a/code/modules/modular_computers/computers/item/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda.dm
@@ -303,6 +303,9 @@
 	starting_programs = list(
 		/datum/computer_file/program/filemanager,
 		/datum/computer_file/program/robotact,
+		/datum/computer_file/program/borg_monitor,
+		/datum/computer_file/program/atmosscan,
+		/datum/computer_file/program/crew_manifest,
 	)
 
 /obj/item/modular_computer/pda/silicon/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request
Ports TG's [#86725](https://github.com/tgstation/tgstation/pull/86725)
Which gives all borgs ``siliconnect``, ``atmosphere`` and ``crew manifest`` as default programs in addition to their default ones.
## Why It's Good For The Game
### Siliconnect - How is everyone else doing?
This combined with crew manifest allows newly arriving borgs to make informed decisions about what module to choose so there isnt too many eggs in one basket. As all borgs are limited each usually likes to take a different specialty. It also lets them keep note if the other borgs are dead, or simply just being quiet. As borg casualties going go unnoticed for long periods of time. Saying only the master AI can notice in a little blerb at the top of their screen and robotics, if they also check siliconnect. 

### Atmosphscan - How is everyone breathing?
The original pull phrases it well, "The AtmoZsphere program, which shows local oxygen/nitrogen data to help make informed decisions on protecting humans." Things like pressure and air can be very hard to gauge when you have no ability to get notifications about it activley hurting you.

### Crew manifest - AI is this lad actually crew?
Currently, borgs kinda have to go with the default assumption that ***EVERYONE*** is crew unless they are a super obvious threat. This app will serve them well for laws and for judging what modules/niches to fill.
##
## Changelog
:cl:
add: Added three programs to cyborg PDAs: SiliConnect, AtmoZphere, and Crew Manifest
/:cl:
