### PR TITLE
HoP supply access and supply access remote

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -544,6 +544,13 @@
 		ACCESS_TELEPORTER,
 		ACCESS_THEATRE,
 		ACCESS_WEAPONS,
+		//monkestation addition start: If the QM isn't a head, then these are part of HoP's responsibility
+		ACCESS_VAULT,
+		ACCESS_MINING,
+		ACCESS_MINING_STATION,
+		ACCESS_MECH_MINING,
+		ACCESS_QM,
+		//monkestation addition end
 		)
 	minimal_wildcard_access = list(
 		ACCESS_HOP,

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -121,7 +121,7 @@
 	region_access = REGION_MEDBAY
 
 /obj/item/door_remote/civilian
-	name = "2-in-1 civilian/supply door remote"
+	name = "civilian+supply door remote"
 	icon_state = "gangtool-white"
 	region_access = (REGION_GENERAL && REGION_SUPPLY) //monkestation addition
 

--- a/code/game/objects/items/control_wand.dm
+++ b/code/game/objects/items/control_wand.dm
@@ -121,9 +121,9 @@
 	region_access = REGION_MEDBAY
 
 /obj/item/door_remote/civilian
-	name = "civilian door remote"
+	name = "2-in-1 civilian/supply door remote"
 	icon_state = "gangtool-white"
-	region_access = REGION_GENERAL
+	region_access = (REGION_GENERAL && REGION_SUPPLY) //monkestation addition
 
 #undef WAND_OPEN
 #undef WAND_BOLT


### PR DESCRIPTION

## About The Pull Request
Gives the HoP some missing supply access, and upgrades their remote to also have supply access, in addition to the civilian access.
## Why It's Good For The Game
If the HoP is supposed to be in charge of supply, then they should at least have proper access to that department. Upgrading their remote let's them properly control access to the supply department, in addition to the vault (which is part of the supply department).
## Changelog
:cl:
balance: The HoP's door remote has been given supply access, in addition to it's civilian access.
balance: The HoP now has access to mining, the QM office, and the vault.
/:cl:
