### PR TITLE
Madness immune exempt from Mass hallucinations

### DIFF
--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -93,6 +93,8 @@
 		if(hallucinating.z != 0 && !is_station_level(hallucinating.z) && !hallucinating.client)
 			continue
 
+		if(HAS_TRAIT(hallucinating, TRAIT_MADNESS_IMMUNE))
+			continue
 		// Not using the wrapper here because we already have a list / arglist
 		hallucinating._cause_hallucination(hallucination_args)
 

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -92,9 +92,10 @@
 		// Unless the mob is off the station z-level. It's unlikely anyone will notice.
 		if(hallucinating.z != 0 && !is_station_level(hallucinating.z) && !hallucinating.client)
 			continue
-
+		//monkestation edit start: Make TRAIT_MADNESS_IMMUNE exempt from hullications.
 		if(HAS_TRAIT(hallucinating, TRAIT_MADNESS_IMMUNE))
 			continue
+		//monkestation edit end:
 		// Not using the wrapper here because we already have a list / arglist
 		hallucinating._cause_hallucination(hallucination_args)
 


### PR DESCRIPTION

## About The Pull Request
Makes it so any carbons with TRAIT_MADNESS_IMMUNE are exempt from mass hallucinations. 
## Why It's Good For The Game
Currently from what I find Madness Immunity is pretty underused.  Mostley existing for the SM hallucinations and hallucination anomalies. Also it makes sense. At least to me.
## Changelog
:cl:
add: Madness Immunity excludes you from mass hallucinations 
/:cl:
