### PR TITLE
Removes tasers from the armory

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -52113,9 +52113,6 @@
 /obj/effect/turf_decal/trimline/red/line{
 	dir = 8
 	},
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory)
 "kdO" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -26105,15 +26105,6 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/gun/energy/taser{
-	pixel_y = 3;
-	pixel_x = -3
-	},
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser{
-	pixel_y = -3;
-	pixel_x = 3
-	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "iuJ" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -48942,9 +48942,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "lzH" = (

--- a/_maps/map_files/Graveyard/Graveyard.dmm
+++ b/_maps/map_files/Graveyard/Graveyard.dmm
@@ -32366,9 +32366,6 @@
 /obj/item/gun/ballistic/automatic/pistol/paco/no_mag{
 	pixel_y = 6
 	},
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
 /obj/effect/turf_decal/tile/dark_red/half{
 	dir = 1
 	},

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -8895,9 +8895,6 @@
 /obj/item/gun/ballistic/automatic/pistol/paco/no_mag{
 	pixel_y = 0
 	},
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
 /turf/open/floor/iron/dark/textured,
 /area/station/ai_monitored/security/armory/upper)
 "cIH" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -15352,9 +15352,6 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "eRh" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -33406,9 +33406,6 @@
 /obj/item/gun/ballistic/automatic/pistol/paco/no_mag{
 	pixel_y = 6
 	},
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "lFo" = (

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -28538,9 +28538,6 @@
 	c_tag = "Security - Armory"
 	},
 /obj/effect/spawner/random/armory/disablers,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
 /turf/open/floor/engine,
 /area/station/ai_monitored/security/armory)
 "ixo" = (

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -27190,9 +27190,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "hPi" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -51354,9 +51354,6 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
-/obj/item/gun/energy/taser,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
 "pph" = (

--- a/monkestation/code/modules/cargo/crates/security.dm
+++ b/monkestation/code/modules/cargo/crates/security.dm
@@ -58,3 +58,10 @@
 	contraband = TRUE
 	contains = list(/obj/item/cortical_cage)
 	crate_name = "anti-borer crate"
+
+/datum/supply_pack/security/armory/taser
+	name = "Taser Crate"
+	desc = "Contains two tasers, ready to tase criminals."
+	cost = CARGO_CRATE_VALUE * 15
+	contains = list(/obj/item/gun/energy/taser = 2)
+	crate_name = "taser crate"


### PR DESCRIPTION
## About The Pull Request
Removes tasers from the armory. Warden still starts with a taser.
Tasers can now be bought from cargo.

## Why It's Good For The Game
Ook thinks it should either Warden exclusive or ordered. This makes it start with warden and orderable from cargo.
![OOK](https://github.com/user-attachments/assets/e12852d8-0507-45b7-b4c6-c322e9a9ab90)


## Changelog
:cl:
del: Removes tasers from the armory.
add: Tasers can be bought at cargo.
/:cl:
