### PR TITLE
Boxstation Security Cleanup

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -3145,7 +3145,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Justice Chamber Exterior"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
@@ -4000,7 +4000,7 @@
 	name = "Labor Camp Shuttle Airlock";
 	shuttledocked = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/processing)
 "bpB" = (
@@ -9021,7 +9021,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Prisoner Processing"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/processing)
 "cSQ" = (
@@ -12055,7 +12055,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Equipment Room"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/lockers)
 "dTD" = (
@@ -14618,7 +14618,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Justice Chamber Interior"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/armory,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
@@ -52228,7 +52228,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Security External Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -58267,7 +58267,7 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Labor Camp Shuttle Dock"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/processing)
 "tjC" = (
@@ -66279,7 +66279,7 @@
 	name = "Labor Camp Shuttle Airlock";
 	req_access = list("brig")
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/processing)
 "vHc" = (
@@ -66360,7 +66360,7 @@
 	id_tag = "justice_chamber";
 	name = "Justice Chamber"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/execution)


### PR DESCRIPTION

## About The Pull Request
Changes the boxstation security locker room to require security access, the security side of the gulag transfer area to require brig access, the justice chamber interior to require brig access, and the justice chamber execution chamber to require armory access.
## Why It's Good For The Game
Consistency with other maps, see #4089.
## Changelog
:cl:
balance: Boxstation's security locker room now requires brig access to enter
balance: The security side of Boxstation's labor camp shuttle transfer area now requires brig access.
balance: The interior of Boxstation's justice chamber now requires brig access, and the execution chamber itself requires armory access.
/:cl:
