### PR TITLE
Fix suiciding ghost player bodies duplicating

### DIFF
--- a/monkestation/code/modules/ghost_players/ghost_player.dm
+++ b/monkestation/code/modules/ghost_players/ghost_player.dm
@@ -51,7 +51,10 @@ GLOBAL_VAR_INIT(disable_ghost_spawning, FALSE)
 	if(. && stat > SOFT_CRIT)
 		life_or_death()
 
-/mob/living/carbon/human/ghost/proc/disolve_ghost()
+/mob/living/carbon/human/ghost/final_checkout(obj/item/suicide_tool, apply_damage)
+	dissolve_and_ghost()
+
+/mob/living/carbon/human/ghost/proc/dissolve_and_ghost()
 	var/mob/dead/observer/new_ghost = ghostize(can_reenter_corpse = FALSE)
 	if(!QDELETED(new_ghost))
 		new_ghost.key = old_key
@@ -64,7 +67,7 @@ GLOBAL_VAR_INIT(disable_ghost_spawning, FALSE)
 	if(dueling)
 		linked_button?.end_duel(src)
 	if(QDELING(src) || QDELETED(client) || client.is_afk())
-		disolve_ghost()
+		dissolve_and_ghost()
 	else
 		move_to_ghostspawn()
 		revive(full_heal_flags = ADMIN_HEAL_ALL)
@@ -88,7 +91,7 @@ GLOBAL_VAR_INIT(disable_ghost_spawning, FALSE)
 		return
 	if(living_owner.revive_prepped)
 		return TRUE
-	living_owner.disolve_ghost()
+	living_owner.dissolve_and_ghost()
 	return TRUE
 
 


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/1164

https://github.com/user-attachments/assets/fc02cb06-4d8f-41e8-a4b6-e7ac13b6cba2


## Why It's Good For The Game

bugfix good :3

## Changelog
:cl:
fix: Fixed suiciding as a centcom ghost player spawning an extra catatonic body.
/:cl:
