### PR TITLE
3+ ascended heretics = lambda alert (+ fix nar'sie/ratvar alert levels)

### DIFF
--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -7,6 +7,8 @@
  * Used in creating spooky-text for heretic ascension announcements.
  */
 /proc/generate_heretic_text(length = 25)
+	if(!isnum(length)) // stupid thing so we can use this directly in replacetext
+		length = 25
 	. = ""
 	for(var/i in 1 to length)
 		. += pick("!", "$", "^", "@", "&", "#", "*", "(", ")", "?")

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -690,6 +690,14 @@
 	cost = 2
 	priority = MAX_KNOWLEDGE_PRIORITY + 1 // Yes, the final ritual should be ABOVE the max priority.
 	required_atoms = list(/mob/living/carbon/human = 3)
+	/// The typepath of the achievement to grant upon successful ascension.
+	var/datum/award/achievement/misc/ascension_achievement
+	/// The text of the ascension announcement.
+	/// %NAME% is replaced with the heretic's real name,
+	/// and %SPOOKY% is replaced with output from [generate_heretic_text]
+	var/announcement_text
+	/// The sound that's played for the ascension announcement.
+	var/announcement_sound
 
 /datum/heretic_knowledge/ultimate/on_research(mob/user, datum/antagonist/heretic/our_heretic)
 	. = ..()
@@ -752,6 +760,15 @@
 		header = "A Heretic is Ascending!",
 		notify_flags = NOTIFY_CATEGORY_DEFAULT,
 	)
+	priority_announce(
+		text = replacetext(replacetext(announcement_text, "%NAME%", user.real_name), "%SPOOKY%", GLOBAL_PROC_REF(generate_heretic_text)),
+		title = generate_heretic_text(),
+		sound = announcement_sound,
+		color_override = "pink",
+	)
+
+	if(!isnull(ascension_achievement))
+		user.client?.give_award(ascension_achievement, user)
 	return TRUE
 
 /datum/heretic_knowledge/ultimate/cleanup_atoms(list/selected_atoms)

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -188,6 +188,9 @@
 		for the Nightwatcher brought forth the rite to mankind! His gaze continues, as now I am one with the flames, \
 		WITNESS MY ASCENSION, THE ASHY LANTERN BLAZES ONCE MORE!"
 	route = PATH_ASH
+	ascension_achievement = /datum/award/achievement/misc/ash_ascension
+	announcement_text = "%SPOOKY% Fear the blaze, for the Ashlord, %NAME% has ascended! The flames shall consume all! %SPOOKY%"
+	announcement_sound = 'sound/ambience/antag/heretic/ascend_ash.ogg'
 	/// A static list of all traits we apply on ascension.
 	var/static/list/traits_to_apply = list(
 		TRAIT_BOMBIMMUNE,
@@ -212,13 +215,6 @@
 
 /datum/heretic_knowledge/ultimate/ash_final/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = ..()
-	priority_announce(
-		text = "[generate_heretic_text()] Fear the blaze, for the Ashlord, [user.real_name] has ascended! The flames shall consume all! [generate_heretic_text()]",
-		title = "[generate_heretic_text()]",
-		sound = 'sound/ambience/antag/heretic/ascend_ash.ogg',
-		color_override = "pink",
-	)
-
 	var/datum/action/cooldown/spell/fire_sworn/circle_spell = new(user.mind)
 	circle_spell.Grant(user)
 
@@ -234,6 +230,4 @@
 	var/datum/action/cooldown/spell/aoe/fiery_rebirth/fiery_rebirth = locate() in user.actions
 	fiery_rebirth?.cooldown_time *= 0.16
 
-	user.client?.give_award(/datum/award/achievement/misc/ash_ascension, user)
-	if(length(traits_to_apply))
-		user.add_traits(traits_to_apply, MAGIC_TRAIT)
+	user.add_traits(traits_to_apply, type)

--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -397,6 +397,9 @@
 	gain_text = "The Torn Champion is freed! I will become the blade reunited, and with my greater ambition, \
 		I AM UNMATCHED! A STORM OF STEEL AND SILVER IS UPON US! WITNESS MY ASCENSION!"
 	route = PATH_BLADE
+	ascension_achievement = /datum/award/achievement/misc/blade_ascension
+	announcement_text = "%SPOOKY% Master of blades, the Torn Champion's disciple, %NAME% has ascended! Their steel is that which will cut reality in a maelstom of silver! %SPOOKY%"
+	announcement_sound = 'sound/ambience/antag/heretic/ascend_blade.ogg'
 
 /datum/heretic_knowledge/ultimate/blade_final/is_valid_sacrifice(mob/living/carbon/human/sacrifice)
 	. = ..()
@@ -407,14 +410,7 @@
 
 /datum/heretic_knowledge/ultimate/blade_final/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = ..()
-	priority_announce(
-		text = "[generate_heretic_text()] Master of blades, the Torn Champion's disciple, [user.real_name] has ascended! Their steel is that which will cut reality in a maelstom of silver! [generate_heretic_text()]",
-		title = "[generate_heretic_text()]",
-		sound = 'sound/ambience/antag/heretic/ascend_blade.ogg',
-		color_override = "pink",
-	)
-	user.client?.give_award(/datum/award/achievement/misc/blade_ascension, user)
-	user.add_traits(list(TRAIT_STUNIMMUNE, TRAIT_NEVER_WOUNDED), name)
+	user.add_traits(list(TRAIT_STUNIMMUNE, TRAIT_NEVER_WOUNDED), type)
 	RegisterSignal(user, COMSIG_HERETIC_BLADE_ATTACK, PROC_REF(on_eldritch_blade))
 	user.apply_status_effect(/datum/status_effect/protective_blades/recharging, null, 8, 30, 0.25 SECONDS, 1 MINUTES)
 

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -234,6 +234,9 @@
 		I closed my eyes with my head laid against their form. I was safe. \
 		WITNESS MY ASCENSION!"
 	route = PATH_COSMIC
+	ascension_achievement = /datum/award/achievement/misc/cosmic_ascension
+	announcement_text = "%SPOOKY% A Star Gazer has arrived into the station, %NAME% has ascended! This station is the domain of the Cosmos! %SPOOKY%"
+	announcement_sound = 'sound/ambience/antag/heretic/ascend_cosmic.ogg'
 	/// A static list of command we can use with our mob.
 	var/static/list/star_gazer_commands = list(
 		/datum/pet_command/idle,
@@ -252,12 +255,6 @@
 
 /datum/heretic_knowledge/ultimate/cosmic_final/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = ..()
-	priority_announce(
-		text = "[generate_heretic_text()] A Star Gazer has arrived into the station, [user.real_name] has ascended! This station is the domain of the Cosmos! [generate_heretic_text()]",
-		title = "[generate_heretic_text()]",
-		sound = 'sound/ambience/antag/heretic/ascend_cosmic.ogg',
-		color_override = "pink",
-	)
 	var/mob/living/basic/heretic_summon/star_gazer/star_gazer_mob = new /mob/living/basic/heretic_summon/star_gazer(loc)
 	star_gazer_mob.maxHealth = INFINITY
 	star_gazer_mob.health = INFINITY

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -308,20 +308,14 @@
 		Reality will bend to THE LORD OF THE NIGHT or be unraveled! WITNESS MY ASCENSION!"
 	required_atoms = list(/mob/living/carbon/human = 4)
 	route = PATH_FLESH
+	ascension_achievement = /datum/award/achievement/misc/flesh_ascension
+	announcement_text = "%SPOOKY% Ever coiling vortex. Reality unfolded. ARMS OUTREACHED, THE LORD OF THE NIGHT, %NAME% has ascended! Fear the ever twisting hand! %SPOOKY%"
+	announcement_sound = 'sound/ambience/antag/heretic/ascend_flesh.ogg'
 
 /datum/heretic_knowledge/ultimate/flesh_final/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = ..()
-	priority_announce(
-		text = "[generate_heretic_text()] Ever coiling vortex. Reality unfolded. ARMS OUTREACHED, THE LORD OF THE NIGHT, [user.real_name] has ascended! Fear the ever twisting hand! [generate_heretic_text()]",
-		title = "[generate_heretic_text()]",
-		sound = 'sound/ambience/antag/heretic/ascend_flesh.ogg',
-		color_override = "pink",
-	)
-
 	var/datum/action/cooldown/spell/shapeshift/shed_human_form/worm_spell = new(user.mind)
 	worm_spell.Grant(user)
-
-	user.client?.give_award(/datum/award/achievement/misc/flesh_ascension, user)
 
 	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)
 	var/datum/heretic_knowledge/limited_amount/flesh_grasp/grasp_ghoul = heretic_datum.get_knowledge(/datum/heretic_knowledge/limited_amount/flesh_grasp)

--- a/code/modules/antagonists/heretic/knowledge/knock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/knock_lore.dm
@@ -197,6 +197,8 @@
 		Reality will soon be torn, the Spider Gate opened! WITNESS ME!"
 	required_atoms = list(/mob/living/carbon/human = 3)
 	route = PATH_KNOCK
+	announcement_text = "Delta-class dimensional anomaly detec%SPOOKY% Reality rended, torn. Gates open, doors open, %NAME% has ascended! Fear the tide! %SPOOKY%"
+	announcement_sound = 'sound/ambience/antag/heretic/ascend_knock.ogg'
 
 /datum/heretic_knowledge/ultimate/knock_final/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
 	. = ..()
@@ -220,14 +222,6 @@
 
 /datum/heretic_knowledge/ultimate/knock_final/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = ..()
-	priority_announce(
-		text = "Delta-class dimensional anomaly detec[generate_heretic_text()] Reality rended, torn. Gates open, doors open, [user.real_name] has ascended! Fear the tide! [generate_heretic_text()]",
-		title = "[generate_heretic_text()]",
-		sound = 'sound/ambience/antag/heretic/ascend_knock.ogg',
-		color_override = "pink",
-	)
-	user.client?.give_award(/datum/award/achievement/misc/knock_ascension, user)
-
 	// buffs
 	var/datum/action/cooldown/spell/shapeshift/eldritch/ascension/transform_spell = new(user.mind)
 	transform_spell.Grant(user)

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -190,6 +190,10 @@
 		for where the Ringleader had started the parade, I shall continue it unto the suns demise \
 		WITNESS MY ASCENSION, THE MOON SMILES ONCE MORE AND FOREVER MORE IT SHALL!"
 	route = PATH_MOON
+	ascension_achievement = /datum/award/achievement/misc/moon_ascension
+	announcement_text = "%SPOOKY% Laugh, for the ringleader %NAME% has ascended! \
+						The truth shall finally devour the lie! %SPOOKY%"
+	announcement_sound = 'sound/ambience/antag/heretic/ascend_moon.ogg'
 
 /datum/heretic_knowledge/ultimate/moon_final/is_valid_sacrifice(mob/living/sacrifice)
 
@@ -202,17 +206,7 @@
 
 /datum/heretic_knowledge/ultimate/moon_final/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = ..()
-	priority_announce(
-		text = "[generate_heretic_text()] Laugh, for the ringleader [user.real_name] has ascended! \
-				The truth shall finally devour the lie! [generate_heretic_text()]",
-		title = "[generate_heretic_text()]",
-		sound = 'sound/ambience/antag/heretic/ascend_moon.ogg',
-		color_override = "pink",
-	)
-
-	user.client?.give_award(/datum/award/achievement/misc/moon_ascension, user)
-	ADD_TRAIT(user, TRAIT_MADNESS_IMMUNE, REF(src))
-
+	ADD_TRAIT(user, TRAIT_MADNESS_IMMUNE, type)
 	RegisterSignal(user, COMSIG_LIVING_LIFE, PROC_REF(on_life))
 
 	var/amount_of_lunatics = 0

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -222,6 +222,9 @@
 	gain_text = "Champion of rust. Corruptor of steel. Fear the dark, for the RUSTBRINGER has come! \
 		The Blacksmith forges ahead! Rusted Hills, CALL MY NAME! WITNESS MY ASCENSION!"
 	route = PATH_RUST
+	ascension_achievement = /datum/award/achievement/misc/rust_ascension
+	announcement_text = "%SPOOKY% Fear the decay, for the Rustbringer, %NAME% has ascended! None shall escape the corrosion! %SPOOKY%"
+	announcement_sound = 'sound/ambience/antag/heretic/ascend_rust.ogg'
 	/// If TRUE, then immunities are currently active.
 	var/immunities_active = FALSE
 	/// A typepath to an area that we must finish the ritual in.
@@ -261,12 +264,6 @@
 
 /datum/heretic_knowledge/ultimate/rust_final/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = ..()
-	priority_announce(
-		text = "[generate_heretic_text()] Fear the decay, for the Rustbringer, [user.real_name] has ascended! None shall escape the corrosion! [generate_heretic_text()]",
-		title = "[generate_heretic_text()]",
-		sound = 'sound/ambience/antag/heretic/ascend_rust.ogg',
-		color_override = "pink",
-	)
 	new /datum/rust_spread(loc)
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(on_move))
 	RegisterSignal(user, COMSIG_LIVING_LIFE, PROC_REF(on_life))

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -183,6 +183,9 @@
 		The Aristocrat stands before me, beckoning. We will play a waltz to the whispers of dying reality, \
 		as the world is destroyed before our eyes. The void will return all to nothing, WITNESS MY ASCENSION!"
 	route = PATH_VOID
+	ascension_achievement = /datum/award/achievement/misc/void_ascension
+	announcement_text = "%SPOOKY% The nobleman of void %NAME% has arrived, stepping along the Waltz that ends worlds! %SPOOKY%"
+	announcement_sound = 'sound/ambience/antag/heretic/ascend_void.ogg'
 	///soundloop for the void theme
 	var/datum/looping_sound/void_loop/sound_loop
 	///Reference to the ongoing voidstrom that surrounds the heretic
@@ -202,14 +205,7 @@
 
 /datum/heretic_knowledge/ultimate/void_final/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = ..()
-	priority_announce(
-		text = "[generate_heretic_text()] The nobleman of void [user.real_name] has arrived, stepping along the Waltz that ends worlds! [generate_heretic_text()]",
-		title = "[generate_heretic_text()]",
-		sound = 'sound/ambience/antag/heretic/ascend_void.ogg',
-		color_override = "pink",
-	)
-	user.client?.give_award(/datum/award/achievement/misc/void_ascension, user)
-	ADD_TRAIT(user, TRAIT_RESISTLOWPRESSURE, MAGIC_TRAIT)
+	ADD_TRAIT(user, TRAIT_RESISTLOWPRESSURE, type)
 
 	// Let's get this show on the road!
 	sound_loop = new(user, TRUE, TRUE)

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -276,7 +276,7 @@
 
 ///security level and shuttle lockdowns for [/proc/begin_the_end()]
 /proc/narsie_start_destroy_station()
-	SSsecurity_level.set_level(SEC_LEVEL_DELTA)
+	SSsecurity_level.set_level(SEC_LEVEL_LAMBDA)
 	SSshuttle.registerHostileEnvironment(GLOB.cult_narsie)
 	SSshuttle.lockdown = TRUE
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(narsie_apocalypse)), 1 MINUTES)

--- a/monkestation/code/modules/antagonists/clock_cult/ratvar.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/ratvar.dm
@@ -133,7 +133,7 @@ GLOBAL_DATUM(cult_ratvar, /obj/ratvar)
 	var/next_attack_tick = 0
 
 /proc/clockcult_ending_start()
-	SSsecurity_level.set_level(3)
+	SSsecurity_level.set_level(SEC_LEVEL_LAMBDA)
 	priority_announce("Huge gravitational-energy spike detected emminating from a neutron star near your sector. Event has been determined to be survivable by 0% of life. \
 					   ESTIMATED TIME UNTIL ENERGY PULSE REACHES [GLOB.station_name]: 56 SECONDS. Godspeed crew, glory to Nanotrasen. -Admiral Telvig.", \
 					   "Central Command Anomolous Materials Division", 'sound/misc/airraid.ogg')

--- a/monkestation/code/modules/antagonists/clock_cult/structures/the_ark.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/structures/the_ark.dm
@@ -90,7 +90,7 @@ GLOBAL_VAR_INIT(ratvar_risen, FALSE)
 				for(var/obj/effect/portal/clockcult/portal in GLOB.portals)
 					qdel(portal)
 				SSshuttle.clearHostileEnvironment(src)
-				SSsecurity_level.set_level(2)
+				SSsecurity_level.set_level(SEC_LEVEL_RED)
 		qdel(src)
 
 /obj/structure/destructible/clockwork/the_ark/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)
@@ -161,7 +161,7 @@ GLOBAL_VAR_INIT(ratvar_risen, FALSE)
 		servant_antag?.add_forbearance(servant_mob)
 
 	sound_to_playing_players('sound/magic/clockwork/invoke_general.ogg', 50)
-	SSsecurity_level.set_level(3)
+	SSsecurity_level.set_level(SEC_LEVEL_DELTA)
 	addtimer(CALLBACK(src, PROC_REF(begin_assault)), ARK_GRACE_PERIOD)
 	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(send_station_support_package), /obj/item/turf_demolisher/reebe), 10 SECONDS)
 

--- a/monkestation/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/monkestation/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -1,0 +1,13 @@
+/datum/heretic_knowledge/ultimate/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
+	. = ..()
+	var/static/have_set_lambda = FALSE
+	if(. && !have_set_lambda)
+		for(var/datum/antagonist/heretic/heretic in GLOB.antagonists)
+			var/mob/living/heretic_body = heretic.owner?.current
+			if(QDELETED(heretic_body) || heretic_body == user || heretic_body.stat == DEAD)
+				continue
+			if(heretic.ascended) // technically i could just put !heretic.ascended in the continue check above, but i feel this is easier to read
+				have_set_lambda = TRUE
+				message_admins("Alert level automatically being raised to Lambda in 5 seconds due to the presence of two or more living ascended heretics")
+				addtimer(CALLBACK(SSsecurity_level, TYPE_PROC_REF(/datum/controller/subsystem/security_level, set_level), SEC_LEVEL_LAMBDA), 5 SECONDS, TIMER_UNIQUE)
+				return

--- a/monkestation/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/monkestation/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -2,12 +2,13 @@
 	. = ..()
 	var/static/have_set_lambda = FALSE
 	if(. && !have_set_lambda)
+		var/ascended_heretics = 1
 		for(var/datum/antagonist/heretic/heretic in GLOB.antagonists)
 			var/mob/living/heretic_body = heretic.owner?.current
-			if(QDELETED(heretic_body) || heretic_body == user || heretic_body.stat == DEAD)
+			if(QDELETED(heretic_body) || heretic_body == user || !heretic.ascended || heretic_body.stat == DEAD)
 				continue
-			if(heretic.ascended) // technically i could just put !heretic.ascended in the continue check above, but i feel this is easier to read
-				have_set_lambda = TRUE
-				message_admins("Alert level automatically being raised to Lambda in 5 seconds due to the presence of two or more living ascended heretics")
-				addtimer(CALLBACK(SSsecurity_level, TYPE_PROC_REF(/datum/controller/subsystem/security_level, set_level), SEC_LEVEL_LAMBDA), 5 SECONDS, TIMER_UNIQUE)
-				return
+			ascended_heretics++
+		if(ascended_heretics >= 3)
+			have_set_lambda = TRUE
+			message_admins("Alert level automatically being raised to Lambda in 5 seconds due to the presence of three or more living ascended heretics")
+			addtimer(CALLBACK(SSsecurity_level, TYPE_PROC_REF(/datum/controller/subsystem/security_level, set_level), SEC_LEVEL_LAMBDA), 5 SECONDS, TIMER_UNIQUE)

--- a/monkestation/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/monkestation/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -1,7 +1,11 @@
 /datum/heretic_knowledge/ultimate/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	. = ..()
+	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)
+	// there's literally a big unique announcement saying "HEY THIS PERSON'S AN ASCENDED HERETIC", no reason to not have them in the orbit menu
+	heretic_datum.show_to_ghosts = TRUE
+	heretic_datum.antagpanel_category = "Ascended Heretics"
 	var/static/have_set_lambda = FALSE
-	if(. && !have_set_lambda)
+	if(!have_set_lambda)
 		var/ascended_heretics = 1
 		for(var/datum/antagonist/heretic/heretic in GLOB.antagonists)
 			var/mob/living/heretic_body = heretic.owner?.current

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6361,6 +6361,7 @@
 #include "monkestation\code\modules\antagonists\florida_man\supplypods.dm"
 #include "monkestation\code\modules\antagonists\fugitive\hunters\hunter_outfits.dm"
 #include "monkestation\code\modules\antagonists\heretic\heretic_antag.dm"
+#include "monkestation\code\modules\antagonists\heretic\heretic_knowledge.dm"
 #include "monkestation\code\modules\antagonists\heretic\heretic_living_heart.dm"
 #include "monkestation\code\modules\antagonists\heretic\heretic_monsters.dm"
 #include "monkestation\code\modules\antagonists\heretic\items\forbidden_book.dm"


### PR DESCRIPTION
## About The Pull Request

according to Huk on discord:
> Lambda is "supposed" to happen when more then 2 heretics ascend

so, if a heretic ascends, while 2 other ascended heretics are alive, this will automatically raise the alert to Lambda (5 secs after the announcement)

I also ported the refactor portion of my upstream PR, https://github.com/tgstation/tgstation/pull/88149, and made it so nar'sie and ratvar properly set the alert to lambda instead of delta (also, clock cult code actually uses the security level defines now instead of just plain numbers)

also made it so ascended heretics are in the ghost orbit menu
![image](https://github.com/user-attachments/assets/ce7e8bd8-5f9e-4fdf-bf2e-5084fd2ac7b0)


## Changelog
:cl:
add: 3+ living ascended heretics will automatically raise the alert level to Lambda.
fix: Nar'sie and Ratvar now properly raise the alert level to Lambda.
qol: Ascended heretics are now in their own category in the ghost orbit menu.
refactor: Cleaned up code relating to heretic ascension announcements and traits.
/:cl:
