### PR TITLE
Update syndie bioweapons + infinite mining point glitch. CC hates this one trick

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -1404,7 +1404,7 @@
 	},
 /obj/structure/tank_dispenser,
 /turf/open/floor/mineral/titanium/tiled/yellow,
-/area/centcom/syndicate_mothership/expansion_bulldozer)
+/area/centcom/syndicate_mothership/expansion_bombthreat)
 "adI" = (
 /obj/structure/closet/crate/freezer{
 	name = "pantry crate"

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -19960,7 +19960,7 @@
 	},
 /area/centcom/central_command_areas/evacuation)
 "drn" = (
-/obj/machinery/disease2/incubator/fullupgrade,
+/obj/machinery/disease2/incubator,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -45,7 +45,6 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 10
 	},
-/obj/structure/sign/poster/contraband/energy_swords/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "aai" = (
@@ -1405,7 +1404,7 @@
 	},
 /obj/structure/tank_dispenser,
 /turf/open/floor/mineral/titanium/tiled/yellow,
-/area/centcom/syndicate_mothership/expansion_bombthreat)
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "adI" = (
 /obj/structure/closet/crate/freezer{
 	name = "pantry crate"
@@ -2185,8 +2184,15 @@
 /turf/open/floor/iron/terracotta/small,
 /area/centcom/central_command_areas/retirement_home)
 "aga" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/closed/indestructible/syndicate,
+/obj/structure/table/glass/plasmaglass,
+/obj/item/stack/sheet/iron,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/medical/gauze,
+/obj/item/stack/sheet/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/mineral/titanium/tiled/yellow,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "agb" = (
 /obj/machinery/door/airlock{
@@ -2355,6 +2361,7 @@
 	},
 /obj/structure/table/optable,
 /obj/machinery/light/cold/directional/north,
+/obj/machinery/defibrillator_mount/loaded/directional/north,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/centcom/syndicate_mothership/control)
 "agx" = (
@@ -3551,8 +3558,8 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
-/obj/machinery/computer/pandemic,
 /obj/structure/noticeboard/directional/north,
+/obj/machinery/disease2/diseaseanalyser/fullupgrade,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "ajH" = (
@@ -4902,9 +4909,15 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/kitchen)
 "ane" = (
-/obj/effect/turf_decal/siding/thinplating_new/dark/end,
-/obj/machinery/vending/hydronutrients,
-/turf/open/floor/mineral/plastitanium/red,
+/obj/machinery/growing/tray,
+/obj/item/seeds/cannabis{
+	pixel_y = 8
+	},
+/obj/item/cultivator{
+	pixel_x = -6;
+	pixel_y = 11
+	},
+/turf/open/floor/mineral/titanium/tiled,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "anf" = (
 /obj/effect/turf_decal/siding/dark/corner{
@@ -5425,40 +5438,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/kitchen)
-"aoH" = (
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 8
-	},
-/obj/structure/table/glass/plasmaglass,
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = -5;
-	pixel_y = 12
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = -2;
-	pixel_y = 13
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = 1;
-	pixel_y = 14
-	},
-/obj/item/reagent_containers/syringe{
-	pixel_x = 4;
-	pixel_y = 15
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/item/reagent_containers/cup/bottle/radium{
-	pixel_x = -8;
-	pixel_y = 9
-	},
-/obj/item/stack/sheet/mineral/plasma,
-/obj/item/stack/sheet/mineral/plasma,
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "aoI" = (
 /obj/structure/table/wood,
 /obj/item/clothing/suit/wizrobe/magusred,
@@ -6423,7 +6402,7 @@
 /area/centcom/central_command_areas/hall)
 "ark" = (
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/centcom/syndicate_mothership/control)
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "arl" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/structure/railing/wood{
@@ -6575,11 +6554,6 @@
 /obj/structure/flora/biolumi/mine,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/retirement_yard)
-"arJ" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/tank/nitrogen,
-/turf/open/space/basic,
-/area/space/nearstation)
 "arK" = (
 /obj/structure/sign/poster/contraband/cc64k_ad,
 /turf/closed/indestructible/syndicate,
@@ -6739,12 +6713,6 @@
 	},
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/admin)
-"asf" = (
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 10
-	},
-/turf/open/floor/mineral/plastitanium/red,
-/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "asg" = (
 /obj/structure/lattice/catwalk,
 /obj/effect/turf_decal/stripes/line{
@@ -6760,16 +6728,11 @@
 /turf/open/floor/mineral/titanium/white,
 /area/centcom/central_command_areas/adminroom)
 "asi" = (
-/obj/machinery/growing/tray,
-/obj/machinery/light/cold/directional/west,
-/obj/item/seeds/cannabis{
-	pixel_y = 8
+/obj/machinery/vending/hydronutrients,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 6
 	},
-/obj/item/cultivator{
-	pixel_x = -6;
-	pixel_y = 11
-	},
-/turf/open/floor/mineral/titanium/tiled,
+/turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "asj" = (
 /obj/structure/hedge,
@@ -8205,12 +8168,6 @@
 "awf" = (
 /turf/open/floor/carpet,
 /area/centcom/central_command_areas/hall)
-"awg" = (
-/obj/machinery/camera/autoname/directional/south{
-	network = list("nukie")
-	},
-/turf/open/floor/circuit/red/off,
-/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "awh" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/green,
@@ -8775,12 +8732,6 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/borbop)
-"axJ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "axK" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 10
@@ -9408,11 +9359,6 @@
 "azk" = (
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
-"azl" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/turf/open/space/basic,
-/area/space/nearstation)
 "azm" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 8
@@ -12753,10 +12699,14 @@
 /turf/open/floor/stone,
 /area/centcom/central_command_areas/evacuation/ship)
 "aIw" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/table/glass/plasmaglass,
+/obj/item/vacuum_pack,
+/obj/item/disk/vacuum_upgrade/biomass,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/tiled/yellow,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "aIx" = (
 /obj/structure/railing/wooden_fence{
 	dir = 6
@@ -15186,9 +15136,6 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
 "aOY" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
@@ -15720,7 +15667,7 @@
 /turf/open/floor/iron/smooth_half{
 	dir = 4
 	},
-/area/centcom/syndicate_mothership/control)
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "aQy" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -17127,13 +17074,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin_hangout)
-"aUd" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "aUe" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -17355,6 +17295,7 @@
 	pixel_x = -2;
 	pixel_y = 6
 	},
+/obj/structure/sign/poster/contraband/energy_swords/directional/west,
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "aUN" = (
@@ -18922,9 +18863,7 @@
 /turf/open/floor/iron/dark/small,
 /area/centcom/central_command_areas/adminroom)
 "aZd" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
+/obj/machinery/light/cold/directional/east,
 /turf/open/floor/engine,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "aZe" = (
@@ -19036,13 +18975,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/armory)
-"aZw" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "aZx" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -19054,10 +18986,12 @@
 	},
 /area/centcom/central_command_areas/adminroom)
 "aZy" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/manifold,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/slime_market_pad,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/tiled/yellow,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "aZz" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
 /turf/open/floor/iron/dark,
@@ -19881,6 +19815,12 @@
 	dir = 1
 	},
 /area/centcom/central_command_areas/evacuation)
+"cPr" = (
+/obj/machinery/corral_corner{
+	mapping_id = "12"
+	},
+/turf/open/floor/circuit/red/off,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "cQu" = (
 /obj/structure/flora/bush/sparsegrass/style_2,
 /turf/open/floor/sandy_dirt,
@@ -20019,6 +19959,17 @@
 	dir = 4
 	},
 /area/centcom/central_command_areas/evacuation)
+"drn" = (
+/obj/machinery/disease2/incubator/fullupgrade,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 1
+	},
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/obj/item/weapon/virusdish/random,
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "dro" = (
 /obj/machinery/computer/communications{
 	dir = 8
@@ -20431,6 +20382,10 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/cruiser_dock)
+"eHW" = (
+/obj/machinery/duct,
+/turf/open/floor/circuit/red/off,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "eJD" = (
 /obj/structure/window/reinforced/tinted/frosted,
 /obj/structure/closet/mini_fridge,
@@ -20480,6 +20435,12 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/cruiser_dock)
+"eRt" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "eSA" = (
 /obj/machinery/door/poddoor/shutters/indestructible/preopen{
 	id = "donutstealthisid"
@@ -20501,6 +20462,12 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /turf/open/floor/plating,
 /area/cruiser_dock)
+"eVE" = (
+/obj/machinery/corral_corner{
+	mapping_id = "13"
+	},
+/turf/open/floor/circuit/red/off,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "eVY" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -20572,6 +20539,43 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/cruiser_dock)
+"fjK" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/obj/structure/table/glass/plasmaglass,
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = -5;
+	pixel_y = 12
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = -2;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = 1;
+	pixel_y = 14
+	},
+/obj/item/reagent_containers/syringe{
+	pixel_x = 4;
+	pixel_y = 15
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/item/reagent_containers/cup/bottle/radium{
+	pixel_x = -8;
+	pixel_y = 9
+	},
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stock_parts/scanning_module/triphasic,
+/obj/item/screwdriver/red,
+/obj/item/extrapolator,
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "flv" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -20654,6 +20658,16 @@
 	},
 /turf/open/floor/iron/dark/textured_edge,
 /area/centcom/central_command_areas/evacuation)
+"fuz" = (
+/obj/machinery/corral_corner{
+	mapping_id = "13"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "13"
+	},
+/obj/machinery/duct,
+/turf/open/floor/circuit/red/off,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "fyA" = (
 /obj/structure/table/greyscale,
 /obj/item/melee/baton{
@@ -21044,6 +21058,12 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
+"gGz" = (
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "13"
+	},
+/turf/open/floor/circuit/red/off,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "gHM" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/structure/chair/sofa/corp/left,
@@ -21140,6 +21160,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/sandy_dirt,
 /area/centcom/central_command_areas/adminroom)
+"gQW" = (
+/obj/machinery/light/cold/directional/west,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 10
+	},
+/obj/machinery/computer/diseasesplicer,
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "gRd" = (
 /obj/machinery/status_display/evac/directional/west,
 /obj/machinery/light/directional/west,
@@ -21214,6 +21242,9 @@
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/admin)
+"hdf" = (
+/turf/open/floor/engine,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "hdA" = (
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/evacuation)
@@ -21465,7 +21496,7 @@
 	pixel_x = 4
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/centcom/syndicate_mothership/control)
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "hDx" = (
 /obj/machinery/door/airlock/vault{
 	color = "543e27";
@@ -21523,6 +21554,10 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
+"hLe" = (
+/obj/machinery/duct,
+/turf/open/floor/engine,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "hLu" = (
 /obj/structure/chair/office/tactical{
 	dir = 8
@@ -22168,6 +22203,12 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/admin)
+"jQp" = (
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "jQK" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/sandy_dirt,
@@ -22184,6 +22225,9 @@
 /obj/item/fishing_rod/telescopic/master,
 /turf/open/misc/dirt/jungle/dark/arena,
 /area/centcom/central_command_areas/admin)
+"jTt" = (
+/turf/closed/indestructible/opsglass,
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "jUj" = (
 /obj/structure/fake_stairs/wood/directional/north,
 /turf/open/misc/dirt/station,
@@ -22413,6 +22457,9 @@
 /obj/structure/flora/grass/jungle/b/style_4,
 /turf/open/misc/dirt/jungle/dark/arena,
 /area/centcom/central_command_areas/admin)
+"kNn" = (
+/turf/closed/indestructible/syndicate,
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "kPU" = (
 /obj/item/reagent_containers/condiment/soymilk,
 /obj/item/reagent_containers/condiment/soymilk,
@@ -22589,6 +22636,14 @@
 /obj/effect/turf_decal/tile/dark_purple/fourcorners,
 /turf/open/floor/iron/textured,
 /area/centcom/central_command_areas/admin)
+"ltN" = (
+/obj/machinery/computer/slime_market,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/mineral/titanium/tiled/yellow,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "lwC" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
@@ -22764,6 +22819,15 @@
 /obj/structure/flora/rock/pile/jungle/large/style_random,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
+"mqJ" = (
+/obj/machinery/corral_corner{
+	mapping_id = "11"
+	},
+/obj/machinery/corral_corner{
+	mapping_id = "13"
+	},
+/turf/open/floor/circuit/red/off,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "mrt" = (
 /obj/structure/railing/wooden_fence,
 /obj/effect/turf_decal/siding/wood{
@@ -22969,7 +23033,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/centcom/syndicate_mothership/control)
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "npG" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 8
@@ -23991,6 +24055,14 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/plastic,
 /area/centcom/central_command_areas/admin)
+"qYj" = (
+/obj/machinery/biomass_recycler,
+/obj/item/stack/biomass,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/mineral/titanium/tiled/yellow,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "qYP" = (
 /obj/structure/railing/wooden_fencing{
 	pixel_y = 16
@@ -24024,6 +24096,24 @@
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin)
+"rfI" = (
+/obj/machinery/reagentgrinder{
+	pixel_x = -1;
+	pixel_y = 8
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/mineral/plasma{
+	pixel_y = 10
+	},
+/obj/structure/table/glass/plasmaglass,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/tiled/yellow,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "rgQ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -24149,7 +24239,7 @@
 	pixel_y = 2
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/centcom/syndicate_mothership/control)
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "rEM" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/carpet/blue,
@@ -24298,6 +24388,13 @@
 /obj/machinery/light/street_lamp,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/admin)
+"rWM" = (
+/obj/machinery/plumbing/ooze_sucker{
+	mapping_id = "12";
+	dir = 1
+	},
+/turf/open/floor/circuit/red/off,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "rWQ" = (
 /obj/structure/railing{
 	dir = 8
@@ -24494,7 +24591,7 @@
 /obj/structure/rack,
 /obj/item/clothing/suit/space/hardsuit/juggernaut,
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/centcom/syndicate_mothership/control)
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "sNI" = (
 /obj/item/food/grown/banana/bunch,
 /turf/open/floor/mineral/bananium,
@@ -24791,6 +24888,16 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/cruiser_dock)
+"tGR" = (
+/obj/machinery/corral_corner{
+	mapping_id = "12"
+	},
+/obj/machinery/slime_pen_controller{
+	mapping_id = "12"
+	},
+/obj/machinery/duct,
+/turf/open/floor/circuit/red/off,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "tHH" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/directional,
@@ -24883,6 +24990,10 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/adminroom)
+"tYq" = (
+/obj/machinery/light/cold/directional/west,
+/turf/open/floor/circuit/red/off,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "tYX" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -25275,6 +25386,10 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
+"vBW" = (
+/obj/machinery/plumbing/ooze_compressor,
+/turf/open/floor/engine,
+/area/centcom/syndicate_mothership/expansion_bioterrorism)
 "vCe" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -25554,7 +25669,7 @@
 /obj/item/storage/toolbox/syndicate,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/centcom/syndicate_mothership/control)
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "wuw" = (
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/donkpockets{
@@ -27067,23 +27182,23 @@ aOL
 aOL
 aOL
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aOL
 aOL
 aOL
 aOL
 aOL
 aOL
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aOL
+aOL
+aOL
+aOL
+aOL
+aOL
+aOL
+aOL
+aOL
+aOL
+aOL
 aaa
 aaa
 aaa
@@ -27325,22 +27440,22 @@ aku
 aOL
 aaa
 aOL
-aOL
-aOL
-aOL
-aOL
-aOL
+aPL
+aPL
+aPL
+aJZ
 aPL
 aPL
 aPL
 aPL
+aPL
+aPL
+aPL
+aPL
+aPL
+aPL
+aPL
 aOL
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -27583,21 +27698,21 @@ aOL
 aOL
 aOL
 aPL
-aPL
-aPL
-aJZ
-aPL
+aKE
+fjK
+jQp
+gQW
 arU
+eVE
 amT
-aWw
+tYq
+eVE
+cPr
+tYq
+amT
+cPr
 aPL
 aOL
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -27836,25 +27951,25 @@ aqc
 aqc
 aqc
 aku
-anK
-anK
-anK
+kNn
+kNn
+kNn
 aPL
-aKE
-aoH
-asf
+avM
+aUe
+aqs
 asi
 auG
+amT
+aWw
+amT
+amT
+amT
+amT
 amT
 amT
 aPL
 aOL
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -28097,21 +28212,21 @@ nmt
 sNq
 rCN
 aPL
-avM
-aUe
-apE
+drn
+acX
+aeO
 ane
 auG
-auG
-auG
+amT
+amT
+gGz
+eHW
+eHW
+rWM
+aWw
+amT
 aPL
 aOL
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -28359,16 +28474,16 @@ acX
 aeO
 aex
 auG
+mqJ
 amT
-awg
+amT
+fuz
+tGR
+amT
+amT
+cPr
 aPL
 aOL
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -28607,25 +28722,25 @@ aJP
 aJP
 azB
 aku
-anK
+jTt
 aQx
-anK
+jTt
 aPL
 amz
 acX
 apE
 avy
 auG
-amT
-amT
+vBW
+hLe
+hLe
+hLe
+hLe
+hLe
+hLe
+vBW
 aPL
 aOL
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -28873,16 +28988,16 @@ aqs
 aHf
 ahS
 auG
-auG
-auG
+hdf
+hdf
+hdf
+hdf
+hdf
+hdf
+hdf
+hdf
 aPL
 aOL
-aOL
-aOL
-aOL
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -29130,16 +29245,16 @@ aeO
 acA
 acA
 aPu
-auG
-axJ
-aga
-aIw
-aIw
-aZw
+hdf
+hdf
+hdf
+eRt
+hdf
+hdf
+hdf
+hdf
+aPL
 aOL
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -29387,16 +29502,16 @@ aLr
 aMT
 aOY
 aFC
-auG
+hdf
 aZd
 aga
-aIw
+rfI
 aIw
 aZy
+ltN
+qYj
+aPL
 aOL
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -29647,13 +29762,13 @@ aNw
 aNw
 aNw
 aNw
-arJ
-azl
-aUd
+aPL
+aPL
+aPL
+aPL
+aPL
+aPL
 aOL
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -29908,9 +30023,9 @@ aNw
 aNw
 aNw
 aOL
-aaa
-aaa
-aaa
+aOL
+aOL
+aOL
 aaa
 aaa
 aaa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -24061,6 +24061,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/item/stack/biomass,
+/obj/item/stack/biomass,
+/obj/item/stack/biomass,
+/obj/item/stack/biomass,
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "qYP" = (

--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -216,6 +216,12 @@
 	name = "Syndicate Elite Squad"
 	icon_state = "syndie-elite"
 
+//monkestation addition
+/area/centcom/syndicate_mothership/expansion_bulldozer
+	name = "Syndicate Juggernaut Armory"
+	icon_state = "syndie-elite"
+	ambience_index = AMBIENCE_DANGER
+
 //CAPTURE THE FLAG
 /area/centcom/ctf
 	name = "Capture the Flag"

--- a/code/game/machinery/computer/orders/order_computer/mining_order.dm
+++ b/code/game/machinery/computer/orders/order_computer/mining_order.dm
@@ -149,7 +149,7 @@
 	icon_state = "data_1"
 
 	///Amount of points this card contains.
-	var/points = 500
+	var/points = 325
 
 /obj/item/card/mining_point_card/examine(mob/user)
 	. = ..()

--- a/monkestation/code/modules/uplink/uplink_items/nukeops.dm
+++ b/monkestation/code/modules/uplink/uplink_items/nukeops.dm
@@ -20,7 +20,7 @@
 	surplus = 60
 
 /datum/uplink_item/suits/cybersun_juggernaut_suit
-	name = "Cybersun Juggernaut Suit"
+	name = "Cybersun Juggernaut Suit Access Card"
 	desc = "Developed by Cybersun for use in clearing heavy space bear infestations in asteroid belt operations.\
 	 It now has a new purpose as the heavy operation suit of the Syndicate. By purchasing this you get a special Authorization Key to the only suit in storage at Firebase Balthazord."
 	item = /obj/item/keycard/syndicate_suit_storage

--- a/monkestation/code/modules/virology/machines/analyzer.dm
+++ b/monkestation/code/modules/virology/machines/analyzer.dm
@@ -227,3 +227,6 @@
 		dish.forceMove(loc)
 		dish = null
 		update_appearance()
+
+/obj/machinery/disease2/diseaseanalyser/fullupgrade
+	circuit = /obj/item/circuitboard/machine/diseaseanalyser/fullupgrade

--- a/monkestation/code/modules/virology/machines/centrifuge.dm
+++ b/monkestation/code/modules/virology/machines/centrifuge.dm
@@ -483,6 +483,9 @@
 	special = CENTRIFUGE_LIGHTSPECIAL_OFF
 	. = ..()
 
+/obj/machinery/disease2/centrifuge/fullupgrade
+	circuit = /obj/item/circuitboard/machine/centrifuge/fullupgrade
+
 #undef CENTRIFUGE_LIGHTSPECIAL_OFF
 #undef CENTRIFUGE_LIGHTSPECIAL_BLINKING
 #undef CENTRIFUGE_LIGHTSPECIAL_ON

--- a/monkestation/code/modules/virology/machines/incubator.dm
+++ b/monkestation/code/modules/virology/machines/incubator.dm
@@ -481,6 +481,9 @@
 	var/updates_new = 0
 	var/updates = 0
 
+/obj/machinery/disease2/incubator/fullupgrade
+	circuit = /obj/machinery/disease2/incubator/fullupgrade
+
 #undef INCUBATOR_DISH_GROWTH
 #undef INCUBATOR_DISH_REAGENT
 #undef INCUBATOR_DISH_MAJOR

--- a/monkestation/code/modules/virology/machines/incubator.dm
+++ b/monkestation/code/modules/virology/machines/incubator.dm
@@ -481,9 +481,6 @@
 	var/updates_new = 0
 	var/updates = 0
 
-/obj/machinery/disease2/incubator/fullupgrade
-	circuit = /obj/machinery/disease2/incubator/fullupgrade
-
 #undef INCUBATOR_DISH_GROWTH
 #undef INCUBATOR_DISH_REAGENT
 #undef INCUBATOR_DISH_MAJOR

--- a/monkestation/code/modules/virology/research/circuitboards.dm
+++ b/monkestation/code/modules/virology/research/circuitboards.dm
@@ -26,6 +26,28 @@
 		/datum/stock_part/micro_laser = 2,
 	)
 
+/obj/item/circuitboard/machine/centrifuge/fullupgrade
+	build_path = /obj/machinery/disease2/centrifuge/fullupgrade
+	req_components = list(
+		/datum/stock_part/manipulator/tier4 = 3,
+	)
+
+/obj/item/circuitboard/machine/diseaseanalyser/fullupgrade
+	build_path = /obj/machinery/disease2/diseaseanalyser/fullupgrade
+	req_components = list(
+		/datum/stock_part/scanning_module/tier4 = 3,
+		/datum/stock_part/manipulator/tier4 = 1,
+		/datum/stock_part/micro_laser/tier4 = 1,
+	)
+
+/obj/item/circuitboard/machine/incubator/fullupgrade
+	build_path = /obj/machinery/disease2/incubator/fullupgrade
+	req_components = list(
+		/datum/stock_part/scanning_module/tier4 = 2,
+		/datum/stock_part/matter_bin/tier4 = 1,
+		/datum/stock_part/micro_laser/tier4 = 2,
+	)
+
 /obj/item/circuitboard/computer/diseasesplicer
 	name = "Disease Splicer"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL

--- a/monkestation/code/modules/virology/research/circuitboards.dm
+++ b/monkestation/code/modules/virology/research/circuitboards.dm
@@ -40,14 +40,6 @@
 		/datum/stock_part/micro_laser/tier4 = 1,
 	)
 
-/obj/item/circuitboard/machine/incubator/fullupgrade
-	build_path = /obj/machinery/disease2/incubator/fullupgrade
-	req_components = list(
-		/datum/stock_part/scanning_module/tier4 = 2,
-		/datum/stock_part/matter_bin/tier4 = 1,
-		/datum/stock_part/micro_laser/tier4 = 2,
-	)
-
 /obj/item/circuitboard/computer/diseasesplicer
 	name = "Disease Splicer"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL


### PR DESCRIPTION
## About The Pull Request
Xenobio and pathology on nukie base is so outdated. When's the the last time youve seen someone buy this area anywho?
Either way update to make the areas functional again! Issue #3834 

Also gave the bulldozer suit its own defined area. 

Nerfed the amount of mining points a mining point redeption card has to prevent an infinite point exploit. Aka fixing issue [#842](https://github.com/Monkestation/Monkestation2.0/issues/842)! 
## Why It's Good For The Game
Fixes a bug




In seriousness though people deserve their tc's worth. Instating a half decent viro/xeno area goes a long way if this is ever used.

And mining point was reduced to 325 points upon purchase to reflect the shuttle discount.

## Changelog
:cl:
add: Added a dedicated expansion area for the juggernaut suit
qol: Renamed the juggernaut suit purchase to reflect your buying access to the suit, not the suit itself. 
balance: Lowered the amount mining transfer cards come with, fixing a infinite mining point exploit. CC hated this one trick. 
fix: Adjusted bioterrorism area in nukie base so you can actually preform xenobio and virology.
/:cl:
