### PR TITLE
Centcom Medical room overhaul

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3612,10 +3612,6 @@
 	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
-"ajM" = (
-/turf/open/space/basic,
-/turf/open/floor/iron/dark/textured,
-/area/centcom/central_command_areas/medical)
 "ajN" = (
 /obj/structure/flora/tree/dead/style_random,
 /obj/structure/flora/grass/both/style_random,
@@ -23213,10 +23209,6 @@
 "kti" = (
 /turf/open/floor/sandy_dirt,
 /area/centcom/central_command_areas/adminroom)
-"kts" = (
-/turf/open/space/basic,
-/turf/closed/indestructible/fakeglass,
-/area/centcom/central_command_areas/medical)
 "kuO" = (
 /obj/machinery/hypnochair{
 	icon_state = "hypnochair_open"
@@ -73780,7 +73772,7 @@ cjJ
 awe
 aCW
 avS
-ajM
+aAO
 nwD
 arP
 aUY
@@ -74806,9 +74798,9 @@ afE
 afE
 aMZ
 awe
-kts
-kts
-kts
+adl
+adl
+adl
 awe
 aaa
 aaa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -25255,7 +25255,6 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
-/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/white/small,
 /area/centcom/central_command_areas/medical)
 "qGw" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -227,7 +227,10 @@
 /obj/machinery/computer/operating{
 	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
 /area/centcom/central_command_areas/medical)
 "aaI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -330,10 +333,11 @@
 /turf/open/floor/iron,
 /area/centcom/wizard_station)
 "aaU" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 9
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/herringbone,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "aaV" = (
 /obj/structure/table/wood,
@@ -913,9 +917,13 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
 "acu" = (
-/obj/structure/organ_creator,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/blue{
+	dir = 8
+	},
+/turf/closed/indestructible/fakeglass,
 /area/centcom/central_command_areas/medical)
 "acv" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -1028,7 +1036,11 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
 	},
-/turf/open/floor/iron/dark/diagonal,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/arrows/white{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "acL" = (
 /obj/structure/table/reinforced,
@@ -1064,10 +1076,14 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/borbop)
 "acR" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 10
+/obj/machinery/stasis{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/diagonal,
+/obj/machinery/defibrillator_mount/loaded/directional/west,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "acS" = (
 /obj/structure/railing/wood{
@@ -1795,8 +1811,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/structure/hedge,
-/turf/open/floor/wood/large,
+/obj/structure/sign/poster/official/periodic_table,
+/turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/medical)
 "aeL" = (
 /obj/structure/destructible/cult/item_dispenser/altar{
@@ -1917,10 +1933,13 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "afg" = (
-/obj/machinery/stasis{
-	dir = 4
+/obj/structure/table/optable{
+	dir = 0
 	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
 /area/centcom/central_command_areas/medical)
 "afh" = (
 /obj/structure/flora/bush/large/style_3,
@@ -2050,12 +2069,14 @@
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/borbop)
 "afE" = (
-/obj/machinery/stasis,
-/turf/open/floor/iron/dark,
+/obj/structure/table/optable,
+/turf/open/floor/circuit,
 /area/centcom/central_command_areas/medical)
 "afF" = (
-/obj/effect/turf_decal/siding/wood/corner,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/orange/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "afG" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -2261,9 +2282,14 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/kitchen)
 "agl" = (
-/obj/structure/hedge,
 /obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/obj/structure/sign/warning/no_smoking{
+	pixel_y = 28
+	},
+/turf/open/floor/iron/white/small,
 /area/centcom/central_command_areas/medical)
 "agm" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
@@ -2371,9 +2397,9 @@
 /turf/open/floor/iron/dark/side,
 /area/centcom/central_command_areas/hall)
 "agz" = (
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 8
-	},
+/obj/structure/window/reinforced/tinted/fulltile,
+/obj/structure/window_sill,
+/obj/structure/grille/window_sill,
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "agA" = (
@@ -2642,11 +2668,10 @@
 /area/centcom/central_command_areas/adminroom)
 "ahm" = (
 /obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 1
-	},
-/obj/structure/railing/wood,
-/turf/open/floor/iron/dark/diagonal,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/blue,
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "ahn" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
@@ -2824,10 +2849,12 @@
 /turf/open/floor/glass/reinforced/plasma,
 /area/centcom/central_command_areas/adminroom)
 "ahM" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
-	},
+/obj/machinery/rnd/production/techfab/department/medical,
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/wood/large,
+/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark/small,
+/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "ahN" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3525,13 +3552,10 @@
 /turf/open/floor/glass/reinforced,
 /area/centcom/central_command_areas/adminroom)
 "ajE" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
 	},
-/obj/structure/railing/wood{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "ajF" = (
 /obj/effect/turf_decal/siding/wideplating{
@@ -3592,23 +3616,11 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "ajM" = (
-/obj/machinery/light/floor/has_bulb,
-/obj/structure/table/reinforced,
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = 6;
-	pixel_y = 10
-	},
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = 6
-	},
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = -6;
-	pixel_y = 10
-	},
-/obj/item/storage/backpack/duffelbag/med/surgery{
-	pixel_x = -6
-	},
-/turf/open/floor/iron/dark,
+/turf/open/space/basic,
+/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/small,
+/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "ajN" = (
 /obj/structure/flora/tree/dead/style_random,
@@ -3881,10 +3893,10 @@
 /turf/closed/indestructible/syndicate,
 /area/centcom/syndicate_mothership/control)
 "akC" = (
-/obj/structure/railing/wood{
-	dir = 1
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
 	},
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "akD" = (
 /obj/structure/table/rolling,
@@ -3956,10 +3968,14 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/botany)
 "akN" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 10
+/obj/machinery/computer/operating{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/herringbone,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "akO" = (
 /obj/structure/hedge,
@@ -4321,7 +4337,11 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/wood/large,
+/obj/machinery/rnd/production/techfab/department/medical,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "alI" = (
 /turf/open/floor/carpet/black,
@@ -4450,9 +4470,10 @@
 /turf/open/floor/carpet,
 /area/centcom/central_command_areas/adminroom)
 "amb" = (
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "amc" = (
 /obj/machinery/light/directional/north,
@@ -4568,10 +4589,14 @@
 /turf/open/floor/carpet/royalblue,
 /area/centcom/central_command_areas/admin)
 "amr" = (
-/obj/effect/turf_decal/siding/blue{
+/obj/machinery/stasis{
+	dir = 4
+	},
+/obj/machinery/defibrillator_mount/loaded/directional/west,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "ams" = (
 /obj/structure/rack,
@@ -5010,13 +5035,11 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "anv" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/arrows/white{
+	dir = 4
 	},
-/obj/structure/railing/wood{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "anw" = (
 /obj/effect/turf_decal/tile/dark/diagonal_edge,
@@ -5029,10 +5052,9 @@
 	},
 /area/centcom/central_command_areas/adminroom)
 "any" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/iv_drip,
+/turf/open/floor/iron/white/small,
 /area/centcom/central_command_areas/medical)
 "anz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -5709,9 +5731,8 @@
 /turf/open/floor/plating/abductor,
 /area/centcom/central_command_areas/adminroom)
 "apw" = (
-/obj/effect/turf_decal/trimline/blue,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark/herringbone,
+/obj/machinery/computer/vitals_reader/advanced,
+/turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/medical)
 "apx" = (
 /obj/machinery/door/airlock/centcom{
@@ -6120,22 +6141,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_mothership/control)
 "aqB" = (
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/effect/turf_decal/siding/blue{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/door/window/right/directional/south,
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "aqC" = (
 /obj/machinery/door/window/survival_pod{
@@ -6578,7 +6587,6 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 1
 	},
-/obj/structure/railing/wood,
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "arQ" = (
@@ -6958,9 +6966,7 @@
 	},
 /area/centcom/wizard_station)
 "asR" = (
-/obj/structure/railing/wood,
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/tactical,
+/obj/effect/turf_decal/tile/orange,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "asS" = (
@@ -7004,9 +7010,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/arcade)
 "asY" = (
-/obj/structure/table/reinforced,
-/obj/machinery/vending/medical,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
 /area/centcom/central_command_areas/medical)
 "asZ" = (
 /obj/structure/railing/corner{
@@ -7087,9 +7094,9 @@
 /turf/closed/indestructible/rock/snow,
 /area/centcom/central_command_areas/adminroom)
 "atk" = (
-/obj/effect/turf_decal/trimline/blue,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark/diagonal,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/mob/living/basic/bot/cleanbot/medbay,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "atl" = (
 /obj/effect/turf_decal/stripes/line,
@@ -7541,7 +7548,9 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 6
 	},
-/turf/open/floor/iron/dark/diagonal,
+/obj/effect/turf_decal/trimline/blue,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "aut" = (
 /obj/docking_port/stationary{
@@ -7567,27 +7576,43 @@
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
 "auw" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/regular,
-/obj/item/storage/medkit/brute{
-	pixel_y = 5;
-	pixel_x = 5
-	},
-/obj/item/storage/medkit/fire{
-	pixel_y = 5;
-	pixel_x = -4
-	},
-/turf/open/floor/wood/large,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aux" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/effect/turf_decal/tile/orange/half/contrasted{
+	dir = 4
 	},
-/obj/structure/hedge,
-/turf/open/floor/wood/large,
+/obj/item/storage/medkit/regular{
+	pixel_x = -6;
+	pixel_y = 0
+	},
+/obj/structure/closet/generic/wall/directional/east{
+	name = "Medkits"
+	},
+/obj/item/storage/medkit/brute{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/item/storage/medkit/brute{
+	pixel_y = 0;
+	pixel_x = 8
+	},
+/obj/item/storage/medkit/regular{
+	pixel_x = -7
+	},
+/obj/item/storage/medkit/fire{
+	pixel_y = 7;
+	pixel_x = 1
+	},
+/obj/item/storage/medkit/fire{
+	pixel_y = 7;
+	pixel_x = 0
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "auy" = (
 /obj/effect/turf_decal/siding/wood{
@@ -7810,10 +7835,13 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
+/obj/machinery/vending/drugs,
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/wood/large,
+/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/small,
+/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "avf" = (
 /obj/structure/window/reinforced/fulltile/indestructible,
@@ -8072,8 +8100,13 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/kitchen)
 "avP" = (
-/obj/structure/flora/bush/large/style_3,
-/turf/open/floor/grass,
+/obj/machinery/chem_dispenser/fullupgrade,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/wood/large,
+/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/small,
+/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "avQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -8083,13 +8116,29 @@
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "avR" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 8
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/closet/generic/wall/directional/south{
+	name = "Combat Medkits"
 	},
-/turf/open/floor/wood/large,
+/obj/item/storage/medkit/tactical{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/obj/item/storage/medkit/tactical{
+	pixel_x = 0;
+	pixel_y = 4
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "avS" = (
+/obj/effect/turf_decal/tile/orange/fourcorners,
+/obj/effect/turf_decal/tile/orange/fourcorners,
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/wood/large,
+/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "avT" = (
 /obj/effect/turf_decal/siding/wood{
@@ -8114,10 +8163,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range)
 "avW" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
-	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/tile/orange/anticorner/contrasted,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "avX" = (
 /obj/machinery/light/small/directional/east,
@@ -8360,10 +8407,7 @@
 	},
 /area/centcom/central_command_areas/adminroom)
 "awG" = (
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "awH" = (
 /obj/machinery/light/floor/has_bulb,
@@ -8396,10 +8440,13 @@
 /turf/open/floor/carpet/royalblue,
 /area/centcom/central_command_areas/admin)
 "awK" = (
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/diagonal,
+/obj/effect/turf_decal/arrows/white{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "awL" = (
 /obj/effect/turf_decal/tile/dark/diagonal_edge,
@@ -8606,11 +8653,10 @@
 /turf/open/floor/wood/large,
 /area/centcom/tdome/observation)
 "axq" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/open/floor/wood/large,
+/turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/medical)
 "axr" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -8989,7 +9035,10 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/hall)
 "ayj" = (
-/obj/structure/fake_stairs/wood/directional/north,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "ayk" = (
@@ -9025,11 +9074,10 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
 "ayo" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
+/obj/machinery/door/airlock/centcom{
+	name = "Emergency Surgery"
 	},
-/obj/structure/hedge,
-/turf/open/floor/wood/large,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "ayp" = (
 /obj/effect/turf_decal/stripes/line,
@@ -9398,8 +9446,11 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
 "azp" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/large,
+/obj/machinery/door/airlock/centcom{
+	dir = 4;
+	name = "Chemistry"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "azq" = (
 /obj/effect/turf_decal/siding/wood{
@@ -9538,13 +9589,13 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
 "azH" = (
-/obj/effect/turf_decal/siding/blue,
-/turf/open/floor/iron/dark/diagonal,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "azI" = (
 /obj/effect/turf_decal/siding/blue,
-/obj/structure/railing/wood,
-/turf/open/floor/iron/dark/diagonal,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "azJ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -9553,9 +9604,7 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ghost_spawn)
 "azK" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 6
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "azL" = (
@@ -9969,11 +10018,11 @@
 /turf/open/floor/mineral/titanium/white,
 /area/centcom/central_command_areas/adminroom)
 "aAO" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/large,
+/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/small,
+/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "aAP" = (
 /obj/machinery/nuclearbomb/beer,
@@ -10198,8 +10247,7 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/evacuation)
 "aBu" = (
-/obj/machinery/vending/drugs,
-/turf/open/floor/iron/dark,
+/turf/open/floor/mineral/plastitanium,
 /area/centcom/central_command_areas/medical)
 "aBv" = (
 /obj/structure/chair/stool/bar/directional/west,
@@ -10574,8 +10622,12 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_mothership/control)
 "aCx" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Medbay"
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Recovery Ward"
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
@@ -10669,14 +10721,12 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "aCM" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
 	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/hedge,
-/turf/open/floor/wood/large,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/item/kirbyplants/fern,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aCN" = (
 /obj/machinery/door/airlock/centcom{
@@ -10694,8 +10744,10 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
 "aCQ" = (
-/obj/structure/injured_spawner,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/iron/white/small,
 /area/centcom/central_command_areas/medical)
 "aCR" = (
 /obj/structure/flora/bush/fullgrass,
@@ -10745,10 +10797,17 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/retirement_yard)
 "aCW" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/structure/sign/warning/no_smoking{
+	pixel_y = 28
+	},
+/obj/structure/closet/secure_closet/chemical{
+	locked = 0
 	},
 /turf/open/floor/wood/large,
+/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/small,
+/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "aCX" = (
 /obj/structure/chair/stool/directional/south,
@@ -11736,15 +11795,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
 "aFF" = (
-/obj/structure/railing/wood,
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/fire{
-	pixel_y = 5;
-	pixel_x = -4
-	},
-/obj/item/storage/medkit/brute,
-/obj/item/storage/medkit/regular{
-	pixel_x = -7
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
@@ -11830,7 +11883,10 @@
 	},
 /area/centcom/central_command_areas/adminroom)
 "aFV" = (
-/obj/structure/closet/crate/freezer/blood,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aFW" = (
@@ -12121,13 +12177,17 @@
 /turf/open/floor/stone,
 /area/centcom/central_command_areas/hall)
 "aGK" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 4
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/blue,
+/obj/structure/table/reinforced,
+/obj/item/storage/box/material{
+	pixel_x = 0;
+	pixel_y = 6
 	},
-/turf/open/floor/wood/large,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aGL" = (
 /obj/structure/table/reinforced,
@@ -12442,12 +12502,10 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
 "aHI" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/effect/turf_decal/siding/blue/corner{
-	dir = 4
-	},
-/obj/structure/railing/wood,
-/turf/open/floor/iron/dark/diagonal,
+/obj/item/surgery_tray/deployed,
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "aHJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12544,8 +12602,13 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "aHW" = (
-/obj/effect/turf_decal/siding/blue/corner,
-/turf/open/floor/iron/dark/herringbone,
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/circuit,
 /area/centcom/central_command_areas/medical)
 "aHX" = (
 /obj/effect/turf_decal/siding/wood{
@@ -12574,15 +12637,22 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
 "aIa" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 9
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
 	},
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/open/floor/iron/dark/diagonal,
+/obj/structure/injured_spawner,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "aIb" = (
 /obj/effect/turf_decal/siding/blue{
-	dir = 5
+	dir = 1
+	},
+/obj/effect/turf_decal/arrows/white{
+	dir = 8
+	},
+/obj/structure/sign/warning/no_smoking{
+	pixel_y = 28
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
@@ -13094,11 +13164,12 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin_hangout)
 "aJA" = (
-/obj/effect/turf_decal/siding/blue/end{
-	dir = 8
+/obj/effect/turf_decal/siding/blue,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/arrows/white{
+	dir = 4
 	},
-/obj/structure/railing/wood,
-/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "aJB" = (
 /obj/effect/turf_decal/siding/wood{
@@ -13427,10 +13498,11 @@
 /turf/open/floor/iron/white/herringbone,
 /area/centcom/central_command_areas/kitchen)
 "aKq" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 9
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/diagonal,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "aKr" = (
 /obj/effect/turf_decal/siding/dark{
@@ -14429,10 +14501,10 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/briefing)
 "aMZ" = (
-/obj/structure/hedge,
-/obj/structure/railing/wood,
 /obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark,
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/storage/medkit/robotic_repair/preemo/stocked,
+/turf/open/floor/circuit,
 /area/centcom/central_command_areas/medical)
 "aNa" = (
 /turf/open/floor/glass/reinforced/plasma,
@@ -14543,8 +14615,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/structure/hedge,
-/turf/open/floor/wood/large,
+/turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/medical)
 "aNr" = (
 /obj/effect/turf_decal/siding/wood{
@@ -14722,14 +14793,18 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "aNR" = (
-/obj/effect/turf_decal/siding/wood/corner{
-	dir = 1
-	},
-/turf/open/floor/wood/large,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/blue,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aNS" = (
-/obj/machinery/rnd/production/techfab/department/medical,
-/turf/open/floor/iron/dark,
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 0;
+	pixel_y = 8
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/circuit,
 /area/centcom/central_command_areas/medical)
 "aNT" = (
 /obj/structure/table/reinforced,
@@ -15070,7 +15145,9 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 5
 	},
-/turf/open/floor/iron/dark/diagonal,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/blue,
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "aOK" = (
 /obj/structure/railing/wood{
@@ -15604,11 +15681,13 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/hall)
 "aQm" = (
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/orange/fourcorners,
+/obj/effect/turf_decal/tile/orange/fourcorners,
 /turf/open/floor/wood/large,
+/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/small,
+/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "aQn" = (
 /obj/structure/hedge,
@@ -15643,11 +15722,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "aQs" = (
-/obj/effect/turf_decal/siding/blue/end{
-	dir = 4
-	},
-/obj/structure/railing/wood,
-/turf/open/floor/iron/dark/diagonal,
+/obj/machinery/stasis,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "aQt" = (
 /obj/structure/table/reinforced,
@@ -15892,12 +15970,10 @@
 /turf/open/floor/carpet/purple,
 /area/centcom/central_command_areas/adminroom)
 "aRe" = (
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/chem_heater/debug,
-/turf/open/floor/wood/large,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aRf" = (
 /obj/structure/chair/sofa/corp/right{
@@ -15969,11 +16045,8 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
 "aRq" = (
-/obj/machinery/chem_dispenser/fullupgrade,
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/wood,
+/turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/medical)
 "aRr" = (
 /obj/machinery/light/floor/has_bulb,
@@ -16206,16 +16279,9 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
 "aRU" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/fire{
-	pixel_y = 5;
-	pixel_x = -4
-	},
-/obj/item/storage/medkit/brute,
-/obj/item/storage/medkit/regular{
-	pixel_x = -7
-	},
-/turf/open/floor/iron/dark,
+/obj/structure/table/reinforced/titaniumglass,
+/obj/item/storage/medkit/robotic_repair/stocked,
+/turf/open/floor/circuit,
 /area/centcom/central_command_areas/medical)
 "aRV" = (
 /obj/structure/table/reinforced,
@@ -16736,12 +16802,20 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "aTl" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 5
-	},
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/chem_heater/debug,
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
 /turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "aTm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17222,6 +17296,13 @@
 /area/centcom/central_command_areas/hall)
 "aUA" = (
 /obj/effect/landmark/navigate_destination/centcom/medical,
+/obj/machinery/door/window{
+	dir = 8;
+	name = "Recovery Ward"
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aUB" = (
@@ -17297,11 +17378,11 @@
 /turf/open/floor/iron,
 /area/centcom/wizard_station)
 "aUK" = (
-/obj/machinery/computer/operating{
-	dir = 4
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/effect/turf_decal/arrows/white{
+	dir = 8
 	},
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "aUL" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
@@ -17391,7 +17472,8 @@
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "aUY" = (
-/turf/open/floor/iron/dark/diagonal,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "aUZ" = (
 /obj/structure/table/reinforced,
@@ -17540,9 +17622,8 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "aVr" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/box/material,
-/turf/open/floor/iron/dark,
+/obj/structure/window/reinforced/spawner/directional/west,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "aVs" = (
 /obj/effect/turf_decal/tile/dark/diagonal_edge,
@@ -17968,19 +18049,13 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/four)
 "aWv" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
+/obj/structure/table/optable{
+	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/fire{
-	pixel_y = 5;
-	pixel_x = -4
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
 	},
-/obj/item/storage/medkit/brute,
-/obj/item/storage/medkit/regular{
-	pixel_x = -7
-	},
-/turf/open/floor/wood/large,
+/turf/open/floor/iron/white/small,
 /area/centcom/central_command_areas/medical)
 "aWw" = (
 /mob/living/basic/slime,
@@ -18152,8 +18227,10 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
 "aWW" = (
-/obj/structure/hedge,
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/medical)
 "aWX" = (
 /obj/effect/turf_decal/siding/wood{
@@ -18539,7 +18616,11 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "aXW" = (
-/obj/machinery/light/floor/has_bulb,
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/structure/chair,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aXX" = (
@@ -18804,8 +18885,9 @@
 /turf/open/floor/carpet,
 /area/centcom/central_command_areas/hall)
 "aYL" = (
-/obj/structure/railing/wood,
-/turf/open/floor/iron/dark,
+/obj/structure/closet/secure_closet/personal/patient,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "aYM" = (
 /obj/structure/closet/cardboard,
@@ -19049,8 +19131,9 @@
 	},
 /area/centcom/central_command_areas/adminroom)
 "aZz" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/iron/dark,
+/obj/item/bedsheet/medical,
+/obj/structure/bed,
+/turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "aZA" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -19497,6 +19580,15 @@
 	},
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
+"bys" = (
+/obj/structure/sign/departments/chemistry/alt/directional/east,
+/obj/effect/turf_decal/tile/orange/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/orange,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/medical)
 "byS" = (
 /obj/structure/railing/wooden_fencing{
 	pixel_y = 16
@@ -19563,6 +19655,16 @@
 	},
 /turf/open/floor/sandy_dirt,
 /area/centcom/central_command_areas/admin)
+"bGO" = (
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Surgery "
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/medical)
 "bHb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -19621,6 +19723,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/retirement_yard)
+"bTX" = (
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/iron/white/small,
+/area/centcom/central_command_areas/medical)
 "bTZ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
@@ -19740,6 +19846,10 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/centcom/central_command_areas/admin)
+"cjJ" = (
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/circuit,
+/area/centcom/central_command_areas/medical)
 "cjY" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -19818,6 +19928,11 @@
 "cxr" = (
 /turf/open/misc/dirt/station,
 /area/centcom/central_command_areas/retirement_yard)
+"cxT" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/medical)
 "cyd" = (
 /obj/structure/chair/office/tactical{
 	dir = 8
@@ -19831,6 +19946,10 @@
 /obj/machinery/suit_storage_unit/industrial/assault_operative,
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
+"cyp" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/medical)
 "cyV" = (
 /obj/structure/bloodsucker/bloodthrone,
 /obj/effect/turf_decal/siding/wood{
@@ -20412,6 +20531,27 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/centcom)
+"dRP" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/medical3{
+	name = "Medical Kits locker";
+	locked = 0
+	},
+/obj/item/storage/medkit/regular,
+/obj/item/storage/medkit/fire,
+/obj/item/storage/medkit/toxin,
+/obj/item/storage/medkit/brute,
+/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
+/obj/item/storage/medkit/advanced,
+/obj/item/storage/medkit/civil_defense/stocked,
+/obj/item/storage/medkit/civil_defense/comfort/stocked,
+/obj/item/storage/medkit/frontier/stocked,
+/obj/item/storage/medkit/combat_surgeon/stocked,
+/obj/item/storage/medkit/tactical/premium,
+/turf/open/floor/iron/white/textured,
+/area/centcom/central_command_areas/medical)
 "dSg" = (
 /turf/closed/indestructible/opsglass,
 /area/centcom/syndicate_mothership/expansion_bulldozer)
@@ -20446,6 +20586,16 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
+"dVW" = (
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 8
+	},
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/white/textured,
+/area/centcom/central_command_areas/medical)
 "dXA" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/red/real_red/filled/line{
@@ -20510,6 +20660,14 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/centcom/central_command_areas/admin)
+"ejG" = (
+/obj/machinery/stasis,
+/obj/machinery/defibrillator_mount/loaded/directional/east,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white/textured,
+/area/centcom/central_command_areas/medical)
 "eka" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/pod/dark,
@@ -20525,6 +20683,16 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/centcom/central_command_areas/adminroom)
+"eru" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4
+	},
+/turf/open/floor/iron/white/textured,
+/area/centcom/central_command_areas/medical)
 "erK" = (
 /obj/structure/flora/bush/fullgrass/style_2,
 /turf/open/floor/grass,
@@ -20743,6 +20911,20 @@
 	},
 /turf/open/floor/plastic,
 /area/centcom/central_command_areas/admin)
+"eYn" = (
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/medical3{
+	name = "Spare surgery kit locker";
+	locked = 0
+	},
+/obj/item/storage/belt/medical,
+/obj/item/cautery/advanced,
+/obj/item/retractor/advanced,
+/obj/item/scalpel/advanced,
+/turf/open/floor/iron/white/textured,
+/area/centcom/central_command_areas/medical)
 "eZi" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/grass,
@@ -20847,6 +21029,11 @@
 	},
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
+"fnA" = (
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
+/obj/structure/sign/poster/official/moth_epi/directional/east,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/medical)
 "fnC" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/street_lamp,
@@ -21219,6 +21406,13 @@
 /obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation)
+"gmS" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical{
+	layer = 3.1
+	},
+/turf/open/floor/iron/white/textured,
+/area/centcom/central_command_areas/medical)
 "gnB" = (
 /obj/structure/table/greyscale,
 /obj/item/paper_bin{
@@ -21239,6 +21433,17 @@
 /obj/machinery/light/directional/east,
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
+"gpy" = (
+/obj/machinery/light/floor/has_bulb,
+/obj/machinery/button/door/directional/west{
+	name = "IPC Repair Shutters";
+	id = "IPCShutters"
+	},
+/obj/structure/sign/warning/no_smoking{
+	pixel_y = 28
+	},
+/turf/open/floor/circuit,
+/area/centcom/central_command_areas/medical)
 "gqw" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 1
@@ -21350,6 +21555,12 @@
 	},
 /turf/open/floor/glass/plasma,
 /area/centcom/central_command_areas/evacuation)
+"gBE" = (
+/obj/structure/window/reinforced/tinted/fulltile,
+/obj/structure/grille/window_sill,
+/obj/structure/window_sill,
+/turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/medical)
 "gCO" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7"
@@ -21417,6 +21628,14 @@
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/centcom/central_command_areas/adminroom)
+"gIx" = (
+/obj/machinery/door/poddoor/shutters{
+	dir = 8;
+	id = "IPCShutters";
+	name = "IPC Repair Shutters"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/central_command_areas/medical)
 "gJY" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -21697,6 +21916,17 @@
 	},
 /turf/open/floor/carpet/orange,
 /area/centcom/central_command_areas/adminroom)
+"hln" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue,
+/obj/machinery/light/floor/has_bulb{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/medical)
 "hna" = (
 /obj/structure/closet/secure_closet{
 	name = "contraband locker";
@@ -21895,6 +22125,14 @@
 	dir = 8
 	},
 /area/centcom/central_command_areas/evacuation)
+"hBi" = (
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 1
+	},
+/obj/structure/bodycontainer/morgue,
+/turf/open/floor/iron/white/small,
+/area/centcom/central_command_areas/medical)
 "hBT" = (
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/carpet/neon/simple/green/nodots,
@@ -22449,6 +22687,17 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
+"iUK" = (
+/obj/machinery/button/door/directional/east{
+	name = "IPC Repair Shutters";
+	id = "IPCShutters"
+	},
+/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
+	dir = 4
+	},
+/obj/structure/chair,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/medical)
 "iVf" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/candle_box/amber,
@@ -22659,6 +22908,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"jDG" = (
+/obj/structure/sign/poster/official/moth_meth,
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/medical)
 "jFk" = (
 /obj/structure/toilet/greyscale{
 	dir = 8
@@ -22984,12 +23237,20 @@
 "kqQ" = (
 /turf/open/floor/iron/stairs/left,
 /area/cruiser_dock)
+"krL" = (
+/obj/structure/sign/poster/official/no_erp,
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/medical)
 "ksD" = (
 /turf/open/floor/engine,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "kti" = (
 /turf/open/floor/sandy_dirt,
 /area/centcom/central_command_areas/adminroom)
+"kts" = (
+/turf/open/space/basic,
+/turf/closed/indestructible/fakeglass,
+/area/centcom/central_command_areas/medical)
 "kuO" = (
 /obj/machinery/hypnochair{
 	icon_state = "hypnochair_open"
@@ -23096,6 +23357,12 @@
 /obj/structure/flora/grass/jungle/b/style_4,
 /turf/open/misc/dirt/jungle/dark/arena,
 /area/centcom/central_command_areas/admin)
+"kNr" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/centcom/central_command_areas/medical)
 "kPU" = (
 /obj/item/reagent_containers/condiment/soymilk,
 /obj/item/reagent_containers/condiment/soymilk,
@@ -23331,6 +23598,12 @@
 	},
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
+"lEm" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/medical)
 "lFj" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
@@ -23482,6 +23755,14 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
+"mgZ" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
+	},
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/blue,
+/turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/medical)
 "mho" = (
 /obj/machinery/light/neon_lining{
 	dir = 1;
@@ -23590,6 +23871,12 @@
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/centcom/central_command_areas/adminroom)
+"mFx" = (
+/obj/structure/sign/warning/no_smoking{
+	pixel_y = 28
+	},
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/kitchen)
 "mFZ" = (
 /obj/item/chair/wood,
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
@@ -23638,6 +23925,10 @@
 	},
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
+"mMg" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/turf/open/floor/iron/white/small,
+/area/centcom/central_command_areas/medical)
 "mMH" = (
 /obj/machinery/light/cold/directional/west,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -23805,6 +24096,10 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/sandy_dirt,
 /area/centcom/central_command_areas/admin)
+"nuN" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/turf/open/floor/iron/white/small,
+/area/centcom/central_command_areas/medical)
 "nvZ" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 8
@@ -23823,6 +24118,12 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/admin)
+"nwD" = (
+/obj/machinery/door/window/right/directional/south,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/dark/textured,
+/area/centcom/central_command_areas/medical)
 "nwM" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -23889,6 +24190,11 @@
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
 /turf/open/floor/plating/reinforced,
 /area/centcom/central_command_areas/admin)
+"nEa" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/medical)
 "nFO" = (
 /obj/machinery/button/door/directional/north{
 	name = "talking time button";
@@ -24221,6 +24527,12 @@
 	dir = 8
 	},
 /area/centcom/central_command_areas/prison)
+"oCY" = (
+/obj/item/surgery_tray/deployed,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/white/textured,
+/area/centcom/central_command_areas/medical)
 "oDh" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/textured_large,
@@ -24599,6 +24911,12 @@
 /obj/structure/chair/sofa/right/maroon,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/admin)
+"pEL" = (
+/obj/machinery/door/airlock/centcom{
+	name = "Chemistry"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/central_command_areas/medical)
 "pHj" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
@@ -24760,6 +25078,17 @@
 	dir = 4
 	},
 /area/cruiser_dock)
+"qbZ" = (
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/bed{
+	dir = 4
+	},
+/obj/item/bedsheet/medical{
+	dir = 4;
+	layer = 3.1
+	},
+/turf/open/floor/iron/white/textured,
+/area/centcom/central_command_areas/medical)
 "qfa" = (
 /turf/open/floor/iron/stairs/left{
 	dir = 8
@@ -24929,6 +25258,17 @@
 /obj/effect/mapping_helpers/airlock/access/any/admin/captain,
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/adminroom)
+"qBw" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/obj/structure/table/reinforced/rglass,
+/obj/item/defibrillator/compact/loaded{
+	pixel_x = -10;
+	pixel_y = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/centcom/central_command_areas/medical)
 "qCm" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -24951,6 +25291,16 @@
 	},
 /turf/open/floor/eighties/red,
 /area/centcom/central_command_areas/admin)
+"qGq" = (
+/obj/machinery/light/floor/has_bulb,
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
+	dir = 8
+	},
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/white/small,
+/area/centcom/central_command_areas/medical)
 "qGw" = (
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/admin)
@@ -25111,6 +25461,14 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/sandy_dirt,
 /area/centcom/central_command_areas/admin)
+"rcc" = (
+/obj/machinery/chem_master,
+/turf/open/floor/wood/large,
+/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/small,
+/turf/open/floor/iron/dark/textured,
+/area/centcom/central_command_areas/medical)
 "rcY" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -25285,6 +25643,13 @@
 	},
 /turf/open/floor/sandy_dirt,
 /area/centcom/central_command_areas/admin)
+"rGz" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
+/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/white/small,
+/area/centcom/central_command_areas/medical)
 "rHE" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 8
@@ -25298,6 +25663,18 @@
 	dir = 4
 	},
 /area/cruiser_dock)
+"rKS" = (
+/obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/item/defibrillator/compact/loaded{
+	pixel_x = 9;
+	pixel_y = 40
+	},
+/obj/item/reagent_containers/cup/rag{
+	pixel_x = 0;
+	pixel_y = 35
+	},
+/turf/open/floor/iron/white/small,
+/area/centcom/central_command_areas/medical)
 "rLi" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -25341,6 +25718,13 @@
 /obj/structure/flora/tree/jungle/style_random,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
+"rPS" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/medical)
 "rQG" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 10
@@ -25501,6 +25885,14 @@
 	},
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/adminroom)
+"sgm" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 9
+	},
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/trimline/blue,
+/turf/open/floor/iron/dark/herringbone,
+/area/centcom/central_command_areas/medical)
 "sgZ" = (
 /turf/open/ballpit,
 /area/centcom/central_command_areas/admin)
@@ -25646,6 +26038,11 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
+"sKl" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/medical_kiosk,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/medical)
 "sKy" = (
 /obj/machinery/computer/arcade{
 	dir = 1
@@ -25688,7 +26085,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
 "sTV" = (
-/mob/living/basic/bot/cleanbot/medbay,
+/obj/effect/turf_decal/tile/purple/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "sUM" = (
@@ -25901,6 +26300,17 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
+"twO" = (
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/closet/generic/wall/directional/south{
+	name = "Advanced Health Analyzers"
+	},
+/obj/item/healthanalyzer/advanced,
+/obj/item/healthanalyzer/advanced,
+/obj/item/healthanalyzer/advanced,
+/obj/item/healthanalyzer/advanced,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/medical)
 "twW" = (
 /mob/living/simple_animal/pet/cat/cak{
 	name = "Truffle";
@@ -26162,6 +26572,10 @@
 	},
 /turf/open/floor/sandy_dirt,
 /area/centcom/central_command_areas/admin)
+"uei" = (
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/mineral/plastitanium,
+/area/centcom/central_command_areas/medical)
 "ueR" = (
 /obj/effect/turf_decal/tile/bar/half/contrasted{
 	dir = 1
@@ -26544,6 +26958,12 @@
 /obj/structure/hedge,
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
+"vjt" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/iron/white/small,
+/area/centcom/central_command_areas/medical)
 "vkm" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_pp,
@@ -26707,6 +27127,12 @@
 "vFm" = (
 /turf/open/floor/mineral/titanium/purple,
 /area/centcom/central_command_areas/adminroom)
+"vFK" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/chem_heater/debug,
+/turf/open/floor/iron/dark/diagonal,
+/turf/open/floor/iron/dark/textured,
+/area/centcom/central_command_areas/medical)
 "vFS" = (
 /obj/effect/turf_decal/tile/hot_pink/full,
 /obj/structure/table/wood/fancy/purple,
@@ -26853,6 +27279,22 @@
 	},
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
+"vWZ" = (
+/obj/effect/turf_decal/tile/orange/fourcorners,
+/obj/effect/turf_decal/tile/orange/fourcorners,
+/turf/open/floor/wood/large,
+/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/dark/textured,
+/area/centcom/central_command_areas/medical)
+"vXv" = (
+/obj/structure/organ_creator,
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
+/area/centcom/central_command_areas/medical)
 "vYm" = (
 /obj/machinery/door/airlock/centcom{
 	dir = 4;
@@ -27148,6 +27590,10 @@
 	dir = 8
 	},
 /area/cruiser_dock)
+"wAE" = (
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/open/floor/iron/dark/diagonal,
+/area/centcom/central_command_areas/medical)
 "wAN" = (
 /obj/effect/turf_decal/weather/dirt,
 /obj/structure/railing/wooden_fence{
@@ -27219,6 +27665,15 @@
 	},
 /turf/open/floor/plastic,
 /area/centcom/central_command_areas/admin)
+"wLl" = (
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/white/small,
+/area/centcom/central_command_areas/medical)
 "wLm" = (
 /obj/effect/turf_decal/weather/dirt{
 	pixel_y = -1
@@ -70283,10 +70738,10 @@ aaa
 aaa
 aaa
 awe
-agl
+hBi
 aaH
 afg
-aMZ
+qGq
 amQ
 aGN
 amQ
@@ -70541,16 +70996,16 @@ aaa
 aaa
 adl
 asY
-aNb
-aNb
-aYL
+bTX
+kNr
+any
 aCM
 aGK
 alH
-avP
+aWW
 awe
 amQ
-amQ
+mFx
 amQ
 amQ
 amQ
@@ -70797,18 +71252,18 @@ aaa
 aaa
 aaa
 adl
-aNS
+qBw
+rKS
+nuN
+mMg
+bGO
 aNb
-aNb
-aNb
-ayj
-aCW
-azp
+twO
 awe
-awe
+dRP
 aKq
 amr
-amr
+dVW
 acR
 awe
 apG
@@ -71054,18 +71509,18 @@ aaa
 aaa
 aaa
 adl
-aVr
-aNb
-aNb
-aNb
+asY
+vjt
+aCQ
+any
 ayj
-aQm
+aNb
 avR
 aRq
 aIa
 awG
 akC
-aUY
+awG
 azH
 awe
 aMm
@@ -71312,19 +71767,19 @@ aaa
 aaa
 awe
 agl
-aNb
-aNb
-aNb
+wLl
+aWv
+rGz
 ayj
-aCW
-avS
-azp
+aNb
+cyp
+ayo
 aqB
 atk
-akC
-atk
-azI
-aWW
+aHI
+vXv
+oCY
+awe
 aEv
 arj
 abX
@@ -71564,24 +72019,24 @@ aaa
 aaa
 aaa
 aaa
-awe
-awe
-adl
-awe
-awe
-agl
-aNb
-aYL
-ayo
+aaa
+aaa
+aaa
+apw
+eru
+aVr
+aVr
+qbZ
+auw
 aNR
-afF
+rPS
 axq
-aTl
-acK
+aIa
+awG
 ajE
-acK
-aHI
-aWW
+awG
+azH
+awe
 aGS
 abX
 arj
@@ -71820,25 +72275,25 @@ aaa
 aaa
 aaa
 aaa
-awe
-awe
-afg
-aUK
-afg
-awe
-awe
-aNb
+aaa
+aaa
+aaa
+aaa
+krL
+aYL
+awG
+awG
 aYL
 auw
-avS
-azp
+aNb
+nEa
 awe
-awe
+eYn
 aaU
-alZ
+ejG
 akN
 aQs
-aWW
+awe
 aKN
 arj
 arj
@@ -72077,25 +72532,25 @@ aaa
 aaa
 aaa
 aaa
-adl
-aCQ
-aNb
-aNb
-aNb
-aZz
-adl
-aNb
-asR
-aux
-avS
-avR
-alH
-aiM
-arP
+aaa
+aaa
+aaa
+aaa
 apw
+aZz
+awG
+awG
+gmS
+auw
+aNb
+sKl
+awe
+awe
+gBE
+awe
 agz
-akN
-aAr
+awe
+awe
 aZP
 aaE
 aaE
@@ -72334,24 +72789,24 @@ aaa
 aaa
 aaa
 aaa
-awe
-ajM
-sTV
-acu
-aNb
+aaa
+aaa
+aaa
+aaa
+adl
 aXW
 aCx
 aUA
 aFF
 aRe
-avS
-avS
+aNb
+lEm
 amb
-adl
-arP
-azk
-azk
-aLc
+aiM
+sgm
+alZ
+alZ
+hln
 aAr
 aqh
 auQ
@@ -72591,24 +73046,24 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
 adl
-aCQ
-aNb
-aNb
-aNb
 aFV
-adl
 aNb
+aNR
 asR
 aux
-avS
+bys
 afF
 avW
-aiM
+acu
 arP
-apw
-aHW
-azK
+azk
+azk
+aLc
 aAr
 aJB
 aET
@@ -72848,25 +73303,25 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+adl
+iUK
+sTV
+sTV
+fnA
 awe
 awe
-afE
-aAO
-afE
-awe
-awe
-aNb
-aYL
-aWv
-avS
 azp
 awe
 awe
 aIb
-aqE
+cxT
 azK
 aJA
-aWW
+awe
 aEv
 arj
 arj
@@ -73106,24 +73561,24 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 awe
 awe
-adl
+gIx
+gIx
 awe
-awe
-agl
-aNb
-aYL
 aeK
 ahM
-avR
-aRq
-aIa
-amr
+aAO
+avP
+wAE
+mgZ
 anv
-amr
+aUK
 ahm
-aWW
+awe
 aGS
 abX
 arj
@@ -73367,20 +73822,20 @@ aaa
 aaa
 aaa
 awe
-agl
-aNb
-aNb
-aNb
-ayj
+gpy
+aBu
+aBu
+cjJ
+awe
 aCW
 avS
-azp
-aqB
-atk
-akC
-atk
+ajM
+nwD
+arP
+aUY
+aUY
 azI
-aWW
+awe
 aKN
 arj
 abX
@@ -73625,18 +74080,18 @@ aaa
 aaa
 adl
 aBu
-aNb
-aNb
-aNb
-ayj
+aBu
+aBu
+aBu
+pEL
 aQm
-afF
-axq
+vWZ
+aQm
 aTl
 awK
-akC
+anv
 aUY
-azH
+aJA
 awe
 aMm
 arj
@@ -73882,16 +74337,16 @@ aaa
 aaa
 adl
 aNS
-aNb
-aNb
-aNb
-ayj
-aCW
-azp
-awe
-awe
+aBu
+aBu
+aHW
+jDG
+aAO
+avS
+aAO
+vFK
 aOJ
-acK
+aqE
 acK
 aus
 awe
@@ -74139,17 +74594,17 @@ aaa
 aaa
 adl
 aRU
-aNb
-aNb
-aYL
+uei
+uei
+aRU
 aNq
 ave
-avW
+rcc
 avP
 awe
 awe
-awe
-awe
+adl
+adl
 awe
 awe
 apG
@@ -74395,14 +74850,14 @@ aaa
 aaa
 aaa
 awe
-agl
-any
+aMZ
+afE
 afE
 aMZ
 awe
-awe
-awe
-awe
+kts
+kts
+kts
 awe
 aaa
 aaa
@@ -74653,8 +75108,8 @@ aaa
 aaa
 awe
 awe
-awe
-awe
+adl
+adl
 awe
 awe
 aaa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -42,6 +42,7 @@
 /turf/closed/indestructible/hive,
 /area/station/hive/one)
 "aai" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/red,
 /obj/item/toy/nuke{
 	pixel_x = -5;
@@ -127,6 +128,7 @@
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/retirement_home)
 "aau" = (
+/obj/structure/table/reinforced,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/plasteel{
@@ -182,6 +184,10 @@
 	},
 /turf/open/floor/stone,
 /area/centcom/central_command_areas/hall)
+"aaB" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/firing_range_checkpoint_control)
 "aaC" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/effect/turf_decal/siding/purple{
@@ -221,10 +227,7 @@
 /obj/machinery/computer/operating{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/small,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aaI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -235,6 +238,7 @@
 /turf/closed/indestructible/fakeglass,
 /area/centcom/central_command_areas/borbop)
 "aaK" = (
+/obj/structure/table/reinforced,
 /obj/item/stack/package_wrap,
 /obj/item/crowbar/power,
 /obj/item/wrench,
@@ -329,8 +333,6 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 9
 	},
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/blue,
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "aaV" = (
@@ -362,6 +364,7 @@
 /area/centcom/central_command_areas/retirement_yard)
 "aaZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
 /obj/item/storage/lockbox,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/west,
@@ -439,6 +442,7 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin_hangout)
 "abj" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/box/zipties,
 /obj/item/crowbar/red,
 /obj/effect/turf_decal/stripes/line{
@@ -577,6 +581,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/botany)
 "abA" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/medkit/regular{
 	pixel_x = -7
 	},
@@ -908,6 +913,8 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
 "acu" = (
+/obj/structure/organ_creator,
+/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "acv" = (
@@ -1021,13 +1028,10 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 4
 	},
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/arrows/white{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/herringbone,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "acL" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/red{
 	dir = 8
 	},
@@ -1060,14 +1064,10 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/borbop)
 "acR" = (
-/obj/machinery/stasis{
-	dir = 4
+/obj/effect/turf_decal/siding/blue{
+	dir = 10
 	},
-/obj/machinery/defibrillator_mount/loaded/directional/west,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "acS" = (
 /obj/structure/railing/wood{
@@ -1391,6 +1391,7 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/kitchen)
 "adF" = (
+/obj/structure/table/reinforced,
 /obj/item/syndicatedetonator{
 	desc = "This gaudy button can be used to instantly detonate syndicate bombs that have been activated on the station. It is also fun to press."
 	},
@@ -1741,6 +1742,7 @@
 /area/centcom/central_command_areas/admin)
 "aeC" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/borbop)
@@ -1751,6 +1753,7 @@
 /turf/open/chasm,
 /area/centcom/central_command_areas/admin)
 "aeE" = (
+/obj/structure/table/reinforced,
 /obj/item/toy/figure/dsquad{
 	pixel_x = -3;
 	pixel_y = 11
@@ -1792,8 +1795,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},
-/obj/structure/sign/poster/official/periodic_table,
-/turf/closed/indestructible/riveted,
+/obj/structure/hedge,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "aeL" = (
 /obj/structure/destructible/cult/item_dispenser/altar{
@@ -1856,6 +1859,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom)
 "aeV" = (
+/obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/taperecorder,
 /turf/open/floor/iron/grimy,
@@ -1913,13 +1917,10 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "afg" = (
-/obj/structure/table/optable{
-	dir = 0
+/obj/machinery/stasis{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/small,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "afh" = (
 /obj/structure/flora/bush/large/style_3,
@@ -2049,13 +2050,12 @@
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/borbop)
 "afE" = (
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/mineral/plastitanium,
+/obj/machinery/stasis,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "afF" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/machinery/medical_kiosk,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "afG" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -2261,8 +2261,9 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/kitchen)
 "agl" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/turf/open/floor/iron/white/textured,
+/obj/structure/hedge,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "agm" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
@@ -2311,6 +2312,7 @@
 /area/centcom/central_command_areas/kitchen)
 "ags" = (
 /obj/structure/railing/wood,
+/obj/structure/table/reinforced,
 /obj/item/toy/sword,
 /obj/item/toy/sword,
 /obj/item/toy/sword,
@@ -2369,9 +2371,9 @@
 /turf/open/floor/iron/dark/side,
 /area/centcom/central_command_areas/hall)
 "agz" = (
-/obj/structure/window/reinforced/tinted/fulltile,
-/obj/structure/window_sill,
-/obj/structure/grille/window_sill,
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "agA" = (
@@ -2456,6 +2458,7 @@
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "agK" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/glass/modglass/small{
 	pixel_y = 19;
 	pixel_x = -7
@@ -2542,6 +2545,7 @@
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
 "agX" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/lockbox/loyalty,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -2613,6 +2617,7 @@
 	dir = 1
 	},
 /obj/machinery/coffeemaker/impressa,
+/obj/structure/table/reinforced,
 /turf/open/floor/glass/reinforced,
 /area/centcom/central_command_areas/admin_hangout)
 "ahi" = (
@@ -2636,11 +2641,12 @@
 	},
 /area/centcom/central_command_areas/adminroom)
 "ahm" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/siding/blue,
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/obj/structure/railing/wood,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "ahn" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
@@ -2679,6 +2685,7 @@
 	},
 /area/centcom/central_command_areas/adminroom)
 "aht" = (
+/obj/structure/table/reinforced,
 /obj/machinery/camera/autoname/directional/east{
 	network = list("nukie")
 	},
@@ -2817,12 +2824,10 @@
 /turf/open/floor/glass/reinforced/plasma,
 /area/centcom/central_command_areas/adminroom)
 "ahM" = (
-/obj/machinery/rnd/production/techfab/department/medical,
-/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
 /turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/small,
-/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "ahN" = (
 /obj/effect/turf_decal/siding/wood{
@@ -3520,10 +3525,13 @@
 /turf/open/floor/glass/reinforced,
 /area/centcom/central_command_areas/adminroom)
 "ajE" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/siding/blue{
+	dir = 4
 	},
-/turf/open/floor/iron/white/textured,
+/obj/structure/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "ajF" = (
 /obj/effect/turf_decal/siding/wideplating{
@@ -3584,12 +3592,22 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "ajM" = (
-/obj/structure/sign/departments/chemistry/alt/directional/east,
-/obj/effect/turf_decal/tile/orange/half/contrasted{
-	dir = 4
-	},
 /obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/orange,
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = 6
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = -6;
+	pixel_y = 10
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery{
+	pixel_x = -6
+	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "ajN" = (
@@ -3598,6 +3616,7 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
 "ajO" = (
+/obj/structure/table/reinforced,
 /obj/item/flashlight/lamp,
 /turf/open/floor/carpet,
 /area/centcom/syndicate_mothership/control)
@@ -3771,6 +3790,7 @@
 /area/centcom/central_command_areas/retirement_home)
 "akq" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/glass/bottle/lizardwine{
 	pixel_x = 11;
 	pixel_y = 12
@@ -3861,10 +3881,10 @@
 /turf/closed/indestructible/syndicate,
 /area/centcom/syndicate_mothership/control)
 "akC" = (
-/obj/item/surgery_tray/deployed,
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/white/textured,
+/obj/structure/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "akD" = (
 /obj/structure/table/rolling,
@@ -3930,6 +3950,7 @@
 /area/centcom/syndicate_mothership/control)
 "akM" = (
 /obj/structure/railing/wood,
+/obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder,
 /obj/effect/turf_decal/trimline/green/line,
 /turf/open/floor/iron/dark,
@@ -3937,11 +3958,6 @@
 "akN" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue,
-/obj/machinery/light/floor/has_bulb{
-	pixel_x = 0;
-	pixel_y = 0
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
@@ -4305,11 +4321,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/machinery/rnd/production/techfab/department/medical,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "alI" = (
 /turf/open/floor/carpet/black,
@@ -4414,6 +4426,7 @@
 /turf/open/floor/carpet/black,
 /area/centcom/central_command_areas/borbop)
 "alY" = (
+/obj/structure/table/reinforced,
 /obj/item/paper/fluff/stations/centcom/disk_memo{
 	pixel_x = -6;
 	pixel_y = -7
@@ -4437,13 +4450,9 @@
 /turf/open/floor/carpet,
 /area/centcom/central_command_areas/adminroom)
 "amb" = (
-/obj/structure/table/reinforced/titaniumglass,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 0;
-	pixel_y = 8
-	},
-/obj/item/storage/toolbox/electrical,
-/turf/open/floor/circuit,
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "amc" = (
 /obj/machinery/light/directional/north,
@@ -4559,14 +4568,10 @@
 /turf/open/floor/carpet/royalblue,
 /area/centcom/central_command_areas/admin)
 "amr" = (
-/obj/machinery/computer/operating{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/siding/blue{
 	dir = 8
 	},
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "ams" = (
 /obj/structure/rack,
@@ -4600,6 +4605,7 @@
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/retirement_home)
 "amt" = (
+/obj/structure/table/reinforced,
 /obj/machinery/microwave{
 	pixel_y = 3
 	},
@@ -5004,8 +5010,13 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "anv" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/iron/dark/herringbone,
+/obj/effect/turf_decal/siding/blue{
+	dir = 8
+	},
+/obj/structure/railing/wood{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "anw" = (
 /obj/effect/turf_decal/tile/dark/diagonal_edge,
@@ -5021,10 +5032,7 @@
 /obj/machinery/computer/operating{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white/small,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "anz" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -5085,6 +5093,7 @@
 /turf/closed/indestructible/syndicate,
 /area/centcom/syndicate_mothership/control)
 "anL" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 4
 	},
@@ -5161,6 +5170,7 @@
 	},
 /area/centcom/central_command_areas/hall)
 "anY" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
@@ -5313,6 +5323,7 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/supply)
 "aos" = (
+/obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen/red,
 /obj/effect/turf_decal/stripes/line{
@@ -5321,6 +5332,7 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "aot" = (
+/obj/structure/table/reinforced,
 /obj/item/stack/package_wrap,
 /obj/item/hand_labeler,
 /obj/effect/turf_decal/stripes/line,
@@ -5437,6 +5449,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/armory)
 "aoM" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -5560,6 +5573,7 @@
 	pixel_y = 3
 	},
 /obj/item/stamp,
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
@@ -5695,10 +5709,9 @@
 /turf/open/floor/plating/abductor,
 /area/centcom/central_command_areas/adminroom)
 "apw" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white/textured,
+/obj/effect/turf_decal/trimline/blue,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "apx" = (
 /obj/machinery/door/airlock/centcom{
@@ -6019,6 +6032,7 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "aqo" = (
+/obj/structure/table/reinforced,
 /obj/item/folder,
 /obj/item/stamp/denied{
 	pixel_x = 3;
@@ -6106,10 +6120,22 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_mothership/control)
 "aqB" = (
-/obj/machinery/door/window/right/directional/south,
 /obj/structure/table/reinforced,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
+	},
+/obj/machinery/door/window/right/directional/south,
 /turf/open/floor/iron/dark/diagonal,
-/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "aqC" = (
 /obj/machinery/door/window/survival_pod{
@@ -6437,6 +6463,7 @@
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/retirement_home)
 "arx" = (
+/obj/structure/table/reinforced,
 /obj/item/knife/combat/survival{
 	pixel_x = 7;
 	pixel_y = 17
@@ -6466,6 +6493,7 @@
 	},
 /area/centcom/syndicate_mothership/control)
 "arB" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -6481,6 +6509,7 @@
 /turf/closed/indestructible/hive,
 /area/station/hive/two)
 "arE" = (
+/obj/structure/table/reinforced,
 /obj/item/radio,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range_checkpoint_control)
@@ -6546,13 +6575,15 @@
 /turf/open/floor/iron/dark/textured_half,
 /area/centcom/syndicate_mothership/control)
 "arP" = (
-/obj/structure/window/reinforced/tinted/fulltile,
-/obj/structure/grille/window_sill,
-/obj/structure/window_sill,
+/obj/effect/turf_decal/siding/blue{
+	dir = 1
+	},
+/obj/structure/railing/wood,
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "arQ" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/table/reinforced,
 /obj/machinery/reagentgrinder{
 	pixel_y = 20;
 	pixel_x = -5
@@ -6828,6 +6859,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
 "asC" = (
+/obj/structure/table/reinforced,
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
@@ -6926,18 +6958,10 @@
 	},
 /area/centcom/wizard_station)
 "asR" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/medical3{
-	name = "Spare surgery kit locker";
-	locked = 0
-	},
-/obj/item/storage/belt/medical,
-/obj/item/cautery/advanced,
-/obj/item/retractor/advanced,
-/obj/item/scalpel/advanced,
-/turf/open/floor/iron/white/textured,
+/obj/structure/railing/wood,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/tactical,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "asS" = (
 /obj/effect/turf_decal/siding/dark{
@@ -6980,13 +7004,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/arcade)
 "asY" = (
-/obj/structure/table/optable{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white/small,
+/obj/structure/table/reinforced,
+/obj/machinery/vending/medical,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "asZ" = (
 /obj/structure/railing/corner{
@@ -7067,9 +7087,9 @@
 /turf/closed/indestructible/rock/snow,
 /area/centcom/central_command_areas/adminroom)
 "atk" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/mob/living/basic/bot/cleanbot/medbay,
-/turf/open/floor/iron/white/textured,
+/obj/effect/turf_decal/trimline/blue,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "atl" = (
 /obj/effect/turf_decal/stripes/line,
@@ -7521,9 +7541,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/blue,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/dark/herringbone,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "aut" = (
 /obj/docking_port/stationary{
@@ -7549,11 +7567,27 @@
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
 "auw" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/iron/dark,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/regular,
+/obj/item/storage/medkit/brute{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/item/storage/medkit/fire{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/medical)
+"aux" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/hedge,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "auy" = (
 /obj/effect/turf_decal/siding/wood{
@@ -7776,13 +7810,10 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/machinery/vending/drugs,
-/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
 /turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
-/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "avf" = (
 /obj/structure/window/reinforced/fulltile/indestructible,
@@ -8023,6 +8054,7 @@
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "avN" = (
 /obj/structure/railing/wood,
+/obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/watering_can/advanced,
 /obj/item/reagent_containers/cup/watering_can/advanced,
 /obj/item/reagent_containers/cup/watering_can/advanced,
@@ -8040,10 +8072,8 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/kitchen)
 "avP" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
-	},
-/turf/closed/indestructible/riveted,
+/obj/structure/flora/bush/large/style_3,
+/turf/open/floor/grass,
 /area/centcom/central_command_areas/medical)
 "avQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -8053,18 +8083,13 @@
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "avR" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white/small,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "avS" = (
-/obj/effect/turf_decal/tile/orange/fourcorners,
-/obj/effect/turf_decal/tile/orange/fourcorners,
-/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "avT" = (
 /obj/effect/turf_decal/siding/wood{
@@ -8089,9 +8114,10 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range)
 "avW" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/white/textured,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "avX" = (
 /obj/machinery/light/small/directional/east,
@@ -8334,7 +8360,10 @@
 	},
 /area/centcom/central_command_areas/adminroom)
 "awG" = (
-/turf/open/floor/iron/white/textured,
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "awH" = (
 /obj/machinery/light/floor/has_bulb,
@@ -8367,8 +8396,10 @@
 /turf/open/floor/carpet/royalblue,
 /area/centcom/central_command_areas/admin)
 "awK" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/turf/open/floor/iron/white/small,
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "awL" = (
 /obj/effect/turf_decal/tile/dark/diagonal_edge,
@@ -8474,6 +8505,7 @@
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/arcade)
 "axb" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/box/material,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/botany)
@@ -8574,10 +8606,11 @@
 /turf/open/floor/wood/large,
 /area/centcom/tdome/observation)
 "axq" = (
+/obj/machinery/chem_master,
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
-/turf/closed/indestructible/riveted,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "axr" = (
 /obj/effect/turf_decal/stripes/corner,
@@ -8686,6 +8719,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
 "axH" = (
+/obj/structure/table/reinforced,
 /obj/machinery/splicer,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/botany)
@@ -8955,10 +8989,8 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/hall)
 "ayj" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Chemistry"
-	},
-/turf/open/floor/mineral/plastitanium,
+/obj/structure/fake_stairs/wood/directional/north,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "ayk" = (
 /obj/structure/railing/wood{
@@ -8993,12 +9025,11 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
 "ayo" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
 	},
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/item/kirbyplants/fern,
-/turf/open/floor/iron/dark,
+/obj/structure/hedge,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "ayp" = (
 /obj/effect/turf_decal/stripes/line,
@@ -9220,6 +9251,7 @@
 /turf/open/floor/carpet/orange,
 /area/centcom/central_command_areas/adminroom)
 "ayS" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/box/emps,
 /obj/structure/sign/departments/medbay/alt/directional/south,
 /obj/effect/turf_decal/stripes/line{
@@ -9358,6 +9390,7 @@
 /area/space/nearstation)
 "azn" = (
 /obj/machinery/light/directional/north,
+/obj/structure/table/reinforced,
 /obj/item/crowbar/red,
 /obj/item/wrench,
 /obj/item/clothing/mask/gas,
@@ -9365,11 +9398,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supply)
 "azp" = (
-/turf/open/space/basic,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
-/turf/open/floor/iron/dark/textured,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "azq" = (
 /obj/effect/turf_decal/siding/wood{
@@ -9464,6 +9494,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/adminroom)
 "azz" = (
+/obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs/cable/zipties,
 /obj/item/assembly/flash/handheld,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -9507,14 +9538,13 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
 "azH" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/white/textured,
+/obj/effect/turf_decal/siding/blue,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "azI" = (
-/obj/item/surgery_tray/deployed,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/white/textured,
+/obj/effect/turf_decal/siding/blue,
+/obj/structure/railing/wood,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "azJ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -9523,7 +9553,9 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ghost_spawn)
 "azK" = (
-/obj/structure/window/reinforced/spawner/directional/west,
+/obj/effect/turf_decal/siding/blue{
+	dir = 6
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "azL" = (
@@ -9802,6 +9834,7 @@
 /area/centcom/syndicate_mothership)
 "aAy" = (
 /obj/structure/railing/wood,
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/green/line,
 /obj/item/book/manual/botanical_lexicon,
 /obj/item/book/manual/botanical_lexicon,
@@ -9820,6 +9853,7 @@
 "aAA" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/table/reinforced,
 /obj/item/storage/box/bodybags{
 	pixel_x = 4
 	},
@@ -9837,6 +9871,7 @@
 /area/centcom/central_command_areas/borbop)
 "aAC" = (
 /obj/effect/turf_decal/tile/brown/diagonal_centre,
+/obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/coffeepot/bluespace{
 	pixel_y = 5;
 	pixel_x = -6
@@ -9934,11 +9969,11 @@
 /turf/open/floor/mineral/titanium/white,
 /area/centcom/central_command_areas/adminroom)
 "aAO" = (
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/machinery/computer/operating{
+	dir = 8
+	},
 /obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/white/small,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aAP" = (
 /obj/machinery/nuclearbomb/beer,
@@ -10163,11 +10198,8 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/evacuation)
 "aBu" = (
-/obj/structure/organ_creator,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured,
+/obj/machinery/vending/drugs,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aBv" = (
 /obj/structure/chair/stool/bar/directional/west,
@@ -10199,6 +10231,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "aBz" = (
+/obj/structure/table/reinforced,
 /obj/effect/spawner/random/bureaucracy/pen,
 /obj/effect/spawner/random/bureaucracy/folder,
 /turf/open/floor/iron,
@@ -10466,6 +10499,7 @@
 /area/space)
 "aCm" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/table/reinforced,
 /obj/structure/desk_bell,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/borbop)
@@ -10531,6 +10565,7 @@
 /area/centcom/syndicate_mothership/control)
 "aCw" = (
 /obj/effect/turf_decal/siding/red,
+/obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/item/stack/spacecash/c10{
 	pixel_x = -19;
@@ -10539,25 +10574,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_mothership/control)
 "aCx" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
+/obj/machinery/door/airlock/centcom{
+	name = "Medbay"
 	},
-/obj/structure/closet/secure_closet/medical3{
-	name = "Medical Kits locker";
-	locked = 0
-	},
-/obj/item/storage/medkit/regular,
-/obj/item/storage/medkit/fire,
-/obj/item/storage/medkit/toxin,
-/obj/item/storage/medkit/brute,
-/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
-/obj/item/storage/medkit/advanced,
-/obj/item/storage/medkit/civil_defense/stocked,
-/obj/item/storage/medkit/civil_defense/comfort/stocked,
-/obj/item/storage/medkit/frontier/stocked,
-/obj/item/storage/medkit/combat_surgeon/stocked,
-/obj/item/storage/medkit/tactical/premium,
-/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aCy" = (
 /obj/structure/table/wood,
@@ -10595,6 +10615,7 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
 "aCD" = (
+/obj/structure/table/reinforced,
 /obj/item/megaphone/sec,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range_checkpoint_control)
@@ -10648,8 +10669,14 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "aCM" = (
-/obj/structure/table/optable,
-/turf/open/floor/circuit,
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/hedge,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "aCN" = (
 /obj/machinery/door/airlock/centcom{
@@ -10667,10 +10694,8 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
 "aCQ" = (
-/obj/structure/window/reinforced/spawner/directional/south,
-/obj/machinery/chem_heater/debug,
-/turf/open/floor/iron/dark/diagonal,
-/turf/open/floor/iron/dark/textured,
+/obj/structure/injured_spawner,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aCR" = (
 /obj/structure/flora/bush/fullgrass,
@@ -10684,6 +10709,7 @@
 /turf/open/floor/iron/dark/small,
 /area/centcom)
 "aCT" = (
+/obj/structure/table/reinforced,
 /obj/structure/railing{
 	dir = 8;
 	layer = 4.1
@@ -10719,14 +10745,10 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/retirement_yard)
 "aCW" = (
-/obj/machinery/door/window{
-	dir = 1;
-	name = "Surgery "
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "aCX" = (
 /obj/structure/chair/stool/directional/south,
@@ -10849,6 +10871,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin_hangout)
 "aDp" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/red{
 	dir = 4
 	},
@@ -10937,6 +10960,7 @@
 /area/centcom/central_command_areas/evacuation/ship)
 "aDB" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/table/reinforced,
 /obj/effect/spawner/random/special_lighter,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/borbop)
@@ -11041,6 +11065,7 @@
 /area/centcom/central_command_areas/hall)
 "aDQ" = (
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/table/reinforced,
 /obj/item/lighter{
 	pixel_y = 9;
 	pixel_x = -8
@@ -11293,6 +11318,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/adminroom)
 "aEB" = (
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
@@ -11673,6 +11699,7 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/hall)
 "aFB" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/box/syringes,
 /obj/item/gun/syringe/rapidsyringe,
 /obj/structure/reagent_dispensers/wall/peppertank/directional/south,
@@ -11709,13 +11736,17 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
 "aFF" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 4
+/obj/structure/railing/wood,
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/fire{
+	pixel_y = 5;
+	pixel_x = -4
 	},
-/obj/effect/turf_decal/siding/blue{
-	dir = 8
+/obj/item/storage/medkit/brute,
+/obj/item/storage/medkit/regular{
+	pixel_x = -7
 	},
-/turf/closed/indestructible/fakeglass,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aFG" = (
 /obj/structure/closet/crate/bin{
@@ -11753,6 +11784,7 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/borbop)
 "aFO" = (
+/obj/structure/table/reinforced,
 /obj/item/computer_disk/quartermaster,
 /obj/item/computer_disk/quartermaster,
 /obj/item/computer_disk/quartermaster,
@@ -11798,12 +11830,8 @@
 	},
 /area/centcom/central_command_areas/adminroom)
 "aFV" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/structure/injured_spawner,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/white/textured,
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aFW" = (
 /obj/effect/turf_decal/bot,
@@ -11813,6 +11841,7 @@
 /area/centcom/central_command_areas/supply)
 "aFX" = (
 /obj/machinery/computer/auxiliary_base/directional/north,
+/obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/radio/headset/headset_cent,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -11832,6 +11861,7 @@
 /turf/open/floor/glass/reinforced,
 /area/centcom/central_command_areas/admin_hangout)
 "aGa" = (
+/obj/structure/table/reinforced,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/taperecorder,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -12029,6 +12059,7 @@
 /area/centcom/syndicate_mothership/control)
 "aGz" = (
 /obj/machinery/computer/auxiliary_base/directional/north,
+/obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/folder/yellow,
 /obj/item/pen/red,
@@ -12090,19 +12121,16 @@
 /turf/open/floor/stone,
 /area/centcom/central_command_areas/hall)
 "aGK" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/blue,
-/obj/structure/table/reinforced,
-/obj/item/storage/box/material{
-	pixel_x = 0;
-	pixel_y = 6
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "aGL" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -12129,6 +12157,7 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/admin_hangout)
 "aGP" = (
+/obj/structure/table/reinforced,
 /obj/effect/spawner/random/bureaucracy/stamp,
 /obj/effect/spawner/random/bureaucracy/stamp,
 /obj/effect/spawner/random/bureaucracy/stamp,
@@ -12286,6 +12315,10 @@
 /obj/structure/sign/warning/yes_smoking/circle/directional/north,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin_hangout)
+"aHn" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/botany)
 "aHo" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
@@ -12409,10 +12442,12 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/centcom/syndicate_mothership/control)
 "aHI" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
+/obj/effect/turf_decal/siding/blue,
+/obj/effect/turf_decal/siding/blue/corner{
+	dir = 4
 	},
-/turf/open/floor/iron/white/small,
+/obj/structure/railing/wood,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "aHJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12472,6 +12507,7 @@
 /area/centcom/central_command_areas/admin_hangout)
 "aHQ" = (
 /obj/effect/turf_decal/tile/brown/diagonal_centre,
+/obj/structure/table/reinforced,
 /obj/machinery/microwave,
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/adminroom)
@@ -12508,8 +12544,8 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "aHW" = (
-/obj/machinery/computer/vitals_reader/advanced,
-/turf/closed/indestructible/riveted,
+/obj/effect/turf_decal/siding/blue/corner,
+/turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "aHX" = (
 /obj/effect/turf_decal/siding/wood{
@@ -12518,6 +12554,7 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/borbop)
 "aHY" = (
+/obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen,
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
@@ -12537,12 +12574,15 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
 "aIa" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 9
+	},
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "aIb" = (
 /obj/effect/turf_decal/siding/blue{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
@@ -12692,6 +12732,11 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/retirement_home)
+"aIy" = (
+/obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/borbop)
 "aIz" = (
 /obj/structure/flora/rock/pile/style_random,
 /turf/open/misc/asteroid/snow/airless,
@@ -13049,9 +13094,11 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin_hangout)
 "aJA" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/iron/dark/herringbone,
+/obj/effect/turf_decal/siding/blue/end{
+	dir = 8
+	},
+/obj/structure/railing/wood,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "aJB" = (
 /obj/effect/turf_decal/siding/wood{
@@ -13117,6 +13164,7 @@
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/hall)
 "aJK" = (
+/obj/structure/table/reinforced,
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/carpet/orange,
 /area/centcom/central_command_areas/admin)
@@ -13200,6 +13248,7 @@
 /turf/open/floor/carpet,
 /area/centcom/central_command_areas/hall)
 "aJW" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/secure/briefcase,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -13275,6 +13324,7 @@
 	pixel_y = 3
 	},
 /obj/item/stamp,
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/briefing)
 "aKf" = (
@@ -13377,11 +13427,10 @@
 /turf/open/floor/iron/white/herringbone,
 /area/centcom/central_command_areas/kitchen)
 "aKq" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/siding/blue{
+	dir = 9
 	},
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/turf/open/floor/iron/white/textured,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "aKr" = (
 /obj/effect/turf_decal/siding/dark{
@@ -13672,6 +13721,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation/ship)
 "aLe" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 8
 	},
@@ -13927,9 +13977,7 @@
 /turf/open/space/basic,
 /area/space)
 "aLN" = (
-/obj/structure/table/optable{
-	dir = 0
-	},
+/obj/structure/table/optable,
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = 28
 	},
@@ -14381,20 +14429,16 @@
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/briefing)
 "aMZ" = (
+/obj/structure/hedge,
+/obj/structure/railing/wood,
 /obj/machinery/light/floor/has_bulb,
-/obj/structure/table/reinforced/rglass,
-/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/white/small,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aNa" = (
 /turf/open/floor/glass/reinforced/plasma,
 /area/centcom/central_command_areas/adminroom)
 "aNb" = (
-/turf/open/floor/mineral/plastitanium,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aNc" = (
 /obj/structure/chair/office{
@@ -14499,7 +14543,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/closed/indestructible/riveted,
+/obj/structure/hedge,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "aNr" = (
 /obj/effect/turf_decal/siding/wood{
@@ -14677,17 +14722,22 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "aNR" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/machinery/vending/medical,
-/turf/open/floor/iron/dark,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "aNS" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/iron/white/textured,
+/obj/machinery/rnd/production/techfab/department/medical,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
+"aNT" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
+/area/centcom/central_command_areas/admin)
 "aNU" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
 /obj/structure/chair/sofa/bench,
@@ -14753,6 +14803,7 @@
 /turf/open/floor/carpet,
 /area/centcom/central_command_areas/adminroom)
 "aOc" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/red{
 	dir = 1
 	},
@@ -14817,6 +14868,7 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/kitchen)
 "aOm" = (
+/obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/folder/white,
 /obj/item/pen/blue,
@@ -14831,6 +14883,7 @@
 /area/centcom/central_command_areas/retirement_home)
 "aOp" = (
 /obj/structure/railing/wood,
+/obj/structure/table/reinforced,
 /obj/item/toy/sword,
 /obj/item/toy/sword,
 /obj/item/toy/sword,
@@ -14958,6 +15011,7 @@
 /turf/open/floor/glass/reinforced,
 /area/centcom/central_command_areas/hall)
 "aOC" = (
+/obj/structure/table/reinforced,
 /obj/item/toy/plush/space_lizard_plushie{
 	name = "Escapes-on-Pods"
 	},
@@ -15006,6 +15060,7 @@
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
 "aOI" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/red/corner{
 	dir = 1
 	},
@@ -15015,9 +15070,7 @@
 /obj/effect/turf_decal/siding/blue{
 	dir = 5
 	},
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/blue,
-/turf/open/floor/iron/dark/herringbone,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "aOK" = (
 /obj/structure/railing/wood{
@@ -15030,13 +15083,10 @@
 /turf/closed/indestructible/rock/snow,
 /area/centcom/syndicate_mothership/control)
 "aOM" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/blue,
-/turf/open/floor/iron/dark/herringbone,
-/area/centcom/central_command_areas/medical)
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supply)
 "aON" = (
 /obj/machinery/vending/magivend,
 /turf/open/floor/engine/cult,
@@ -15061,6 +15111,7 @@
 /area/centcom/central_command_areas/ferry)
 "aOR" = (
 /obj/effect/turf_decal/tile/brown/diagonal_centre,
+/obj/structure/table/reinforced,
 /obj/machinery/coffeemaker/impressa,
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/adminroom)
@@ -15235,6 +15286,7 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "aPt" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/effect/turf_decal/stripes/line{
@@ -15377,6 +15429,11 @@
 /obj/structure/sign/poster/contraband/gorlex_recruitment/directional/west,
 /turf/open/floor/mineral/titanium,
 /area/centcom/syndicate_mothership/control)
+"aPO" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/botany)
 "aPP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
@@ -15423,6 +15480,7 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/three)
 "aPX" = (
+/obj/structure/table/reinforced,
 /obj/item/folder/red{
 	pixel_x = -2;
 	pixel_y = -2
@@ -15545,6 +15603,13 @@
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/hall)
+"aQm" = (
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/medical)
 "aQn" = (
 /obj/structure/hedge,
 /turf/open/floor/wood/large,
@@ -15578,12 +15643,14 @@
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "aQs" = (
-/obj/machinery/stasis,
-/obj/machinery/defibrillator_mount/loaded/directional/east,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/turf/open/floor/iron/white/textured,
+/obj/effect/turf_decal/siding/blue/end{
+	dir = 4
+	},
+/obj/structure/railing/wood,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "aQt" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical{
 	pixel_y = 8;
 	pixel_x = 4
@@ -15639,6 +15706,7 @@
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/hall)
 "aQB" = (
+/obj/structure/table/reinforced,
 /obj/structure/railing{
 	dir = 4;
 	layer = 4.1
@@ -15805,6 +15873,7 @@
 	id = "CC_firing_range_checkpoint";
 	name = "Checkpoint Shutters"
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range_checkpoint_control)
 "aRb" = (
@@ -15823,10 +15892,12 @@
 /turf/open/floor/carpet/purple,
 /area/centcom/central_command_areas/adminroom)
 "aRe" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/iron/white/textured,
+/obj/machinery/chem_heater/debug,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "aRf" = (
 /obj/structure/chair/sofa/corp/right{
@@ -15865,6 +15936,7 @@
 /turf/open/floor/catwalk_floor,
 /area/centcom/central_command_areas/evacuation/ship)
 "aRl" = (
+/obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /turf/open/floor/carpet,
 /area/centcom/syndicate_mothership/control)
@@ -15898,12 +15970,10 @@
 /area/centcom/central_command_areas/evacuation/ship)
 "aRq" = (
 /obj/machinery/chem_dispenser/fullupgrade,
-/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
 /turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
-/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "aRr" = (
 /obj/machinery/light/floor/has_bulb,
@@ -15963,6 +16033,10 @@
 	icon_state = "boxing"
 	},
 /area/centcom/central_command_areas/hall)
+"aRy" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/firing_range)
 "aRz" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -16026,6 +16100,7 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/hall)
 "aRF" = (
+/obj/structure/table/reinforced,
 /obj/item/crowbar/red,
 /obj/item/tank/internals/emergency_oxygen/engi,
 /obj/item/clothing/mask/gas,
@@ -16131,13 +16206,19 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation/ship)
 "aRU" = (
-/obj/machinery/door/airlock/centcom{
-	dir = 4;
-	name = "Chemistry"
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/fire{
+	pixel_y = 5;
+	pixel_x = -4
 	},
-/turf/open/floor/iron/dark/textured,
+/obj/item/storage/medkit/brute,
+/obj/item/storage/medkit/regular{
+	pixel_x = -7
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aRV" = (
+/obj/structure/table/reinforced,
 /obj/item/restraints/handcuffs,
 /obj/item/radio,
 /obj/effect/turf_decal/stripes/line{
@@ -16160,6 +16241,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/botany)
 "aRY" = (
+/obj/structure/table/reinforced,
 /obj/structure/sign/poster/official/moth_meth/directional/west,
 /turf/open/floor/iron/white/corner,
 /area/centcom/central_command_areas/adminroom)
@@ -16241,6 +16323,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_mothership/control)
 "aSk" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/medkit/regular,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -16302,6 +16385,7 @@
 /turf/open/floor/plastic,
 /area/centcom/syndicate_mothership/expansion_fridgerummage)
 "aSq" = (
+/obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/folder/yellow,
 /obj/effect/turf_decal/stripes/line{
@@ -16475,6 +16559,7 @@
 /area/centcom/central_command_areas/kitchen)
 "aSL" = (
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/table/reinforced,
 /obj/item/storage/box/coffeepack/robusta,
 /obj/item/storage/box/coffeepack/robusta{
 	pixel_y = -3;
@@ -16573,6 +16658,7 @@
 /area/centcom/central_command_areas/evacuation/ship)
 "aSY" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/table/reinforced,
 /obj/machinery/chem_dispenser/drinks/beer,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/borbop)
@@ -16645,24 +16731,17 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "aTk" = (
+/obj/structure/table/reinforced,
 /obj/effect/spawner/random/bureaucracy/paper,
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "aTl" = (
+/obj/effect/turf_decal/siding/blue{
+	dir = 5
+	},
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
-/obj/item/reagent_containers/cup/beaker/bluespace,
+/obj/machinery/chem_heater/debug,
 /turf/open/floor/iron/dark/diagonal,
-/turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "aTm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16870,6 +16949,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_chemicalwarfare)
 "aTI" = (
+/obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -16920,6 +17000,7 @@
 /area/centcom/tdome/observation)
 "aTO" = (
 /obj/machinery/keycard_auth/directional/south,
+/obj/structure/table/reinforced,
 /obj/item/stack/package_wrap,
 /obj/item/stack/cable_coil,
 /obj/item/hand_labeler,
@@ -17141,13 +17222,6 @@
 /area/centcom/central_command_areas/hall)
 "aUA" = (
 /obj/effect/landmark/navigate_destination/centcom/medical,
-/obj/machinery/door/window{
-	dir = 8;
-	name = "Recovery Ward"
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aUB" = (
@@ -17162,6 +17236,7 @@
 /turf/open/floor/wood/large,
 /area/centcom/tdome/observation)
 "aUD" = (
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/red/corner,
 /obj/item/folder/red,
 /obj/item/pen/red,
@@ -17188,6 +17263,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin_hangout)
 "aUH" = (
+/obj/structure/table/reinforced,
 /obj/item/stamp/centcom{
 	pixel_x = -7;
 	pixel_y = 5
@@ -17221,11 +17297,11 @@
 /turf/open/floor/iron,
 /area/centcom/wizard_station)
 "aUK" = (
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
-/turf/open/floor/iron/dark/textured,
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aUL" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
@@ -17284,6 +17360,7 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supply)
 "aUU" = (
+/obj/structure/table/reinforced,
 /obj/item/paper_bin/carbon,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range_checkpoint_control)
@@ -17314,12 +17391,10 @@
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "aUY" = (
-/obj/machinery/light/floor/has_bulb,
-/obj/structure/table/reinforced/titaniumglass,
-/obj/item/storage/medkit/robotic_repair/preemo/stocked,
-/turf/open/floor/circuit,
+/turf/open/floor/iron/dark/diagonal,
 /area/centcom/central_command_areas/medical)
 "aUZ" = (
+/obj/structure/table/reinforced,
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
@@ -17388,6 +17463,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "aVh" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery{
 	pixel_y = 10;
 	pixel_x = 2
@@ -17431,6 +17507,7 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
 "aVm" = (
+/obj/structure/table/reinforced,
 /obj/item/papercutter,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
@@ -17463,10 +17540,8 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "aVr" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
+/obj/structure/table/reinforced,
+/obj/item/storage/box/material,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aVs" = (
@@ -17583,6 +17658,7 @@
 /turf/open/floor/iron/grimy,
 /area/centcom/central_command_areas/adminroom)
 "aVE" = (
+/obj/structure/table/reinforced,
 /obj/item/gun/ballistic/automatic/wt550,
 /obj/item/flashlight/seclite,
 /obj/structure/noticeboard/directional/north,
@@ -17892,11 +17968,19 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/four)
 "aWv" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/blue,
-/turf/open/floor/iron/dark/herringbone,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/medkit/fire{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/obj/item/storage/medkit/brute,
+/obj/item/storage/medkit/regular{
+	pixel_x = -7
+	},
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "aWw" = (
 /mob/living/basic/slime,
@@ -18068,12 +18152,8 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/hall)
 "aWW" = (
-/obj/machinery/stasis,
-/obj/machinery/defibrillator_mount/loaded/directional/east,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/white/textured,
+/obj/structure/hedge,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/medical)
 "aWX" = (
 /obj/effect/turf_decal/siding/wood{
@@ -18104,6 +18184,7 @@
 /area/centcom/central_command_areas/adminroom)
 "aWY" = (
 /obj/machinery/light/directional/north,
+/obj/structure/table/reinforced,
 /obj/item/crowbar/red,
 /obj/item/wrench,
 /obj/item/clothing/mask/gas,
@@ -18142,6 +18223,7 @@
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "aXe" = (
+/obj/structure/table/reinforced,
 /obj/item/grenade/c4{
 	pixel_x = 6
 	},
@@ -18270,6 +18352,7 @@
 /area/centcom/central_command_areas/retirement_home)
 "aXr" = (
 /obj/machinery/keycard_auth/directional/south,
+/obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/machinery/button/door/indestructible{
 	id = "XCCFerry";
@@ -18457,7 +18540,7 @@
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "aXW" = (
 /obj/machinery/light/floor/has_bulb,
-/turf/open/floor/circuit,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aXX" = (
 /obj/effect/turf_decal/siding/dark{
@@ -18473,6 +18556,7 @@
 /obj/structure/railing/wood{
 	dir = 4
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/glass/reinforced,
 /area/centcom/central_command_areas/admin_hangout)
 "aXZ" = (
@@ -18507,6 +18591,7 @@
 /area/centcom/central_command_areas/arcade)
 "aYg" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
+/obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/glass/bottle/vodka/badminka{
 	pixel_y = 19;
 	pixel_x = 9
@@ -18567,9 +18652,7 @@
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/retirement_home)
 "aYm" = (
-/obj/structure/table/optable{
-	dir = 0
-	},
+/obj/structure/table/optable,
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/centcom/central_command_areas/adminroom)
 "aYn" = (
@@ -18650,6 +18733,7 @@
 /turf/open/floor/iron/white/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
 "aYy" = (
+/obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/folder/yellow,
 /obj/item/pen/blue,
@@ -18720,15 +18804,8 @@
 /turf/open/floor/carpet,
 /area/centcom/central_command_areas/hall)
 "aYL" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/medical{
-	dir = 4;
-	layer = 3.1
-	},
-/turf/open/floor/iron/white/textured,
+/obj/structure/railing/wood,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aYM" = (
 /obj/structure/closet/cardboard,
@@ -18907,6 +18984,7 @@
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
 "aZl" = (
+/obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/folder/red,
 /obj/item/pen/red,
@@ -18971,9 +19049,8 @@
 	},
 /area/centcom/central_command_areas/adminroom)
 "aZz" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/north,
-/turf/open/floor/iron/dark/herringbone,
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "aZA" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
@@ -19107,6 +19184,7 @@
 	pixel_y = 3
 	},
 /obj/item/stamp,
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
@@ -19253,12 +19331,6 @@
 /obj/structure/flora/bush/sparsegrass/style_2,
 /turf/open/misc/dirt/jungle/dark/arena,
 /area/centcom/central_command_areas/admin)
-"biP" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "biX" = (
 /obj/effect/turf_decal/siding/dark_green{
 	dir = 8
@@ -19538,7 +19610,8 @@
 /turf/open/floor/mineral/bananium,
 /area/centcom/central_command_areas/admin)
 "bQE" = (
-/turf/open/floor/catwalk_floor/iron_smooth)
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "bTx" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -19667,11 +19740,6 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/centcom/central_command_areas/admin)
-"cjS" = (
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/trimline/blue,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "cjY" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -19803,6 +19871,7 @@
 	pixel_y = 9;
 	id = "vaultg7"
 	},
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/red/real_red/filled/line{
 	dir = 9
 	},
@@ -19875,9 +19944,7 @@
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 1
 	},
-/obj/structure/table/optable{
-	dir = 0
-	},
+/obj/structure/table/optable,
 /obj/machinery/light/cold/directional/north,
 /obj/machinery/defibrillator_mount/loaded/directional/north,
 /turf/open/floor/mineral/titanium/tiled/blue,
@@ -19890,15 +19957,6 @@
 /obj/machinery/door/puzzle/keycard/assault_ops_chemistry,
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
-"cKX" = (
-/obj/structure/table/reinforced/titaniumglass,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 0;
-	pixel_y = 8
-	},
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/circuit,
-/area/centcom/central_command_areas/medical)
 "cLJ" = (
 /obj/structure/mirror/magic{
 	pixel_y = 28
@@ -19959,17 +20017,6 @@
 	},
 /turf/open/floor/lowered/iron/pool/cobble,
 /area/centcom/central_command_areas/adminroom)
-"cOm" = (
-/obj/machinery/light/floor/has_bulb,
-/obj/machinery/button/door/directional/west{
-	name = "IPC Repair Shutters";
-	id = "IPCShutters"
-	},
-/obj/structure/sign/warning/no_smoking{
-	pixel_y = 28
-	},
-/turf/open/floor/circuit,
-/area/centcom/central_command_areas/medical)
 "cOz" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 6
@@ -20006,20 +20053,12 @@
 	},
 /turf/open/floor/carpet/donk,
 /area/centcom/central_command_areas/adminroom)
-"cTd" = (
-/obj/effect/turf_decal/tile/orange/fourcorners,
-/obj/effect/turf_decal/tile/orange/fourcorners,
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
-/turf/open/floor/iron/dark/textured,
-/area/centcom/central_command_areas/medical)
 "cTr" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
 	},
 /obj/structure/noticeboard/directional/north,
+/obj/machinery/disease2/diseaseanalyser/fullupgrade,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
 "cTB" = (
@@ -20050,12 +20089,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
-"cYo" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron/white/small,
-/area/centcom/central_command_areas/medical)
 "dbJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Veth's Plantery"
@@ -20130,18 +20163,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
-"dlU" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/arrows/white{
-	dir = 8
-	},
-/obj/structure/sign/warning/no_smoking{
-	pixel_y = 28
-	},
-/turf/open/floor/iron/dark/herringbone,
-/area/centcom/central_command_areas/medical)
 "dnC" = (
 /obj/item/canvas/twentyfour_twentyfour,
 /obj/item/canvas/twentyfour_twentyfour,
@@ -20268,28 +20289,12 @@
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
-"dBL" = (
-/obj/machinery/stasis{
-	dir = 4
-	},
-/obj/machinery/defibrillator_mount/loaded/directional/west,
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured,
-/area/centcom/central_command_areas/medical)
 "dCz" = (
 /obj/structure/statue/sandstone/venus{
 	name = "Justice"
 	},
 /turf/open/floor/glass/plasma,
 /area/centcom/central_command_areas/evacuation)
-"dCO" = (
-/obj/structure/sign/warning/no_smoking{
-	pixel_y = 28
-	},
-/turf/closed/indestructible/riveted,
-/area/centcom/central_command_areas/kitchen)
 "dCT" = (
 /obj/structure/grille/window_sill,
 /obj/structure/window/reinforced/tinted/fulltile{
@@ -20359,6 +20364,10 @@
 /area/centcom/central_command_areas/admin)
 "dNQ" = (
 /obj/structure/table/greyscale,
+/obj/machinery/fax/messageadmins{
+	fax_name = "Central Command Intern Office";
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/admin)
 "dPS" = (
@@ -20404,7 +20413,8 @@
 /turf/open/floor/iron/dark/small,
 /area/centcom)
 "dSg" = (
-/turf/closed/indestructible/opsglass)
+/turf/closed/indestructible/opsglass,
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "dSX" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/carpet/red,
@@ -20419,10 +20429,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/admin)
-"dTU" = (
-/obj/effect/turf_decal/tile/orange/anticorner/contrasted,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "dUc" = (
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
@@ -20440,14 +20446,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
-"dVl" = (
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/obj/structure/bodycontainer/morgue,
-/turf/open/floor/iron/white/small,
-/area/centcom/central_command_areas/medical)
 "dXA" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/red/real_red/filled/line{
@@ -20516,11 +20514,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/pod/dark,
 /area/centcom/central_command_areas/prison/cells)
-"ekG" = (
-/obj/structure/table/reinforced/titaniumglass,
-/obj/item/storage/medkit/robotic_repair/stocked,
-/turf/open/floor/circuit,
-/area/centcom/central_command_areas/medical)
 "ekW" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 1
@@ -20629,12 +20622,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
-"eCN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "eEo" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
@@ -20646,16 +20633,9 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin)
-<<<<<<< HEAD
 "eFJ" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 1
-=======
-"eGt" = (
-/obj/item/banhammer{
-	desc = "A terrible weapon that has seen countless use over the ages. This one appears to have taken a beating.";
-	force = -10
->>>>>>> Centcom-Medical-Overhaul
 	},
 /obj/effect/turf_decal/caution/stand_clear/blue{
 	pixel_y = -6
@@ -20848,10 +20828,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/cruiser_dock)
-"fkp" = (
-/obj/effect/turf_decal/tile/orange,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "flv" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -20932,6 +20908,7 @@
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
 "ftT" = (
+/obj/structure/table/reinforced,
 /obj/machinery/coffeemaker/impressa{
 	pixel_y = 6;
 	pixel_x = 2
@@ -21012,18 +20989,10 @@
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
 "fJf" = (
-<<<<<<< HEAD
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/item/razor,
 /obj/item/razor{
 	pixel_x = -8
-=======
-/obj/machinery/light/floor/has_bulb,
-/obj/item/storage/box/coffeepack/robusta,
-/obj/item/storage/box/coffeepack/robusta{
-	pixel_y = -3;
-	pixel_x = 4
->>>>>>> Centcom-Medical-Overhaul
 	},
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/west,
 /turf/open/floor/iron/dark,
@@ -21137,16 +21106,6 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation)
-"ggp" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/bed{
-	dir = 4
-	},
-/obj/item/bedsheet/medical{
-	dir = 4
-	},
-/turf/open/floor/iron/white/textured,
-/area/centcom/central_command_areas/medical)
 "ggS" = (
 /obj/machinery/light/neon_lining{
 	icon_state = "pink2_1"
@@ -21305,13 +21264,6 @@
 /obj/structure/sign/poster/official/report_crimes/directional/west,
 /turf/open/floor/plastic,
 /area/centcom/central_command_areas/admin)
-"gsz" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "guG" = (
 /obj/structure/closet,
 /obj/item/toy/plush/greek_cucumber,
@@ -21622,7 +21574,8 @@
 "gYp" = (
 /obj/item/storage/toolbox/syndicate,
 /obj/effect/decal/cleanable/oil/slippery,
-/turf/open/floor/catwalk_floor/iron_smooth)
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "gZm" = (
 /obj/structure/chair/office/tactical{
 	dir = 8
@@ -21777,13 +21730,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
-"hou" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/arrows/white{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/herringbone,
-/area/centcom/central_command_areas/medical)
 "hpt" = (
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/light/street_lamp,
@@ -21796,38 +21742,6 @@
 /obj/structure/flora/bush/large/style_3,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/admin)
-"hqe" = (
-/obj/effect/turf_decal/tile/orange/half/contrasted{
-	dir = 4
-	},
-/obj/item/storage/medkit/regular{
-	pixel_x = -6;
-	pixel_y = 0
-	},
-/obj/structure/closet/generic/wall/directional/east{
-	name = "Medkits"
-	},
-/obj/item/storage/medkit/brute{
-	pixel_x = 6;
-	pixel_y = 0
-	},
-/obj/item/storage/medkit/brute{
-	pixel_y = 0;
-	pixel_x = 8
-	},
-/obj/item/storage/medkit/regular{
-	pixel_x = -7
-	},
-/obj/item/storage/medkit/fire{
-	pixel_y = 7;
-	pixel_x = 1
-	},
-/obj/item/storage/medkit/fire{
-	pixel_y = 7;
-	pixel_x = 0
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "hqj" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -22031,6 +21945,7 @@
 /turf/open/floor/plating,
 /area/cruiser_dock)
 "hIB" = (
+/obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/soda_cans/cola{
 	pixel_y = 11;
 	pixel_x = 7
@@ -22249,6 +22164,7 @@
 	},
 /area/centcom/central_command_areas/evacuation)
 "iiK" = (
+/obj/structure/table/reinforced,
 /obj/item/tank/jetpack/oxygen/harness{
 	pixel_y = 10;
 	pixel_x = -2
@@ -22257,7 +22173,7 @@
 	pixel_y = -3
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
-/area/space)
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "ijF" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -22335,13 +22251,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/admin)
-"itC" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 9
-	},
-/obj/structure/sign/departments/medbay/directional/north,
-/turf/open/floor/wood/large,
-/area/centcom/central_command_areas/hall)
 "itR" = (
 /obj/machinery/plumbing/ooze_compressor,
 /turf/open/floor/engine,
@@ -22524,21 +22433,12 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
-"iTq" = (
-/obj/machinery/door/window{
-	dir = 8;
-	name = "Recovery Ward"
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "iTG" = (
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/admin)
 "iTH" = (
-/turf/closed/indestructible/syndicate)
+/turf/closed/indestructible/syndicate,
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "iTT" = (
 /obj/machinery/light/directional/east{
 	dir = 2
@@ -22636,6 +22536,7 @@
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
 "jmO" = (
+/obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
 	dir = 4
 	},
@@ -22647,25 +22548,10 @@
 "jmZ" = (
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/evacuation)
-"jnc" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/closet/generic/wall/directional/south{
-	name = "Advanced Health Analyzers"
-	},
-/obj/item/healthanalyzer/advanced,
-/obj/item/healthanalyzer/advanced,
-/obj/item/healthanalyzer/advanced,
-/obj/item/healthanalyzer/advanced,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "jpy" = (
 /obj/effect/baseturf_helper/asteroid,
 /turf/closed/indestructible/syndicate,
 /area/cruiser_dock)
-"jpV" = (
-/obj/structure/sign/poster/official/moth_meth,
-/turf/closed/indestructible/riveted,
-/area/centcom/central_command_areas/medical)
 "jqB" = (
 /obj/structure/table/reinforced/plasmarglass,
 /obj/item/clothing/suit/costume/gumball_wizard_robe,
@@ -22742,6 +22628,7 @@
 /turf/open/floor/iron/textured,
 /area/centcom/central_command_areas/admin)
 "jzr" = (
+/obj/structure/table/reinforced,
 /obj/item/paper_bin{
 	pixel_x = -5;
 	pixel_y = 4
@@ -22762,6 +22649,7 @@
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/adminroom)
 "jCy" = (
+/obj/structure/table/reinforced,
 /obj/item/reagent_containers/cup/soda_cans/dr_gibb{
 	pixel_x = -5;
 	pixel_y = 7
@@ -22808,6 +22696,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/evacuation)
 "jHW" = (
+/obj/structure/table/reinforced,
 /obj/item/flashlight/lantern/syndicate{
 	pixel_x = 8;
 	pixel_y = 15
@@ -22823,14 +22712,10 @@
 	pixel_x = 4
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
-<<<<<<< HEAD
 /area/centcom/syndicate_mothership/expansion_bulldozer)
 "jIA" = (
 /turf/open/floor/iron/dark/small,
 /area/centcom/central_command_areas/prison)
-=======
-/area/space)
->>>>>>> Centcom-Medical-Overhaul
 "jJi" = (
 /obj/structure/table/wood,
 /turf/open/floor/wood/large,
@@ -22898,31 +22783,17 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/admin)
-<<<<<<< HEAD
 "jPj" = (
 /obj/structure/closet/secure_closet/brig/genpop,
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/prison)
-=======
-"jPr" = (
-/obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/item/defibrillator/compact/loaded{
-	pixel_x = 9;
-	pixel_y = 40
-	},
-/obj/item/reagent_containers/cup/rag{
-	pixel_x = 0;
-	pixel_y = 35
-	},
-/turf/open/floor/iron/white/small,
-/area/centcom/central_command_areas/medical)
->>>>>>> Centcom-Medical-Overhaul
 "jQu" = (
 /obj/machinery/door/puzzle/keycard/syndicate_suit_storage,
 /turf/open/floor/iron/smooth_half{
 	dir = 4
-	})
+	},
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "jQK" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/sandy_dirt,
@@ -22975,14 +22846,6 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/closed/indestructible/wood,
 /area/centcom/central_command_areas/admin)
-"jZy" = (
-/obj/machinery/chem_master,
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
-/turf/open/floor/iron/dark/textured,
-/area/centcom/central_command_areas/medical)
 "jZA" = (
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
@@ -23366,15 +23229,6 @@
 	dir = 1
 	},
 /area/centcom/central_command_areas/evacuation)
-"liN" = (
-/obj/effect/turf_decal/siding/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/arrows/white{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/herringbone,
-/area/centcom/central_command_areas/medical)
 "lki" = (
 /obj/effect/turf_decal/trimline/dark_blue/line,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
@@ -23456,12 +23310,6 @@
 	},
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
-"lAO" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/iron/white/small,
-/area/centcom/central_command_areas/medical)
 "lBd" = (
 /turf/open/floor/iron/smooth_corner,
 /area/cruiser_dock)
@@ -23508,16 +23356,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/admin/captain,
 /turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/admin)
-"lIo" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/white/textured,
-/area/centcom/central_command_areas/medical)
 "lJV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -23696,17 +23534,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/adminroom)
-"msH" = (
-/obj/machinery/button/door/directional/east{
-	name = "IPC Repair Shutters";
-	id = "IPCShutters"
-	},
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted{
-	dir = 4
-	},
-/obj/structure/chair,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "mvd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb{
 	dir = 8;
@@ -23902,11 +23729,6 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /turf/open/floor/iron/smooth,
 /area/cruiser_dock)
-"ney" = (
-/obj/effect/turf_decal/tile/purple/anticorner/contrasted,
-/obj/structure/sign/poster/official/moth_epi/directional/east,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "neL" = (
 /obj/machinery/flasher/directional/west,
 /obj/structure/table,
@@ -24018,17 +23840,6 @@
 	},
 /turf/open/floor/glass/plasma,
 /area/centcom/central_command_areas/evacuation)
-"nyk" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical{
-	layer = 3.1
-	},
-/turf/open/floor/iron/white/textured,
-/area/centcom/central_command_areas/medical)
-"nyz" = (
-/obj/structure/sign/poster/official/no_erp,
-/turf/closed/indestructible/riveted,
-/area/centcom/central_command_areas/medical)
 "nzM" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_yw/style_random,
@@ -24143,10 +23954,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
-"nOH" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "nPn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -24247,6 +24054,7 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/arcade)
 "ocR" = (
+/obj/structure/table/reinforced,
 /obj/machinery/computer/terminal{
 	dir = 8
 	},
@@ -24523,7 +24331,8 @@
 "oTU" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/space/hardsuit/juggernaut,
-/turf/open/floor/catwalk_floor/iron_smooth)
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "oWK" = (
 /obj/machinery/fishing_portal_generator,
 /turf/open/floor/sandy_dirt,
@@ -24561,7 +24370,8 @@
 	pixel_x = -4;
 	pixel_y = 2
 	},
-/turf/open/floor/catwalk_floor/iron_smooth)
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/centcom/syndicate_mothership/expansion_bulldozer)
 "oZc" = (
 /obj/machinery/disease2/incubator,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -24835,16 +24645,17 @@
 /obj/item/extrapolator,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
-"pKk" = (
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/white/small,
-/area/centcom/central_command_areas/medical)
 "pKn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/adminroom)
+"pLm" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/white/textured,
+/area/centcom/central_command_areas/admin)
 "pMg" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/sandy_dirt,
@@ -24876,10 +24687,6 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/centcom/central_command_areas/admin)
-"pPa" = (
-/turf/open/space/basic,
-/turf/closed/indestructible/fakeglass,
-/area/centcom/central_command_areas/medical)
 "pQa" = (
 /obj/item/flashlight/flare/candle/amber,
 /turf/open/floor/lowered/iron/pool/cobble/side,
@@ -25085,12 +24892,6 @@
 "qwu" = (
 /turf/open/floor/plating,
 /area/cruiser_dock)
-"qxi" = (
-/obj/structure/chair/sofa/corp/right,
-/obj/effect/turf_decal/tile/dark/opposingcorners,
-/obj/structure/sign/departments/chemistry/alt/directional/north,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/hall)
 "qyJ" = (
 /turf/closed/indestructible{
 	base_icon_state = "crystal_cascade_1";
@@ -25245,24 +25046,12 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
-<<<<<<< HEAD
 "qRd" = (
 /obj/machinery/light/cold/directional/north,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/structure/mirror/directional/north,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/prison)
-=======
-"qPG" = (
-/obj/effect/turf_decal/tile/orange/fourcorners,
-/obj/effect/turf_decal/tile/orange/fourcorners,
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/textured,
-/area/centcom/central_command_areas/medical)
->>>>>>> Centcom-Medical-Overhaul
 "qRn" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 5
@@ -25353,13 +25142,6 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/centcom/central_command_areas/admin)
-"riG" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/structure/reagent_dispensers/water_cooler,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "rjG" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -25418,12 +25200,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/adminroom)
-"rpI" = (
-/obj/effect/turf_decal/tile/purple/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "rpU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -25516,14 +25292,6 @@
 /obj/structure/shipping_container/kosmologistika,
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
-"rIk" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 8;
-	id = "IPCShutters";
-	name = "IPC Repair Shutters"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/centcom/central_command_areas/medical)
 "rJt" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/iron/smooth_edge{
@@ -25643,12 +25411,6 @@
 	},
 /turf/open/indestructible/plating,
 /area/centcom/central_command_areas/admin)
-"rUL" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Emergency Surgery"
-	},
-/turf/open/floor/iron/white/textured,
-/area/centcom/central_command_areas/medical)
 "rVD" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -25729,6 +25491,7 @@
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/centcom/central_command_areas/kitchen)
 "sco" = (
+/obj/structure/table/reinforced,
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
@@ -25788,19 +25551,6 @@
 /obj/structure/billboard/space_cola,
 /turf/open/floor/iron/dark/textured_corner,
 /area/centcom/central_command_areas/evacuation)
-"smm" = (
-/obj/effect/turf_decal/siding/blue,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/arrows/white{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/herringbone,
-/area/centcom/central_command_areas/medical)
-"smx" = (
-/obj/item/bedsheet/medical,
-/obj/structure/bed,
-/turf/open/floor/iron/white/textured,
-/area/centcom/central_command_areas/medical)
 "ssC" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -25811,17 +25561,9 @@
 /obj/machinery/light/directional/west,
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
-<<<<<<< HEAD
 "suo" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/supplypod/supplypod_temp_holding)
-=======
-"stt" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/machinery/iv_drip,
-/turf/open/floor/iron/white/small,
-/area/centcom/central_command_areas/medical)
->>>>>>> Centcom-Medical-Overhaul
 "sxc" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -25852,12 +25594,6 @@
 /obj/structure/aquarium,
 /turf/open/floor/sandy_dirt,
 /area/centcom/central_command_areas/admin)
-"sAj" = (
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "sAG" = (
 /turf/open/floor/iron/smooth_edge,
 /area/cruiser_dock)
@@ -25917,15 +25653,10 @@
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/centcom/central_command_areas/admin)
 "sMc" = (
-<<<<<<< HEAD
 /obj/structure/flora/bush/grassy,
 /obj/structure/flora/bush/flowers_pp,
 /obj/structure/window/reinforced/survival_pod/spawner/directional/south,
 /turf/open/floor/grass,
-=======
-/obj/machinery/coffeemaker/impressa,
-/turf/open/floor/carpet,
->>>>>>> Centcom-Medical-Overhaul
 /area/centcom/central_command_areas/prison)
 "sNI" = (
 /obj/item/food/grown/banana/bunch,
@@ -25957,8 +25688,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
 "sTV" = (
-/obj/effect/turf_decal/siding/wood,
-/turf/closed/indestructible/riveted,
+/mob/living/basic/bot/cleanbot/medbay,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/medical)
 "sUM" = (
 /obj/structure/chair/plastic,
@@ -26384,12 +26115,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/cruiser_dock)
-"tXL" = (
-/obj/effect/turf_decal/tile/orange/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "tYb" = (
 /obj/structure/flora/bush/sparsegrass/style_2,
 /turf/open/misc/grass,
@@ -26450,6 +26175,7 @@
 /turf/open/floor/carpet/neon/simple/green/nodots,
 /area/centcom/central_command_areas/admin)
 "uhR" = (
+/obj/structure/table/reinforced,
 /obj/item/trash/popcorn,
 /turf/open/floor/carpet/orange,
 /area/centcom/central_command_areas/admin)
@@ -26494,21 +26220,6 @@
 /obj/structure/flora/bush/fullgrass/style_random,
 /turf/open/floor/glass/plasma,
 /area/centcom/central_command_areas/adminroom)
-"usH" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/closet/generic/wall/directional/south{
-	name = "Combat Medkits"
-	},
-/obj/item/storage/medkit/tactical{
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/obj/item/storage/medkit/tactical{
-	pixel_x = 0;
-	pixel_y = 4
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "uuc" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 1
@@ -26567,14 +26278,6 @@
 	},
 /turf/open/floor/iron/textured,
 /area/centcom/central_command_areas/admin)
-"uBu" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 1
-	},
-/obj/structure/chair,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/medical)
 "uCA" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
@@ -26671,13 +26374,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/admin/captain,
 /turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/admin)
-"uPb" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/effect/turf_decal/arrows/white{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/herringbone,
-/area/centcom/central_command_areas/medical)
 "uPS" = (
 /obj/effect/turf_decal/siding/dark_green{
 	dir = 8
@@ -26853,16 +26549,6 @@
 /obj/structure/flora/bush/flowers_pp,
 /turf/open/floor/glass/reinforced/plasma,
 /area/centcom/central_command_areas/adminroom)
-"vlz" = (
-/obj/machinery/light/floor/has_bulb,
-/obj/effect/turf_decal/tile/blue/anticorner/contrasted{
-	dir = 4
-	},
-/obj/structure/sign/warning/no_smoking{
-	pixel_y = 28
-	},
-/turf/open/floor/iron/white/small,
-/area/centcom/central_command_areas/medical)
 "voy" = (
 /obj/structure/table/wood/fancy/red,
 /obj/effect/turf_decal/siding/wood{
@@ -26961,16 +26647,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/admin/captain,
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
-"vwv" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron/white/small,
-/area/centcom/central_command_areas/medical)
 "vxh" = (
 /turf/closed/indestructible/riveted,
 /area/centcom/central_command_areas/prison)
 "vxz" = (
+/obj/structure/table/reinforced,
 /obj/effect/spawner/random/trash,
 /turf/open/floor/carpet/orange,
 /area/centcom/central_command_areas/admin)
@@ -27582,19 +27263,6 @@
 	dir = 8
 	},
 /area/cruiser_dock)
-"wRZ" = (
-/obj/structure/sign/warning/no_smoking{
-	pixel_y = 28
-	},
-/obj/structure/closet/secure_closet/chemical{
-	locked = 0
-	},
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
-/turf/open/floor/iron/dark/textured,
-/area/centcom/central_command_areas/medical)
 "wTZ" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/bot_white,
@@ -27651,6 +27319,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
 "xbN" = (
+/obj/structure/table/reinforced,
 /obj/machinery/vending/boozeomat/syndicate_access,
 /turf/open/floor/carpet/orange,
 /area/centcom/central_command_areas/admin)
@@ -27668,6 +27337,10 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
+"xdY" = (
+/obj/structure/table/reinforced,
+/turf/open/floor/carpet/orange,
+/area/centcom/central_command_areas/admin)
 "xea" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/space/hardsuit/juggernaut,
@@ -27805,6 +27478,7 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation)
 "xxE" = (
+/obj/structure/table/reinforced,
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
@@ -28046,17 +27720,6 @@
 /obj/structure/flora/bush/lavendergrass/style_4,
 /turf/open/misc/grass,
 /area/centcom)
-"yeu" = (
-/obj/effect/turf_decal/tile/blue/half/contrasted{
-	dir = 1
-	},
-/obj/structure/table/reinforced/rglass,
-/obj/item/defibrillator/compact/loaded{
-	pixel_x = -10;
-	pixel_y = 8
-	},
-/turf/open/floor/iron/white/small,
-/area/centcom/central_command_areas/medical)
 "yfp" = (
 /obj/structure/railing/wood{
 	dir = 1
@@ -54444,7 +54107,7 @@ aaa
 aaa
 aaa
 aIh
-ahz
+aOM
 amG
 anl
 apd
@@ -62911,7 +62574,7 @@ aaa
 aaa
 adS
 jvd
-aLK
+aHn
 axH
 tse
 adS
@@ -64974,7 +64637,7 @@ acc
 aXE
 amg
 aZp
-atv
+aPO
 aYZ
 aWG
 aWG
@@ -65720,12 +65383,12 @@ aOn
 cYk
 aSh
 cyd
-aGq
+aNT
 iTT
 aOn
 gGe
 aUa
-jSt
+pLm
 aZf
 aDs
 mWN
@@ -66593,7 +66256,7 @@ atU
 atU
 afO
 amw
-aGM
+aaB
 aGM
 akP
 alr
@@ -66765,7 +66428,7 @@ aaa
 aaa
 aaa
 agL
-aLK
+aHn
 aLK
 aLK
 aRX
@@ -67262,7 +66925,7 @@ aOn
 kTt
 bdM
 ajh
-pWj
+xdY
 aOn
 xAF
 gZm
@@ -68856,7 +68519,7 @@ aLh
 aJm
 aJm
 adY
-aJm
+aIy
 aui
 aJm
 aLa
@@ -69156,15 +68819,15 @@ aaa
 aaa
 aFn
 adc
-aBo
+aRy
 asC
-aBo
+aRy
 asC
-aBo
+aRy
 asC
-aBo
+aRy
 asC
-aBo
+aRy
 aUZ
 aFn
 aaa
@@ -70620,7 +70283,7 @@ aaa
 aaa
 aaa
 awe
-dVl
+agl
 aaH
 afg
 aMZ
@@ -70877,17 +70540,17 @@ aaa
 aaa
 aaa
 adl
-aHI
-pKk
-vwv
-stt
-ayo
+asY
+aNb
+aNb
+aYL
+aCM
 aGK
 alH
 avP
 awe
 amQ
-dCO
+amQ
 amQ
 amQ
 amQ
@@ -71134,17 +70797,17 @@ aaa
 aaa
 aaa
 adl
-yeu
-jPr
-awK
-avR
+aNS
+aNb
+aNb
+aNb
+ayj
 aCW
-acu
-jnc
+azp
 awe
-aCx
+awe
 aKq
-dBL
+amr
 amr
 acR
 awe
@@ -71391,18 +71054,18 @@ aaa
 aaa
 aaa
 adl
-aHI
-lAO
-cYo
-stt
 aVr
-acu
-usH
-sTV
-aFV
+aNb
+aNb
+aNb
+ayj
+aQm
+avR
+aRq
+aIa
 awG
-apw
-awG
+akC
+aUY
 azH
 awe
 aMm
@@ -71648,20 +71311,20 @@ aaa
 aaa
 aaa
 awe
-vlz
-any
-asY
-aAO
-aVr
-acu
-nOH
-rUL
-aRe
+agl
+aNb
+aNb
+aNb
+ayj
+aCW
+avS
+azp
+aqB
 atk
 akC
-aBu
+atk
 azI
-awe
+aWW
 aEv
 arj
 abX
@@ -71901,24 +71564,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aHW
-ggp
-agl
-agl
-aYL
-auw
-cjS
-gsz
-axq
-aFV
-awG
-ajE
-awG
-azH
 awe
+awe
+adl
+awe
+awe
+agl
+aNb
+aYL
+ayo
+aNR
+afF
+axq
+aTl
+acK
+ajE
+acK
+aHI
+aWW
 aGS
 abX
 arj
@@ -72157,25 +71820,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-nyz
-avW
-awG
-awG
-avW
+awe
+awe
+afg
+aUK
+afg
+awe
+awe
+aNb
+aYL
 auw
-acu
-aNR
+avS
+azp
 awe
-asR
-aNS
-aWW
-lIo
+awe
+aaU
+alZ
+akN
 aQs
-awe
+aWW
 aKN
 arj
 arj
@@ -72414,26 +72077,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aHW
-smx
-awG
-awG
-nyk
-auw
-acu
-afF
-awe
-awe
+adl
+aCQ
+aNb
+aNb
+aNb
+aZz
+adl
+aNb
+asR
+aux
+avS
+avR
+alH
+aiM
 arP
-awe
+apw
 agz
-awe
-awe
-itC
+akN
+aAr
+aZP
 aaE
 aaE
 aqf
@@ -72671,24 +72334,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-adl
-uBu
-iTq
-aUA
-ahm
-biP
+awe
+ajM
+sTV
 acu
-eCN
-sAj
-aiM
-aaU
-alZ
-alZ
-akN
+aNb
+aXW
+aCx
+aUA
+aFF
+aRe
+avS
+avS
+amb
+adl
+arP
+azk
+azk
+aLc
 aAr
 aqh
 auQ
@@ -72928,24 +72591,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
 adl
-riG
-acu
-cjS
-fkp
-hqe
-ajM
-tXL
-dTU
-aFF
-aIb
-azk
-azk
-aLc
+aCQ
+aNb
+aNb
+aNb
+aFV
+adl
+aNb
+asR
+aux
+avS
+afF
+avW
+aiM
+arP
+apw
+aHW
+azK
 aAr
 aJB
 aET
@@ -73185,26 +72848,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-adl
-msH
-rpI
-rpI
-ney
 awe
 awe
-aRU
+afE
+aAO
+afE
 awe
 awe
-dlU
-aZz
+aNb
+aYL
+aWv
+avS
+azp
+awe
+awe
+aIb
+aqE
 azK
-smm
-awe
-qxi
+aJA
+aWW
+aEv
 arj
 arj
 aXb
@@ -73443,24 +73106,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 awe
 awe
-rIk
-rIk
+adl
 awe
+awe
+agl
+aNb
+aYL
 aeK
 ahM
-aUK
+avR
 aRq
 aIa
-aOM
-hou
-uPb
-aWv
-awe
+amr
+anv
+amr
+ahm
+aWW
 aGS
 abX
 arj
@@ -73704,20 +73367,20 @@ aaa
 aaa
 aaa
 awe
-cOm
+agl
 aNb
 aNb
-aXW
-awe
-wRZ
+aNb
+ayj
+aCW
 avS
 azp
 aqB
-aIb
-anv
-anv
-aJA
-awe
+atk
+akC
+atk
+azI
+aWW
 aKN
 arj
 abX
@@ -73961,19 +73624,19 @@ aaa
 aaa
 aaa
 adl
-aNb
+aBu
 aNb
 aNb
 aNb
 ayj
-cTd
-qPG
-cTd
+aQm
+afF
+axq
 aTl
-liN
-hou
-anv
-smm
+awK
+akC
+aUY
+azH
 awe
 aMm
 arj
@@ -74218,17 +73881,17 @@ aaa
 aaa
 aaa
 adl
-cKX
+aNS
 aNb
 aNb
-amb
-jpV
-aUK
-avS
-aUK
-aCQ
+aNb
+ayj
+aCW
+azp
+awe
+awe
 aOJ
-aqE
+acK
 acK
 aus
 awe
@@ -74475,18 +74138,18 @@ aaa
 aaa
 aaa
 adl
-ekG
-afE
-afE
-ekG
+aRU
+aNb
+aNb
+aYL
 aNq
 ave
-jZy
-aRq
+avW
+avP
 awe
 awe
-adl
-adl
+awe
+awe
 awe
 awe
 apG
@@ -74732,14 +74395,14 @@ aaa
 aaa
 aaa
 awe
-aUY
-aCM
-aCM
-aUY
+agl
+any
+afE
+aMZ
 awe
-pPa
-pPa
-pPa
+awe
+awe
+awe
 awe
 aaa
 aaa
@@ -74990,8 +74653,8 @@ aaa
 aaa
 awe
 awe
-adl
-adl
+awe
+awe
 awe
 awe
 aaa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2851,9 +2851,6 @@
 "ahM" = (
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/machinery/light/floor/has_bulb,
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/small,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "ahN" = (
@@ -3617,9 +3614,6 @@
 /area/centcom/central_command_areas/supply)
 "ajM" = (
 /turf/open/space/basic,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "ajN" = (
@@ -7832,15 +7826,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/control)
 "ave" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
 /obj/machinery/vending/drugs,
 /obj/machinery/light/floor/has_bulb,
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "avf" = (
@@ -8102,10 +8089,6 @@
 "avP" = (
 /obj/machinery/chem_dispenser/fullupgrade,
 /obj/machinery/light/floor/has_bulb,
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "avQ" = (
@@ -8134,10 +8117,6 @@
 /obj/effect/turf_decal/tile/orange/fourcorners,
 /obj/effect/turf_decal/tile/orange/fourcorners,
 /obj/machinery/light/floor/has_bulb,
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/textured,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "avT" = (
@@ -10018,10 +9997,6 @@
 /turf/open/floor/mineral/titanium/white,
 /area/centcom/central_command_areas/adminroom)
 "aAO" = (
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "aAP" = (
@@ -10803,10 +10778,6 @@
 /obj/structure/closet/secure_closet/chemical{
 	locked = 0
 	},
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "aCX" = (
@@ -15683,10 +15654,6 @@
 "aQm" = (
 /obj/effect/turf_decal/tile/orange/fourcorners,
 /obj/effect/turf_decal/tile/orange/fourcorners,
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "aQn" = (
@@ -16814,7 +16781,6 @@
 /obj/item/reagent_containers/cup/beaker/bluespace,
 /obj/item/reagent_containers/cup/beaker/bluespace,
 /obj/item/reagent_containers/cup/beaker/bluespace,
-/turf/open/floor/iron/dark/diagonal,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "aTm" = (
@@ -24121,7 +24087,6 @@
 "nwD" = (
 /obj/machinery/door/window/right/directional/south,
 /obj/structure/table/reinforced,
-/turf/open/floor/iron/dark/diagonal,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "nwM" = (
@@ -25463,10 +25428,6 @@
 /area/centcom/central_command_areas/admin)
 "rcc" = (
 /obj/machinery/chem_master,
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/small,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "rcY" = (
@@ -27130,7 +27091,6 @@
 "vFK" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/chem_heater/debug,
-/turf/open/floor/iron/dark/diagonal,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/medical)
 "vFS" = (
@@ -27279,15 +27239,6 @@
 	},
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
-"vWZ" = (
-/obj/effect/turf_decal/tile/orange/fourcorners,
-/obj/effect/turf_decal/tile/orange/fourcorners,
-/turf/open/floor/wood/large,
-/turf/open/floor/iron/white/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/textured,
-/turf/open/floor/iron/dark/textured,
-/area/centcom/central_command_areas/medical)
 "vXv" = (
 /obj/structure/organ_creator,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
@@ -74085,7 +74036,7 @@ aBu
 aBu
 pEL
 aQm
-vWZ
+aQm
 aQm
 aTl
 awK

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -15,7 +15,6 @@
 // BEGIN_INCLUDE
 #include "__odlint.dm"
 #include "_maps\_basemap.dm"
-#include "_maps\map_files\generic\CentCom.dmm"
 #include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"
 #include "code\_experiments.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -15,6 +15,7 @@
 // BEGIN_INCLUDE
 #include "__odlint.dm"
 #include "_maps\_basemap.dm"
+#include "_maps\map_files\generic\CentCom.dmm"
 #include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"
 #include "code\_experiments.dm"


### PR DESCRIPTION

## About The Pull Request
Updated and overhaul the centcom medical room. 
## Why It's Good For The Game

There was a lot of wasted space in the centcom medical room as well as just limited items and just being boring to look at. This is to pretty up centcom medical, add more items overall and trim the waste of excess space. Hopefully in return not only making the medical centcom better to look at, making it own thing as well but also something people can enjoy a lot more of.

## Changelog

Remove the top bubble like room in it, made new rooms. Moved and added things, lockers and kits. Extra space expand for centcom while removing empty space that just there to be there, added new flooring and signs to let people know it is medical. Added extra surgery kits, defibs, iv drips. Water cooler, a few chairs and made new rooms for surgery. High risk surgery room, a patient recoverly room and a IPC/Borg repair room with just tools, nothing added to allow grief in theory. Added extra windows as well and medkits. Added a few wall lockers to hold them.

:cl: Jason Farqiour
add: Added more items to the medical room in centcom.
add: Added rooms and a IPC/Borg repair room.
del: Removed the old bubble room up top for extra space to expand Centcom.
qol: Pretty up medical centcom while trimming the wasted space as well as add extra stuff.
