### PR TITLE
[Fix] SSD examine shows correct cyropod time.

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -367,7 +367,7 @@
 			else if(brain.temporary_sleep)
 				msg += "[span_deadsay("[t_He] [t_is] temporarly disconnected from their mind. Recovery is likely.")]\n"
 			else if(!client)
-				if(round(((world.time - lastclienttime) / (1 MINUTES)),1) >= 15)
+				if(round(((world.time - lastclienttime) / (1 MINUTES)),1) >= 30) // monkestation edit: Our cyropod time is 30 minutes
 					msg += "[t_He] [t_has] a blank, absent-minded stare and [t_has] been completely unresponsive to anything for [round(((world.time - lastclienttime) / (1 MINUTES)),1)] minutes. [t_He] may snap out of it soon. They are able to be put into a cryopod by you.\n"
 				else
 					msg += "[t_He] [t_has] a blank, absent-minded stare and [t_has] been completely unresponsive to anything for [round(((world.time - lastclienttime) / (1 MINUTES)),1)] minutes. [t_He] may snap out of it soon.\n"


### PR DESCRIPTION

## About The Pull Request
Fixes the examine text about when you cyropod someone
## Why It's Good For The Game
Gaslighting about cyropods is bad.
## Changelog
:cl:
fix: Fix ssd examine text to show the correct cyro time. (30 minutes)
/:cl:
