### PR TITLE
Blob infestation

### DIFF
--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -225,7 +225,9 @@ Medical HUD! Basic mode needs suit sensors on.
 
 	var/virus_threat = check_virus()
 	holder.pixel_y = get_cached_height() - world.icon_size
-	if(HAS_TRAIT(src, TRAIT_XENO_HOST))
+	if(HAS_TRAIT(src, TRAIT_BLOB_ALLY)) //Monkestation edit: In the edge where case a blob host has a xeno in them. I think the fact they are a blob host is more important.
+		holder.icon_state = "hudill5"
+	else if(HAS_TRAIT(src, TRAIT_XENO_HOST))
 		holder.icon_state = "hudxeno"
 	else if(stat == DEAD || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))
 		if((key || get_ghost(FALSE, TRUE)) && (can_defib() & DEFIB_REVIVABLE_STATES))

--- a/code/modules/events/ghost_role/blob.dm
+++ b/code/modules/events/ghost_role/blob.dm
@@ -1,10 +1,10 @@
 /datum/round_event_control/blob
 	name = "Blob"
 	typepath = /datum/round_event/ghost_role/blob
-	weight = 5  //monkie edit: 10 to 5
+	weight = 4 //monkie edit: 10 to 4
 	max_occurrences = 1
 	min_players = 35  //monkie edit: 20 to 35
-	earliest_start = 80 MINUTES //monkie edit: 20 to 90
+	earliest_start = 80 MINUTES //monkie edit: 20 to 80
 	//dynamic_should_hijack = TRUE
 	category = EVENT_CATEGORY_ENTITIES
 	description = "Spawns a new blob overmind."

--- a/monkestation/code/modules/antagonist/blob/blob_antag.dm
+++ b/monkestation/code/modules/antagonist/blob/blob_antag.dm
@@ -1,0 +1,7 @@
+/datum/antagonist/blob/infection/on_gain()
+	ADD_TRAIT(owner.current, TRAIT_BLOB_ALLY, DISEASE_TRAIT)
+	return ..()
+
+/datum/antagonist/blob/infection/on_removal()
+	REMOVE_TRAIT(owner.current, TRAIT_BLOB_ALLY, DISEASE_TRAIT)
+	return ..()

--- a/monkestation/code/modules/antagonist/blob/blob_antag.dm
+++ b/monkestation/code/modules/antagonist/blob/blob_antag.dm
@@ -1,7 +1,4 @@
-/datum/antagonist/blob/infection/on_gain()
-	ADD_TRAIT(owner.current, TRAIT_BLOB_ALLY, DISEASE_TRAIT)
-	return ..()
-
-/datum/antagonist/blob/infection/on_removal()
-	REMOVE_TRAIT(owner.current, TRAIT_BLOB_ALLY, DISEASE_TRAIT)
-	return ..()
+/datum/antagonist/blob/infection/apply_innate_effects(mob/mob_override)
+	. = ..()
+	var/mob/target = mob_override || owner.current
+	ADD_TRAIT(target, TRAIT_BLOB_ALLY, type)

--- a/monkestation/code/modules/storytellers/converted_events/event_overrides.dm
+++ b/monkestation/code/modules/storytellers/converted_events/event_overrides.dm
@@ -22,6 +22,10 @@
 	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_EXTERNAL, TAG_ALIEN)
 	checks_antag_cap = TRUE
 
+/datum/round_event_control/antagonist/solo/blob_infection
+	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_EXTERNAL, TAG_ALIEN)
+	checks_antag_cap = TRUE
+	
 /datum/round_event_control/brain_trauma
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_TARGETED, TAG_MAGICAL) //im putting magical on this because I think this can give the magic brain traumas

--- a/monkestation/code/modules/storytellers/converted_events/solo/blob_infection.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/blob_infection.dm
@@ -1,0 +1,31 @@
+/datum/round_event_control/antagonist/solo/blob_infection
+	name = "Blob Infection"
+	weight = 4
+	antag_flag = ROLE_BLOB_INFECTION
+	tags = list(TAG_COMBAT)
+	antag_datum = /datum/antagonist/blob/infection
+		min_players = 35
+	maximum_antags = 1
+	max_occurrences = 1
+	earliest_start = 80 MINUTES
+	protected_roles = list(
+		JOB_CAPTAIN,
+		JOB_NANOTRASEN_REPRESENTATIVE,
+		JOB_BLUESHIELD,
+		JOB_HEAD_OF_PERSONNEL,
+		JOB_CHIEF_ENGINEER,
+		JOB_CHIEF_MEDICAL_OFFICER,
+		JOB_RESEARCH_DIRECTOR,
+		JOB_DETECTIVE,
+		JOB_HEAD_OF_SECURITY,
+		JOB_PRISONER,
+		JOB_SECURITY_OFFICER,
+		JOB_WARDEN,
+		JOB_SECURITY_ASSISTANT,
+		JOB_BRIG_PHYSICIAN,
+	)
+	restricted_roles = list(
+		JOB_AI,
+		JOB_CYBORG,
+	)
+	description = "Infects a crew with the blob overmind."

--- a/monkestation/code/modules/storytellers/converted_events/solo/blob_infection.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/blob_infection.dm
@@ -2,9 +2,8 @@
 	name = "Blob Infection"
 	weight = 4
 	antag_flag = ROLE_BLOB_INFECTION
-	tags = list(TAG_COMBAT)
 	antag_datum = /datum/antagonist/blob/infection
-		min_players = 35
+	min_players = 35
 	maximum_antags = 1
 	max_occurrences = 1
 	earliest_start = 80 MINUTES
@@ -28,4 +27,4 @@
 		JOB_AI,
 		JOB_CYBORG,
 	)
-	description = "Infects a crew with the blob overmind."
+	description = "Infects a crewmember with the blob overmind."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8160,6 +8160,7 @@
 #include "monkestation\code\modules\storytellers\antag_rep\helper_procs.dm"
 #include "monkestation\code\modules\storytellers\converted_events\_base_event.dm"
 #include "monkestation\code\modules\storytellers\converted_events\event_overrides.dm"
+#include "monkestation\code\modules\storytellers\converted_events\solo\blob_infection.dm"
 #include "monkestation\code\modules\storytellers\converted_events\solo\bloodcult.dm"
 #include "monkestation\code\modules\storytellers\converted_events\solo\bloodsuckers.dm"
 #include "monkestation\code\modules\storytellers\converted_events\solo\brother.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6192,6 +6192,7 @@
 #include "monkestation\code\modules\and_roll_credits\_credits.dm"
 #include "monkestation\code\modules\and_roll_credits\credits_subsystem.dm"
 #include "monkestation\code\modules\and_roll_credits\episode_names.dm"
+#include "monkestation\code\modules\antagonist\blob\blob_antag.dm"
 #include "monkestation\code\modules\antagonists\_common\antag_datum.dm"
 #include "monkestation\code\modules\antagonists\_common\antag_hud.dm"
 #include "monkestation\code\modules\antagonists\abductor\abductor.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
"So long as the _Overmind_ lives so does the infection, Captain. By the point it makes itself known, all the crew is already infected with its spores. To evacuate means to spread it further, everyone becoming _Overmind_ in wait. So. Kill it, whether by laser or blade, bullet or explosion, heavens forbid even using the nuke we gave you. We do not care how, no shuttles will be sent until then, you are all dead men walking." - Last recovered transcript from central command to station 5 from on station Blackbox.

- Lowers the weight of blob (ghostrole). (5->4)
- Enables a new form of blob, blob infection (Midround), which was previously only triggered through admins. One crew member will be picked to become infected, (based on blob infestation preference). They are given 6 minutes to prepare and find a spot for their core. Either when they choose to, or when they run out of time, they 'pop' leading to the creation of a new Overmind at their feet. From there normal blob rules apply.
- Blob infections will be revealed by a max Ill status on medical huds. Allowing for potential early spotting and interpretation on who and where a blob could be.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
## Why It's Good For The Game
### Contextualizes some lore
Ever since I've seen it activated I found blob infestation a lot more interesting conceptually than normal blobs. Infection feels much more like a proper biohazard than the normal blob which just appears. 

And more so why the crew can't/doesn't just leave from one. Unlike a level 7 biohazards, blobs can lay dormant and undetected in their targets for who knows how long. Which is why shuttles can't be called. Much like how Central can't risk revolutionary ideas escaping to Central, they also can't risk this rampant biohazard from sneaking its way onboard. As dying isn't even an option to escape becoming the over mind. As It'll burst from your body either way.

### Gameplay
The main change/difference is their six minutes
They have six minutes to prepare, set up, think over their lives and their unescapable deaths. These six minutes are both a blessing and a curse for the infected. As while they have those minutes to gather supplies to help the biohazard they also have to spend those six minutes on finding a ideal spot. As wherever they choose they have to make it there, on foot. Limited by their access and ability to break in. If they want to take advantage of atmospherics? They have to make it into atmospherics on foot. While trying to avoid gazes of anyone with a medical hud.
  
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added Blob Infections as a triggerable event. A dormant host containing acting as the vessel of a Overmind in them. 
balance: Infected Blob hosts will show as sick no matter their active state.
balance: Lowered the weight of blobs spawning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
