### PR TITLE
AP shotgun slugs

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -28,6 +28,12 @@
 	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*2.5)
 	projectile_type = /obj/projectile/bullet/shotgun_beanbag
 
+/obj/item/ammo_casing/shotgun/apds
+	name = "armor-peircing slug"
+	desc = "A 12-guage shotgun slug, reloaded with a saboted tungsten penetrator. Armor? What armor!"
+	icon_state = "apshell"
+	projectile_type = /obj/projectile/bullet/shotgun_slug/apds
+
 /obj/item/ammo_casing/shotgun/incendiary
 	name = "incendiary slug"
 	desc = "An incendiary-coated shotgun slug."

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -15,6 +15,19 @@
 	sharpness = NONE
 	wound_bonus = 80
 
+/obj/projectile/bullet/shotgun_slug/apds
+    name = "tungsten sabot-slug"
+	icon_state = "gaussstrong"
+	damage = 35 //15 less than slugs
+	speed = 1.8 //sub-caliber + lighter = speed
+	armour_penetration = 80 //Tis a solid-tungsten penetrator, what do you expect?
+	wound_bonus = 15 //35 seemed kinda wimpy, 15 extra is reasonable, right?
+	ricochets_max = 2 //same as the match-grade ammo for the syndicate LMG
+	ricochet_chance = 60
+	ricochet_auto_aim_range = 4
+	ricochet_incidence_leeway = 55
+	embedding = null
+
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"
 	icon_state = "pellet"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -17,16 +17,17 @@
 
 /obj/projectile/bullet/shotgun_slug/apds
 	name = "tungsten sabot-slug"
-	icon_state = "gaussstrong"
+	icon_state = "gauss"
 	damage = 35 //15 less than slugs
-	speed = 1.8 //sub-caliber + lighter = speed
+	speed = 0.2 //sub-caliber + lighter = speed
 	armour_penetration = 80 //Tis a solid-tungsten penetrator, what do you expect?
 	wound_bonus = 15 //35 seemed kinda wimpy, 15 extra is reasonable, right?
-	ricochets_max = 2 //same as the match-grade ammo for the syndicate LMG
+	ricochets_max = 2 //Unlike slugs which tend to squish on impact, these are hard enough to bounce rarely.
 	ricochet_chance = 60
 	ricochet_auto_aim_range = 4
 	ricochet_incidence_leeway = 55
 	embedding = null
+	demolition_mod = 20
 
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -16,7 +16,7 @@
 	wound_bonus = 80
 
 /obj/projectile/bullet/shotgun_slug/apds
-    name = "tungsten sabot-slug"
+	name = "tungsten sabot-slug"
 	icon_state = "gaussstrong"
 	damage = 35 //15 less than slugs
 	speed = 1.8 //sub-caliber + lighter = speed

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -18,8 +18,8 @@
 /obj/projectile/bullet/shotgun_slug/apds
 	name = "tungsten sabot-slug"
 	icon_state = "gauss"
-	damage = 35 //15 less than slugs
-	speed = 0.2 //sub-caliber + lighter = speed
+	damage = 35 //15 less than slugs.
+	speed = 0.3 //sub-caliber + lighter = speed. (Smaller number = faster)
 	armour_penetration = 80 //Tis a solid-tungsten penetrator, what do you expect?
 	wound_bonus = 15 //35 seemed kinda wimpy, 15 extra is reasonable, right?
 	ricochets_max = 2 //Unlike slugs which tend to squish on impact, these are hard enough to bounce rarely.
@@ -27,7 +27,8 @@
 	ricochet_auto_aim_range = 4
 	ricochet_incidence_leeway = 55
 	embedding = null
-	demolition_mod = 20
+	demolition_mod = 3 //Just how low do I need to make it??
+	//projectile_phasing = PASSGRILLE //Wire mesh is NOT going to stop this, sorry mate. Edit: Guh
 
 /obj/projectile/bullet/shotgun_beanbag
 	name = "beanbag slug"

--- a/monkestation/code/modules/blueshift/armaments/vitezstvi.dm
+++ b/monkestation/code/modules/blueshift/armaments/vitezstvi.dm
@@ -129,6 +129,9 @@
 /datum/armament_entry/company_import/vitezstvi/shot_shells/slugs
 	item_type = /obj/item/ammo_box/advanced/s12gauge
 
+/datum/armament_entry/company_import/vitezstvi/shot_shells/AP_slugs
+	item_type = /obj/item/ammo_box/advanced/s12gauge/apds
+
 /datum/armament_entry/company_import/vitezstvi/shot_shells/buckshot
 	item_type = /obj/item/ammo_box/advanced/s12gauge/buckshot
 

--- a/monkestation/code/modules/blueshift/items/ammo.dm
+++ b/monkestation/code/modules/blueshift/items/ammo.dm
@@ -1030,6 +1030,14 @@
 	ammo_type = /obj/item/ammo_casing/shotgun/hunter
 	max_ammo = 15
 
+/obj/item/ammo_box/advanced/s12gauge/apds
+	name = "AP sabot-slug ammo box"
+	desc = "A box of 15 tungsten sabot-slugs. A vastly higher velocity combined with greater sectional density renders most armor irrelevant."
+	icon_state = "apshell"
+	ammo_type = /obj/item/ammo_casing/shotgun/apds
+	max_ammo = 15
+
+
 /obj/item/ammo_box/advanced/s12gauge/flechette
 	name = "Flechette ammo box"
 	desc = "A box of 15 flechette shells. Each shell contains a small group of tumbling blades that excel at causing terrible wounds."


### PR DESCRIPTION

## About The Pull Request

Adds 12-guage AP slugs, along with the import ammo box to buy them in.
![image](https://github.com/user-attachments/assets/76402234-2be5-4c0e-9800-0f6f9f61b3a3)

Damage after one standard slug to the chest wearing sacrificial armor:
![image](https://github.com/user-attachments/assets/15333720-6f55-4842-99c9-11e200a32b01)

Damage after one AP slug to the chest wearing sacrificial armor:
![image](https://github.com/user-attachments/assets/6e4f8461-0c6d-4570-bc79-6fb69d88efa1)

Unarmored, slugs critted in 2 shots
AP took 3-5 depending on wounding.

Stats compared to basic slugs:
- 15 damage
+ 80 AP (from zero)
~1.5x speed, didn't have a base value and tis hard to judge
+ 15 wound bonus (from zero)
No embedding
Low ricochet chance
A slight demolition bonus, putting them just above slugs in damage to objects


## Why It's Good For The Game

At the moment, NONE of the shotgun shells have AP, this seems to be a niche that is lacking. I would certainly appreciate them sometimes, and it gives a bit more counterplay against the fancy cargo armor and nukies. In addition, several people on discord seemed to be interested in the idea.

## Changelog

Adds tungsten sabot AP shells, along with the ammo box and import entry.

:cl:
add: Added more things
/:cl:

