### PR TITLE
Moves IPC limbs from under robot

### DIFF
--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -147,6 +147,33 @@
 	icon = FA_ICON_BOMB
 	//All effects are handled directly in butts.dm
 
+/datum/quirk/tunnel_vision
+	name = "Tunnel Vision"
+	desc = "You spent too long scoped in. You cant see behind you!"
+	value = -2
+	icon = FA_ICON_QUESTION
+	gain_text = span_notice("You have trouble focusing on what you left behind.")
+	lose_text = span_notice("You feel paranoid, constantly checking your back...")
+	medical_record_text = "Patient had trouble noticing people walking up from behind during the examination."
+
+/datum/quirk/tunnel_vision/add_unique(client/client_source)
+	var/range_name = client_source?.prefs.read_preference(/datum/preference/choiced/tunnel_vision_fov) || "Minor (90 Degrees)"
+	var/fov_range
+	switch(range_name)
+		if ("Severe (270 Degrees)")
+			fov_range = FOV_270_DEGREES
+		if ("Moderate (180 Degrees)")
+			fov_range = FOV_180_DEGREES
+		else
+			fov_range = FOV_90_DEGREES
+	quirk_holder.add_fov_trait("tunnel vision quirk", fov_range)
+/*
+/datum/quirk/tunnel_vision/add()
+	quirk_holder.add_fov_trait("tunnel vision quirk", fov_range)
+*/
+/datum/quirk/tunnel_vision/remove()
+	quirk_holder.remove_fov_trait("tunnel vision quirk")
+
 //IPC PUNISHMENT SYSTEM//
 /datum/quirk/frail/add()
 	if(!iscarbon(quirk_holder))
@@ -212,30 +239,3 @@
 /datum/quirk/item_quirk/allergic/post_add()
 	if(isipc(quirk_holder)) //monkestation addition
 		to_chat(quirk_holder, span_boldnotice("Your chassis feels frail."))
-
-/datum/quirk/tunnel_vision
-	name = "Tunnel Vision"
-	desc = "You spent too long scoped in. You cant see behind you!"
-	value = -2
-	icon = FA_ICON_QUESTION
-	gain_text = span_notice("You have trouble focusing on what you left behind.")
-	lose_text = span_notice("You feel paranoid, constantly checking your back...")
-	medical_record_text = "Patient had trouble noticing people walking up from behind during the examination."
-
-/datum/quirk/tunnel_vision/add_unique(client/client_source)
-	var/range_name = client_source?.prefs.read_preference(/datum/preference/choiced/tunnel_vision_fov) || "Minor (90 Degrees)"
-	var/fov_range
-	switch(range_name)
-		if ("Severe (270 Degrees)")
-			fov_range = FOV_270_DEGREES
-		if ("Moderate (180 Degrees)")
-			fov_range = FOV_180_DEGREES
-		else
-			fov_range = FOV_90_DEGREES
-	quirk_holder.add_fov_trait("tunnel vision quirk", fov_range)
-/*
-/datum/quirk/tunnel_vision/add()
-	quirk_holder.add_fov_trait("tunnel vision quirk", fov_range)
-*/
-/datum/quirk/tunnel_vision/remove()
-	quirk_holder.remove_fov_trait("tunnel vision quirk")

--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -147,33 +147,6 @@
 	icon = FA_ICON_BOMB
 	//All effects are handled directly in butts.dm
 
-/datum/quirk/tunnel_vision
-	name = "Tunnel Vision"
-	desc = "You spent too long scoped in. You cant see behind you!"
-	value = -2
-	icon = FA_ICON_QUESTION
-	gain_text = span_notice("You have trouble focusing on what you left behind.")
-	lose_text = span_notice("You feel paranoid, constantly checking your back...")
-	medical_record_text = "Patient had trouble noticing people walking up from behind during the examination."
-
-/datum/quirk/tunnel_vision/add_unique(client/client_source)
-	var/range_name = client_source?.prefs.read_preference(/datum/preference/choiced/tunnel_vision_fov) || "Minor (90 Degrees)"
-	var/fov_range
-	switch(range_name)
-		if ("Severe (270 Degrees)")
-			fov_range = FOV_270_DEGREES
-		if ("Moderate (180 Degrees)")
-			fov_range = FOV_180_DEGREES
-		else
-			fov_range = FOV_90_DEGREES
-	quirk_holder.add_fov_trait("tunnel vision quirk", fov_range)
-/*
-/datum/quirk/tunnel_vision/add()
-	quirk_holder.add_fov_trait("tunnel vision quirk", fov_range)
-*/
-/datum/quirk/tunnel_vision/remove()
-	quirk_holder.remove_fov_trait("tunnel vision quirk")
-
 //IPC PUNISHMENT SYSTEM//
 /datum/quirk/frail/add()
 	if(!iscarbon(quirk_holder))
@@ -239,3 +212,30 @@
 /datum/quirk/item_quirk/allergic/post_add()
 	if(isipc(quirk_holder)) //monkestation addition
 		to_chat(quirk_holder, span_boldnotice("Your chassis feels frail."))
+
+/datum/quirk/tunnel_vision
+	name = "Tunnel Vision"
+	desc = "You spent too long scoped in. You cant see behind you!"
+	value = -2
+	icon = FA_ICON_QUESTION
+	gain_text = span_notice("You have trouble focusing on what you left behind.")
+	lose_text = span_notice("You feel paranoid, constantly checking your back...")
+	medical_record_text = "Patient had trouble noticing people walking up from behind during the examination."
+
+/datum/quirk/tunnel_vision/add_unique(client/client_source)
+	var/range_name = client_source?.prefs.read_preference(/datum/preference/choiced/tunnel_vision_fov) || "Minor (90 Degrees)"
+	var/fov_range
+	switch(range_name)
+		if ("Severe (270 Degrees)")
+			fov_range = FOV_270_DEGREES
+		if ("Moderate (180 Degrees)")
+			fov_range = FOV_180_DEGREES
+		else
+			fov_range = FOV_90_DEGREES
+	quirk_holder.add_fov_trait("tunnel vision quirk", fov_range)
+/*
+/datum/quirk/tunnel_vision/add()
+	quirk_holder.add_fov_trait("tunnel vision quirk", fov_range)
+*/
+/datum/quirk/tunnel_vision/remove()
+	quirk_holder.remove_fov_trait("tunnel vision quirk")

--- a/monkestation/code/modules/research/designs/mechfabricator_designs.dm
+++ b/monkestation/code/modules/research/designs/mechfabricator_designs.dm
@@ -17,7 +17,7 @@
 	build_type = MECHFAB
 	construction_time = 15 SECONDS
 	materials = list(/datum/material/iron = 4000, /datum/material/glass = 500)
-	build_path = /obj/item/bodypart/head/robot/ipc
+	build_path = /obj/item/bodypart/head/ipc
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_MISC
 	)
@@ -29,7 +29,7 @@
 	build_type = MECHFAB
 	construction_time = 15 SECONDS
 	materials = list(/datum/material/iron = 5000)
-	build_path = /obj/item/bodypart/chest/robot/ipc
+	build_path = /obj/item/bodypart/chest/ipc
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_MISC
 	)
@@ -41,7 +41,7 @@
 	build_type = MECHFAB
 	construction_time = 15 SECONDS
 	materials = list(/datum/material/iron = 2000)
-	build_path = /obj/item/bodypart/arm/left/robot/ipc
+	build_path = /obj/item/bodypart/arm/left/ipc
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_MISC
 	)
@@ -53,7 +53,7 @@
 	build_type = MECHFAB
 	construction_time = 15 SECONDS
 	materials = list(/datum/material/iron = 2000)
-	build_path = /obj/item/bodypart/arm/right/robot/ipc
+	build_path = /obj/item/bodypart/arm/right/ipc
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_MISC
 	)
@@ -65,7 +65,7 @@
 	build_type = MECHFAB
 	construction_time = 15 SECONDS
 	materials = list(/datum/material/iron = 2000)
-	build_path = /obj/item/bodypart/leg/left/robot/ipc
+	build_path = /obj/item/bodypart/leg/left/ipc
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_MISC
 	)
@@ -77,7 +77,7 @@
 	build_type = MECHFAB
 	construction_time = 15 SECONDS
 	materials = list(/datum/material/iron = 2000)
-	build_path = /obj/item/bodypart/leg/right/robot/ipc
+	build_path = /obj/item/bodypart/leg/right/ipc
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_MISC
 	)

--- a/monkestation/code/modules/smithing/ipcs/body/base_bodyparts.dm
+++ b/monkestation/code/modules/smithing/ipcs/body/base_bodyparts.dm
@@ -52,6 +52,7 @@
 	icon_static = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	limb_id = "synth"
 	icon_state = "synth_l_arm"
+	flags_1 = CONDUCT_1
 	should_draw_greyscale = FALSE
 	biological_state = BIO_ROBOTIC | BIO_JOINTED | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
@@ -75,6 +76,7 @@
 	icon_static = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	limb_id = "synth"
 	icon_state = "synth_r_arm"
+	flags_1 = CONDUCT_1
 	should_draw_greyscale = FALSE
 	biological_state = BIO_ROBOTIC | BIO_JOINTED | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
@@ -98,6 +100,7 @@
 	icon_static = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	limb_id = "synth"
 	icon_state = "synth_l_leg"
+	flags_1 = CONDUCT_1
 	should_draw_greyscale = FALSE
 	biological_state = BIO_ROBOTIC | BIO_JOINTED | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
@@ -119,6 +122,7 @@
 	icon_static = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	limb_id = "synth"
 	icon_state = "synth_r_leg"
+	flags_1 = CONDUCT_1
 	should_draw_greyscale = FALSE
 	biological_state = BIO_ROBOTIC | BIO_JOINTED | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC

--- a/monkestation/code/modules/smithing/ipcs/body/base_bodyparts.dm
+++ b/monkestation/code/modules/smithing/ipcs/body/base_bodyparts.dm
@@ -1,4 +1,4 @@
-/obj/item/bodypart/head/robot/ipc
+/obj/item/bodypart/head/ipc
 	icon = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	icon_greyscale = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	icon_static = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
@@ -15,7 +15,14 @@
 	body_damage_coeff = 1.1	//IPC's Head can dismember	//Monkestation Edit
 	max_damage = 40	//Keep in mind that this value is used in the //Monkestation Edit
 	dmg_overlay_type = "synth"
-/obj/item/bodypart/chest/robot/ipc
+
+	disabling_threshold_percentage = 1
+
+	biological_state = (BIO_ROBOTIC|BIO_JOINTED)
+
+	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT, CLONE = DEFAULT_CLONE_EXAMINE_TEXT)
+
+/obj/item/bodypart/chest/ipc
 	icon = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	icon_greyscale = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	icon_static = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
@@ -33,7 +40,13 @@
 
 	dmg_overlay_type = "synth"
 
-/obj/item/bodypart/arm/left/robot/ipc
+	disabling_threshold_percentage = 1
+
+	biological_state = (BIO_ROBOTIC|BIO_JOINTED)
+
+	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT, CLONE = DEFAULT_CLONE_EXAMINE_TEXT)
+
+/obj/item/bodypart/arm/left/ipc
 	icon = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	icon_greyscale = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	icon_static = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
@@ -50,7 +63,13 @@
 
 	dmg_overlay_type = "synth"
 
-/obj/item/bodypart/arm/right/robot/ipc
+	disabling_threshold_percentage = 1
+
+	biological_state = (BIO_ROBOTIC|BIO_JOINTED)
+
+	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT, CLONE = DEFAULT_CLONE_EXAMINE_TEXT)
+
+/obj/item/bodypart/arm/right/ipc
 	icon = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	icon_greyscale = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	icon_static = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
@@ -67,7 +86,13 @@
 
 	dmg_overlay_type = "synth"
 
-/obj/item/bodypart/leg/left/robot/ipc
+	disabling_threshold_percentage = 1
+
+	biological_state = (BIO_ROBOTIC|BIO_JOINTED)
+
+	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT, CLONE = DEFAULT_CLONE_EXAMINE_TEXT)
+
+/obj/item/bodypart/leg/left/ipc
 	icon = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	icon_greyscale = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	icon_static = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
@@ -82,7 +107,13 @@
 	dmg_overlay_type = "synth"
 	step_sounds = list('sound/effects/servostep.ogg')
 
-/obj/item/bodypart/leg/right/robot/ipc
+	disabling_threshold_percentage = 1
+
+	biological_state = (BIO_ROBOTIC|BIO_JOINTED)
+
+	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT, CLONE = DEFAULT_CLONE_EXAMINE_TEXT)
+
+/obj/item/bodypart/leg/right/ipc
 	icon = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	icon_greyscale = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
 	icon_static = 'monkestation/icons/mob/species/ipc/bodyparts.dmi'
@@ -99,3 +130,9 @@
 
 	dmg_overlay_type = "synth"
 	step_sounds = list('sound/effects/servostep.ogg')
+
+	disabling_threshold_percentage = 1
+
+	biological_state = (BIO_ROBOTIC|BIO_JOINTED)
+
+	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT, CLONE = DEFAULT_CLONE_EXAMINE_TEXT)

--- a/monkestation/code/modules/smithing/ipcs/species.dm
+++ b/monkestation/code/modules/smithing/ipcs/species.dm
@@ -56,12 +56,12 @@
 	exotic_bloodtype = /datum/blood_type/oil
 
 	bodypart_overrides = list(
-		BODY_ZONE_HEAD = /obj/item/bodypart/head/robot/ipc,
-		BODY_ZONE_CHEST = /obj/item/bodypart/chest/robot/ipc,
-		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/robot/ipc,
-		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/robot/ipc,
-		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/robot/ipc,
-		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/robot/ipc,
+		BODY_ZONE_HEAD = /obj/item/bodypart/head/ipc,
+		BODY_ZONE_CHEST = /obj/item/bodypart/chest/ipc,
+		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/ipc,
+		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/ipc,
+		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/ipc,
+		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/ipc,
 	)
 
 	bodytemp_heat_damage_limit = CELCIUS_TO_KELVIN(450)


### PR DESCRIPTION
## About The Pull Request
Moves IPC limbs from being a /robot/ subtype. This should have no different effects besides fixing a few bugs such as,
IPCs not properly applying physiology modifiers, IPC limbs not changing on race change.
I saw no bugs in testing but could probably use a test merge

Also moves tunnel vision to above IPC punishment system


After looking at code on yog, where IPCs are ported from, they were never supposed to be a /robot/ type in the first place which explains why most our issues came from that
## Why It's Good For The Game
Fixes bugs

## Changelog

:cl:
fix: IPCs not applying physiology modifiers
code: moved IPC limbs from under robot, this should have no gameplay changes please report any
/:cl:

