### PR TITLE
[PORT] Allows creating new areas on the tram asteroid and surrounding mini-asteroids

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -88,6 +88,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(list(
 	// Ignore these areas and dont let people expand them. They can expand into them though
 	var/static/list/blacklisted_areas = typecacheof(list(
 		/area/space,
+		/area/station/asteroid,
 		))
 
 	var/error = ""

--- a/code/game/area/areas/station.dm
+++ b/code/game/area/areas/station.dm
@@ -1488,6 +1488,7 @@
 	power_light = FALSE
 	requires_power = TRUE
 	ambience_index = AMBIENCE_MINING
+	outdoors = TRUE
 
 // Telecommunications Satellite
 


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/80260, exactly what it says on the tin.

## Why It's Good For The Game

> Allows people to expand rooms into the asteroid, or create new rooms within it.

## Changelog
:cl: Absolucy, Y0SH1M4S73R
qol: The asteroid on Tramstation can now have areas expanded into or created within.
/:cl:
