### PR TITLE
Fix signboard transparency area not moving with the sign

### DIFF
--- a/code/datums/components/seethrough.dm
+++ b/code/datums/components/seethrough.dm
@@ -19,7 +19,7 @@
 	var/use_parent_turf
 
 ///see_through_map is a define pointing to a specific map. It's basically defining the area which is considered behind. See see_through_maps.dm for a list of maps
-/datum/component/seethrough/Initialize(see_through_map = SEE_THROUGH_MAP_DEFAULT, target_alpha = 100, animation_time = 0.5 SECONDS, perimeter_reset_timer = 2 SECONDS, clickthrough = TRUE, use_parent_turf = FALSE)
+/datum/component/seethrough/Initialize(see_through_map = SEE_THROUGH_MAP_DEFAULT, target_alpha = 100, animation_time = 0.5 SECONDS, perimeter_reset_timer = 2 SECONDS, clickthrough = TRUE, use_parent_turf = FALSE, movement_source = null)
 	. = ..()
 
 	relative_turf_coords = GLOB.see_through_maps[see_through_map]
@@ -35,7 +35,7 @@
 	src.clickthrough = clickthrough
 	src.use_parent_turf = use_parent_turf
 
-	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(dismantle_perimeter))
+	RegisterSignal(movement_source || parent, COMSIG_MOVABLE_MOVED, PROC_REF(dismantle_perimeter))
 
 	setup_perimeter(parent)
 

--- a/monkestation/code/modules/signboards/_signboard.dm
+++ b/monkestation/code/modules/signboards/_signboard.dm
@@ -206,7 +206,7 @@
 	. = ..()
 	if(!istype(loc, /obj/structure/signboard) || QDELING(loc))
 		return INITIALIZE_HINT_QDEL
-	AddComponent(/datum/component/seethrough, SEE_THROUGH_MAP_THREE_X_TWO, 112, use_parent_turf = TRUE)
+	AddComponent(/datum/component/seethrough, SEE_THROUGH_MAP_THREE_X_TWO, 112, use_parent_turf = TRUE, movement_source = loc)
 
 /obj/effect/abstract/signboard_holder/Destroy(force)
 	if(!force && istype(loc, /obj/structure/signboard) && !QDELING(loc))


### PR DESCRIPTION
## Changelog
:cl:
fix: Signboards no longer "leave behind" their text transparency area whenever they're moved.
/:cl:
