### PR TITLE
Adds HoP's hardsuit to his locker

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -77159,7 +77159,6 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/official/random/directional/north,
-/obj/item/clothing/suit/space/hardsuit/hop,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "wSi" = (

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -44,6 +44,7 @@
 	new /obj/item/circuitboard/machine/techfab/department/service(src)
 	new /obj/item/storage/photo_album/hop(src)
 	new /obj/item/storage/lockbox/medal/hop(src)
+	new /obj/item/clothing/suit/space/hardsuit/hop(src) //monkestation addition
 
 /obj/structure/closet/secure_closet/hos
 	name = "head of security's locker"


### PR DESCRIPTION

## About The Pull Request
Adds the HoP's hardsuit to his locker as part of it's standard contents.
## Why It's Good For The Game
Allows the HoP access to it from any station, rather than only Theseus.
## Changelog
:cl:
add: The HoP's hardsuit is now available on all maps
/:cl:
