### PR TITLE
web sounds (admin/curator music + walkmans) should now show the english title if youtube provides one

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -77,7 +77,7 @@
 	var/stop_web_sounds = FALSE
 	var/list/music_extra_data = list()
 	if(istext(input))
-		var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[input]\"")
+		var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist --extractor-args \"youtube:lang=en\" -- \"[input]\"")
 		var/errorlevel = output[SHELLEO_ERRORLEVEL]
 		var/stdout = output[SHELLEO_STDOUT]
 		var/stderr = output[SHELLEO_STDERR]

--- a/monkestation/code/modules/cassettes/machines/dj_station.dm
+++ b/monkestation/code/modules/cassettes/machines/dj_station.dm
@@ -282,7 +282,7 @@ GLOBAL_VAR(dj_booth)
 			///scrubbing the input before putting it in the shell
 			var/shell_scrubbed_input = shell_url_scrub(web_sound_input)
 			///putting it in the shell
-			var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[shell_scrubbed_input]\"")
+			var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist --extractor-args \"youtube:lang=en\" -- \"[shell_scrubbed_input]\"")
 			///any errors
 			var/errorlevel = output[SHELLEO_ERRORLEVEL]
 			///the standard output

--- a/monkestation/code/modules/cassettes/machines/stationary_mixer.dm
+++ b/monkestation/code/modules/cassettes/machines/stationary_mixer.dm
@@ -115,7 +115,7 @@
 				///scrub the url before passing it through a shell
 				var/shell_scrubbed_input = shell_url_scrub(url2)
 				///the command being sent to the shell after being scrubbed
-				var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[shell_scrubbed_input]\"")
+				var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist --extractor-args \"youtube:lang=en\" -- \"[shell_scrubbed_input]\"")
 				///any errors
 				var/errorlevel = output[SHELLEO_ERRORLEVEL]
 				///the standard output

--- a/monkestation/code/modules/cassettes/walkman/_walkmen.dm
+++ b/monkestation/code/modules/cassettes/walkman/_walkmen.dm
@@ -156,7 +156,7 @@ GLOBAL_LIST_INIT(youtube_exempt, list(
 					///scrubbing the input before putting it in the shell
 					var/shell_scrubbed_input = shell_url_scrub(web_sound_input)
 					///putting it in the shell
-					var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist -- \"[shell_scrubbed_input]\"")
+					var/list/output = world.shelleo("[ytdl] --geo-bypass --format \"bestaudio\[ext=mp3]/best\[ext=mp4]\[height <= 360]/bestaudio\[ext=m4a]/bestaudio\[ext=aac]\" --dump-single-json --no-playlist --extractor-args \"youtube:lang=en\" -- \"[shell_scrubbed_input]\"")
 					///any errors
 					var/errorlevel = output[SHELLEO_ERRORLEVEL]
 					///the standard output


### PR DESCRIPTION
## About The Pull Request

this just adds `--extractor-args "youtube:lang=en"` to the yt-dlp cli args

## Changelog
:cl:
qol: Web sounds (admin/curator music + walkmans) should now show the english title if youtube provides one.
/:cl:
