### PR TITLE
Fix railing stacking

### DIFF
--- a/code/controllers/subsystem/materials.dm
+++ b/code/controllers/subsystem/materials.dm
@@ -27,7 +27,7 @@ SUBSYSTEM_DEF(materials)
 		new /datum/stack_recipe("Sink Frame", /obj/structure/sinkframe, one_per_turf = TRUE, on_solid_ground = TRUE, applies_mats = TRUE, category = CAT_FURNITURE),
 		new /datum/stack_recipe("Material floor tile", /obj/item/stack/tile/material, 1, 4, 20, applies_mats = TRUE, check_density = FALSE, category = CAT_TILES),
 		new /datum/stack_recipe("Material airlock assembly", /obj/structure/door_assembly/door_assembly_material, 4, time = 5 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, applies_mats = TRUE, category = CAT_DOORS),
-		new /datum/stack_recipe("Railing", /obj/structure/railing, one_per_turf = FALSE, on_solid_ground = TRUE, applies_mats = TRUE, category = CAT_FURNITURE),
+		new /datum/stack_recipe("Railing", /obj/structure/railing, one_per_turf = FALSE, on_solid_ground = TRUE, check_direction = TRUE, applies_mats = TRUE, category = CAT_FURNITURE),
 	)
 	///List of stackcrafting recipes for materials using rigid recipes
 	var/list/rigid_stack_recipes = list(


### PR DESCRIPTION

## About The Pull Request

for some reason the recipe to craft from rods set `check_direction = TRUE`, but not the generic material recipe?? this fixes that.

https://github.com/user-attachments/assets/b99cc8b2-a953-4607-ba1a-2e160872801a

## Why It's Good For The Game

bugfix good

## Changelog
:cl:
fix: Fixed railing stacking.
/:cl:
