### PR TITLE
Fixed Stamina Projectiles dealing DOUBLE STAMINA DAMAGE (WHY WAS THIS A THING FOR SO LONG?!!) + Debilitated Rebalancing + Shotgun Rebalancing

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -268,8 +268,8 @@
 	if(immobilize)
 		apply_effect(immobilize, EFFECT_IMMOBILIZE, blocked)
 
-	if(stamina)
-		apply_damage(stamina, STAMINA, null, blocked)
+	//if(stamina) //monkestation removal
+	//	apply_damage(stamina, STAMINA, null, blocked) //IF THIS ISN'T AN EFFECT AND IS A DAMAGE TYPE WHY IS IT HERE?
 
 	if(drowsy)
 		adjust_drowsiness(drowsy)

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -79,7 +79,7 @@
 	desc = "A 12 gauge buckshot shell."
 	icon_state = "gshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot
-	pellets = 6
+	pellets = 8 //monkestation edit was 6
 	variance = 25
 
 /obj/item/ammo_casing/shotgun/rubbershot
@@ -87,8 +87,8 @@
 	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
 	icon_state = "rshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_rubbershot
-	pellets = 6
-	variance = 20
+	pellets = 5 //monkestation edit
+	variance = 25 // 5 pellets for 15 stam and 3 damage each
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*2)
 
 /obj/item/ammo_casing/shotgun/incapacitate
@@ -96,8 +96,8 @@
 	desc = "A shotgun casing filled with... something. used to incapacitate targets."
 	icon_state = "bountyshell"
 	projectile_type = /obj/projectile/bullet/pellet/shotgun_incapacitate
-	pellets = 12//double the pellets, but half the stun power of each, which makes this best for just dumping right in someone's face.
-	variance = 25
+	pellets = 20//monkestation edit 12 to 20
+	variance = 30 //monkestation edit
 	custom_materials = list(/datum/material/iron=SHEET_MATERIAL_AMOUNT*2)
 
 /obj/item/ammo_casing/shotgun/improvised

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -256,7 +256,7 @@
 
 	// i know that this is probably more with wands and gun mods in mind, but it's a bit silly that the projectile on_hit signal doesn't ping the projectile itself.
 	// maybe we care what the projectile thinks! See about combining these via args some time when it's not 5AM
-	if(stamina >= 10 && isliving(target))
+	if(stamina >= 15 && isliving(target))
 		var/mob/living/living = target
 		var/datum/status_effect/stacking/debilitated/effect = living.has_status_effect(/datum/status_effect/stacking/debilitated)
 		if(effect)

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -45,12 +45,12 @@
 /obj/projectile/bullet/c38/match/bouncy
 	name = ".38 Rubber bullet"
 	damage = 10
-	stamina = 30
+	stamina = 40 //30 to 40 monkestation edit
 	weak_against_armour = TRUE
 	ricochets_max = 6
 	ricochet_incidence_leeway = 0
 	ricochet_chance = 130
-	ricochet_decay_damage = 0.8
+	ricochet_decay_damage = 1 //0.8 to 1 monkestation edit let them have fun
 	shrapnel_type = null
 	sharpness = NONE
 	embedding = null

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -18,8 +18,8 @@
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
 	icon_state = "pellet"
-	damage = 10
-	stamina = 65 //monkestation edit
+	damage = 5 //10 to 5 monkestation edit
+	stamina = 75 //monkestation edit
 	wound_bonus = 20
 	sharpness = NONE
 	embedding = null
@@ -84,9 +84,10 @@
 /obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubber shot pellet"
 	damage = 3
-	stamina = 30 //monkestation edit
+	stamina = 15 //monkestation edit
 	sharpness = NONE
 	embedding = null
+	tile_dropoff_s = 0 //monkestation edit
 	speed = 1.2
 	ricochets_max = 4
 	ricochet_chance = 120
@@ -106,7 +107,8 @@
 /obj/projectile/bullet/pellet/shotgun_incapacitate
 	name = "incapacitating pellet"
 	damage = 1
-	stamina = 6
+	stamina = 12
+	tile_dropoff_s = 3 //monkestation edit spitting distance
 	embedding = null
 
 /obj/projectile/bullet/pellet/shotgun_improvised

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -107,7 +107,7 @@
 /obj/projectile/bullet/pellet/shotgun_incapacitate
 	name = "incapacitating pellet"
 	damage = 1
-	stamina = 12
+	stamina = 12 //monkestation edit
 	tile_dropoff_s = 3 //monkestation edit spitting distance
 	embedding = null
 

--- a/monkestation/code/modules/blood_datum/debilitated.dm
+++ b/monkestation/code/modules/blood_datum/debilitated.dm
@@ -5,9 +5,9 @@
 /datum/status_effect/stacking/debilitated
 	id = "debilitated"
 	stacks = 0
-	max_stacks = 10
+	max_stacks = 5
 	tick_interval = 10 SECONDS
-	delay_before_decay = 3 MINUTES
+	delay_before_decay = 1 MINUTES
 	consumed_on_threshold = FALSE
 	alert_type = /atom/movable/screen/alert/status_effect/debilitated
 	status_type = STATUS_EFFECT_REFRESH
@@ -15,15 +15,13 @@
 	///our base stamina loss multiplier
 	var/loss_multiplier = 1
 	///our per stack increase to stamina loss
-	var/per_stack_multiplier_increase = 0.1
-	///our cached stamina_mod
-	var/cached_stamina
+	var/per_stack_multiplier_increase = 0.2
 
 /datum/status_effect/stacking/debilitated/on_apply()
 	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human = owner
-		cached_stamina = human.physiology.temp_stamina_mod
+		human.physiology.temp_stamina_mod = loss_multiplier + (stacks * per_stack_multiplier_increase)
 
 /datum/status_effect/stacking/debilitated/add_stacks(stacks_added)
 	. = ..()

--- a/monkestation/code/modules/blueshift/items/ammo.dm
+++ b/monkestation/code/modules/blueshift/items/ammo.dm
@@ -1153,30 +1153,6 @@
 	<i>HORNET'S NEST: Fire an overwhelming amount of projectiles in a single shot.</i>"
 	can_be_printed = FALSE
 
-/obj/item/ammo_casing/shotgun/buckshot
-	name = "buckshot shell"
-	desc = "A 12 gauge buckshot shell."
-	icon_state = "gshell"
-	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot
-	pellets = 8 // 8 * 6 for 48 damage if every pellet hits, we want to keep lethal shells ~50 damage
-	variance = 25
-
-/obj/projectile/bullet/pellet/shotgun_buckshot
-	name = "buckshot pellet"
-	damage = 6
-
-/obj/item/ammo_casing/shotgun/rubbershot
-	name = "rubber shot"
-	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
-	icon_state = "rshell"
-	projectile_type = /obj/projectile/bullet/pellet/shotgun_rubbershot
-	pellets = 6 // 6 * 10 for 60 stamina damage, + some small amount of brute, we want to keep less lethal shells ~60
-	variance = 20
-	harmful = FALSE
-
-/obj/projectile/bullet/pellet/shotgun_rubbershot
-	stamina = 10
-
 /obj/item/ammo_casing/shotgun/magnum
 	name = "magnum blockshot shell"
 	desc = "A 12 gauge shell that fires fewer, larger pellets than buckshot. A favorite of SolFed anti-piracy enforcers, \
@@ -1285,7 +1261,7 @@
 	icon = 'monkestation/code/modules/blueshift/icons/projectiles.dmi'
 	icon_state = "stardust"
 	damage = 2
-	stamina = 10
+	stamina = 7
 	wound_bonus = 0
 	bare_wound_bonus = 0
 	stutter = 3 SECONDS
@@ -1293,7 +1269,7 @@
 	eyeblur = 1 SECONDS
 	sharpness = NONE
 	range = 7
-	embedding = list(embed_chance=70, pain_chance=25, fall_chance=15, jostle_chance=80, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.9, pain_mult=2, rip_time=10)
+	embedding = list(embed_chance=75, pain_chance=50, fall_chance=15, jostle_chance=80, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.9, pain_mult=2, rip_time=10)
 
 /obj/projectile/bullet/pellet/shotgun_buckshot/antitide/on_range()
 	do_sparks(1, TRUE, src)
@@ -1331,9 +1307,6 @@
 /obj/projectile/bullet/shotgun_slug/hunter/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/bane, mob_biotypes = MOB_BEAST, damage_multiplier = 5)
-
-/obj/projectile/bullet/pellet/shotgun_improvised
-	weak_against_armour = TRUE // We will not have Improvised are Better 2.0
 
 /obj/item/ammo_casing/shotgun/honkshot
 	name = "confetti shell"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Projectiles were applying stamina damage through basic damage types and effects. So I removed stamina from being considered an effect that is applied. Balanced debilitated to go away after 1 minute with a maximum of 5 stack each stack adding a 0.2 multiplier to stamina drain for a max of **2** at 5 stacks. Debilitated only procs on projectiles dealing more than 15 damage also so stuff like rubbershot and stardust won't proc debilitated. This is to counteract stamina projectiles not dealing DOUBLE STRAMINA DAMAGE anymore. Disabler beams and paco rubbers take 4 hits now instead of 3. 
THIS PR WILL PROBABLY NEED A LOT MORE ADJUSTMENT.

Rebalanced shotgun ammo to make ammo like buckshot/rubbershot/beanbags more effective.
## Why It's Good For The Game

Fixes a major bug

## Changelog

:cl:
fix: Fixed stamina projectiles dealing DOUBLE STAMINA DAMAGE. Rebalanced the debilitated status effect accordingly. 
balance: Rebalanced shotgun ammo.
balance: C38 rubber rounds do not lose kinetic force on ricochet and deal slightly more stamina damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

Stardust might be pretty bad right now and needs more balancing.
