### PR TITLE
Sabo borg and more medical tools for assault operatives

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -21193,7 +21193,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 9
 	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/misc/asteroid,
 /area/cruiser_dock)
 "gkT" = (
 /obj/machinery/light/directional/west,
@@ -24046,7 +24046,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 10
 	},
-/turf/open/floor/iron/dark/textured_large,
+/turf/open/misc/asteroid,
 /area/cruiser_dock)
 "nWh" = (
 /turf/open/floor/iron/stairs/right{
@@ -25665,6 +25665,7 @@
 /turf/open/floor/iron/smooth_edge,
 /area/cruiser_dock)
 "sBp" = (
+/obj/machinery/computer/vitals_reader/advanced/directional/south,
 /obj/machinery/computer/operating{
 	dir = 1
 	},
@@ -26170,13 +26171,10 @@
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
 "tWy" = (
+/obj/item/reagent_containers/cup/beaker/meta/rezadone,
 /obj/item/stack/sheet/mineral/plasma/twenty,
 /obj/item/reagent_containers/cup/beaker/large,
 /obj/structure/closet/crate/cardboard,
-/obj/item/reagent_containers/cup/beaker/synthflesh,
-/obj/item/reagent_containers/cup/beaker/synthflesh,
-/obj/item/reagent_containers/cup/beaker/synthflesh,
-/obj/item/reagent_containers/cup/beaker/synthflesh,
 /turf/open/floor/iron/smooth,
 /area/cruiser_dock)
 "tWL" = (
@@ -27571,7 +27569,6 @@
 /area/centcom/central_command_areas/evacuation)
 "xwc" = (
 /obj/machinery/stasis,
-/obj/machinery/computer/vitals_reader/advanced/directional/south,
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
 	},

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -20954,11 +20954,6 @@
 /obj/item/mop,
 /turf/open/floor/iron/dark/small,
 /area/centcom)
-"fCc" = (
-/turf/open/floor/iron/smooth_corner{
-	dir = 1
-	},
-/area/cruiser_dock)
 "fDz" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -21063,13 +21058,6 @@
 /obj/structure/flora/rock/pile/jungle/style_random,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
-"fWV" = (
-/obj/structure/closet/crate/cardboard,
-/obj/item/storage/backpack/duffelbag/syndie/med,
-/turf/open/floor/iron/smooth_edge{
-	dir = 8
-	},
-/area/cruiser_dock)
 "fXa" = (
 /turf/open/misc/dirt/jungle/dark/arena,
 /area/centcom/central_command_areas/admin)
@@ -21129,10 +21117,6 @@
 	dir = 1
 	},
 /area/centcom/central_command_areas/evacuation)
-"ghg" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/turf/open/floor/iron/smooth,
-/area/cruiser_dock)
 "ghD" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
@@ -21188,13 +21172,6 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation)
-"gkq" = (
-/obj/machinery/light/cold/directional/south,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 9
-	},
-/turf/open/misc/asteroid,
-/area/cruiser_dock)
 "gkT" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/carpet/neon/simple/green/nodots,
@@ -21823,10 +21800,6 @@
 	paint_color = "#5f6361"
 	},
 /area/centcom/central_command_areas/admin)
-"htV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/turf/open/floor/iron/smooth_large,
-/area/cruiser_dock)
 "huN" = (
 /turf/open/floor/glass/reinforced,
 /area/centcom/central_command_areas/prison)
@@ -22039,11 +22012,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/centcom/central_command_areas/admin)
-"hNO" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
-/turf/open/floor/iron/smooth_edge,
-/area/cruiser_dock)
 "hNX" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -22493,14 +22461,6 @@
 	dir = 4
 	},
 /area/centcom/central_command_areas/adminroom)
-"iWc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/smooth_edge{
-	dir = 8
-	},
-/area/cruiser_dock)
 "iWt" = (
 /obj/structure/closet/secure_closet/ert_med,
 /obj/item/storage/toolbox/mechanical{
@@ -23721,13 +23681,6 @@
 /obj/structure/falsewall/wood,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
-"mPy" = (
-/obj/structure/closet/cardboard,
-/mob/living/basic/bot/medbot/nukie/assop{
-	name = "Kahn"
-	},
-/turf/open/floor/iron/smooth,
-/area/cruiser_dock)
 "mQI" = (
 /obj/structure/table/greyscale,
 /obj/machinery/light/directional/north,
@@ -24041,13 +23994,6 @@
 /obj/structure/fence,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/admin)
-"nVX" = (
-/obj/machinery/light/cold/directional/north,
-/obj/effect/turf_decal/siding/thinplating_new/dark{
-	dir = 10
-	},
-/turf/open/misc/asteroid,
-/area/cruiser_dock)
 "nWh" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 4
@@ -24426,10 +24372,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/centcom/syndicate_mothership/expansion_bulldozer)
-"oYY" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/open/floor/iron/smooth_edge,
-/area/cruiser_dock)
 "oZc" = (
 /obj/machinery/disease2/incubator,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -24451,10 +24393,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/retirement_yard)
-"pec" = (
-/obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/iron/smooth,
-/area/cruiser_dock)
 "peK" = (
 /obj/structure/railing/wood{
 	dir = 4
@@ -25656,20 +25594,8 @@
 /obj/structure/aquarium,
 /turf/open/floor/sandy_dirt,
 /area/centcom/central_command_areas/admin)
-"sAz" = (
-/turf/open/floor/iron/smooth_corner{
-	dir = 8
-	},
-/area/cruiser_dock)
 "sAG" = (
 /turf/open/floor/iron/smooth_edge,
-/area/cruiser_dock)
-"sBp" = (
-/obj/machinery/computer/vitals_reader/advanced/directional/south,
-/obj/machinery/computer/operating{
-	dir = 1
-	},
-/turf/open/floor/iron/smooth,
 /area/cruiser_dock)
 "sCN" = (
 /obj/effect/spawner/random/vending/colavend,
@@ -25810,6 +25736,9 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/retirement_yard)
+"tcJ" = (
+/turf/open/floor/iron/dark,
+/area/cruiser_dock)
 "tez" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Raziel's Theatre"
@@ -26170,13 +26099,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
-"tWy" = (
-/obj/item/reagent_containers/cup/beaker/meta/rezadone,
-/obj/item/stack/sheet/mineral/plasma/twenty,
-/obj/item/reagent_containers/cup/beaker/large,
-/obj/structure/closet/crate/cardboard,
-/turf/open/floor/iron/smooth,
-/area/cruiser_dock)
 "tWL" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/structure/railing/wood{
@@ -26906,12 +26828,6 @@
 /obj/effect/landmark/ctf,
 /turf/open/space/basic,
 /area/space)
-"vTk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/smooth_large,
-/area/cruiser_dock)
 "vUQ" = (
 /obj/structure/bed/dogbed{
 	name = "pet bed";
@@ -27266,22 +27182,6 @@
 	},
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
-"wFY" = (
-/obj/structure/table,
-/obj/item/wrench/medical{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/cup/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/obj/machinery/reagentgrinder{
-	pixel_x = -7;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/smooth_edge,
-/area/cruiser_dock)
 "wGr" = (
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop,
@@ -27567,12 +27467,6 @@
 	dir = 4
 	},
 /area/centcom/central_command_areas/evacuation)
-"xwc" = (
-/obj/machinery/stasis,
-/turf/open/floor/iron/smooth_edge{
-	dir = 1
-	},
-/area/cruiser_dock)
 "xwy" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/plastic,
@@ -27647,6 +27541,13 @@
 /obj/effect/decal/cleanable/piss_stain,
 /turf/open/misc/sandy_dirt,
 /area/centcom/central_command_areas/admin)
+"xJC" = (
+/obj/structure/closet/cardboard,
+/mob/living/basic/bot/medbot/nukie/assop{
+	name = "Kahn"
+	},
+/turf/open/floor/iron/dark/textured_large,
+/area/cruiser_dock)
 "xKq" = (
 /obj/structure/railing/wooden_fencing{
 	pixel_y = 16
@@ -74218,7 +74119,7 @@ anV
 anV
 anV
 anV
-anV
+tcJ
 anV
 anV
 anV
@@ -80626,9 +80527,9 @@ iSx
 iSx
 qwj
 iSx
-uAz
-rXO
-lBd
+iSx
+iSx
+iSx
 iSx
 hVj
 rXO
@@ -80880,13 +80781,13 @@ iDX
 lWT
 xWM
 hrx
-nIX
+xJC
 axV
-nVX
-sAG
-iDX
-lWT
-gkq
+nvZ
+fEL
+fEL
+fEL
+bTZ
 axV
 eiE
 vAz
@@ -81139,11 +81040,11 @@ vJI
 axV
 axV
 axV
-axV
-sAG
-iDX
-lWT
-axV
+anV
+aBs
+aBs
+anV
+anV
 axV
 iKz
 iKz
@@ -81395,13 +81296,13 @@ uYh
 axV
 anV
 anV
-axV
-tWy
-fCc
-rXO
-sAz
-mPy
-axV
+anV
+anV
+anV
+anV
+anV
+anV
+anV
 anV
 fEL
 fEL
@@ -81652,13 +81553,13 @@ lWT
 tYX
 anV
 anV
-axV
-wFY
-rXO
-iDX
-rXO
-lWT
-axV
+anV
+anV
+anV
+anV
+anV
+anV
+anV
 anV
 anV
 axV
@@ -81909,13 +81810,13 @@ lWT
 nYE
 aBs
 anV
-axV
-oYY
-htV
-iDX
-rXO
-xwc
-axV
+anV
+anV
+anV
+anV
+anV
+anV
+anV
 anV
 anV
 anV
@@ -82166,13 +82067,13 @@ lWT
 nYE
 aBs
 anV
-axV
-hNO
-vTk
-iDX
-lBd
-sBp
-axV
+anV
+anV
+anV
+anV
+anV
+anV
+anV
 anV
 anV
 anV
@@ -82423,13 +82324,13 @@ lWT
 nYE
 aBs
 anV
-axV
-ghg
-iWc
-fWV
-pec
-axV
-axV
+anV
+anV
+anV
+anV
+anV
+anV
+anV
 anV
 anV
 anV
@@ -82680,12 +82581,12 @@ lWT
 tGB
 anV
 anV
-axV
-axV
-axV
-axV
-axV
-axV
+anV
+anV
+anV
+anV
+anV
+anV
 anV
 anV
 anV

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -25736,9 +25736,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/retirement_yard)
-"tcJ" = (
-/turf/open/floor/iron/dark,
-/area/cruiser_dock)
 "tez" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Raziel's Theatre"
@@ -74119,7 +74116,7 @@ anV
 anV
 anV
 anV
-tcJ
+anV
 anV
 anV
 anV

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -20954,6 +20954,11 @@
 /obj/item/mop,
 /turf/open/floor/iron/dark/small,
 /area/centcom)
+"fCc" = (
+/turf/open/floor/iron/smooth_corner{
+	dir = 1
+	},
+/area/cruiser_dock)
 "fDz" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -21058,6 +21063,13 @@
 /obj/structure/flora/rock/pile/jungle/style_random,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
+"fWV" = (
+/obj/structure/closet/crate/cardboard,
+/obj/item/storage/backpack/duffelbag/syndie/med,
+/turf/open/floor/iron/smooth_edge{
+	dir = 8
+	},
+/area/cruiser_dock)
 "fXa" = (
 /turf/open/misc/dirt/jungle/dark/arena,
 /area/centcom/central_command_areas/admin)
@@ -21117,6 +21129,10 @@
 	dir = 1
 	},
 /area/centcom/central_command_areas/evacuation)
+"ghg" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/turf/open/floor/iron/smooth,
+/area/cruiser_dock)
 "ghD" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
 	dir = 8
@@ -21172,6 +21188,13 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation)
+"gkq" = (
+/obj/machinery/light/cold/directional/south,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 9
+	},
+/turf/open/misc/asteroid,
+/area/cruiser_dock)
 "gkT" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/carpet/neon/simple/green/nodots,
@@ -21800,6 +21823,10 @@
 	paint_color = "#5f6361"
 	},
 /area/centcom/central_command_areas/admin)
+"htV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
+/turf/open/floor/iron/smooth_large,
+/area/cruiser_dock)
 "huN" = (
 /turf/open/floor/glass/reinforced,
 /area/centcom/central_command_areas/prison)
@@ -22012,6 +22039,11 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/centcom/central_command_areas/admin)
+"hNO" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/anesthetic_mix,
+/turf/open/floor/iron/smooth_edge,
+/area/cruiser_dock)
 "hNX" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -22461,6 +22493,14 @@
 	dir = 4
 	},
 /area/centcom/central_command_areas/adminroom)
+"iWc" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/smooth_edge{
+	dir = 8
+	},
+/area/cruiser_dock)
 "iWt" = (
 /obj/structure/closet/secure_closet/ert_med,
 /obj/item/storage/toolbox/mechanical{
@@ -23681,6 +23721,13 @@
 /obj/structure/falsewall/wood,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
+"mPy" = (
+/obj/structure/closet/cardboard,
+/mob/living/basic/bot/medbot/nukie/assop{
+	name = "Kahn"
+	},
+/turf/open/floor/iron/smooth,
+/area/cruiser_dock)
 "mQI" = (
 /obj/structure/table/greyscale,
 /obj/machinery/light/directional/north,
@@ -23994,6 +24041,13 @@
 /obj/structure/fence,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/admin)
+"nVX" = (
+/obj/machinery/light/cold/directional/north,
+/obj/effect/turf_decal/siding/thinplating_new/dark{
+	dir = 10
+	},
+/turf/open/misc/asteroid,
+/area/cruiser_dock)
 "nWh" = (
 /turf/open/floor/iron/stairs/right{
 	dir = 4
@@ -24372,6 +24426,10 @@
 	},
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/centcom/syndicate_mothership/expansion_bulldozer)
+"oYY" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/turf/open/floor/iron/smooth_edge,
+/area/cruiser_dock)
 "oZc" = (
 /obj/machinery/disease2/incubator,
 /obj/effect/turf_decal/siding/thinplating_new/dark{
@@ -24393,6 +24451,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/retirement_yard)
+"pec" = (
+/obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/iron/smooth,
+/area/cruiser_dock)
 "peK" = (
 /obj/structure/railing/wood{
 	dir = 4
@@ -25594,8 +25656,20 @@
 /obj/structure/aquarium,
 /turf/open/floor/sandy_dirt,
 /area/centcom/central_command_areas/admin)
+"sAz" = (
+/turf/open/floor/iron/smooth_corner{
+	dir = 8
+	},
+/area/cruiser_dock)
 "sAG" = (
 /turf/open/floor/iron/smooth_edge,
+/area/cruiser_dock)
+"sBp" = (
+/obj/machinery/computer/vitals_reader/advanced/directional/south,
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
 /area/cruiser_dock)
 "sCN" = (
 /obj/effect/spawner/random/vending/colavend,
@@ -25736,9 +25810,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/retirement_yard)
-"tcJ" = (
-/turf/open/floor/iron/dark,
-/area/cruiser_dock)
 "tez" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Raziel's Theatre"
@@ -26099,6 +26170,13 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
+"tWy" = (
+/obj/item/reagent_containers/cup/beaker/meta/rezadone,
+/obj/item/stack/sheet/mineral/plasma/twenty,
+/obj/item/reagent_containers/cup/beaker/large,
+/obj/structure/closet/crate/cardboard,
+/turf/open/floor/iron/smooth,
+/area/cruiser_dock)
 "tWL" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/structure/railing/wood{
@@ -26828,6 +26906,12 @@
 /obj/effect/landmark/ctf,
 /turf/open/space/basic,
 /area/space)
+"vTk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible{
+	dir = 9
+	},
+/turf/open/floor/iron/smooth_large,
+/area/cruiser_dock)
 "vUQ" = (
 /obj/structure/bed/dogbed{
 	name = "pet bed";
@@ -27182,6 +27266,22 @@
 	},
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
+"wFY" = (
+/obj/structure/table,
+/obj/item/wrench/medical{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/cup/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 3
+	},
+/obj/machinery/reagentgrinder{
+	pixel_x = -7;
+	pixel_y = 5
+	},
+/turf/open/floor/iron/smooth_edge,
+/area/cruiser_dock)
 "wGr" = (
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop,
@@ -27467,6 +27567,12 @@
 	dir = 4
 	},
 /area/centcom/central_command_areas/evacuation)
+"xwc" = (
+/obj/machinery/stasis,
+/turf/open/floor/iron/smooth_edge{
+	dir = 1
+	},
+/area/cruiser_dock)
 "xwy" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /turf/open/floor/plastic,
@@ -27541,13 +27647,6 @@
 /obj/effect/decal/cleanable/piss_stain,
 /turf/open/misc/sandy_dirt,
 /area/centcom/central_command_areas/admin)
-"xJC" = (
-/obj/structure/closet/cardboard,
-/mob/living/basic/bot/medbot/nukie/assop{
-	name = "Kahn"
-	},
-/turf/open/floor/iron/dark/textured_large,
-/area/cruiser_dock)
 "xKq" = (
 /obj/structure/railing/wooden_fencing{
 	pixel_y = 16
@@ -74119,7 +74218,7 @@ anV
 anV
 anV
 anV
-tcJ
+anV
 anV
 anV
 anV
@@ -80527,9 +80626,9 @@ iSx
 iSx
 qwj
 iSx
-iSx
-iSx
-iSx
+uAz
+rXO
+lBd
 iSx
 hVj
 rXO
@@ -80781,13 +80880,13 @@ iDX
 lWT
 xWM
 hrx
-xJC
+nIX
 axV
-nvZ
-fEL
-fEL
-fEL
-bTZ
+nVX
+sAG
+iDX
+lWT
+gkq
 axV
 eiE
 vAz
@@ -81040,11 +81139,11 @@ vJI
 axV
 axV
 axV
-anV
-aBs
-aBs
-anV
-anV
+axV
+sAG
+iDX
+lWT
+axV
 axV
 iKz
 iKz
@@ -81296,13 +81395,13 @@ uYh
 axV
 anV
 anV
-anV
-anV
-anV
-anV
-anV
-anV
-anV
+axV
+tWy
+fCc
+rXO
+sAz
+mPy
+axV
 anV
 fEL
 fEL
@@ -81553,13 +81652,13 @@ lWT
 tYX
 anV
 anV
-anV
-anV
-anV
-anV
-anV
-anV
-anV
+axV
+wFY
+rXO
+iDX
+rXO
+lWT
+axV
 anV
 anV
 axV
@@ -81810,13 +81909,13 @@ lWT
 nYE
 aBs
 anV
-anV
-anV
-anV
-anV
-anV
-anV
-anV
+axV
+oYY
+htV
+iDX
+rXO
+xwc
+axV
 anV
 anV
 anV
@@ -82067,13 +82166,13 @@ lWT
 nYE
 aBs
 anV
-anV
-anV
-anV
-anV
-anV
-anV
-anV
+axV
+hNO
+vTk
+iDX
+lBd
+sBp
+axV
 anV
 anV
 anV
@@ -82324,13 +82423,13 @@ lWT
 nYE
 aBs
 anV
-anV
-anV
-anV
-anV
-anV
-anV
-anV
+axV
+ghg
+iWc
+fWV
+pec
+axV
+axV
 anV
 anV
 anV
@@ -82581,12 +82680,12 @@ lWT
 tGB
 anV
 anV
-anV
-anV
-anV
-anV
-anV
-anV
+axV
+axV
+axV
+axV
+axV
+axV
 anV
 anV
 anV

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -21193,7 +21193,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 9
 	},
-/turf/open/misc/asteroid,
+/turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
 "gkT" = (
 /obj/machinery/light/directional/west,
@@ -24046,7 +24046,7 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 10
 	},
-/turf/open/misc/asteroid,
+/turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
 "nWh" = (
 /turf/open/floor/iron/stairs/right{
@@ -25665,7 +25665,6 @@
 /turf/open/floor/iron/smooth_edge,
 /area/cruiser_dock)
 "sBp" = (
-/obj/machinery/computer/vitals_reader/advanced/directional/south,
 /obj/machinery/computer/operating{
 	dir = 1
 	},
@@ -26171,10 +26170,13 @@
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
 "tWy" = (
-/obj/item/reagent_containers/cup/beaker/meta/rezadone,
 /obj/item/stack/sheet/mineral/plasma/twenty,
 /obj/item/reagent_containers/cup/beaker/large,
 /obj/structure/closet/crate/cardboard,
+/obj/item/reagent_containers/cup/beaker/synthflesh,
+/obj/item/reagent_containers/cup/beaker/synthflesh,
+/obj/item/reagent_containers/cup/beaker/synthflesh,
+/obj/item/reagent_containers/cup/beaker/synthflesh,
 /turf/open/floor/iron/smooth,
 /area/cruiser_dock)
 "tWL" = (
@@ -27569,6 +27571,7 @@
 /area/centcom/central_command_areas/evacuation)
 "xwc" = (
 /obj/machinery/stasis,
+/obj/machinery/computer/vitals_reader/advanced/directional/south,
 /turf/open/floor/iron/smooth_edge{
 	dir = 1
 	},

--- a/_maps/shuttles/nova/goldeneye_cruiser.dmm
+++ b/_maps/shuttles/nova/goldeneye_cruiser.dmm
@@ -481,9 +481,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/medical)
 "wb" = (
-/obj/structure/table/optable,
 /obj/effect/turf_decal/bot,
 /obj/machinery/defibrillator_mount/loaded/directional/north,
+/obj/machinery/stasis{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/medical)
 "ws" = (
@@ -638,7 +640,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/brig)
 "FM" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
+/obj/machinery/smartfridge/assualt/preloaded,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/medical)
 "FO" = (

--- a/monkestation/code/modules/assault_ops/code/armaments/utility.dm
+++ b/monkestation/code/modules/assault_ops/code/armaments/utility.dm
@@ -68,3 +68,9 @@
 	description = "Flash this at someone to hit them with an electromagnetic pulse."
 	item_type = /obj/item/flashlight/emp
 	cost = 2
+
+/datum/armament_entry/assault_operatives/utility/borg
+	name = "Saboteur Cyborg Beacon"
+	description = "A single-use beacon that summons a saboteur cyborg to assist alongside you on your mission."
+	item_type = /obj/item/antag_spawner/assault_operative
+	cost = 25

--- a/monkestation/code/modules/assault_ops/code/cyborg.dm
+++ b/monkestation/code/modules/assault_ops/code/cyborg.dm
@@ -1,0 +1,144 @@
+//big ol copy of nukie code but to make it play nice with assualt ops datums
+/obj/item/antag_spawner/assault_operative
+	name = "syndicate saboteur beacon"
+	desc = "A single-use beacon designed to quickly launch reinforcement operatives into the field."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "locator"
+	var/borg_to_spawn
+	/// The name of the special role given to the recruit
+	var/special_role_name = ROLE_ASSAULT_OPERATIVE
+	/// The antag datum applied
+	var/datum/antagonist/assault_operative/antag_datum = /datum/antagonist/assault_operative
+	/// Style used by the droppod
+	var/pod_style = STYLE_SYNDICATE
+
+/obj/item/antag_spawner/assault_operative/proc/check_usability(mob/user)
+	if(used)
+		to_chat(user, span_warning("[src] is out of power!"))
+		return FALSE
+	if(!user.mind.has_antag_datum(/datum/antagonist/assault_operative,TRUE))
+		to_chat(user, span_danger("AUTHENTICATION FAILURE. ACCESS DENIED."))
+		return FALSE
+	return TRUE
+
+/// Creates the drop pod the nukie will be dropped by
+/obj/item/antag_spawner/assault_operative/proc/setup_pod()
+	var/obj/structure/closet/supplypod/pod = new(null, pod_style)
+	pod.explosionSize = list(0,0,0,0)
+	pod.bluespace = TRUE
+	return pod
+
+/obj/item/antag_spawner/assault_operative/attack_self(mob/user)
+	if(!(check_usability(user)))
+		return
+
+	to_chat(user, span_notice("You activate [src] and wait for confirmation."))
+	var/mob/chosen_one = SSpolling.poll_ghost_candidates("Do you want to play as a reinforcement [special_role_name]?", check_jobban = ROLE_ASSAULT_OPERATIVE, role = ROLE_ASSAULT_OPERATIVE, poll_time = 15 SECONDS, ignore_category = POLL_IGNORE_SYNDICATE, alert_pic = src, role_name_text = special_role_name, amount_to_pick = 1)
+	if(chosen_one)
+		if(QDELETED(src) || !check_usability(user))
+			return
+		used = TRUE
+		spawn_antag(chosen_one.client, get_turf(src), "assault_operative", user.mind)
+		do_sparks(4, TRUE, src)
+		qdel(src)
+	else
+		to_chat(user, span_warning("Unable to connect to Syndicate command. Please wait and try again later or use the beacon on your uplink to get your points refunded."))
+
+/obj/item/antag_spawner/assault_operative/spawn_antag(client/our_client, turf/T, kind, datum/mind/user)
+	var/mob/living/silicon/robot/borg = new /mob/living/silicon/robot/model/syndicate/saboteur/operative()
+	var/datum/antagonist/assault_operative/creator_op = user.has_antag_datum(/datum/antagonist/assault_operative,TRUE)
+	if(!creator_op)
+		return
+	our_client.prefs.safe_transfer_prefs_to(borg, is_antag = TRUE)
+	borg.ckey = our_client.key
+	var/obj/structure/closet/supplypod/pod = setup_pod()
+	var/brainfirstname = pick(GLOB.first_names_male)
+	if(prob(50))
+		brainfirstname = pick(GLOB.first_names_female)
+	var/brainopslastname = pick(GLOB.last_names)
+	var/brainopsname = "[brainfirstname] [brainopslastname]"
+
+	borg.mmi.name = "[initial(borg.mmi.name)]: [brainopsname]"
+	borg.mmi.brain.name = "[brainopsname]'s brain"
+	borg.mmi.brainmob.real_name = brainopsname
+	borg.mmi.brainmob.name = brainopsname
+	borg.real_name = borg.name
+	borg.update_name_tag() // monkestation edit: name tags
+
+	borg.key = our_client.key
+
+	var/datum/antagonist/assault_operative/new_borg = new()
+	new_borg.send_to_spawnpoint = FALSE
+	borg.mind.add_antag_datum(new_borg,creator_op.assault_team)
+	borg.mind.special_role = "Syndicate Cyborg"
+	borg.forceMove(pod)
+	new /obj/effect/pod_landingzone(get_turf(src), pod)
+
+/mob/living/silicon/robot/model/syndicate/saboteur/operative
+	icon_state = "synd_engi"
+	playstyle_string = "<span class='big bold'>You are a Syndicate saboteur cyborg!</span><br>\
+		<b>You are armed with robust engineering tools to aid you in your mission: help the operatives secure the golden eye authentication disks. \
+		Your destination tagger will allow you to stealthily traverse the disposal network across the station \
+		Your welder will allow you to repair yourself and your fellow cyborgs.  \
+		Your cyborg chameleon projector allows you to assume the appearance and registered name of a Nanotrasen engineering borg, and undertake covert actions on the station \
+		Be aware that almost any physical contact or incidental damage will break your camouflage \
+		<i>Help the operatives secure the disks at all costs!</i></b>"
+	set_model = /obj/item/robot_model/saboteur/operative
+
+/obj/item/robot_model/saboteur/operative
+	basic_modules = list(
+		/obj/item/assembly/flash/cyborg,
+		/obj/item/borg/sight/thermal,
+		/obj/item/construction/rcd/borg/syndicate,
+		/obj/item/pipe_dispenser,
+		/obj/item/extinguisher,
+		/obj/item/weldingtool/largetank/cyborg,
+		/obj/item/screwdriver/nuke,
+		/obj/item/wrench/cyborg,
+		/obj/item/crowbar/cyborg,
+		/obj/item/wirecutters/cyborg,
+		/obj/item/multitool/cyborg,
+		/obj/item/analyzer,
+		/obj/item/stack/sheet/iron,
+		/obj/item/stack/sheet/glass,
+		/obj/item/assembly/signaler/cyborg,
+		/obj/item/borg/apparatus/sheet_manipulator,
+		/obj/item/stack/rods/cyborg,
+		/obj/item/stack/tile/iron/base/cyborg,
+		/obj/item/holosign_creator/atmos,
+		/obj/item/dest_tagger/borg,
+		/obj/item/stack/cable_coil,
+		/obj/item/restraints/handcuffs/cable/zipties,
+		/obj/item/pinpointer/operative_cyborg,
+		/obj/item/borg_chameleon,
+		/obj/item/card/emag,
+		/obj/item/borg/stun,
+	)
+
+/obj/item/pinpointer/operative_cyborg
+	name = "cyborg syndicate pinpointer"
+	desc = "An integrated tracking device, jury-rigged to search for living assualt operatives."
+	flags_1 = NONE
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+
+/obj/item/pinpointer/operative_cyborg/Initialize(mapload)
+	. = ..()
+	ADD_TRAIT(src, TRAIT_NODROP, CYBORG_ITEM_TRAIT)
+
+/obj/item/pinpointer/operative_cyborg/cyborg_unequip(mob/user)
+	if(!active)
+		return
+	toggle_on()
+
+/obj/item/pinpointer/operative_cyborg/scan_for_target()
+	target = null
+	var/list/possible_targets = list()
+	var/turf/here = get_turf(src)
+	for(var/V in get_antag_minds(/datum/antagonist/assault_operative))
+		var/datum/mind/M = V
+		if(ishuman(M.current) && M.current.stat != DEAD)
+			possible_targets |= M.current
+	var/mob/living/closest_operative = get_closest_atom(/mob/living/carbon/human, possible_targets, here)
+	if(closest_operative)
+		target = closest_operative
+	..()

--- a/monkestation/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/monkestation/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -4,3 +4,17 @@
 
 /obj/machinery/smartfridge/ui_static_data(mob/user)
 	return list("ui_theme" = tgui_theme)
+
+/obj/machinery/smartfridge/assualt
+	name = "smart chemical storage"
+	desc = "A refrigerated storage unit for curing a few dire aliments."
+
+/obj/machinery/smartfridge/assualt/preloaded
+	initial_contents = list(
+		/obj/item/reagent_containers/pill/epinephrine = 12,
+		/obj/item/reagent_containers/pill/multiver = 5,
+		/obj/item/reagent_containers/cup/bottle/epinephrine = 1,
+		/obj/item/reagent_containers/cup/bottle/multiver = 1,
+		/obj/item/reagent_containers/cup/bottle/formaldehyde,
+		/obj/item/reagent_containers/cup/beaker/large/synthflesh = 2,
+		/obj/item/reagent_containers/cup/beaker/large/plasma = 2,)

--- a/monkestation/code/modules/reagents/reagent_containers/cups/_cup.dm
+++ b/monkestation/code/modules/reagents/reagent_containers/cups/_cup.dm
@@ -54,3 +54,11 @@
 		pour_amount = "10_25"
 
 	return prob(1) ? rare_pouring_sound[pour_amount] : pick(pouring_sounds_categorized[pour_amount])
+
+/obj/item/reagent_containers/cup/beaker/large/synthflesh
+	name = "large synthflesh beaker"
+	list_reagents = list(/datum/reagent/medicine/c2/synthflesh = 100)
+
+/obj/item/reagent_containers/cup/beaker/large/plasma
+	name = "large plasma beaker"
+	list_reagents = list(/datum/reagent/toxin/plasma = 100)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6504,6 +6504,7 @@
 #include "monkestation\code\modules\assault_ops\code\areas.dm"
 #include "monkestation\code\modules\assault_ops\code\assault_op_vendor.dm"
 #include "monkestation\code\modules\assault_ops\code\covert_modsuit.dm"
+#include "monkestation\code\modules\assault_ops\code\cyborg.dm"
 #include "monkestation\code\modules\assault_ops\code\goldeneye.dm"
 #include "monkestation\code\modules\assault_ops\code\interrogator.dm"
 #include "monkestation\code\modules\assault_ops\code\midround_event.dm"


### PR DESCRIPTION
## About The Pull Request
- Adds a variant of the saboteur borg for the assault ops for 25 points (Half their uplink). Most notable difference is having a cyborg stun baton from the emag engineer module. 
- Gives more medical supplies to the goldeneye cruiser.
## Why It's Good For The Game

### saboteur cyborg
Assault operatives aren't in the best balance spot I believe most people can agree. And something I had noticed is compared to the other high threats, Wizards, Nuke Ops, Malf ai's, cults, (and god forbid even rev's), is the ability to conscript additional people Saboteur cyborgs. Whether through conversion or recruitment. But Assault ops is the one exception to this. You start with five and you'll end with 5. (Or less when your friends die).

So, to alleviate this I've added to their beacon a saboteur cyborg. Very much within their themeing of infiltration and stealth. Carrying both a disguise for itself and a pipe transporter. And has the potential to help fully with all of the objectives short of inserting the goldeneye disks into the console. 

So for half their individual budget they can buy a extra hand to assist with a good variety of infiltration and extraction tools.

### Medical

Heads can be brought back in a variety of states which require treament, the natural sunk cost to hurting heads is taking the time to fix their body after the fact. However they sometime lacks the tools to help alleviate this.

The biggest of which I can think of is if a head takes a heavy bleeder challenge or if they are a oozeling. As such I added a stasis bed and a few more chemicals to their smart fridge. Namely formaldehyde to prevent organ decay, as they cant reverse it easily, synthflesh to undo husks, and plasma for oozelings. 
## Changelog
:cl:
add: New purchase for assault operatives, "Saboteur cyborg beacon"
add: Added chemicals to the goldeneye cruiser and a stasis bed for surgery.

/:cl:
