### PR TITLE
Fixes Issue:4401, letting you print AP shells with the ammo workbench

### DIFF
--- a/monkestation/code/modules/blueshift/items/ammo.dm
+++ b/monkestation/code/modules/blueshift/items/ammo.dm
@@ -1094,6 +1094,12 @@
 	desc = "A 12 gauge iron slug."
 	custom_materials = AMMO_MATS_SHOTGUN
 
+/obj/item/ammo_casing/shotgun/apds  //This SHOULD let you print the shells in the ammo lathe
+	can_be_printed = TRUE
+	advanced_print_req = TRUE
+	custom_materials = AMMO_MATS_SHOTGUN_PLASMA //plastanium -> tungsten approximation
+
+
 // THE BELOW TWO SLUGS ARE NOTED AS ADMINONLY AND HAVE ***EIGHTY*** WOUND BONUS. NOT BARE WOUND BONUS. FLAT WOUND BONUS.
 /obj/item/ammo_casing/shotgun/executioner
 	name = "expanding shotgun slug"


### PR DESCRIPTION

## About The Pull Request
Re: Title
## Why It's Good For The Game
All the other "standard" shells can be printed at the ammo workbench, why not these?
## Changelog
:cl:
fix: You can now print AP shells at the ammo workbench
/:cl:
