### PR TITLE
Prevent clown fault artifacts from creating multiple clown spawners simultaneously

### DIFF
--- a/monkestation/code/modules/art_sci_overrides/faults/clowning.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/clowning.dm
@@ -12,11 +12,23 @@
 
 	weight = ARTIFACT_VERYRARE
 
+	/// Weakref to the last spawner created by this artifact.
+	/// Used to ensure another spawner isn't created while the last one exists.
+	var/datum/weakref/spawner_weakref
+
+/datum/artifact_fault/clown/Destroy(force)
+	spawner_weakref = null
+	return ..()
+
 /datum/artifact_fault/clown/on_trigger()
+	var/obj/structure/spawner/clown/hehe = spawner_weakref?.resolve()
+	if(!QDELETED(hehe))
+		return
 	var/center_turf = get_turf(our_artifact.parent)
 
 	if(!center_turf)
 		CRASH("[src] had attempted to trigger, but failed to find the center turf!")
 
-	var/obj/structure/spawner/clown/hehe = new(center_turf)
+	hehe = new(center_turf)
+	spawner_weakref = WEAKREF(hehe)
 	QDEL_IN(hehe, 3 MINUTES)


### PR DESCRIPTION

## About The Pull Request

When a clown fault artifact creates a clown spawner, it'll keep a weakref to the spawner, and will not create a new one if the previous one still exists. The spawners already self-delete after 3 minutes anyways, this just ensures it doesn't create a morbillion of them.

## Why It's Good For The Game

infinite clownworks must be stopped...

## Changelog
:cl:
balance: Clown spawner artifacts will no longer spawn another spawner if the previous one still exists.
/:cl:
