### PR TITLE
Cybernetic Revolution adjustments + New leg cybernetic 'sprinter'

### DIFF
--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -207,12 +207,14 @@
 	trait_to_give = STATION_TRAIT_CYBERNETIC_REVOLUTION
 	/// List of all job types with the cybernetics they should receive.
 	var/static/list/job_to_cybernetic = list(
-		/datum/job/assistant = /obj/item/organ/internal/heart/cybernetic, //real cardiac
+		/datum/job/assistant = /obj/item/organ/internal/cyberimp/leg/table_glider, /obj/item/organ/internal/cyberimp/leg/table_glider/l,// monkestation edit: The greytide begins...
 		/datum/job/atmospheric_technician = /obj/item/organ/internal/cyberimp/arm/item_set/atmospherics, // monkestation edit: cybernetics overhaul (useful job stuff)
 		/datum/job/bartender = /obj/item/organ/internal/liver/cybernetic/tier3,
 		/datum/job/bitrunner = /obj/item/organ/internal/eyes/robotic/thermals,
 		/datum/job/blueshield = /obj/item/organ/internal/cyberimp/arm/ammo_counter, // monkestation edit: cybernetics for recently added job
+		/datum/job/brig_physician = /obj/item/organ/internal/cyberimp/arm/item_set/surgery, // monkestation edit: Same as med docs.
 		/datum/job/botanist = /obj/item/organ/internal/cyberimp/arm/item_set/botany, // monkestation edit: cybernetics overhaul (useful job stuff)
+		/datum/job/candysalesman =  /obj/item/organ/internal/cyberimp/chest/nutriment/plus, // monkestation edit:
 		/datum/job/captain = /obj/item/organ/internal/heart/cybernetic/tier3,
 		/datum/job/cargo_technician = /obj/item/organ/internal/stomach/cybernetic/tier2,
 		/datum/job/chaplain = /obj/item/organ/internal/cyberimp/brain/anti_drop,
@@ -220,16 +222,19 @@
 		/datum/job/chief_engineer = /obj/item/organ/internal/cyberimp/chest/thrusters,
 		/datum/job/chief_medical_officer = /obj/item/organ/internal/cyberimp/brain/linked_surgery/perfect/nt, // monkestation edit: cybernetics overhaul (couldn't think of anything else that was good for cmo)
 		/datum/job/clown = /obj/item/organ/internal/cyberimp/chest/knockout, // monkestation edit: cybernetics overhaul (honk!!! it's the clown mech fist shrunken down after all)
-		/datum/job/cook = /obj/item/organ/internal/cyberimp/chest/nutriment/plus,
+		/datum/job/cook = /obj/item/organ/internal/cyberimp/arm/item_set/cook, // monkestatoin edit: Give the toolarm some use, plus they should be cooking evenways!
 		/datum/job/curator = /obj/item/organ/internal/eyes/robotic/glow,
 		/datum/job/detective = /obj/item/organ/internal/lungs/cybernetic/tier3,
+		/datum/job/godzilla = /obj/item/organ/internal/cyberimp/brain/anti_stun, //monkestation edit: Hard to keep gozilla down.
 		/datum/job/doctor = /obj/item/organ/internal/cyberimp/arm/item_set/surgery,
 		/datum/job/geneticist = /obj/item/organ/internal/fly, //we don't care about implants, we have cancer.
-		/datum/job/head_of_personnel = /obj/item/organ/internal/eyes/robotic,
+		/datum/job/gorilla = /obj/item/organ/internal/cyberimp/arm/muscle, // monkestation edit: monke strong
+		/datum/job/head_of_personnel = /obj/item/organ/internal/cyberimp/eyes/hud/security, // monkestation edit:
 		/datum/job/head_of_security = /obj/item/organ/internal/cyberimp/arm/item_set/combat, // monkestation edit: cybernetics overhaul (no more validhunt eyes, instead you get a shoddy stunprod in your arm)
 		/datum/job/janitor = /obj/item/organ/internal/cyberimp/arm/item_set/janitor, // monkestation edit: cybernetics overhaul (useful job stuff)
 		/datum/job/lawyer = /obj/item/organ/internal/heart/cybernetic/tier2,
 		/datum/job/mime = /obj/item/organ/internal/tongue/robot, //...
+		/datum/job/nanotrasen_representative = /obj/item/organ/internal/cyberimp/leg/shove_resist, /obj/item/organ/internal/cyberimp/leg/shove_resist/l, // monkestation edit: NT kneels to noone.
 		/datum/job/paramedic = /obj/item/organ/internal/cyberimp/arm/item_set/paramedic, // monkestation edit: cybernetics overhaul (on-site healing / assistance)
 		/datum/job/prisoner = /obj/item/organ/internal/eyes/robotic/shield,
 		/datum/job/psychologist = /obj/item/organ/internal/ears/cybernetic/upgraded,
@@ -237,12 +242,14 @@
 		/datum/job/research_director = /obj/item/organ/internal/cyberimp/bci,
 		/datum/job/roboticist = /obj/item/organ/internal/cyberimp/arm/item_set/connector, // monkestation edit: cybernetics overhaul (useful job stuff)
 		/datum/job/scientist = /obj/item/organ/internal/ears/cybernetic,
-		/datum/job/security_assistant = /obj/item/organ/internal/cyberimp/leg/accelerator, // monkestation edit: cybernetics for recently added job
+		/datum/job/security_assistant = /obj/item/organ/internal/cyberimp/leg/accelerator, /obj/item/organ/internal/cyberimp/leg/accelerator/l, // monkestation edit: cybernetics for recently added job
 		/datum/job/security_officer = /obj/item/organ/internal/cyberimp/arm/item_set/flash,
 		/datum/job/shaft_miner = /obj/item/organ/internal/cyberimp/arm/item_set/mining_drill/diamond, // monkestation edit: cybernetics overhaul (useful job stuff)
+		/datum/job/signal_technician = /obj/item/organ/internal/cyberimp/arm/heater, // monkestation edit: Tcomms is cold
 		/datum/job/station_engineer = /obj/item/organ/internal/cyberimp/arm/item_set/toolset,
 		/datum/job/virologist = /obj/item/organ/internal/lungs/cybernetic/tier2,
 		/datum/job/warden = /obj/item/organ/internal/cyberimp/eyes/hud/security,
+		/datum/job/yellowclown = /obj/item/organ/internal/cyberimp/chest/knockout, // monkestation edit: double trouble
 	)
 
 /datum/station_trait/cybernetic_revolution/New()

--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -216,7 +216,7 @@
 		/datum/job/botanist = /obj/item/organ/internal/cyberimp/arm/item_set/botany, // monkestation edit: cybernetics overhaul (useful job stuff)
 		/datum/job/candysalesman =  /obj/item/organ/internal/cyberimp/chest/nutriment/plus, // monkestation edit:
 		/datum/job/captain = /obj/item/organ/internal/heart/cybernetic/tier3,
-		/datum/job/cargo_technician = /obj/item/organ/internal/stomach/cybernetic/tier2,
+		/datum/job/cargo_technician = /obj/item/organ/internal/cyberimp/leg/sprinter, /obj/item/organ/internal/cyberimp/leg/sprinter/l, //monkestation edit: For all the running they do
 		/datum/job/chaplain = /obj/item/organ/internal/cyberimp/brain/anti_drop,
 		/datum/job/chemist = /obj/item/organ/internal/liver/cybernetic/tier3,
 		/datum/job/chief_engineer = /obj/item/organ/internal/cyberimp/chest/thrusters,

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1421,6 +1421,7 @@
 		"ci-reviver",
 		"ci-surgery",
 		"ci-toolset",
+		"ci-sprinter", //monkestation edit:
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 

--- a/monkestation/code/modules/cybernetics/augments/leg_augments/traits.dm
+++ b/monkestation/code/modules/cybernetics/augments/leg_augments/traits.dm
@@ -57,3 +57,29 @@
 	if(tackler)
 		qdel(tackler)
 	return ..()
+
+/obj/item/organ/internal/cyberimp/leg/sprinter
+	name = "accelerator  leg implant"
+	desc = "Mechicanical servos in ones leg that increases one's natural stride. Popular amongst parkour enthusiasts. You need to implant this in both of your legs to make it work."
+	encode_info = AUGMENT_NT_LOWLEVEL
+	double_legged = TRUE
+
+/obj/item/organ/internal/cyberimp/leg/sprinter/update_implants()
+	if(!check_compatibility())
+		REMOVE_TRAIT(owner,TRAIT_FREERUNNING,type)
+		REMOVE_TRAIT(owner,TRAIT_LIGHT_STEP,type)
+		return
+	ADD_TRAIT(owner,TRAIT_FREERUNNING,type)
+	ADD_TRAIT(owner,TRAIT_LIGHT_STEP,type)
+
+/obj/item/organ/internal/cyberimp/leg/sprinter/on_full_insert(mob/living/carbon/M, special, drop_if_replaced)
+	. = ..()
+	if(!check_compatibility())
+		return
+	ADD_TRAIT(owner,TRAIT_FREERUNNING,type)
+	ADD_TRAIT(owner,TRAIT_LIGHT_STEP,type)
+
+/obj/item/organ/internal/cyberimp/leg/sprinter/Remove(mob/living/carbon/M, special)
+	REMOVE_TRAIT(owner,TRAIT_FREERUNNING,type)
+	REMOVE_TRAIT(owner,TRAIT_LIGHT_STEP,type)
+	return ..()

--- a/monkestation/code/modules/cybernetics/augments/leg_augments/traits.dm
+++ b/monkestation/code/modules/cybernetics/augments/leg_augments/traits.dm
@@ -4,6 +4,9 @@
 	encode_info = AUGMENT_NT_LOWLEVEL
 	double_legged = TRUE
 
+/obj/item/organ/internal/cyberimp/leg/table_glider/l
+	zone = BODY_ZONE_L_LEG
+
 /obj/item/organ/internal/cyberimp/leg/table_glider/update_implants()
 	if(!check_compatibility())
 		REMOVE_TRAIT(owner,TRAIT_FAST_CLIMBER,type)
@@ -42,6 +45,9 @@
 	REMOVE_TRAIT(owner,TRAIT_SHOVE_RESIST,type)
 	return ..()
 
+/obj/item/organ/internal/cyberimp/leg/shove_resist/l
+	zone = BODY_ZONE_L_LEG
+
 /obj/item/organ/internal/cyberimp/leg/accelerator
 	name = "P.R.Y.Z.H.O.K. accelerator system"
 	desc = "Russian implant that allows you to tackle people. You need to implant this in both of your legs to make it work."
@@ -58,9 +64,12 @@
 		qdel(tackler)
 	return ..()
 
+/obj/item/organ/internal/cyberimp/leg/accelerator/l
+	zone = BODY_ZONE_L_LEG
+
 /obj/item/organ/internal/cyberimp/leg/sprinter
-	name = "accelerator  leg implant"
-	desc = "Mechicanical servos in ones leg that increases one's natural stride. Popular amongst parkour enthusiasts. You need to implant this in both of your legs to make it work."
+	name = "Vacuole ligament system"
+	desc = "Mechicanical servos in ones leg that increases their natural stride. Popular amongst parkour enthusiasts. You need to implant this in both of your legs to make it work."
 	encode_info = AUGMENT_NT_LOWLEVEL
 	double_legged = TRUE
 
@@ -83,3 +92,6 @@
 	REMOVE_TRAIT(owner,TRAIT_FREERUNNING,type)
 	REMOVE_TRAIT(owner,TRAIT_LIGHT_STEP,type)
 	return ..()
+
+/obj/item/organ/internal/cyberimp/leg/sprinter/l
+	zone = BODY_ZONE_L_LEG

--- a/monkestation/code/modules/research/designs/medical_designs.dm
+++ b/monkestation/code/modules/research/designs/medical_designs.dm
@@ -74,7 +74,7 @@
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	construction_time = 50
 	materials = list(/datum/material/iron = 1500, /datum/material/glass = 1000, /datum/material/silver =SMALL_MATERIAL_AMOUNT*5, /datum/material/gold =SMALL_MATERIAL_AMOUNT*5)
-	build_path = /obj/item/organ/internal/cyberimp/eyes/hud/medical
+	build_path = /obj/item/organ/internal/cyberimp/leg/sprinter
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)

--- a/monkestation/code/modules/research/designs/medical_designs.dm
+++ b/monkestation/code/modules/research/designs/medical_designs.dm
@@ -69,7 +69,7 @@
 
 /datum/design/cyberimp_sprinter
 	name = "Vacuole ligament system"
-	desc = "These cybernetic eyes will display a medical HUD over everything you see. Wiggle eyes to control."
+	desc = "Mechicanical servos in ones leg that increases their natural stride. Popular amongst parkour enthusiasts. You need to implant this in both of your legs to make it work."
 	id = "ci-sprinter"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	construction_time = 50

--- a/monkestation/code/modules/research/designs/medical_designs.dm
+++ b/monkestation/code/modules/research/designs/medical_designs.dm
@@ -73,7 +73,7 @@
 	id = "ci-sprinter"
 	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
 	construction_time = 50
-	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/silver =SMALL_MATERIAL_AMOUNT*5, /datum/material/gold =SMALL_MATERIAL_AMOUNT*5)
+	materials = list(/datum/material/iron = 1500, /datum/material/glass = 1000, /datum/material/silver =SMALL_MATERIAL_AMOUNT*5, /datum/material/gold =SMALL_MATERIAL_AMOUNT*5)
 	build_path = /obj/item/organ/internal/cyberimp/eyes/hud/medical
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY

--- a/monkestation/code/modules/research/designs/medical_designs.dm
+++ b/monkestation/code/modules/research/designs/medical_designs.dm
@@ -23,7 +23,6 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
-
 /datum/design/surgery/healing/filter_upgrade
 	name = "Filter Blood Upgrade"
 	desc = "Newfound knowledge allows us to remove the effect of toxins on the body whenever filtering someone's blood."
@@ -53,7 +52,7 @@
 	surgery = /datum/surgery/robot_healing
 	id = "surgery_heal_robot_base"
 	research_icon_state = "surgery_chest"
-	
+
 /datum/design/surgery/robot_healing/upgraded
 	name = "Repair Robotic Limbs (Physical) Upgrade"
 	desc = "A surgical procedure that provides highly effective repairs and maintenance to robotic limbs. Is somewhat more efficient when the patient is severely damaged."
@@ -67,3 +66,16 @@
 	surgery = /datum/surgery/robot_healing/experimental
 	id = "surgery_heal_robot_upgrade_femto"
 	research_icon_state = "surgery_chest"
+
+/datum/design/cyberimp_sprinter
+	name = "Vacuole ligament system"
+	desc = "These cybernetic eyes will display a medical HUD over everything you see. Wiggle eyes to control."
+	id = "ci-sprinter"
+	build_type = PROTOLATHE | AWAY_LATHE | MECHFAB
+	construction_time = 50
+	materials = list(/datum/material/iron = 600, /datum/material/glass = 600, /datum/material/silver =SMALL_MATERIAL_AMOUNT*5, /datum/material/gold =SMALL_MATERIAL_AMOUNT*5)
+	build_path = /obj/item/organ/internal/cyberimp/eyes/hud/medical
+	category = list(
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL


### PR DESCRIPTION

## About The Pull Request

- Gives (most) new jobs cybernetics for cybernetic revolution. (I cant think of anything for ghost or skeleton but they are dead anywho)
- Replace some old jobs cybernetics with more appropriate cybernetics.
- Added new leg cybernetic, Vacuole ligament system, aka 'sprinter'. A cybernetic acting as a reinforcement to the legs granting the benefits of free running and light step. Requiring advanced cybernetics. (Same tier as toolset arms.)
## Why It's Good For The Game
### Cybernetic revolution changes
- Assistant - Tier 1 cybernetic heart -> Table glider. | Getting a worse heart just feels bad. Even prisoners are given something better while having less rights. This allows assistants to ~~greytide~~ parkour harder by climbing tables faster.
- Brig physician - nothing -> Surgical toolset arm. | As much as I want to give something unique to doctors I really cant. Its good and reliable.
- Cargo tech - t2 stomach -> Vacuole ligament system | Cargo is the job next to paramedic that sprints around the most. Hopefully, this means deliveries/mail will given faster. And not just... left outside cargo. 
- Candy salesman - nothing -> Nutripump Plus | The candy salesman bounty is plentyful. They shall not go hungry
- Cook - Nutripump + -> Cook toolarm | The cook is the last job needing of a nutripump. To use it they need to stop doing their job. Also they have a toolarm!
- Godzilla - nothing -> CNS Rebooter. | Godzilla is hard to keep down.
- Gorilla - nothing -> Strongarm | Monke strong. Need I say more?
- Head of Personel -> Robotic eyes -> Security Hud | Same with assistant getting nothing but being affected by EMP's, a downside, on a positive station trait sucks. Flat out. While there isnt many cybernetics that fit HOP giving them the head to see jobs is good enough.
- Nanotransen Rep - nothing -> antishove | Nt's finest bows to no man.
- Signal Tech - nothing -> Dermal Heater | Tcomms is cold and this should help warm em up.
- Yellow Clown - nothing -> Knockout implant. | So the two clowns can box eachother.

### Vacuole ligament system
The VLS is a new cybernetic reinforcing ones legs to new benefits. it gives the benefits of free runner and light step. So you can sprint longer and faster and walk through glass.
This gives the crew a consistent leg cybernetic option. Mind you the only leg cybernetic option but beside the point!
While being part of advanced cybernetics I kept the encryption level low so it remains incompatible with the Terran link so sec has to go through extra trouble to get it. 
## Changelog
:cl:
add: Added more cybernetics into the cybernetic revolution station trait.
add: Added new leg cybernetic for research "Vacuole ligament system"
/:cl:
