### PR TITLE
Permit-lock is lifted when security level is set to red or above.

### DIFF
--- a/code/controllers/subsystem/security_level.dm
+++ b/code/controllers/subsystem/security_level.dm
@@ -64,6 +64,11 @@ SUBSYSTEM_DEF(security_level)
 	SEND_SIGNAL(src, COMSIG_SECURITY_LEVEL_CHANGED, selected_level.number_level)
 	SSblackbox.record_feedback("tally", "security_level_changes", 1, selected_level.name)
 
+//monkestation addition start: lifts permit-locks when security level is set to red or above
+	if(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED)
+		GLOB.permit_pin_unrestricted = TRUE
+//monkestation addition end
+
 /**
  * Returns the current security level as a number
  */

--- a/monkestation/code/modules/blueshift/cargo/company_import.dm
+++ b/monkestation/code/modules/blueshift/cargo/company_import.dm
@@ -81,9 +81,6 @@ GLOBAL_VAR_INIT(permit_pin_unrestricted, FALSE)
 	if(GLOB.permit_pin_unrestricted)
 		return TRUE
 
-	if(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED) // Let's security levels red and above allow the gun to be fired
-		return TRUE
-
 	var/obj/item/card/id/the_id = user.get_idcard()
 
 	if(!the_id && is_station_level(station_check.z))

--- a/monkestation/code/modules/blueshift/cargo/company_import.dm
+++ b/monkestation/code/modules/blueshift/cargo/company_import.dm
@@ -81,6 +81,9 @@ GLOBAL_VAR_INIT(permit_pin_unrestricted, FALSE)
 	if(GLOB.permit_pin_unrestricted)
 		return TRUE
 
+	if(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED) // Let's security levels red and above allow the gun to be fired
+		return TRUE
+
 	var/obj/item/card/id/the_id = user.get_idcard()
 
 	if(!the_id && is_station_level(station_check.z))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, the permit-lifting mechanic is rarely used outside of warops. This will hopefully make this mechanic more well know, and let people actually use their weapons with a permit if command doesn't bother to lift/reinstate the lock.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Permit-locked firing pins will have their locks lifted on red alert and higher. The locks can be reinstated at communication consoles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
