### PR TITLE
Fixes supermatter surge only choosing class 1

### DIFF
--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -46,7 +46,7 @@
 	announce_when = 4
 	end_when = SURGE_DURATION_MIN
 	/// How powerful is the supermatter surge going to be?
-	var/surge_class =  SURGE_SEVERITY_MIN
+	var/surge_class = null //monkestation edit
 	/// Typecasted reference to the supermatter chosen at event start
 	var/obj/machinery/power/supermatter_crystal/engine
 	/// Typecasted reference to the nitrogen properies in the SM chamber


### PR DESCRIPTION

## About The Pull Request
Fixes the supermatter surge random event only ever choosing a class 1 surge, instead of a random power level
## Why It's Good For The Game
Bug bad
## Changelog
:cl:
fix: Fixed the supermatter power surge event only ever being class 1
/:cl:
