### PR TITLE
Adds christmas tree spawners to Blueshift

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -24330,6 +24330,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/spawner/xmastree,
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
 "eGI" = (
@@ -58494,6 +58495,10 @@
 	dir = 9
 	},
 /area/station/hallway/secondary/exit)
+"loV" = (
+/obj/effect/spawner/xmastree,
+/turf/open/floor/stone,
+/area/station/hallway/primary/central)
 "loW" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -157198,7 +157203,7 @@ jKx
 bBd
 bOT
 gCJ
-gCJ
+loV
 gCJ
 dGC
 bGm


### PR DESCRIPTION

## About The Pull Request

![2024-12-12 (1734045224) ~ dreamseeker](https://github.com/user-attachments/assets/7b138017-f542-4f56-90fa-3c46295dbcf4)

![2024-12-12 (1734045229) ~ dreamseeker](https://github.com/user-attachments/assets/8aa495bd-0659-4340-93d4-3d3f23033741)

## Why It's Good For The Game

yay christmas :3

## Changelog
:cl:
add: Added christmas tree spawners to Blueshift - one north of science on the upper floor, one west of botany on the lower floor.
/:cl:
