### PR TITLE
Drones now have built-in diagnostic HUDs

### DIFF
--- a/monkestation/code/modules/mob/living/basic/drone/_drone.dm
+++ b/monkestation/code/modules/mob/living/basic/drone/_drone.dm
@@ -1,0 +1,11 @@
+/mob/living/basic/drone
+	/// Should this drone be given a diagnostic HUD?
+	/// This is only a thing so bardrones don't get the unneeded HUD.
+	var/show_diag_hud = TRUE
+
+/mob/living/basic/drone/Initialize(mapload)
+	. = ..()
+	if(show_diag_hud)
+		var/datum/atom_hud/hud = GLOB.huds[DATA_HUD_DIAGNOSTIC_BASIC]
+		hud.show_to(src)
+		ADD_TRAIT(src, TRAIT_DIAGNOSTIC_HUD, INNATE_TRAIT)

--- a/monkestation/code/modules/mob/living/basic/drone/bardrone.dm
+++ b/monkestation/code/modules/mob/living/basic/drone/bardrone.dm
@@ -1,3 +1,6 @@
+/mob/living/basic/drone/snowflake/bardrone
+	show_diag_hud = FALSE
+
 /obj/effect/mob_spawn/ghost_role/drone/bar
 	name = "bardrone shell"
 	desc = "A modified shell of a maintenance drone, an nonexpendable robot built to serve drinks and chat."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7382,6 +7382,7 @@
 #include "monkestation\code\modules\mob\living\status_procs.dm"
 #include "monkestation\code\modules\mob\living\basic\animatronic.dm"
 #include "monkestation\code\modules\mob\living\basic\bots\medbot\medbot.dm"
+#include "monkestation\code\modules\mob\living\basic\drone\_drone.dm"
 #include "monkestation\code\modules\mob\living\basic\drone\bardrone.dm"
 #include "monkestation\code\modules\mob\living\basic\ggg\glerm.dm"
 #include "monkestation\code\modules\mob\living\basic\ggg\susflash.dm"


### PR DESCRIPTION

## About The Pull Request

This gives drones a built-in diagnostic HUD.

Bardrones are exempt, as they don't really need it.

## Why It's Good For The Game

Helps in repairing things - main use I can think of being electrified doors.

## Changelog
:cl:
add: Drones now have built-in diagnostic HUDs.
/:cl:
