### PR TITLE
bounty cycler shotgun fix + mail token tray for borgs

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -98,7 +98,7 @@
 /obj/item/gun/ballistic/shotgun/automatic/dual_tube/bounty
 	name = "bounty cycler shotgun"
 	desc = "An advanced shotgun with two separate magazine tubes. This one shows signs of bounty hunting customization, meaning it likely has a dual rubber shot/fire slug load."
-	alt_accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/tube/fire
+	//alt_accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/tube/fire   monkestation edit
 
 /obj/item/gun/ballistic/shotgun/automatic/dual_tube/examine(mob/user)
 	. = ..()

--- a/monkestation/code/modules/cargo/mail/mail_token.dm
+++ b/monkestation/code/modules/cargo/mail/mail_token.dm
@@ -1,7 +1,6 @@
 /obj/item/cargo/mail_token
 	name = "mail token"
-	desc = "A plastic mail token. Part of a new program to get Nanotrasen cargo employees to deliver mail.\
-	Can be exported to Central Command for an increase to the budget. The back of the token seems to have barcode on it for handling tips."
+	desc = "A plastic mail token. Part of a new program to get Nanotrasen cargo employees to deliver mail. It can be exported to Central Command for an increase to the budget. The back of the token seems to have barcode on it for handling tips."
 	icon = 'monkestation/code/modules/cargo/mail/mail.dmi'
 	w_class = WEIGHT_CLASS_TINY
 	icon_state = "mailtoken-1"
@@ -19,3 +18,18 @@
 	unit_name = "mail token"
 	k_elasticity = 0
 	export_types = list(/obj/item/cargo/mail_token)
+
+/obj/item/storage/bag/mail_token_catcher
+	name = "mail token tray"
+	desc = "A tray for holding mail tokens."
+	icon = 'icons/obj/bureaucracy.dmi'
+	icon_state = "paper_bin0"
+
+/obj/item/storage/bag/mail_token_catcher/Initialize(mapload)
+	. = ..()
+	atom_storage.max_total_storage = 200
+	atom_storage.max_slots = 7
+	atom_storage.numerical_stacking = FALSE
+	atom_storage.set_holdable(list(
+		/obj/item/cargo/mail_token,
+	))

--- a/monkestation/code/modules/cargoborg/code/cargo_module.dm
+++ b/monkestation/code/modules/cargoborg/code/cargo_module.dm
@@ -14,6 +14,7 @@
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/borg/hydraulic_clamp,
 		/obj/item/borg/hydraulic_clamp/mail,
+		/obj/item/storage/bag/mail_token_catcher, //monkestation edit
 		/obj/item/hand_labeler/cyborg,
 		/obj/item/dest_tagger,
 		/obj/item/crowbar/cyborg,


### PR DESCRIPTION
## About The Pull Request
Title.
## Why It's Good For The Game
Bug fix and QoL tool for cargo borgs so they don't have to drag mail tokens one by one to cargo.
## Changelog
:cl:
qol: The cyborg cargo module now has a tray for collecting mail tokens.
fix: Fixed reloading for the bounty cycler shotgun.
/:cl:
