### PR TITLE
Fix runtime with really fast kinetic crushers

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -151,9 +151,10 @@
 	destabilizer.hammer_synced = src
 	playsound(user, 'sound/weapons/plasma_cutter.ogg', 100, TRUE)
 	destabilizer.fire()
-	charged = FALSE
-	update_appearance()
-	addtimer(CALLBACK(src, PROC_REF(Recharge)), charge_time)
+	if(charge_time > 0)
+		charged = FALSE
+		update_appearance()
+		addtimer(CALLBACK(src, PROC_REF(Recharge)), charge_time)
 
 /obj/item/kinetic_crusher/proc/Recharge()
 	if(!charged)


### PR DESCRIPTION

## About The Pull Request

So apparently it's possible for charge time to be _negative_, presumably due to trophies. This causes a runtime due to passing a negative wait to addtimer.

This just makes it so it will stay charged if charge_time <= 0

## Why It's Good For The Game

runtimes bad

## Changelog
:cl:
fix: Proto-kinetic crushers with zero or negative recharge times will just not de-charge at all.
/:cl:
