### PR TITLE
Syndicate implants are now properly hidden from HUDs/scanners

### DIFF
--- a/monkestation/code/modules/cybernetics/augments/_base_changes.dm
+++ b/monkestation/code/modules/cybernetics/augments/_base_changes.dm
@@ -3,7 +3,6 @@
 
 /obj/item/organ/internal/cyberimp
 	var/hacked = FALSE
-	var/syndicate_implant = FALSE //Makes the implant invisible to health analyzers and medical HUDs.
 
 	var/list/encode_info = AUGMENT_NO_REQ
 

--- a/monkestation/code/modules/cybernetics/augments/_base_changes.dm
+++ b/monkestation/code/modules/cybernetics/augments/_base_changes.dm
@@ -182,6 +182,7 @@
 
 /obj/item/organ/internal/cyberimp/cyberlink/syndicate
 	name = "Cybersun Cybernetics Access System"
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
 	encode_info = AUGMENT_SYNDICATE_LEVEL_LINK
 
 /obj/item/organ/internal/cyberimp/cyberlink/admin

--- a/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/weapons.dm
+++ b/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/weapons.dm
@@ -43,6 +43,7 @@
 	name = "arm-mounted energy blade"
 	desc = "An illegal and highly dangerous cybernetic implant that can project a deadly blade of concentrated energy."
 	items_to_create = list(/obj/item/melee/energy/blade/hardlight)
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
 	encode_info = AUGMENT_SYNDICATE_LEVEL
 
 /obj/item/organ/internal/cyberimp/arm/item_set/medibeam
@@ -95,6 +96,7 @@
 	name = "A.R.A.S.A.K.A. mantis blade implants"
 	desc = "Modernized mantis blade designed coined by Tiger operatives, much sharper blade with energy actuators makes it a much deadlier weapon."
 	items_to_create = list(/obj/item/mantis_blade/syndicate)
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
 	encode_info = AUGMENT_SYNDICATE_LEVEL
 
 /obj/item/organ/internal/cyberimp/arm/item_set/syndie_mantis/l
@@ -104,10 +106,11 @@
 	name = "razorwire spool implant"
 	desc = "An integrated spool of razorwire, capable of being used as a weapon when whipped at your foes. \
 		Built into the back of your hand, try your best to not get it tangled."
-	items_to_create = list(/obj/item/melee/razorwire)
-	encode_info = AUGMENT_SYNDICATE_LEVEL
 	icon = 'monkestation/code/modules/cybernetics/icons/implants.dmi'
 	icon_state = "razorwire"
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
+	encode_info = AUGMENT_SYNDICATE_LEVEL
+	items_to_create = list(/obj/item/melee/razorwire)
 	visual_implant = TRUE
 	bodypart_overlay = /datum/bodypart_overlay/simple/razorwire
 

--- a/monkestation/code/modules/cybernetics/augments/arm_augments/unsorted.dm
+++ b/monkestation/code/modules/cybernetics/augments/arm_augments/unsorted.dm
@@ -204,6 +204,7 @@
 	update_hud_elements()
 
 /obj/item/organ/internal/cyberimp/arm/ammo_counter/syndicate
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
 	encode_info = AUGMENT_SYNDICATE_LEVEL
 
 /obj/item/organ/internal/cyberimp/arm/cooler

--- a/monkestation/code/modules/cybernetics/augments/chest_augments.dm
+++ b/monkestation/code/modules/cybernetics/augments/chest_augments.dm
@@ -16,10 +16,11 @@
 /obj/item/organ/internal/cyberimp/chest/sandevistan
 	name = "Militech Apogee Sandevistan"
 	desc = "This model of Sandevistan doesn't exist, at least officially. Off the record, there's gossip of secret Militech Lunar labs producing covert cyberware. It was never meant to be mass produced, but an army would only really need a few pieces like this one to dominate their enemy."
-	encode_info = AUGMENT_SYNDICATE_LEVEL
-	icon_state = "sandy"
-	actions_types = list(/datum/action/item_action/organ_action/sandy)
 	icon = 'monkestation/code/modules/cybernetics/icons/implants.dmi'
+	icon_state = "sandy"
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
+	encode_info = AUGMENT_SYNDICATE_LEVEL
+	actions_types = list(/datum/action/item_action/organ_action/sandy)
 
 	COOLDOWN_DECLARE(in_the_zone)
 	/// The bodypart overlay datum we should apply to whatever mob we are put into
@@ -60,7 +61,7 @@
 /obj/item/organ/internal/cyberimp/chest/sandevistan/refurbished
 	name = "refurbished sandevistan"
 	desc = "The branding has been scratched off of these and it looks hastily put together."
-
+	organ_flags = parent_type::organ_flags & ~ORGAN_HIDDEN
 	cooldown_time = 65 SECONDS
 
 /obj/item/organ/internal/cyberimp/chest/sandevistan/refurbished/ui_action_click(mob/user, actiontype)
@@ -94,9 +95,10 @@
 /obj/item/organ/internal/cyberimp/chest/chemvat
 	name = "R.A.G.E. chemical system"
 	desc = "Extremely dangerous system that fills the user with a mix of potent drugs."
-	encode_info = AUGMENT_SYNDICATE_LEVEL
-	icon_state = "chemvat_back_held"
 	icon = 'monkestation/code/modules/cybernetics/icons/implants_onmob.dmi'
+	icon_state = "chemvat_back_held"
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
+	encode_info = AUGMENT_SYNDICATE_LEVEL
 
 	var/obj/item/clothing/mask/chemvat/forced
 	var/obj/item/chemvat_tank/forced_tank
@@ -566,6 +568,7 @@
 	desc = "Short for Complementary Combat Maneuvering System, it processes spinal nerve signals and enacts forced complementary maneuvers on the opposite side of the user's body when they attack. In layman's terms, it lets you dual wield."
 	icon = 'monkestation/code/modules/cybernetics/icons/implants.dmi'
 	icon_state = "ccms"
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
 	encode_info = AUGMENT_SYNDICATE_LEVEL
 
 	visual_implant = TRUE

--- a/monkestation/code/modules/cybernetics/augments/leg_augments/chemplants.dm
+++ b/monkestation/code/modules/cybernetics/augments/leg_augments/chemplants.dm
@@ -76,6 +76,7 @@
 	name = "deep-vein emergency morale rejuvenator"
 	desc = "Dangerous implant used by the syndicate to reinforce their assault forces that go on suicide missions."
 	implant_color = "#74942a"
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
 	encode_info = AUGMENT_SYNDICATE_LEVEL
 	reagent_list = list(
 		/datum/reagent/determination = 5,

--- a/monkestation/code/modules/cybernetics/implant_items/autosurgeons.dm
+++ b/monkestation/code/modules/cybernetics/implant_items/autosurgeons.dm
@@ -1,3 +1,9 @@
+/obj/item/autosurgeon/organ/syndicate/Initialize(mapload)
+	. = ..()
+	if(istype(stored_organ, /obj/item/organ/internal/cyberimp))
+		var/obj/item/organ/internal/cyberimp/starting_implant = stored_organ
+		starting_implant.organ_flags |= ORGAN_HIDDEN
+
 /obj/item/autosurgeon/organ/syndicate/ammo_counter
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/ammo_counter/syndicate
 


### PR DESCRIPTION
## About This Pull Request

This makes it so syndicate implants (i.e mantis blades or sandevistan from the traitor uplink) are no longer revealed by health analyzers or examining with a medical HUD.

Just to be sure, any cybernetic implant that spawns as a part of a syndicate (suspicious) autosurgeon is given the "hidden" flag, altho the individual syndicate implants themselves are also given this flag on their own too.

## Changelog
:cl:
fix: Syndicate implants are now properly hidden from HUDs/scanners.
/:cl:
