### PR TITLE
Making the hotel ruin, an actual hotel

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
@@ -8,20 +8,20 @@
 /obj/item/shadowcloak,
 /obj/item/storage/belt/utility/full/engi,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "al" = (
 /obj/machinery/door/airlock{
 	name = "Showers"
 	},
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "ao" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "ap" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -30,7 +30,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"as" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel/dock)
 "aw" = (
 /obj/structure/bed/pod{
 	dir = 4
@@ -39,19 +42,19 @@
 	dir = 4
 	},
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "aB" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "aG" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "aO" = (
 /obj/structure/closet/secure_closet/freezer/meat/open,
 /obj/item/food/meat/rawbacon,
@@ -77,15 +80,15 @@
 /obj/item/food/fishmeat/carp,
 /obj/item/sharpener,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "aQ" = (
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "aX" = (
 /obj/item/beacon,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "aY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
@@ -100,11 +103,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/storage/box/beanbag,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
+"be" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/hotel)
 "bj" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "bm" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/item/food/grown/potato,
@@ -128,16 +134,16 @@
 /obj/item/reagent_containers/condiment/milk,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "bn" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "bo" = (
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "bp" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -146,53 +152,56 @@
 /obj/structure/table/wood/fancy/royalblue,
 /obj/machinery/light/directional/north,
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "bs" = (
 /obj/structure/frame/computer,
 /turf/open/floor/circuit/green,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "bt" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair,
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "bu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "bx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "bC" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 8
 	},
 /turf/open/floor/carpet/lone,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "bK" = (
 /obj/structure/chair/comfy/lime{
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"bQ" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel/power)
 "bR" = (
 /obj/structure/chair/wood,
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "cd" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 8
 	},
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "ce" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -202,7 +211,7 @@
 	dir = 4
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "ch" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -211,13 +220,13 @@
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "ci" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "cm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -226,7 +235,7 @@
 	icon_state = "plant-13"
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "cp" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -237,7 +246,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "cy" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/item/grenade/chem_grenade/cleaner,
@@ -248,14 +257,14 @@
 /obj/item/clothing/head/costume/maidheadband,
 /obj/item/clothing/gloves/maid,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/custodial)
 "cB" = (
 /obj/structure/chair/plastic{
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "cD" = (
 /obj/effect/turf_decal/delivery/white{
 	color = "A46106"
@@ -263,23 +272,23 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/medical,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "cI" = (
 /obj/structure/chair/sofa/corp/left,
 /obj/machinery/light/directional/north,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "cK" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "cS" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "cT" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -287,13 +296,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "cV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "cX" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Freezer"
@@ -302,7 +311,7 @@
 /turf/open/floor/iron/textured_half{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "dh" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -317,10 +326,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "dj" = (
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "dl" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
@@ -337,14 +346,14 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "dp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "dr" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/siding/white,
@@ -352,25 +361,25 @@
 	dir = 4
 	},
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "ds" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/structure/displaycase/trophy,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "dt" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "dy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "dD" = (
 /obj/structure/flora/bush/leavy/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -379,29 +388,29 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/window/fulltile,
 /turf/open/floor/grass,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "dF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "dI" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "dN" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "dP" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/sign/poster/official/no_erp/directional/north,
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "dR" = (
 /obj/structure/chair/sofa/corner,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
@@ -409,18 +418,18 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "dW" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "dX" = (
 /obj/item/flashlight/flare/candle/infinite{
 	pixel_y = 6
 	},
 /obj/structure/table/wood/fancy,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "eb" = (
 /obj/structure/bed/pod{
 	dir = 4
@@ -429,14 +438,22 @@
 	dir = 4
 	},
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "eg" = (
 /obj/structure/window/spawner/directional/east,
 /obj/structure/toilet{
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
+"en" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Hotel Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "ep" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -445,7 +462,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "et" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -461,7 +478,7 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "ez" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -476,11 +493,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "eB" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
+"eD" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "eK" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -492,7 +512,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "eM" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
@@ -501,10 +521,10 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/neon/simple/red/nodots,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "eR" = (
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "eS" = (
 /obj/structure/toilet/secret{
 	dir = 1
@@ -514,7 +534,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "eT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -522,7 +542,7 @@
 /obj/structure/sign/poster/random/directional/north,
 /obj/machinery/vending/imported/yangyu,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "eX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -531,27 +551,30 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "eY" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/airlock/grunge{
 	name = "Hotel Staff Room"
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "fa" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"ff" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel/workroom)
 "fh" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "fs" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/kirbyplants{
@@ -561,13 +584,17 @@
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "fy" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/carpet/royalblue,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
+"fB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel/power)
 "fC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -576,48 +603,59 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "fD" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
+"fH" = (
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "fN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "fQ" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "fR" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet/purple,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "fY" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "ga" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "gj" = (
 /obj/machinery/shower/directional/east,
 /obj/item/bikehorn/rubberducky,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
+"gm" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Hotel Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "go" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -626,21 +664,21 @@
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "gp" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "gx" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/wood/large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "gB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -650,13 +688,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "gC" = (
 /obj/structure/chair/plastic{
 	dir = 8
 	},
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "gI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -664,7 +702,7 @@
 /obj/structure/closet/crate/bin,
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "gN" = (
 /obj/structure/railing{
 	dir = 1
@@ -676,21 +714,26 @@
 	dir = 4
 	},
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "gS" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/flashlight/lamp,
 /turf/open/floor/carpet/green,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "gX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"ha" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel/security)
 "hi" = (
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "hp" = (
 /obj/structure/chair/sofa/right,
 /obj/item/bedsheet/patriot{
@@ -703,11 +746,11 @@
 	dir = 9
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "hs" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "hy" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -716,13 +759,13 @@
 	icon_state = "plant-16"
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "hz" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
 /obj/machinery/power/smes/engineering,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "hA" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dock"
@@ -732,19 +775,19 @@
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "hC" = (
 /obj/structure/table/wood/fancy/green,
 /turf/open/floor/carpet/purple,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "hG" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/displaycase/trophy,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "hK" = (
 /turf/open/floor/carpet/royalblue,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "hQ" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 4
@@ -754,19 +797,19 @@
 	dir = 4
 	},
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "hR" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/ian,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "hU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "hY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -774,37 +817,50 @@
 /obj/machinery/light/small/directional/north,
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "id" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "iq" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
+"is" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/toilet{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
+"iw" = (
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
+"iz" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel)
 "iA" = (
 /obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/item/card/id/away/hotel/security,
 /turf/open/floor/carpet/neon/simple/red/nodots,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "iB" = (
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "iM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "iN" = (
 /obj/structure/fluff/beach_umbrella/syndi,
 /turf/open/misc/beach/sand,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "iR" = (
 /obj/structure/cable,
 /obj/structure/closet/secure_closet{
@@ -815,20 +871,20 @@
 /obj/item/card/emagfake,
 /obj/item/card/id/fake_card,
 /turf/open/floor/carpet/neon/simple/red/nodots,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "iS" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/toilet{
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "iU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "iX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -836,35 +892,40 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/mug/tea,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "jf" = (
 /obj/structure/fluff/tram_rail/end,
 /obj/structure/fluff/tram_rail/end{
 	pixel_y = 17
 	},
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "jg" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "jh" = (
 /obj/structure/table/wood/fancy/green,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/carpet/purple,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
+"jA" = (
+/obj/structure/window/spawner/directional/south,
+/obj/machinery/shower/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "jG" = (
 /obj/structure/table/wood/fancy/cyan,
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "jH" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "jI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -879,32 +940,32 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "jR" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "jU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/closed/wall,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "kn" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "kq" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/teleport/station,
 /turf/open/floor/wood/large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "ks" = (
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "ku" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
@@ -912,20 +973,24 @@
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "ky" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"kz" = (
+/obj/item/soap,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "kI" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/storage/medkit/regular,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "kQ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -935,7 +1000,7 @@
 	network = list("spacehotel")
 	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "kW" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -943,16 +1008,16 @@
 /obj/item/pillow/clown,
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "lc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "lf" = (
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "ll" = (
 /obj/structure/cable,
 /obj/structure/rack,
@@ -965,18 +1030,18 @@
 	desc = "A 'Nanotrasen Special Response Team' helmet, according to the tag."
 	},
 /turf/open/floor/glass/reinforced,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "lA" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "lC" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/comfy,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "lD" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -984,29 +1049,32 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"lL" = (
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "lT" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "mc" = (
 /obj/structure/table/wood/fancy/purple,
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "me" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "mg" = (
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "mk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1016,36 +1084,43 @@
 /obj/machinery/light/directional/north,
 /obj/item/reagent_containers/cup/glass/mug/tea,
 /turf/open/floor/carpet/royalblue,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "mn" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hotel Maintenance"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "mo" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "mx" = (
 /obj/structure/chair/wood,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
+"my" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Hotel Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel)
 "mB" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "mH" = (
 /obj/structure/toilet{
 	dir = 1
 	},
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "mQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1053,28 +1128,28 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "mU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "mX" = (
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "mZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "nd" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "ng" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1089,18 +1164,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
+"nm" = (
+/obj/item/soap,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "nn" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair,
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/wood/large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "nq" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "ns" = (
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 4
@@ -1112,46 +1191,46 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "nu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "nz" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "nG" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair,
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood/large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "nK" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "nQ" = (
 /obj/machinery/door/airlock{
 	name = "Public Restroom/Showers"
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "nR" = (
 /obj/structure/table/wood/fancy/cyan,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/carpet/red,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "nW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "nX" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1159,12 +1238,12 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "ob" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "od" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1175,29 +1254,36 @@
 	pixel_y = 24
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "oj" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/black,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"on" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "oq" = (
 /turf/open/misc/beach/coastline_t{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "ot" = (
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "ov" = (
 /obj/machinery/light/directional/west,
 /turf/open/misc/beach/sand,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "oE" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"oK" = (
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/hotel)
 "oL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -1208,31 +1294,31 @@
 /obj/effect/mapping_helpers/airlock/access/any/away/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "oQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "oV" = (
 /obj/structure/table/wood,
 /obj/item/paper/pamphlet/ruin/spacehotel,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "oW" = (
 /obj/structure/frame,
 /obj/item/stack/cable_coil/five,
 /obj/item/stock_parts/micro_laser/quadultra,
 /turf/open/floor/circuit/green,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "oZ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "pb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1240,13 +1326,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "pc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "pd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -1254,31 +1340,34 @@
 	dir = 1
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "pl" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "pn" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "pp" = (
 /obj/structure/sink/kitchen/directional/west,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
+"pr" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel)
 "ps" = (
 /obj/structure/railing,
 /turf/open/floor/iron/stairs/old{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "pt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1290,14 +1379,25 @@
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"px" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "pA" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
+"pE" = (
+/obj/structure/window/spawner/directional/north,
+/obj/machinery/shower/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "pN" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/structure/cable,
@@ -1306,17 +1406,17 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "pO" = (
 /obj/structure/sink/directional/east,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "pU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "pZ" = (
 /obj/effect/turf_decal/delivery/white{
 	color = "A46106"
@@ -1328,32 +1428,32 @@
 /obj/effect/spawner/random/engineering/material_cheap,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "qa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "qb" = (
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "qc" = (
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "qd" = (
 /obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/machinery/coffeemaker,
 /turf/open/floor/glass/reinforced,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "qe" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1362,37 +1462,37 @@
 	icon_state = "plant-05"
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "qg" = (
 /obj/structure/cable,
 /obj/structure/rack,
 /obj/item/melee/baton/security/loaded,
 /turf/open/floor/glass/reinforced,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "qh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "qi" = (
 /obj/structure/fluff/tram_rail/end{
 	dir = 8
 	},
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "qr" = (
 /obj/structure/chair/plastic,
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "qt" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/red,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "qv" = (
 /obj/item/book/manual/wiki/detective,
 /obj/structure/table/reinforced/plastitaniumglass,
@@ -1406,10 +1506,10 @@
 	dir = 10
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "qH" = (
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "qJ" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -1418,7 +1518,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "qO" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1427,7 +1527,7 @@
 /obj/structure/table/wood/fancy/cyan,
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet/red,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "qS" = (
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_x = 7;
@@ -1439,7 +1539,7 @@
 	},
 /obj/structure/table/wood/fancy,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "ra" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -1447,30 +1547,38 @@
 	id = "htsec"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "re" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"rj" = (
+/obj/structure/window/spawner/directional/south,
+/obj/machinery/shower/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "rA" = (
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "rB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
+"rG" = (
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "rI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "rN" = (
 /obj/machinery/button{
 	id = "hcb1";
@@ -1482,7 +1590,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "rT" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/sign/warning/fire{
@@ -1493,13 +1601,13 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "rY" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "rZ" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -1507,26 +1615,26 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "sc" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "sh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "si" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "sj" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "sk" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -1534,15 +1642,15 @@
 	id = "htsec"
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "sq" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "sr" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/neon/simple/red/nodots,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "ss" = (
 /obj/structure/fluff/tram_rail{
 	pixel_y = 17
@@ -1550,12 +1658,12 @@
 /obj/structure/fluff/tram_rail,
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "su" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "sv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/microwave{
@@ -1563,58 +1671,69 @@
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "sy" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "sC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "sF" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "sH" = (
 /obj/structure/chair/plastic{
 	dir = 1
 	},
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "sJ" = (
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "sK" = (
 /turf/open/floor/carpet/green,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
+"sS" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom"
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "sU" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"sW" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "sX" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "sZ" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/toilet{
 	pixel_y = 5
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "tc" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-06"
 	},
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "td" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -1622,7 +1741,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "tf" = (
 /obj/structure/railing{
 	dir = 1
@@ -1630,24 +1749,24 @@
 /turf/open/floor/iron/stairs/old{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "to" = (
 /obj/structure/table/wood,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "tp" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "tt" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "tv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1662,33 +1781,36 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "tw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "ty" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"tz" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "tF" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
 /obj/structure/cable,
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "tG" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "tH" = (
 /obj/item/reagent_containers/condiment/flour,
 /obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "tL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1697,14 +1819,14 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "tP" = (
 /obj/structure/fluff/tram_rail/end{
 	dir = 8;
 	pixel_y = 17
 	},
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "tT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1713,7 +1835,10 @@
 	icon_state = "plant-03"
 	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"tU" = (
+/turf/open/floor/iron/grimy,
+/area/ruin/space/has_grav/hotel)
 "tY" = (
 /obj/structure/cable,
 /obj/structure/table/reinforced,
@@ -1721,23 +1846,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/recharger,
 /turf/open/floor/carpet/neon/simple/red/nodots,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "uc" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"ue" = (
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "uh" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/directional/south,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "ul" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "um" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1751,7 +1879,7 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "up" = (
 /obj/structure/chair/sofa/middle,
 /obj/item/pillow/clown,
@@ -1760,7 +1888,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "us" = (
 /obj/effect/turf_decal/delivery/white{
 	color = "A46106"
@@ -1768,33 +1896,33 @@
 /obj/structure/closet/crate/wooden/toy,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "ux" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "uT" = (
 /obj/structure/table/wood/fancy/purple,
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "uZ" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "va" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "vc" = (
 /obj/structure/cable,
 /turf/open/floor/glass/reinforced,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "vl" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1811,13 +1939,13 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "vn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "vo" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -1829,7 +1957,7 @@
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "vq" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
@@ -1839,17 +1967,17 @@
 /obj/effect/mapping_helpers/airlock/access/any/away/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "vr" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/carpet/black,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "vy" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal,
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "vz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -1858,13 +1986,13 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "vI" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "vJ" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/red/line,
@@ -1876,7 +2004,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "vL" = (
 /obj/structure/frame,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1884,18 +2012,25 @@
 /obj/item/stock_parts/micro_laser/quadultra,
 /obj/item/stock_parts/matter_bin/adv,
 /turf/open/floor/circuit/green,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"vO" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "vP" = (
 /obj/structure/cable,
 /obj/structure/closet,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "vX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /obj/structure/railing,
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "wr" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1903,17 +2038,17 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/firedoor,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "ws" = (
 /obj/structure/cable,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "wt" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "wu" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Hotel Staff Room"
@@ -1926,49 +2061,61 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "wv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"ww" = (
+/obj/structure/dresser,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "wx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "wB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "wD" = (
 /obj/item/soap,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "wF" = (
 /obj/structure/sign/poster/random/directional/north,
 /turf/closed/wall,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
+"wM" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Hotel Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel/power)
 "wP" = (
 /turf/open/misc/beach/sand,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "wQ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "wR" = (
 /obj/structure/window/spawner/directional/north,
 /obj/machinery/shower/directional/south,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "wT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -1976,10 +2123,10 @@
 	},
 /obj/structure/cable,
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "wX" = (
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "xa" = (
 /obj/structure/chair/sofa/bench/left,
 /obj/effect/turf_decal/trimline/red/line{
@@ -1990,43 +2137,43 @@
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "xc" = (
 /turf/open/floor/carpet/purple,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "xe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "xg" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /obj/structure/railing/corner,
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "xi" = (
 /obj/structure/fluff/tram_rail{
 	pixel_y = 17
 	},
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "xk" = (
 /obj/structure/cable,
 /turf/open/floor/carpet/purple,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "xn" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "xp" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "xt" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dock"
@@ -2035,20 +2182,20 @@
 /turf/open/floor/iron/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "xu" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "xw" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 9
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "xx" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2056,7 +2203,7 @@
 /obj/structure/table/wood/fancy/red,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /turf/open/floor/carpet/green,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "xB" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/under/syndicate/tacticool,
@@ -2065,17 +2212,21 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "xD" = (
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "xI" = (
 /obj/structure/cable,
 /obj/item/paperwork/security,
 /obj/structure/table/reinforced,
 /turf/open/floor/carpet/neon/simple/red/nodots,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
+"xM" = (
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
 "xN" = (
 /obj/item/gun/ballistic/automatic/pistol/m1911{
 	spawnwithmagazine = 0
@@ -2089,11 +2240,20 @@
 /obj/item/bodybag/environmental/prisoner/pressurized,
 /obj/item/bodybag/environmental/prisoner/pressurized,
 /turf/open/floor/carpet/neon/simple/red/nodots,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
+"xR" = (
+/obj/structure/flora/bush/leavy/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/jungle/c/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/window/fulltile,
+/turf/open/floor/grass,
+/area/ruin/space/has_grav/hotel)
 "xS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "xU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2102,16 +2262,19 @@
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "xV" = (
 /obj/machinery/griddle,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "xX" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"yn" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel/power)
 "yo" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -2121,25 +2284,25 @@
 	},
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "yq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "yt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "yv" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "yy" = (
 /obj/structure/table/wood,
 /obj/item/paper/pamphlet/ruin/spacehotel,
@@ -2147,20 +2310,28 @@
 	dir = 5
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "yz" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-03"
 	},
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "yA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Guest Suites"
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"yF" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom"
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "yG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor{
@@ -2174,21 +2345,21 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet/neon/simple/red/nodots,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "yM" = (
 /obj/structure/toilet{
 	pixel_y = 5
 	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "yN" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "yO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -2197,13 +2368,13 @@
 /obj/structure/railing/corner,
 /obj/structure/cable,
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "yQ" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/light/directional/south,
 /obj/structure/sign/poster/contraband/random/directional/south,
 /turf/open/floor/iron/dark/smooth_edge,
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "zc" = (
 /obj/structure/mop_bucket/janitorialcart,
 /obj/item/mop/advanced,
@@ -2214,34 +2385,34 @@
 /obj/item/lightreplacer,
 /obj/structure/sign/poster/official/cleanliness/directional/north,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/custodial)
 "zd" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "zi" = (
 /obj/machinery/power/solar,
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "zm" = (
 /obj/structure/filingcabinet,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "zn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "zr" = (
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "zt" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
@@ -2252,7 +2423,7 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "zx" = (
 /obj/structure/chair/office/tactical,
 /obj/machinery/button{
@@ -2262,25 +2433,25 @@
 	pixel_y = -1
 	},
 /turf/open/floor/glass/reinforced,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "zy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "zz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "zC" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "zY" = (
 /obj/structure/sink/directional/north,
 /obj/effect/turf_decal/trimline/red/line{
@@ -2290,14 +2461,14 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "Aa" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Ab" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2305,13 +2476,25 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/table/wood/fancy/green,
 /turf/open/floor/carpet/purple,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
+"Ad" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom"
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
+"Af" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel/dock)
 "Am" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Ao" = (
 /obj/structure/cable,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
@@ -2319,7 +2502,11 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/neon/simple/red/nodots,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
+"Ar" = (
+/obj/item/soap,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "Ay" = (
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 1
@@ -2329,12 +2516,12 @@
 	},
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "AA" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/reagent_containers/cup/glass/mug/tea,
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "AC" = (
 /obj/effect/turf_decal/trimline/red/line,
 /obj/effect/turf_decal/trimline/red/corner{
@@ -2345,25 +2532,28 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "AF" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /turf/open/floor/carpet/black,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "AI" = (
 /obj/effect/turf_decal/trimline/red/line,
 /obj/effect/turf_decal/trimline/yellow/line,
 /obj/structure/sign/poster/contraband/clown/directional/south,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
+"AL" = (
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "AQ" = (
 /obj/structure/sign/poster/contraband/random/directional/west,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "AT" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -2371,7 +2561,7 @@
 	},
 /obj/item/paper_bin,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "AX" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
@@ -2379,35 +2569,35 @@
 	name = "Cargo Bay Shutters"
 	},
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Bh" = (
 /obj/structure/cable,
 /obj/structure/table/reinforced,
 /obj/item/clothing/suit/armor/vest/old,
 /obj/item/clothing/head/helmet/old,
 /turf/open/floor/glass/reinforced,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "Bl" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "Bm" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 6
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Bo" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
 /turf/open/floor/carpet/royalblue,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "Bq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -2420,7 +2610,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Bs" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/sign/warning/fire{
@@ -2431,7 +2621,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Bv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2441,7 +2631,7 @@
 	network = list("spacehotel")
 	},
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "BA" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/bag/tray,
@@ -2449,10 +2639,10 @@
 	pixel_x = 5
 	},
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "BB" = (
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "BC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -2460,7 +2650,7 @@
 	id = "htsec"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "BE" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/kirbyplants{
@@ -2468,7 +2658,7 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "BL" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 8
@@ -2476,7 +2666,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "BN" = (
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 10
@@ -2485,21 +2675,21 @@
 	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "BP" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "BV" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/effect/spawner/random/bureaucracy,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "BX" = (
 /turf/open/floor/glass/reinforced,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "BZ" = (
 /obj/structure/chair/comfy{
 	dir = 4
@@ -2508,7 +2698,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Cm" = (
 /obj/structure/table/wood,
 /obj/item/paper/pamphlet/ruin/spacehotel,
@@ -2516,47 +2706,47 @@
 	dir = 6
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Co" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/green,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "Cv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "CB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "CK" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Swimming Pool";
 	network = list("spacehotel")
 	},
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "CN" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "CO" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "CS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "CW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2571,7 +2761,7 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "CX" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/structure/table/reinforced,
@@ -2588,14 +2778,14 @@
 	pixel_y = -11
 	},
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Da" = (
 /obj/structure/chair/plastic{
 	dir = 1
 	},
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Db" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -2604,7 +2794,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Dg" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -2615,7 +2805,7 @@
 	},
 /obj/structure/cable,
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Dj" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2628,7 +2818,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Dk" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor{
@@ -2636,14 +2826,14 @@
 	name = "Cargo Dock"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Dl" = (
 /obj/effect/decal/cleanable/food/flour,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Dp" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -2654,7 +2844,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Dq" = (
 /obj/structure/railing{
 	dir = 1
@@ -2664,32 +2854,40 @@
 	},
 /obj/structure/rack,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
+"Ds" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom"
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "Du" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/carpet/black,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Dv" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Dw" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Dy" = (
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "DA" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "DD" = (
 /obj/effect/turf_decal/trimline/red/line,
 /obj/effect/turf_decal/trimline/red/line{
@@ -2700,25 +2898,29 @@
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "DN" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "DT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 4
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "DW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/carpet/green,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
+"DZ" = (
+/obj/item/soap,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "Ec" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
@@ -2727,7 +2929,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Ed" = (
 /obj/machinery/light/directional/north,
 /obj/structure/chair/comfy{
@@ -2736,7 +2938,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Ee" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2744,11 +2946,11 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/table/wood/fancy/purple,
 /turf/open/floor/carpet/lone,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "Eh" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Es" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Hotel Kitchen"
@@ -2759,13 +2961,18 @@
 /turf/open/floor/iron/textured_half{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
+"Ew" = (
+/obj/structure/cable,
+/obj/item/clothing/head/cone,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel/power)
 "EC" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/siding/white,
 /obj/structure/rack,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "EG" = (
 /obj/structure/table/wood/fancy/purple,
 /obj/item/paper_bin,
@@ -2774,44 +2981,44 @@
 /obj/structure/cable,
 /obj/item/pen,
 /turf/open/floor/carpet/lone,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "EH" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "EL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/glass/reinforced,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "EN" = (
 /obj/structure/fluff/tram_rail/end,
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "EP" = (
 /obj/structure/table/wood/fancy/red,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "EV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet/purple,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "Fa" = (
 /obj/structure/window/spawner/directional/east,
 /obj/structure/toilet{
 	pixel_y = 5
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "Fj" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "Fk" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
@@ -2821,7 +3028,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Fq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/processor{
@@ -2831,34 +3038,34 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Fr" = (
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Fs" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/carpet/royalblue,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "Ft" = (
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Fv" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Fz" = (
 /mob/living/simple_animal/bot/secbot/beepsky/armsky{
 	name = "Hotelsky";
 	desc = "It's Hotelsky! He's a disgruntled servant of the hotel that would probably shoot you if he had hands."
 	},
 /turf/open/floor/carpet/neon/simple/red/nodots,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "FC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -2869,14 +3076,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "FG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"FM" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel/custodial)
 "FS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -2890,18 +3100,22 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
+"FT" = (
+/obj/structure/dresser,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "FU" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/egg_box,
 /obj/item/knife/kitchen,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "FY" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Gd" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -2910,11 +3124,11 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Gh" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Gi" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 1
@@ -2922,7 +3136,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Gn" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -2931,20 +3145,26 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Gw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "GE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/structure/musician/piano,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
+"GK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/has_grav/hotel)
 "GP" = (
 /obj/machinery/light/directional/north,
 /obj/structure/sign/poster/contraband/random/directional/north,
@@ -2952,12 +3172,12 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "GS" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "GW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hotel Maintenance"
@@ -2965,14 +3185,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "GX" = (
 /obj/structure/fluff/tram_rail,
 /obj/structure/fluff/tram_rail/end{
 	pixel_y = 17
 	},
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "GY" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -2980,47 +3200,59 @@
 /obj/item/crowbar/large/old,
 /obj/effect/mapping_helpers/apc/cell_10k,
 /turf/open/floor/glass/reinforced,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "GZ" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Ha" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Hb" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Hk" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Hl" = (
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"Ho" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel/bar)
 "Hp" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
+"Hq" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
+"Hs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "Hv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/glass/reinforced,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "HO" = (
 /obj/structure/chair/plastic,
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "HT" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/structure/table/reinforced,
@@ -3037,7 +3269,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "HU" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -3045,7 +3277,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "HV" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/cell_5k,
@@ -3053,7 +3285,7 @@
 /obj/structure/sink/directional/west,
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/custodial)
 "HW" = (
 /obj/structure/bed/pod{
 	dir = 4
@@ -3062,40 +3294,47 @@
 	dir = 4
 	},
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "HZ" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "Ia" = (
 /obj/structure/table/wood/fancy/green,
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "Ic" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
+"Il" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
+"Im" = (
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "Iu" = (
 /obj/structure/fluff/tram_rail,
 /obj/structure/fluff/tram_rail{
 	pixel_y = 17
 	},
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "Ix" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "IA" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "IJ" = (
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/button{
@@ -3105,20 +3344,24 @@
 	pixel_y = 8
 	},
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "IK" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"IP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel/bar)
 "IQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "IW" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "IX" = (
 /obj/structure/closet/crate/secure/engineering,
 /obj/item/wrench/caravan,
@@ -3130,50 +3373,58 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Ja" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "Jg" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/computer/teleporter,
 /turf/open/floor/wood/large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Jh" = (
 /obj/structure/chair/comfy,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Jj" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Jn" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"Js" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel)
+"Jy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel)
 "Jz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "JF" = (
 /obj/structure/cable,
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "JG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "JI" = (
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "JO" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -3184,7 +3435,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "JQ" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -3195,13 +3446,13 @@
 	width = 35
 	},
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "JV" = (
 /obj/structure/chair{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "JW" = (
 /obj/structure/railing/corner{
 	dir = 4
@@ -3210,7 +3461,7 @@
 	dir = 6
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Ka" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -3219,26 +3470,26 @@
 /obj/structure/table/wood/fancy/purple,
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet/lone,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "Kd" = (
 /obj/machinery/atmospherics/components/tank/air{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "Ki" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/carpet/green,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "Km" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 8
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Ko" = (
 /obj/structure/frame,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3246,12 +3497,12 @@
 /obj/item/stack/cable_coil/five,
 /obj/item/stock_parts/matter_bin/adv,
 /turf/open/floor/circuit/green,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Kv" = (
 /obj/machinery/light/directional/west,
 /obj/structure/dresser,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "Kw" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -3259,52 +3510,52 @@
 	dir = 1
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "KE" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/carpet/lone,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "KF" = (
 /obj/structure/chair/stool/directional/east,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "KM" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "KP" = (
 /obj/structure/sign/warning/no_smoking,
 /turf/closed/wall,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "KR" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "KS" = (
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "KV" = (
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "KW" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Lb" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Lk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Lo" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "Lt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -3323,52 +3574,59 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Lv" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet/purple,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "Lz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "LB" = (
 /obj/effect/mob_spawn/ghost_role/human/hotel_staff,
 /turf/open/floor/iron/dark/smooth_corner,
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "LC" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-16"
 	},
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "LG" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "LK" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"LO" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
+"LQ" = (
+/obj/item/soap,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "LT" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "LW" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/closet/crate/bin,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Me" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 4
@@ -3376,11 +3634,15 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"Mf" = (
+/obj/structure/sink/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "Mg" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Mm" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/food/grown/wheat,
@@ -3410,25 +3672,29 @@
 	color = "A46106"
 	},
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Mr" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Guest Hallway Port";
 	network = list("spacehotel")
 	},
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Mt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Mu" = (
 /obj/structure/chair/wood,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
+"Mx" = (
+/obj/structure/sink/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "MC" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Lobby";
@@ -3445,13 +3711,13 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "MF" = (
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "MJ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -3463,7 +3729,7 @@
 	pixel_y = -24
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "ML" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -3471,25 +3737,25 @@
 	dir = 4
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "MM" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner,
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "MO" = (
 /obj/machinery/shower/directional/east,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "MP" = (
 /obj/structure/chair/wood,
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "MT" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "MU" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/paper_bin,
@@ -3498,7 +3764,7 @@
 /obj/structure/cable,
 /obj/item/pen,
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "MV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3506,7 +3772,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
+"MX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/has_grav/hotel)
 "MZ" = (
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 5
@@ -3517,7 +3787,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "Nf" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -3525,7 +3795,13 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"Ni" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "Nj" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -3536,13 +3812,13 @@
 	name = "Handy Shop"
 	},
 /turf/open/floor/iron/dark/textured_half,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Nl" = (
 /obj/structure/chair/plastic{
 	dir = 8
 	},
 /turf/open/misc/beach/sand,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Np" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -3555,13 +3831,13 @@
 	pixel_y = -24
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Nv" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "NB" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -3569,14 +3845,20 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/table/wood/fancy/orange,
 /turf/open/floor/carpet/royalblue,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
+"NC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "ND" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "NK" = (
 /obj/structure/railing{
 	dir = 4
@@ -3585,13 +3867,13 @@
 	dir = 4
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "NL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "NM" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -3599,7 +3881,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "NO" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/kirbyplants{
@@ -3607,51 +3889,51 @@
 	},
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/corner,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "NS" = (
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "NT" = (
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "NU" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/red,
 /turf/open/floor/carpet/green,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "NW" = (
 /obj/structure/chair/sofa/corp/right,
 /obj/machinery/light/directional/north,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "NX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "NY" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "NZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
 	name = "Pool"
 	},
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Oa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/open/space/basic,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Ob" = (
 /turf/open/floor/carpet/red,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "Of" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/spawner/random/entertainment/arcade{
@@ -3660,7 +3942,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Oi" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/kirbyplants{
@@ -3669,7 +3951,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Ou" = (
 /obj/machinery/light/directional/north,
 /obj/item/kirbyplants{
@@ -3678,15 +3960,26 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"Ov" = (
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/hotel)
+"Ow" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Hotel Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel/bar)
 "OB" = (
 /turf/closed/wall/r_wall,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "OD" = (
 /obj/machinery/light/directional/east,
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/carpet/black,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "OG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -3697,7 +3990,7 @@
 	},
 /obj/structure/cable,
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "OI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -3707,7 +4000,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "OO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -3715,7 +4008,7 @@
 	dir = 4
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "OQ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
@@ -3723,7 +4016,7 @@
 	name = "Cargo Bay Shutters"
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "OR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -3737,11 +4030,11 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/purple,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "OS" = (
 /obj/structure/dresser,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "Pe" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -3749,17 +4042,17 @@
 /obj/structure/table/wood,
 /obj/item/instrument/guitar,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Pn" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /turf/open/floor/carpet/purple,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "Pp" = (
 /obj/item/toy/beach_ball,
 /turf/open/misc/beach/sand,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Pq" = (
 /obj/structure/cable,
 /obj/structure/table/reinforced,
@@ -3767,30 +4060,30 @@
 /obj/structure/window/reinforced/survival_pod/spawner/directional/east,
 /obj/item/storage/toolbox/mechanical/old/clean,
 /turf/open/floor/carpet/neon/simple/red/nodots,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "Pv" = (
 /obj/structure/table/wood/fancy/purple,
 /turf/open/floor/carpet/lone,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "Px" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "PB" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "PC" = (
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "PE" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "PK" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
 /obj/effect/turf_decal/trimline/red/warning{
@@ -3801,19 +4094,19 @@
 	},
 /obj/machinery/vending/imported,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "PL" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "PM" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "PN" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/security/glass{
@@ -3821,14 +4114,14 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/away/security,
 /turf/open/floor/carpet/neon/simple/red/nodots,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "PT" = (
 /obj/machinery/light/directional/south,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "PU" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/siding/wood{
@@ -3837,7 +4130,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "PW" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -3849,26 +4142,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "PX" = (
 /turf/open/floor/carpet/lone,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "PY" = (
 /obj/structure/cable,
 /obj/machinery/power/solar_control{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
+"Qb" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel/custodial)
 "Qf" = (
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Qg" = (
 /obj/structure/cable,
 /obj/item/clothing/head/cone,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Qh" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -3885,24 +4181,24 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Qi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Qj" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "Qn" = (
 /obj/structure/cable,
 /turf/open/floor/circuit/green,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Qq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -3915,17 +4211,17 @@
 	pixel_y = -24
 	},
 /turf/open/floor/carpet/green,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "Qu" = (
 /obj/structure/cable,
 /obj/item/clothing/gloves/color/yellow,
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "Qy" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/closed/wall,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "QA" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/sign/warning/fire{
@@ -3936,7 +4232,7 @@
 	pixel_y = 24
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "QB" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -3944,12 +4240,12 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/structure/table/wood/fancy/cyan,
 /turf/open/floor/carpet/red,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "QF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "QG" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -3963,7 +4259,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "QH" = (
 /obj/structure/frame/computer{
 	dir = 1
@@ -3971,45 +4267,45 @@
 /obj/item/stack/sheet/glass,
 /obj/item/stack/sheet/glass,
 /turf/open/floor/circuit/green,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "QL" = (
 /obj/structure/sign/poster/official/cleanliness/directional/north,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "QO" = (
 /obj/structure/chair/sofa/left/brown{
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblue,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "QQ" = (
 /obj/machinery/door/airlock{
 	name = "Toilet"
 	},
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "QS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "QX" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "QY" = (
 /obj/structure/chair/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Rb" = (
 /obj/structure/fluff/tram_rail,
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "Rd" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet"
@@ -4018,23 +4314,31 @@
 /obj/effect/mapping_helpers/airlock/access/any/away/maintenance,
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_half,
-/area/space)
+/area/ruin/space/has_grav/hotel/custodial)
 "Rf" = (
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Rg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
+"Rk" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom"
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "Rm" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Rq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -4043,60 +4347,63 @@
 /obj/structure/table/wood/fancy/green,
 /obj/machinery/light/directional/south,
 /turf/open/floor/carpet/purple,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "Rt" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Rv" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/item/kirbyplants{
 	icon_state = "plant-05"
 	},
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "RE" = (
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
+"RL" = (
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "RM" = (
 /obj/structure/cable,
 /obj/effect/mob_spawn/ghost_role/human/hotel_staff/security,
 /turf/open/floor/glass/reinforced,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "RO" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "RQ" = (
 /turf/open/misc/beach/coastline_b{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "RX" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "RZ" = (
 /turf/open/misc/beach/coastline_t{
 	dir = 4
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Sb" = (
 /obj/structure/window/spawner/directional/south,
 /obj/machinery/shower/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "Sc" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/cup/glass/mug/tea,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Sd" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -4106,12 +4413,12 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "Sf" = (
 /obj/structure/chair/sofa/bench/right,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/north,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "Sh" = (
 /obj/structure/cable,
 /obj/structure/table/reinforced,
@@ -4119,7 +4426,7 @@
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/carpet/neon/simple/red/nodots,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "Sm" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-05"
@@ -4130,7 +4437,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Sn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -4138,19 +4445,19 @@
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /obj/structure/table/wood/fancy/royalblue,
 /turf/open/floor/carpet/orange,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "Sq" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/bureaucracy/briefcase,
 /turf/open/floor/carpet/black,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Ss" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
 	dir = 8
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "SA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -4158,7 +4465,7 @@
 	dir = 8
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "SC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4171,61 +4478,64 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "SG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "SH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
+"SI" = (
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "SJ" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "SN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/recharge_station,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "SP" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood/large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "SQ" = (
 /obj/structure/sink/directional/east,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "SS" = (
 /obj/effect/turf_decal/siding/yellow/end,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/circuit/red,
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "SU" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "SX" = (
 /obj/structure/fluff/tram_rail/end{
 	pixel_y = 17
 	},
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "Te" = (
 /obj/machinery/button{
 	id = "hcd1";
@@ -4234,12 +4544,12 @@
 	pixel_y = -25
 	},
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Tf" = (
 /obj/structure/cable,
 /obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/custodial)
 "Th" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
@@ -4247,7 +4557,7 @@
 	name = "Cargo Bay Shutters"
 	},
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Tk" = (
 /obj/machinery/button{
 	id = "hcb2";
@@ -4258,7 +4568,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Tl" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -4272,7 +4582,7 @@
 	dir = 8
 	},
 /turf/open/floor/carpet/lone,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "Tm" = (
 /obj/machinery/oven/range,
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
@@ -4281,7 +4591,7 @@
 	network = list("spacehotel")
 	},
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Tn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -4291,24 +4601,24 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Ts" = (
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Tu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 5
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Ty" = (
 /obj/structure/closet/emcloset,
 /obj/item/card/id/away/hotel,
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Tz" = (
 /obj/machinery/computer/security{
 	dir = 4;
@@ -4318,7 +4628,7 @@
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "TB" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -4328,38 +4638,38 @@
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "TC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "TE" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "TG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "TI" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "TJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "TQ" = (
 /obj/structure/sign/poster/random/directional/south,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "TT" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/machinery/light_switch/directional/south,
@@ -4367,30 +4677,30 @@
 	dir = 4
 	},
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "Uc" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Uf" = (
 /obj/structure/table/wood/fancy/cyan,
 /turf/open/floor/carpet/red,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "Uj" = (
 /obj/effect/mob_spawn/ghost_role/human/hotel_staff,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
 "Uk" = (
 /obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Um" = (
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Un" = (
 /obj/structure/flora/bush/leavy/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -4399,12 +4709,12 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/effect/spawner/structure/window,
 /turf/open/floor/grass,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Us" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Uu" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -4413,21 +4723,21 @@
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Ux" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Lobby";
 	network = list("spacehotel")
 	},
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Uy" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 1
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "UA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -4439,19 +4749,19 @@
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "UB" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
 	},
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "UE" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/glass/reinforced,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "UL" = (
 /obj/structure/table/wood/fancy/cyan,
 /obj/machinery/light_switch/directional/north,
@@ -4459,40 +4769,43 @@
 	dir = 8
 	},
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_3)
 "UQ" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "US" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
+"UW" = (
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "UY" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/teleport/hub,
 /turf/open/floor/wood/large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "UZ" = (
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Vh" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Vj" = (
 /obj/machinery/light/small/directional/south,
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Vq" = (
 /obj/structure/railing{
 	dir = 1
@@ -4501,23 +4814,27 @@
 	dir = 1
 	},
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Vv" = (
 /obj/structure/toilet{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
+"VC" = (
+/obj/structure/sign/warning/vacuum,
+/turf/closed/wall,
+/area/ruin/space/has_grav/hotel/dock)
 "VD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "VG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "VM" = (
 /obj/effect/turf_decal/delivery/white{
 	color = "A46106"
@@ -4525,72 +4842,75 @@
 /obj/effect/spawner/random/structure/crate_abandoned,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
+"VN" = (
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "VP" = (
 /obj/structure/bed/pod,
 /obj/item/bedsheet/orange,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "VS" = (
 /obj/effect/turf_decal/trimline/red/line,
 /obj/effect/turf_decal/trimline/yellow/line,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "VT" = (
 /obj/structure/rack,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "VU" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Wa" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Wd" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/wood/parquet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_2)
 "We" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "Wh" = (
 /obj/effect/turf_decal/bot,
 /obj/item/wirecutters,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "Wi" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
 	dir = 10
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Wq" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Wr" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
 	dir = 4
 	},
 /turf/template_noop,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Wt" = (
 /obj/item/circuitboard/machine/ore_silo,
 /obj/structure/frame/machine/secured,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Wx" = (
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_x = 7;
@@ -4608,53 +4928,53 @@
 	},
 /obj/structure/table/wood/fancy,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Wz" = (
 /obj/structure/cable,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "WA" = (
 /obj/structure/frame,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/circuitboard/machine/emitter,
 /obj/item/stack/cable_coil/five,
 /turf/open/floor/circuit/green,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "WL" = (
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating/airless,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "WS" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "WT" = (
 /obj/structure/fluff/tram_rail{
 	pixel_y = 17
 	},
 /obj/structure/fluff/tram_rail,
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "Xa" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/chair/comfy,
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Xc" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
 /turf/open/space/basic,
-/area/space)
+/area/ruin/space/has_grav/hotel/power)
 "Xm" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Xp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -4664,7 +4984,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured_half,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Xw" = (
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_x = 7;
@@ -4679,15 +4999,15 @@
 	},
 /obj/structure/table/wood/fancy,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Xy" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/dark/side,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Xz" = (
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "XE" = (
 /obj/structure/closet/crate/internals,
 /obj/item/storage/toolbox/emergency,
@@ -4701,14 +5021,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/tank/internals/emergency_oxygen/double,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "XF" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Guest Hallway Starboard";
 	network = list("spacehotel")
 	},
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "XI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -4718,14 +5038,24 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "XO" = (
 /obj/effect/turf_decal/siding/yellow/end{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/circuit/red,
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
+"XZ" = (
+/obj/structure/sink/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
+"Yd" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "Yf" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 4
@@ -4734,44 +5064,44 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/tile,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Yg" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Yh" = (
 /obj/machinery/door/airlock{
 	name = "Bathroom"
 	},
 /turf/open/floor/carpet,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "Yj" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Yk" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Ym" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "Yy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "YA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/structure/table/wood,
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "YF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -4786,7 +5116,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "YH" = (
 /obj/machinery/door/airlock{
 	name = "Public Restroom/Showers"
@@ -4794,34 +5124,38 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "YI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/iron/grimy,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "YN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
+"YO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/parquet,
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "YP" = (
 /obj/structure/chair/wood{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "YQ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "YS" = (
 /turf/open/floor/carpet/black,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "YT" = (
 /obj/machinery/button{
 	id = "hcb1";
@@ -4838,27 +5172,30 @@
 /obj/effect/decal/cleanable/garbage,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured_large,
-/area/space)
+/area/ruin/space/has_grav/hotel/dock)
 "YU" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/tank_holder/oxygen/yellow,
 /turf/open/floor/plating,
-/area/space)
+/area/ruin/space/has_grav/hotel)
+"YW" = (
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_5)
 "YZ" = (
 /obj/structure/window/spawner/directional/north,
 /obj/machinery/shower/directional/north,
 /turf/open/floor/iron/showroomfloor,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "Za" = (
 /turf/closed/wall,
-/area/space)
+/area/ruin/space/has_grav/hotel/pool)
 "Zd" = (
 /obj/structure/railing/corner,
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
 /turf/open/floor/stone,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Zh" = (
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 8
@@ -4867,18 +5204,18 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "Zl" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet/lone,
-/area/space)
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "Zu" = (
 /obj/machinery/deepfryer,
 /turf/open/floor/iron/cafeteria,
-/area/space)
+/area/ruin/space/has_grav/hotel/bar)
 "Zw" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-16"
@@ -4886,19 +5223,19 @@
 /obj/structure/sign/poster/random/directional/north,
 /obj/structure/sign/poster/random/directional/west,
 /turf/open/floor/carpet/blue,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "ZF" = (
 /obj/structure/cable,
 /obj/machinery/power/tracker,
 /turf/open/floor/iron/solarpanel/airless,
-/area/space)
+/area/ruin/space/has_grav/hotel)
 "ZG" = (
 /obj/structure/fluff/tram_rail{
 	pixel_y = 17
 	},
 /obj/structure/fluff/tram_rail/end,
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "ZH" = (
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 1
@@ -4913,7 +5250,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured,
-/area/space)
+/area/ruin/space/has_grav/hotel/security)
 "ZM" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -4926,7 +5263,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /mob/living/basic/bot/medbot/derelict,
 /turf/open/floor/circuit/red,
-/area/space)
+/area/ruin/space/has_grav/hotel/workroom)
+"ZQ" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/grimy,
+/area/ruin/space/has_grav/hotel)
 
 (1,1,1) = {"
 kn
@@ -5175,14 +5516,14 @@ NY
 Ja
 Ja
 Hb
-Za
+pr
 aB
-Za
-Za
-Za
-Za
-Za
-Za
+pr
+pr
+pr
+pr
+pr
+pr
 WL
 Ja
 Ja
@@ -5195,12 +5536,12 @@ tP
 kn
 kn
 kn
-Za
+pr
 FG
 Ja
 Ja
 FG
-Za
+pr
 kn
 kn
 kn
@@ -5248,14 +5589,14 @@ kn
 kn
 kn
 kn
-Za
+pr
 vL
 WA
 sh
 sh
 Ko
 oW
-Za
+pr
 kn
 kn
 kn
@@ -5270,8 +5611,8 @@ NY
 Ja
 Ja
 FG
-Za
-Za
+pr
+pr
 FG
 Ja
 Ja
@@ -5321,14 +5662,14 @@ kn
 kn
 kn
 kn
-Za
+pr
 bs
 Qn
 Wq
 Wq
 Qn
 QH
-Za
+pr
 kn
 kn
 kn
@@ -5341,12 +5682,12 @@ xi
 kn
 kn
 kn
-Za
+pr
 FG
 Ja
 Ja
 FG
-Za
+pr
 kn
 kn
 kn
@@ -5394,14 +5735,14 @@ NY
 Ja
 Ja
 Hb
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+pr
+pr
+pr
+pr
+pr
+pr
+pr
+pr
 WL
 Ja
 Ja
@@ -5480,13 +5821,13 @@ kn
 kn
 kn
 kn
-Za
-MT
-MT
-MT
-MT
-MT
-Za
+Ho
+IP
+IP
+IP
+IP
+IP
+Ho
 kn
 FG
 kn
@@ -5553,13 +5894,13 @@ kn
 kn
 kn
 kn
-Za
+Ho
 Pe
 YA
 GE
 YA
 iX
-Za
+Ho
 kn
 FG
 kn
@@ -5626,13 +5967,13 @@ kn
 kn
 kn
 kn
-Za
+Ho
 YI
 rA
 KF
 rA
 uh
-Za
+Ho
 Ja
 dF
 Ja
@@ -5681,38 +6022,38 @@ Ja
 Ja
 Ja
 Ja
-Za
+tz
 kn
 kn
 kn
 kn
 kn
-Za
+LO
 Ja
 Ja
 Ja
 Ja
-Za
-MT
-MT
-Za
-Za
-MT
-MT
-Za
+LO
+IP
+IP
+Ho
+Ho
+IP
+IP
+Ho
 Zd
 NK
 NK
 NK
 JW
-Za
-MT
-MT
-Za
-Za
-MT
-MT
-Za
+Ho
+IP
+IP
+Ho
+Ho
+IP
+IP
+Ho
 ce
 kn
 kn
@@ -5749,43 +6090,43 @@ Ja
 Ja
 Ja
 Ja
-Za
-Za
-Za
-Za
-Za
-Za
-MT
-MT
-Za
-MT
-MT
-Za
-Za
-Za
-Za
-Za
-Za
+tz
+tz
+tz
+tz
+tz
+tz
+Jy
+Jy
+pr
+Jy
+Jy
+LO
+LO
+LO
+LO
+LO
+LO
 eB
 Xw
 pA
 mx
 Xw
 TE
-Za
+Ho
 ps
 Mu
 qS
 YP
 tf
-Za
+Ho
 bR
 Xw
 pA
 mx
 Xw
 vI
-Za
+Ho
 rY
 kn
 kn
@@ -5822,23 +6163,23 @@ kn
 kn
 kn
 Ja
-Za
+tz
 GS
 HW
 HW
 TT
-Za
+tz
 Rv
-ot
+tU
 id
-ot
+tU
 rI
-Za
+LO
 Ia
 aw
 aw
 dt
-Za
+LO
 Fv
 ot
 ot
@@ -5858,7 +6199,7 @@ ot
 ot
 ot
 nz
-Za
+Ho
 Nf
 Km
 yO
@@ -5895,23 +6236,23 @@ kn
 kn
 kn
 Ja
-Za
-OS
-NT
+tz
+FT
+AL
 iM
-NL
+Yd
 dh
 WS
-Gw
-Gw
-Gw
+GK
+GK
+GK
 Db
 jI
 NL
 dp
 NT
-eR
-Za
+iw
+LO
 MP
 Xw
 vI
@@ -5931,9 +6272,9 @@ vI
 eB
 Xw
 vI
-Za
+pr
 NM
-Za
+bQ
 tF
 kn
 kn
@@ -5958,7 +6299,7 @@ kn
 kn
 kn
 kn
-Qf
+xM
 kn
 kn
 kn
@@ -5968,23 +6309,23 @@ PE
 kn
 kn
 Ja
-Za
+tz
 bp
 Sn
 ul
 cp
-Za
+tz
 QA
-TJ
-Gw
+MX
+GK
 zn
 Bq
-Za
+LO
 OR
 EV
 Ab
 Rq
-Za
+LO
 ot
 ot
 TJ
@@ -6004,12 +6345,12 @@ Gw
 Gw
 Gw
 ND
-Za
+pr
 VD
-Za
+bQ
 QF
-Za
-Za
+bQ
+bQ
 Ja
 Ja
 Ja
@@ -6041,49 +6382,49 @@ kn
 kn
 kn
 Ja
-Za
+tz
 zr
 zr
 zr
 MU
-Za
+tz
 QX
-ot
-Gw
-ot
+tU
+GK
+tU
 oZ
-Za
+LO
 jh
 xk
 xk
 Pn
-Za
+LO
 QY
 Wx
 xU
 PW
 Tn
-Za
-Za
+Ho
+Ho
 sv
 Ic
 UB
 HT
 CX
-Za
+Ho
 Lt
-Za
-Za
+Ho
+Ho
 XI
 Dj
-Za
+pr
 xD
 lD
-Za
+bQ
 gp
 Kd
-Za
-Za
+bQ
+bQ
 kn
 kn
 nK
@@ -6114,30 +6455,30 @@ kn
 kn
 kn
 Ja
-Za
+tz
 cd
 Fj
 zr
 AA
-Za
+tz
 Rv
-ot
-Gw
-ot
+tU
+GK
+tU
 yo
-Za
+LO
 hC
 xc
 fR
 Lv
-Za
-Za
-Za
-Za
+LO
+Ho
+Ho
+Ho
 rB
 qH
 dD
-Za
+Ho
 Zu
 bo
 YN
@@ -6145,18 +6486,18 @@ pU
 wX
 Es
 rA
-Za
+Ho
 dD
 Lk
 iU
-Za
+pr
 VD
 VD
-Za
+bQ
 NX
 lT
 Sd
-MT
+fB
 kn
 kn
 nK
@@ -6186,31 +6527,31 @@ kn
 kn
 kn
 kn
-Za
-Za
-mn
-Za
-ku
-Za
-Za
-Za
+pr
+pr
+my
+pr
+sS
+tz
+tz
+pr
 Ts
-Gw
+GK
 Rf
-Za
-Za
-Za
+pr
+LO
+LO
 Yh
-Za
-GW
-Za
+LO
+gm
+LO
 IK
 jH
-Za
+Ho
 hY
 cV
 dD
-Za
+Ho
 xV
 wX
 BA
@@ -6218,18 +6559,18 @@ aY
 wX
 RE
 bm
-Za
+Ho
 dD
 qH
 xe
-Za
+pr
 VD
-Za
-Za
+bQ
+bQ
 SN
 sq
 hz
-Za
+bQ
 Ja
 Ja
 nK
@@ -6259,31 +6600,31 @@ kn
 kn
 kn
 kn
-MT
+Jy
 fa
-mX
-Za
-JI
-JI
-JI
-Za
+iz
+pr
+VN
+VN
+VN
+pr
 EH
 Ec
 TQ
-Za
-JI
+pr
+YW
 pO
-JI
-Za
-lT
-Za
-lT
-lT
-GW
+YW
+LO
+Js
+pr
+Js
+Js
+Ow
 iU
 qH
 dD
-Za
+Ho
 Tm
 wX
 FU
@@ -6291,18 +6632,18 @@ Fq
 wX
 cX
 tH
-Za
+Ho
 dD
 qH
 iU
-Za
+pr
 ky
 vq
 lc
 lc
 lT
 Qu
-MT
+fB
 kn
 kn
 nK
@@ -6332,50 +6673,50 @@ kn
 kn
 kn
 kn
-MT
+Jy
 Yk
-mX
-Za
+iz
+pr
 HZ
-wD
+LQ
 YZ
-Za
+pr
 Xz
 OI
 Mr
-Za
+pr
 Sb
 wD
 hs
-Za
-lT
-Za
-lT
-mX
-Za
+LO
+Js
+pr
+Js
+iz
+Ho
 Yy
 qH
 dD
-Za
+Ho
 Uk
 pp
 Hp
 Dl
 Nv
-Za
+Ho
 aO
-Za
+Ho
 dD
 qH
 iU
-Za
+pr
 ky
-Za
-Za
-Za
-Za
-Za
-Za
+pr
+bQ
+bQ
+bQ
+bQ
+bQ
 kn
 kn
 Ja
@@ -6393,7 +6734,7 @@ kn
 kn
 kn
 kn
-Qf
+xM
 Ja
 Ja
 PE
@@ -6405,43 +6746,43 @@ Ja
 Ja
 Ja
 Ja
-MT
+Jy
 fa
-mX
-Za
-JI
+iz
+pr
+VN
 iS
-Za
-Za
-ot
+tz
+pr
+tU
 OI
-ot
-Za
-Za
+tU
+pr
+LO
 sZ
-JI
-Za
-lT
-Za
-lT
-Za
-Za
+YW
+LO
+Js
+pr
+Js
+pr
+Ho
 Qh
 tv
-Za
-Za
-Za
-Za
-Za
+Ho
+ff
+ff
+ff
+ff
 wu
-Za
-Za
-Za
-Za
-Za
+ff
+ff
+ff
+ff
+Ho
 um
 vl
-Za
+pr
 ky
 Za
 MO
@@ -6477,32 +6818,32 @@ kn
 kn
 xw
 Km
-Za
-Za
+pr
+pr
 xD
-mX
-Za
-Za
-Za
-Za
+iz
+pr
+eD
+eD
+eD
 hG
-ot
+tU
 OI
-ot
+tU
 ds
-Za
-Za
-Za
-Za
-lT
-Za
-lT
-lT
-Za
+Hq
+Hq
+Hq
+Hq
+Js
+pr
+Js
+Js
+pr
 gX
 eR
 yt
-Za
+ff
 LB
 AQ
 dl
@@ -6510,7 +6851,7 @@ mQ
 Qj
 Tz
 kI
-Za
+ff
 BE
 eR
 wQ
@@ -6551,31 +6892,31 @@ kn
 wT
 nK
 fQ
-lT
+Js
 rZ
-lT
-Za
-JI
+Js
+pr
+ue
 eg
-Za
-Za
-ot
+eD
+pr
+tU
 OI
-ot
-Za
-Za
+tU
+pr
+Hq
 Fa
-JI
-Za
-lT
-Za
-Za
-lT
-Za
+rG
+Hq
+Js
+pr
+pr
+Js
+pr
 TC
 qa
 Hk
-Za
+ff
 GP
 sJ
 XO
@@ -6583,7 +6924,7 @@ ZM
 SS
 jg
 yQ
-Za
+ff
 uc
 eR
 Am
@@ -6622,33 +6963,33 @@ Ja
 kn
 kn
 wT
-Za
-Za
-Za
+pr
+pr
+pr
 xD
-lT
-Za
-HZ
-wD
+Js
+pr
+Il
+DZ
 wR
-Za
+pr
 Xz
 OI
-ot
-Za
-Sb
-wD
-hs
-Za
-lT
-lT
-lT
-lT
-Za
+tU
+pr
+jA
+kz
+on
+Hq
+Js
+Js
+Js
+Js
+pr
 JG
 eR
 tT
-Za
+ff
 Uj
 Ix
 zt
@@ -6656,7 +6997,7 @@ sy
 zm
 pN
 vo
-Za
+ff
 FY
 Px
 me
@@ -6695,42 +7036,42 @@ Ja
 kn
 kn
 wT
-Za
+pr
 VU
-lT
-lT
-lT
-Za
-JI
-hi
-JI
-Za
-Fv
+Js
+Js
+Js
+pr
+ue
+Mx
+ue
+pr
+ZQ
 Yf
 Ym
-Za
-JI
+pr
+rG
 hi
-JI
-Za
+rG
+Hq
 xp
-Za
-lT
+pr
+Js
 Yk
-Za
+pr
 bu
 eR
-Za
-Za
-Za
-Za
-Za
+pr
+ff
+ff
+ff
+ff
 et
-Za
-Za
-Za
-Za
-Za
+ff
+ff
+ff
+ff
+pr
 eR
 Am
 Za
@@ -6768,32 +7109,32 @@ Ja
 kn
 kn
 wT
-Za
+pr
 xp
 RX
-Za
-Za
-Za
-ku
-Za
-Za
-Za
+pr
+pr
+pr
+Ad
+eD
+eD
+pr
 Ts
-Gw
-ot
-Za
-Za
-Za
-ku
-Za
-Za
-Za
-lT
-Za
-Za
+GK
+tU
+pr
+Hq
+Hq
+Rk
+Hq
+Hq
+Hq
+Js
+pr
+pr
 tp
 eR
-Za
+pr
 Zw
 bK
 cS
@@ -6803,7 +7144,7 @@ TI
 eY
 Ux
 LC
-Za
+pr
 Hl
 Am
 nQ
@@ -6841,32 +7182,32 @@ Ja
 kn
 kn
 wT
-Za
+pr
 jH
-lT
-Za
+Js
+pr
 QO
 Fs
 hK
 fy
-Za
+eD
 sc
-ot
-Gw
-ot
+tU
+GK
+tU
 yo
-Za
+Hq
 Uf
 Ob
 qt
 fh
-GW
-lT
-Za
+en
+Js
+pr
 lC
 gX
 eR
-dD
+xR
 xX
 BB
 AT
@@ -6876,7 +7217,7 @@ CN
 Qy
 BB
 Rm
-dD
+xR
 eR
 PT
 Za
@@ -6914,32 +7255,32 @@ Ja
 kn
 kn
 wT
-Za
-Za
-lT
-mn
+pr
+pr
+Js
+my
 hK
 hK
 hK
 Bo
-Za
+eD
 QX
 xS
-Gw
+GK
 ty
 wv
-Za
+Hq
 nR
 Ob
 Ob
 dN
-Za
+Hq
 GZ
-Za
+pr
 Xa
 gX
 eR
-Za
+pr
 cI
 BB
 yy
@@ -6949,7 +7290,7 @@ BV
 Cm
 BB
 pl
-Za
+pr
 Fr
 Am
 Za
@@ -6977,7 +7318,7 @@ kn
 kn
 kn
 kn
-Qf
+xM
 Ja
 Ja
 ux
@@ -6988,27 +7329,27 @@ Ja
 Ja
 wT
 Ja
-Za
-lT
-Za
+pr
+Js
+pr
 mk
 NB
 vn
 FS
-Za
+eD
 Bs
-ot
-Gw
-ot
+tU
+GK
+tU
 Np
-Za
+Hq
 od
 Jz
 QB
 qO
-Za
-Za
-Za
+Hq
+pr
+pr
 LW
 gX
 eR
@@ -7022,13 +7363,13 @@ ci
 BB
 BB
 Sc
-dD
+xR
 eR
 mU
-Za
+pr
 vr
 AF
-Za
+pr
 QL
 PC
 YH
@@ -7061,28 +7402,28 @@ kn
 kn
 wT
 Ja
-Za
-lT
-Za
+pr
+Js
+pr
 Kv
-NT
-iM
-NL
+SI
+YO
+px
 ng
 WS
-Gw
-Gw
+GK
+GK
 nu
 pb
 QG
 Lz
 zz
-NT
+lL
 OS
-Za
+Qb
 zc
-Za
-Za
+Qb
+Qb
 gX
 fN
 td
@@ -7095,13 +7436,13 @@ Cv
 ep
 PB
 ao
-Za
+pr
 nq
 bx
-Za
+pr
 oj
 Sq
-Za
+pr
 Za
 Za
 Za
@@ -7134,31 +7475,31 @@ kn
 kn
 wT
 Ja
-Za
-lT
-Za
+pr
+Js
+pr
 mo
 VP
 VP
 nd
-Za
+eD
 Rv
-ot
-Gw
-ot
+tU
+GK
+tU
 qe
-Za
+Hq
 UL
 hR
 hR
 jG
-Za
-mX
+Qb
+FM
 Tf
 Rd
 CB
 eR
-Za
+pr
 NW
 sU
 Un
@@ -7168,14 +7509,14 @@ eR
 Un
 sj
 oE
-Za
+pr
 Hl
 Am
 Nj
 YS
 YS
 Du
-Za
+pr
 Ja
 Za
 qr
@@ -7207,31 +7548,31 @@ kn
 kn
 wT
 Ja
-Za
-lT
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+pr
+Js
+bQ
+bQ
+bQ
+bQ
+bQ
+bQ
+pr
 dI
 Yg
 dI
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+pr
+Hq
+Hq
+Hq
+Hq
+Hq
+Qb
 cy
 HV
-Za
+Qb
 CB
 eR
-dD
+xR
 NS
 zd
 vz
@@ -7241,14 +7582,14 @@ ci
 vz
 aG
 xn
-dD
+xR
 eR
 Am
-Za
+pr
 OD
 YS
 Du
-Za
+pr
 Ja
 Za
 HO
@@ -7280,31 +7621,31 @@ kn
 kn
 wT
 Ja
-Za
-lT
-Za
+pr
+Js
+bQ
 Kd
 Kd
 Kd
 Lo
-Za
+bQ
 NO
-ot
+tU
 Ec
-ot
+tU
 eK
-Za
+pr
 Ou
 BZ
 Me
 Of
-Za
-Za
-Za
-Za
+Qb
+Qb
+Qb
+Qb
 Mt
 Xm
-Za
+pr
 eT
 Cv
 Cv
@@ -7317,12 +7658,12 @@ hy
 KP
 Xm
 jR
-Za
-Za
+pr
+pr
 CW
-Za
-Za
-Za
+pr
+pr
+pr
 Za
 LG
 qb
@@ -7353,22 +7694,22 @@ kn
 kn
 wT
 Ja
-Za
-lT
-GW
-Qg
+pr
+Js
+wM
+Ew
 lT
 zC
-mX
-Za
+yn
+bQ
 dP
-ot
+tU
 OI
-ot
+tU
 Dw
 yA
-sJ
-sJ
+oK
+oK
 re
 cK
 ga
@@ -7418,18 +7759,18 @@ kn
 kn
 kn
 kn
-Qf
+xM
 kn
 kn
 kn
 kn
 kn
 wT
-Za
-Za
-mX
-Za
-Za
+pr
+pr
+iz
+bQ
+bQ
 US
 IQ
 lc
@@ -7437,7 +7778,7 @@ oL
 sX
 Wa
 OI
-Gw
+GK
 ap
 Xp
 wB
@@ -7498,50 +7839,50 @@ kn
 kn
 kn
 wT
-Za
+pr
 IK
-mX
+iz
 GZ
-Za
+bQ
 PY
 vy
 iB
-Za
+bQ
 fs
-ot
+tU
 Yf
-ot
+tU
 pt
-Za
+pr
 Ed
 to
 Uu
 Oi
-Za
-mn
-Za
+pr
+my
+pr
 Vh
 YQ
-Za
+as
 Th
 Th
-Za
+as
 TB
-Za
-Za
+pr
+pr
 eX
 fC
 LT
-Za
-Za
-MT
-Za
-MT
-MT
-Za
-MT
-MT
-Za
+pr
+pr
+Jy
+pr
+Jy
+Jy
+pr
+Jy
+Jy
+pr
 Za
 IW
 Qi
@@ -7571,41 +7912,41 @@ kn
 kn
 kn
 wT
-Za
+pr
 xp
-mX
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+iz
+pr
+bQ
+bQ
+bQ
+bQ
+bQ
+pr
 dI
 Yg
 dI
-Za
-Za
-Za
-Za
-Za
-Za
-Za
-mX
-Za
-Za
-Za
-Za
+pr
+RL
+RL
+RL
+RL
+RL
+RL
+iz
+pr
+pr
+pr
+as
 MV
 CS
 YT
 CS
 ag
-Za
+as
 hA
 mZ
 xt
-Za
+as
 Ja
 kn
 kn
@@ -7644,42 +7985,42 @@ kn
 PE
 kn
 wT
-Za
-Za
-mX
-Za
+pr
+pr
+iz
+pr
 EP
 Wd
 Bl
 hQ
-Za
+sW
 Rv
-ot
-Gw
-ot
+tU
+GK
+tU
 qe
-Za
+RL
 mc
 eb
 eb
 uT
-Za
-mX
-Za
+RL
+iz
+pr
 BP
 BP
-Za
+as
 mB
 CO
 CO
 Vj
-Za
-Za
+as
+as
 fD
 Rg
 KR
-Za
-Za
+as
+as
 kn
 kn
 kn
@@ -7718,30 +8059,30 @@ PE
 Ja
 wT
 Ja
-Za
-mX
-Za
+pr
+iz
+pr
 uZ
 lf
 tw
-NL
+Ni
 ez
 WS
-Gw
-Gw
-Gw
+GK
+GK
+GK
 Db
 YF
-NL
-zz
-NT
-OS
-Za
-mX
-mn
-mX
-mX
-Za
+Hs
+NC
+Im
+ww
+RL
+iz
+my
+iz
+iz
+as
 CO
 VM
 CO
@@ -7752,7 +8093,7 @@ wx
 Us
 SH
 gx
-MT
+Af
 kn
 kn
 kn
@@ -7791,30 +8132,30 @@ ux
 kn
 wT
 Ja
-Za
-mX
-Za
+pr
+iz
+pr
 DW
 Ki
 xx
 Qq
-Za
+sW
 rT
-ot
-Gw
-ot
+tU
+GK
+tU
 MJ
-Za
+RL
 Tl
 KE
 Ee
 Ka
-Za
+RL
 Yj
-Za
-Za
+pr
+pr
 Wt
-Za
+as
 ob
 IX
 CO
@@ -7825,7 +8166,7 @@ fD
 Us
 KS
 SP
-MT
+Af
 kn
 kn
 kn
@@ -7864,41 +8205,41 @@ PE
 kn
 wT
 Ja
-Za
-mX
-Za
+pr
+iz
+pr
 gS
 sK
 sK
 sK
-Za
+sW
 LK
-ot
-Gw
-ot
+tU
+GK
+tU
 wv
-Za
+RL
 EG
 PX
 PX
 PX
-Za
-mX
+RL
+iz
 xp
-Za
-Za
-Za
+pr
+pr
+as
 mB
 us
 CO
 XE
-Za
-Za
+as
+as
 PM
 dy
 DN
 UA
-Za
+as
 kn
 kn
 kn
@@ -7937,41 +8278,41 @@ PE
 kn
 wT
 Ja
-Za
-mX
-Za
+pr
+iz
+pr
 Co
 sK
 NU
 NU
-Za
+sW
 Rv
-ot
-Gw
-ot
+tU
+GK
+tU
 gI
-Za
+RL
 Pv
 PX
 Zl
 bC
-Za
-mX
-mX
-mX
-mX
-Za
+RL
+iz
+iz
+iz
+iz
+as
 CO
 cD
 CO
 Mm
-Za
+as
 nG
 fD
 Us
 KS
 cm
-MT
+Af
 kn
 kn
 kn
@@ -8010,41 +8351,41 @@ ux
 kn
 wT
 Ja
-Za
-mX
-Za
-Za
-ku
-Za
-Za
-Za
-Za
+pr
+iz
+pr
+sW
+Ds
+sW
+sW
+sW
+pr
 Ts
-Gw
+GK
 XF
-Za
-Za
-Za
-ku
-Za
-Za
-Za
-Za
-Za
-Za
-mX
-Za
+pr
+RL
+RL
+yF
+RL
+RL
+RL
+pr
+pr
+pr
+iz
+as
 ob
 pZ
 CO
 xB
-Za
+as
 bt
 fD
 Us
 KS
 go
-MT
+Af
 kn
 kn
 kn
@@ -8083,41 +8424,41 @@ PE
 Ja
 wT
 Ja
-Za
-mX
-Za
-pO
-JI
+pr
+iz
+pr
+Mf
+fH
 bj
-Za
+sW
 yv
 Xy
-ot
+tU
 Ec
 Ym
-Za
-JI
-pO
-JI
-Za
+pr
+UW
+XZ
+UW
+RL
 IK
-lT
-lT
-lT
-mX
-mX
-Za
+Js
+Js
+Js
+iz
+iz
+as
 mn
-Za
-Za
-Za
-Za
+as
+as
+as
+as
 nn
 fD
 Us
 Mg
 go
-MT
+Af
 kn
 kn
 kn
@@ -8155,42 +8496,42 @@ kn
 ux
 kn
 wT
-Za
-Za
-mX
-mn
-JI
-wD
-YZ
-Za
+pr
+pr
+iz
+my
+fH
+Ar
+pE
+sW
 ks
 Xy
-TJ
+MX
 OI
 hU
-Za
-Sb
-wD
-JI
-Za
+pr
+rj
+nm
+UW
+RL
 jH
-lT
-Za
+Js
+pr
 vP
 Qg
-lT
-lT
-lT
-Za
+Js
+Js
+Js
+pr
 jH
 IK
-Za
-Za
+pr
+as
 yN
 Us
-xD
-Za
-Za
+VC
+as
+as
 kn
 kn
 kn
@@ -8228,36 +8569,36 @@ kn
 kn
 kn
 wT
-Za
+pr
 jH
-mX
-Za
-JI
-iS
-Za
-Za
-Za
-Za
-Fv
+iz
+pr
+fH
+vO
+sW
+sW
+sW
+pr
+ZQ
 OI
 Rf
-Za
-Za
-sZ
-JI
-Za
+pr
+RL
+is
+UW
+RL
 xp
-lT
-Za
+Js
+pr
 xD
 Lb
 xD
-Za
-lT
-lT
-lT
-lT
-lT
+pr
+Js
+Js
+Js
+Js
+Js
 GW
 fD
 Us
@@ -8301,42 +8642,42 @@ kn
 kn
 kn
 wT
-Za
+pr
 IK
-mX
-Za
-Za
-Za
-Za
-mX
-mn
+iz
+pr
+pr
+pr
+pr
+iz
+my
 Xy
-ot
+tU
 OI
-ot
+tU
 Sm
-Za
-Za
-mn
-Za
-Za
-lT
-Za
+pr
+pr
+my
+pr
+pr
+Js
+pr
 bn
-mX
+iz
 Ha
-Za
-Za
-Za
-Za
-Za
-Za
-Za
+pr
+pr
+pr
+pr
+pr
+as
+as
 MF
 Us
-xD
-Za
-Za
+VC
+as
+as
 kn
 kn
 kn
@@ -8374,42 +8715,42 @@ kn
 kn
 kn
 wT
-Za
+pr
 BP
-mX
-mX
-mX
+iz
+iz
+iz
 Yk
-Za
-mX
-Za
+pr
+iz
+pr
 Jh
-ot
+tU
 Yf
 Wz
 PU
 GW
-lT
-lT
-lT
-lT
-lT
-Za
+Js
+Js
+Js
+Js
+Js
+pr
 Ty
-mX
+iz
 JV
-MT
+Jy
 kn
 kn
 kn
 kn
-MT
+Af
 Jg
 Ft
 Us
 Dv
 go
-MT
+Af
 kn
 kn
 kn
@@ -8447,42 +8788,42 @@ kn
 kn
 kn
 wT
-Za
-Za
+pr
+pr
 wt
-Za
-mX
-mX
-mX
-mX
-Za
+pr
+iz
+iz
+iz
+iz
+pr
 Jh
-ot
-Gw
-ot
+tU
+GK
+tU
 Gd
-Za
-Za
-mX
-Za
+pr
+pr
+iz
+pr
 xD
 Aa
-Za
+pr
 bn
-Um
+Ov
 YU
-Za
+pr
 kn
 kn
 kn
 kn
-MT
+Af
 kq
 Ft
 Us
 KS
 go
-MT
+Af
 kn
 kn
 kn
@@ -8521,41 +8862,41 @@ nK
 SA
 Kw
 nK
-Za
-MT
-Za
+pr
+Jy
+pr
 BP
 BP
-Za
-Za
-Za
+pr
+pr
+pr
 Jh
-ot
-Gw
-ot
+tU
+GK
+tU
 nX
-Za
+pr
 GZ
-mX
+iz
 BP
-Za
-mX
-Za
+pr
+iz
+pr
 IK
-mX
+iz
 JV
-MT
+Jy
 kn
 kn
 kn
 kn
-MT
+Af
 UY
 sC
 Us
 TG
 go
-MT
+Af
 kn
 kn
 kn
@@ -8596,39 +8937,39 @@ Ja
 nK
 nK
 nK
-Za
-MT
-MT
-Za
+pr
+Jy
+Jy
+pr
 OB
-OB
-OB
+be
+be
 EH
-Gw
-ot
+GK
+tU
 jU
-Za
-Za
-Za
-Za
-Za
+pr
+pr
+pr
+pr
+pr
 Xc
-Za
-Za
+pr
+pr
 Aa
-Za
-Za
+pr
+pr
 Ja
 Ja
 Ja
 Ja
-Za
-Za
+as
+as
 lA
 mg
 KS
-Za
-Za
+as
+as
 kn
 kn
 kn
@@ -8675,11 +9016,11 @@ DT
 Wr
 OB
 xN
-OB
-ot
+be
+tU
 ch
-ot
-Za
+tU
+pr
 Qf
 Qf
 MM
@@ -8687,15 +9028,15 @@ DT
 DT
 DT
 DT
-MT
-mX
-MT
+Jy
+iz
+Jy
 kn
 kn
 kn
 kn
 kn
-MT
+Af
 Wh
 Ft
 Um
@@ -8748,11 +9089,11 @@ kn
 Uy
 OB
 Fz
-OB
-ot
+be
+tU
 ch
-ot
-Za
+tU
+pr
 Qf
 Qf
 qh
@@ -8760,15 +9101,15 @@ kn
 kn
 kn
 kn
-Za
+pr
 Xc
-Za
+pr
 kn
 kn
 kn
 kn
 kn
-MT
+Af
 kQ
 iq
 Um
@@ -8841,13 +9182,13 @@ kn
 kn
 kn
 kn
-Za
-Za
-Za
+as
+as
+as
 ku
-Za
-Za
-Za
+as
+as
+as
 kn
 kn
 kn
@@ -8895,7 +9236,7 @@ Uy
 sF
 vc
 xI
-QF
+ha
 tL
 PK
 BN
@@ -8915,11 +9256,11 @@ kn
 kn
 kn
 Jn
-Za
+as
 Vv
 JI
 SQ
-Za
+as
 Jn
 kn
 kn
@@ -8988,11 +9329,11 @@ kn
 kn
 kn
 Jn
-Za
+as
 SJ
 SJ
 SJ
-Za
+as
 Jn
 kn
 kn

--- a/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
@@ -730,6 +730,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/security)
+"he" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/telecomms/relay/preset/auto{
+	name = "Hotel"
+	},
+/turf/open/floor/catwalk_floor,
+/area/ruin/space/has_grav/hotel)
 "hi" = (
 /obj/structure/sink/directional/west,
 /turf/open/floor/iron/showroomfloor,
@@ -2373,6 +2380,7 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/light/directional/south,
 /obj/structure/sign/poster/contraband/random/directional/south,
+/obj/item/megaphone,
 /turf/open/floor/iron/dark/smooth_edge,
 /area/ruin/space/has_grav/hotel/workroom)
 "zc" = (
@@ -3062,7 +3070,9 @@
 "Fz" = (
 /mob/living/simple_animal/bot/secbot/beepsky/armsky{
 	name = "Hotelsky";
-	desc = "It's Hotelsky! He's a disgruntled servant of the hotel that would probably shoot you if he had hands."
+	desc = "It's Hotelsky! He's a disgruntled servant of the hotel that would probably shoot you if he had hands.";
+	maints_access_required = list("away_sec");
+	access_card = list("away_general")
 	},
 /turf/open/floor/carpet/neon/simple/red/nodots,
 /area/ruin/space/has_grav/hotel/security)
@@ -3199,6 +3209,7 @@
 /obj/structure/table/reinforced,
 /obj/item/crowbar/large/old,
 /obj/effect/mapping_helpers/apc/cell_10k,
+/obj/item/megaphone/sec,
 /turf/open/floor/glass/reinforced,
 /area/ruin/space/has_grav/hotel/security)
 "GZ" = (
@@ -4806,6 +4817,11 @@
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/hotel/dock)
+"Vk" = (
+/obj/structure/cable,
+/obj/machinery/bluespace_beacon,
+/turf/open/floor/catwalk_floor,
+/area/ruin/space/has_grav/hotel)
 "Vq" = (
 /obj/structure/railing{
 	dir = 1
@@ -5245,7 +5261,7 @@
 	},
 /obj/machinery/door/window/survival_pod{
 	name = "Holding Cell A";
-	req_access = list("security");
+	req_access = list("away_sec");
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5593,7 +5609,7 @@ pr
 vL
 WA
 sh
-sh
+he
 Ko
 oW
 pr
@@ -5666,7 +5682,7 @@ pr
 bs
 Qn
 Wq
-Wq
+Vk
 Qn
 QH
 pr

--- a/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
@@ -386,7 +386,7 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/jungle/c/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/window/fulltile,
+/obj/structure/window/spawner/directional/south,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/hotel/bar)
 "dF" = (
@@ -404,6 +404,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/apc/away_general_access,
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/hotel/guestroom/room_3)
 "dP" = (
@@ -695,6 +696,15 @@
 	},
 /turf/open/floor/iron/sepia,
 /area/ruin/space/has_grav/hotel/pool)
+"gE" = (
+/obj/structure/flora/bush/leavy/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/jungle/c/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/window/spawner/directional/north,
+/turf/open/floor/grass,
+/area/ruin/space/has_grav/hotel/bar)
 "gI" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -739,6 +749,7 @@
 /area/ruin/space/has_grav/hotel)
 "hi" = (
 /obj/structure/sink/directional/west,
+/obj/structure/mirror/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/hotel/guestroom/room_3)
 "hp" = (
@@ -770,7 +781,7 @@
 "hz" = (
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
-/obj/machinery/power/smes/engineering,
+/obj/machinery/power/smes/super/full,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/power)
 "hA" = (
@@ -791,6 +802,11 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/displaycase/trophy,
 /turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/hotel)
+"hI" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
 "hK" = (
 /turf/open/floor/carpet/royalblue,
@@ -857,9 +873,9 @@
 /area/ruin/space/has_grav/hotel/security)
 "iB" = (
 /obj/structure/cable,
-/obj/machinery/power/smes/engineering,
+/obj/machinery/power/smes/super/full,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/hotel/power)
+/area/ruin/space/has_grav/hotel)
 "iM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood/parquet,
@@ -993,7 +1009,10 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_3)
 "kI" = (
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/storage/medkit/regular,
+/obj/machinery/fax{
+	name = "Hotel Fax Machine";
+	fax_name = "Twin Nexus Hotel"
+	},
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 4
 	},
@@ -1027,7 +1046,6 @@
 /area/ruin/space/has_grav/hotel/guestroom/room_2)
 "ll" = (
 /obj/structure/cable,
-/obj/structure/rack,
 /obj/item/clothing/suit/space/syndicate/black/blue{
 	desc = "A 'Nanotrasen Special Response Team' space suit, according to the tag.";
 	name = "Nanotrasen SRT space suit"
@@ -1036,6 +1054,9 @@
 	name = "Nanotrasen SRT space helmet";
 	desc = "A 'Nanotrasen Special Response Team' helmet, according to the tag."
 	},
+/obj/machinery/suit_storage_unit,
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/glass/reinforced,
 /area/ruin/space/has_grav/hotel/security)
 "lA" = (
@@ -1301,7 +1322,7 @@
 /obj/effect/mapping_helpers/airlock/access/any/away/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/hotel/power)
+/area/ruin/space/has_grav/hotel)
 "oQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -1360,6 +1381,7 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 4
 	},
+/obj/structure/desk_bell,
 /turf/open/floor/wood/tile,
 /area/ruin/space/has_grav/hotel)
 "pp" = (
@@ -1410,12 +1432,14 @@
 /obj/structure/cable,
 /obj/item/paper_bin,
 /obj/structure/sign/poster/contraband/random/directional/east,
+/obj/item/pen,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
 /area/ruin/space/has_grav/hotel/workroom)
 "pO" = (
 /obj/structure/sink/directional/east,
+/obj/structure/mirror/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/hotel/guestroom/room_5)
 "pU" = (
@@ -1434,6 +1458,11 @@
 /obj/effect/spawner/random/engineering/material,
 /obj/effect/spawner/random/engineering/material_cheap,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/iron/twenty,
+/obj/item/stack/sheet/glass{
+	amount = 15
+	},
+/obj/item/lightreplacer,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/hotel/dock)
 "qa" = (
@@ -1526,6 +1555,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/sepia,
 /area/ruin/space/has_grav/hotel/pool)
+"qL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/apc/away_general_access,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/machinery/power/apc/auto_name/directional/east,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel/power)
 "qO" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1630,6 +1667,7 @@
 /area/ruin/space/has_grav/hotel)
 "sh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/spaceship_navigation_beacon,
 /turf/open/floor/catwalk_floor,
 /area/ruin/space/has_grav/hotel)
 "si" = (
@@ -1902,8 +1940,15 @@
 	},
 /obj/structure/closet/crate/wooden/toy,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/under/syndicate/tacticool,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/hotel/dock)
+"uw" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel)
 "ux" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -1918,6 +1963,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/apc/away_general_access,
 /turf/open/floor/wood/parquet,
 /area/ruin/space/has_grav/hotel/guestroom/room_2)
 "va" = (
@@ -1959,8 +2005,11 @@
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
 /obj/item/gps/spaceruin{
-	name = "hotel gps"
+	name = "hotel gps";
+	pixel_x = 6;
+	pixel_y = 12
 	},
+/obj/effect/mapping_helpers/apc/away_general_access,
 /turf/open/floor/iron/dark/smooth_corner{
 	dir = 1
 	},
@@ -1984,7 +2033,7 @@
 /obj/machinery/power/terminal,
 /obj/structure/rack,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/hotel/power)
+/area/ruin/space/has_grav/hotel)
 "vz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -2100,14 +2149,6 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel/pool)
-"wM" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Hotel Maintenance"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/hotel/power)
 "wP" = (
 /turf/open/misc/beach/sand,
 /area/ruin/space/has_grav/hotel/pool)
@@ -2122,7 +2163,7 @@
 /obj/structure/window/spawner/directional/north,
 /obj/machinery/shower/directional/south,
 /turf/open/floor/iron/freezer,
-/area/ruin/space/has_grav/hotel/bar)
+/area/ruin/space/has_grav/hotel/guestroom/room_4)
 "wT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -2212,12 +2253,21 @@
 /turf/open/floor/carpet/green,
 /area/ruin/space/has_grav/hotel/guestroom/room_2)
 "xB" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/under/syndicate/tacticool,
 /obj/effect/turf_decal/delivery/white{
 	color = "A46106"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/circuitboard/machine/hydroponics,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/circuitboard/machine/biogenerator,
+/obj/item/reagent_containers/cup/bucket,
+/obj/item/vending_refill/hydronutrients,
+/obj/item/vending_refill/hydroseeds,
+/obj/item/circuitboard/machine/vending,
+/obj/item/circuitboard/machine/vending,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/hotel/dock)
 "xD" = (
@@ -2235,10 +2285,6 @@
 /turf/template_noop,
 /area/template_noop)
 "xN" = (
-/obj/item/gun/ballistic/automatic/pistol/m1911{
-	spawnwithmagazine = 0
-	},
-/obj/item/ammo_box/magazine/m45,
 /obj/structure/closet/syndicate{
 	anchored = 1
 	},
@@ -2246,6 +2292,9 @@
 /obj/machinery/light/directional/west,
 /obj/item/bodybag/environmental/prisoner/pressurized,
 /obj/item/bodybag/environmental/prisoner/pressurized,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/ammo_box/magazine/m45,
+/obj/item/gun/ballistic/automatic/pistol/m1911,
 /turf/open/floor/carpet/neon/simple/red/nodots,
 /area/ruin/space/has_grav/hotel/security)
 "xR" = (
@@ -2254,7 +2303,8 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/jungle/c/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/window/fulltile,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/window/spawner/directional/north,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/hotel)
 "xS" = (
@@ -2279,9 +2329,6 @@
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/carpet/blue,
 /area/ruin/space/has_grav/hotel)
-"yn" = (
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/hotel/power)
 "yo" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -2380,7 +2427,14 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/light/directional/south,
 /obj/structure/sign/poster/contraband/random/directional/south,
-/obj/item/megaphone,
+/obj/item/megaphone{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/obj/item/storage/medkit/regular{
+	pixel_x = 23;
+	pixel_y = 0
+	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/ruin/space/has_grav/hotel/workroom)
 "zc" = (
@@ -2459,7 +2513,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/hotel/power)
+/area/ruin/space/has_grav/hotel)
 "zY" = (
 /obj/structure/sink/directional/north,
 /obj/effect/turf_decal/trimline/red/line{
@@ -2604,6 +2658,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/apc/away_general_access,
 /turf/open/floor/carpet/royalblue,
 /area/ruin/space/has_grav/hotel/guestroom/room_4)
 "Bq" = (
@@ -2970,11 +3025,6 @@
 	dir = 4
 	},
 /area/ruin/space/has_grav/hotel/bar)
-"Ew" = (
-/obj/structure/cable,
-/obj/item/clothing/head/cone,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/hotel/power)
 "EC" = (
 /obj/structure/railing,
 /obj/effect/turf_decal/siding/white,
@@ -2988,6 +3038,7 @@
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
 /obj/item/pen,
+/obj/effect/mapping_helpers/apc/away_general_access,
 /turf/open/floor/carpet/lone,
 /area/ruin/space/has_grav/hotel/guestroom/room_1)
 "EH" = (
@@ -3295,6 +3346,7 @@
 /obj/structure/cable,
 /obj/structure/sink/directional/west,
 /obj/item/reagent_containers/spray/cleaner,
+/obj/effect/mapping_helpers/apc/away_general_access,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/custodial)
 "HW" = (
@@ -3367,7 +3419,7 @@
 "IQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/hotel/power)
+/area/ruin/space/has_grav/hotel)
 "IW" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/sign/warning/no_smoking/circle/directional/north,
@@ -3473,6 +3525,11 @@
 	},
 /turf/open/floor/stone,
 /area/ruin/space/has_grav/hotel/bar)
+"JY" = (
+/obj/structure/mirror/directional/west,
+/obj/structure/sink/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_6)
 "Ka" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -3553,6 +3610,7 @@
 "KW" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/firealarm/directional/north,
+/obj/structure/mirror/directional/east,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/hotel/pool)
 "Lb" = (
@@ -3563,10 +3621,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/hotel/bar)
+"Lm" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/ruin/space/has_grav/hotel/guestroom/room_1)
 "Lo" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/hotel/power)
+/area/ruin/space/has_grav/hotel)
 "Lt" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -3648,6 +3710,7 @@
 /area/ruin/space/has_grav/hotel)
 "Mf" = (
 /obj/structure/sink/directional/east,
+/obj/structure/mirror/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/hotel/guestroom/room_2)
 "Mg" = (
@@ -3704,6 +3767,7 @@
 /area/ruin/space/has_grav/hotel/bar)
 "Mx" = (
 /obj/structure/sink/directional/west,
+/obj/structure/mirror/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/hotel/guestroom/room_4)
 "MC" = (
@@ -3774,6 +3838,7 @@
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
 /obj/item/pen,
+/obj/effect/mapping_helpers/apc/away_general_access,
 /turf/open/floor/carpet/orange,
 /area/ruin/space/has_grav/hotel/guestroom/room_6)
 "MV" = (
@@ -3963,6 +4028,14 @@
 	dir = 8
 	},
 /area/ruin/space/has_grav/hotel)
+"Oo" = (
+/obj/machinery/light/directional/east,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atm/directional/east,
+/turf/open/floor/wood/tile,
+/area/ruin/space/has_grav/hotel)
 "Ou" = (
 /obj/machinery/light/directional/north,
 /obj/item/kirbyplants{
@@ -4058,6 +4131,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/cell_5k,
+/obj/effect/mapping_helpers/apc/away_general_access,
 /turf/open/floor/carpet/purple,
 /area/ruin/space/has_grav/hotel/guestroom/room_5)
 "Pp" = (
@@ -4163,7 +4237,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/hotel/power)
+/area/ruin/space/has_grav/hotel)
 "Qb" = (
 /turf/closed/wall,
 /area/ruin/space/has_grav/hotel/custodial)
@@ -4275,8 +4349,12 @@
 /obj/structure/frame/computer{
 	dir = 1
 	},
-/obj/item/stack/sheet/glass,
-/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass{
+	amount = 15
+	},
+/obj/item/stack/sheet/glass{
+	amount = 15
+	},
 /turf/open/floor/circuit/green,
 /area/ruin/space/has_grav/hotel)
 "QL" = (
@@ -4626,7 +4704,6 @@
 /area/ruin/space/has_grav/hotel)
 "Ty" = (
 /obj/structure/closet/emcloset,
-/obj/item/card/id/away/hotel,
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel)
@@ -4693,6 +4770,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/structure/cable,
+/obj/effect/mapping_helpers/apc/away_general_access,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/hotel/pool)
 "Uf" = (
@@ -4718,7 +4796,10 @@
 /obj/structure/flora/bush/flowers_br/style_random,
 /obj/structure/flora/bush/jungle/c/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
-/obj/effect/spawner/structure/window,
+/obj/structure/window/spawner/directional/south,
+/obj/structure/window/spawner/directional/north,
+/obj/structure/window/spawner/directional/east,
+/obj/structure/window/spawner/directional/west,
 /turf/open/floor/grass,
 /area/ruin/space/has_grav/hotel)
 "Us" = (
@@ -4759,6 +4840,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/apc/away_general_access,
 /turf/open/floor/wood/large,
 /area/ruin/space/has_grav/hotel/dock)
 "UB" = (
@@ -4785,12 +4867,6 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/hotel)
-"US" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/effect/mapping_helpers/apc/cell_5k,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/hotel/power)
 "UW" = (
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/hotel/guestroom/room_1)
@@ -4801,6 +4877,7 @@
 /area/ruin/space/has_grav/hotel/dock)
 "UZ" = (
 /obj/structure/sink/directional/west,
+/obj/structure/mirror/directional/east,
 /turf/open/floor/iron/freezer,
 /area/ruin/space/has_grav/hotel/pool)
 "Vh" = (
@@ -4817,11 +4894,6 @@
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/hotel/dock)
-"Vk" = (
-/obj/structure/cable,
-/obj/machinery/bluespace_beacon,
-/turf/open/floor/catwalk_floor,
-/area/ruin/space/has_grav/hotel)
 "Vq" = (
 /obj/structure/railing{
 	dir = 1
@@ -4985,8 +5057,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/space/basic,
-/area/ruin/space/has_grav/hotel/power)
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/hotel)
 "Xm" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood/tile,
@@ -5064,6 +5136,7 @@
 /area/ruin/space/has_grav/hotel/workroom)
 "XZ" = (
 /obj/structure/sink/directional/east,
+/obj/structure/mirror/directional/west,
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/hotel/guestroom/room_1)
 "Yd" = (
@@ -5682,7 +5755,7 @@ pr
 bs
 Qn
 Wq
-Vk
+Wq
 Qn
 QH
 pr
@@ -6493,7 +6566,7 @@ Ho
 Ho
 rB
 qH
-dD
+gE
 Ho
 Zu
 bo
@@ -6566,7 +6639,7 @@ jH
 Ho
 hY
 cV
-dD
+gE
 Ho
 xV
 wX
@@ -6621,7 +6694,7 @@ fa
 iz
 pr
 VN
-VN
+JY
 VN
 pr
 EH
@@ -6639,7 +6712,7 @@ Js
 Ow
 iU
 qH
-dD
+gE
 Ho
 Tm
 wX
@@ -6655,7 +6728,7 @@ iU
 pr
 ky
 vq
-lc
+qL
 lc
 lT
 Qu
@@ -6712,7 +6785,7 @@ iz
 Ho
 Yy
 qH
-dD
+gE
 Ho
 Uk
 pp
@@ -7566,12 +7639,12 @@ wT
 Ja
 pr
 Js
-bQ
-bQ
-bQ
-bQ
-bQ
-bQ
+pr
+pr
+pr
+pr
+pr
+pr
 pr
 dI
 Yg
@@ -7639,12 +7712,12 @@ wT
 Ja
 pr
 Js
-bQ
-Kd
-Kd
-Kd
+pr
+uw
+uw
+uw
 Lo
-bQ
+pr
 NO
 tU
 Ec
@@ -7712,12 +7785,12 @@ wT
 Ja
 pr
 Js
-wM
-Ew
-lT
+GW
+Qg
+Js
 zC
-yn
-bQ
+iz
+pr
 dP
 tU
 OI
@@ -7785,11 +7858,11 @@ wT
 pr
 pr
 iz
-bQ
-bQ
-US
+pr
+pr
+Js
 IQ
-lc
+hI
 oL
 sX
 Wa
@@ -7811,7 +7884,7 @@ Gn
 Gn
 rN
 Am
-qc
+Oo
 QS
 Am
 Am
@@ -7859,11 +7932,11 @@ pr
 IK
 iz
 GZ
-bQ
+pr
 PY
 vy
 iB
-bQ
+pr
 fs
 tU
 Yf
@@ -7932,11 +8005,11 @@ pr
 xp
 iz
 pr
-bQ
-bQ
-bQ
-bQ
-bQ
+pr
+pr
+pr
+pr
+pr
 pr
 dI
 Yg
@@ -8528,7 +8601,7 @@ hU
 pr
 rj
 nm
-UW
+Lm
 RL
 jH
 Js
@@ -8883,8 +8956,8 @@ Jy
 pr
 BP
 BP
-pr
-pr
+jH
+BP
 pr
 Jh
 tU

--- a/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
@@ -1,0 +1,9821 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ag" = (
+/obj/structure/rack,
+/obj/item/crowbar/red,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/item/shadowcloak,
+/obj/item/storage/belt/utility/full/engi,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"al" = (
+/obj/machinery/door/airlock{
+	name = "Showers"
+	},
+/turf/open/floor/iron/freezer,
+/area/space)
+"ao" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/blue,
+/area/space)
+"ap" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/space)
+"aw" = (
+/obj/structure/bed/pod{
+	dir = 4
+	},
+/obj/item/bedsheet/green{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/space)
+"aB" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/space)
+"aG" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"aO" = (
+/obj/structure/closet/secure_closet/freezer/meat/open,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/meat/slab/killertomato,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/meat/slab/human/mutant/lizard,
+/obj/item/food/sausage,
+/obj/item/food/sausage,
+/obj/item/food/meat/rawcutlet,
+/obj/item/food/meat/rawcutlet,
+/obj/item/food/meat/rawcutlet,
+/obj/item/food/fishmeat/carp,
+/obj/item/food/fishmeat/carp,
+/obj/item/food/fishmeat/carp,
+/obj/item/food/fishmeat/carp,
+/obj/item/sharpener,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/space)
+"aQ" = (
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/carpet/blue,
+/area/space)
+"aX" = (
+/obj/item/beacon,
+/turf/open/floor/wood/tile,
+/area/space)
+"aY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/reagent_containers/condiment/enzyme{
+	layer = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/storage/box/beanbag,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"bj" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"bm" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/whitebeet,
+/obj/item/food/grown/whitebeet,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/rice,
+/obj/item/food/grown/rice,
+/obj/item/food/grown/icepepper,
+/obj/item/food/grown/icepepper,
+/obj/item/food/grown/citrus/lemon,
+/obj/item/food/grown/citrus/lime,
+/obj/item/food/grown/citrus/orange,
+/obj/item/food/grown/cherries,
+/obj/item/food/grown/apple,
+/obj/item/food/grown/ambrosia/deus,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/milk,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/space)
+"bn" = (
+/obj/structure/closet,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/space)
+"bo" = (
+/obj/effect/decal/cleanable/food/flour,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"bp" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
+/obj/structure/table/wood/fancy/royalblue,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/orange,
+/area/space)
+"bs" = (
+/obj/structure/frame/computer,
+/turf/open/floor/circuit/green,
+/area/space)
+"bt" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair,
+/obj/machinery/light/directional/north,
+/turf/open/floor/wood/large,
+/area/space)
+"bu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/wood/tile,
+/area/space)
+"bx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"bC" = (
+/obj/structure/chair/sofa/left/brown{
+	dir = 8
+	},
+/turf/open/floor/carpet/lone,
+/area/space)
+"bK" = (
+/obj/structure/chair/comfy/lime{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"bR" = (
+/obj/structure/chair/wood,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/grimy,
+/area/space)
+"cd" = (
+/obj/structure/chair/sofa/right/brown{
+	dir = 8
+	},
+/turf/open/floor/carpet/orange,
+/area/space)
+"ce" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 4
+	},
+/turf/template_noop,
+/area/space)
+"ch" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/turf/open/floor/iron/grimy,
+/area/space)
+"ci" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"cm" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-13"
+	},
+/turf/open/floor/wood/large,
+/area/space)
+"cp" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/south{
+	id = "a6";
+	name = "privacy button"
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/orange,
+/area/space)
+"cy" = (
+/obj/structure/closet/l3closet/janitor,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/grenade/chem_grenade/cleaner,
+/obj/item/clothing/under/rank/civilian/janitor/maid,
+/obj/item/clothing/neck/maid,
+/obj/item/clothing/head/costume/maidheadband,
+/obj/item/clothing/gloves/maid,
+/turf/open/floor/plating,
+/area/space)
+"cB" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/sepia,
+/area/space)
+"cD" = (
+/obj/effect/turf_decal/delivery/white{
+	color = "A46106"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate/medical,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"cI" = (
+/obj/structure/chair/sofa/corp/left,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/blue,
+/area/space)
+"cK" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/dark,
+/area/space)
+"cS" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"cT" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"cV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/space)
+"cX" = (
+/obj/machinery/door/airlock/freezer{
+	name = "Freezer"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/space)
+"dh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/airlock{
+	id_tag = "a6";
+	name = "Guest Room A6"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"dj" = (
+/turf/open/floor/iron/freezer,
+/area/space)
+"dl" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/structure/rack,
+/obj/item/card/id/away/hotel{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/card/id/away/hotel,
+/obj/item/card/id/away/hotel{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/space)
+"dp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/space)
+"dr" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/sepia,
+/area/space)
+"ds" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/displaycase/trophy,
+/turf/open/floor/wood/tile,
+/area/space)
+"dt" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood/parquet,
+/area/space)
+"dy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/space)
+"dD" = (
+/obj/structure/flora/bush/leavy/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/jungle/c/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/window/fulltile,
+/turf/open/floor/grass,
+/area/space)
+"dF" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/space)
+"dI" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/grimy,
+/area/space)
+"dN" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/space)
+"dP" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/sign/poster/official/no_erp/directional/north,
+/turf/open/floor/iron/dark/side,
+/area/space)
+"dR" = (
+/obj/structure/chair/sofa/corner,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"dW" = (
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/carpet/blue,
+/area/space)
+"dX" = (
+/obj/item/flashlight/flare/candle/infinite{
+	pixel_y = 6
+	},
+/obj/structure/table/wood/fancy,
+/turf/open/floor/wood,
+/area/space)
+"eb" = (
+/obj/structure/bed/pod{
+	dir = 4
+	},
+/obj/item/bedsheet/purple{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/space)
+"eg" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"ep" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/chair/comfy/lime{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"et" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Hotel Staff Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/space)
+"ez" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/airlock{
+	id_tag = "a2";
+	name = "Guest Room A2"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"eB" = (
+/obj/structure/chair/wood,
+/turf/open/floor/iron/grimy,
+/area/space)
+"eK" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/space)
+"eM" = (
+/obj/structure/cable,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/computer/records/security{
+	dir = 1
+	},
+/turf/open/floor/carpet/neon/simple/red/nodots,
+/area/space)
+"eR" = (
+/turf/open/floor/wood/tile,
+/area/space)
+"eS" = (
+/obj/structure/toilet/secret{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/machinery/door/window/survival_pod{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"eT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/sign/poster/random/directional/north,
+/obj/machinery/vending/imported/yangyu,
+/turf/open/floor/carpet/blue,
+/area/space)
+"eX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"eY" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/airlock/grunge{
+	name = "Hotel Staff Room"
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"fa" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"fh" = (
+/obj/structure/chair/sofa/right/brown{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/red,
+/area/space)
+"fs" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
+	},
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/space)
+"fy" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"fC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/space)
+"fD" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"fN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"fQ" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space)
+"fR" = (
+/obj/structure/chair/sofa/right/brown{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/carpet/purple,
+/area/space)
+"fY" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/space)
+"ga" = (
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood/tile,
+/area/space)
+"gj" = (
+/obj/machinery/shower/directional/east,
+/obj/item/bikehorn/rubberducky,
+/turf/open/floor/iron/freezer,
+/area/space)
+"go" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/space)
+"gp" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space)
+"gx" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/wood/large,
+/area/space)
+"gB" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Pool"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/space)
+"gC" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/iron/sepia,
+/area/space)
+"gI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/closet/crate/bin,
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/wood/tile,
+/area/space)
+"gN" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/sepia,
+/area/space)
+"gS" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/flashlight/lamp,
+/turf/open/floor/carpet/green,
+/area/space)
+"gX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"hi" = (
+/obj/structure/sink/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"hp" = (
+/obj/structure/chair/sofa/right,
+/obj/item/bedsheet/patriot{
+	pixel_y = 3;
+	pixel_x = 6
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/effect/turf_decal/siding/dark{
+	dir = 9
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"hs" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"hy" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-16"
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"hz" = (
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plating,
+/area/space)
+"hA" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Dock"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/space)
+"hC" = (
+/obj/structure/table/wood/fancy/green,
+/turf/open/floor/carpet/purple,
+/area/space)
+"hG" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/displaycase/trophy,
+/turf/open/floor/wood/tile,
+/area/space)
+"hK" = (
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"hQ" = (
+/obj/structure/chair/sofa/right/brown{
+	dir = 4
+	},
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/space)
+"hR" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/ian,
+/turf/open/floor/wood/parquet,
+/area/space)
+"hU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/iron/grimy,
+/area/space)
+"hY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/north,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/wood,
+/area/space)
+"id" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/grimy,
+/area/space)
+"iq" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"iA" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/item/card/id/away/hotel/security,
+/turf/open/floor/carpet/neon/simple/red/nodots,
+/area/space)
+"iB" = (
+/obj/structure/cable,
+/obj/machinery/power/smes/engineering,
+/turf/open/floor/plating,
+/area/space)
+"iM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/parquet,
+/area/space)
+"iN" = (
+/obj/structure/fluff/beach_umbrella/syndi,
+/turf/open/misc/beach/sand,
+/area/space)
+"iR" = (
+/obj/structure/cable,
+/obj/structure/closet/secure_closet{
+	name = "contraband locker"
+	},
+/obj/effect/spawner/random/contraband/armory,
+/obj/effect/spawner/random/contraband,
+/obj/item/card/emagfake,
+/obj/item/card/id/fake_card,
+/turf/open/floor/carpet/neon/simple/red/nodots,
+/area/space)
+"iS" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"iU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/space)
+"iX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/mug/tea,
+/turf/open/floor/stone,
+/area/space)
+"jf" = (
+/obj/structure/fluff/tram_rail/end,
+/obj/structure/fluff/tram_rail/end{
+	pixel_y = 17
+	},
+/turf/template_noop,
+/area/space)
+"jg" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/space)
+"jh" = (
+/obj/structure/table/wood/fancy/green,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/carpet/purple,
+/area/space)
+"jG" = (
+/obj/structure/table/wood/fancy/cyan,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood/parquet,
+/area/space)
+"jH" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/space)
+"jI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/airlock{
+	id_tag = "a5";
+	name = "Guest Room A5"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"jR" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"jU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/space)
+"kn" = (
+/turf/template_noop,
+/area/space)
+"kq" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/teleport/station,
+/turf/open/floor/wood/large,
+/area/space)
+"ks" = (
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron,
+/area/space)
+"ku" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom"
+	},
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/space)
+"ky" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/space)
+"kI" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/storage/medkit/regular,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
+/area/space)
+"kQ" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/camera/directional/east{
+	c_tag = "Docking Area";
+	network = list("spacehotel")
+	},
+/turf/open/floor/iron/dark,
+/area/space)
+"kW" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/item/pillow/clown,
+/obj/effect/turf_decal/siding/dark,
+/turf/open/floor/carpet/blue,
+/area/space)
+"lc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/space)
+"lf" = (
+/obj/structure/cable,
+/turf/open/floor/wood/parquet,
+/area/space)
+"ll" = (
+/obj/structure/cable,
+/obj/structure/rack,
+/obj/item/clothing/suit/space/syndicate/black/blue{
+	desc = "A 'Nanotrasen Special Response Team' space suit, according to the tag.";
+	name = "Nanotrasen SRT space suit"
+	},
+/obj/item/clothing/head/helmet/space/syndicate/blue{
+	name = "Nanotrasen SRT space helmet";
+	desc = "A 'Nanotrasen Special Response Team' helmet, according to the tag."
+	},
+/turf/open/floor/glass/reinforced,
+/area/space)
+"lA" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"lC" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/comfy,
+/turf/open/floor/iron/dark,
+/area/space)
+"lD" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/space)
+"lT" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space)
+"mc" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/wood/parquet,
+/area/space)
+"me" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"mg" = (
+/obj/item/beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/space)
+"mk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
+/obj/structure/table/wood/fancy/orange,
+/obj/machinery/light/directional/north,
+/obj/item/reagent_containers/cup/glass/mug/tea,
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"mn" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Hotel Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
+/turf/open/floor/plating,
+/area/space)
+"mo" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood/parquet,
+/area/space)
+"mx" = (
+/obj/structure/chair/wood,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/grimy,
+/area/space)
+"mB" = (
+/obj/machinery/light/small/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"mH" = (
+/obj/structure/toilet{
+	dir = 1
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/freezer,
+/area/space)
+"mQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/space)
+"mU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"mX" = (
+/turf/open/floor/plating,
+/area/space)
+"mZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/space)
+"nd" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/wood/parquet,
+/area/space)
+"ng" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/airlock{
+	id_tag = "a4";
+	name = "Guest Room A4"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"nn" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair,
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
+/turf/open/floor/wood/large,
+/area/space)
+"nq" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"ns" = (
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"nu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/space)
+"nz" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/iron/grimy,
+/area/space)
+"nG" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/wood/large,
+/area/space)
+"nK" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/template_noop,
+/area/space)
+"nQ" = (
+/obj/machinery/door/airlock{
+	name = "Public Restroom/Showers"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood/tile,
+/area/space)
+"nR" = (
+/obj/structure/table/wood/fancy/cyan,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/carpet/red,
+/area/space)
+"nW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"nX" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"ob" = (
+/obj/structure/sign/poster/contraband/random/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"od" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/south{
+	id = "a3";
+	name = "privacy button";
+	pixel_y = 24
+	},
+/turf/open/floor/carpet/red,
+/area/space)
+"oj" = (
+/obj/structure/table/wood,
+/turf/open/floor/carpet/black,
+/area/space)
+"oq" = (
+/turf/open/misc/beach/coastline_t{
+	dir = 8
+	},
+/area/space)
+"ot" = (
+/turf/open/floor/iron/grimy,
+/area/space)
+"ov" = (
+/obj/machinery/light/directional/west,
+/turf/open/misc/beach/sand,
+/area/space)
+"oE" = (
+/obj/structure/chair/sofa/corp{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"oL" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering{
+	name = "Utilities"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/away/general,
+/obj/effect/mapping_helpers/airlock/access/any/away/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/space)
+"oQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/sepia,
+/area/space)
+"oV" = (
+/obj/structure/table/wood,
+/obj/item/paper/pamphlet/ruin/spacehotel,
+/turf/open/floor/wood/tile,
+/area/space)
+"oW" = (
+/obj/structure/frame,
+/obj/item/stack/cable_coil/five,
+/obj/item/stock_parts/micro_laser/quadultra,
+/turf/open/floor/circuit/green,
+/area/space)
+"oZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/wood/tile,
+/area/space)
+"pb" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"pc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"pd" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/template_noop,
+/area/space)
+"pl" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/blue,
+/area/space)
+"pn" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"pp" = (
+/obj/structure/sink/kitchen/directional/west,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"ps" = (
+/obj/structure/railing,
+/turf/open/floor/iron/stairs/old{
+	dir = 8
+	},
+/area/space)
+"pt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/space)
+"pA" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/grimy,
+/area/space)
+"pN" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/structure/cable,
+/obj/item/paper_bin,
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
+/area/space)
+"pO" = (
+/obj/structure/sink/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"pU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"pZ" = (
+/obj/effect/turf_decal/delivery/white{
+	color = "A46106"
+	},
+/obj/structure/closet/crate/rcd,
+/obj/effect/spawner/random/decoration/carpet,
+/obj/effect/spawner/random/decoration/material,
+/obj/effect/spawner/random/engineering/material,
+/obj/effect/spawner/random/engineering/material_cheap,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"qa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"qb" = (
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"qc" = (
+/obj/machinery/light/directional/east,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"qd" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/machinery/coffeemaker,
+/turf/open/floor/glass/reinforced,
+/area/space)
+"qe" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"qg" = (
+/obj/structure/cable,
+/obj/structure/rack,
+/obj/item/melee/baton/security/loaded,
+/turf/open/floor/glass/reinforced,
+/area/space)
+"qh" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/turf/template_noop,
+/area/space)
+"qi" = (
+/obj/structure/fluff/tram_rail/end{
+	dir = 8
+	},
+/turf/template_noop,
+/area/space)
+"qr" = (
+/obj/structure/chair/plastic,
+/obj/structure/cable,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/sepia,
+/area/space)
+"qt" = (
+/obj/structure/chair/sofa/left/brown{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet/red,
+/area/space)
+"qv" = (
+/obj/item/book/manual/wiki/detective,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/food/burger/crazy,
+/obj/item/reagent_containers/cup/soda_cans/cola{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/effect/turf_decal/siding/dark{
+	dir = 10
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"qH" = (
+/turf/open/floor/wood,
+/area/space)
+"qJ" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"qO" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
+/obj/structure/table/wood/fancy/cyan,
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/red,
+/area/space)
+"qS" = (
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/structure/table/wood/fancy,
+/turf/open/floor/wood,
+/area/space)
+"ra" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "htsec"
+	},
+/turf/open/floor/plating,
+/area/space)
+"re" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/space)
+"rA" = (
+/turf/open/floor/stone,
+/area/space)
+"rB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
+/turf/open/floor/wood,
+/area/space)
+"rI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood/tile,
+/area/space)
+"rN" = (
+/obj/machinery/button{
+	id = "hcb1";
+	name = "shutters control";
+	pixel_x = 26;
+	pixel_y = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"rT" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 1;
+	icon_state = "roomnum";
+	name = "Room Number 2";
+	pixel_y = 24
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"rY" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/template_noop,
+/area/space)
+"rZ" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space)
+"sc" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/closet/crate/bin,
+/turf/open/floor/wood/tile,
+/area/space)
+"sh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor,
+/area/space)
+"si" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/sepia,
+/area/space)
+"sj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"sk" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "htsec"
+	},
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"sq" = (
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plating,
+/area/space)
+"sr" = (
+/obj/structure/cable,
+/turf/open/floor/carpet/neon/simple/red/nodots,
+/area/space)
+"ss" = (
+/obj/structure/fluff/tram_rail{
+	pixel_y = 17
+	},
+/obj/structure/fluff/tram_rail,
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/space)
+"su" = (
+/obj/structure/filingcabinet,
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/tile,
+/area/space)
+"sv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/microwave{
+	pixel_y = 7
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"sy" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
+/area/space)
+"sC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"sF" = (
+/obj/structure/cable,
+/turf/closed/wall/r_wall,
+/area/space)
+"sH" = (
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/turf/open/floor/iron/sepia,
+/area/space)
+"sJ" = (
+/turf/open/floor/iron/dark,
+/area/space)
+"sK" = (
+/turf/open/floor/carpet/green,
+/area/space)
+"sU" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/blue,
+/area/space)
+"sX" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/side,
+/area/space)
+"sZ" = (
+/obj/structure/window/spawner/directional/west,
+/obj/structure/toilet{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"tc" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-06"
+	},
+/turf/open/floor/iron/sepia,
+/area/space)
+"td" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/space)
+"tf" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/stairs/old{
+	dir = 8
+	},
+/area/space)
+"to" = (
+/obj/structure/table/wood,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/space)
+"tp" = (
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"tt" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/freezer,
+/area/space)
+"tv" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Dining"
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/space)
+"tw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood/parquet,
+/area/space)
+"ty" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/grimy,
+/area/space)
+"tF" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing,
+/obj/structure/cable,
+/turf/template_noop,
+/area/space)
+"tG" = (
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/iron/dark,
+/area/space)
+"tH" = (
+/obj/item/reagent_containers/condiment/flour,
+/obj/effect/decal/cleanable/food/flour,
+/turf/open/floor/iron/kitchen_coldroom/freezerfloor,
+/area/space)
+"tL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"tP" = (
+/obj/structure/fluff/tram_rail/end{
+	dir = 8;
+	pixel_y = 17
+	},
+/turf/template_noop,
+/area/space)
+"tT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-03"
+	},
+/turf/open/floor/iron/dark,
+/area/space)
+"tY" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/recharger,
+/turf/open/floor/carpet/neon/simple/red/nodots,
+/area/space)
+"uc" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark,
+/area/space)
+"uh" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/light/directional/south,
+/turf/open/floor/stone,
+/area/space)
+"ul" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/orange,
+/area/space)
+"um" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Dining"
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/space)
+"up" = (
+/obj/structure/chair/sofa/middle,
+/obj/item/pillow/clown,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/effect/turf_decal/siding/dark{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"us" = (
+/obj/effect/turf_decal/delivery/white{
+	color = "A46106"
+	},
+/obj/structure/closet/crate/wooden/toy,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"ux" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/template_noop,
+/area/space)
+"uT" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood/parquet,
+/area/space)
+"uZ" = (
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/turf/open/floor/wood/parquet,
+/area/space)
+"va" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"vc" = (
+/obj/structure/cable,
+/turf/open/floor/glass/reinforced,
+/area/space)
+"vl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Dining"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/space)
+"vn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"vo" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/obj/item/gps/spaceruin{
+	name = "hotel gps"
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 1
+	},
+/area/space)
+"vq" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering{
+	name = "Utilities"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/away/general,
+/obj/effect/mapping_helpers/airlock/access/any/away/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/space)
+"vr" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/carpet/black,
+/area/space)
+"vy" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/space)
+"vz" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/chair/comfy/lime{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"vI" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/grimy,
+/area/space)
+"vJ" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/red/line,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/food/burger/rat,
+/obj/item/reagent_containers/cup/soda_cans/cola{
+	pixel_x = -7;
+	pixel_y = 13
+	},
+/obj/effect/turf_decal/trimline/yellow/line,
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"vL" = (
+/obj/structure/frame,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/circuitboard/machine/announcement_system,
+/obj/item/stock_parts/micro_laser/quadultra,
+/obj/item/stock_parts/matter_bin/adv,
+/turf/open/floor/circuit/green,
+/area/space)
+"vP" = (
+/obj/structure/cable,
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/space)
+"vX" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/railing,
+/turf/template_noop,
+/area/space)
+"wr" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/firedoor,
+/turf/open/floor/stone,
+/area/space)
+"ws" = (
+/obj/structure/cable,
+/turf/open/floor/iron/sepia,
+/area/space)
+"wt" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"wu" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Hotel Staff Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/space)
+"wv" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"wx" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"wB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/space)
+"wD" = (
+/obj/item/soap,
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"wF" = (
+/obj/structure/sign/poster/random/directional/north,
+/turf/closed/wall,
+/area/space)
+"wP" = (
+/turf/open/misc/beach/sand,
+/area/space)
+"wQ" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"wR" = (
+/obj/structure/window/spawner/directional/north,
+/obj/machinery/shower/directional/south,
+/turf/open/floor/iron/freezer,
+/area/space)
+"wT" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/template_noop,
+/area/space)
+"wX" = (
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"xa" = (
+/obj/structure/chair/sofa/bench/left,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"xc" = (
+/turf/open/floor/carpet/purple,
+/area/space)
+"xe" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/wood,
+/area/space)
+"xg" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/railing/corner,
+/turf/template_noop,
+/area/space)
+"xi" = (
+/obj/structure/fluff/tram_rail{
+	pixel_y = 17
+	},
+/turf/template_noop,
+/area/space)
+"xk" = (
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/space)
+"xn" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"xp" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/space)
+"xt" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Dock"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/textured_half{
+	dir = 1
+	},
+/area/space)
+"xu" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space)
+"xw" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/template_noop,
+/area/space)
+"xx" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy/red,
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
+/turf/open/floor/carpet/green,
+/area/space)
+"xB" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/under/syndicate/tacticool,
+/obj/effect/turf_decal/delivery/white{
+	color = "A46106"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"xD" = (
+/obj/structure/sign/warning/vacuum,
+/turf/closed/wall,
+/area/space)
+"xI" = (
+/obj/structure/cable,
+/obj/item/paperwork/security,
+/obj/structure/table/reinforced,
+/turf/open/floor/carpet/neon/simple/red/nodots,
+/area/space)
+"xN" = (
+/obj/item/gun/ballistic/automatic/pistol/m1911{
+	spawnwithmagazine = 0
+	},
+/obj/item/ammo_box/magazine/m45,
+/obj/structure/closet/syndicate{
+	anchored = 1
+	},
+/obj/item/clothing/glasses/night,
+/obj/machinery/light/directional/west,
+/obj/item/bodybag/environmental/prisoner/pressurized,
+/obj/item/bodybag/environmental/prisoner/pressurized,
+/turf/open/floor/carpet/neon/simple/red/nodots,
+/area/space)
+"xS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/grimy,
+/area/space)
+"xU" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/space)
+"xV" = (
+/obj/machinery/griddle,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"xX" = (
+/obj/structure/chair/sofa/corp/right,
+/turf/open/floor/carpet/blue,
+/area/space)
+"yo" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
+	},
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/wood/tile,
+/area/space)
+"yq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
+"yt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/iron/dark,
+/area/space)
+"yv" = (
+/obj/effect/spawner/random/vending/snackvend,
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron,
+/area/space)
+"yy" = (
+/obj/structure/table/wood,
+/obj/item/paper/pamphlet/ruin/spacehotel,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"yz" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-03"
+	},
+/turf/open/floor/iron/freezer,
+/area/space)
+"yA" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Guest Suites"
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/space)
+"yG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Armory Desk";
+	req_access = list("armory")
+	},
+/obj/machinery/door/window/left/directional/south{
+	name = "Reception Desk";
+	req_access = list("security")
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/neon/simple/red/nodots,
+/area/space)
+"yM" = (
+/obj/structure/toilet{
+	pixel_y = 5
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/freezer,
+/area/space)
+"yN" = (
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"yO" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing/corner,
+/obj/structure/cable,
+/turf/template_noop,
+/area/space)
+"yQ" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/light/directional/south,
+/obj/structure/sign/poster/contraband/random/directional/south,
+/turf/open/floor/iron/dark/smooth_edge,
+/area/space)
+"zc" = (
+/obj/structure/mop_bucket/janitorialcart,
+/obj/item/mop/advanced,
+/obj/item/storage/bag/trash,
+/obj/item/holosign_creator/janibarrier,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/lightreplacer,
+/obj/structure/sign/poster/official/cleanliness/directional/north,
+/turf/open/floor/plating,
+/area/space)
+"zd" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"zi" = (
+/obj/machinery/power/solar,
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel/airless,
+/area/space)
+"zm" = (
+/obj/structure/filingcabinet,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
+/area/space)
+"zn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/grimy,
+/area/space)
+"zr" = (
+/turf/open/floor/carpet/orange,
+/area/space)
+"zt" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/structure/rack,
+/obj/item/crowbar,
+/obj/item/storage/medkit/regular,
+/obj/item/paper/fluff/ruins/spacehotel/notice,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
+/area/space)
+"zx" = (
+/obj/structure/chair/office/tactical,
+/obj/machinery/button{
+	id = "htsec";
+	name = "shutters control";
+	pixel_x = -25;
+	pixel_y = -1
+	},
+/turf/open/floor/glass/reinforced,
+/area/space)
+"zy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"zz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/wood/parquet,
+/area/space)
+"zC" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"zY" = (
+/obj/structure/sink/directional/north,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"Aa" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"Ab" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
+/obj/structure/table/wood/fancy/green,
+/turf/open/floor/carpet/purple,
+/area/space)
+"Am" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"Ao" = (
+/obj/structure/cable,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/machinery/computer/security{
+	dir = 1
+	},
+/turf/open/floor/carpet/neon/simple/red/nodots,
+/area/space)
+"Ay" = (
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"AA" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/reagent_containers/cup/glass/mug/tea,
+/turf/open/floor/carpet/orange,
+/area/space)
+"AC" = (
+/obj/effect/turf_decal/trimline/red/line,
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/line,
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"AF" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/space)
+"AI" = (
+/obj/effect/turf_decal/trimline/red/line,
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/structure/sign/poster/contraband/clown/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"AQ" = (
+/obj/structure/sign/poster/contraband/random/directional/west,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/space)
+"AT" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/item/paper_bin,
+/turf/open/floor/wood/tile,
+/area/space)
+"AX" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters{
+	id = "hcb2";
+	name = "Cargo Bay Shutters"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"Bh" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/armor/vest/old,
+/obj/item/clothing/head/helmet/old,
+/turf/open/floor/glass/reinforced,
+/area/space)
+"Bl" = (
+/obj/structure/chair/sofa/left/brown{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/wood/parquet,
+/area/space)
+"Bm" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 6
+	},
+/turf/template_noop,
+/area/space)
+"Bo" = (
+/obj/structure/table/wood/fancy/orange,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"Bq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 6;
+	icon_state = "roomnum";
+	name = "Room Number 5";
+	pixel_y = -24
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"Bs" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 8;
+	icon_state = "roomnum";
+	name = "Room Number 4";
+	pixel_y = 24
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"Bv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/camera/directional/east{
+	c_tag = "Diner";
+	network = list("spacehotel")
+	},
+/turf/open/floor/iron/grimy,
+/area/space)
+"BA" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/bag/tray,
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = 5
+	},
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"BB" = (
+/turf/open/floor/carpet/blue,
+/area/space)
+"BC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "htsec"
+	},
+/turf/open/floor/plating,
+/area/space)
+"BE" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/item/kirbyplants{
+	icon_state = "applebush"
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/dark,
+/area/space)
+"BL" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"BN" = (
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 10
+	},
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"BP" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/space)
+"BV" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood/corner,
+/obj/effect/spawner/random/bureaucracy,
+/turf/open/floor/wood/tile,
+/area/space)
+"BX" = (
+/turf/open/floor/glass/reinforced,
+/area/space)
+"BZ" = (
+/obj/structure/chair/comfy{
+	dir = 4
+	},
+/obj/structure/sign/poster/random/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/space)
+"Cm" = (
+/obj/structure/table/wood,
+/obj/item/paper/pamphlet/ruin/spacehotel,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"Co" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/green,
+/area/space)
+"Cv" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"CB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"CK" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Swimming Pool";
+	network = list("spacehotel")
+	},
+/turf/open/floor/iron/sepia,
+/area/space)
+"CN" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"CO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"CS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"CW" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Handy Shop"
+	},
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/space)
+"CX" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks{
+	dir = 4;
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/glass/shaker{
+	pixel_x = 6;
+	pixel_y = 17
+	},
+/obj/item/gun/ballistic/shotgun/doublebarrel{
+	pixel_y = -11
+	},
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"Da" = (
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/iron/sepia,
+/area/space)
+"Db" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"Dg" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/template_noop,
+/area/space)
+"Dj" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/stone,
+/area/space)
+"Dk" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor{
+	id = "hcd1";
+	name = "Cargo Dock"
+	},
+/turf/open/floor/plating,
+/area/space)
+"Dl" = (
+/obj/effect/decal/cleanable/food/flour,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"Dp" = (
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"Dq" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/structure/rack,
+/turf/open/floor/iron/sepia,
+/area/space)
+"Du" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/carpet/black,
+/area/space)
+"Dv" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron/dark/side,
+/area/space)
+"Dw" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/space)
+"Dy" = (
+/turf/open/floor/iron/sepia,
+/area/space)
+"DA" = (
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"DD" = (
+/obj/effect/turf_decal/trimline/red/line,
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/line,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"DN" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark/side,
+/area/space)
+"DT" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/template_noop,
+/area/space)
+"DW" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/green,
+/area/space)
+"Ec" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"Ed" = (
+/obj/machinery/light/directional/north,
+/obj/structure/chair/comfy{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/space)
+"Ee" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
+/obj/structure/table/wood/fancy/purple,
+/turf/open/floor/carpet/lone,
+/area/space)
+"Eh" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/sepia,
+/area/space)
+"Es" = (
+/obj/machinery/door/airlock/grunge{
+	name = "Hotel Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/iron/textured_half{
+	dir = 4
+	},
+/area/space)
+"EC" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/white,
+/obj/structure/rack,
+/turf/open/floor/iron/sepia,
+/area/space)
+"EG" = (
+/obj/structure/table/wood/fancy/purple,
+/obj/item/paper_bin,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/obj/item/pen,
+/turf/open/floor/carpet/lone,
+/area/space)
+"EH" = (
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/grimy,
+/area/space)
+"EL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/glass/reinforced,
+/area/space)
+"EN" = (
+/obj/structure/fluff/tram_rail/end,
+/turf/template_noop,
+/area/space)
+"EP" = (
+/obj/structure/table/wood/fancy/red,
+/turf/open/floor/wood/parquet,
+/area/space)
+"EV" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/space)
+"Fa" = (
+/obj/structure/window/spawner/directional/east,
+/obj/structure/toilet{
+	pixel_y = 5
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"Fj" = (
+/obj/structure/chair/sofa/left/brown{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/carpet/orange,
+/area/space)
+"Fk" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/maintenance{
+	name = "Hotel Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/space)
+"Fq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/processor{
+	pixel_y = 12
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"Fr" = (
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
+/turf/open/floor/wood/tile,
+/area/space)
+"Fs" = (
+/obj/structure/chair/sofa/right/brown{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"Ft" = (
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"Fv" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/grimy,
+/area/space)
+"Fz" = (
+/mob/living/simple_animal/bot/secbot/beepsky/armsky{
+	name = "Hotelsky";
+	desc = "It's Hotelsky! He's a disgruntled servant of the hotel that would probably shoot you if he had hands."
+	},
+/turf/open/floor/carpet/neon/simple/red/nodots,
+/area/space)
+"FC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/stone,
+/area/space)
+"FG" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space)
+"FS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/button/door/directional/south{
+	id = "a4";
+	name = "privacy button"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"FU" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/egg_box,
+/obj/item/knife/kitchen,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"FY" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron/dark,
+/area/space)
+"Gd" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"Gh" = (
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/freezer,
+/area/space)
+"Gi" = (
+/obj/effect/turf_decal/siding/white/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"Gn" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"Gw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/space)
+"GE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/musician/piano,
+/turf/open/floor/stone,
+/area/space)
+"GP" = (
+/obj/machinery/light/directional/north,
+/obj/structure/sign/poster/contraband/random/directional/north,
+/obj/effect/mob_spawn/ghost_role/human/hotel_staff,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/space)
+"GS" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/flashlight/lamp,
+/turf/open/floor/wood/parquet,
+/area/space)
+"GW" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Hotel Maintenance"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/maintenance,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space)
+"GX" = (
+/obj/structure/fluff/tram_rail,
+/obj/structure/fluff/tram_rail/end{
+	pixel_y = 17
+	},
+/turf/template_noop,
+/area/space)
+"GY" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/table/reinforced,
+/obj/item/crowbar/large/old,
+/obj/effect/mapping_helpers/apc/cell_10k,
+/turf/open/floor/glass/reinforced,
+/area/space)
+"GZ" = (
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/space)
+"Ha" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plating,
+/area/space)
+"Hb" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space)
+"Hk" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/dark,
+/area/space)
+"Hl" = (
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/wood/tile,
+/area/space)
+"Hp" = (
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"Hv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/glass/reinforced,
+/area/space)
+"HO" = (
+/obj/structure/chair/plastic,
+/obj/structure/cable,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/sepia,
+/area/space)
+"HT" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/structure/table/reinforced,
+/obj/machinery/chem_dispenser/drinks/beer{
+	dir = 4;
+	pixel_x = -4;
+	pixel_y = 0
+	},
+/obj/item/reagent_containers/cup/rag{
+	pixel_x = 10;
+	pixel_y = 17
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"HU" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"HV" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/obj/structure/sink/directional/west,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/plating,
+/area/space)
+"HW" = (
+/obj/structure/bed/pod{
+	dir = 4
+	},
+/obj/item/bedsheet/blue{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/space)
+"HZ" = (
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"Ia" = (
+/obj/structure/table/wood/fancy/green,
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/wood/parquet,
+/area/space)
+"Ic" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"Iu" = (
+/obj/structure/fluff/tram_rail,
+/obj/structure/fluff/tram_rail{
+	pixel_y = 17
+	},
+/turf/template_noop,
+/area/space)
+"Ix" = (
+/obj/structure/sign/poster/contraband/random/directional/east,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
+/area/space)
+"IA" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/freezer,
+/area/space)
+"IJ" = (
+/obj/effect/turf_decal/loading_area,
+/obj/machinery/button{
+	id = "hcb2";
+	name = "shutters control";
+	pixel_x = -25;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/dark,
+/area/space)
+"IK" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plating,
+/area/space)
+"IQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/space)
+"IW" = (
+/obj/machinery/firealarm/directional/east,
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
+/turf/open/floor/iron/sepia,
+/area/space)
+"IX" = (
+/obj/structure/closet/crate/secure/engineering,
+/obj/item/wrench/caravan,
+/obj/item/wirecutters/caravan,
+/obj/item/crowbar/red/caravan,
+/obj/item/screwdriver/caravan,
+/obj/effect/turf_decal/delivery/white{
+	color = "A46106"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"Ja" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/space)
+"Jg" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/computer/teleporter,
+/turf/open/floor/wood/large,
+/area/space)
+"Jh" = (
+/obj/structure/chair/comfy,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/dark/side,
+/area/space)
+"Jj" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"Jn" = (
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/airless,
+/area/space)
+"Jz" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/space)
+"JF" = (
+/obj/structure/cable,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/sepia,
+/area/space)
+"JG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"JI" = (
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"JO" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/stone,
+/area/space)
+"JQ" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 24;
+	name = "Space Hotel docking station";
+	shuttle_id = "whiteship_home";
+	width = 35
+	},
+/turf/template_noop,
+/area/space)
+"JV" = (
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side,
+/area/space)
+"JW" = (
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/stone,
+/area/space)
+"Ka" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
+/obj/structure/table/wood/fancy/purple,
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/lone,
+/area/space)
+"Kd" = (
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"Ki" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/green,
+/area/space)
+"Km" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/template_noop,
+/area/space)
+"Ko" = (
+/obj/structure/frame,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/circuitboard/machine/pacman,
+/obj/item/stack/cable_coil/five,
+/obj/item/stock_parts/matter_bin/adv,
+/turf/open/floor/circuit/green,
+/area/space)
+"Kv" = (
+/obj/machinery/light/directional/west,
+/obj/structure/dresser,
+/turf/open/floor/wood/parquet,
+/area/space)
+"Kw" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/template_noop,
+/area/space)
+"KE" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/carpet/lone,
+/area/space)
+"KF" = (
+/obj/structure/chair/stool/directional/east,
+/turf/open/floor/stone,
+/area/space)
+"KM" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/freezer,
+/area/space)
+"KP" = (
+/obj/structure/sign/warning/no_smoking,
+/turf/closed/wall,
+/area/space)
+"KR" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/side,
+/area/space)
+"KS" = (
+/turf/open/floor/iron/dark/side,
+/area/space)
+"KV" = (
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"KW" = (
+/obj/structure/sink/directional/west,
+/obj/machinery/firealarm/directional/north,
+/turf/open/floor/iron/freezer,
+/area/space)
+"Lb" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/plating,
+/area/space)
+"Lk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/wood,
+/area/space)
+"Lo" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/space)
+"Lt" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/caution/stand_clear{
+	dir = 8
+	},
+/obj/machinery/door/airlock/grunge{
+	name = "Hotel Kitchen"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/space)
+"Lv" = (
+/obj/structure/chair/sofa/left/brown{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/carpet/purple,
+/area/space)
+"Lz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/space)
+"LB" = (
+/obj/effect/mob_spawn/ghost_role/human/hotel_staff,
+/turf/open/floor/iron/dark/smooth_corner,
+/area/space)
+"LC" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-16"
+	},
+/obj/structure/sign/poster/random/directional/west,
+/turf/open/floor/carpet/blue,
+/area/space)
+"LG" = (
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/sepia,
+/area/space)
+"LK" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/wood/tile,
+/area/space)
+"LT" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side,
+/area/space)
+"LW" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/closet/crate/bin,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/space)
+"Me" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/space)
+"Mg" = (
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark/side,
+/area/space)
+"Mm" = (
+/obj/structure/closet/crate/freezer,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/wheat,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/potato,
+/obj/item/food/grown/carrot,
+/obj/item/food/grown/carrot,
+/obj/item/food/grown/carrot,
+/obj/item/food/grown/carrot,
+/obj/item/food/grown/carrot,
+/obj/item/food/grown/carrot,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/item/food/grown/tomato,
+/obj/effect/turf_decal/delivery/white{
+	color = "A46106"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"Mr" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Guest Hallway Port";
+	network = list("spacehotel")
+	},
+/turf/open/floor/iron/grimy,
+/area/space)
+"Mt" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"Mu" = (
+/obj/structure/chair/wood,
+/turf/open/floor/wood,
+/area/space)
+"MC" = (
+/obj/machinery/camera{
+	c_tag = "Medbay Lobby";
+	dir = 5;
+	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/trimline/red/end{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/end{
+	dir = 4
+	},
+/obj/machinery/computer/arcade{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"MF" = (
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"MJ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	icon_state = "roomnum";
+	name = "Room Number 1";
+	pixel_y = -24
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"ML" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/template_noop,
+/area/space)
+"MM" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner,
+/turf/template_noop,
+/area/space)
+"MO" = (
+/obj/machinery/shower/directional/east,
+/turf/open/floor/iron/freezer,
+/area/space)
+"MP" = (
+/obj/structure/chair/wood,
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
+/turf/open/floor/iron/grimy,
+/area/space)
+"MT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
+"MU" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/paper_bin,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/obj/item/pen,
+/turf/open/floor/carpet/orange,
+/area/space)
+"MV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"MZ" = (
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 5
+	},
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"Nf" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/template_noop,
+/area/space)
+"Nj" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Handy Shop"
+	},
+/turf/open/floor/iron/dark/textured_half,
+/area/space)
+"Nl" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/misc/beach/sand,
+/area/space)
+"Np" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 4;
+	icon_state = "roomnum";
+	name = "Room Number 3";
+	pixel_y = -24
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"Nv" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"NB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
+/obj/structure/table/wood/fancy/orange,
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"ND" = (
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/grimy,
+/area/space)
+"NK" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/space)
+"NL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/parquet,
+/area/space)
+"NM" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/space)
+"NO" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/corner,
+/area/space)
+"NS" = (
+/obj/structure/chair/sofa/corp/left,
+/turf/open/floor/carpet/blue,
+/area/space)
+"NT" = (
+/turf/open/floor/wood/parquet,
+/area/space)
+"NU" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/red,
+/turf/open/floor/carpet/green,
+/area/space)
+"NW" = (
+/obj/structure/chair/sofa/corp/right,
+/obj/machinery/light/directional/north,
+/turf/open/floor/carpet/blue,
+/area/space)
+"NX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/layer_manifold/supply{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
+"NY" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/burgundy,
+/turf/template_noop,
+/area/space)
+"NZ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Pool"
+	},
+/turf/open/floor/iron/freezer,
+/area/space)
+"Oa" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/space)
+"Ob" = (
+/turf/open/floor/carpet/red,
+/area/space)
+"Of" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/space)
+"Oi" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/space)
+"Ou" = (
+/obj/machinery/light/directional/north,
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 4
+	},
+/area/space)
+"OB" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"OD" = (
+/obj/machinery/light/directional/east,
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/floor/carpet/black,
+/area/space)
+"OG" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/template_noop,
+/area/space)
+"OI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"OO" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/template_noop,
+/area/space)
+"OQ" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters{
+	id = "hcb2";
+	name = "Cargo Bay Shutters"
+	},
+/turf/open/floor/plating,
+/area/space)
+"OR" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/south{
+	id = "a5";
+	name = "privacy button";
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/purple,
+/area/space)
+"OS" = (
+/obj/structure/dresser,
+/turf/open/floor/wood/parquet,
+/area/space)
+"Pe" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/structure/table/wood,
+/obj/item/instrument/guitar,
+/turf/open/floor/stone,
+/area/space)
+"Pn" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/turf/open/floor/carpet/purple,
+/area/space)
+"Pp" = (
+/obj/item/toy/beach_ball,
+/turf/open/misc/beach/sand,
+/area/space)
+"Pq" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/east,
+/obj/item/storage/toolbox/mechanical/old/clean,
+/turf/open/floor/carpet/neon/simple/red/nodots,
+/area/space)
+"Pv" = (
+/obj/structure/table/wood/fancy/purple,
+/turf/open/floor/carpet/lone,
+/area/space)
+"Px" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/wood/tile,
+/area/space)
+"PB" = (
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"PC" = (
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/space)
+"PE" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/template_noop,
+/area/space)
+"PK" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 9
+	},
+/obj/machinery/vending/imported,
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"PL" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/space)
+"PM" = (
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"PN" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/security/glass{
+	name = "Hotel Armory"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/security,
+/turf/open/floor/carpet/neon/simple/red/nodots,
+/area/space)
+"PT" = (
+/obj/machinery/light/directional/south,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"PU" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"PW" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/stone,
+/area/space)
+"PX" = (
+/turf/open/floor/carpet/lone,
+/area/space)
+"PY" = (
+/obj/structure/cable,
+/obj/machinery/power/solar_control{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/space)
+"Qf" = (
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/space)
+"Qg" = (
+/obj/structure/cable,
+/obj/item/clothing/head/cone,
+/turf/open/floor/plating,
+/area/space)
+"Qh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Dining"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/space)
+"Qi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/sepia,
+/area/space)
+"Qj" = (
+/obj/structure/closet/crate/bin,
+/obj/machinery/airalarm/directional/west,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/space)
+"Qn" = (
+/obj/structure/cable,
+/turf/open/floor/circuit/green,
+/area/space)
+"Qq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy/red,
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
+/obj/machinery/button/door/directional/north{
+	id = "a2";
+	name = "privacy button";
+	pixel_y = -24
+	},
+/turf/open/floor/carpet/green,
+/area/space)
+"Qu" = (
+/obj/structure/cable,
+/obj/item/clothing/gloves/color/yellow,
+/obj/structure/rack,
+/turf/open/floor/plating,
+/area/space)
+"Qy" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/closed/wall,
+/area/space)
+"QA" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 10;
+	icon_state = "roomnum";
+	name = "Room Number 6";
+	pixel_y = 24
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"QB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
+/obj/structure/table/wood/fancy/cyan,
+/turf/open/floor/carpet/red,
+/area/space)
+"QF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space)
+"QG" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/airlock{
+	id_tag = "a3";
+	name = "Guest Room A3"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"QH" = (
+/obj/structure/frame/computer{
+	dir = 1
+	},
+/obj/item/stack/sheet/glass,
+/obj/item/stack/sheet/glass,
+/turf/open/floor/circuit/green,
+/area/space)
+"QL" = (
+/obj/structure/sign/poster/official/cleanliness/directional/north,
+/turf/open/floor/iron/freezer,
+/area/space)
+"QO" = (
+/obj/structure/chair/sofa/left/brown{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblue,
+/area/space)
+"QQ" = (
+/obj/machinery/door/airlock{
+	name = "Toilet"
+	},
+/turf/open/floor/iron/freezer,
+/area/space)
+"QS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"QX" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/tile,
+/area/space)
+"QY" = (
+/obj/structure/chair/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/space)
+"Rb" = (
+/obj/structure/fluff/tram_rail,
+/turf/template_noop,
+/area/space)
+"Rd" = (
+/obj/machinery/door/airlock{
+	name = "Custodial Closet"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/away/general,
+/obj/effect/mapping_helpers/airlock/access/any/away/maintenance,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured_half,
+/area/space)
+"Rf" = (
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/grimy,
+/area/space)
+"Rg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/space)
+"Rm" = (
+/obj/structure/chair/sofa/corp/left{
+	dir = 1
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"Rq" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
+/obj/structure/table/wood/fancy/green,
+/obj/machinery/light/directional/south,
+/turf/open/floor/carpet/purple,
+/area/space)
+"Rt" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"Rv" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
+	},
+/turf/open/floor/wood/tile,
+/area/space)
+"RE" = (
+/obj/machinery/vending/boozeomat,
+/turf/closed/wall,
+/area/space)
+"RM" = (
+/obj/structure/cable,
+/obj/effect/mob_spawn/ghost_role/human/hotel_staff/security,
+/turf/open/floor/glass/reinforced,
+/area/space)
+"RO" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/siding/white,
+/turf/open/floor/iron/sepia,
+/area/space)
+"RQ" = (
+/turf/open/misc/beach/coastline_b{
+	dir = 8
+	},
+/area/space)
+"RX" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/maintenance,
+/turf/open/floor/plating,
+/area/space)
+"RZ" = (
+/turf/open/misc/beach/coastline_t{
+	dir = 4
+	},
+/area/space)
+"Sb" = (
+/obj/structure/window/spawner/directional/south,
+/obj/machinery/shower/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"Sc" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/cup/glass/mug/tea,
+/turf/open/floor/carpet/blue,
+/area/space)
+"Sd" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/machinery/power/solar_control{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"Sf" = (
+/obj/structure/chair/sofa/bench/right,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/north,
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"Sh" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/south,
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/carpet/neon/simple/red/nodots,
+/area/space)
+"Sm" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-05"
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/space)
+"Sn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
+/obj/structure/table/wood/fancy/royalblue,
+/turf/open/floor/carpet/orange,
+/area/space)
+"Sq" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/random/bureaucracy/briefcase,
+/turf/open/floor/carpet/black,
+/area/space)
+"Ss" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/template_noop,
+/area/space)
+"SA" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/template_noop,
+/area/space)
+"SC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/security/glass{
+	name = "Hotel Brig"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/away/security,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"SG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/space)
+"SH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side,
+/area/space)
+"SJ" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/space)
+"SN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/space)
+"SP" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood/large,
+/area/space)
+"SQ" = (
+/obj/structure/sink/directional/east,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"SS" = (
+/obj/effect/turf_decal/siding/yellow/end,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/circuit/red,
+/area/space)
+"SU" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/firealarm/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"SX" = (
+/obj/structure/fluff/tram_rail/end{
+	pixel_y = 17
+	},
+/turf/template_noop,
+/area/space)
+"Te" = (
+/obj/machinery/button{
+	id = "hcd1";
+	name = "shutters control";
+	pixel_x = -25;
+	pixel_y = -25
+	},
+/turf/open/floor/iron/dark/side,
+/area/space)
+"Tf" = (
+/obj/structure/cable,
+/obj/item/reagent_containers/cup/bucket,
+/turf/open/floor/plating,
+/area/space)
+"Th" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters{
+	id = "hcb1";
+	name = "Cargo Bay Shutters"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"Tk" = (
+/obj/machinery/button{
+	id = "hcb2";
+	name = "shutters control";
+	pixel_x = -25;
+	pixel_y = -25
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"Tl" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/north{
+	id = "a1";
+	name = "privacy button"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/carpet/lone,
+/area/space)
+"Tm" = (
+/obj/machinery/oven/range,
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Kitchen";
+	network = list("spacehotel")
+	},
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"Tn" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/stone,
+/area/space)
+"Ts" = (
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
+/turf/open/floor/iron/grimy,
+/area/space)
+"Tu" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/template_noop,
+/area/space)
+"Ty" = (
+/obj/structure/closet/emcloset,
+/obj/item/card/id/away/hotel,
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/floor/plating,
+/area/space)
+"Tz" = (
+/obj/machinery/computer/security{
+	dir = 4;
+	network = list("spacehotel")
+	},
+/obj/structure/sign/poster/contraband/random/directional/west,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/space)
+"TB" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/iron/dark/textured_half{
+	dir = 1
+	},
+/area/space)
+"TC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"TE" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/iron/grimy,
+/area/space)
+"TG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side,
+/area/space)
+"TI" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/wood/tile,
+/area/space)
+"TJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/grimy,
+/area/space)
+"TQ" = (
+/obj/structure/sign/poster/random/directional/south,
+/turf/open/floor/iron/grimy,
+/area/space)
+"TT" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/machinery/light_switch/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood/parquet,
+/area/space)
+"Uc" = (
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/space)
+"Uf" = (
+/obj/structure/table/wood/fancy/cyan,
+/turf/open/floor/carpet/red,
+/area/space)
+"Uj" = (
+/obj/effect/mob_spawn/ghost_role/human/hotel_staff,
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
+/area/space)
+"Uk" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"Um" = (
+/turf/open/floor/iron,
+/area/space)
+"Un" = (
+/obj/structure/flora/bush/leavy/style_random,
+/obj/structure/flora/bush/fullgrass/style_random,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/flora/bush/jungle/c/style_random,
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/grass,
+/area/space)
+"Us" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/space)
+"Uu" = (
+/obj/structure/chair/comfy{
+	dir = 8
+	},
+/obj/structure/sign/poster/random/directional/east,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/space)
+"Ux" = (
+/obj/machinery/camera/directional/west{
+	c_tag = "Lobby";
+	network = list("spacehotel")
+	},
+/turf/open/floor/carpet/blue,
+/area/space)
+"Uy" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/template_noop,
+/area/space)
+"UA" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/obj/structure/cable,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/space)
+"UB" = (
+/obj/structure/window/reinforced/survival_pod/spawner/directional/west,
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo"
+	},
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"UE" = (
+/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/glass/reinforced,
+/area/space)
+"UL" = (
+/obj/structure/table/wood/fancy/cyan,
+/obj/machinery/light_switch/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/wood/parquet,
+/area/space)
+"UQ" = (
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/plating/airless,
+/area/space)
+"US" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/obj/effect/mapping_helpers/apc/cell_5k,
+/turf/open/floor/plating,
+/area/space)
+"UY" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/teleport/hub,
+/turf/open/floor/wood/large,
+/area/space)
+"UZ" = (
+/obj/structure/sink/directional/west,
+/turf/open/floor/iron/freezer,
+/area/space)
+"Vh" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/closet/crate/bin,
+/turf/open/floor/iron/dark,
+/area/space)
+"Vj" = (
+/obj/machinery/light/small/directional/south,
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/rnd/production/techfab/department/service,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"Vq" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/white{
+	dir = 1
+	},
+/turf/open/floor/iron/sepia,
+/area/space)
+"Vv" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"VD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/space)
+"VG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
+"VM" = (
+/obj/effect/turf_decal/delivery/white{
+	color = "A46106"
+	},
+/obj/effect/spawner/random/structure/crate_abandoned,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"VP" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/orange,
+/turf/open/floor/wood/parquet,
+/area/space)
+"VS" = (
+/obj/effect/turf_decal/trimline/red/line,
+/obj/effect/turf_decal/trimline/yellow/line,
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"VT" = (
+/obj/structure/rack,
+/turf/open/floor/iron/sepia,
+/area/space)
+"VU" = (
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/space)
+"Wa" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/grimy,
+/area/space)
+"Wd" = (
+/obj/structure/table/wood/fancy/red,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/wood/parquet,
+/area/space)
+"We" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"Wh" = (
+/obj/effect/turf_decal/bot,
+/obj/item/wirecutters,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/iron/dark,
+/area/space)
+"Wi" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/template_noop,
+/area/space)
+"Wq" = (
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/space)
+"Wr" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing/corner{
+	dir = 4
+	},
+/turf/template_noop,
+/area/space)
+"Wt" = (
+/obj/item/circuitboard/machine/ore_silo,
+/obj/structure/frame/machine/secured,
+/turf/open/floor/plating,
+/area/space)
+"Wx" = (
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/flashlight/flare/candle/infinite{
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood/fancy,
+/turf/open/floor/stone,
+/area/space)
+"Wz" = (
+/obj/structure/cable,
+/turf/open/floor/iron/grimy,
+/area/space)
+"WA" = (
+/obj/structure/frame,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/circuitboard/machine/emitter,
+/obj/item/stack/cable_coil/five,
+/turf/open/floor/circuit/green,
+/area/space)
+"WL" = (
+/obj/effect/turf_decal/stripes/end,
+/turf/open/floor/plating/airless,
+/area/space)
+"WS" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"WT" = (
+/obj/structure/fluff/tram_rail{
+	pixel_y = 17
+	},
+/obj/structure/fluff/tram_rail,
+/turf/template_noop,
+/area/space)
+"Xa" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/comfy,
+/obj/structure/sign/warning/no_smoking/circle/directional/north,
+/turf/open/floor/iron/dark,
+/area/space)
+"Xc" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
+"Xm" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood/tile,
+/area/space)
+"Xp" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Guest Suites"
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured_half,
+/area/space)
+"Xw" = (
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = 7;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/flashlight/flare/candle/infinite{
+	pixel_y = 6
+	},
+/obj/structure/table/wood/fancy,
+/turf/open/floor/iron/grimy,
+/area/space)
+"Xy" = (
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/dark/side,
+/area/space)
+"Xz" = (
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/grimy,
+/area/space)
+"XE" = (
+/obj/structure/closet/crate/internals,
+/obj/item/storage/toolbox/emergency,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath,
+/obj/effect/turf_decal/delivery/white{
+	color = "A46106"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/tank/internals/emergency_oxygen/double,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"XF" = (
+/obj/machinery/camera/directional/south{
+	c_tag = "Guest Hallway Starboard";
+	network = list("spacehotel")
+	},
+/turf/open/floor/iron/grimy,
+/area/space)
+"XI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/stone,
+/area/space)
+"XO" = (
+/obj/effect/turf_decal/siding/yellow/end{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/circuit/red,
+/area/space)
+"Yf" = (
+/obj/effect/turf_decal/siding/wood/end{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood/tile,
+/area/space)
+"Yg" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/grimy,
+/area/space)
+"Yh" = (
+/obj/machinery/door/airlock{
+	name = "Bathroom"
+	},
+/turf/open/floor/carpet,
+/area/space)
+"Yj" = (
+/obj/structure/sign/poster/contraband/random/directional/north,
+/turf/open/floor/plating,
+/area/space)
+"Yk" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/space)
+"Ym" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/grimy,
+/area/space)
+"Yy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/space)
+"YA" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/table/wood,
+/turf/open/floor/stone,
+/area/space)
+"YF" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/door/airlock{
+	id_tag = "a1";
+	name = "Guest Room A1"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/sepia,
+/area/space)
+"YH" = (
+/obj/machinery/door/airlock{
+	name = "Public Restroom/Showers"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/turf/open/floor/iron/freezer,
+/area/space)
+"YI" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/chair/stool/directional/west,
+/turf/open/floor/iron/grimy,
+/area/space)
+"YN" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"YP" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/space)
+"YQ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/dark,
+/area/space)
+"YS" = (
+/turf/open/floor/carpet/black,
+/area/space)
+"YT" = (
+/obj/machinery/button{
+	id = "hcb1";
+	name = "shutters control";
+	pixel_x = -25;
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/textured_large,
+/area/space)
+"YU" = (
+/obj/machinery/light/small/directional/south,
+/obj/structure/tank_holder/oxygen/yellow,
+/turf/open/floor/plating,
+/area/space)
+"YZ" = (
+/obj/structure/window/spawner/directional/north,
+/obj/machinery/shower/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/space)
+"Za" = (
+/turf/closed/wall,
+/area/space)
+"Zd" = (
+/obj/structure/railing/corner,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/stone,
+/area/space)
+"Zh" = (
+/obj/effect/turf_decal/trimline/red/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"Zl" = (
+/obj/structure/chair/sofa/right/brown{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/carpet/lone,
+/area/space)
+"Zu" = (
+/obj/machinery/deepfryer,
+/turf/open/floor/iron/cafeteria,
+/area/space)
+"Zw" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-16"
+	},
+/obj/structure/sign/poster/random/directional/north,
+/obj/structure/sign/poster/random/directional/west,
+/turf/open/floor/carpet/blue,
+/area/space)
+"ZF" = (
+/obj/structure/cable,
+/obj/machinery/power/tracker,
+/turf/open/floor/iron/solarpanel/airless,
+/area/space)
+"ZG" = (
+/obj/structure/fluff/tram_rail{
+	pixel_y = 17
+	},
+/obj/structure/fluff/tram_rail/end,
+/turf/template_noop,
+/area/space)
+"ZH" = (
+/obj/effect/turf_decal/trimline/red/warning{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 1
+	},
+/obj/machinery/door/window/survival_pod{
+	name = "Holding Cell A";
+	req_access = list("security");
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/textured,
+/area/space)
+"ZM" = (
+/obj/effect/turf_decal/siding/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/yellow{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/mob/living/basic/bot/medbot/derelict,
+/turf/open/floor/circuit/red,
+/area/space)
+
+(1,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(2,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+qi
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+ZF
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(3,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+xu
+kn
+kn
+kn
+kn
+xu
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+qi
+Rb
+kn
+kn
+kn
+kn
+kn
+xu
+kn
+kn
+xu
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+nK
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(4,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+NY
+Ja
+Ja
+Hb
+Za
+aB
+Za
+Za
+Za
+Za
+Za
+Za
+WL
+Ja
+Ja
+NY
+kn
+kn
+Rb
+Rb
+tP
+kn
+kn
+kn
+Za
+FG
+Ja
+Ja
+FG
+Za
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+nK
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+"}
+(5,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Za
+vL
+WA
+sh
+sh
+Ko
+oW
+Za
+kn
+kn
+kn
+kn
+kn
+kn
+Rb
+Rb
+xi
+kn
+NY
+Ja
+Ja
+FG
+Za
+Za
+FG
+Ja
+Ja
+NY
+kn
+kn
+Ja
+Ja
+Ja
+Ja
+Ja
+nK
+nK
+nK
+Ja
+Ja
+Ja
+Ja
+Ja
+kn
+"}
+(6,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+kn
+kn
+kn
+kn
+PE
+kn
+kn
+kn
+kn
+kn
+kn
+Za
+bs
+Qn
+Wq
+Wq
+Qn
+QH
+Za
+kn
+kn
+kn
+kn
+kn
+kn
+Rb
+Rb
+xi
+kn
+kn
+kn
+Za
+FG
+Ja
+Ja
+FG
+Za
+kn
+kn
+kn
+zi
+zi
+zi
+zi
+zi
+zi
+nK
+Ja
+nK
+zi
+zi
+zi
+zi
+zi
+zi
+"}
+(7,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+PE
+Ja
+Ja
+Ja
+Ja
+PE
+kn
+kn
+NY
+Ja
+Ja
+Hb
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+WL
+Ja
+Ja
+NY
+kn
+kn
+Rb
+Rb
+xi
+kn
+kn
+kn
+kn
+FG
+kn
+kn
+FG
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+Qf
+Qf
+Qf
+nK
+Qf
+nK
+Qf
+Qf
+Qf
+Ja
+kn
+kn
+"}
+(8,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+PE
+kn
+kn
+Ja
+kn
+kn
+PE
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+dF
+kn
+kn
+kn
+kn
+dF
+kn
+kn
+kn
+kn
+kn
+kn
+Za
+MT
+MT
+MT
+MT
+MT
+Za
+kn
+FG
+kn
+kn
+FG
+kn
+kn
+kn
+kn
+zi
+zi
+zi
+zi
+zi
+zi
+nK
+Ja
+nK
+zi
+zi
+zi
+zi
+zi
+zi
+"}
+(9,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+PE
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+dF
+kn
+kn
+kn
+kn
+dF
+kn
+kn
+kn
+kn
+kn
+kn
+Za
+Pe
+YA
+GE
+YA
+iX
+Za
+kn
+FG
+kn
+kn
+FG
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+Qf
+Qf
+Qf
+nK
+Qf
+nK
+Qf
+Qf
+Qf
+Ja
+kn
+kn
+"}
+(10,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+PE
+kn
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+dF
+kn
+kn
+kn
+kn
+dF
+kn
+kn
+kn
+kn
+kn
+kn
+Za
+YI
+rA
+KF
+rA
+uh
+Za
+Ja
+dF
+Ja
+Ja
+dF
+Ja
+kn
+kn
+kn
+zi
+zi
+zi
+zi
+zi
+zi
+nK
+Ja
+nK
+zi
+zi
+zi
+zi
+zi
+zi
+"}
+(11,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+kn
+Ja
+Ja
+Ja
+Ja
+Ja
+Za
+kn
+kn
+kn
+kn
+kn
+Za
+Ja
+Ja
+Ja
+Ja
+Za
+MT
+MT
+Za
+Za
+MT
+MT
+Za
+Zd
+NK
+NK
+NK
+JW
+Za
+MT
+MT
+Za
+Za
+MT
+MT
+Za
+ce
+kn
+kn
+Ja
+Ja
+Ja
+Ja
+xw
+nK
+Qf
+nK
+qh
+Ja
+Ja
+Ja
+Ja
+kn
+"}
+(12,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+Ja
+Ja
+Ja
+Ja
+Za
+Za
+Za
+Za
+Za
+Za
+MT
+MT
+Za
+MT
+MT
+Za
+Za
+Za
+Za
+Za
+Za
+eB
+Xw
+pA
+mx
+Xw
+TE
+Za
+ps
+Mu
+qS
+YP
+tf
+Za
+bR
+Xw
+pA
+mx
+Xw
+vI
+Za
+rY
+kn
+kn
+kn
+kn
+kn
+kn
+Uy
+nK
+Ja
+nK
+qh
+kn
+kn
+kn
+kn
+kn
+"}
+(13,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+Ja
+Za
+GS
+HW
+HW
+TT
+Za
+Rv
+ot
+id
+ot
+rI
+Za
+Ia
+aw
+aw
+dt
+Za
+Fv
+ot
+ot
+ot
+ot
+ot
+wr
+qH
+Mu
+dX
+YP
+qH
+wr
+ot
+ot
+ot
+ot
+ot
+nz
+Za
+Nf
+Km
+yO
+Dg
+Dg
+Dg
+Dg
+OG
+nK
+Qf
+nK
+qh
+Ja
+Ja
+Ja
+Ja
+kn
+"}
+(14,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+Ja
+Za
+OS
+NT
+iM
+NL
+dh
+WS
+Gw
+Gw
+Gw
+Db
+jI
+NL
+dp
+NT
+eR
+Za
+MP
+Xw
+vI
+eB
+Xw
+vI
+wr
+qH
+yq
+qH
+VG
+qH
+wr
+eB
+Xw
+vI
+eB
+Xw
+vI
+Za
+NM
+Za
+tF
+kn
+kn
+kn
+kn
+kn
+nK
+Ja
+nK
+zi
+zi
+zi
+zi
+zi
+zi
+"}
+(15,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Qf
+kn
+kn
+kn
+PE
+PE
+PE
+kn
+kn
+Ja
+Za
+bp
+Sn
+ul
+cp
+Za
+QA
+TJ
+Gw
+zn
+Bq
+Za
+OR
+EV
+Ab
+Rq
+Za
+ot
+ot
+TJ
+Gw
+Gw
+Bv
+JO
+iU
+iU
+iU
+iU
+iU
+FC
+Gw
+SG
+Gw
+Gw
+Gw
+ND
+Za
+VD
+Za
+QF
+Za
+Za
+Ja
+Ja
+Ja
+nK
+Qf
+nK
+Qf
+Qf
+Qf
+Ja
+kn
+kn
+"}
+(16,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+Za
+zr
+zr
+zr
+MU
+Za
+QX
+ot
+Gw
+ot
+oZ
+Za
+jh
+xk
+xk
+Pn
+Za
+QY
+Wx
+xU
+PW
+Tn
+Za
+Za
+sv
+Ic
+UB
+HT
+CX
+Za
+Lt
+Za
+Za
+XI
+Dj
+Za
+xD
+lD
+Za
+gp
+Kd
+Za
+Za
+kn
+kn
+nK
+Ja
+nK
+zi
+zi
+zi
+zi
+zi
+zi
+"}
+(17,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+Za
+cd
+Fj
+zr
+AA
+Za
+Rv
+ot
+Gw
+ot
+yo
+Za
+hC
+xc
+fR
+Lv
+Za
+Za
+Za
+Za
+rB
+qH
+dD
+Za
+Zu
+bo
+YN
+pU
+wX
+Es
+rA
+Za
+dD
+Lk
+iU
+Za
+VD
+VD
+Za
+NX
+lT
+Sd
+MT
+kn
+kn
+nK
+nK
+nK
+Qf
+Qf
+Qf
+Ja
+kn
+kn
+"}
+(18,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+PE
+PE
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Za
+Za
+mn
+Za
+ku
+Za
+Za
+Za
+Ts
+Gw
+Rf
+Za
+Za
+Za
+Yh
+Za
+GW
+Za
+IK
+jH
+Za
+hY
+cV
+dD
+Za
+xV
+wX
+BA
+aY
+wX
+RE
+bm
+Za
+dD
+qH
+xe
+Za
+VD
+Za
+Za
+SN
+sq
+hz
+Za
+Ja
+Ja
+nK
+Ja
+nK
+zi
+zi
+zi
+zi
+zi
+zi
+"}
+(19,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+ux
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+MT
+fa
+mX
+Za
+JI
+JI
+JI
+Za
+EH
+Ec
+TQ
+Za
+JI
+pO
+JI
+Za
+lT
+Za
+lT
+lT
+GW
+iU
+qH
+dD
+Za
+Tm
+wX
+FU
+Fq
+wX
+cX
+tH
+Za
+dD
+qH
+iU
+Za
+ky
+vq
+lc
+lc
+lT
+Qu
+MT
+kn
+kn
+nK
+nK
+nK
+Ja
+Ja
+Ja
+Ja
+Ja
+kn
+"}
+(20,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+MT
+Yk
+mX
+Za
+HZ
+wD
+YZ
+Za
+Xz
+OI
+Mr
+Za
+Sb
+wD
+hs
+Za
+lT
+Za
+lT
+mX
+Za
+Yy
+qH
+dD
+Za
+Uk
+pp
+Hp
+Dl
+Nv
+Za
+aO
+Za
+dD
+qH
+iU
+Za
+ky
+Za
+Za
+Za
+Za
+Za
+Za
+kn
+kn
+Ja
+Qf
+Ja
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(21,1,1) = {"
+kn
+kn
+kn
+kn
+Qf
+Ja
+Ja
+PE
+Ja
+Ja
+Ja
+Ja
+Ja
+Ja
+Ja
+Ja
+MT
+fa
+mX
+Za
+JI
+iS
+Za
+Za
+ot
+OI
+ot
+Za
+Za
+sZ
+JI
+Za
+lT
+Za
+lT
+Za
+Za
+Qh
+tv
+Za
+Za
+Za
+Za
+Za
+wu
+Za
+Za
+Za
+Za
+Za
+um
+vl
+Za
+ky
+Za
+MO
+gj
+MO
+Za
+qh
+kn
+kn
+Ja
+Qf
+Ja
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(22,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+kn
+kn
+Ja
+kn
+kn
+xw
+Km
+Za
+Za
+xD
+mX
+Za
+Za
+Za
+Za
+hG
+ot
+OI
+ot
+ds
+Za
+Za
+Za
+Za
+lT
+Za
+lT
+lT
+Za
+gX
+eR
+yt
+Za
+LB
+AQ
+dl
+mQ
+Qj
+Tz
+kI
+Za
+BE
+eR
+wQ
+Fk
+ky
+Za
+IA
+dj
+tt
+Za
+Ss
+Km
+Km
+Km
+Qf
+Km
+Km
+Km
+Wi
+kn
+kn
+kn
+"}
+(23,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+kn
+kn
+Ja
+kn
+kn
+wT
+nK
+fQ
+lT
+rZ
+lT
+Za
+JI
+eg
+Za
+Za
+ot
+OI
+ot
+Za
+Za
+Fa
+JI
+Za
+lT
+Za
+Za
+lT
+Za
+TC
+qa
+Hk
+Za
+GP
+sJ
+XO
+ZM
+SS
+jg
+yQ
+Za
+uc
+eR
+Am
+Za
+Za
+wF
+wF
+al
+Za
+Za
+Za
+Za
+kn
+Ja
+kn
+Ja
+kn
+Za
+qh
+kn
+kn
+kn
+"}
+(24,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+ux
+kn
+kn
+Ja
+kn
+kn
+wT
+Za
+Za
+Za
+xD
+lT
+Za
+HZ
+wD
+wR
+Za
+Xz
+OI
+ot
+Za
+Sb
+wD
+hs
+Za
+lT
+lT
+lT
+lT
+Za
+JG
+eR
+tT
+Za
+Uj
+Ix
+zt
+sy
+zm
+pN
+vo
+Za
+FY
+Px
+me
+Za
+yM
+QQ
+dj
+dj
+dj
+QQ
+mH
+Za
+MT
+Za
+MT
+Za
+MT
+Za
+qh
+kn
+kn
+kn
+"}
+(25,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+ux
+kn
+kn
+Ja
+kn
+kn
+wT
+Za
+VU
+lT
+lT
+lT
+Za
+JI
+hi
+JI
+Za
+Fv
+Yf
+Ym
+Za
+JI
+hi
+JI
+Za
+xp
+Za
+lT
+Yk
+Za
+bu
+eR
+Za
+Za
+Za
+Za
+Za
+et
+Za
+Za
+Za
+Za
+Za
+eR
+Am
+Za
+Za
+Za
+yz
+dj
+yz
+Za
+Za
+Za
+wP
+ov
+wP
+ov
+wP
+Za
+qh
+kn
+kn
+kn
+"}
+(26,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+kn
+kn
+Ja
+kn
+kn
+wT
+Za
+xp
+RX
+Za
+Za
+Za
+ku
+Za
+Za
+Za
+Ts
+Gw
+ot
+Za
+Za
+Za
+ku
+Za
+Za
+Za
+lT
+Za
+Za
+tp
+eR
+Za
+Zw
+bK
+cS
+su
+eR
+TI
+eY
+Ux
+LC
+Za
+Hl
+Am
+nQ
+dj
+dj
+dj
+dj
+dj
+QQ
+mH
+Za
+wP
+wP
+wP
+wP
+wP
+Za
+qh
+kn
+kn
+kn
+"}
+(27,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+kn
+kn
+Ja
+kn
+kn
+wT
+Za
+jH
+lT
+Za
+QO
+Fs
+hK
+fy
+Za
+sc
+ot
+Gw
+ot
+yo
+Za
+Uf
+Ob
+qt
+fh
+GW
+lT
+Za
+lC
+gX
+eR
+dD
+xX
+BB
+AT
+CN
+eR
+CN
+Qy
+BB
+Rm
+dD
+eR
+PT
+Za
+KW
+UZ
+UZ
+dj
+KM
+Za
+Za
+Za
+RZ
+RZ
+RZ
+RZ
+RZ
+Za
+Za
+Za
+kn
+kn
+"}
+(28,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+kn
+kn
+Ja
+kn
+kn
+wT
+Za
+Za
+lT
+mn
+hK
+hK
+hK
+Bo
+Za
+QX
+xS
+Gw
+ty
+wv
+Za
+nR
+Ob
+Ob
+dN
+Za
+GZ
+Za
+Xa
+gX
+eR
+Za
+cI
+BB
+yy
+pn
+oV
+BV
+Cm
+BB
+pl
+Za
+Fr
+Am
+Za
+Za
+Za
+Za
+Gh
+Uc
+Za
+VT
+EC
+RQ
+RQ
+RQ
+RQ
+RQ
+Dq
+VT
+Za
+kn
+kn
+"}
+(29,1,1) = {"
+kn
+kn
+kn
+kn
+Qf
+Ja
+Ja
+ux
+Ja
+Ja
+Ja
+Ja
+Ja
+wT
+Ja
+Za
+lT
+Za
+mk
+NB
+vn
+FS
+Za
+Bs
+ot
+Gw
+ot
+Np
+Za
+od
+Jz
+QB
+qO
+Za
+Za
+Za
+LW
+gX
+eR
+td
+BB
+BB
+BB
+ci
+ci
+ci
+BB
+BB
+Sc
+dD
+eR
+mU
+Za
+vr
+AF
+Za
+QL
+PC
+YH
+ws
+RO
+RQ
+RQ
+RQ
+RQ
+RQ
+Vq
+Dy
+Za
+kn
+kn
+"}
+(30,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+kn
+kn
+kn
+kn
+kn
+wT
+Ja
+Za
+lT
+Za
+Kv
+NT
+iM
+NL
+ng
+WS
+Gw
+Gw
+nu
+pb
+QG
+Lz
+zz
+NT
+OS
+Za
+zc
+Za
+Za
+gX
+fN
+td
+BB
+dW
+ep
+Cv
+Cv
+Cv
+ep
+PB
+ao
+Za
+nq
+bx
+Za
+oj
+Sq
+Za
+Za
+Za
+Za
+JF
+RO
+RQ
+RQ
+RQ
+RQ
+RQ
+Vq
+Da
+Za
+kn
+kn
+"}
+(31,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+ux
+kn
+kn
+kn
+kn
+kn
+wT
+Ja
+Za
+lT
+Za
+mo
+VP
+VP
+nd
+Za
+Rv
+ot
+Gw
+ot
+qe
+Za
+UL
+hR
+hR
+jG
+Za
+mX
+Tf
+Rd
+CB
+eR
+Za
+NW
+sU
+Un
+eR
+aX
+eR
+Un
+sj
+oE
+Za
+Hl
+Am
+Nj
+YS
+YS
+Du
+Za
+Ja
+Za
+qr
+dr
+RQ
+RQ
+RQ
+RQ
+RQ
+gN
+Eh
+Za
+kn
+kn
+"}
+(32,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+ux
+PE
+PE
+kn
+kn
+kn
+kn
+wT
+Ja
+Za
+lT
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+dI
+Yg
+dI
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+cy
+HV
+Za
+CB
+eR
+dD
+NS
+zd
+vz
+ci
+ci
+ci
+vz
+aG
+xn
+dD
+eR
+Am
+Za
+OD
+YS
+Du
+Za
+Ja
+Za
+HO
+qJ
+oq
+oq
+oq
+oq
+oq
+Dp
+sH
+Za
+kn
+kn
+"}
+(33,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+kn
+kn
+wT
+Ja
+Za
+lT
+Za
+Kd
+Kd
+Kd
+Lo
+Za
+NO
+ot
+Ec
+ot
+eK
+Za
+Ou
+BZ
+Me
+Of
+Za
+Za
+Za
+Za
+Mt
+Xm
+Za
+eT
+Cv
+Cv
+Cv
+Cv
+Cv
+Cv
+Cv
+hy
+KP
+Xm
+jR
+Za
+Za
+CW
+Za
+Za
+Za
+Za
+LG
+qb
+wP
+wP
+iN
+Nl
+wP
+HU
+CK
+Za
+kn
+kn
+"}
+(34,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+kn
+kn
+kn
+kn
+kn
+wT
+Ja
+Za
+lT
+GW
+Qg
+lT
+zC
+mX
+Za
+dP
+ot
+OI
+ot
+Dw
+yA
+sJ
+sJ
+re
+cK
+ga
+nW
+TI
+eR
+CB
+eR
+eR
+eR
+eR
+nW
+eR
+eR
+eR
+va
+eR
+eR
+eR
+eR
+Am
+eR
+nW
+eR
+eR
+DA
+eR
+NZ
+ws
+qb
+wP
+Nl
+Pp
+wP
+wP
+HU
+sH
+Za
+kn
+kn
+"}
+(35,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Qf
+kn
+kn
+kn
+kn
+kn
+wT
+Za
+Za
+mX
+Za
+Za
+US
+IQ
+lc
+oL
+sX
+Wa
+OI
+Gw
+ap
+Xp
+wB
+wB
+wB
+fY
+Am
+Am
+Am
+Am
+Am
+Am
+Gn
+Gn
+rN
+Am
+qc
+QS
+Am
+Am
+Am
+SU
+Am
+Am
+Am
+Am
+Am
+qc
+Am
+Am
+SU
+gB
+pc
+BL
+cT
+cT
+cT
+cT
+cT
+Gi
+sH
+Za
+kn
+kn
+"}
+(36,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+wT
+Za
+IK
+mX
+GZ
+Za
+PY
+vy
+iB
+Za
+fs
+ot
+Yf
+ot
+pt
+Za
+Ed
+to
+Uu
+Oi
+Za
+mn
+Za
+Vh
+YQ
+Za
+Th
+Th
+Za
+TB
+Za
+Za
+eX
+fC
+LT
+Za
+Za
+MT
+Za
+MT
+MT
+Za
+MT
+MT
+Za
+Za
+IW
+Qi
+Dy
+Dy
+Dy
+Dy
+Dy
+oQ
+si
+Za
+kn
+kn
+"}
+(37,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+wT
+Za
+xp
+mX
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+dI
+Yg
+dI
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+mX
+Za
+Za
+Za
+Za
+MV
+CS
+YT
+CS
+ag
+Za
+hA
+mZ
+xt
+Za
+Ja
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Za
+Za
+gC
+cB
+tc
+gC
+gC
+cB
+tc
+Za
+Za
+kn
+kn
+"}
+(38,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+kn
+wT
+Za
+Za
+mX
+Za
+EP
+Wd
+Bl
+hQ
+Za
+Rv
+ot
+Gw
+ot
+qe
+Za
+mc
+eb
+eb
+uT
+Za
+mX
+Za
+BP
+BP
+Za
+mB
+CO
+CO
+Vj
+Za
+Za
+fD
+Rg
+KR
+Za
+Za
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Za
+MT
+Za
+MT
+MT
+MT
+Za
+MT
+Za
+kn
+kn
+kn
+"}
+(39,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+Ja
+wT
+Ja
+Za
+mX
+Za
+uZ
+lf
+tw
+NL
+ez
+WS
+Gw
+Gw
+Gw
+Db
+YF
+NL
+zz
+NT
+OS
+Za
+mX
+mn
+mX
+mX
+Za
+CO
+VM
+CO
+Tk
+OQ
+IJ
+wx
+Us
+SH
+gx
+MT
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+xi
+Rb
+kn
+Rb
+kn
+WT
+kn
+kn
+kn
+kn
+"}
+(40,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+ux
+kn
+wT
+Ja
+Za
+mX
+Za
+DW
+Ki
+xx
+Qq
+Za
+rT
+ot
+Gw
+ot
+MJ
+Za
+Tl
+KE
+Ee
+Ka
+Za
+Yj
+Za
+Za
+Wt
+Za
+ob
+IX
+CO
+Jj
+AX
+tG
+fD
+Us
+KS
+SP
+MT
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+xi
+Rb
+kn
+Rb
+kn
+WT
+kn
+kn
+kn
+kn
+"}
+(41,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+kn
+wT
+Ja
+Za
+mX
+Za
+gS
+sK
+sK
+sK
+Za
+LK
+ot
+Gw
+ot
+wv
+Za
+EG
+PX
+PX
+PX
+Za
+mX
+xp
+Za
+Za
+Za
+mB
+us
+CO
+XE
+Za
+Za
+PM
+dy
+DN
+UA
+Za
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+xi
+Rb
+kn
+Rb
+kn
+WT
+kn
+kn
+kn
+kn
+"}
+(42,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+kn
+wT
+Ja
+Za
+mX
+Za
+Co
+sK
+NU
+NU
+Za
+Rv
+ot
+Gw
+ot
+gI
+Za
+Pv
+PX
+Zl
+bC
+Za
+mX
+mX
+mX
+mX
+Za
+CO
+cD
+CO
+Mm
+Za
+nG
+fD
+Us
+KS
+cm
+MT
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+xi
+Rb
+kn
+Rb
+kn
+ss
+kn
+kn
+kn
+kn
+"}
+(43,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+ux
+kn
+wT
+Ja
+Za
+mX
+Za
+Za
+ku
+Za
+Za
+Za
+Za
+Ts
+Gw
+XF
+Za
+Za
+Za
+ku
+Za
+Za
+Za
+Za
+Za
+Za
+mX
+Za
+ob
+pZ
+CO
+xB
+Za
+bt
+fD
+Us
+KS
+go
+MT
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+xi
+EN
+kn
+Rb
+kn
+WT
+kn
+kn
+kn
+kn
+"}
+(44,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+PE
+Ja
+wT
+Ja
+Za
+mX
+Za
+pO
+JI
+bj
+Za
+yv
+Xy
+ot
+Ec
+Ym
+Za
+JI
+pO
+JI
+Za
+IK
+lT
+lT
+lT
+mX
+mX
+Za
+mn
+Za
+Za
+Za
+Za
+nn
+fD
+Us
+Mg
+go
+MT
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+xi
+kn
+kn
+Rb
+kn
+jf
+kn
+kn
+kn
+kn
+"}
+(45,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+ux
+kn
+wT
+Za
+Za
+mX
+mn
+JI
+wD
+YZ
+Za
+ks
+Xy
+TJ
+OI
+hU
+Za
+Sb
+wD
+JI
+Za
+jH
+lT
+Za
+vP
+Qg
+lT
+lT
+lT
+Za
+jH
+IK
+Za
+Za
+yN
+Us
+xD
+Za
+Za
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+xi
+kn
+kn
+Rb
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(46,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+wT
+Za
+jH
+mX
+Za
+JI
+iS
+Za
+Za
+Za
+Za
+Fv
+OI
+Rf
+Za
+Za
+sZ
+JI
+Za
+xp
+lT
+Za
+xD
+Lb
+xD
+Za
+lT
+lT
+lT
+lT
+lT
+GW
+fD
+Us
+PL
+mX
+Rt
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+SX
+kn
+kn
+Rb
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(47,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+zi
+kn
+zi
+kn
+zi
+kn
+kn
+kn
+wT
+Za
+IK
+mX
+Za
+Za
+Za
+Za
+mX
+mn
+Xy
+ot
+OI
+ot
+Sm
+Za
+Za
+mn
+Za
+Za
+lT
+Za
+bn
+mX
+Ha
+Za
+Za
+Za
+Za
+Za
+Za
+Za
+MF
+Us
+xD
+Za
+Za
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+EN
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(48,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+zi
+kn
+zi
+kn
+zi
+kn
+kn
+kn
+wT
+Za
+BP
+mX
+mX
+mX
+Yk
+Za
+mX
+Za
+Jh
+ot
+Yf
+Wz
+PU
+GW
+lT
+lT
+lT
+lT
+lT
+Za
+Ty
+mX
+JV
+MT
+kn
+kn
+kn
+kn
+MT
+Jg
+Ft
+Us
+Dv
+go
+MT
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(49,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+zi
+Ja
+zi
+Ja
+zi
+kn
+kn
+kn
+wT
+Za
+Za
+wt
+Za
+mX
+mX
+mX
+mX
+Za
+Jh
+ot
+Gw
+ot
+Gd
+Za
+Za
+mX
+Za
+xD
+Aa
+Za
+bn
+Um
+YU
+Za
+kn
+kn
+kn
+kn
+MT
+kq
+Ft
+Us
+KS
+go
+MT
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(50,1,1) = {"
+kn
+Qf
+Ja
+Ja
+Qf
+zi
+Ja
+zi
+Ja
+zi
+nK
+nK
+SA
+Kw
+nK
+Za
+MT
+Za
+BP
+BP
+Za
+Za
+Za
+Jh
+ot
+Gw
+ot
+nX
+Za
+GZ
+mX
+BP
+Za
+mX
+Za
+IK
+mX
+JV
+MT
+kn
+kn
+kn
+kn
+MT
+UY
+sC
+Us
+TG
+go
+MT
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(51,1,1) = {"
+Qf
+ZF
+nK
+nK
+nK
+Oa
+nK
+Oa
+nK
+Oa
+nK
+Ja
+nK
+Ja
+nK
+nK
+nK
+Za
+MT
+MT
+Za
+OB
+OB
+OB
+EH
+Gw
+ot
+jU
+Za
+Za
+Za
+Za
+Za
+Xc
+Za
+Za
+Aa
+Za
+Za
+Ja
+Ja
+Ja
+Ja
+Za
+Za
+lA
+mg
+KS
+Za
+Za
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(52,1,1) = {"
+kn
+Qf
+Ja
+Ja
+Qf
+zi
+Ja
+zi
+Ja
+zi
+nK
+nK
+OO
+OO
+ML
+Ja
+xg
+DT
+DT
+DT
+Wr
+OB
+xN
+OB
+ot
+ch
+ot
+Za
+Qf
+Qf
+MM
+DT
+DT
+DT
+DT
+MT
+mX
+MT
+kn
+kn
+kn
+kn
+kn
+MT
+Wh
+Ft
+Um
+Te
+Dk
+UQ
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(53,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+zi
+Ja
+zi
+Ja
+zi
+kn
+kn
+kn
+kn
+pd
+nK
+vX
+kn
+kn
+kn
+Uy
+OB
+Fz
+OB
+ot
+ch
+ot
+Za
+Qf
+Qf
+qh
+kn
+kn
+kn
+kn
+Za
+Xc
+Za
+kn
+kn
+kn
+kn
+kn
+MT
+kQ
+iq
+Um
+Mg
+Dk
+UQ
+JQ
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(54,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+zi
+kn
+zi
+kn
+zi
+kn
+kn
+kn
+kn
+nK
+Ja
+nK
+kn
+kn
+kn
+Uy
+sF
+sr
+sF
+BC
+SC
+sk
+ra
+ra
+OB
+qh
+kn
+kn
+kn
+kn
+xi
+kn
+Rb
+kn
+kn
+kn
+kn
+kn
+Za
+Za
+Za
+ku
+Za
+Za
+Za
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(55,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+zi
+kn
+zi
+kn
+zi
+kn
+kn
+kn
+kn
+nK
+nK
+nK
+kn
+kn
+kn
+Uy
+sF
+vc
+xI
+QF
+tL
+PK
+BN
+eS
+ra
+qh
+kn
+kn
+kn
+kn
+SX
+kn
+Rb
+kn
+kn
+kn
+kn
+kn
+Jn
+Za
+Vv
+JI
+SQ
+Za
+Jn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(56,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+zi
+zi
+zi
+zi
+nK
+zi
+zi
+zi
+zi
+Uy
+OB
+UE
+zx
+yG
+tL
+Sf
+Zh
+zY
+ra
+qh
+kn
+kn
+kn
+kn
+kn
+kn
+EN
+kn
+kn
+kn
+kn
+kn
+Jn
+Za
+SJ
+SJ
+SJ
+Za
+Jn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(57,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+Ja
+nK
+Ja
+Ja
+kn
+kn
+Uy
+ra
+RM
+BX
+Sh
+tL
+xa
+KV
+VS
+ra
+qh
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Jn
+Qf
+Qf
+Qf
+Qf
+Qf
+Jn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(58,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+zi
+zi
+zi
+zi
+nK
+zi
+zi
+zi
+zi
+Uy
+ra
+qd
+BX
+iA
+tL
+Ay
+KV
+vJ
+OB
+qh
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Jn
+kn
+kn
+kn
+kn
+kn
+Jn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(59,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+Ja
+nK
+Ja
+Ja
+kn
+kn
+Uy
+OB
+GY
+Hv
+tY
+tL
+ZH
+zy
+AI
+OB
+qh
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+WT
+kn
+kn
+kn
+kn
+kn
+WT
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(60,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+zi
+zi
+zi
+zi
+nK
+zi
+zi
+zi
+zi
+Uy
+ra
+ll
+EL
+eM
+tL
+MZ
+ns
+AC
+ra
+qh
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Iu
+kn
+kn
+kn
+kn
+kn
+WT
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(61,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Qf
+nK
+Qf
+kn
+kn
+kn
+Uy
+ra
+qg
+BX
+Ao
+tL
+hp
+qv
+DD
+ra
+qh
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Iu
+kn
+kn
+kn
+kn
+kn
+WT
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(62,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+nK
+Ja
+kn
+kn
+kn
+Uy
+OB
+Bh
+BX
+Pq
+tL
+up
+aQ
+DD
+OB
+qh
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+GX
+kn
+kn
+kn
+kn
+kn
+ZG
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(63,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Ja
+nK
+Ja
+kn
+kn
+kn
+Uy
+ra
+iR
+sr
+PN
+We
+dR
+kW
+MC
+ra
+qh
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+EN
+kn
+kn
+kn
+kn
+kn
+SX
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(64,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Qf
+zi
+Qf
+kn
+kn
+kn
+Uy
+ra
+ra
+BC
+OB
+OB
+OB
+BC
+ra
+ra
+qh
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(65,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+Qf
+kn
+kn
+kn
+kn
+Tu
+DT
+DT
+DT
+DT
+DT
+DT
+DT
+DT
+DT
+Bm
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(66,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}
+(67,1,1) = {"
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+kn
+"}

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -178,8 +178,8 @@
 	description = "An interstellar hotel, where the weary spaceman can rest their head and relax, assured that the residental staff will not murder them in their sleep. Probably."
 
 /datum/map_template/ruin/space/spacerealhotel
-	id = "spacehotel"
-	suffix = "spacehotel.dmm"
+	id = "spacerealhotel"
+	suffix = "spacerealhotel.dmm"
 	name = "The Twin-Nexus Hotel"
 	description = "An actual working interstellar hotel, where the weary spaceman can rest their head and relax, assured that the residental staff will not murder them in their sleep. Probably."
 

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -177,6 +177,12 @@
 	name = "The Twin-Nexus Hotel"
 	description = "An interstellar hotel, where the weary spaceman can rest their head and relax, assured that the residental staff will not murder them in their sleep. Probably."
 
+/datum/map_template/ruin/space/spacerealhotel
+	id = "spacehotel"
+	suffix = "spacehotel.dmm"
+	name = "The Twin-Nexus Hotel"
+	description = "An actual working interstellar hotel, where the weary spaceman can rest their head and relax, assured that the residental staff will not murder them in their sleep. Probably."
+
 /datum/map_template/ruin/space/turreted_outpost
 	id = "turreted-outpost"
 	suffix = "turretedoutpost.dmm"


### PR DESCRIPTION

## About The Pull Request

Make a space hotel variant, that actually work as a hotel. Mostly removed the syndicate stuff, the destruction and added 3 staff sleeper and one security sleeper.

In SDMM :
![image](https://github.com/user-attachments/assets/541235ad-44e9-454f-8b5e-9581f564779e)

## Why It's Good For The Game

Ghost roles, amiright ?

## Changelog

:cl:
add: Added a version of the space hotel ruin, that actually work as a hotel. With ghost roles.
:cl:

