### PR TITLE
[Bug fixes] Some funny little ol map fixes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
+++ b/_maps/RandomRuins/SpaceRuins/caravanambush.dmm
@@ -240,9 +240,9 @@
 "fv" = (
 /obj/effect/turf_decal/bot_white,
 /obj/structure/closet/crate/secure/engineering,
-/obj/item/organ/internal/cyberimp/arm/item_set,
 /obj/item/organ/internal/cyberimp/eyes/hud/medical,
 /obj/item/organ/internal/cyberimp/brain/anti_stun,
+/obj/item/organ/internal/cyberimp/arm/item_set/toolset,
 /turf/open/floor/iron/dark/airless,
 /area/shuttle/ruin/caravan/freighter3)
 "fy" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -25768,6 +25768,7 @@
 	},
 /obj/item/wirecutters,
 /obj/item/vacuum_pack,
+/obj/item/disk/vacuum_upgrade/biomass,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "isa" = (


### PR DESCRIPTION
# About The Pull Request

- Replace an unusable and unintended cybernetic arm with a toolset implant on the caravan ruin (Fixes #4081, fixes #4267) 
- Added biomass links to box station for xenobio (Fixes #4404)

## Why It's Good For The Game

- Several reports and functionally serves no purpose when installed. Now still requires a link to use but funny enough
- Biomass link upgrades are pretty standard for xenobiology's. This should help that and fix reported issue

## Changelog

:cl:
add: Added biomass links to Box's xenobio.
fix: Replaced caravan space ruin arm-mounted implant with a toolset implant.
/:cl:
