### PR TITLE
[PORT] Small and tiny mobs cannot bump open doors (when AI controlled)

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -234,6 +234,11 @@
 	if(!density || (obj_flags & EMAGGED))
 		return
 
+	if(isliving(user) && isnull(user.mind))
+		var/mob/living/living_user = user
+		if(living_user.mob_size < MOB_SIZE_HUMAN)
+			return
+
 	if(elevator_mode && elevator_status == LIFT_PLATFORM_UNLOCKED)
 		open()
 	else if(requiresID() && allowed(user))

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -149,13 +149,15 @@
 		return
 
 	add_fingerprint(user)
-	if(!requiresID())
-		user = null
+	if(isliving(user) && isnull(user.mind))
+		var/mob/living/living_user = user
+		if(living_user.mob_size < MOB_SIZE_HUMAN)
+			return
 
 	if(elevator_mode && elevator_status == LIFT_PLATFORM_UNLOCKED)
 		open()
 
-	else if(allowed(user))
+	else if(requiresID() && allowed(user))
 		open_and_close()
 
 	else

--- a/code/modules/mob/living/basic/alien/queen.dm
+++ b/code/modules/mob/living/basic/alien/queen.dm
@@ -35,5 +35,5 @@
 		/obj/item/food/meat/slab/xeno = 10,
 		/obj/item/stack/sheet/animalhide/xeno = 2,
 	)
-	mob_size = MOB_SIZE_LARGE
+	mob_size = MOB_SIZE_HUGE
 	gold_core_spawnable = NO_SPAWN

--- a/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
+++ b/code/modules/mob/living/basic/farm_animals/bee/_bee.dm
@@ -27,7 +27,7 @@
 
 	guaranteed_butcher_results = list(/obj/item/stack/sheet/animalhide/bee = 1 )
 
-	mob_size = MOB_SIZE_LARGE
+	mob_size = MOB_SIZE_SMALL
 	pixel_x = -16
 	base_pixel_x = -16
 

--- a/code/modules/mob/living/basic/jungle/mega_arachnid/mega_arachnid.dm
+++ b/code/modules/mob/living/basic/jungle/mega_arachnid/mega_arachnid.dm
@@ -26,7 +26,7 @@
 	lighting_cutoff_red = 5
 	lighting_cutoff_green = 20
 	lighting_cutoff_blue = 25
-	mob_size = MOB_SIZE_LARGE
+	mob_size = MOB_SIZE_HUGE
 
 	speak_emote = list("chitters")
 	attack_sound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
+++ b/code/modules/mob/living/basic/space_fauna/space_dragon/space_dragon.dm
@@ -36,7 +36,7 @@
 	melee_damage_upper = 35
 	melee_damage_lower = 35
 	melee_attack_cooldown = CLICK_CD_MELEE
-	mob_size = MOB_SIZE_LARGE
+	mob_size = MOB_SIZE_HUGE
 	armour_penetration = 30
 	pixel_x = -16
 	base_pixel_x = -16

--- a/code/modules/mob/living/carbon/alien/adult/queen.dm
+++ b/code/modules/mob/living/carbon/alien/adult/queen.dm
@@ -7,7 +7,7 @@
 	maptext_height = 64
 	maptext_width = 64
 	bubble_icon = "alienroyal"
-	mob_size = MOB_SIZE_LARGE
+	mob_size = MOB_SIZE_HUGE
 	layer = LARGE_MOB_LAYER //above most mobs, but below speechbubbles
 	plane = GAME_PLANE_UPPER_FOV_HIDDEN
 	pressure_resistance = 200 //Because big, stompy xenos should not be blown around like paper.

--- a/code/modules/mob/living/simple_animal/hostile/jungle/_jungle_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/_jungle_mobs.dm
@@ -14,4 +14,4 @@
 	lighting_cutoff_red = 5
 	lighting_cutoff_green = 20
 	lighting_cutoff_blue = 25
-	mob_size = MOB_SIZE_LARGE
+	mob_size = MOB_SIZE_HUGE


### PR DESCRIPTION

## About The Pull Request

Port of https://github.com/MrMelbert/MapleStationCode/pull/611

## Why It's Good For The Game

stop jumpscaring me

## Changelog
:cl: Absolucy, Melbert
qol: Cockroaches, butterflies, chickens, and similarly small mobs can't bump open (public access) airlocks unless they are controlled by a player.
qol: Tweaked the sizes of a few mobs.
/:cl:
