### PR TITLE
Fix naked clownop leaders (+ nukeop code cleanup)

### DIFF
--- a/monkestation/code/modules/mob/inventory.dm
+++ b/monkestation/code/modules/mob/inventory.dm
@@ -1,0 +1,14 @@
+/**
+ * Drops and deletes all items in the mob's inventory.
+ *
+ * Argument(s):
+ * * Optional - include_pockets (TRUE/FALSE), whether or not to also clear items in their pockets and suit storage.
+ * * Optional - include_held_items (TRUE/FALSE), whether or not to also clear any held items.
+ */
+/mob/living/proc/clear_inventory(include_pockets = TRUE, include_held_items = TRUE)
+	var/list/items = get_equipped_items(include_pockets)
+	if(include_held_items)
+		items |= held_items
+	for(var/item in items)
+		dropItemToGround(item, force = TRUE, silent = TRUE, invdrop = FALSE)
+		qdel(item)

--- a/monkestation/code/modules/storytellers/converted_events/_base_event.dm
+++ b/monkestation/code/modules/storytellers/converted_events/_base_event.dm
@@ -337,6 +337,8 @@
 	old_mob.client.prefs.safe_transfer_prefs_to(new_character)
 	new_character.dna.update_dna_identity()
 	old_mob.mind.transfer_to(new_character)
+	if(old_mob.has_quirk(/datum/quirk/anime)) // stupid special case bc this quirk is basically janky wrapper shitcode around some optional appearance prefs
+		new_character.add_quirk(/datum/quirk/anime)
 	if(qdel_old_mob)
 		qdel(old_mob)
 	return new_character

--- a/monkestation/code/modules/storytellers/converted_events/solo/clown_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/clown_operative.dm
@@ -1,127 +1,15 @@
-/datum/round_event_control/antagonist/solo/clown_operative
+/datum/round_event_control/antagonist/solo/nuclear_operative/clown
 	name = "Roundstart Clown Operative"
 	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_EXTERNAL)
 	antag_flag = ROLE_CLOWN_OPERATIVE
 	antag_datum = /datum/antagonist/nukeop/clownop
-	typepath = /datum/round_event/antagonist/solo/clown_operative
-	shared_occurence_type = SHARED_HIGH_THREAT
-	restricted_roles = list(
-		JOB_AI,
-		JOB_CAPTAIN,
-		JOB_NANOTRASEN_REPRESENTATIVE,
-		JOB_BLUESHIELD,
-		JOB_CHIEF_ENGINEER,
-		JOB_CHIEF_MEDICAL_OFFICER,
-		JOB_CYBORG,
-		JOB_DETECTIVE,
-		JOB_HEAD_OF_PERSONNEL,
-		JOB_HEAD_OF_SECURITY,
-		JOB_PRISONER,
-		JOB_RESEARCH_DIRECTOR,
-		JOB_SECURITY_OFFICER,
-		JOB_WARDEN,
-		JOB_BRIG_PHYSICIAN,
-	)
-	base_antags = 3
-	maximum_antags = 5
-	enemy_roles = list(
-		JOB_AI,
-		JOB_CYBORG,
-		JOB_CAPTAIN,
-		JOB_BLUESHIELD,
-		JOB_DETECTIVE,
-		JOB_HEAD_OF_SECURITY,
-		JOB_SECURITY_OFFICER,
-		JOB_SECURITY_ASSISTANT,
-		JOB_WARDEN,
-	)
-	required_enemies = 5
-	// I give up, just there should be enough heads with 35 players...
-	min_players = 35
-	roundstart = TRUE
-	earliest_start = 0 SECONDS
+	typepath = /datum/round_event/antagonist/solo/nuclear_operative/clown
 	weight = 1 //these are meant to be very rare
 	max_occurrences = 1
 	event_icon_state = "flukeops"
 
-/datum/round_event/antagonist/solo/clown_operative
-	excute_round_end_reports = TRUE
-	end_when = 60000 /// we will end on our own when revs win
-	var/static/datum/team/nuclear/nuke_team
-	var/set_leader = FALSE
-	var/required_role = ROLE_CLOWN_OPERATIVE
-
-/datum/round_event/antagonist/solo/clown_operative/setup()
-	. = ..()
-	var/obj/machinery/nuclearbomb/syndicate/syndicate_nuke = locate() in GLOB.nuke_list
-	if(syndicate_nuke)
-		var/turf/nuke_turf = get_turf(syndicate_nuke)
-		if(nuke_turf)
-			new /obj/machinery/nuclearbomb/syndicate/bananium(nuke_turf)
-			qdel(syndicate_nuke)
-
-/datum/round_event/antagonist/solo/clown_operative/add_datum_to_mind(datum/mind/antag_mind)
-	var/mob/living/current_mob = antag_mind.current
-	SSjob.FreeRole(antag_mind.assigned_role.title)
-	var/list/items = current_mob.get_equipped_items(TRUE)
-	current_mob.unequip_everything()
-	for(var/obj/item/item as anything in items)
-		qdel(item)
-
-	create_human_mob_copy(get_turf(current_mob), current_mob)
-	antag_mind.set_assigned_role(SSjob.GetJobType(/datum/job/clown_operative))
-	antag_mind.special_role = ROLE_CLOWN_OPERATIVE
-
-	var/datum/mind/most_experienced = get_most_experienced(setup_minds, required_role)
-	if(!most_experienced)
-		most_experienced = antag_mind
-
-	if(!set_leader)
-		set_leader = TRUE
-		var/datum/antagonist/nukeop/leader/leader_antag_datum = new()
-		var/mob/living/carbon/human/leader_mob = most_experienced.current
-		leader_mob = create_human_mob_copy(get_turf(leader_mob), leader_mob)
-		nuke_team = leader_antag_datum.nuke_team
-		most_experienced.add_antag_datum(leader_antag_datum)
-		leader_mob.equip_species_outfit(/datum/outfit/syndicate/clownop/leader)
-
-	if(antag_mind == most_experienced)
-		return
-
-	var/datum/antagonist/nukeop/new_op = new antag_datum()
-	antag_mind.add_antag_datum(new_op)
-
-
-/datum/round_event/antagonist/solo/clown_operative/round_end_report()
-	var/result = nuke_team.get_result()
-	switch(result)
-		if(NUKE_RESULT_FLUKE)
-			SSticker.mode_result = "loss - syndicate nuked - disk secured"
-			SSticker.news_report = NUKE_SYNDICATE_BASE
-		if(NUKE_RESULT_NUKE_WIN)
-			SSticker.mode_result = "win - syndicate nuke"
-			SSticker.news_report = STATION_DESTROYED_NUKE
-		if(NUKE_RESULT_NOSURVIVORS)
-			SSticker.mode_result = "halfwin - syndicate nuke - did not evacuate in time"
-			SSticker.news_report = STATION_DESTROYED_NUKE
-		if(NUKE_RESULT_WRONG_STATION)
-			SSticker.mode_result = "halfwin - blew wrong station"
-			SSticker.news_report = NUKE_MISS
-		if(NUKE_RESULT_WRONG_STATION_DEAD)
-			SSticker.mode_result = "halfwin - blew wrong station - did not evacuate in time"
-			SSticker.news_report = NUKE_MISS
-		if(NUKE_RESULT_CREW_WIN_SYNDIES_DEAD)
-			SSticker.mode_result = "loss - evacuation - disk secured - syndi team dead"
-			SSticker.news_report = OPERATIVES_KILLED
-		if(NUKE_RESULT_CREW_WIN)
-			SSticker.mode_result = "loss - evacuation - disk secured"
-			SSticker.news_report = OPERATIVES_KILLED
-		if(NUKE_RESULT_DISK_LOST)
-			SSticker.mode_result = "halfwin - evacuation - disk not secured"
-			SSticker.news_report = OPERATIVE_SKIRMISH
-		if(NUKE_RESULT_DISK_STOLEN)
-			SSticker.mode_result = "halfwin - detonation averted"
-			SSticker.news_report = OPERATIVE_SKIRMISH
-		else
-			SSticker.mode_result = "halfwin - interrupted"
-			SSticker.news_report = OPERATIVE_SKIRMISH
+/datum/round_event/antagonist/solo/nuclear_operative/clown
+	required_role = ROLE_CLOWN_OPERATIVE
+	job_type = /datum/job/clown_operative
+	antag_type = /datum/antagonist/nukeop/clownop
+	leader_antag_type = /datum/antagonist/nukeop/leader/clownop

--- a/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
@@ -46,49 +46,34 @@
 
 /datum/round_event/antagonist/solo/nuclear_operative
 	excute_round_end_reports = TRUE
-	var/static/datum/team/nuclear/nuke_team
-	var/set_leader = FALSE
 	var/required_role = ROLE_NUCLEAR_OPERATIVE
-	var/datum/mind/most_experienced
+	var/job_type = /datum/job/nuclear_operative
+	var/antag_type = /datum/antagonist/nukeop
+	var/leader_antag_type = /datum/antagonist/nukeop/leader
+	var/datum/team/nuclear/nuke_team
 
-/datum/round_event/antagonist/solo/nuclear_operative/add_datum_to_mind(datum/mind/antag_mind)
-	if(most_experienced == antag_mind)
-		return
+/datum/round_event/antagonist/solo/nuclear_operative/start()
+	var/datum/mind/most_experienced = get_most_experienced(setup_minds, required_role) || setup_minds[1]
+	prepare(most_experienced)
+	var/datum/antagonist/nukeop/leader/leader = most_experienced.add_antag_datum(leader_antag_type)
+	nuke_team = leader.nuke_team
+	for(var/datum/mind/antag_mind as anything in setup_minds - most_experienced)
+		prepare(antag_mind)
+		var/datum/antagonist/nukeop/op = new antag_type
+		op.nuke_team = nuke_team
+		antag_mind.add_antag_datum(op)
+
+/// Frees the target mind's job slot, clears and deletes all their items, creates a fresh body for them, and sets
+/datum/round_event/antagonist/solo/nuclear_operative/proc/prepare(datum/mind/antag_mind)
 	var/mob/living/current_mob = antag_mind.current
 	SSjob.FreeRole(antag_mind.assigned_role.title)
-	var/list/items = current_mob.get_equipped_items(TRUE)
-	current_mob.unequip_everything()
-	for(var/obj/item/item as anything in items)
-		qdel(item)
-
+	current_mob.clear_inventory()
 	create_human_mob_copy(get_turf(current_mob), current_mob)
-	if(!most_experienced)
-		most_experienced = get_most_experienced(setup_minds, required_role) || antag_mind
+	antag_mind.set_assigned_role(SSjob.GetJobType(job_type))
+	antag_mind.special_role = required_role
 
-	if(!set_leader)
-		set_leader = TRUE
-		if(antag_mind != most_experienced)
-			var/mob/living/leader_mob = most_experienced.current
-			SSjob.FreeRole(most_experienced.assigned_role.title)
-			var/list/leader_items = leader_mob.get_equipped_items(TRUE)
-			leader_mob.unequip_everything()
-			for(var/obj/item/item as anything in leader_items)
-				qdel(item)
-			leader_mob = create_human_mob_copy(get_turf(leader_mob), leader_mob)
-		most_experienced.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
-		most_experienced.special_role = ROLE_NUCLEAR_OPERATIVE
-		var/datum/antagonist/nukeop/leader/leader_antag_datum = most_experienced.add_antag_datum(/datum/antagonist/nukeop/leader)
-		nuke_team = leader_antag_datum.nuke_team
-
-	if(antag_mind == most_experienced)
-		return
-
-	antag_mind.set_assigned_role(SSjob.GetJobType(/datum/job/nuclear_operative))
-	antag_mind.special_role = ROLE_NUCLEAR_OPERATIVE
-
-	var/datum/antagonist/nukeop/new_op = new antag_datum()
-	antag_mind.add_antag_datum(new_op)
-
+/datum/round_event/antagonist/solo/nuclear_operative/add_datum_to_mind(datum/mind/antag_mind)
+	CRASH("this should not be called")
 
 /datum/round_event/antagonist/solo/nuclear_operative/round_end_report()
 	var/result = nuke_team.get_result()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7489,6 +7489,7 @@
 #include "monkestation\code\modules\mining\accelerators\shotgun.dm"
 #include "monkestation\code\modules\mining\lavaland\megafauna_loot.dm"
 #include "monkestation\code\modules\mining\lavaland\tendril_loot.dm"
+#include "monkestation\code\modules\mob\inventory.dm"
 #include "monkestation\code\modules\mob\login.dm"
 #include "monkestation\code\modules\mob\mob.dm"
 #include "monkestation\code\modules\mob\mob_defines.dm"


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/3982

Also just cleaned up nuke op / clown op code in general - and clown op stuff is just a subtype of nuke ops, to prevent the unneeded code duplication that caused the issue in the first place.

<details>
<summary>Screenshot / Proof of Testing</summary>

![2024-12-03 (1733249330) ~ dreamseeker](https://github.com/user-attachments/assets/02500d14-7113-4e64-b95a-e55e9172c53f)

</details>

## Changelog
:cl:
fix: Clown operative leaders now properly spawn with their gear.
fix: Anime quirk appearance prefs now properly transfer when becoming a roundstart nuke/clown operative.
fix: Clean up the inventory/items of players becoming roundstart nuke/clown operatives more thoroughly and quietly.
refactor: Cleaned up code related to roundstart nuke/clown operatives.
/:cl:
