### PR TITLE
Foreign department station trait.

### DIFF
--- a/monkestation/code/datums/station_traits/negative_traits.dm
+++ b/monkestation/code/datums/station_traits/negative_traits.dm
@@ -29,14 +29,17 @@
 /datum/station_trait/uncommonlanguage/New()
 	. = ..()
 	blacklist += subtypesof(/datum/station_trait/uncommonlanguage) - type //All but ourselves
-	report_message = "Due to staffing shortages, we have hired foreigners to fill in for the [department_name] department and assistants."
+	report_message = "Due to staffing shortages, we have hired foreigners to fill in for the [department_name] department. Assistants have been trained to act as translators."
 	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
 
 
 /datum/station_trait/uncommonlanguage/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)
 	SIGNAL_HANDLER
+	
+	if(job.title = JOB_ASSISTANT)
+		spawned.grant_language(/datum/language/uncommon, TRUE, TRUE, LANGUAGE_MIND)
 
-	if(!((job.departments_bitflags & department_to_apply_to) || (job.title = JOB_ASSISTANT)))
+	if(!(job.departments_bitflags & department_to_apply_to))
 		return
 
 	spawned.grant_language(/datum/language/uncommon, TRUE, TRUE, LANGUAGE_MIND)
@@ -64,26 +67,12 @@
 	department_to_apply_to = DEPARTMENT_BITFLAG_ENGINEERING
 	department_name = "Engineering"
 
-///datum/station_trait/uncommonlanguage/command
-//	name = "Foreign Command"
-//	trait_flags = NONE
-//	weight = 1
-//	department_to_apply_to = DEPARTMENT_BITFLAG_COMMAND
-//	department_name = "Command"
-
 /datum/station_trait/uncommonlanguage/science
 	name = "Foreign Science"
 	trait_flags = NONE
 	weight = 2
 	department_to_apply_to = DEPARTMENT_BITFLAG_SCIENCE
 	department_name = "Science"
-
-/datum/station_trait/uncommonlanguage/security
-	name = "Foreign Security"
-	trait_flags = NONE
-	weight = 1
-	department_to_apply_to = DEPARTMENT_BITFLAG_SECURITY
-	department_name = "Security"
 
 /datum/station_trait/uncommonlanguage/medical
 	name = "Foreign Medical"

--- a/monkestation/code/datums/station_traits/negative_traits.dm
+++ b/monkestation/code/datums/station_traits/negative_traits.dm
@@ -36,7 +36,7 @@
 /datum/station_trait/uncommonlanguage/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)
 	SIGNAL_HANDLER
 	
-	if(job.title = JOB_ASSISTANT)
+	if(job.title == JOB_ASSISTANT)
 		spawned.grant_language(/datum/language/uncommon, TRUE, TRUE, LANGUAGE_MIND)
 
 	if(!(job.departments_bitflags & department_to_apply_to))

--- a/monkestation/code/datums/station_traits/negative_traits.dm
+++ b/monkestation/code/datums/station_traits/negative_traits.dm
@@ -16,3 +16,78 @@
 		CRASH("Failed to find valid job to pick for overflow!")
 	chosen_job_name = lowertext(picked_job.title) // like Chief Engineers vs like chief engineers
 	SSjob.set_overflow_role(picked_job.type)
+
+/datum/station_trait/uncommonlanguage
+	name = "Foreign Department"
+	trait_type = STATION_TRAIT_NEGATIVE
+	show_in_report = TRUE
+	trait_flags = STATION_TRAIT_ABSTRACT
+
+	var/department_to_apply_to
+	var/department_name = "department"
+
+/datum/station_trait/uncommonlanguage/New()
+	. = ..()
+	blacklist += subtypesof(/datum/station_trait/uncommonlanguage) - type //All but ourselves
+	report_message = "Due to staffing shortages, we have hired foreigners to fill in for the [department_name] department and assistants."
+	RegisterSignal(SSdcs, COMSIG_GLOB_JOB_AFTER_SPAWN, PROC_REF(on_job_after_spawn))
+
+
+/datum/station_trait/uncommonlanguage/proc/on_job_after_spawn(datum/source, datum/job/job, mob/living/spawned, client/player_client)
+	SIGNAL_HANDLER
+
+	if(!((job.departments_bitflags & department_to_apply_to) || (job.title = JOB_ASSISTANT)))
+		return
+
+	spawned.grant_language(/datum/language/uncommon, TRUE, TRUE, LANGUAGE_MIND)
+	spawned.remove_language(/datum/language/common, TRUE, TRUE)
+
+
+/datum/station_trait/uncommonlanguage/service
+	name = "Foreign Service"
+	trait_flags = NONE
+	weight = 2
+	department_to_apply_to = DEPARTMENT_BITFLAG_SERVICE
+	department_name = "Service"
+
+/datum/station_trait/uncommonlanguage/cargo
+	name = "Foreign Cargo"
+	trait_flags = NONE
+	weight = 2
+	department_to_apply_to = DEPARTMENT_BITFLAG_CARGO
+	department_name = "Cargo"
+
+/datum/station_trait/uncommonlanguage/engineering
+	name = "Foreign Engineering"
+	trait_flags = NONE
+	weight = 2
+	department_to_apply_to = DEPARTMENT_BITFLAG_ENGINEERING
+	department_name = "Engineering"
+
+///datum/station_trait/uncommonlanguage/command
+//	name = "Foreign Command"
+//	trait_flags = NONE
+//	weight = 1
+//	department_to_apply_to = DEPARTMENT_BITFLAG_COMMAND
+//	department_name = "Command"
+
+/datum/station_trait/uncommonlanguage/science
+	name = "Foreign Science"
+	trait_flags = NONE
+	weight = 2
+	department_to_apply_to = DEPARTMENT_BITFLAG_SCIENCE
+	department_name = "Science"
+
+/datum/station_trait/uncommonlanguage/security
+	name = "Foreign Security"
+	trait_flags = NONE
+	weight = 1
+	department_to_apply_to = DEPARTMENT_BITFLAG_SECURITY
+	department_name = "Security"
+
+/datum/station_trait/uncommonlanguage/medical
+	name = "Foreign Medical"
+	trait_flags = NONE
+	weight = 2
+	department_to_apply_to = DEPARTMENT_BITFLAG_MEDICAL
+	department_name = "Medical"


### PR DESCRIPTION
## About The Pull Request
Adds new negative station trait, that makes a department only speak uncommon. (Shamelessly stole code from deathrattled departments.) Assistants get to speak both common and uncommon so they may act as translators.

Security and command departments can not roll this.

## Why It's Good For The Game
Funny department that's difficult to communicate with.

## Changelog
:cl:
add: Adds new negative station trait, that makes a department only speak uncommon.
/:cl:
