### PR TITLE
Fix some clothing not updating when alt clicked while worn

### DIFF
--- a/monkestation/code/modules/blueshift/components/toggle_clothing.dm
+++ b/monkestation/code/modules/blueshift/components/toggle_clothing.dm
@@ -24,4 +24,5 @@
 	toggled = !toggled
 	source.icon_state = (toggled ? toggled_icon_state : initial(source.icon_state))
 	to_chat(clicker, "You toggle \the [source]!")
+	source.update_slot_icon()
 	clicker.update_appearance()


### PR DESCRIPTION

## About The Pull Request
Title, most notably ponchos, the cardigan, the small bow, the long cap, and the mentor cloak.
## Why It's Good For The Game
Bug bad
## Changelog
:cl:
fix: Fixed some loadout clothing not updating after alt-clicking while worn
/:cl:
