### PR TITLE
Costume "armor" storage buff

### DIFF
--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -66,7 +66,10 @@
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	armor_type = /datum/armor/costume_justice
-	allowed = GLOB.security_vest_allowed
+
+/obj/item/clothing/suit/costume/justice/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.security_vest_allowed
 
 /datum/armor/costume_justice
 	melee = 35
@@ -553,7 +556,11 @@
 	icon_state = "soviet_suit"
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	allowed = GLOB.security_vest_allowed
+
+/obj/item/clothing/suit/costume/soviet/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.security_vest_allowed
+
 
 /obj/item/clothing/suit/costume/yuri
 	name = "yuri initiate coat"
@@ -561,7 +568,10 @@
 	icon_state = "yuri_coat"
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|ARMS
-	allowed = GLOB.security_vest_allowed
+
+/obj/item/clothing/suit/costume/yuri/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.security_vest_allowed
 
 /obj/item/clothing/suit/costume/tmc
 	name = "\improper Lost M.C. cut"
@@ -586,4 +596,7 @@
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
-	allowed = GLOB.security_vest_allowed
+
+/obj/item/clothing/suit/costume/irs/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.security_vest_allowed

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -66,6 +66,7 @@
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	armor_type = /datum/armor/costume_justice
+	allowed = GLOB.security_vest_allowed
 
 /datum/armor/costume_justice
 	melee = 35
@@ -552,6 +553,7 @@
 	icon_state = "soviet_suit"
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
+	allowed = GLOB.security_vest_allowed
 
 /obj/item/clothing/suit/costume/yuri
 	name = "yuri initiate coat"
@@ -559,6 +561,7 @@
 	icon_state = "yuri_coat"
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|ARMS
+	allowed = GLOB.security_vest_allowed
 
 /obj/item/clothing/suit/costume/tmc
 	name = "\improper Lost M.C. cut"
@@ -583,3 +586,4 @@
 	inhand_icon_state = null
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+	allowed = GLOB.security_vest_allowed

--- a/monkestation/code/modules/clothing/suits/coats.dm
+++ b/monkestation/code/modules/clothing/suits/coats.dm
@@ -116,6 +116,7 @@
 	icon = 'monkestation/icons/obj/clothing/suits.dmi'
 	worn_icon = 'monkestation/icons/mob/clothing/suit.dmi'
 	icon_state = "guardman_vest"
+	allowed = GLOB.security_vest_allowed
 
 /obj/item/clothing/suit/armor/civilprotection_vest
 	name = "civil protection vest"
@@ -123,6 +124,7 @@
 	icon = 'monkestation/icons/obj/clothing/suits.dmi'
 	worn_icon = 'monkestation/icons/mob/clothing/suit.dmi'
 	icon_state = "civilprotection_vest"
+	allowed = GLOB.security_vest_allowed
 
 //Only basic and scientist labcoats get to STAPH
 

--- a/monkestation/code/modules/clothing/suits/coats.dm
+++ b/monkestation/code/modules/clothing/suits/coats.dm
@@ -116,7 +116,10 @@
 	icon = 'monkestation/icons/obj/clothing/suits.dmi'
 	worn_icon = 'monkestation/icons/mob/clothing/suit.dmi'
 	icon_state = "guardman_vest"
-	allowed = GLOB.security_vest_allowed
+
+/obj/item/clothing/suit/armor/guardmanvest/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.security_vest_allowed
 
 /obj/item/clothing/suit/armor/civilprotection_vest
 	name = "civil protection vest"
@@ -124,7 +127,11 @@
 	icon = 'monkestation/icons/obj/clothing/suits.dmi'
 	worn_icon = 'monkestation/icons/mob/clothing/suit.dmi'
 	icon_state = "civilprotection_vest"
-	allowed = GLOB.security_vest_allowed
+
+/obj/item/clothing/suit/armor/civilprotection_vest/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.security_vest_allowed
+
 
 //Only basic and scientist labcoats get to STAPH
 

--- a/monkestation/code/modules/clothing/suits/costume.dm
+++ b/monkestation/code/modules/clothing/suits/costume.dm
@@ -97,7 +97,10 @@
 	icon_state = "helldiver_armor"
 	worn_icon_state = "helldiver_armor"
 	flags_inv = HIDEJUMPSUIT
-	allowed = GLOB.security_vest_allowed
+
+/obj/item/clothing/suit/helldiverarmor/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.security_vest_allowed
 
 /datum/loadout_item/suit/helldiverarmor
 	name = "Helldiver Armor"

--- a/monkestation/code/modules/clothing/suits/costume.dm
+++ b/monkestation/code/modules/clothing/suits/costume.dm
@@ -97,6 +97,7 @@
 	icon_state = "helldiver_armor"
 	worn_icon_state = "helldiver_armor"
 	flags_inv = HIDEJUMPSUIT
+	allowed = GLOB.security_vest_allowed
 
 /datum/loadout_item/suit/helldiverarmor
 	name = "Helldiver Armor"

--- a/monkestation/code/modules/clothing/~donator/clothing.dm
+++ b/monkestation/code/modules/clothing/~donator/clothing.dm
@@ -442,6 +442,7 @@
 	dog_fashion = /datum/dog_fashion/back
 	supports_variations_flags = NONE
 	armor_type = /datum/armor/none
+	allowed = GLOB.security_vest_allowed
 
 // Donation reward for inferno707
 /obj/item/clothing/mask/hheart
@@ -542,6 +543,7 @@
 	worn_icon = 'monkestation/icons/donator/mob/clothing/suit.dmi'
 	worn_icon_state = "scraparmor"
 	body_parts_covered = CHEST
+	allowed = GLOB.security_vest_allowed
 
 // Donation reward for Enzoman
 /obj/item/clothing/mask/luchador/enzo

--- a/monkestation/code/modules/clothing/~donator/clothing.dm
+++ b/monkestation/code/modules/clothing/~donator/clothing.dm
@@ -442,7 +442,10 @@
 	dog_fashion = /datum/dog_fashion/back
 	supports_variations_flags = NONE
 	armor_type = /datum/armor/none
-	allowed = GLOB.security_vest_allowed
+
+/obj/item/clothing/suit/armor/vest/darkcarapace/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.security_vest_allowed
 
 // Donation reward for inferno707
 /obj/item/clothing/mask/hheart
@@ -543,7 +546,10 @@
 	worn_icon = 'monkestation/icons/donator/mob/clothing/suit.dmi'
 	worn_icon_state = "scraparmor"
 	body_parts_covered = CHEST
-	allowed = GLOB.security_vest_allowed
+
+/obj/item/clothing/suit/scraparmour/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.security_vest_allowed
 
 // Donation reward for Enzoman
 /obj/item/clothing/mask/luchador/enzo


### PR DESCRIPTION

## About The Pull Request
Lets costume "armor" hold the same stuff as security armor.
## Why It's Good For The Game
It was requested for a specific suit of it (helldivers) in support of a gimmick, but on reflection I don't see why all costume armor shouldn't have it.
If someone wants to forgo wearing easily-obtainable real armor in favor of drip, they may as well at least be able to fit a pistol in it.
It is not as though getting REAL armor for powergaming is difficult, thus I don't see any issues with exploiting it.
## Changelog
:cl:
balance: Most costume armors now have the same storage as security armor
/:cl:
