### PR TITLE
Spatial Rift Nullifier buffs + refactor

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -24,7 +24,7 @@
 
 	// Traitor steal objective
 	new /obj/item/areaeditor/blueprints(src)
-	new /obj/item/gun/ballistic/SRN_rocketlauncher(src)
+	new /obj/item/gun/ballistic/srn_rocketlauncher(src)
 	new /obj/item/pipe_dispenser(src)
 
 /obj/structure/closet/secure_closet/engineering_electrical

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -24,7 +24,6 @@
 
 	// Traitor steal objective
 	new /obj/item/areaeditor/blueprints(src)
-	new /obj/item/gun/ballistic/srn_rocketlauncher(src)
 	new /obj/item/pipe_dispenser(src)
 
 /obj/structure/closet/secure_closet/engineering_electrical

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -437,6 +437,8 @@
 	..()
 	if(current_size >= STAGE_THREE)
 		for(var/obj/item/hand in held_items)
+			if(istype(hand, /obj/item/gun/ballistic/srn_rocketlauncher) && HAS_TRAIT(hand, TRAIT_WIELDED)) // monkestation edit: remember to wield your SRN so it won't get yanked out of your hand
+				continue
 			if(prob(current_size * 5) && hand.w_class >= ((11-current_size)/2)  && dropItemToGround(hand))
 				step_towards(hand, src)
 				to_chat(src, span_warning("\The [S] pulls \the [hand] from your grip!"))

--- a/monkestation/code/datums/components/singularity.dm
+++ b/monkestation/code/datums/components/singularity.dm
@@ -1,0 +1,4 @@
+/datum/component/singularity/consume_bullets(datum/source, obj/projectile/projectile)
+	if(istype(projectile, /obj/projectile/bullet/srn_rocket))
+		return NONE
+	return ..()

--- a/monkestation/code/game/objects/items/guns/SRN.dm
+++ b/monkestation/code/game/objects/items/guns/SRN.dm
@@ -1,4 +1,6 @@
-/obj/item/gun/ballistic/SRN_rocketlauncher
+GLOBAL_VAR_INIT(_TEST_HOMING_SPEED, 5)
+
+/obj/item/gun/ballistic/srn_rocketlauncher
 	desc = "A rocket designed with the power of bluespace to send a singularity or tesla back to the shadow realm"
 	name = "Spatial Rift Nullifier"
 	icon = 'monkestation/icons/obj/guns/guns.dmi'
@@ -6,7 +8,7 @@
 	inhand_icon_state = "srnlauncher"
 	lefthand_file = 'monkestation/icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'monkestation/icons/mob/inhands/weapons/guns_righthand.dmi'
-	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/SRN_rocket
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/srn_rocket
 	fire_sound = 'sound/weapons/gun/general/rocket_launch.ogg'
 	bolt_type = BOLT_TYPE_NO_BOLT
 	fire_sound_volume = 80
@@ -24,85 +26,145 @@
 	empty_alarm = TRUE
 	tac_reloads = FALSE
 
-/obj/item/gun/ballistic/SRN_rocketlauncher/attack_self(mob/user)
+/obj/item/gun/ballistic/srn_rocketlauncher/attack_self(mob/user)
 	return //too difficult to remove the rocket with TK
 
-/obj/item/gun/ballistic/SRN_rocketlauncher/chamber_round(keep_bullet = FALSE, spin_cylinder, replace_new_round)
+/obj/item/gun/ballistic/srn_rocketlauncher/chamber_round(keep_bullet = FALSE, spin_cylinder, replace_new_round)
 	chambered = magazine.get_round(FALSE)
 
 
-
 ///SRN Internal Magazine
-/obj/item/ammo_box/magazine/internal/SRN_rocket
+/obj/item/ammo_box/magazine/internal/srn_rocket
 	name = "SRN Rocket"
-	ammo_type = /obj/item/ammo_casing/caseless/SRN_rocket
+	ammo_type = /obj/item/ammo_casing/caseless/srn_rocket
 	caliber = "84mm"
 	max_ammo = 3
 
-
-
 /// SRN caseless ammo casing
-/obj/item/ammo_casing/caseless/SRN_rocket
+/obj/item/ammo_casing/caseless/srn_rocket
 	name = "\improper Spatial Rift Nullifier Rocket"
 	desc = "A prototype Spatial Rift Nullifier (SRN) Rocket. Fire at a rogue singularity or Tesla and pray it hits"
 	caliber = "84mm"
 	icon = 'monkestation/icons/obj/guns/projectiles.dmi'
 	icon_state = "srn_rocket"
-	projectile_type = /obj/projectile/bullet/SRN_rocket
+	projectile_type = /obj/projectile/bullet/srn_rocket
 
-
+/obj/item/ammo_casing/caseless/srn_rocket/ready_proj(atom/target, mob/living/user, quiet, zone_override, atom/fired_from)
+	. = ..()
+	if(!loaded_projectile)
+		return
+	if(is_srn_target(target))
+		loaded_projectile.set_homing_target(target)
+	else
+		var/obj/new_target = find_nearest_srn_target(fired_from)
+		if(!QDELETED(new_target))
+			loaded_projectile.original = new_target
+			loaded_projectile.set_homing_target(new_target)
 
 /// SRN Rocket Projectile
-/obj/projectile/bullet/SRN_rocket
+/obj/projectile/bullet/srn_rocket
 	name = "SRN rocket"
 	icon = 'monkestation/icons/obj/guns/projectiles.dmi'
 	icon_state = "srn_rocket"
-	hitsound = "sound/effects/meteorimpact.ogg"
+	hitsound = 'sound/effects/meteorimpact.ogg'
 	damage = 10
 	ricochets_max = 0 //it's a MISSILE
+	projectile_phasing = PASSTABLE | PASSGRILLE
+	var/pierces_remaining = 3
+	var/static/list/pierce_costs
 
-/obj/projectile/bullet/SRN_rocket/on_hit(atom/target, blocked = 0, pierce_hit)
+/obj/projectile/bullet/srn_rocket/Initialize(mapload)
+	. = ..()
+	homing_turn_speed = GLOB._TEST_HOMING_SPEED
+	if(isnull(pierce_costs))
+		pierce_costs = zebra_typecacheof(list(
+			/turf/closed/wall = 1,
+			/turf/closed/mineral = 1.5,
+			/obj/structure/falsewall = 1,
+			/obj/structure/window = 0.5,
+			/obj/structure/window_sill = 0,
+			/obj/structure/closet = 0,
+		))
+
+/obj/projectile/bullet/srn_rocket/prehit_pierce(atom/target)
+	var/cost = pierce_costs[target.type]
+	if(!isnull(cost))
+		if(cost <= 0)
+			return PROJECTILE_PIERCE_PHASE
+		else if(pierces_remaining >= cost)
+			pierces_remaining -= cost
+			return PROJECTILE_PIERCE_PHASE
+	return ..()
+
+/obj/projectile/bullet/srn_rocket/on_hit(atom/target, blocked = 0, pierce_hit)
 	..()
-	if(ishuman(target))
-		var/mob/living/carbon/human/M = target
-		playsound(src.loc, "pierce", 100, 1)
-		M.oxyloss = 5
-		to_chat(M, "<span class='alert'>You are struck by a spatial nullifier! Thankfully it didn't affect you... much.</span>")
-		M.emote("scream")
+	if(isliving(target))
+		var/mob/living/living_target = target
+		playsound(living_target, 'sound/weapons/pierce.ogg', vol = 100, vary = TRUE)
+		living_target.adjustOxyLoss(5)
+		to_chat(living_target, span_warning("You are struck by a spatial nullifier! Thankfully it didn't affect you... much."))
+		living_target.emote("scream")
 	else
-		playsound(src.loc, "sparks", 100, 1)
+		playsound(target, SFX_SPARKS, vol = 100, vary = TRUE)
 	return BULLET_ACT_HIT
 
-/obj/projectile/bullet/SRN_rocket/Impact(atom/A)
+/obj/projectile/bullet/srn_rocket/Impact(atom/hit)
 	. = ..()
-	if(istype(A, /obj/singularity))
+	if(is_srn_target(hit))
 		var/mob/living/user = firer
-		user.client.give_award(/datum/award/achievement/misc/singularity_buster, user)
-		user.emote("scream")
+		if(!QDELETED(user))
+			user.client?.give_award(/datum/award/achievement/misc/singularity_buster, user)
+			user.emote("scream")
 
 		for(var/mob/player as anything in GLOB.player_list)
-			SEND_SOUND(player, sound('sound/magic/charge.ogg', volume = player.client.prefs.channel_volume["[CHANNEL_SOUND_EFFECTS]"]))
-			to_chat(player, "<span class='boldannounce'>You feel reality distort for a moment...</span>")
-			shake_camera(player, 15, 3)
+			if(isnewplayer(player) || QDELETED(player))
+				continue
+			player.playsound_local(player, 'sound/magic/charge.ogg', vol = 75, pressure_affected = FALSE, mixer_channel = CHANNEL_SOUND_EFFECTS)
+			to_chat(player, span_boldannounce("You feel reality distort for a moment..."))
+			shake_camera(player, duration = 1.5 SECONDS, strength = 3)
 
-		new/obj/spatial_rift(A.loc)
-		qdel(A)
+		new /obj/spatial_rift(get_turf(hit))
+		qdel(hit)
 
-	if(istype(A, /obj/energy_ball))
-		var/mob/living/user = firer
-		user.client.give_award(/datum/award/achievement/misc/singularity_buster, user)
-		user.emote("scream")
+/obj/projectile/bullet/srn_rocket/select_target(turf/our_turf, atom/target, atom/bumped)
+	if(is_srn_target(bumped) && can_hit_target(bumped, original == bumped, FALSE, TRUE))
+		return bumped
+	for(var/thingy in our_turf)
+		if(is_srn_target(thingy) && can_hit_target(thingy, thingy == original, TRUE, thingy == bumped))
+			return thingy
+	return ..()
 
-		for(var/mob/player as anything in GLOB.player_list)
-			SEND_SOUND(player, sound('sound/magic/charge.ogg', volume = player.client.prefs.channel_volume["[CHANNEL_SOUND_EFFECTS]"]))
-			to_chat(player, "<span class='boldannounce'>You feel reality distort for a moment...</span>")
-			shake_camera(player, 15, 3)
+/obj/projectile/bullet/srn_rocket/process()
+	if(QDELETED(src))
+		return
+	// try to lock on to the nearest tesla or singularity if we aren't already locked onto one
+	if(!is_srn_target(original))
+		var/obj/new_target = find_nearest_srn_target(src)
+		if(!QDELETED(new_target))
+			original = new_target
+			set_homing_target(new_target)
+	if(check_singularity_hit(original))
+		return
+	return ..()
 
-		new/obj/spatial_rift(A.loc)
-		qdel(A)
+/obj/projectile/bullet/srn_rocket/proc/check_singularity_hit(obj/singularity/singuloth)
+	if(QDELETED(src) || !istype(singuloth) || QDELING(singuloth))
+		return FALSE
+	var/collision_dist = singuloth.current_size - 1
+	if(collision_dist < 1)
+		return FALSE
+	if(get_dist(src, singuloth) <= collision_dist)
+		Impact(singuloth)
+		return TRUE
+	return FALSE
 
-	return
+/obj/projectile/bullet/srn_rocket/singularity_act(singularity_size, obj/parent)
+	if(!QDELETED(src) && is_srn_target(parent))
+		Impact(parent)
 
+/obj/projectile/bullet/srn_rocket/singularity_pull(obj/singularity/singularity, current_size)
+	. = ..()
+	check_singularity_hit(singularity)
 
 /datum/award/achievement/misc/singularity_buster
 	name = "Scrungularity"
@@ -140,32 +202,56 @@
 /obj/spatial_rift/process()
 	consume()
 
-/obj/spatial_rift/proc/consume(atom/A)
-	if(isturf(A))
-		A.singularity_act()
+/obj/spatial_rift/proc/consume(atom/movable/thing)
+	if(!ismovable(thing))
+		if(isturf(thing))
+			thing.singularity_act()
 		return
-	var/atom/movable/AM = A
-	var/turf/T = get_turf(src)
-	if(!istype(AM))
+	var/turf/our_turf = get_turf(src)
+	if(isliving(thing))
+		var/mob/living/living_thing = thing
+		investigate_log("([key_name(living_thing)]) has been consumed by the Spatial rift at [AREACOORD(our_turf)].", INVESTIGATE_ENGINE)
+		living_thing.ghostize(can_reenter_corpse = FALSE)
+	else if(is_srn_target(thing))
+		investigate_log("([key_name(thing)]) has been consumed by the Spatial rift at [AREACOORD(our_turf)].", INVESTIGATE_ENGINE)
 		return
-	if(isliving(AM))
-		var/mob/living/M = AM
-		investigate_log("([key_name(A)]) has been consumed by the Spatial rift at [AREACOORD(T)].", INVESTIGATE_ENGINE)
-		M.ghostize(FALSE)
-	else if(istype(AM, /obj/singularity))
-		investigate_log("([key_name(A)]) has been consumed by the Spatial rift at [AREACOORD(T)].", INVESTIGATE_ENGINE)
-		return
-	AM.forceMove(src)
+	thing.forceMove(src)
 
 /obj/spatial_rift/proc/admin_investigate_setup()
-	var/turf/T = get_turf(src)
-	message_admins("A Spatial rift has been created at [ADMIN_VERBOSEJMP(T)].]")
-	investigate_log("was created at [AREACOORD(T)].", INVESTIGATE_ENGINE)
+	var/turf/our_turf = get_turf(src)
+	message_admins("A Spatial rift has been created at [ADMIN_VERBOSEJMP(our_turf)].]")
+	investigate_log("was created at [AREACOORD(our_turf)].", INVESTIGATE_ENGINE)
 
 /obj/spatial_rift/attack_tk(mob/living/user)
-	if(!istype(user))
+	if(!isliving(user))
 		return
-	to_chat(user, "<span class='userdanger'>You don't feel like you are real anymore.</span>")
+	to_chat(user, span_userdanger("You don't feel like you are real anymore."))
 	user.dust_animation()
 	user.spawn_dust()
-	addtimer(CALLBACK(src, PROC_REF(consume), user), 5)
+	addtimer(CALLBACK(src, PROC_REF(consume), user), 0.5 SECONDS)
+
+/proc/is_srn_target(obj/target)
+	. = FALSE
+	if(!isobj(target) || QDELING(target))
+		return FALSE
+	if(istype(target, /obj/singularity))
+		return TRUE
+	if(istype(target, /obj/energy_ball))
+		var/obj/energy_ball/lady_tesla = target
+		return !lady_tesla.orbiting // don't target miniballs
+
+/proc/find_nearest_srn_target(turf/center)
+	center = get_turf(center)
+	if(!center)
+		return
+	var/obj/closest_target
+	var/closest_distance
+	for(var/obj/thing in range(world.view, center))
+		if(!is_srn_target(thing))
+			continue
+		var/distance = get_dist(center, thing)
+		if(!closest_target || (closest_distance > distance))
+			closest_distance = distance
+			closest_target = thing
+	if(!QDELETED(closest_target))
+		return closest_target

--- a/monkestation/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/monkestation/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -1,0 +1,3 @@
+/obj/structure/closet/secure_closet/engineering_chief/populate_contents_immediate()
+	. = ..()
+	new /obj/item/gun/ballistic/srn_rocketlauncher(src)

--- a/monkestation/code/modules/cargo/crates/large.dm
+++ b/monkestation/code/modules/cargo/crates/large.dm
@@ -57,6 +57,6 @@
 	name = "Spatial Rift Nullifier Pack"
 	desc = "Everything that the crew needs to take down a rogue Singularity or Tesla."
 	cost = 5000
-	contains = list(/obj/item/gun/ballistic/SRN_rocketlauncher = 4)
+	contains = list(/obj/item/gun/ballistic/srn_rocketlauncher = 4)
 	crate_name = "Spatial Rift Nullifier (SRN)"
 	crate_type = /obj/structure/closet/crate/secure

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5953,6 +5953,7 @@
 #include "monkestation\code\datums\components\lock_on_cursor.dm"
 #include "monkestation\code\datums\components\multi_hit.dm"
 #include "monkestation\code\datums\components\pixel_shift.dm"
+#include "monkestation\code\datums\components\singularity.dm"
 #include "monkestation\code\datums\components\throw_bounce.dm"
 #include "monkestation\code\datums\components\turf_checker_complex.dm"
 #include "monkestation\code\datums\components\turf_healing.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6122,6 +6122,7 @@
 #include "monkestation\code\game\objects\structures\crates_lockers\closets.dm"
 #include "monkestation\code\game\objects\structures\crates_lockers\crates.dm"
 #include "monkestation\code\game\objects\structures\crates_lockers\closets\secure\brig_physician.dm"
+#include "monkestation\code\game\objects\structures\crates_lockers\closets\secure\engineering.dm"
 #include "monkestation\code\game\objects\structures\crates_lockers\closets\secure\security.dm"
 #include "monkestation\code\game\objects\structures\crates_lockers\crates\secure.dm"
 #include "monkestation\code\game\turfs\open\water.dm"


### PR DESCRIPTION
## About The Pull Request

This is a basically the SRN deshittification PR - I made the functionality much less jank, with more reliable code.

I feel the changelog describes the changes pretty well, so I won't just copy-paste them here.

PR is draft bc I need to do more testing.

## Why It's Good For The Game

makes it so the SRN won't be broken by jank, and just makes it more consistent overall, which is good

## Changelog
:cl:
balance: Spatial Rift Nullifier rockets now have mild homing towards singularities or teslas.
balance: Firing a Spatial Rift Nullifier will automatically target a nearby singularity or tesla (if there is one) if you miss clicking on it.
balance: Spatial Rift Nullifier rockets will now collide with the sprite of a singularity, rather than needing to hit directly in the center.
balance: Spatial Rift Nullifier rockets now have limited "piercing", and can go through walls or windows, albeit only a few times, with the amount of pierces based on what's actually in the way.
balance: Stage 3+ singularities won't pull spatial rift nullifiers out of your hand if you are holding it with two hands.
refactor: Cleaned up Spatial Rift Nullifier code quite a bit, they should be quite a bit less janky now.
/:cl:
