### PR TITLE
Company Imports Armory Lock Update

### DIFF
--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -170,6 +170,40 @@
 					/obj/item/conversion_kit,
 				)
 
+/datum/supply_pack/security/mini_egun
+	name = "Miniature Energy Gun Crate"
+	desc = "Contains three miniature energy guns, a popular choice for security personnel in on-world Nanotransen facilities, \
+		has slightly less charge capacity than a normal lazer gun"
+	cost = CARGO_CRATE_VALUE * 6
+	contains = list(/obj/item/gun/energy/e_gun/mini = 3)
+	crate_name = "miniature energy gun crate"
+
+/datum/supply_pack/security/ammobenchsupport
+	name = "Ammunition Workbench Care Package"
+	desc = "Engineers are vaporized?  Cargo Technicians blew the budget on cats and pizza? \
+		This is the crate for you, containing the necessary supplies to create a complete \
+		ammunition production platform!"
+	cost = CARGO_CRATE_VALUE * 6
+	contains = list(/obj/item/circuitboard/machine/ammo_workbench,
+					/obj/item/disk/ammo_workbench/advanced,
+					/obj/item/circuitboard/machine/dish_drive/bullet,
+					/obj/item/stack/sheet/iron = 10,
+					/obj/item/stack/cable_coil = 30,
+					/obj/item/stock_parts/manipulator = 3,
+					/obj/item/stock_parts/matter_bin = 4,
+					/obj/item/stock_parts/micro_laser = 2,
+					/obj/item/stack/sheet/glass = 1,
+					/obj/item/wrench,
+					/obj/item/screwdriver,
+					/obj/item/paper/fluff{
+	default_raw_text = "To set up your ammo platform, you'll need to crawl before you can shoot! \
+	After setting up your Ammo Workbench, insert the Advanced Munitions Disk and go to the designs tab in the bench. \
+	Finally, finalize the connection between the disk and computer by pressing 'upload', and there you have it!  Git' some!";
+	name = "Notice from Ammunation"
+	},
+				)
+	crate_name = "Ammunition Workbench Care Package"
+
 /// Armory packs
 
 /datum/supply_pack/security/armory
@@ -317,3 +351,92 @@
 	cost = CARGO_CRATE_VALUE * 7
 	contains = list(/obj/item/storage/belt/holster/energy/thermal = 2)
 	crate_name = "thermal pistol crate"
+
+/datum/supply_pack/security/armory/qarad
+	name = "Elite Import Weapon:  Qarad Light Machinegun"
+	desc = "Heavy duty, heavy kicking, heavy penetration weapon, \
+		normally reserved for all out warfare, comes with a gun case \
+		and spare magazines."
+	cost = CARGO_CRATE_VALUE * 15
+	contains = list(/obj/item/gun/ballistic/automatic/sol_rifle/machinegun,
+					/obj/item/storage/toolbox/guncase/skyrat/empty,
+					/obj/item/ammo_box/magazine/c40sol_rifle/standard/starts_empty = 2,
+				)
+	crate_name = "elite import qarad light machine gun crate"
+
+/datum/supply_pack/security/armory/lancabrifle
+	name = "Elite Import Weapon:  Lanca Battle Rifle"
+	desc = "Sleek, scoped, special operatives rifle, \
+		now in your own hands!  Caseless ammunition \
+		will additionally keep your foes guessing!"
+	cost = CARGO_CRATE_VALUE * 15
+	contains = list(/obj/item/gun/ballistic/automatic/lanca,
+					/obj/item/storage/toolbox/guncase/skyrat/empty,
+					/obj/item/ammo_box/magazine/lanca/spawns_empty = 2,
+				)
+	crate_name = "elite import lanca battle rifle"
+
+/datum/supply_pack/security/armory/bogseo
+	name = "Elite Import Weapon: Bogseo Submachinegun"
+	desc = "Among the Honor Guard, training oneself to handle this monster is a test, \
+		though it is more an inside joke regarding its brief high-caliber \
+		chambering run."
+	cost = CARGO_CRATE_VALUE * 15
+	contains = list(/obj/item/gun/ballistic/automatic/xhihao_smg,
+					/obj/item/storage/toolbox/guncase/skyrat/empty,
+					/obj/item/ammo_box/magazine/miecz/spawns_empty = 2,
+				)
+	crate_name = "elite import bogseo submachinegun"
+
+/datum/supply_pack/security/armory/cawomarksman
+	name = "Elite Import Weapon: Cawil Marksman"
+	desc = "Though many soldiers trained in long range ballistics prefer to hold their breath, \
+		the Cawil Marksman's excellent recoil pattern makes it practical in the hands of any \
+		SolFed Cadet."
+	cost = CARGO_CRATE_VALUE * 15
+	contains = list(/obj/item/gun/ballistic/automatic/sol_rifle/marksman,
+					/obj/item/storage/toolbox/guncase/skyrat/empty,
+					/obj/item/ammo_box/magazine/c40sol_rifle/starts_empty = 2,
+				)
+	crate_name = "elite import cawil marksman"
+
+/datum/supply_pack/security/armory/cawobattlerifle
+	name = "Elite Import Weapon: Carwo-Cawil Battle Rifle"
+	desc = "Standard among SolFed troopers, furious all the same, sometimes rarity \
+		doesn't need to constitute robustness."
+	cost = CARGO_CRATE_VALUE * 15
+	contains = list(/obj/item/gun/ballistic/automatic/sol_rifle,
+					/obj/item/storage/toolbox/guncase/skyrat/empty,
+					/obj/item/ammo_box/magazine/c40sol_rifle/standard/starts_empty = 2,
+				)
+	crate_name = "elite import carwo-cawil battle rifle"
+
+/datum/supply_pack/security/armory/mieczsmg
+	name = "Miecz Submachinegun Crate"
+	desc = "Two Miecz subemachineguns now available for purchase, a direct competitor to \
+		the Sindano SolFed SMG, comes in a two pack, considered better value by \
+		P.M.C companies across the Spinward."
+	cost = CARGO_CRATE_VALUE * 10
+	contains = list(/obj/item/gun/ballistic/automatic/miecz = 2)
+	crate_name = "Miecz Submachinegun Crate"
+
+/datum/supply_pack/security/armory/ion_carbine
+	name = "Ion Carbine Special Crate"
+	desc = "Perhaps some rogue Spinward pirates have stolen your ion rifle, or the \
+		clown has taken it for a joy ride?  This ion carbine is a compact solution to \
+		any robotic foes or electronic issues!  Warranty void if used to cook food."
+	cost = CARGO_CRATE_VALUE * 20
+	contains = list(/obj/item/gun/energy/ionrifle/carbine)
+	crate_name = "Ion Carbine Special Crate"
+
+/datum/supply_pack/security/armory/wylomantimat
+	name = "Elite Import:  Wylom Anti-Material Rifle"
+	desc = "Do you really want everything in one direction to not be seen? \
+		We have the weapon for you!  No matter the case, a rogue HONK-mech, \
+		an annoying assistant, or even small space pods, Wylom is here for you!"
+	cost = CARGO_CRATE_VALUE * 15
+	contains = list(/obj/item/gun/ballistic/automatic/wylom,
+					/obj/item/ammo_box/magazine/wylom = 2,
+					/obj/item/storage/toolbox/guncase/skyrat/empty,
+				)
+	crate_name = "elite import wylom anti-material rifle"

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -188,7 +188,7 @@
 					/obj/item/disk/ammo_workbench/advanced,
 					/obj/item/circuitboard/machine/dish_drive/bullet,
 					/obj/item/stack/sheet/iron = 10,
-					/obj/item/stack/cable_coil = 30,
+					/obj/item/stack/cable_coil = 1,
 					/obj/item/stock_parts/manipulator = 3,
 					/obj/item/stock_parts/matter_bin = 4,
 					/obj/item/stock_parts/micro_laser = 2,

--- a/monkestation/code/modules/blueshift/armaments/nri.dm
+++ b/monkestation/code/modules/blueshift/armaments/nri.dm
@@ -93,44 +93,9 @@
 	item_type = /obj/item/gun/ballistic/automatic/pistol/plasma_marksman
 	cost = PAYCHECK_COMMAND * 6
 
-/datum/armament_entry/company_import/nri_surplus/firearm/miecz
-	item_type = /obj/item/gun/ballistic/automatic/miecz
-	cost = PAYCHECK_COMMAND * 10
-
-/datum/armament_entry/company_import/nri_surplus/firearm/sakhno_rifle
-	item_type = /obj/item/gun/ballistic/rifle/boltaction
-	cost = PAYCHECK_COMMAND * 12
-
-/datum/armament_entry/company_import/nri_surplus/firearm/lanca
-	item_type = /obj/item/gun/ballistic/automatic/lanca
-	contraband = TRUE
-	cost = PAYCHECK_COMMAND * 14
-	restricted = TRUE
-
-/datum/armament_entry/company_import/nri_surplus/firearm/anti_materiel_rifle
-	item_type = /obj/item/gun/ballistic/automatic/wylom
-	contraband = TRUE
-	cost = PAYCHECK_COMMAND * 16
-	restricted = TRUE
-
 /datum/armament_entry/company_import/nri_surplus/firearm_ammo
 	subcategory = "Firearm Magazines"
 	cost = PAYCHECK_CREW
 
 /datum/armament_entry/company_import/nri_surplus/firearm_ammo/plasma_battery
 	item_type = /obj/item/ammo_box/magazine/recharge/plasma_battery
-
-/datum/armament_entry/company_import/nri_surplus/firearm_ammo/miecz
-	item_type = /obj/item/ammo_box/magazine/miecz/spawns_empty
-
-/datum/armament_entry/company_import/nri_surplus/firearm_ammo/sakhno
-	item_type = /obj/item/ammo_box/strilka310
-
-/datum/armament_entry/company_import/nri_surplus/firearm_ammo/lanca
-	item_type = /obj/item/ammo_box/magazine/lanca/spawns_empty
-	contraband = TRUE
-
-/datum/armament_entry/company_import/nri_surplus/firearm_ammo/amr_magazine
-	item_type = /obj/item/ammo_box/magazine/wylom
-	contraband = TRUE
-	cost = PAYCHECK_CREW * 3

--- a/monkestation/code/modules/blueshift/armaments/nri.dm
+++ b/monkestation/code/modules/blueshift/armaments/nri.dm
@@ -99,3 +99,18 @@
 
 /datum/armament_entry/company_import/nri_surplus/firearm_ammo/plasma_battery
 	item_type = /obj/item/ammo_box/magazine/recharge/plasma_battery
+
+/datum/armament_entry/company_import/nri_surplus/firearm_ammo/miecz
+	item_type = /obj/item/ammo_box/magazine/miecz/spawns_empty
+
+/datum/armament_entry/company_import/nri_surplus/firearm_ammo/sakhno
+	item_type = /obj/item/ammo_box/strilka310
+
+/datum/armament_entry/company_import/nri_surplus/firearm_ammo/lanca
+	item_type = /obj/item/ammo_box/magazine/lanca/spawns_empty
+	contraband = TRUE
+
+/datum/armament_entry/company_import/nri_surplus/firearm_ammo/amr_magazine
+	item_type = /obj/item/ammo_box/magazine/wylom
+	contraband = TRUE
+	cost = PAYCHECK_CREW * 3

--- a/monkestation/code/modules/blueshift/armaments/sol.dm
+++ b/monkestation/code/modules/blueshift/armaments/sol.dm
@@ -109,34 +109,6 @@
 	item_type = /obj/item/gun/ballistic/shotgun/riot/sol
 	cost = PAYCHECK_COMMAND * 6
 
-/datum/armament_entry/company_import/sol_defense/longarm/sindano
-	item_type = /obj/item/gun/ballistic/automatic/sol_smg
-	cost = PAYCHECK_COMMAND * 6
-
-/datum/armament_entry/company_import/sol_defense/longarm/elite
-	item_type = /obj/item/gun/ballistic/automatic/sol_rifle/marksman
-	cost = PAYCHECK_COMMAND * 12
-
-/datum/armament_entry/company_import/sol_defense/longarm/bogseo
-	item_type = /obj/item/gun/ballistic/automatic/xhihao_smg
-	cost = PAYCHECK_COMMAND * 10
-	contraband = TRUE
-
-/datum/armament_entry/company_import/sol_defense/longarm/infanterie
-	item_type = /obj/item/gun/ballistic/automatic/sol_rifle
-	cost = PAYCHECK_COMMAND * 14
-	contraband = TRUE
-
-/datum/armament_entry/company_import/sol_defense/longarm/outomaties
-	item_type = /obj/item/gun/ballistic/automatic/sol_rifle/machinegun
-	cost = PAYCHECK_COMMAND * 23
-	contraband = TRUE
-
-/datum/armament_entry/company_import/sol_defense/longarm/kiboko
-	item_type = /obj/item/gun/ballistic/automatic/sol_grenade_launcher
-	cost = PAYCHECK_COMMAND * 46
-	contraband = TRUE
-
 /datum/armament_entry/company_import/sol_defense/magazines
 	subcategory = "Magazines"
 	cost = PAYCHECK_CREW
@@ -149,19 +121,4 @@
 
 /datum/armament_entry/company_import/sol_defense/magazines/c585_mag
 	item_type = /obj/item/ammo_box/magazine/c585trappiste_pistol/spawns_empty
-
-/datum/armament_entry/company_import/sol_defense/magazines/sol_rifle_short
-	item_type = /obj/item/ammo_box/magazine/c40sol_rifle/starts_empty
-
-/datum/armament_entry/company_import/sol_defense/magazines/sol_rifle_standard
-	item_type = /obj/item/ammo_box/magazine/c40sol_rifle/standard/starts_empty
-	cost = PAYCHECK_COMMAND
-
-/datum/armament_entry/company_import/sol_defense/magazines/sol_grenade_standard
-	item_type = /obj/item/ammo_box/magazine/c980_grenade/starts_empty
-	cost = PAYCHECK_COMMAND * 2
-
-/datum/armament_entry/company_import/sol_defense/magazines/sol_grenade_drum
-	item_type = /obj/item/ammo_box/magazine/c980_grenade/drum/starts_empty
-	cost = PAYCHECK_CREW * 3
-	contraband = TRUE
+	

--- a/monkestation/code/modules/blueshift/armaments/sol.dm
+++ b/monkestation/code/modules/blueshift/armaments/sol.dm
@@ -121,4 +121,19 @@
 
 /datum/armament_entry/company_import/sol_defense/magazines/c585_mag
 	item_type = /obj/item/ammo_box/magazine/c585trappiste_pistol/spawns_empty
-	
+
+/datum/armament_entry/company_import/sol_defense/magazines/sol_rifle_short
+	item_type = /obj/item/ammo_box/magazine/c40sol_rifle/starts_empty
+
+/datum/armament_entry/company_import/sol_defense/magazines/sol_rifle_standard
+	item_type = /obj/item/ammo_box/magazine/c40sol_rifle/standard/starts_empty
+	cost = PAYCHECK_COMMAND
+
+/datum/armament_entry/company_import/sol_defense/magazines/sol_grenade_standard
+	item_type = /obj/item/ammo_box/magazine/c980_grenade/starts_empty
+	cost = PAYCHECK_COMMAND * 2
+
+/datum/armament_entry/company_import/sol_defense/magazines/sol_grenade_drum
+	item_type = /obj/item/ammo_box/magazine/c980_grenade/drum/starts_empty
+	cost = PAYCHECK_CREW * 3
+	contraband = TRUE	

--- a/monkestation/code/modules/factory_type_beat/machinery/grabber.dm
+++ b/monkestation/code/modules/factory_type_beat/machinery/grabber.dm
@@ -11,7 +11,7 @@
 	/// How many time manipulator need to take and drop item.
 	var/working_speed = 2 SECONDS
 	/// Using high tier manipulators speeds up big manipulator and requires more energy.
-	var/power_use_lvl = 0.2
+	var/power_use_lvl = 0.002
 	/// When manipulator already working with item inside he don't take any new items.
 	var/on_work = FALSE
 	/// Activate mechanism.
@@ -123,22 +123,22 @@
 	switch(locate_servo.tier)
 		if(1)
 			working_speed = 2 SECONDS
-			power_use_lvl = 0.2
+			power_use_lvl = 0.002
 			set_greyscale(COLOR_YELLOW)
 			manipulator_hand?.set_greyscale(COLOR_YELLOW)
 		if(2)
 			working_speed = 1.4 SECONDS
-			power_use_lvl = 0.4
+			power_use_lvl = 0.004
 			set_greyscale(COLOR_ORANGE)
 			manipulator_hand?.set_greyscale(COLOR_ORANGE)
 		if(3)
 			working_speed = 0.8 SECONDS
-			power_use_lvl = 0.6
+			power_use_lvl = 0.006
 			set_greyscale(COLOR_RED)
 			manipulator_hand?.set_greyscale(COLOR_RED)
 		if(4)
 			working_speed = 0.2 SECONDS
-			power_use_lvl = 0.8
+			power_use_lvl = 0.008
 			set_greyscale(COLOR_PURPLE)
 			manipulator_hand?.set_greyscale(COLOR_PURPLE)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -15,6 +15,7 @@
 // BEGIN_INCLUDE
 #include "__odlint.dm"
 #include "_maps\_basemap.dm"
+#include "_maps\map_files\debug\runtimestation.dmm"
 #include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"
 #include "code\_experiments.dm"


### PR DESCRIPTION
## About The Pull Request

Changes various things about the Company Imports / Blueshift update.  This PR, hopefully to be continued in a series sharing the title, aims to halt a flow of guns into the station that is completely unrelegated and unchecked.  Additionally adds some nice bonus crates to security, available through cargo.  Lastly, attempts to fix Big Manipulators, added around the time of Blueshift, which have been breaking the game for half a year, and seemingly have never been fixed. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

First, I will state, we are not primarily an HRP server, we do not have a whitelist, and we do not have an environment that would support everyone being armed to the teeth so their personal roleplay is less likely to be interrupted.  A gun is a gun, by philosophy of ourselves prior to this update and /TG/, guns should be scarce.  Although we cannot return to this philosophy, this update will give space-amazon its slap on the wrist, no more machine guns from a store catalogue.  Antagonists and security should be the ones with military grade weaponry, not 'civilians'.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

Removes and re-concentrates a variety of weapons into more appropriate categories.  'Military' grade weapons have been moved to the armory, primarily this includes company import weapons.  Select few have been added to the security tab along with a proper support package for the ammunition workbench.  Removes the refurbished mosin nagant from the catalogue, this is traitor exclusive.

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

🆑
add: 'Elite' Company Imports in the Armory tab, composed of all removed guns from the imports section.
add: Miniature energy gun crate available in Security tab at cargo.
add: Ammunition Workbench care package, available in the Security tab at cargo.
del: Removed powerful guns from available purchase for people with a weapon permit in the Imports tab at cargo.
del: Removed the refurbished mosin nagant from purchase at the Imports tab, this is uniquely not been added to armory.
balance: Company Imports tab.
fix: Attempts to fix the Big Manipulators from draining 200 kw of power via decreasing the total power consumption.

/🆑
