### PR TITLE
Fix jaunts sending you to kingdom come after roundend

### DIFF
--- a/code/game/objects/effects/phased_mob.dm
+++ b/code/game/objects/effects/phased_mob.dm
@@ -38,7 +38,7 @@
 		return
 
 	var/area/destination_area = get_area(eject_spot)
-	if(destination_area.area_flags & NOTELEPORT)
+	if((destination_area.area_flags & NOTELEPORT) && (SSticker.current_state < GAME_STATE_FINISHED)) // monkestation edit: allow jaunts to work after roundend
 		// this ONLY happens if someone uses a phasing effect
 		// to try to land in a NOTELEPORT zone after it is created, AKA trying to exploit.
 		if(isliving(jaunter))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Followup to https://github.com/Monkestation/Monkestation2.0/pull/3806 to fix some stuff that wasn't properly patched

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Jaunts now ACTUALLY work at centcom after roundend, for realsies.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
