### PR TITLE
Gives Centcom Members (Blueshield and NT Rep) Loud Mode on Comms

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -333,11 +333,9 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 /obj/item/radio/headset/headset_cent/empty
 	keyslot = null
 	keyslot2 = null
-	command = TRUE
 
 /obj/item/radio/headset/headset_cent/commander
 	keyslot2 = /obj/item/encryptionkey/heads/captain
-	command = TRUE
 
 /obj/item/radio/headset/headset_cent/alt
 	name = "\improper CentCom bowman headset"
@@ -345,7 +343,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	icon_state = "cent_headset_alt"
 	worn_icon_state = "cent_headset_alt"
 	keyslot2 = null
-	command = TRUE
 
 /obj/item/radio/headset/headset_cent/alt/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -328,13 +328,16 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	worn_icon_state = "cent_headset"
 	keyslot = /obj/item/encryptionkey/headset_cent
 	keyslot2 = /obj/item/encryptionkey/headset_com
+	command = TRUE
 
 /obj/item/radio/headset/headset_cent/empty
 	keyslot = null
 	keyslot2 = null
+	command = TRUE
 
 /obj/item/radio/headset/headset_cent/commander
 	keyslot2 = /obj/item/encryptionkey/heads/captain
+	command = TRUE
 
 /obj/item/radio/headset/headset_cent/alt
 	name = "\improper CentCom bowman headset"
@@ -342,6 +345,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	icon_state = "cent_headset_alt"
 	worn_icon_state = "cent_headset_alt"
 	keyslot2 = null
+	command = TRUE
 
 /obj/item/radio/headset/headset_cent/alt/Initialize(mapload)
 	. = ..()

--- a/monkestation/code/modules/blueshield/clothing.dm
+++ b/monkestation/code/modules/blueshield/clothing.dm
@@ -210,12 +210,14 @@
 	worn_icon_state = "bshield_headset"
 	keyslot = /obj/item/encryptionkey/heads/blueshield
 	keyslot2 = /obj/item/encryptionkey/headset_cent
+	command = TRUE
 
 /obj/item/radio/headset/headset_bs/alt
 	name = "\proper the blueshield's bowman headset"
 	desc = "The headset of the guy who keeps the administration alive. Protects your ears from flashbangs."
 	icon_state = "bshield_headset_alt"
 	worn_icon_state = "bshield_headset_alt"
+	command = TRUE
 
 /obj/item/radio/headset/headset_bs/alt/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Gives the the NT Rep and Blueshield loud mode on comms

## Why It's Good For The Game

They're both centcom, it makes sense that they'd be heard over all the other chatter on the radio. It will also be nice being able to scream at people to max their suit sensors in loud mode.

Also allowing ERT headsets to use loud mode, so that if they come to rescue the crew they can more easily take control of the situation over comms.

## Changelog



:cl:
qol: Added loud mode to centcom headsets
/:cl:
