### PR TITLE
Fixes the recover ship's morgue opening through a window

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -10803,7 +10803,9 @@
 /area/centcom/central_command_areas/admin)
 "aDa" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/bodycontainer/morgue,
+/obj/structure/bodycontainer/morgue{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/white,


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
Bug bad
## Changelog
:cl:
fix: The recovery ship's morgue should no longer open through a window
/:cl:
