### PR TITLE
Adds upload to research directors remote

### DIFF
--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -474,6 +474,7 @@
 #define REGION_RESEARCH "Research"
 /// Used to seed the accesses_by_region list in SSid_access. A list of all research regional accesses that are overseen by the RD.
 #define REGION_ACCESS_RESEARCH list( \
+	ACCESS_AI_UPLOAD, \
 	ACCESS_GENETICS, \
 	ACCESS_MECH_SCIENCE, \
 	ACCESS_MINISAT, \


### PR DESCRIPTION

## About The Pull Request
Allows the RD's remote to additionally toggle the AI upload doors.
## Why It's Good For The Game
"Supervise research efforts, ensure Robotics is in working order, make sure the AI and its Cyborgs aren't rogue, replacing them if  they are" is the research directors description. The AI Locking down its own upload prevents all access and prevents any potential for them to access the upload on their own merits. Having to contact the captain to get past the reinforced doors.

The ai still has plenty of resources and tools to stop the upload doors if they so please. Of which I will not snitch.
## Changelog
:cl:
balance: Research directors remote now has AI upload access.
/:cl:
