### PR TITLE
Makes Secure crates more secure, Nerfs Chainsaw's demolition multiplier

### DIFF
--- a/code/game/objects/items/chainsaw.dm
+++ b/code/game/objects/items/chainsaw.dm
@@ -14,7 +14,7 @@
 	throwforce = 13
 	throw_speed = 2
 	throw_range = 4
-	demolition_mod = 1.5
+	demolition_mod = 1.4
 	custom_materials = list(/datum/material/iron= SHEET_MATERIAL_AMOUNT * 6.5)
 	attack_verb_continuous = list("saws", "tears", "lacerates", "cuts", "chops", "dices")
 	attack_verb_simple = list("saw", "tear", "lacerate", "cut", "chop", "dice")

--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -7,7 +7,7 @@
 	max_integrity = 500
 	armor_type = /datum/armor/crate_secure
 	var/tamperproof = 0
-	damage_deflection = 25
+	damage_deflection = 35
 
 /datum/armor/crate_secure
 	melee = 30


### PR DESCRIPTION

## About The Pull Request
Makes secure crates more secure by increasing their minimum damage required from 25 to 35. Also reduces the multiplier chainsaws get from hitting structures from 1.5 to 1.4
## Why It's Good For The Game
Currently, there's been an issue with cargo grabbing a chainsaw and mass ordering weapon crates in order to heavily arm themselves. While this would normally be an IC issue for HoP/security, neither generally wants to stop them either due to being busy with other issues, or because cargo is more heavily armed than them, making dealing with them incredibly difficult.
## Changelog
:cl:
balance: Chainsaw's structure damage multiplier reduced from 1.5 to 1.4 (36 damage to 33.6)
balance: Secure crate's minimum damage required increased from 25 to 35
/:cl:
