### PR TITLE
Makes gulag more secure

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -12280,7 +12280,7 @@ fQ
 fQ
 fQ
 aj
-pU
+aj
 pU
 pU
 wr
@@ -12796,7 +12796,7 @@ pU
 aj
 aj
 aj
-pU
+aj
 sy
 wE
 pU
@@ -13054,7 +13054,7 @@ aj
 aj
 aj
 aj
-pU
+aj
 pU
 pU
 uU
@@ -13312,7 +13312,7 @@ fQ
 aj
 aj
 aj
-pU
+aj
 pU
 uU
 uU
@@ -15378,8 +15378,8 @@ aj
 aj
 aj
 aj
-pU
-pU
+aj
+aj
 aj
 aj
 aj
@@ -15894,7 +15894,7 @@ aj
 fQ
 aj
 aj
-pU
+aj
 uU
 uU
 uU
@@ -16673,7 +16673,7 @@ aj
 aj
 aj
 aj
-pU
+aj
 pU
 pU
 uU
@@ -16925,7 +16925,7 @@ aj
 aj
 fQ
 aj
-pU
+aj
 ad
 pU
 aj
@@ -17438,7 +17438,7 @@ fQ
 fQ
 fQ
 fQ
-pU
+aj
 aj
 aj
 aj
@@ -17696,7 +17696,7 @@ fQ
 fQ
 fQ
 fQ
-pU
+aj
 aj
 aj
 fQ

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -16937,7 +16937,7 @@ aj
 aj
 uU
 uU
-pU
+aj
 aj
 aj
 aj
@@ -17198,7 +17198,7 @@ aj
 aj
 aj
 aj
-pU
+aj
 uU
 uU
 uU
@@ -19536,7 +19536,7 @@ pU
 pU
 aj
 aj
-pU
+aj
 pU
 uU
 uU
@@ -19793,8 +19793,8 @@ ai
 ai
 pU
 aj
-pU
-pU
+aj
+aj
 uU
 uU
 uU
@@ -24939,7 +24939,7 @@ ZY
 pU
 aj
 aj
-pU
+aj
 pU
 pU
 pU
@@ -25195,7 +25195,7 @@ ZY
 pU
 aj
 aj
-pU
+aj
 pU
 pU
 pU
@@ -25965,7 +25965,7 @@ ZY
 ZY
 aj
 aj
-pU
+aj
 JD
 RP
 RP
@@ -26222,7 +26222,7 @@ ZY
 pU
 aj
 aj
-pU
+aj
 JD
 RP
 RP
@@ -26992,7 +26992,7 @@ ZY
 ZY
 aj
 aj
-pU
+aj
 pU
 JD
 RP
@@ -27763,7 +27763,7 @@ ZY
 ZY
 aj
 aj
-pU
+aj
 pU
 rN
 RP
@@ -28278,7 +28278,7 @@ ZY
 pU
 aj
 aj
-pU
+aj
 pU
 pU
 pU
@@ -28536,7 +28536,7 @@ ZY
 aj
 aj
 aj
-pU
+aj
 pU
 pU
 aj
@@ -29049,7 +29049,7 @@ ZY
 ZY
 ZY
 pU
-pU
+aj
 aj
 aj
 aj
@@ -29584,7 +29584,7 @@ aj
 Od
 qx
 Od
-pU
+aj
 an
 dJ
 rF
@@ -30613,7 +30613,7 @@ pV
 Xw
 aj
 aj
-pU
+aj
 cU
 aj
 aj
@@ -30864,12 +30864,12 @@ aj
 aj
 aj
 aj
-pU
-pU
+aj
+aj
 kt
 yh
 kt
-pU
+aj
 pU
 zU
 pU
@@ -31121,8 +31121,8 @@ aj
 aj
 aj
 pU
-pU
-pU
+aj
+aj
 jc
 Kh
 jc
@@ -33703,7 +33703,7 @@ kt
 HO
 jc
 Ae
-pU
+aj
 aj
 aj
 pU
@@ -33964,7 +33964,7 @@ qe
 aj
 aj
 aj
-pU
+aj
 pU
 pU
 aj
@@ -34218,11 +34218,11 @@ pU
 pU
 dJ
 pU
-pU
-pU
 aj
 aj
-pU
+aj
+aj
+aj
 pU
 aj
 aj
@@ -34477,12 +34477,12 @@ dJ
 dJ
 dJ
 pU
-pU
 aj
 aj
 aj
 aj
-pU
+aj
+aj
 pU
 aj
 aj


### PR DESCRIPTION

## About The Pull Request
Makes the gulag more secure by adding an extra lava tile around various locations around said gulag, requiring crossing at least 2 tiles of lava in order to escape.
## Why It's Good For The Game
Apparently due to the fire extinguisher and burn meds, players are able to cross 1 tile of lava and survive, allowing them to easily escape the gulag with nothing but the tools there. This makes it take some more work to escape other.
## Changelog
:cl:
balance: The gulag is now more secure using more lava tiles
/:cl:
