### PR TITLE
[Code Bounty] Makes pins display what they represent more clearly in the name (AKA: "rainbow pride pin" instead of "pride pin")

### DIFF
--- a/code/datums/quirks/neutral_quirks/pride_pin.dm
+++ b/code/datums/quirks/neutral_quirks/pride_pin.dm
@@ -18,6 +18,7 @@
 
 	pin.current_skin = pride_choice
 	pin.icon_state = pride_reskin
+	pin.post_reskin()
 	//MONKESTATION EDIT START
 	var/mob/living/carbon/human/H = quirk_holder
 	if (istype(H))

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -195,6 +195,18 @@ GLOBAL_LIST_INIT(pride_pin_reskins, list(
 	. = ..()
 	unique_reskin = GLOB.pride_pin_reskins
 
+/obj/item/clothing/accessory/pride/reskin_obj(mob/M)
+	. = ..()
+	post_reskin(M)
+
+/obj/item/clothing/accessory/pride/post_reskin(mob/our_mob)
+	for(var/pride_name as anything in GLOB.pride_pin_reskins)
+		if(GLOB.pride_pin_reskins[pride_name] == icon_state)
+			name = "[lowertext(pride_name)] pin"
+			return
+
+	name = initial(name) // If we somehow fail to find our pride in the global list, just make us generic
+
 ///Awarded for being dutiful and extinguishing the debt from the "Indebted" quirk.
 /obj/item/clothing/accessory/debt_payer_pin
 	name = "debt payer pin"

--- a/monkestation/code/modules/blueshift/items/badges.dm
+++ b/monkestation/code/modules/blueshift/items/badges.dm
@@ -186,7 +186,7 @@ GLOBAL_LIST_INIT(pride_pin_reskins, list(
 	"Transgender Pride" = "pride_trans",
 	"Intersex Pride" = "pride_intersex",
 	"Lesbian Pride" = "pride_lesbian",
-	"Man-Loving-Man / Gay Pride" = "pride_mlm",
+	"Gay Pride" = "pride_mlm",
 	"Genderfluid Pride" = "pride_genderfluid",
 	"Genderqueer Pride" = "pride_genderqueer",
 	"Aromantic Pride" = "pride_aromantic",


### PR DESCRIPTION
## About The Pull Request

- Made the pride pin display what it represents in the name, instead of being purelly in the icon

![image](https://github.com/user-attachments/assets/00dfb792-1b42-42f2-8ae0-b3cd037d2a6d)

## Why It's Good For The Game

> Made the pride pin display what it represents in the name, instead of being purelly in the icon

(quoted from the discord code bounty, as i myself dont use them so couldn't really say it better)
- "it is very hard to tell what flag a pride pin is due to their angle when removed and the fact they tend to get obscured by bags making them kind of pointless"

## Changelog

:cl:
qol: Made pride pins display their pride in the name, like "transexual pride pin" instead of "pride pin"
/:cl:
