### PR TITLE
Adds a cooldown to HELP ARTIFACT MAKING ME SPEAK

### DIFF
--- a/monkestation/code/modules/art_sci_overrides/faults/say.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/say.dm
@@ -1,17 +1,31 @@
+#define SPEECH_ARTIFACT_COOLDOWN_MIN	(10 SECONDS)
+#define SPEECH_ARTIFACT_COOLDOWN_MAX	(25 SECONDS)
+
 /datum/artifact_fault/speech
 	name = "Talkative Fault"
 	trigger_chance = 25
 	research_value = 50
+	/// Cooldown to prevent constant chat spam.
+	COOLDOWN_DECLARE(spam_cooldown)
 
 /datum/artifact_fault/speech/on_trigger()
+	if(!COOLDOWN_FINISHED(src, spam_cooldown))
+		return
 	var/center_turf = get_turf(our_artifact.parent)
 
 	if(!center_turf)
 		CRASH("[src] had attempted to trigger, but failed to find the center turf!")
 
+	var/did_anything = FALSE
 	for(var/mob/living/living in viewers(rand(7, 10), center_turf))
-		if(living.stat != CONSCIOUS || !living.can_speak())
+		if(living.stat != CONSCIOUS || !living.can_speak() || prob(30))
 			continue
 		var/speak_over_radio = prob(10) ? "; " : ""
 		var/forced_message = pick_list_replacements(ARTIFACT_FILE, "speech_artifact")
-		living.say(speak_over_radio + forced_message, forced = "artifact ([src])")
+		INVOKE_ASYNC(living, TYPE_PROC_REF(/atom/movable, say), speak_over_radio + forced_message, forced = "artifact ([src])")
+		did_anything = TRUE
+	if(did_anything)
+		COOLDOWN_START(src, spam_cooldown, rand(SPEECH_ARTIFACT_COOLDOWN_MIN, SPEECH_ARTIFACT_COOLDOWN_MAX))
+
+#undef SPEECH_ARTIFACT_COOLDOWN_MAX
+#undef SPEECH_ARTIFACT_COOLDOWN_MIN


### PR DESCRIPTION

## About The Pull Request

This adds a cooldown to the talkative fault for artifacts. Cooldown is random between 10-25 seconds.

In addition, there's a 30% chance for the fault to just skip a mob entirely.

## Why It's Good For The Game

because it legit causes client-side lagspikes when I'm a ghost and someone drags one of these into a populated area and 500 "HELP ARTIFACT MAKING ME SPEAK"s are sent every 2 seconds.

## Changelog
:cl:
qol: Artifacts with the Talkative Fault now have an actual cooldown between forcing people to speak, preventing client-side lag whenever someone decides to be annoying and activate it 500 times in a populated area.
/:cl:
