### PR TITLE
Makes transfer votes way less annoying

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -247,7 +247,7 @@ SUBSYSTEM_DEF(vote)
 		generated_actions += voting_action
 
 		if(current_vote.vote_sound && (new_voter.prefs.read_preference(/datum/preference/toggle/sound_announcements)))
-			SEND_SOUND(new_voter, sound(current_vote.vote_sound))
+			SEND_SOUND(new_voter, sound(current_vote.vote_sound, volume = current_vote.vote_sound_volume)) // monkestation edit
 
 	return TRUE
 

--- a/monkestation/code/datums/votes/_vote_datum.dm
+++ b/monkestation/code/datums/votes/_vote_datum.dm
@@ -1,6 +1,6 @@
 /datum/vote
 	/// The volume of the vote sound, from 0 to 100 or above.
-	var/vote_sound_volume
+	var/vote_sound_volume = 100
 
 /datum/vote/proc/can_vote(mob/voter)
 	return TRUE

--- a/monkestation/code/datums/votes/_vote_datum.dm
+++ b/monkestation/code/datums/votes/_vote_datum.dm
@@ -1,2 +1,6 @@
+/datum/vote
+	/// The volume of the vote sound, from 0 to 100 or above.
+	var/vote_sound_volume
+
 /datum/vote/proc/can_vote(mob/voter)
 	return TRUE

--- a/monkestation/code/datums/votes/transfer_vote.dm
+++ b/monkestation/code/datums/votes/transfer_vote.dm
@@ -59,7 +59,7 @@
 /datum/vote/shuttle_call/get_vote_result(list/non_voters)
 	for(var/ckey in non_voters)
 		var/client/client = non_voters[ckey]
-		if(client.mob && can_vote(client.mob))
+		if(client?.mob && can_vote(client.mob))
 			choices[CHOICE_CONTINUE]++ // Everyone defaults to continue, since they may be in the middle of something when the vote starts.
 	if(choices[CHOICE_CALL] + choices[CHOICE_CONTINUE] <= 0) // No-one is alive. Call it.
 		return CHOICE_CALL

--- a/monkestation/code/datums/votes/transfer_vote.dm
+++ b/monkestation/code/datums/votes/transfer_vote.dm
@@ -61,6 +61,8 @@
 		var/client/client = non_voters[ckey]
 		if(client.mob && can_vote(client.mob))
 			choices[CHOICE_CONTINUE]++ // Everyone defaults to continue, since they may be in the middle of something when the vote starts.
+	if(choices[CHOICE_CALL] + choices[CHOICE_CONTINUE] <= 0) // No-one is alive. Call it.
+		return CHOICE_CALL
 	return ..()
 
 #undef CHOICE_CONTINUE

--- a/monkestation/code/datums/votes/transfer_vote.dm
+++ b/monkestation/code/datums/votes/transfer_vote.dm
@@ -10,6 +10,7 @@
 		CHOICE_CONTINUE,
 	)
 	player_startable = FALSE
+	vote_sound_volume = 150 // Make it loud so people don't miss it.
 
 /datum/vote/shuttle_call/reset()
 	. = ..()
@@ -29,6 +30,12 @@
 /datum/vote/shuttle_call/initiate_vote(initiator, duration)
 	. = ..()
 	SSautotransfer.doing_transfer_vote = TRUE
+	priority_announce(
+		text = "The shift has eclipsed its standard duration. If the crew wish to leave, a scheduled shuttle will be sent to the station from Central Command.",
+		title = "Crew Transfer Vote",
+		has_important_message = TRUE,
+		color_override = "green",
+	)
 
 /datum/vote/shuttle_call/finalize_vote(winning_option)
 	switch(winning_option)
@@ -45,6 +52,16 @@
 		return TRUE
 	if(isobserver(voter) || voter.stat == DEAD || !(voter.ckey in GLOB.joined_player_list)) // only living crew gets to vote
 		return FALSE
+
+/datum/vote/shuttle_call/tiebreaker(list/winners)
+	return CHOICE_CONTINUE // Generally, this is less likely to make people mad. It still can, don't get me wrong, but it's safer.
+
+/datum/vote/shuttle_call/get_vote_result(list/non_voters)
+	for(var/ckey in non_voters)
+		var/client/client = non_voters[ckey]
+		if(client.mob && can_vote(client.mob))
+			choices[CHOICE_CONTINUE]++ // Everyone defaults to continue, since they may be in the middle of something when the vote starts.
+	return ..()
 
 #undef CHOICE_CONTINUE
 #undef CHOICE_CALL


### PR DESCRIPTION

## About The Pull Request

This PR weighs transfer votes toward continuing the round quite a bit.
However, the main idea is to make the votes more fair and to increase engagement with them.

One, transfer votes now default every living, cliented and non-afk player to the continue option.
Second, they will always tiebreak to continuing the round. Just call it on your own at that point.
Third, the sound they make is louder and has an associated Central Command announcement.
## Why It's Good For The Game

Currently, transfer votes are often missed by players who are actively engaged with the game.
This is a problem, because once a transfer vote has passed, it's unrecallable outside of admin intervention.
It's been brought up before in discussion threads and the issue was left to fester for quite a while.

This PR is intended to put that to rest by increasing the visibility of the transfer votes.
The auto-vote helps players who are too engaged with the round to vote.

Additionally, continuing the round is a much safer option than an unrecallable shuttle.
That's because players can just call it on their own if they don't like the result of the vote.
Of course, they then have to deal with backlash from other players. But that's just how it goes.
It's either a democratic vote, or you have to strongarm the station into a call they may not want.
## Changelog
:cl:
add: Transfer votes now have an announcement and default to continuing the round for any non-voters.
/:cl:
