### PR TITLE
Add an "Export Lighting Info" mapping verb

### DIFF
--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -55,6 +55,7 @@ GLOBAL_LIST_INIT(admin_verbs_debug_mapping, list(
 	/client/proc/station_food_debug,
 	/client/proc/station_stack_debug,
 	/client/proc/check_for_obstructed_atmospherics,
+	/client/proc/export_lighting_info, // monkestation addition
 ))
 GLOBAL_PROTECT(admin_verbs_debug_mapping)
 

--- a/monkestation/code/modules/admin/verbs/mapping.dm
+++ b/monkestation/code/modules/admin/verbs/mapping.dm
@@ -1,0 +1,47 @@
+/// Returns a list of the lighting level of each open turf on a z-level.
+/proc/encode_lighting_levels(z) as /list
+	RETURN_TYPE(/list)
+	if(!isnum(z) || !ISINRANGE(z, 1, world.maxz))
+		z = SSmapping.levels_by_trait(ZTRAIT_STATION)[1]
+		stack_trace("Invalid z-level given, defaulting to first station z-level ([z])")
+	var/list/lighting = new(world.maxx, world.maxy)
+	for(var/turf/open/floor/floor in Z_TURFS(z))
+		lighting[floor.x][floor.y] = floor.is_softly_lit() ? 0 : floor.get_lumcount()
+		CHECK_TICK
+	return lighting
+
+/client/proc/export_lighting_info()
+	set name = "Export Lighting Info"
+	set desc = "Exports a JSON file containing info about the lighting level of all floor turfs on a given Z-level."
+	set category = "Mapping"
+
+	if(!check_rights(R_DEBUG))
+		return
+	var/list/options = list("All Station Z-Levels")
+	var/turf/our_turf = get_turf(mob)
+	if(!isnewplayer(mob) && !isnull(our_turf))
+		options += "Current Z-Level"
+	var/list/zs
+	switch(tgui_alert(src, "What Z-levels would you like to export lighting info for?", "Select Z Levels", options + list("Cancel")))
+		if("All Station Z-Levels")
+			zs = SSmapping.levels_by_trait(ZTRAIT_STATION)
+		if("Current Z-Level")
+			zs = list(our_turf.z)
+		else
+			return
+
+	var/list/lighting_info = list()
+	switch(length(zs))
+		if(1)
+			lighting_info = encode_lighting_levels(zs[1])
+		if(2 to INFINITY)
+			for(var/z in zs)
+				lighting_info["[z]"] = encode_lighting_levels(z)
+		else
+			to_chat(src, span_warning("No Z-levels selected!"))
+			return
+
+	var/file_name = "[ckey]_lighting_info_[time2text(world.timeofday, "MMM_DD_YYYY_hh-mm-ss")].json"
+	var/json_file = file("tmp/[file_name]")
+	WRITE_FILE(json_file, json_encode(lighting_info))
+	DIRECT_OUTPUT(src, ftp(json_file, file_name))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6164,6 +6164,7 @@
 #include "monkestation\code\modules\admin\smites\where_are_your_fingers.dm"
 #include "monkestation\code\modules\admin\verbs\getlogs.dm"
 #include "monkestation\code\modules\admin\verbs\kick_player_by_ckey.dm"
+#include "monkestation\code\modules\admin\verbs\mapping.dm"
 #include "monkestation\code\modules\admin\verbs\selectequipment.dm"
 #include "monkestation\code\modules\admin\verbs\spawn_mixtape.dm"
 #include "monkestation\code\modules\admin\verbs\tracy.dm"


### PR DESCRIPTION

## About The Pull Request

This adds a mapping verb (behind Mapping Verbs - Enable) that exports the lighting info of z levels into a json file, for use with https://github.com/Absolucy/lighting-info-overlay

## Why It's Good For The Game

Useful tooling for helping improve lighting coverage in maps.

## Changelog
:cl:
admin: Added a new mapping verb, Export Lighting Info (behind Mapping Verbs - Enable) that exports the lighting info of z levels into a json file.
/:cl:
