### PR TITLE
adds the command drobe to all maps

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -68819,8 +68819,7 @@
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hop)
 "qoo" = (
-/obj/structure/table/wood,
-/obj/item/pai_card,
+/obj/machinery/vending/access/command,
 /turf/open/floor/wood,
 /area/station/command/meeting_room/council)
 "qoA" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -39810,7 +39810,7 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Bridge Conference Room"
 	},
-/obj/machinery/computer/slot_machine,
+/obj/machinery/vending/access/command,
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "mLV" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -40826,7 +40826,7 @@
 /area/station/security/courtroom)
 "oeX" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/spawner/random/vending/snackvend,
+/obj/machinery/vending/access/command,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "ofc" = (

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -41689,6 +41689,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera/directional/east,
+/obj/machinery/vending/access/command,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "moN" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -14425,7 +14425,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "dyH" = (
-/obj/structure/table/reinforced,
+/obj/machinery/vending/access/command,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "dyI" = (


### PR DESCRIPTION
## About The Pull Request

Adds the command wardrobe vending machine to all maps which lack it. 

## Why It's Good For The Game

It is present on some maps but not others, and there's some nice clothing options in there for more RP and fashion focused heads of staff (and QMs!). I've tried to place in in such a way that it doesnt interfere with the existing map designs, replacing vending machines and tables instead of creating new space. 

## Changelog

:cl:
add: Added the CommDrobe (Command Outfitting Station) to the maps which lacked it. These can be found in the bridge. 
/:cl:

