### PR TITLE
Nerfs sunset's healing

### DIFF
--- a/monkestation/code/modules/reagents/sunset_sarsaparilla.dm
+++ b/monkestation/code/modules/reagents/sunset_sarsaparilla.dm
@@ -17,6 +17,6 @@
 
 /datum/reagent/consumable/sunset_sarsaparilla/on_mob_life(mob/living/carbon/drinker)
 	. = ..()
-	drinker.heal_bodypart_damage(brute = 2.5)
-	drinker.heal_bodypart_damage(burn = 2.5)
+	drinker.heal_bodypart_damage(brute = 0.5)
+	drinker.heal_bodypart_damage(burn = 0.5)
 

--- a/monkestation/code/modules/reagents/sunset_sarsaparilla.dm
+++ b/monkestation/code/modules/reagents/sunset_sarsaparilla.dm
@@ -15,7 +15,7 @@
 	icon = 'monkestation/icons/obj/drinks/soda.dmi'
 	icon_state = "sunset_sarsparillaglass"
 
-/datum/reagent/consumable/sunset_sarsaparilla/on_mob_life(mob/living/carbon/drinker)
+/datum/reagent/consumable/sunset_sarsaparilla/on_mob_life(mob/living/carbon/drinker, seconds_per_tick)
 	var/heal_amt = 1.5 * REM * seconds_per_tick
 	drinker.heal_bodypart_damage(brute = heal_amt, updating_health = FALSE)
 	drinker.heal_bodypart_damage(burn = heal_amt, updating_health = FALSE)

--- a/monkestation/code/modules/reagents/sunset_sarsaparilla.dm
+++ b/monkestation/code/modules/reagents/sunset_sarsaparilla.dm
@@ -16,7 +16,8 @@
 	icon_state = "sunset_sarsparillaglass"
 
 /datum/reagent/consumable/sunset_sarsaparilla/on_mob_life(mob/living/carbon/drinker)
-	. = ..()
-	drinker.heal_bodypart_damage(brute = 0.5)
-	drinker.heal_bodypart_damage(burn = 0.5)
-
+	var/heal_amt = 1.5 * REM * seconds_per_tick
+	drinker.heal_bodypart_damage(brute = heal_amt, updating_health = FALSE)
+	drinker.heal_bodypart_damage(burn = heal_amt, updating_health = FALSE)
+	drinker.updatehealth()
+	return ..()


### PR DESCRIPTION
## About The Pull Request
Reduces sunset sarsaparilla's healing from 2.5 burn and brute on a limb to 1.5 brute and burn on a limb
## Why It's Good For The Game
The amount of healing this drink gives out is absurd, especially for a soda that can be synthethised. This will make it less of a power gamer healing drink and more of a minor healing drink.
## Changelog
:cl:
balance: Reduced sunset sarsaparilla's limb healing from 2.5 brute and burn per life tick to 1.5 brute and burn.
/:cl:
