### PR TITLE
Slime changes

### DIFF
--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -243,13 +243,14 @@
 	SIGNAL_HANDLER
 
 	for(var/i in human_parent.buckled_mobs)
-		var/mob/living/rider = i
-		human_parent.unbuckle_mob(rider)
-		rider.Paralyze(1 SECONDS)
-		rider.Knockdown(4 SECONDS)
-		human_parent.visible_message(span_danger("[rider] topples off of [human_parent] as they both fall to the ground!"), \
-					span_warning("You fall to the ground, bringing [rider] with you!"), span_hear("You hear two consecutive thuds."), COMBAT_MESSAGE_RANGE, ignored_mobs=rider)
-		to_chat(rider, span_danger("[human_parent] falls to the ground, bringing you with [human_parent.p_them()]!"))
+		if(!isslime(rider)) //No resting to get away from slimes.
+			var/mob/living/rider = i
+			human_parent.unbuckle_mob(rider)
+			rider.Paralyze(1 SECONDS)
+			rider.Knockdown(4 SECONDS)
+			human_parent.visible_message(span_danger("[rider] topples off of [human_parent] as they both fall to the ground!"), \
+						span_warning("You fall to the ground, bringing [rider] with you!"), span_hear("You hear two consecutive thuds."), COMBAT_MESSAGE_RANGE, ignored_mobs=rider)
+			to_chat(rider, span_danger("[human_parent] falls to the ground, bringing you with [human_parent.p_them()]!"))
 
 /datum/component/riding/creature/human/handle_vehicle_layer(dir)
 	var/atom/movable/AM = parent

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -243,8 +243,8 @@
 	SIGNAL_HANDLER
 
 	for(var/i in human_parent.buckled_mobs)
+		var/mob/living/rider = i
 		if(!isslime(rider)) //No resting to get away from slimes.
-			var/mob/living/rider = i
 			human_parent.unbuckle_mob(rider)
 			rider.Paralyze(1 SECONDS)
 			rider.Knockdown(4 SECONDS)

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -60,6 +60,9 @@
 	// for fireman carries, check if the ridden is stunned/restrained
 	else if((ride_check_flags & CARRIER_NEEDS_ARM) && (HAS_TRAIT(living_parent, TRAIT_RESTRAINED) || living_parent.incapacitated(IGNORE_RESTRAINTS|IGNORE_GRAB)))
 		. = FALSE
+	
+	if(isslime(rider)) //Slimes are sticky.
+		. = TRUE
 
 	if(. || !consequences)
 		return

--- a/monkestation/code/modules/slimecore/components/latch_feeding.dm
+++ b/monkestation/code/modules/slimecore/components/latch_feeding.dm
@@ -113,6 +113,10 @@
 		stop_feeding()
 		return
 
+	if(isdead(living_target) == DEAD)
+		stop_feeding()
+		return
+
 	if(!check_and_replace || (check_and_replace && !check_and_replace.Invoke()))
 		if(iscarbon(living_target))
 			living_target.apply_damage(damage_amount, damage_type, spread_damage = TRUE)

--- a/monkestation/code/modules/slimecore/components/latch_feeding.dm
+++ b/monkestation/code/modules/slimecore/components/latch_feeding.dm
@@ -108,6 +108,7 @@
 		return
 
 	var/mob/living/living_target = target
+	var/mob/living/basic_mob = parent
 	if((living_target.stat >= SOFT_CRIT) && stops_at_crit && living_target.client)
 		stop_feeding()
 		return
@@ -117,6 +118,8 @@
 			living_target.apply_damage(damage_amount, damage_type, spread_damage = TRUE)
 		else
 			living_target.apply_damage(damage_amount, BRUTE, spread_damage = TRUE)
+		basic_mob.adjustBruteLoss(-damage_amount, TRUE)
+		basic_mob.adjustFireLoss(-damage_amount, TRUE)
 
 	if(!QDELETED(parent)) // ??? I was getting runtimes for no parent but IDK how
 		SEND_SIGNAL(parent, COMSIG_MOB_FEED, target, hunger_restore)

--- a/monkestation/code/modules/slimecore/components/latch_feeding.dm
+++ b/monkestation/code/modules/slimecore/components/latch_feeding.dm
@@ -119,7 +119,6 @@
 		else
 			living_target.apply_damage(damage_amount, BRUTE, spread_damage = TRUE)
 		basic_mob.adjustBruteLoss(-damage_amount, TRUE)
-		basic_mob.adjustFireLoss(-damage_amount, TRUE)
 
 	if(!QDELETED(parent)) // ??? I was getting runtimes for no parent but IDK how
 		SEND_SIGNAL(parent, COMSIG_MOB_FEED, target, hunger_restore)

--- a/monkestation/code/modules/slimecore/mobs/_base_slime.dm
+++ b/monkestation/code/modules/slimecore/mobs/_base_slime.dm
@@ -562,6 +562,22 @@
 	worn_accessory = attacking_item
 	attacking_item.forceMove(src)
 	update_appearance()
+	
+	if(check_item_passthrough(attacking_item, user))
+		return
+
+///Checks if an item harmlessly passes through the slime
+/mob/living/basic/slime/proc/check_item_passthrough(obj/item/attacking_item, mob/living/user)
+	if(attacking_item.force <= 0)
+		return FALSE
+
+	if(!prob(25))
+		return FALSE
+
+	user.do_attack_animation(src)
+	user.changeNext_move(CLICK_CD_MELEE)
+	to_chat(user, span_danger("[attacking_item] passes right through [src]!"))
+	return TRUE
 
 /mob/living/basic/slime/attack_hand(mob/living/carbon/human/user, list/modifiers)
 	. = ..()
@@ -586,6 +602,26 @@
 		powerlevel++
 	
 	. = ..()
+
+/mob/living/basic/slime/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	powerlevel = 0 // oh no, the power!
+
+///If a slime is attack with an empty hand, shoves included, try to wrestle them off the mob they are on
+/mob/living/basic/slime/proc/on_attack_hand(mob/living/basic/slime/defender_slime, mob/living/attacker)
+	SIGNAL_HANDLER
+
+	if(isnull(buckled))
+		return
+
+	if(buckled == attacker ? prob(60) : prob(30)) //its easier to remove the slime from yourself
+		attacker.visible_message(span_warning("[attacker] attempts to wrestle \the [defender_slime.name] off [buckled == attacker ? "" : buckled] !"), \
+		span_danger("[buckled == attacker ? "You attempt" : "[attacker] attempts" ] to wrestle \the [defender_slime.name] off [buckled == attacker ? "" : buckled]!"))
+		return
+
+	attacker.visible_message(span_warning("[attacker] manages to wrestle \the [defender_slime.name] off!"), span_notice("You manage to wrestle \the [defender_slime.name] off!"))
 
 /mob/living/basic/slime/proc/apply_water()
 	adjustBruteLoss(rand(15, 20))

--- a/monkestation/code/modules/slimecore/mobs/_base_slime.dm
+++ b/monkestation/code/modules/slimecore/mobs/_base_slime.dm
@@ -495,6 +495,9 @@
 /mob/living/basic/slime/proc/on_slime_pre_attack(mob/living/basic/slime/our_slime, atom/target, proximity, modifiers)
 	SIGNAL_HANDLER
 
+	if(LAZYACCESS(modifiers, RIGHT_CLICK))
+		return COMPONENT_HOSTILE_NO_ATTACK
+
 	if(isAI(target)) //The aI is not tasty!
 		target.balloon_alert(our_slime, "not tasty!")
 		return COMPONENT_HOSTILE_NO_ATTACK

--- a/monkestation/code/modules/slimecore/mobs/_base_slime.dm
+++ b/monkestation/code/modules/slimecore/mobs/_base_slime.dm
@@ -412,6 +412,14 @@
 	for(var/datum/slime_trait/trait as anything in slime_traits)
 		new_slime.add_trait(trait.type)
 	new_slime.recompile_ai_tree()
+	if(mind.has_antag_datum(/datum/antagonist/pyro_slime)) //Pyroclastic slime gives birth to sentient slimes!!!
+		SSpolling.poll_ghosts_for_target(check_jobban = ROLE_SENTIENCE, poll_time = 10 SECONDS, checked_target = new_slime, ignore_category = POLL_IGNORE_PYROSLIME, alert_pic = pyro, role_name_text = "pyroclastic anomaly slime")
+		if(isnull(chosen_one))
+			return
+		new_slime.key = chosen_one.key
+		new_slime.mind.special_role = ROLE_PYROCLASTIC_SLIME
+		new_slime.mind.add_antag_datum(/datum/antagonist/pyro_slime)
+		new_slime.log_message("was made into a slime by pyroclastic slime split", LOG_GAME)
 
 /mob/living/basic/slime/proc/start_mutating(random = FALSE)
 	if(!pick_mutation(random))

--- a/monkestation/code/modules/slimecore/mobs/_base_slime.dm
+++ b/monkestation/code/modules/slimecore/mobs/_base_slime.dm
@@ -149,6 +149,7 @@
 	RegisterSignal(src, COMSIG_MOB_OVERATE, PROC_REF(attempt_change))
 	RegisterSignals(src, list(COMSIG_AI_BLACKBOARD_KEY_CLEARED(BB_CURRENT_PET_TARGET), COMSIG_AI_BLACKBOARD_KEY_SET(BB_CURRENT_PET_TARGET)), PROC_REF(on_blackboard_key_changed))
 	RegisterSignal(src, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, PROC_REF(on_slime_pre_attack))
+	RegisterSignal(src, COMSIG_ATOM_ATTACK_HAND, PROC_REF(on_attack_hand) )
 
 	for(var/datum/slime_mutation_data/listed as anything in current_color.possible_mutations)
 		var/datum/slime_mutation_data/data = new listed

--- a/monkestation/code/modules/slimecore/mobs/_base_slime.dm
+++ b/monkestation/code/modules/slimecore/mobs/_base_slime.dm
@@ -401,8 +401,7 @@
 	SEND_SIGNAL(src, COMSIG_MOB_ADJUST_HUNGER, -200)
 
 	slime_flags &= ~SPLITTING_SLIME
-	if(!mind)
-		ai_controller.reset_ai_status()
+	ai_controller.reset_ai_status()
 
 	var/mob/living/basic/slime/new_slime = new(loc, current_color.type, TRUE)
 	new_slime.mutation_chance = mutation_chance
@@ -462,8 +461,7 @@
 	change_color(mutating_into)
 
 	slime_flags &= ~MUTATING_SLIME
-	if(!mind)
-		ai_controller.reset_ai_status()
+	ai_controller.reset_ai_status()
 
 
 /mob/living/basic/slime/proc/pick_mutation(random = FALSE)

--- a/monkestation/code/modules/slimecore/mobs/_base_slime.dm
+++ b/monkestation/code/modules/slimecore/mobs/_base_slime.dm
@@ -19,6 +19,10 @@
 
 	melee_damage_lower = 5
 	melee_damage_upper = 15
+	
+	habitable_atmos = list("min_oxy" = 0, "max_oxy" = 0, "min_plas" = 0, "max_plas" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
+	
+	damage_coeff = list(BRUTE = 1, BURN = -1, TOX = 1, STAMINA = 0, OXY = 1)
 
 	//emote_see = list("jiggles", "bounces in place")
 	speak_emote = list("blorbles")
@@ -190,7 +194,7 @@
 		buckled?.unbuckle_mob(src, force = TRUE)
 		return
 	else if(CanReach(target) && !HAS_TRAIT(target, TRAIT_LATCH_FEEDERED))
-		AddComponent(/datum/component/latch_feeding, target, TOX, 2, 4, FALSE, CALLBACK(src, TYPE_PROC_REF(/mob/living/basic/slime, latch_callback), target))
+		AddComponent(/datum/component/latch_feeding, target, CLONE, 2, 4, FALSE, CALLBACK(src, TYPE_PROC_REF(/mob/living/basic/slime, latch_callback), target))
 		return
 	. = ..()
 
@@ -360,7 +364,8 @@
 	SEND_SIGNAL(src, COMSIG_MOB_ADJUST_HUNGER, -200)
 
 	slime_flags &= ~SPLITTING_SLIME
-	ai_controller.reset_ai_status()
+	if(!mind)
+		ai_controller.reset_ai_status()
 
 	var/mob/living/basic/slime/new_slime = new(loc, current_color.type, TRUE)
 	new_slime.mutation_chance = mutation_chance
@@ -412,7 +417,8 @@
 	change_color(mutating_into)
 
 	slime_flags &= ~MUTATING_SLIME
-	ai_controller.reset_ai_status()
+	if(!mind)
+		ai_controller.reset_ai_status()
 
 
 /mob/living/basic/slime/proc/pick_mutation(random = FALSE)
@@ -508,5 +514,5 @@
 	. = ..()
 	if(SEND_SIGNAL(src, COMSIG_FRIENDSHIP_CHECK_LEVEL, throwingdatum.thrower, FRIENDSHIP_FRIEND))
 		if(!HAS_TRAIT(hit_atom, TRAIT_LATCH_FEEDERED) && isliving(hit_atom))
-			AddComponent(/datum/component/latch_feeding, hit_atom, TOX, 2, 4, FALSE, CALLBACK(src, PROC_REF(latch_callback), hit_atom), FALSE)
+			AddComponent(/datum/component/latch_feeding, hit_atom, CLONE, 2, 4, FALSE, CALLBACK(src, PROC_REF(latch_callback), hit_atom), FALSE)
 			visible_message(span_danger("[throwingdatum.thrower] hucks [src] at [hit_atom] causing the [src] to stick to [hit_atom]."))

--- a/monkestation/code/modules/slimecore/mobs/_base_slime.dm
+++ b/monkestation/code/modules/slimecore/mobs/_base_slime.dm
@@ -413,7 +413,7 @@
 		new_slime.add_trait(trait.type)
 	new_slime.recompile_ai_tree()
 	if(mind.has_antag_datum(/datum/antagonist/pyro_slime)) //Pyroclastic slime gives birth to sentient slimes!!!
-		SSpolling.poll_ghosts_for_target(check_jobban = ROLE_SENTIENCE, poll_time = 10 SECONDS, checked_target = new_slime, ignore_category = POLL_IGNORE_PYROSLIME, alert_pic = pyro, role_name_text = "pyroclastic anomaly slime")
+		var/mob/chosen_one = SSpolling.poll_ghosts_for_target(check_jobban = ROLE_SENTIENCE, poll_time = 10 SECONDS, checked_target = new_slime, ignore_category = POLL_IGNORE_PYROSLIME, alert_pic = new_slime, role_name_text = "pyroclastic anomaly slime")
 		if(isnull(chosen_one))
 			return
 		new_slime.key = chosen_one.key

--- a/monkestation/code/modules/slimecore/mobs/_base_slime.dm
+++ b/monkestation/code/modules/slimecore/mobs/_base_slime.dm
@@ -149,7 +149,7 @@
 	RegisterSignal(src, COMSIG_MOB_OVERATE, PROC_REF(attempt_change))
 	RegisterSignals(src, list(COMSIG_AI_BLACKBOARD_KEY_CLEARED(BB_CURRENT_PET_TARGET), COMSIG_AI_BLACKBOARD_KEY_SET(BB_CURRENT_PET_TARGET)), PROC_REF(on_blackboard_key_changed))
 	RegisterSignal(src, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, PROC_REF(on_slime_pre_attack))
-	RegisterSignal(src, COMSIG_ATOM_ATTACK_HAND, PROC_REF(on_attack_hand) )
+	RegisterSignal(src, COMSIG_ATOM_ATTACK_HAND, PROC_REF(on_attack_hand))
 
 	for(var/datum/slime_mutation_data/listed as anything in current_color.possible_mutations)
 		var/datum/slime_mutation_data/data = new listed

--- a/monkestation/code/modules/slimecore/mobs/ai_controller/behaviours/feed.dm
+++ b/monkestation/code/modules/slimecore/mobs/ai_controller/behaviours/feed.dm
@@ -16,7 +16,7 @@
 		var/atom/target = controller.blackboard[target_key]
 		var/mob/living/basic/slime/basic_mob = controller.pawn
 		if(basic_mob.CanReach(target) && !HAS_TRAIT(target, TRAIT_LATCH_FEEDERED))
-			basic_mob.AddComponent(/datum/component/latch_feeding, target, TOX, 2, 4, FALSE, CALLBACK(basic_mob, TYPE_PROC_REF(/mob/living/basic/slime, latch_callback), target))
+			basic_mob.AddComponent(/datum/component/latch_feeding, target, CLONE, 2, 4, FALSE, CALLBACK(basic_mob, TYPE_PROC_REF(/mob/living/basic/slime, latch_callback), target))
 		controller.clear_blackboard_key(target_key)
 	. = ..()
 


### PR DESCRIPTION
## About The Pull Request
Mixture of stuff I took from TG and stuff I did on my own.
-Fixes player controlled slimes getting an AI when splitting or mutating.
-Adds electricity attacks to slimes.
-Slimes heal when absorbing.
-Slimes heal from burn damage.
-Slimes no longer breathe. (Makes it so pyroclastic slimes aren't suffocating the moment they spawn.)
-When a pyroclastic slime splits, the new slime can be played by a ghost, becoming a new pyroclastic slime.
-Slimes now have more damage by default, and even more damage when an adult.
-Slimes get extra max health as an adult.
-Slimes cannot attack the target they are absorbing.
-Slimes don't stop absorbing if the target falls onto the ground, slimes are also harder to shove off.
-Slimes now deal clone damage instead of toxin.
-Hits have a chance to pass through a slime.
## Why It's Good For The Game
Slimes are quite weak to play as, this makes them stronger, and gives them a lot of the strength they had back originally before the slime ranching update.
Pyroclastic slimes splitting into more sentient slimes is a funny way to cause a headache to the crew.
## Changelog
:cl:
add: When a pyroclastic slime splits, ghosts are polled to play the new slime.
balance: Slimes are much stronger
fix: Fixes player controlled slimes getting an AI controlling them when splitting/mutating.
/:cl:
