### PR TITLE
Disables VethDay

### DIFF
--- a/monkestation/code/datums/announcers/vethday.dm
+++ b/monkestation/code/datums/announcers/vethday.dm
@@ -1,3 +1,4 @@
+/* disabled (its not my birthday, this has a weight of 0 and somehow still rolls)
 /datum/centcom_announcer/vethday
 	welcome_sounds = list('monkestation/sound/ai/vethbirthday/welcome/ccveth.ogg')
 
@@ -30,5 +31,5 @@
 						ANNOUNCER_SHUTTLEDOCK = 'monkestation/sound/ai/vethbirthday/abShuttleDocked.ogg',
 						ANNOUNCER_SHUTTLERECALLED = 'monkestation/sound/ai/vethbirthday/abShuttleRecalled.ogg',
 						ANNOUNCER_SPANOMALIES = 'monkestation/sound/ai/vethbirthday/chenSpanomalies.ogg')
-
+*/
 

--- a/monkestation/code/datums/station_traits/neutral_traits.dm
+++ b/monkestation/code/datums/station_traits/neutral_traits.dm
@@ -30,6 +30,7 @@
 	. = ..()
 	SSstation.announcer = /datum/centcom_announcer/dagoth
 
+/* disabled (its not my birthday, this has a weight of 0 and yet somehow still rolls)
 /datum/station_trait/announcement_veth_birthday
 	name = "Announcement Veth's Birthday"
 	trait_type = STATION_TRAIT_NEUTRAL
@@ -41,5 +42,5 @@
 /datum/station_trait/announcement_veth_birthday/New()
 	. = ..()
 	SSstation.announcer = /datum/centcom_announcer/vethday
-
+*/
 


### PR DESCRIPTION
Disables the custom announcerpack that I made for my birthday. It has a weight of 0, yet can still roll, so I've disabled it. Also I cringe everytime I have to hear my own voice.

## Changelog
:cl:
del: Disabled VethDay announcer pack.

/:cl:
