### PR TITLE
Pathology fixes

### DIFF
--- a/monkestation/code/modules/virology/disease/symptom_varients/base.dm
+++ b/monkestation/code/modules/virology/disease/symptom_varients/base.dm
@@ -51,6 +51,7 @@
 		return FALSE
 	host_symptom.run_effect(host_disease.affected_mob, host_disease)
 	COOLDOWN_START(src, host_cooldown, cooldown_time)
+	return TRUE
 
 /datum/symptom_varient/proc/Copy(datum/symptom/new_symp)
 	return new type(new_symp)

--- a/monkestation/code/modules/virology/disease/symptom_varients/recursive.dm
+++ b/monkestation/code/modules/virology/disease/symptom_varients/recursive.dm
@@ -17,10 +17,9 @@
 	UnregisterSignal(host_symptom, COMSIG_SYMPTOM_TRIGGER)
 
 /datum/symptom_varient/recursive/proc/start_chain()
-	trigger_symptom()
-
-	addtimer(CALLBACK(src, PROC_REF(trigger)), 2 SECONDS)
-	addtimer(CALLBACK(src, PROC_REF(trigger)), 4 SECONDS)
+	if(trigger_symptom())
+		addtimer(CALLBACK(src, PROC_REF(trigger)), 2 SECONDS, TIMER_DELETE_ME)
+		addtimer(CALLBACK(src, PROC_REF(trigger)), 4 SECONDS, TIMER_DELETE_ME)
 
 /datum/symptom_varient/recursive/proc/trigger()
 	host_symptom.run_effect(host_disease.affected_mob, host_disease)

--- a/monkestation/code/modules/virology/disease/symtoms/_symptom.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/_symptom.dm
@@ -32,6 +32,9 @@
 	var/datum/symptom_varient/attached_varient
 		// This is our attached varient used for updating desc and Symptom copy code.
 
+/datum/symptom/Destroy(force)
+	QDEL_NULL(attached_varient)
+	return ..()
 
 /datum/symptom/proc/minormutate()
 	if (prob(20))

--- a/monkestation/code/modules/virology/disease/symtoms/helpful/plasma_heal.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/helpful/plasma_heal.dm
@@ -24,8 +24,9 @@
 
 /datum/symptom/plasma_heal/first_activate(mob/living/carbon/mob, datum/disease/advanced/disease)
 	. = ..()
+	if(HAS_TRAIT(mob, TRAIT_PLASMA_LOVER_METABOLISM))
+		to_chat(mob, span_notice("You suddenly love plasma."))
 	ADD_TRAIT(mob, TRAIT_PLASMA_LOVER_METABOLISM, type)
-	to_chat(mob, span_notice("You suddenly love plasma."))
 
 /datum/symptom/plasma_heal/side_effect(mob/living/mob)
 	. = ..()

--- a/monkestation/code/modules/virology/disease/symtoms/helpful/plasma_heal.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/helpful/plasma_heal.dm
@@ -24,7 +24,7 @@
 
 /datum/symptom/plasma_heal/first_activate(mob/living/carbon/mob, datum/disease/advanced/disease)
 	. = ..()
-	if(HAS_TRAIT(mob, TRAIT_PLASMA_LOVER_METABOLISM))
+	if(!HAS_TRAIT(mob, TRAIT_PLASMA_LOVER_METABOLISM))
 		to_chat(mob, span_notice("You suddenly love plasma."))
 	ADD_TRAIT(mob, TRAIT_PLASMA_LOVER_METABOLISM, type)
 


### PR DESCRIPTION
## Changelog
:cl:
fix: The recursive symptom varient should now work as intended rather than cascading horribly.
fix: The "Quantumly Entangled" (bluespace) symptom varient should work properly now.
fix: Symptoms being deleted properly cleanup their attached varients now.
/:cl:
