### PR TITLE
Locked rd consoles

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -30,7 +30,7 @@ Nothing else in the console has ID requirements.
 	/// The stored design disk, if present
 	var/obj/item/disk/design_disk/d_disk
 	/// Determines if the console is locked, and consequently if actions can be performed with it
-	var/locked = FALSE
+	var/locked = TRUE //Monkestation edit.
 	/// Used for compressing data sent to the UI via static_data as payload size is of concern
 	var/id_cache = list()
 	/// Sequence var for the id cache


### PR DESCRIPTION

## About The Pull Request
Makes R&D consoles locked by default.
## Why It's Good For The Game
Locking a console is currently very pointless. 
Simply screwdriving to rebuild a console will bypass the lock. Allowing other jobs (Engineering) to build consoles and research to their free will. despite even if a Research Directors wants to control their research.
In addition brings more purpose to other items such as emag's function to unlock R&D consoles. 
## Changelog
:cl:
add: R&D consoles are now locked by default when built.
/:cl:
