### PR TITLE
Fix broken opfor links

### DIFF
--- a/tgui/packages/tgui/interfaces/OpposingForcePanel.jsx
+++ b/tgui/packages/tgui/interfaces/OpposingForcePanel.jsx
@@ -223,7 +223,7 @@ export const OpposingForceTab = (props) => {
               </a>
             </Stack.Item>
             <Stack.Item>
-              <a href="https://wiki.monkestation.com/en/home">
+              <a href="https://wiki.monkestation.com/info/rules">
                 <Button
                   icon="question"
                   color="yellow"

--- a/tgui/packages/tgui/interfaces/OpposingForcePanel.jsx
+++ b/tgui/packages/tgui/interfaces/OpposingForcePanel.jsx
@@ -203,7 +203,7 @@ export const OpposingForceTab = (props) => {
           </Stack>
           <Stack>
             <Stack.Item>
-              <a href="https://wiki.monkestation.com/en/opfor">
+              <a href="https://wiki.monkestation.com/en/info/opfor">
                 <Button
                   icon="info"
                   color="orange"
@@ -213,7 +213,7 @@ export const OpposingForceTab = (props) => {
               </a>
             </Stack.Item>
             <Stack.Item>
-              <a href="https://wiki.monkestation.com/en/opfor">
+              <a href="https://wiki.monkestation.com/en/info/opfor">
                 <Button
                   icon="wrench"
                   color="red"


### PR DESCRIPTION
## About The Pull Request

adds `info/` to opfor info links in the opfor menu so you no longer go to a blank page, this does include changing from the home page to the rules page as we moved them there aswell

## Why It's Good For The Game

Less brokey wiki links good

## Changelog

:cl:
fix: fixed the opfor panel linking you to the wrong wiki pages when asking for help
/:cl: