### PR TITLE
Signboard improvements!

### DIFF
--- a/code/datums/components/seethrough.dm
+++ b/code/datums/components/seethrough.dm
@@ -15,9 +15,11 @@
 	var/perimeter_reset_timer
 	///Does this object let clicks from players its transparent to pass through it
 	var/clickthrough
+	/// Whether to always use the final turf of the parent as the "effective" parent for calculating coords.
+	var/use_parent_turf
 
 ///see_through_map is a define pointing to a specific map. It's basically defining the area which is considered behind. See see_through_maps.dm for a list of maps
-/datum/component/seethrough/Initialize(see_through_map = SEE_THROUGH_MAP_DEFAULT, target_alpha = 100, animation_time = 0.5 SECONDS, perimeter_reset_timer = 2 SECONDS, clickthrough = TRUE)
+/datum/component/seethrough/Initialize(see_through_map = SEE_THROUGH_MAP_DEFAULT, target_alpha = 100, animation_time = 0.5 SECONDS, perimeter_reset_timer = 2 SECONDS, clickthrough = TRUE, use_parent_turf = FALSE)
 	. = ..()
 
 	relative_turf_coords = GLOB.see_through_maps[see_through_map]
@@ -31,6 +33,7 @@
 	src.animation_time = animation_time
 	src.perimeter_reset_timer = perimeter_reset_timer
 	src.clickthrough = clickthrough
+	src.use_parent_turf = use_parent_turf
 
 	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(dismantle_perimeter))
 
@@ -40,8 +43,9 @@
 /datum/component/seethrough/proc/setup_perimeter(atom/parent)
 	watched_turfs = list()
 
+	var/atom/effective_parent = use_parent_turf ? get_turf(parent) : parent
 	for(var/list/coordinates as anything in relative_turf_coords)
-		var/turf/target = TURF_FROM_COORDS_LIST(list(parent.x + coordinates[1], parent.y + coordinates[2], parent.z + coordinates[3]))
+		var/turf/target = TURF_FROM_COORDS_LIST(list(effective_parent.x + coordinates[1], effective_parent.y + coordinates[2], effective_parent.z + coordinates[3]))
 
 		if(isnull(target))
 			continue

--- a/monkestation/code/modules/signboards/_signboard.dm
+++ b/monkestation/code/modules/signboards/_signboard.dm
@@ -175,10 +175,10 @@
 		return
 	var/bwidth = src.bound_width || world.icon_size
 	var/bheight = src.bound_height || world.icon_size
-	var/text_html = MAPTEXT_GRAND9K("<span style='text-align: center'>[html_encode(sign_text)]</span>")
+	var/text_html = MAPTEXT_GRAND9K("<span style='text-align: center; line-height: 1'>[html_encode(sign_text)]</span>")
 	SET_PLANE_EXPLICIT(text_holder, GAME_PLANE_UPPER_FOV_HIDDEN, src)
 	text_holder.layer = ABOVE_ALL_MOB_LAYER
-	text_holder.alpha = 140
+	text_holder.alpha = 192
 	text_holder.maptext = text_html
 	text_holder.maptext_x = (SIGNBOARD_WIDTH - bwidth) * -0.5
 	text_holder.maptext_y = bheight
@@ -206,6 +206,7 @@
 	. = ..()
 	if(!istype(loc, /obj/structure/signboard) || QDELING(loc))
 		return INITIALIZE_HINT_QDEL
+	AddComponent(/datum/component/seethrough, SEE_THROUGH_MAP_THREE_X_TWO, 112, use_parent_turf = TRUE)
 
 /obj/effect/abstract/signboard_holder/Destroy(force)
 	if(!force && istype(loc, /obj/structure/signboard) && !QDELING(loc))


### PR DESCRIPTION
## About The Pull Request

This makes signboard text become more transparent while above the signboard, decreases the line height, and restores the original alpha (while not above it)

![2024-11-081731075204dreamseeker-ezgif com-optimize](https://github.com/user-attachments/assets/2e0aab72-21ef-4013-9d45-6e8129393495)

## Why It's Good For The Game

Makes them easier to read, while being less obtrusive.

## Changelog
:cl:
qol: Signboard text now appears more transparent for players when they are standing behind the text.
qol: Decreased line height for signboard text, so the text takes up less vertical space.
qol: Restored the original alpha for signboard text.
/:cl:
