### PR TITLE
Lobby Notices

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -96,6 +96,7 @@
 	if (fexists("[directory]/ezdb.txt"))
 		LoadEntries("ezdb.txt")
 	loadmaplist(CONFIG_MAPS_FILE)
+	LoadMisc() // Monkestation edit: other configuration stuff
 	LoadMOTD()
 	LoadPolicy()
 	LoadChatFilter()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -194,7 +194,10 @@ SUBSYSTEM_DEF(ticker)
 			send2chat(new /datum/tgs_message_content("New round starting on [SSmapping.config.map_name]!"), CONFIG_GET(string/channel_announce_new_game))
 			current_state = GAME_STATE_PREGAME
 			SEND_SIGNAL(src, COMSIG_TICKER_ENTER_PREGAME)
-
+			// MONKESTATION EDIT START - lobby notices
+			if (length(config.lobby_notices))
+				config.ShowLobbyNotices(world)
+			// MONKESTATION END
 			fire()
 		if(GAME_STATE_PREGAME)
 				//lobby stats for statpanels

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -194,6 +194,8 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	else
 		to_chat(src, span_notice("The Message of the Day has not been set."))
 
+	config.ShowLobbyNotices(src) // monkestation edit
+
 /client/proc/self_notes()
 	set name = "View Admin Remarks"
 	set category = "OOC"

--- a/code/modules/mob/dead/new_player/latejoin_menu.dm
+++ b/code/modules/mob/dead/new_player/latejoin_menu.dm
@@ -45,6 +45,7 @@ GLOBAL_DATUM_INIT(latejoin_menu, /datum/latejoin_menu, new)
 		"disable_jobs_for_non_observers" = SSlag_switch.measures[DISABLE_NON_OBSJOBS],
 		"round_duration" = DisplayTimeText(world.time - SSticker.round_start_time, round_seconds_to = 1),
 		"departments" = departments,
+		"notices" = config.lobby_notices, // monkestation edit - lobby notices
 	)
 	if(SSshuttle.emergency)
 		switch(SSshuttle.emergency.mode)

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -36,6 +36,10 @@
 	if(motd)
 		to_chat(src, "<div class=\"motd\">[motd]</div>", handle_whitespace=FALSE)
 
+	// MONKESTATION EDIT START - lobby notices
+	if (SSticker.current_state != GAME_STATE_STARTUP && length(config.lobby_notices))
+		config.ShowLobbyNotices(src)
+	// MONKESTATION END
 	if(GLOB.admin_notice)
 		to_chat(src, span_notice("<b>Admin Notice:</b>\n \t [GLOB.admin_notice]"))
 

--- a/config/lobby_notices.json
+++ b/config/lobby_notices.json
@@ -1,0 +1,3 @@
+[
+  "This is an example of speex, an audio compression codec specifically tuned for the reproduction of human speech."
+]

--- a/config/lobby_notices.json
+++ b/config/lobby_notices.json
@@ -1,3 +1,1 @@
-[
-  "This is an example of speex, an audio compression codec specifically tuned for the reproduction of human speech."
-]
+[]

--- a/monkestation/code/controllers/configuration/configuration.dm
+++ b/monkestation/code/controllers/configuration/configuration.dm
@@ -1,0 +1,5 @@
+/datum/controller/configuration/LoadMOTD()
+	. = ..()
+
+	if (text2num(rustg_unix_timestamp()) < 1736064000)
+		motd = motd + "[motd]<br>" + "<span class='red big'>Monkestation admins are <span class='bold'>NO LONGER</span> accepting appeals for permanent bans until <span class='notice'>January 5th, 2025</span></span><br><hr><span class='yellowteamradio big'>Any permanent ban appeals made before said date will be <span class='bold red'>AUTOMATICALLY DENIED!</span></span><br><span class='big notice'>So don't get caught doing something stupid, ya hear?</span>"

--- a/monkestation/code/controllers/configuration/configuration.dm
+++ b/monkestation/code/controllers/configuration/configuration.dm
@@ -4,6 +4,25 @@
 /datum/controller/configuration/proc/LoadMisc()
 	load_important_notices()
 
+/*
+// JSON example of how lobby_notices.json works.
+
+[
+  "this notice will show in both the chatbox, and tgui. will do HTML like the others but using classes that are used in the chatbox will not show in tgui as they are separate",
+  {
+    "TGUI_SAFE": "This shows in tgui! <span style='font-size: 110%'>you can also use html! but not the classes used the chatbox, as said above</span>",
+    "CHATBOX_SAFE": "This shows in tgui! <span class='bold red'>(with special formatting!)</span>."
+  },
+  {
+    "TGUI_SAFE": [
+      "this is the first line",
+      "this is the second line. notice how this object doesn't have a chatbox_safe?",
+      "that means it'll only show in Tgui"
+    ]
+  }
+]
+
+*/
 /datum/controller/configuration/proc/load_important_notices()
 	var/rawnotices = file2text("[directory]/lobby_notices.json")
 	if(rawnotices)

--- a/monkestation/code/controllers/configuration/configuration.dm
+++ b/monkestation/code/controllers/configuration/configuration.dm
@@ -16,16 +16,25 @@
 
 /datum/controller/configuration/proc/ShowLobbyNotices(target)
 	if (!config.lobby_notices) return FALSE
-	var/final_notices = "<hr class='solid'>"
+	var/final_notices = ""
+	var/do_final_top_separator = FALSE
 	for (var/notice as anything in config.lobby_notices)
+		var/do_separator = FALSE
 		if (islist(notice))
 			var/list/_notice = notice
-			final_notices = "[final_notices]<br>[_notice["CHATBOX_SAFE"]]"
+			if (_notice["CHATBOX_SAFE"])
+				do_separator = TRUE
+				final_notices = "[final_notices]<br>[_notice["CHATBOX_SAFE"]]"
 		else
 			final_notices = "[final_notices]<br>[notice]"
-		final_notices = "[final_notices]<br><hr class='solid'>"
+			do_separator = TRUE
 
-		to_chat(target, final_notices)
+		if (do_separator)
+			do_final_top_separator = TRUE
+			final_notices = "[final_notices]<hr class='solid'>"
+
+	to_chat(target, "[do_final_top_separator ? "<hr class='solid'>" : ""][final_notices]")
+
 	return TRUE
 // I want to use this but i decided i didnt need to use it
 /*

--- a/monkestation/code/controllers/configuration/configuration.dm
+++ b/monkestation/code/controllers/configuration/configuration.dm
@@ -2,9 +2,9 @@
 	var/list/lobby_notices
 
 /datum/controller/configuration/proc/LoadMisc()
-	LoadImportantNotices()
+	load_important_notices()
 
-/datum/controller/configuration/proc/LoadImportantNotices()
+/datum/controller/configuration/proc/load_important_notices()
 	var/rawnotices = file2text("[directory]/lobby_notices.json")
 	if(rawnotices)
 		var/parsed = safe_json_decode(rawnotices)

--- a/monkestation/code/controllers/configuration/configuration.dm
+++ b/monkestation/code/controllers/configuration/configuration.dm
@@ -1,5 +1,16 @@
 /datum/controller/configuration/LoadMOTD()
 	. = ..()
 
-	if (text2num(rustg_unix_timestamp()) < 1736064000)
+	var/cur_day = text2num(time2text(world.realtime, "DD", "PT"))
+	var/cur_mon = text2num(time2text(world.realtime, "MM", "PT"))
+	var/cur_year = text2num(time2text(world.realtime, "YYYY", "PT"))
+
+	if (!compare_dates(cur_year, cur_mon, cur_day, 2025, 1, 5))
 		motd = motd + "[motd]<br>" + "<span class='red big'>Monkestation admins are <span class='bold'>NO LONGER</span> accepting appeals for permanent bans until <span class='notice'>January 5th, 2025</span></span><br><hr><span class='yellowteamradio big'>Any permanent ban appeals made before said date will be <span class='bold red'>AUTOMATICALLY DENIED!</span></span><br><span class='big notice'>So don't get caught doing something stupid, ya hear?</span>"
+
+/proc/compare_dates(year1, month1, day1, year2, month2, day2)
+		// TRUE if date1 >= date2, FALSE if date1 < date2
+    var/comparable_date1 = year1 * 10000 + month1 * 100 + day1
+    var/comparable_date2 = year2 * 10000 + month2 * 100 + day2
+
+    return comparable_date1 >= comparable_date2

--- a/monkestation/code/controllers/configuration/configuration.dm
+++ b/monkestation/code/controllers/configuration/configuration.dm
@@ -5,8 +5,8 @@
 	var/cur_mon = text2num(time2text(world.realtime, "MM", "PT"))
 	var/cur_year = text2num(time2text(world.realtime, "YYYY", "PT"))
 
-	if (!compare_dates(cur_year, cur_mon, cur_day, 2025, 1, 5))
-		motd = motd + "[motd]<br>" + "<span class='red big'>Monkestation admins are <span class='bold'>NO LONGER</span> accepting appeals for permanent bans until <span class='notice'>January 5th, 2025</span></span><br><hr><span class='yellowteamradio big'>Any permanent ban appeals made before said date will be <span class='bold red'>AUTOMATICALLY DENIED!</span></span><br><span class='big notice'>So don't get caught doing something stupid, ya hear?</span>"
+	if (!compare_dates(cur_year, cur_mon, cur_day, 2025, 1, 15))
+		motd = motd + "[motd]<br>" + "<span class='red big'>Monkestation admins are <span class='bold'>NO LONGER</span> accepting appeals for permanent bans until <span class='notice'>January 15th, 2025</span></span><br><hr><span class='yellowteamradio big'>Any permanent ban appeals made before said date will be <span class='bold red'>AUTOMATICALLY DENIED!</span></span><br><span class='big notice'>So don't get caught doing something stupid, ya hear?</span>"
 
 /proc/compare_dates(year1, month1, day1, year2, month2, day2)
 		// TRUE if date1 >= date2, FALSE if date1 < date2

--- a/monkestation/code/controllers/configuration/configuration.dm
+++ b/monkestation/code/controllers/configuration/configuration.dm
@@ -1,16 +1,47 @@
-/datum/controller/configuration/LoadMOTD()
-	. = ..()
+/datum/controller/configuration
+	var/list/lobby_notices
 
-	var/cur_day = text2num(time2text(world.realtime, "DD", "PT"))
-	var/cur_mon = text2num(time2text(world.realtime, "MM", "PT"))
-	var/cur_year = text2num(time2text(world.realtime, "YYYY", "PT"))
+/datum/controller/configuration/proc/LoadMisc()
+	LoadImportantNotices()
 
-	if (!compare_dates(cur_year, cur_mon, cur_day, 2025, 1, 15))
-		motd = motd + "[motd]<br>" + "<span class='red big'>Monkestation admins are <span class='bold'>NO LONGER</span> accepting appeals for permanent bans until <span class='notice'>January 15th, 2025</span></span><br><hr><span class='yellowteamradio big'>Any permanent ban appeals made before said date will be <span class='bold red'>AUTOMATICALLY DENIED!</span></span><br><span class='big notice'>So don't get caught doing something stupid, ya hear?</span>"
+/datum/controller/configuration/proc/LoadImportantNotices()
+	var/rawnotices = file2text("[directory]/lobby_notices.json")
+	if(rawnotices)
+		var/parsed = safe_json_decode(rawnotices)
+		if(!parsed)
+			log_config("JSON parsing failure for lobby_notices.json")
+			DelayedMessageAdmins("JSON parsing failure for lobby_notices.json")
+		else
+			lobby_notices = parsed
 
+/datum/controller/configuration/proc/ShowLobbyNotices(target)
+	if (!config.lobby_notices) return FALSE
+	var/final_notices = "<hr class='solid'>"
+	for (var/notice as anything in config.lobby_notices)
+		if (islist(notice))
+			var/list/_notice = notice
+			final_notices = "[final_notices]<br>[_notice["CHATBOX_SAFE"]]"
+		else
+			final_notices = "[final_notices]<br>[notice]"
+		final_notices = "[final_notices]<br><hr class='solid'>"
+
+		to_chat(target, final_notices)
+	return TRUE
+// I want to use this but i decided i didnt need to use it
+/*
 /proc/compare_dates(year1, month1, day1, year2, month2, day2)
 		// TRUE if date1 >= date2, FALSE if date1 < date2
     var/comparable_date1 = year1 * 10000 + month1 * 100 + day1
     var/comparable_date2 = year2 * 10000 + month2 * 100 + day2
 
     return comparable_date1 >= comparable_date2
+*/
+
+/*  in some other proc
+	var/cur_day = text2num(time2text(world.realtime, "DD", "PT"))
+	var/cur_mon = text2num(time2text(world.realtime, "MM", "PT"))
+	var/cur_year = text2num(time2text(world.realtime, "YYYY", "PT"))
+
+	if (!compare_dates(cur_year, cur_mon, cur_day, 2025, 1, 15))
+		motd = motd + "[motd]<br>" + ""
+*/

--- a/monkestation/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/monkestation/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -1,0 +1,5 @@
+/proc/_floor(a)
+	return floor(a)
+
+/proc/_ceil(a)
+	return ceil(a)

--- a/monkestation/code/modules/store/pre_round/_pre_round_store.dm
+++ b/monkestation/code/modules/store/pre_round/_pre_round_store.dm
@@ -23,7 +23,10 @@ GLOBAL_LIST_EMPTY(cached_preround_items)
 
 /datum/pre_round_store/ui_data(mob/user)
 	. = ..()
-	var/list/data = list()
+
+	var/list/data = list(
+		"notices" = config.lobby_notices
+	)
 	var/list/buyables = list()
 
 	if(!length(GLOB.cached_preround_items))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5909,6 +5909,7 @@
 #include "monkestation\code\area\areas\direction_names.dm"
 #include "monkestation\code\area\areas\ruins.dm"
 #include "monkestation\code\area\areas\station.dm"
+#include "monkestation\code\controllers\configuration\configuration.dm"
 #include "monkestation\code\controllers\subsystem\autotransfer.dm"
 #include "monkestation\code\controllers\subsystem\economy.dm"
 #include "monkestation\code\controllers\subsystem\glowshroom.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6148,6 +6148,7 @@
 #include "monkestation\code\modules\admin\verbs\spawn_mixtape.dm"
 #include "monkestation\code\modules\admin\verbs\tracy.dm"
 #include "monkestation\code\modules\admin\verbs\traits.dm"
+#include "monkestation\code\modules\admin\verbs\SDQL2\SDQL_2_wrappers.dm"
 #include "monkestation\code\modules\aesthetics\airlock\airlock.dm"
 #include "monkestation\code\modules\aesthetics\items\clothing.dm"
 #include "monkestation\code\modules\aesthetics\mapping\tilecoloring.dm"

--- a/tgui/packages/tgui/interfaces/JobSelection.tsx
+++ b/tgui/packages/tgui/interfaces/JobSelection.tsx
@@ -13,6 +13,7 @@ import { Inferno } from 'inferno';
 import { JOB2ICON } from './common/JobToIcon';
 import { deepMerge } from 'common/collections';
 import { BooleanLike } from 'common/react';
+import { LobbyNotices, LobbyNoticesType } from './common/LobbyNotices';
 
 type Job = {
   unavailable_reason: string | null;
@@ -37,6 +38,7 @@ type Data = {
   disable_jobs_for_non_observers: BooleanLike;
   priority: BooleanLike;
   round_duration: string;
+  notices: LobbyNoticesType;
 };
 
 export const JobEntry: Inferno.SFC<{
@@ -119,6 +121,7 @@ export const JobSelection = (props) => {
       }}
     >
       <Window.Content scrollable>
+        <LobbyNotices notices={data.notices} />
         <StyleableSection
           title={
             <>

--- a/tgui/packages/tgui/interfaces/PreRoundStore.jsx
+++ b/tgui/packages/tgui/interfaces/PreRoundStore.jsx
@@ -9,6 +9,7 @@ import {
   Section,
 } from '../components';
 import { Window } from '../layouts';
+import { LobbyNotices } from './common/LobbyNotices';
 
 const ItemListEntry = (props) => {
   const {
@@ -54,6 +55,7 @@ export const PreRoundStore = (_props) => {
     <Window resizable title="Pre Round Shop" width={450} height={700}>
       <Window.Content scrollable>
         <Section>
+          <LobbyNotices notices={data.notices} />
           <BlockQuote>
             Purchase an item that will spawn with you round start!
           </BlockQuote>

--- a/tgui/packages/tgui/interfaces/common/LobbyNotices.tsx
+++ b/tgui/packages/tgui/interfaces/common/LobbyNotices.tsx
@@ -42,25 +42,3 @@ export const LobbyNotices = (props: { notices?: LobbyNoticesType }) => {
     </>
   );
 };
-
-const UI_WARNINGS = [
-  [
-    {
-      TGUI_SAFE: [
-        "Monkestation admins are <span class='bold'>NO LONGER</span> accepting appeals for permanent bans until <span class='notice'>January 5th, 2025</span>",
-        "Any permanent ban appeals made before said date will be <span class='bold red'>AUTOMATICALLY DENIED!</span>",
-        "So don't get caught doing something stupid, ya hear?",
-      ],
-      CHATBOX_SAFE:
-        "<span class='red big'>Monkestation admins are <span class='bold'>NO LONGER</span> accepting appeals for permanent bans until <span class='notice'>January 15th, 2025</span></span><br><hr><span class='yellowteamradio big'>Any permanent ban appeals made before said date will be <span class='bold red'>AUTOMATICALLY DENIED!</span></span><br><span class='big notice'>So don't get caught doing something stupid, ya hear?</span>",
-    },
-  ],
-  // ADD DIVIDER
-  'oooga booga.',
-  // ADD DIVIDER
-  {
-    // this is also fine too, it doesnt have to be an array.
-    TGUI_SAFE: 'SDLKJDJSDFSDFFGSGSGSGS',
-    CHATBOX_SAFE: 'llooOLOLLLOLL',
-  },
-];

--- a/tgui/packages/tgui/interfaces/common/LobbyNotices.tsx
+++ b/tgui/packages/tgui/interfaces/common/LobbyNotices.tsx
@@ -41,9 +41,6 @@ export const LobbyNotices = (props: { notices?: LobbyNoticesType }) => {
                     )}
               </>
             )}
-            {index < filteredLobbyNotices.length - 1 && (
-              <hr className="solid" />
-            )}
           </>
         </NoticeBox>
       ))}

--- a/tgui/packages/tgui/interfaces/common/LobbyNotices.tsx
+++ b/tgui/packages/tgui/interfaces/common/LobbyNotices.tsx
@@ -1,0 +1,74 @@
+import { Fragment } from 'inferno';
+import { Box, NoticeBox } from '../../components';
+
+export type LobbyNoticesType = (
+  | string
+  | { TGUI_SAFE?: string | string[]; CHATBOX_SAFE?: string }
+)[];
+
+export const LobbyNotices = (props: { notices?: LobbyNoticesType }) => {
+  if (!props.notices || props.notices.length === 0) return null;
+  const filteredLobbyNotices = props.notices.filter(
+    (warning) =>
+      typeof warning === 'string' ||
+      (typeof warning === 'object' && warning.TGUI_SAFE),
+  );
+
+  if (filteredLobbyNotices.length === 0) return null;
+
+  return (
+    <>
+      {filteredLobbyNotices.map((notice, index) => (
+        <NoticeBox danger>
+          <>
+            {typeof notice === 'string' ? (
+              <Box key={index + '_'}>{notice}</Box>
+            ) : (
+              // Process object with TGUI_SAFE
+              <>
+                {Array.isArray(notice.TGUI_SAFE)
+                  ? notice.TGUI_SAFE.map((notice, index) => (
+                      <Box
+                        key={index + '__'}
+                        dangerouslySetInnerHTML={{ __html: notice }}
+                      />
+                    ))
+                  : notice.TGUI_SAFE && (
+                      <Box
+                        key={index + '___'}
+                        dangerouslySetInnerHTML={{ __html: notice.TGUI_SAFE }}
+                      />
+                    )}
+              </>
+            )}
+            {index < filteredLobbyNotices.length - 1 && (
+              <hr className="solid" />
+            )}
+          </>
+        </NoticeBox>
+      ))}
+    </>
+  );
+};
+
+const UI_WARNINGS = [
+  [
+    {
+      TGUI_SAFE: [
+        "Monkestation admins are <span class='bold'>NO LONGER</span> accepting appeals for permanent bans until <span class='notice'>January 5th, 2025</span>",
+        "Any permanent ban appeals made before said date will be <span class='bold red'>AUTOMATICALLY DENIED!</span>",
+        "So don't get caught doing something stupid, ya hear?",
+      ],
+      CHATBOX_SAFE:
+        "<span class='red big'>Monkestation admins are <span class='bold'>NO LONGER</span> accepting appeals for permanent bans until <span class='notice'>January 15th, 2025</span></span><br><hr><span class='yellowteamradio big'>Any permanent ban appeals made before said date will be <span class='bold red'>AUTOMATICALLY DENIED!</span></span><br><span class='big notice'>So don't get caught doing something stupid, ya hear?</span>",
+    },
+  ],
+  // ADD DIVIDER
+  'oooga booga.',
+  // ADD DIVIDER
+  {
+    // this is also fine too, it doesnt have to be an array.
+    TGUI_SAFE: 'SDLKJDJSDFSDFFGSGSGSGS',
+    CHATBOX_SAFE: 'llooOLOLLLOLL',
+  },
+];

--- a/tgui/packages/tgui/interfaces/common/LobbyNotices.tsx
+++ b/tgui/packages/tgui/interfaces/common/LobbyNotices.tsx
@@ -19,29 +19,24 @@ export const LobbyNotices = (props: { notices?: LobbyNoticesType }) => {
   return (
     <>
       {filteredLobbyNotices.map((notice, index) => (
-        <NoticeBox danger>
-          <>
-            {typeof notice === 'string' ? (
-              <Box key={index + '_'}>{notice}</Box>
-            ) : (
-              // Process object with TGUI_SAFE
-              <>
-                {Array.isArray(notice.TGUI_SAFE)
-                  ? notice.TGUI_SAFE.map((notice, index) => (
-                      <Box
-                        key={index + '__'}
-                        dangerouslySetInnerHTML={{ __html: notice }}
-                      />
-                    ))
-                  : notice.TGUI_SAFE && (
-                      <Box
-                        key={index + '___'}
-                        dangerouslySetInnerHTML={{ __html: notice.TGUI_SAFE }}
-                      />
-                    )}
-              </>
-            )}
-          </>
+        <NoticeBox danger key={index}>
+          {typeof notice === 'string' ? (
+            <Box key={index + '_'}>{notice}</Box>
+          ) : Array.isArray(notice.TGUI_SAFE) ? (
+            notice.TGUI_SAFE.map((notice, index) => (
+              <Box
+                key={index + '__'}
+                dangerouslySetInnerHTML={{ __html: notice }}
+              />
+            ))
+          ) : (
+            notice.TGUI_SAFE && (
+              <Box
+                key={index + '___'}
+                dangerouslySetInnerHTML={{ __html: notice.TGUI_SAFE }}
+              />
+            )
+          )}
         </NoticeBox>
       ))}
     </>

--- a/tgui/packages/tgui/styles/reset.scss
+++ b/tgui/packages/tgui/styles/reset.scss
@@ -62,3 +62,29 @@ th {
   vertical-align: baseline;
   text-align: left;
 }
+
+$border-color: #bbb;
+
+@mixin hr-style($width, $style) {
+  border: none;
+  border-top: $width $style $border-color;
+}
+
+hr {
+  &.dashed {
+    @include hr-style(3px, dashed);
+  }
+
+  &.dotted {
+    @include hr-style(2px, dotted);
+  }
+
+  &.solid {
+    @include hr-style(3px, solid);
+  }
+
+  &.rounded {
+    @include hr-style(8px, solid);
+    border-radius: 5px;
+  }
+}


### PR DESCRIPTION
## About The Pull Request

Adds the ability to add lobby notices via config `config/lobby_notices`. These will show in the pre-round shop, latejoin menu, and in chat when you first join.

Typically, the MOTD gets drowned out during server initialization. There's code that will make sure to show these lobby notices AFTER the server has loaded.

## `config/lobby_notices.json`

```json
[
  "this notice will show in both the chatbox, and tgui. will do HTML like the others but using classes that are used in the chatbox will not show in tgui as they are separate",
  {
    "TGUI_SAFE": "This shows in tgui! <span style='font-size: 110%'>you can also use html! but not the classes used the chatbox, as said above</span>",
    "CHATBOX_SAFE": "This shows in tgui! <span class='bold red'>(with special formatting!)</span>."
  },
  {
    "TGUI_SAFE": [
      "this is the first line",
      "this is the second line. notice how this object doesn't have a chatbox_safe?",
      "that means it'll only show in Tgui"
    ]
  }
]
```

## Why It's Good For The Game

For important notices that players NEED TO SEE

## Changelog
:cl:
server: Adds the ability to add lobby notices. These will show in the pre-round shop, latejoin menu, and in chat when you first join.
/:cl:
