### PR TITLE
Update allergic.dm

### DIFF
--- a/code/datums/quirks/negative_quirks/allergic.dm
+++ b/code/datums/quirks/negative_quirks/allergic.dm
@@ -17,7 +17,9 @@
 		/datum/reagent/medicine/omnizine/godblood,
 		/datum/reagent/medicine/cordiolis_hepatico,
 		/datum/reagent/medicine/synaphydramine,
-		/datum/reagent/medicine/diphenhydramine
+		/datum/reagent/medicine/diphenhydramine,
+		/datum/reagent/medicine/changelingadrenaline,
+		/datum/reagent/medicine/spaceacillin
 		)
 	var/allergy_string
 


### PR DESCRIPTION
Two of these paths don't exist anymore but the code doesn't recognise em - so I just added them to the blacklist of chemicals chosen for allergens.

Fixes Issue #4249 
## Changelog


:cl:

fix: fixed allergens from the Allergies perk sometimes being blank.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
