### PR TITLE
Prevents AI radio speech sounds from stacking

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -37,14 +37,6 @@ GLOBAL_LIST_INIT(freqtospan, list(
 /atom/movable/proc/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), message_range=0)
 	SEND_SIGNAL(src, COMSIG_MOVABLE_HEAR, args)
 
-//MONKESTATION EDIT
-/mob/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), message_range)
-	. = ..()
-	if(client && radio_freq)
-		var/atom/movable/virtualspeaker/V = speaker
-		if(isAI(V.source))
-			playsound_local(get_turf(src), 'goon/sounds/radio_ai.ogg', 170, 1, 0, 0, pressure_affected = FALSE, use_reverb = FALSE, mixer_channel = CHANNEL_MOB_SOUNDS)
-//MONKESTATION EDIT END
 /**
  * Checks if our movable can speak the provided message, passing it through filters
  * and spam detection. Does not call can_speak. CAN include feedback messages about

--- a/monkestation/code/game/say.dm
+++ b/monkestation/code/game/say.dm
@@ -1,0 +1,14 @@
+/mob/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), message_range)
+	. = ..()
+	if(client && (radio_freq && (radio_freq == FREQ_COMMON || radio_freq < MIN_FREQ)))
+		var/atom/movable/virtualspeaker/vspeaker = speaker
+		if(isAI(vspeaker.source))
+			playsound_local(
+				get_turf(src),
+				'goon/sounds/radio_ai.ogg',
+				vol = 100,
+				vary = TRUE,
+				pressure_affected = FALSE,
+				use_reverb = FALSE,
+				mixer_channel = CHANNEL_MOB_SOUNDS
+			)

--- a/monkestation/code/game/say.dm
+++ b/monkestation/code/game/say.dm
@@ -6,7 +6,7 @@
 			playsound_local(
 				get_turf(src),
 				'goon/sounds/radio_ai.ogg',
-				vol = 150,
+				vol = 170,
 				vary = TRUE,
 				pressure_affected = FALSE,
 				use_reverb = FALSE,

--- a/monkestation/code/game/say.dm
+++ b/monkestation/code/game/say.dm
@@ -6,7 +6,7 @@
 			playsound_local(
 				get_turf(src),
 				'goon/sounds/radio_ai.ogg',
-				vol = 100,
+				vol = 150,
 				vary = TRUE,
 				pressure_affected = FALSE,
 				use_reverb = FALSE,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5899,6 +5899,7 @@
 #include "monkestation\code\datums\weather\weather_types\radiation_storm.dm"
 #include "monkestation\code\datums\wires\particle_accelerator.dm"
 #include "monkestation\code\game\atom.dm"
+#include "monkestation\code\game\say.dm"
 #include "monkestation\code\game\sound.dm"
 #include "monkestation\code\game\world.dm"
 #include "monkestation\code\game\area\areas.dm"


### PR DESCRIPTION
## About The Pull Request

see changelog

## Why It's Good For The Game

hearing 5 ai speech sounds stacked on top of each other while observing because the AI decided to go full 1984 and set every intercom to broadcast over AI private is very much unpleasant and uncomfortable

tbh maybe this should be moved to /mob/living

## Changelog
:cl:
qol: The AI radio speech sound effect now only plays from over "normal" frequencies - AI private and non-departmental frequencies will not play the speech sound.
/:cl:
