### PR TITLE
Reduces Glock-o burst fire size

### DIFF
--- a/monkestation/code/modules/blueshield/gun.dm
+++ b/monkestation/code/modules/blueshield/gun.dm
@@ -81,7 +81,7 @@
 /obj/item/gun/ballistic/automatic/pistol/tech_9
 	name = "\improper Glock-O"
 	desc = "The standard issue service pistol of blueshield agents."
-	burst_size = 10 //lol
+	burst_size = 4
 	fire_delay = 1
 
 	icon = 'monkestation/code/modules/blueshield/icons/gun.dmi'


### PR DESCRIPTION

## About The Pull Request
Title, reduce the glock-o burst fire size from 10 to 4
## Why It's Good For The Game
Glock-O's current burst size, while comical, is not particularly well balanced. Since it uses paco mags/ammo, a single burst of paco lethal rounds will do about 200 damage. The burst of non-lethal rounds is overkill, considering only 3-4 rounds are needed to stun someone. It also makes the clip size awkward, considering it effectively has 1.6 shots before needing to reload. Lowering it to 4 will let the gun be much less "Instant death" by reducing the damage down to 80 in a burst, and letting each magazine have 4 shots before needing to reload is much less awkward.
## Changelog
:cl:
balance: Reduced the glock-o (Tech9)'s burst size from 10 to 4
/:cl:
