### PR TITLE
Make glocko burst 8

### DIFF
--- a/monkestation/code/modules/blueshield/gun.dm
+++ b/monkestation/code/modules/blueshield/gun.dm
@@ -81,7 +81,7 @@
 /obj/item/gun/ballistic/automatic/pistol/tech_9
 	name = "\improper Glock-O"
 	desc = "The standard issue service pistol of blueshield agents."
-	burst_size = 10 //lol
+	burst_size = 8 //lol
 	fire_delay = 1
 
 	icon = 'monkestation/code/modules/blueshield/icons/gun.dmi'


### PR DESCRIPTION
This lets glocko have 2 clean bursts, instead of that weird 1 and a half bursts

## About The Pull Request

Simple. Give the glocko burst 8. This gives it 2 clean bursts instead of that weird 1 and a half burst it has

## Why It's Good For The Game

It will feel so much less weird and will make the OCD happy

## Changelog

:cl:
change: Literally just the number 10 to 8 in glocko burst size
/:cl:
