### PR TITLE
Removes some company imports so you have to get them with science, and nerfs crew's retractor plates.

### DIFF
--- a/monkestation/code/modules/blueshift/armaments/deforest_medical.dm
+++ b/monkestation/code/modules/blueshift/armaments/deforest_medical.dm
@@ -181,10 +181,6 @@
 	item_type = /obj/item/surgery_tray
 	cost = PAYCHECK_COMMAND
 
-/datum/armament_entry/company_import/deforest/equipment/advanced_health_analyer
-	item_type = /obj/item/healthanalyzer/advanced
-	cost = PAYCHECK_COMMAND * 3
-
 /datum/armament_entry/company_import/deforest/equipment/penlite_defib_mount
 	item_type = /obj/item/wallframe/defib_mount/charging
 	cost = PAYCHECK_CREW * 3
@@ -242,7 +238,3 @@
 /datum/armament_entry/company_import/deforest/medical_modules/thread_ripper
 	name = "MOD thread ripper module"
 	item_type = /obj/item/mod/module/thread_ripper
-
-/datum/armament_entry/company_import/deforest/medical_modules/surgical_processor
-	name = "MOD surgical processor module"
-	item_type = /obj/item/mod/module/surgical_processor

--- a/monkestation/code/modules/blueshift/armaments/microstar.dm
+++ b/monkestation/code/modules/blueshift/armaments/microstar.dm
@@ -34,10 +34,6 @@
 	item_type = /obj/item/gun/energy/e_gun
 	cost = PAYCHECK_COMMAND * 4
 
-/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/mcr
-	item_type = /obj/item/gun/microfusion/mcr01/advanced
-	cost = PAYCHECK_COMMAND * 5
-
 /datum/armament_entry/company_import/microstar/basic_energy_long_weapons/mod_laser_small
 	item_type = /obj/item/gun/energy/modular_laser_rifle/carbine
 	cost = PAYCHECK_COMMAND * 5
@@ -54,3 +50,7 @@
 
 /datum/armament_entry/company_import/microstar/experimental_energy/hellfire
 	item_type = /obj/item/gun/energy/laser/hellgun
+
+/datum/armament_entry/company_import/microstar/experimental_energy/mcr
+	item_type = /obj/item/gun/microfusion/mcr01/advanced
+	restricted = FALSE

--- a/monkestation/code/modules/blueshift/armaments/microstar.dm
+++ b/monkestation/code/modules/blueshift/armaments/microstar.dm
@@ -34,6 +34,10 @@
 	item_type = /obj/item/gun/energy/e_gun
 	cost = PAYCHECK_COMMAND * 4
 
+/datum/armament_entry/company_import/microstar/basic_energy_long_weapons/mcr
+	item_type = /obj/item/gun/microfusion/mcr01/advanced
+	cost = PAYCHECK_COMMAND * 5
+
 /datum/armament_entry/company_import/microstar/basic_energy_long_weapons/mod_laser_small
 	item_type = /obj/item/gun/energy/modular_laser_rifle/carbine
 	cost = PAYCHECK_COMMAND * 5
@@ -50,12 +54,3 @@
 
 /datum/armament_entry/company_import/microstar/experimental_energy/hellfire
 	item_type = /obj/item/gun/energy/laser/hellgun
-
-/datum/armament_entry/company_import/microstar/experimental_energy/ion_carbine
-	item_type = /obj/item/gun/energy/ionrifle/carbine
-
-/datum/armament_entry/company_import/microstar/experimental_energy/xray_gun
-	item_type = /obj/item/gun/energy/xray
-
-/datum/armament_entry/company_import/microstar/experimental_energy/tesla_cannon
-	item_type = /obj/item/gun/energy/tesla_cannon

--- a/monkestation/code/modules/blueshift/armaments/nakamura.dm
+++ b/monkestation/code/modules/blueshift/armaments/nakamura.dm
@@ -19,43 +19,6 @@
 	item_type = /obj/item/mod/core/ethereal
 	cost = PAYCHECK_CREW
 
-// MOD plating
-
-/datum/armament_entry/company_import/nakamura_modsuits/plating
-	subcategory = "MOD External Plating"
-
-/datum/armament_entry/company_import/nakamura_modsuits/plating/standard
-	name = "MOD Standard Plating"
-	item_type = /obj/item/mod/construction/plating
-	cost = PAYCHECK_CREW
-
-/datum/armament_entry/company_import/nakamura_modsuits/plating/medical
-	name = "MOD Medical Plating"
-	item_type = /obj/item/mod/construction/plating/medical
-	cost = PAYCHECK_COMMAND
-
-/datum/armament_entry/company_import/nakamura_modsuits/plating/engineering
-	name = "MOD Engineering Plating"
-	item_type = /obj/item/mod/construction/plating/engineering
-	cost = PAYCHECK_COMMAND
-
-/datum/armament_entry/company_import/nakamura_modsuits/plating/atmospherics
-	name = "MOD Atmospherics Plating"
-	item_type = /obj/item/mod/construction/plating/atmospheric
-	cost = PAYCHECK_COMMAND
-
-/datum/armament_entry/company_import/nakamura_modsuits/plating/security
-	name = "MOD Security Plating"
-	item_type = /obj/item/mod/construction/plating/security
-	cost = PAYCHECK_COMMAND * 2
-	restricted = TRUE
-
-/datum/armament_entry/company_import/nakamura_modsuits/plating/clown
-	name = "MOD CosmoHonk (TM) Plating"
-	item_type = /obj/item/mod/construction/plating/cosmohonk
-	cost = PAYCHECK_COMMAND * 2
-	contraband = TRUE
-
 // MOD modules
 
 // Protection, so shielding and whatnot

--- a/monkestation/code/modules/blueshift/armaments/nakamura.dm
+++ b/monkestation/code/modules/blueshift/armaments/nakamura.dm
@@ -114,8 +114,8 @@
 	item_type = /obj/item/mod/module/storage
 	cost = PAYCHECK_LOWER
 
-/datum/armament_entry/company_import/nakamura_modsuits/utility_modules/expanded_storage
-	item_type = /obj/item/mod/module/storage/large_capacity
+/datum/armament_entry/company_import/nakamura_modsuits/utility_modules/pepper
+	item_type = /obj/item/mod/module/pepper_shoulders
 	cost = PAYCHECK_COMMAND
 
 /datum/armament_entry/company_import/nakamura_modsuits/utility_modules/retract_plates
@@ -190,15 +190,3 @@
 /datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/hat_stabilizer
 	item_type = /obj/item/mod/module/hat_stabilizer
 	cost = PAYCHECK_CREW
-
-/datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/kinesis
-	item_type = /obj/item/mod/module/anomaly_locked/kinesis/prebuilt/locked
-	cost = PAYCHECK_COMMAND * 15
-
-/datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/antigrav
-	item_type = /obj/item/mod/module/anomaly_locked/antigrav/prebuilt/locked
-	cost = PAYCHECK_COMMAND * 15
-
-/datum/armament_entry/company_import/nakamura_modsuits/novelty_modules/teleporter
-	item_type = /obj/item/mod/module/anomaly_locked/teleporter/prebuilt/locked
-	cost = PAYCHECK_COMMAND * 20

--- a/monkestation/code/modules/blueshift/armaments/nakamura.dm
+++ b/monkestation/code/modules/blueshift/armaments/nakamura.dm
@@ -80,6 +80,7 @@
 /datum/armament_entry/company_import/nakamura_modsuits/utility_modules/pepper
 	item_type = /obj/item/mod/module/pepper_shoulders
 	cost = PAYCHECK_COMMAND
+	restricted = TRUE
 
 /datum/armament_entry/company_import/nakamura_modsuits/utility_modules/retract_plates
 	item_type = /obj/item/mod/module/plate_compression

--- a/monkestation/code/modules/blueshift/items/retractable_armor.dm
+++ b/monkestation/code/modules/blueshift/items/retractable_armor.dm
@@ -5,6 +5,7 @@
 	complexity = 3
 	speed_added = 0.25
 	armor_mod = /datum/armor/retractive_plates
+	removable = TRUE
 
 /datum/armor/retractive_plates
 	melee = 20

--- a/monkestation/code/modules/blueshift/items/retractable_armor.dm
+++ b/monkestation/code/modules/blueshift/items/retractable_armor.dm
@@ -2,7 +2,7 @@
 	name = "MOD retractive plates module"
 	desc = "A complex set of actuators, micro-seals and a simple guide on how to install it, This... \"Modification\" allows the plating around the joints to retract, giving minor protection and a bit better mobility."
 	removable = TRUE
-	complexity = 1
+	complexity = 3
 	speed_added = 0.25
 	armor_mod = /datum/armor/retractive_plates
 


### PR DESCRIPTION

## About The Pull Request
-Removes x-ray gun from imports.
-Removes ion carbine from imports.
-Removes tesla cannon from imports.
-Removes anomaly locked modules from imports.
-Removes large mod storage module from company imports.
-Removes MOD plating from company imports.
-Nerfs the retractor plates available in company imports to have 3 complexity. (From 1)
-Adds MCR and pepper shoulders to imports. (So it isn't so lonely after removals.)
-Makes retractor plates removable because why shouldn't they be.

## Why It's Good For The Game
Company imports shouldn't be replacing the need for science to research things and gather anomalies, and people being able to order stuff like x-ray guns immediately in the round can unbalance the game.
MCR and pepper shoulders help make the imports not as lonely after the removals.
For being such a straight upgrade retractor plates should take a non-insignificant amount of complexity. (It might still deserve nerfs after this but that's not for this PR.)

## Changelog
:cl:
add: Adds MCR and pepperspray shoulders to company imports.
balance: Removes some science locked things from company imports.
balance: Removes anomaly locked modsuit modules from company imports.
balance: Crew retractor modsuit module now takes 3 complexity, and can be removed after installation.
/:cl:
