### PR TITLE
Mice/rats can nibble food + basic mob emote support

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -648,6 +648,7 @@ Behavior that's still missing from this component that original food items had t
 	if(bitecount >= 5)
 		var/satisfaction_text = pick("burps from enjoyment.", "squeaks for more!", "squeaks twice.", "looks at the area where \the [parent] was.")
 		L.manual_emote(satisfaction_text)
+		SEND_SIGNAL(parent, COMSIG_FOOD_CONSUMED)
 		qdel(parent)
 	else
 		if(prob(50))

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -587,7 +587,7 @@ Behavior that's still missing from this component that original food items had t
 
 	if(desired_mask != current_mask)
 		current_mask = desired_mask
-		src.add_filter("bite", 0, alpha_mask_filter(icon=icon('goon/icons/obj/food.dmi', "eating[desired_mask]")))
+		parent.add_filter("bite", 0, alpha_mask_filter(icon=icon('goon/icons/obj/food.dmi', "eating[desired_mask]")))
 
 	. = COMPONENT_CANCEL_ATTACK_CHAIN
 	L.taste(owner.reagents) // why should carbons get all the fun?
@@ -625,3 +625,31 @@ Behavior that's still missing from this component that original food items had t
 		playsound(get_turf(eater),'sound/items/eatfood.ogg', rand(30,50), TRUE)
 		qdel(eaten_food)
 		return COMPONENT_ATOM_EATEN
+//MONKESTATION EDIT START
+/datum/component/edible/proc/UseByMouse(datum/source, mob/user)
+
+	SIGNAL_HANDLER
+
+	var/atom/owner = parent
+	var/mob/living/L = user
+	bitecount++
+	var/desired_mask = (total_bites / bitecount)
+	desired_mask = round(desired_mask)
+	desired_mask = max(1,desired_mask)
+	desired_mask = min(desired_mask, 4)
+
+	if(desired_mask != current_mask)
+		current_mask = desired_mask
+		parent.add_filter("bite", 0, alpha_mask_filter(icon=icon('goon/icons/obj/food.dmi', "eating[desired_mask]")))
+
+	. = COMPONENT_CANCEL_ATTACK_CHAIN
+	L.taste(owner.reagents) // why should carbons get all the fun?
+	playsound(user.loc,'sound/items/eatfood.ogg', rand(5,20), TRUE)
+	if(bitecount >= 5)
+		var/satisfaction_text = pick("burps from enjoyment.", "squeaks for more!", "squeaks twice.", "looks at the area where \the [parent] was.")
+		L.manual_emote(satisfaction_text)
+		qdel(parent)
+	else
+		if(prob(50))
+			L.manual_emote("nibbles away at \the [parent].")
+//MONKESTATION EDIT STOP

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -328,3 +328,11 @@
 		SET_PLANE(held, ABOVE_HUD_PLANE, our_turf)
 		held.screen_loc = ui_hand_position(index)
 		client.screen |= held
+
+//MONKESTATION EDIT START
+/mob/living/basic/proc/get_scream_sound()
+    return
+/mob/living/basic/proc/get_laugh_sound()
+    return
+//MONKESTATION EDIT STOP
+

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -331,8 +331,8 @@
 
 //MONKESTATION EDIT START
 /mob/living/basic/proc/get_scream_sound()
-    return
+	return
 /mob/living/basic/proc/get_laugh_sound()
-    return
+	return
 //MONKESTATION EDIT STOP
 

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -27,6 +27,10 @@
 	response_harm_simple = "splat"
 
 	ai_controller = /datum/ai_controller/basic_controller/mouse
+	//MONKESTATION EDIT START
+	death_sound = 'sound/effects/mousesqueek.ogg'
+	death_message = "falls limp and lifeless..."
+	//MONKESTATION EDIT STOP
 
 	/// Whether this rat is friendly to players
 	var/tame = FALSE
@@ -38,6 +42,13 @@
 	var/cable_zap_prob = 85
 
 	var/chooses_bodycolor = TRUE
+
+//MONKESTATION EDIT START
+/mob/living/basic/mouse/get_scream_sound()
+	return 'sound/effects/mousesqueek.ogg'
+/mob/living/basic/mouse/get_laugh_sound()
+	return 'sound/effects/mousesqueek.ogg'
+//MONKESTATION EDIT STOP
 
 /mob/living/basic/mouse/Initialize(mapload, tame = FALSE, new_body_color)
 	. = ..()
@@ -147,6 +158,24 @@
 	if(istype(attack_target, /obj/item/food/cheese))
 		try_consume_cheese(attack_target)
 		return TRUE
+	//MONKESTATION EDIT START
+	if(istype(attack_target, /obj/item))
+		if(!attack_target.GetComponent(/datum/component/edible))
+			return
+		if(istype(attack_target, /obj/item/food/cheese))
+			return //mice savour cheese differently
+		var/datum/component/edible/edible = attack_target.GetComponent(/datum/component/edible)
+		edible.UseByMouse(edible, src)
+
+		for(var/datum/reagent/target_reagent in attack_target.reagents.reagent_list)
+			if(istype(target_reagent, /datum/reagent/toxin))
+				visible_message(
+					span_warning("[src] devours [attack_target]! They pause for a moment..."),
+					span_warning("You devour [attack_target], something tastes off..."),
+				)
+				if(health != 0)
+					adjust_health(1)
+	//MONKESTATION EDIT STOP
 
 	if(istype(attack_target, /obj/structure/cable))
 		try_bite_cable(attack_target)

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -174,7 +174,7 @@
 					span_warning("You devour [attack_target], something tastes off..."),
 				)
 				if(health != 0)
-					adjust_health(1)
+					adjust_health(4)
 	//MONKESTATION EDIT STOP
 
 	if(istype(attack_target, /obj/structure/cable))

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -290,6 +290,11 @@
 
 	var/obj/item/organ/internal/tongue/tongue = user.get_organ_slot(ORGAN_SLOT_TONGUE)
 	return tongue?.get_laugh_sound(user)
+
+/datum/emote/living/laugh/get_sound(mob/living/basic/user)
+	if(isbasicmob(user))
+		var/mob/living/basic/mob = user
+		. = mob.get_laugh_sound()
 // MonkeStation Edit End
 
 /datum/emote/living/look

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -280,21 +280,18 @@
 	return ..() && user.can_speak(allow_mimes = TRUE)
 
 // MonkeStation Edit Start
-/datum/emote/living/laugh/get_sound(mob/living/carbon/human/user)
-	if(!istype(user))
-		return
-
-	// Alternative Laugh Hook
-	if(user.alternative_laughs.len)
-		return pick(user.alternative_laughs)
-
-	var/obj/item/organ/internal/tongue/tongue = user.get_organ_slot(ORGAN_SLOT_TONGUE)
-	return tongue?.get_laugh_sound(user)
-
-/datum/emote/living/laugh/get_sound(mob/living/basic/user)
+/datum/emote/living/laugh/get_sound(mob/living/user)
 	if(isbasicmob(user))
 		var/mob/living/basic/mob = user
 		. = mob.get_laugh_sound()
+	if(ishuman(user))
+		var/mob/living/carbon/human/human_user = user
+		// Alternative Laugh Hook
+		if(human_user.alternative_laughs.len)
+			return pick(human_user.alternative_laughs)
+
+		var/obj/item/organ/internal/tongue/tongue = human_user.get_organ_slot(ORGAN_SLOT_TONGUE)
+		return tongue?.get_laugh_sound(human_user)
 // MonkeStation Edit End
 
 /datum/emote/living/look

--- a/monkestation/code/modules/emotes/code/emote.dm
+++ b/monkestation/code/modules/emotes/code/emote.dm
@@ -167,6 +167,9 @@
 			return pick(human_user.alternative_screams)
 		var/obj/item/organ/internal/tongue/tongue = human_user.get_organ_slot(ORGAN_SLOT_TONGUE)
 		. = tongue?.get_scream_sound()
+	if(isbasicmob(user))
+		var/mob/living/basic/mob = user
+		. = mob.get_scream_sound()
 
 /datum/emote/living/scream/should_vary(mob/living/user)
 	if(ishuman(user) && !is_cat_enough(user))


### PR DESCRIPTION
## About The Pull Request
Lets mice/rats take small nibbles of food or any item with the edible component. If what they eat contains toxin of any kind it damages them.
Added two procs to basic mobs to grab custom sounds for the scream and laugh emote.
## Why It's Good For The Game

The kitchen can now have a genuine rat problem.

## Changelog
:cl:
add: Mice/rats have figured out how to eat a larger variety of food.
/:cl:
