### PR TITLE
Gives the HoP his backpacks round-start

### DIFF
--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -66,6 +66,12 @@
 	suit = /obj/item/clothing/suit/armor/vest/hop
 	implants = list(/obj/item/implant/mindshield)
 
+	//monkestation addition start:
+	backpack = /obj/item/storage/backpack/head_of_personnel
+	satchel = /obj/item/storage/backpack/satchel/head_of_personnel
+	duffelbag = /obj/item/storage/backpack/duffelbag/head_of_personnel
+	//monkestation addition end
+
 	chameleon_extras = list(
 		/obj/item/gun/energy/e_gun,
 		/obj/item/stamp/head/hop,


### PR DESCRIPTION

## About The Pull Request
The HoP will now spawn with his custom backpacks, rather than the generic grey ones.
## Why It's Good For The Game
Consistency with other head jobs.
## Changelog
:cl:
add: The HoP will now spawn with his HoP backpacks, rather than the standard grey ones.
/:cl:
