### PR TITLE
Doubles number of explorer role slots

### DIFF
--- a/monkestation/code/modules/jobs/job_types/explorer.dm
+++ b/monkestation/code/modules/jobs/job_types/explorer.dm
@@ -4,8 +4,8 @@
 		Visit strange places. Die in space."
 	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 6
+	spawn_positions = 6
 	supervisors = SUPERVISOR_QM
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "EXPLORER"

--- a/monkestation/code/modules/ranching/satyr/abilities.dm
+++ b/monkestation/code/modules/ranching/satyr/abilities.dm
@@ -1,7 +1,7 @@
 /datum/action/cooldown/mob_cooldown/dash/headbutt
 	name = "Headbutt"
 	desc = "Dashes 3 tiles in a direction headbutting anyone in the last tile. (You can overshoot your dash!)"
-	check_flags = AB_CHECK_INCAPACITATED | AB_CHECK_HANDS_BLOCKED | AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_INCAPACITATED | AB_CHECK_HANDS_BLOCKED | AB_CHECK_CONSCIOUS | AB_CHECK_IMMOBILE
 	cooldown_time = 1 MINUTES
 	dash_range = 3
 

--- a/monkestation/code/modules/ranching/satyr/abilities.dm
+++ b/monkestation/code/modules/ranching/satyr/abilities.dm
@@ -1,7 +1,6 @@
 /datum/action/cooldown/mob_cooldown/dash/headbutt
 	name = "Headbutt"
 	desc = "Dashes 3 tiles in a direction headbutting anyone in the last tile. (You can overshoot your dash!)"
-	check_flags = AB_CHECK_INCAPACITATED | AB_CHECK_HANDS_BLOCKED | AB_CHECK_CONSCIOUS | AB_CHECK_IMMOBILE
 	cooldown_time = 1 MINUTES
 	dash_range = 3
 

--- a/monkestation/code/modules/ranching/satyr/abilities.dm
+++ b/monkestation/code/modules/ranching/satyr/abilities.dm
@@ -1,6 +1,7 @@
 /datum/action/cooldown/mob_cooldown/dash/headbutt
 	name = "Headbutt"
 	desc = "Dashes 3 tiles in a direction headbutting anyone in the last tile. (You can overshoot your dash!)"
+	check_flags = AB_CHECK_INCAPACITATED | AB_CHECK_HANDS_BLOCKED | AB_CHECK_CONSCIOUS
 	cooldown_time = 1 MINUTES
 	dash_range = 3
 


### PR DESCRIPTION

## About The Pull Request
Increases number of explorer job slots from 3 to 6.

## Why It's Good For The Game
Honestly not a big fan of explorer as a job, but I do think we need this.
Explorer fills up literally every round as far as I've seen.
We want more people in space based off the recent annoucements and have done lots to encourage space explorer. However we have also buffed space around these guys adding tons of deadly threats and otherwise making it hard for non explorers to explore space without making massive prep which while not bad, really just puts them behind and makes it almost pointless to explore if you aren't one of these guys.

Increasing the number of explorers will allow more people to explore space again as we want. More people in space also makes more interaction in space and otherwise.

It may need a bigger increase, if it continues to fill up every round I may make another increase PR. 

## Changelog

:cl:
add: Explorer now has 6 slots
/:cl:

