### PR TITLE
Tweaks on Manly Dorf

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -754,15 +754,15 @@
 	. = ..()
 	if(ishuman(drinker))
 		var/mob/living/carbon/human/potential_dwarf = drinker
-		if(HAS_TRAIT(potential_dwarf, TRAIT_DWARF))
+		if(HAS_TRAIT(potential_dwarf, TRAIT_DWARF) || HAS_TRAIT(potential_dwarf, TRAIT_ALCOHOL_TOLERANCE))
 			to_chat(potential_dwarf, span_notice("Now THAT is MANLY!"))
 			boozepwr = 50 // will still smash but not as much.
 			dorf_mode = TRUE
 
 /datum/reagent/consumable/ethanol/manly_dorf/on_mob_life(mob/living/carbon/dwarf, seconds_per_tick, times_fired)
 	if(dorf_mode)
-		dwarf.adjustBruteLoss(-2 * REM * seconds_per_tick, required_bodytype = affected_bodytype)
-		dwarf.adjustFireLoss(-2 * REM * seconds_per_tick, required_bodytype = affected_bodytype)
+		dwarf.adjustBruteLoss(-1.75 * REM * seconds_per_tick, required_bodytype = affected_bodytype)
+		dwarf.adjustFireLoss(-1.75 * REM * seconds_per_tick, required_bodytype = affected_bodytype)
 	return ..()
 
 /datum/reagent/consumable/ethanol/longislandicedtea


### PR DESCRIPTION
## About The Pull Request

Slightly nerfs the healing from Manly Dorf (Was 2|2 brute|burn), and re-adds people with alcohol tolerance getting the effect.

## Why It's Good For The Game

As it stands, Manly Dorf is a very powerful healing drink, but only for dwarves. This makes it slightly weaker, but available to a wider range of people. People with the alcohol tolerance quirk being honorary dwarves for the purpose of alcohol makes sense to me.

## Changelog

2/2 brute/burn to 1.75/1.75, makes it work for those with alcohol tolerance.

:cl:
balance: rebalanced something
/:cl: