### PR TITLE
Stowaways are properly removed from manifest

### DIFF
--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -63,11 +63,7 @@
 	addtimer(CALLBACK(src, PROC_REF(datacore_deletion)), 5 SECONDS)
 
 /datum/quirk/stowaway/proc/datacore_deletion()
-	var/mob/living/carbon/human/stowaway = quirk_holder
-	var/perpname = stowaway.name
-	var/datum/record/crew/record_deletion = find_record(perpname, GLOB.manifest.general)
-	SSjob.FreeRole(quirk_holder.mind.assigned_role)  //open their job slot back up
-	qdel(record_deletion)
+	quirk_holder.mind.remove_from_manifest()
 
 /obj/item/card/id/fake_card //not a proper ID but still shares a lot of functions
 	name = "\"ID Card\""

--- a/monkestation/code/datums/quirks/negative_quirks.dm
+++ b/monkestation/code/datums/quirks/negative_quirks.dm
@@ -60,10 +60,7 @@
 /datum/quirk/stowaway/post_add()
 	. = ..()
 	to_chat(quirk_holder, span_boldnotice("You've awoken to find yourself inside [GLOB.station_name] without real identification!"))
-	addtimer(CALLBACK(src, PROC_REF(datacore_deletion)), 5 SECONDS)
-
-/datum/quirk/stowaway/proc/datacore_deletion()
-	quirk_holder.mind.remove_from_manifest()
+	addtimer(CALLBACK(quirk_holder.mind, TYPE_PROC_REF(/datum/mind, remove_from_manifest)), 5 SECONDS)
 
 /obj/item/card/id/fake_card //not a proper ID but still shares a lot of functions
 	name = "\"ID Card\""


### PR DESCRIPTION
## About The Pull Request
Makes stowaways properly removed from manifest
Removes code that tries to open a slot in stowaways job

## Why It's Good For The Game
Fixes bug
While it didn't work, stowaways shouldn't auto open a slot in the job they join, removing this was ok'd by abraxis. Them automatically opening a slot while making sense isn't great from a gameplay side of things making two of jobs that possibly shouldn't and such.

## Changelog

:cl:
del: deleted stowaway code that tried to open a new job slot
fix: stowaways are properly removed from the manifest
/:cl:

