### PR TITLE
Linking Ooze Sucker Fix

### DIFF
--- a/monkestation/code/modules/slimecore/machines/ooze_sucker.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_sucker.dm
@@ -261,6 +261,14 @@ GLOBAL_LIST_EMPTY_TYPED(ooze_suckers, /obj/machinery/plumbing/ooze_sucker)
 	balloon_alert_to_viewers("[turned_on ? "enabled" : "disabled"] ooze sucker")
 	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
+/obj/machinery/plumbing/ooze_sucker/multitool_act(mob/living/user, obj/item/tool)
+	if(!multitool_check_buffer(user, tool))
+		return
+	var/obj/item/multitool/multitool = tool
+	multitool.buffer = src
+	to_chat(user, span_notice("You save the data in the [multitool.name]'s buffer."))
+	return TOOL_ACT_TOOLTYPE_SUCCESS
+
 /obj/item/disk/sucker_upgrade
 	name = "ooze sucker upgrade disk"
 	desc = "An upgrade disk for an ooze sucker."


### PR DESCRIPTION

## About The Pull Request

Addresses issue: https://github.com/Monkestation/Monkestation2.0/issues/2983
Code adds the ability for new ooze suckers to be linked to the console for remote sucker activation and internal chem tank monitoring. Currently they were lacking code to link player made ones especially if they wanted to make new pens. Currently only one sucker per console, meaning one sucker per pen.

## Why It's Good For The Game

Fixings a minor bug and makes the current tool tip for the console accurate.

## Changelog
:cl:
add: Ooze sucker machinery can be stored in multi tool buffer.
fix: Allows ooze suckers to be linked if its inside a valid pen, that is also linked to the same controller.
/:cl:
