### PR TITLE
fix random lipstick having no proper icon state

### DIFF
--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -13,6 +13,9 @@
 	/// A trait that's applied while someone has this lipstick applied, and is removed when the lipstick is removed
 	var/lipstick_trait
 
+	///Defines if lipstick color can be spawned as a random lipstick
+	var/lipstick_random = TRUE
+
 /obj/item/lipstick/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/update_icon_updates_onmob)
@@ -24,8 +27,10 @@
 		update_appearance(UPDATE_ICON)
 
 /obj/item/lipstick/update_icon_state()
-	icon_state = "[initial(icon_state)][open ? "_uncap" : null]"
-	inhand_icon_state = "[initial(icon_state)][open ? "open" : null]"
+	var/initial_icon_state = icon_state
+	icon_state = "[icon_state][open ? "_uncap" : null]"
+	inhand_icon_state = "[icon_state][open ? "open" : null]"
+	icon_state = initial_icon_state
 	return ..()
 
 /obj/item/lipstick/update_overlays()
@@ -71,6 +76,7 @@
 	icon_state = "slipstick"
 	lipstick_color = COLOR_SYNDIE_RED
 	lipstick_trait = TRAIT_SYNDIE_KISS
+	lipstick_random = FALSE
 
 /obj/item/lipstick/random
 	name = "lipstick"
@@ -85,7 +91,8 @@
 		for(var/obj/item/lipstick/lipstick_path as anything in (typesof(/obj/item/lipstick) - src.type))
 			if(!initial(lipstick_path.lipstick_color))
 				continue
-			possible_colors[initial(lipstick_path.lipstick_color)] = initial(lipstick_path.name)
+			if(lipstick_path.lipstick_random)
+				possible_colors[initial(lipstick_path.lipstick_color)] = initial(lipstick_path.name)
 	lipstick_color = pick(possible_colors)
 	name = possible_colors[lipstick_color]
 	update_appearance()


### PR DESCRIPTION
## About The Pull Request
fixes random lipstick having random lipstick icon state on spawn
also makes syndie lipstick not be able to be spawned as a random color to avoid confusion
fixes #4546

## Changelog

:cl:
fix: Random lipstick now has proper icon upon spawn.
del: Syndie lipstick can no longer spawn as a random lipstick color.
/:cl:
