### PR TITLE
Use 1,1 instead of CENTER as relay_loc on 516 builds

### DIFF
--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -34,6 +34,14 @@
 		stack_trace("Hey brother, our key [key] is already in use by a plane master group on the passed in hud, belonging to [viewing_hud.mymob]. Ya fucked up, why are there dupes")
 		return
 
+#if MIN_COMPILER_VERSION > 516
+	#warn Fully change default relay_loc to "1,1", rather than changing it based on client version
+#endif
+
+	if(viewing_hud.mymob?.client?.byond_version > 515)
+		relay_loc = "1,1"
+		rebuild_plane_masters()
+
 	our_hud = viewing_hud
 	our_hud.master_groups[key] = src
 	show_hud()

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -297,7 +297,7 @@
 	render_relay_planes = list(RENDER_PLANE_MASTER)
 
 /**
- * Plane master proc called in Initialize() that creates relay objects, and sets them uo as needed
+ * Plane master proc called in Initialize() that creates relay objects, and sets them up as needed
  * Sets:
  * * layer from plane to avoid z-fighting
  * * planes to relay the render to
@@ -307,6 +307,9 @@
  * Other vars such as alpha will automatically be applied with the render source
  */
 /atom/movable/screen/plane_master/proc/generate_render_relays()
+#if MIN_COMPILER_VERSION > 516
+	#warn Fully change default relay_loc to "1,1"
+#endif
 	var/relay_loc = home?.relay_loc || "CENTER"
 	// If we're using a submap (say for a popup window) make sure we draw onto it
 	if(home?.map)
@@ -341,7 +344,7 @@
 	if(!length(relays) && !initial(render_target))
 		render_target = OFFSET_RENDER_TARGET(get_plane_master_render_base(name), offset)
 	if(!relay_loc)
-		relay_loc = "CENTER"
+		relay_loc = (show_to?.byond_version > 515) ? "1,1" : "CENTER"
 		// If we're using a submap (say for a popup window) make sure we draw onto it
 		if(home?.map)
 			relay_loc = "[home.map]:[relay_loc]"


### PR DESCRIPTION
## About The Pull Request

Port of my own upstream PR, https://github.com/tgstation/tgstation/pull/84035

As of 516 build 1640, whenever render_source is used, the replacement icon is now _ALWAYS_ anchored to the bottom left of the replaced icon. This kinda breaks things that relied on the previous behavior of everything being centered.

## Testing Evidence

![image](https://github.com/user-attachments/assets/90183b58-7b59-4235-82f9-3a93c4541291)
![image](https://github.com/user-attachments/assets/ee57f621-a0bc-44c3-902c-d35fc6e3c596)

## Why It's Good For The Game

Because having the game work is good.

## Changelog

None because 516 is still not a public beta yet.