### PR TITLE
Tumor Shard works on ghosted elites

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -379,7 +379,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	. = ..()
 	if(istype(target, /mob/living/simple_animal/hostile/asteroid/elite) && proximity_flag)
 		var/mob/living/simple_animal/hostile/asteroid/elite/E = target
-		if(E.stat != DEAD || E.sentience_type != SENTIENCE_BOSS || !E.key)
+		if(E.stat != DEAD || E.sentience_type != SENTIENCE_BOSS) //MONKESTATION EDIT: removed || !E.key
 			user.visible_message(span_notice("It appears [E] is unable to be revived right now.  Perhaps try again later."))
 			return
 		E.faction = list("[REF(user)]")
@@ -391,6 +391,7 @@ While using this makes the system rely on OnFire, it still gives options for tim
 		E.maxHealth = E.maxHealth * 0.4
 		E.health = E.maxHealth
 		E.desc = "[E.desc]  However, this one appears appears less wild in nature, and calmer around people."
+		E.grab_ghost() // MONKESTATION ADDITION
 		E.sentience_type = SENTIENCE_ORGANIC
 		qdel(src)
 	else


### PR DESCRIPTION

## About The Pull Request
No longer requires dead elite faunas ghost to be in body for tumor shard to revive them.

## Why It's Good For The Game
Currently, after you kill a elite and get a tumor shard, most the time they have left their body, since who sits in it. This makes them unable to be revived even though they have a soul, This allows you to revive them even if their ghost is not inside their body.

## Changelog

:cl:
add: Tumor Shard now works on elites not in their body
/:cl:

