### PR TITLE
Monophobia Quirk

### DIFF
--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -172,7 +172,7 @@
 	name = "Monophobia"
 	desc = "Patient feels sick and distressed when not around other people, leading to potentially lethal levels of stress."
 	scan_desc = "monophobia"
-	gain_text = ""
+	gain_text = "You no longer feel safe being alone." //monkestation edit
 	lose_text = span_notice("You feel like you could be safe on your own.")
 	var/stress = 0
 

--- a/code/datums/quirks/negative_quirks/monophobia.dm
+++ b/code/datums/quirks/negative_quirks/monophobia.dm
@@ -1,6 +1,6 @@
 /datum/quirk/monophobia
 	name = "Monophobia"
-	desc = "You are extremley stressed when left alone, leading to potenitally lethal levels of anxiety."
+	desc = "You are extremely stressed when left alone, leading to potentially lethal levels of anxiety."
 	value = -6
 	icon = FA_ICON_USER_FRIENDS
 	medical_record_text = "Patient has an irrational fear of something."

--- a/code/datums/quirks/negative_quirks/monophobia.dm
+++ b/code/datums/quirks/negative_quirks/monophobia.dm
@@ -1,0 +1,15 @@
+/datum/quirk/monophobia
+	name = "Monophobia"
+	desc = "You are extremley stressed when left alone, leading to potenitally lethal levels of anxiety."
+	icon = FA_ICON_USERS
+	value = -6
+	medical_record_text = "Patient has an irrational fear of something."
+	mail_goodies = list(/obj/item/choice_beacon/pet)
+
+/datum/quirk/monophobia/add(client/client_source)
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	human_holder.gain_trauma(new /datum/brain_trauma/severe/monophobia, TRAUMA_RESILIENCE_ABSOLUTE)
+
+/datum/quirk/monophobia/remove()
+	var/mob/living/carbon/human/human_holder = quirk_holder
+	human_holder.cure_trauma_type(/datum/brain_trauma/severe/monophobia, TRAUMA_RESILIENCE_ABSOLUTE)

--- a/code/datums/quirks/negative_quirks/monophobia.dm
+++ b/code/datums/quirks/negative_quirks/monophobia.dm
@@ -2,6 +2,7 @@
 	name = "Monophobia"
 	desc = "You are extremley stressed when left alone, leading to potenitally lethal levels of anxiety."
 	value = -6
+	icon = FA_ICON_USER_FRIENDS
 	medical_record_text = "Patient has an irrational fear of something."
 	mail_goodies = list(/obj/item/choice_beacon/pet)
 

--- a/code/datums/quirks/negative_quirks/monophobia.dm
+++ b/code/datums/quirks/negative_quirks/monophobia.dm
@@ -1,7 +1,6 @@
 /datum/quirk/monophobia
 	name = "Monophobia"
 	desc = "You are extremley stressed when left alone, leading to potenitally lethal levels of anxiety."
-	icon = FA_ICON_USERS
 	value = -6
 	medical_record_text = "Patient has an irrational fear of something."
 	mail_goodies = list(/obj/item/choice_beacon/pet)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1651,6 +1651,7 @@
 #include "code\datums\quirks\negative_quirks\insanity.dm"
 #include "code\datums\quirks\negative_quirks\junkie.dm"
 #include "code\datums\quirks\negative_quirks\light_drinker.dm"
+#include "code\datums\quirks\negative_quirks\monophobia.dm"
 #include "code\datums\quirks\negative_quirks\mute.dm"
 #include "code\datums\quirks\negative_quirks\nearsighted.dm"
 #include "code\datums\quirks\negative_quirks\non_violent.dm"


### PR DESCRIPTION

## About The Pull Request
Adds a new quirk, monophobia, at -6 points
## Why It's Good For The Game
More interesting quirks is always fun for the game. And it helps with obsessed hiding their trauma some with making seeing monophobia a more common event.

I justify it being a -6 event quirk based on similar esk perks and the potentiality of it being lethal. (Heart attacks)
## Changelog
:cl:
add: Added a new negative quirk, "Monophobia" (-6 points), being alone never been so stressful
/:cl:
