### PR TITLE
Increases nanite buff costs

### DIFF
--- a/monkestation/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -3,7 +3,7 @@
 /datum/nanite_program/nervous
 	name = "Nerve Support"
 	desc = "The nanites act as a secondary nervous system, reducing the amount of time the host is stunned."
-	use_rate = 1.5
+	use_rate = 2.5
 	rogue_types = list(/datum/nanite_program/nerve_decay)
 
 /datum/nanite_program/nervous/enable_passive_effect()
@@ -21,7 +21,7 @@
 /datum/nanite_program/hardening
 	name = "Dermal Hardening"
 	desc = "The nanites form a mesh under the host's skin, protecting them from melee and bullet impacts."
-	use_rate = 0.5
+	use_rate = 2
 	rogue_types = list(/datum/nanite_program/skin_decay)
 
 //TODO on_hit effect that turns skin grey for a moment
@@ -49,7 +49,7 @@
 /datum/nanite_program/refractive
 	name = "Dermal Refractive Surface"
 	desc = "The nanites form a membrane above the host's skin, reducing the effect of laser and energy impacts."
-	use_rate = 0.50
+	use_rate = 2
 	rogue_types = list(/datum/nanite_program/skin_decay)
 
 /datum/nanite_program/refractive/enable_passive_effect()
@@ -67,7 +67,7 @@
 /datum/nanite_program/coagulating
 	name = "Vein Repressurization"
 	desc = "The nanites re-route circulating blood away from open wounds, dramatically reducing bleeding rate."
-	use_rate = 0.20
+	use_rate = 1
 	rogue_types = list(/datum/nanite_program/suffocating)
 
 /datum/nanite_program/coagulating/enable_passive_effect()
@@ -85,7 +85,7 @@
 /datum/nanite_program/conductive
 	name = "Electric Conduction"
 	desc = "The nanites act as a grounding rod for electric shocks, protecting the host. Shocks can still damage the nanites themselves."
-	use_rate = 0.20
+	use_rate = 1.5
 	program_flags = NANITE_SHOCK_IMMUNE
 	rogue_types = list(/datum/nanite_program/nerve_decay)
 
@@ -100,7 +100,7 @@
 /datum/nanite_program/mindshield
 	name = "Mental Barrier"
 	desc = "The nanites form a protective membrane around the host's brain, shielding them from abnormal influences while they're active."
-	use_rate = 0.40
+	use_rate = 2
 	rogue_types = list(/datum/nanite_program/brain_decay, /datum/nanite_program/brain_misfire)
 
 /datum/nanite_program/mindshield/enable_passive_effect()


### PR DESCRIPTION

## About The Pull Request
Increases the costs of the nanite buff programs.
## Why It's Good For The Game
These things are dirt cheap considering how powerful they can be. This will hopefully make it so it isn't easy to combine them into one program without causing significant nanite drain.
## Changelog
:cl:
balance: Nerve support cost increased from 1.5 to 2.5
balance: Dermal hardening cost increased from 0.5 to 2
balance: Dermal refractive surface cost increased from 0.5 to 2
balance: Vein repressurization cost increased from 0.2 to 1
balance: Electric conduction cost increased from 0.2 to 1.5
balance: Mental Barrier increased from 0.4 to 2
/:cl:
