### PR TITLE
NT Rep Clarification

### DIFF
--- a/monkestation/code/modules/NTrep/NTrep.dm
+++ b/monkestation/code/modules/NTrep/NTrep.dm
@@ -15,7 +15,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "NANOTRASEN_REPRESENTATIVE"
 
-	allow_bureaucratic_error = FALSE
+	allow_bureaucratic_error = FALSEe
 	allow_overflow = FALSE
 
 	outfit = /datum/outfit/job/nanotrasen_representative

--- a/monkestation/code/modules/NTrep/NTrep.dm
+++ b/monkestation/code/modules/NTrep/NTrep.dm
@@ -15,7 +15,7 @@
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "NANOTRASEN_REPRESENTATIVE"
 
-	allow_bureaucratic_error = FALSEe
+	allow_bureaucratic_error = FALSE
 	allow_overflow = FALSE
 
 	outfit = /datum/outfit/job/nanotrasen_representative

--- a/monkestation/code/modules/NTrep/NTrep.dm
+++ b/monkestation/code/modules/NTrep/NTrep.dm
@@ -1,6 +1,6 @@
 /datum/job/nanotrasen_representative
 	title = JOB_NANOTRASEN_REPRESENTATIVE
-	description = "Ensure company interests and Standard Operating Procedure is upheld onboard the station, and get out as soon as you can when it inevitably falls apart."
+	description = "Ensure company interests and report whether Standard Operating Procedure is upheld onboard the station, and get out as soon as you can when it inevitably falls apart. You do not have the authority to give orders, except to the blueshield."
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD
 	department_head = list("CentCom")
 	faction = FACTION_STATION


### PR DESCRIPTION

## About The Pull Request
This pr clarifies in the description of the NT rep that they cannot give out orders (except to the blueshield), and that they are more there to see that the SoP is followed, not to enforce it.
## Why It's Good For The Game
Helps to clarify that the NT rep can't give orders to the rest of command, and that they are more of an "Observe and report" role.
## Changelog
:cl:
spellcheck: Clarified NT representative's description as being more an "Observe and report" role, and that they cannot give orders to command (They can still make suggestions).
/:cl:
