### PR TITLE
Properly give all xenobio slimeperson subspecies slime wings

### DIFF
--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -156,6 +156,7 @@
 	limb_id = SPECIES_SLIMEPERSON
 	is_dimorphic = TRUE
 	composition_effects = list(/datum/element/soft_landing = 0.5)
+	wing_types = list(/obj/item/organ/external/wings/functional/slime)
 	palette = /datum/color_palette/generic_colors
 	palette_key = MUTANT_COLOR
 
@@ -199,6 +200,7 @@
 	biological_state = (BIO_FLESH|BIO_BLOODED)
 	limb_id = SPECIES_LUMINESCENT
 	is_dimorphic = TRUE
+	wing_types = list(/obj/item/organ/external/wings/functional/slime)
 	palette = /datum/color_palette/generic_colors
 	palette_key = MUTANT_COLOR
 


### PR DESCRIPTION

## About The Pull Request

Slimepeople and luminscents (not oozelings, the xenobio ones) have `/obj/item/bodypart/chest/slime` instead of `/obj/item/bodypart/chest/jelly`, which doesn't have a wing type set, resulting in them having the default wings.

So this sets `chest/slime` to also have the slime wings

## Why It's Good For The Game

consistency.

## Changelog
:cl:
fix: The xenobio Slimeperson and Luminscent subspecies will now properly get slime wings from drinking a flight potion.
/:cl:
