### PR TITLE
Fix heretic sac not restoring blood and leaving chems inside the sac target.

### DIFF
--- a/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -314,7 +314,7 @@
 
 	sac_target.apply_status_effect(/datum/status_effect/unholy_determination, SACRIFICE_REALM_DURATION)
 	//monkestation addition start:
-	sac_target.reagents?.remove_all(1000) //stops chems from killing in the mansus
+	sac_target.reagents?.remove_all(sac_target.reagents.total_volume) //stops chems from killing in the mansus
 	sac_target.restore_blood() //stops target from just dying from low blood in the mansus
 	//monkestation addition end
 	addtimer(CALLBACK(src, PROC_REF(after_target_wakes), sac_target), SACRIFICE_SLEEP_DURATION * 0.5) // Begin the minigame

--- a/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -255,9 +255,14 @@
 	// and if we fail to revive them, don't proceede the chain
 	sac_target.adjustOxyLoss(-100, FALSE)
 	sac_target.grab_ghost() // monke edit: try to grab their ghost
+
 	if(!sac_target.heal_and_revive(50, span_danger("[sac_target]'s heart begins to beat with an unholy force as they return from death!")))
 		return
 
+	//monkestation addition start:
+	sac_target.reagents.remove_all() //stops chems from killing in the mansus
+	sac_target.restore_blood() //stops target from just dying from low blood in the mansus
+	//monkestation addition end
 	if(sac_target.AdjustUnconscious(SACRIFICE_SLEEP_DURATION))
 		to_chat(sac_target, span_hypnophrase("Your mind feels torn apart as you fall into a shallow slumber..."))
 	else
@@ -308,6 +313,10 @@
 	to_chat(sac_target, span_big(span_hypnophrase("Unnatural forces begin to claw at your every being from beyond the veil.")))
 
 	sac_target.apply_status_effect(/datum/status_effect/unholy_determination, SACRIFICE_REALM_DURATION)
+	//monkestation addition start:
+	sac_target.reagents.remove_all(1000) //stops chems from killing in the mansus
+	sac_target.restore_blood() //stops target from just dying from low blood in the mansus
+	//monkestation addition end
 	addtimer(CALLBACK(src, PROC_REF(after_target_wakes), sac_target), SACRIFICE_SLEEP_DURATION * 0.5) // Begin the minigame
 
 	RegisterSignal(sac_target, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(on_target_escape)) // Cheese condition

--- a/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -314,7 +314,7 @@
 
 	sac_target.apply_status_effect(/datum/status_effect/unholy_determination, SACRIFICE_REALM_DURATION)
 	//monkestation addition start:
-	sac_target.reagents.remove_all(1000) //stops chems from killing in the mansus
+	sac_target.reagents?.remove_all(1000) //stops chems from killing in the mansus
 	sac_target.restore_blood() //stops target from just dying from low blood in the mansus
 	//monkestation addition end
 	addtimer(CALLBACK(src, PROC_REF(after_target_wakes), sac_target), SACRIFICE_SLEEP_DURATION * 0.5) // Begin the minigame

--- a/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -260,7 +260,7 @@
 		return
 
 	//monkestation addition start:
-	sac_target.reagents?.remove_all() //stops chems from killing in the mansus
+	sac_target.reagents?.remove_all(sac_target.reagents.total_volume) //stops chems from killing in the mansus
 	sac_target.restore_blood() //stops target from just dying from low blood in the mansus
 	//monkestation addition end
 	if(sac_target.AdjustUnconscious(SACRIFICE_SLEEP_DURATION))

--- a/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -260,7 +260,7 @@
 		return
 
 	//monkestation addition start:
-	sac_target.reagents.remove_all() //stops chems from killing in the mansus
+	sac_target.reagents?.remove_all() //stops chems from killing in the mansus
 	sac_target.restore_blood() //stops target from just dying from low blood in the mansus
 	//monkestation addition end
 	if(sac_target.AdjustUnconscious(SACRIFICE_SLEEP_DURATION))


### PR DESCRIPTION

## About The Pull Request
Title, fixes #1401
## Why It's Good For The Game
The mansus is supposed to be an opportunity to avoid death, but not restoring blood and leaving in any chems usually means that the sacrifice target wakes up, and almost instantly dies. This prevents these conditions from insta-killing sacrifice targets in the mansus.
## Changelog
:cl:
fix: Heretic sacrifice targets will have their blood restored and cleared of chems if they are sent to the mansus.
/:cl:
