### PR TITLE
Raising the Tower of Babel: try 3

### DIFF
--- a/code/modules/admin/smites/curse_of_babel.dm
+++ b/code/modules/admin/smites/curse_of_babel.dm
@@ -1,3 +1,4 @@
+/* monkestation removal. if you REALLY want to do this for some reason, call the proc yourself.
 /// Strikes the target with a lightning bolt
 /datum/smite/curse_of_babel
 	name = "Curse of Babel"
@@ -15,3 +16,4 @@
 
 	target.apply_status_effect(/datum/status_effect/tower_of_babel, duration)
 	to_chat(target, span_userdanger("The gods have punished you for your sins!"), confidential = TRUE)
+monkestation end */

--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -294,6 +294,7 @@ GLOBAL_DATUM(everyone_an_antag, /datum/everyone_is_an_antag_controller)
 
 			summon_magic(holder.mob, survivor_probability)
 
+/* monkestation removal: if you REALLY want to do this for some reason, call the proc yourself.
 		if("towerOfBabel")
 			if(!is_funmin)
 				return
@@ -305,6 +306,7 @@ GLOBAL_DATUM(everyone_an_antag, /datum/everyone_is_an_antag_controller)
 			if(!is_funmin)
 				return
 			holder.tower_of_babel_undo()
+monkestation end */
 
 		if("events")
 			if(!is_funmin)

--- a/code/modules/events/wizard/tower_of_babel.dm
+++ b/code/modules/events/wizard/tower_of_babel.dm
@@ -1,3 +1,4 @@
+/* monkestation removal. if you REALLY want to do this for some reason, call the proc yourself.
 /datum/round_event_control/wizard/tower_of_babel
 	name = "Tower of Babel"
 	weight = 3
@@ -10,4 +11,4 @@
 
 /datum/round_event/wizard/tower_of_babel/start()
 	GLOB.tower_of_babel = new /datum/tower_of_babel()
-
+monkestation end */

--- a/code/modules/mob/living/basic/space_fauna/carp/magicarp.dm
+++ b/code/modules/mob/living/basic/space_fauna/carp/magicarp.dm
@@ -9,7 +9,7 @@ GLOBAL_LIST_INIT(magicarp_spell_types, list(
 	/obj/projectile/magic/resurrection = "vital",
 	/obj/projectile/magic/spellblade = "vorpal",
 	/obj/projectile/magic/teleport = "warping",
-	/obj/projectile/magic/babel = "babbling",
+	/* /obj/projectile/magic/babel = "babbling", [monkestation removal: staff of babel is admin-only now] */
 ))
 
 /// A reduced list of spells for magicarp spawned in xenobiology, less disruptive
@@ -33,7 +33,7 @@ GLOBAL_LIST_INIT(magicarp_spell_colours, list(
 	/obj/projectile/magic/resurrection = COLOR_CARP_PALE_GREEN,
 	/obj/projectile/magic/spellblade = COLOR_CARP_SILVER,
 	/obj/projectile/magic/teleport = COLOR_CARP_GRAPE,
-	/obj/projectile/magic/babel = COLOR_CARP_BROWN,
+	/*  /obj/projectile/magic/babel = COLOR_CARP_BROWN, [monkestation removal: staff of babel is admin-only now] */
 ))
 
 /**

--- a/code/modules/spells/spell_types/right_and_wrong.dm
+++ b/code/modules/spells/spell_types/right_and_wrong.dm
@@ -81,7 +81,7 @@ GLOBAL_LIST_INIT(summoned_magic, list(
 	/obj/item/gun/magic/wand/fireball,
 	/obj/item/gun/magic/staff/healing,
 	/obj/item/gun/magic/staff/door,
-	/obj/item/gun/magic/staff/babel,
+	/* /obj/item/gun/magic/staff/babel, [monkestation removal: this is admin only now] */	
 	/obj/item/scrying,
 	/obj/item/warp_whistle,
 	/obj/item/immortality_talisman,

--- a/monkestation/code/modules/spells/spell_types/pointed/smite.dm
+++ b/monkestation/code/modules/spells/spell_types/pointed/smite.dm
@@ -25,7 +25,7 @@
 	var/list/heavy_smites = list(/datum/smite/berforate, /datum/smite/bloodless, /datum/smite/boneless, /datum/smite/brain_damage, /datum/smite/bread, /datum/smite/bsa, \
 								 /datum/smite/fireball, /datum/smite/gib, /datum/smite/lightning, /datum/smite/nugget, /datum/smite/puzzgrid, /datum/smite/puzzle)
 	//list of smites that have a low effect on the target
-	var/list/light_smites = list(/datum/smite/bad_luck, /datum/smite/curse_of_babel, /datum/smite/fake_bwoink, /datum/smite/fat, /datum/smite/ghost_control, /datum/smite/immerse, \
+	var/list/light_smites = list(/datum/smite/bad_luck, /* /datum/smite/curse_of_babel, */ /datum/smite/fake_bwoink, /datum/smite/fat, /datum/smite/ghost_control, /datum/smite/immerse, \
 								 /datum/smite/knot_shoes, /datum/smite/ocky_icky, /datum/smite/scarify)
 
 /datum/action/cooldown/spell/pointed/smite/is_valid_target(atom/cast_on)
@@ -61,10 +61,12 @@
 			var/datum/smite/berforate/shoot_smite = new picked_smite
 			shoot_smite.hatred = "A lot"
 			do_smite(shoot_smite, cast_on)
+/* monkestation removal: no. just. no.
 		if(/datum/smite/curse_of_babel)
 			var/datum/smite/curse_of_babel/babel_smite = new picked_smite
 			babel_smite.duration = 5 MINUTES
 			do_smite(babel_smite, cast_on)
+monkestation end */
 		if(/datum/smite/puzzgrid)
 			var/datum/smite/puzzgrid/puzz_smite = new picked_smite
 			puzz_smite.gib_on_loss = TRUE

--- a/monkestation/code/modules/spells/spell_types/pointed/smite.dm
+++ b/monkestation/code/modules/spells/spell_types/pointed/smite.dm
@@ -25,7 +25,7 @@
 	var/list/heavy_smites = list(/datum/smite/berforate, /datum/smite/bloodless, /datum/smite/boneless, /datum/smite/brain_damage, /datum/smite/bread, /datum/smite/bsa, \
 								 /datum/smite/fireball, /datum/smite/gib, /datum/smite/lightning, /datum/smite/nugget, /datum/smite/puzzgrid, /datum/smite/puzzle)
 	//list of smites that have a low effect on the target
-	var/list/light_smites = list(/datum/smite/bad_luck, /* /datum/smite/curse_of_babel, */ /datum/smite/fake_bwoink, /datum/smite/fat, /datum/smite/ghost_control, /datum/smite/immerse, \
+	var/list/light_smites = list(/datum/smite/bad_luck, /datum/smite/fake_bwoink, /datum/smite/fat, /datum/smite/ghost_control, /datum/smite/immerse, \
 								 /datum/smite/knot_shoes, /datum/smite/ocky_icky, /datum/smite/scarify)
 
 /datum/action/cooldown/spell/pointed/smite/is_valid_target(atom/cast_on)
@@ -61,12 +61,6 @@
 			var/datum/smite/berforate/shoot_smite = new picked_smite
 			shoot_smite.hatred = "A lot"
 			do_smite(shoot_smite, cast_on)
-/* monkestation removal: no. just. no.
-		if(/datum/smite/curse_of_babel)
-			var/datum/smite/curse_of_babel/babel_smite = new picked_smite
-			babel_smite.duration = 5 MINUTES
-			do_smite(babel_smite, cast_on)
-monkestation end */
 		if(/datum/smite/puzzgrid)
 			var/datum/smite/puzzgrid/puzz_smite = new picked_smite
 			puzz_smite.gib_on_loss = TRUE

--- a/tgui/packages/tgui/interfaces/Secrets.jsx
+++ b/tgui/packages/tgui/interfaces/Secrets.jsx
@@ -598,32 +598,6 @@ const FunForYouTab = (props) => {
           </Stack.Item>
         </Stack>
       </Stack.Item>
-      <Stack.Item>
-        <Stack fill>
-          <Stack.Item>
-            <NoticeBox danger width={19.6} mb={0}>
-              <Button
-                color="red"
-                icon="comment-slash"
-                fluid
-                content="Tower of Babel"
-                onClick={() => act('towerOfBabel')}
-              />
-            </NoticeBox>
-          </Stack.Item>
-          <Stack.Item>
-            <NoticeBox info width={19.6} mb={0}>
-              <Button
-                color="blue"
-                icon="comment"
-                fluid
-                content="Undo Tower of Babel"
-                onClick={() => act('cureTowerOfBabel')}
-              />
-            </NoticeBox>
-          </Stack.Item>
-        </Stack>
-      </Stack.Item>
     </Stack>
   );
 };


### PR DESCRIPTION
## About The Pull Request

This removes the Tower of Babel wizard event + smite.

Admins can still trigger Tower of Babel, either individually or globally, if they _really really insist on it_ (please don't, for everyone's sake), through manually calling procs.

[i just made a new pr instead of reopening it so it wouldn't be forgotten at the bottom of the list]

## Why It's Good For The Game

This place is a message... and part of a system of messages... pay attention to it!
Sending this message was important to us. We considered ourselves to be a powerful culture.
This place is not a place of honor... no highly esteemed deed is commemorated here... nothing valued is here.
What is here was dangerous and repulsive to us. This message is a warning about danger. 

## Changelog
:cl:
del: Removed the Tower of Babel wizard event.
del: Staff of Babel is now admin-only.
/:cl:
