### PR TITLE
Should fix arachnogenesis runtime

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/harmful/mob_spawn_symptoms.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/harmful/mob_spawn_symptoms.dm
@@ -8,7 +8,7 @@
 	///what gets added based on multiplier NOT INCLUSIVE OF PREVIOUS TIERS
 	var/list/multipler_unlocks = list()
 
-/datum/symptom/spawn/activate(mob/living/carbon/mob)
+/datum/symptom/spawn/activate(mob/living/mob)
 	check_unlocks()
 	playsound(mob.loc, 'sound/effects/splat.ogg', 50, 1)
 	var/atom/spawn_type = pick_weight(spawn_types)


### PR DESCRIPTION
## About The Pull Request
Hopefully prevents a runtime that happens when arachnogenesis activates on mice.
## Why It's Good For The Game
The game exploding is not good
## Changelog
:cl: Syndie Kate
fix: Made mice vomiting spiders NOT explode the game
:cl:

