### PR TITLE
Fix some lighting-related runtime errors

### DIFF
--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -84,11 +84,11 @@
 
 /datum/lighting_corner/proc/vis_update()
 	for (var/datum/light_source/light_source as anything in affecting)
-		light_source.vis_update()
+		light_source?.vis_update()
 
 /datum/lighting_corner/proc/full_update()
 	for (var/datum/light_source/light_source as anything in affecting)
-		light_source.recalc_corner(src)
+		light_source?.recalc_corner(src)
 
 // God that was a mess, now to do the rest of the corner code! Hooray!
 /datum/lighting_corner/proc/update_lumcount(delta_r, delta_g, delta_b)

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -197,6 +197,8 @@
 	applied = FALSE
 	var/list/turfs_to_mark = list()
 	for (var/datum/lighting_corner/corner as anything in effect_str)
+		if(isnull(corner))
+			continue
 		REMOVE_CORNER(corner)
 		LAZYREMOVE(corner.affecting, src)
 
@@ -404,12 +406,16 @@
 
 	if (needs_update == LIGHTING_VIS_UPDATE)
 		for (var/datum/lighting_corner/corner as anything in new_corners)
+			if(isnull(corner))
+				continue
 			APPLY_CORNER(corner)
 			if (. != 0)
 				LAZYADD(corner.affecting, src)
 				effect_str[corner] = .
 	else
 		for (var/datum/lighting_corner/corner as anything in new_corners)
+			if(isnull(corner))
+				continue
 			APPLY_CORNER(corner)
 			if (. != 0)
 				LAZYADD(corner.affecting, src)
@@ -418,6 +424,8 @@
 		// New corners are a subset of corners. so if they're both the same length, there are NO old corners!
 		if(length(corners) != length(new_corners))
 			for (var/datum/lighting_corner/corner as anything in corners - new_corners) // Existing corners
+				if(isnull(corner))
+					continue
 				APPLY_CORNER(corner)
 				if (. != 0)
 					effect_str[corner] = .
@@ -428,6 +436,8 @@
 
 	var/list/datum/lighting_corner/gone_corners = effect_str - corners
 	for (var/datum/lighting_corner/corner as anything in gone_corners)
+		if(isnull(corner))
+			continue
 		REMOVE_CORNER(corner)
 		LAZYREMOVE(corner.affecting, src)
 	effect_str -= gone_corners


### PR DESCRIPTION

## About The Pull Request

null errors in lighting code are seemingly showing up quite a bit, so I sprinkled some `if(isnull(corner)) continue` around.

## Changelog
:cl:
fix: Fixed some seemingly common runtime errors related to lighting.
/:cl:
