### PR TITLE
Removes TWitch from normal rounds, and blacklists key chems from stra

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -72,7 +72,7 @@
 	///infusion damage
 	var/infusion_damage = 0
 	///Blacklist for strange seeds, because botany is already as strong as it is.
-	var/static/list/reagent_blacklist = typechacheof(list(
+	var/static/list/reagent_blacklist = typecacheof(list(
 		/datum/reagent/drug/twitch,
 		/datum/reagent/medicine/adminordrazine,
 		/datum/reagent/medicine/changelingadrenaline,

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -71,7 +71,16 @@
 	var/list/infusion_mutations = list()
 	///infusion damage
 	var/infusion_damage = 0
-
+	///Blacklist for strange seeds, because botany is already as strong as it is.
+	var/static/list/reagent_blacklist = typechacheof(list(
+		/datum/reagent/drug/twitch,
+		/datum/reagent/medicine/adminordrazine,
+		/datum/reagent/medicine/changelingadrenaline,
+		/datum/reagent/medicine/changelinghaste,
+		/datum/reagent/medicine/adminordrazine/quantum_heal,
+		/datum/reagent/drug/demoneye,
+		/datum/reagnet/drug/methamphetamine/borer_version
+	))
 /obj/item/seeds/Initialize(mapload, nogenes = FALSE)
 	. = ..()
 	pixel_x = base_pixel_x + rand(-8, 8)
@@ -610,6 +619,9 @@
 	var/amount_random_reagents = rand(lower, upper)
 	for(var/i in 1 to amount_random_reagents)
 		var/random_amount = rand(4, 15) * 0.01 // this must be multiplied by 0.01, otherwise, it will not properly associate
+		var/datum/reagent/chosen_reagent = get_random_reagent_id()
+		if (is_type_in_typecache(chosen_reagent, reagent_blacklist)) //MONKESTATION EDIT : To remove chems that have no reasons to exist in plants. Im looking at you Changeling chems, and twitch.
+			continue
 		var/datum/plant_gene/reagent/R = new(get_random_reagent_id(), random_amount)
 		if(R.can_add(src))
 			if(!R.try_upgrade_gene(src))

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -79,7 +79,10 @@
 		/datum/reagent/medicine/changelinghaste,
 		/datum/reagent/medicine/adminordrazine/quantum_heal,
 		/datum/reagent/drug/demoneye,
-		/datum/reagnet/drug/methamphetamine/borer_version
+		/datum/reagent/medicine/syndicate_nanites,
+		/datum/reagent/drug/methamphetamine/borer_version,
+		/datum/reagent/medicine/stimulants,
+		/datum/reagent/medicine/muscle_stimulant
 	))
 /obj/item/seeds/Initialize(mapload, nogenes = FALSE)
 	. = ..()

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -71,19 +71,7 @@
 	var/list/infusion_mutations = list()
 	///infusion damage
 	var/infusion_damage = 0
-	///Blacklist for strange seeds, because botany is already as strong as it is.
-	var/static/list/reagent_blacklist = typecacheof(list(
-		/datum/reagent/drug/twitch,
-		/datum/reagent/medicine/adminordrazine,
-		/datum/reagent/medicine/changelingadrenaline,
-		/datum/reagent/medicine/changelinghaste,
-		/datum/reagent/medicine/adminordrazine/quantum_heal,
-		/datum/reagent/drug/demoneye,
-		/datum/reagent/medicine/syndicate_nanites,
-		/datum/reagent/drug/methamphetamine/borer_version,
-		/datum/reagent/medicine/stimulants,
-		/datum/reagent/medicine/muscle_stimulant
-	))
+
 /obj/item/seeds/Initialize(mapload, nogenes = FALSE)
 	. = ..()
 	pixel_x = base_pixel_x + rand(-8, 8)
@@ -622,9 +610,6 @@
 	var/amount_random_reagents = rand(lower, upper)
 	for(var/i in 1 to amount_random_reagents)
 		var/random_amount = rand(4, 15) * 0.01 // this must be multiplied by 0.01, otherwise, it will not properly associate
-		var/datum/reagent/chosen_reagent = get_random_reagent_id()
-		if (is_type_in_typecache(chosen_reagent, reagent_blacklist)) //MONKESTATION EDIT : To remove chems that have no reasons to exist in plants. Im looking at you Changeling chems, and twitch.
-			continue
 		var/datum/plant_gene/reagent/R = new(get_random_reagent_id(), random_amount)
 		if(R.can_add(src))
 			if(!R.try_upgrade_gene(src))

--- a/monkestation/code/modules/blueshift/armaments/deforest_medical.dm
+++ b/monkestation/code/modules/blueshift/armaments/deforest_medical.dm
@@ -150,11 +150,6 @@
 	item_type = /obj/item/reagent_containers/hypospray/medipen/deforest/synalvipitol
 	contraband = TRUE
 
-/datum/armament_entry/company_import/deforest/medpens_stim/twitch
-	item_type = /obj/item/reagent_containers/hypospray/medipen/deforest/twitch
-	cost = PAYCHECK_COMMAND * 3
-	contraband = TRUE
-
 /datum/armament_entry/company_import/deforest/medpens_stim/demoneye
 	item_type = /obj/item/reagent_containers/hypospray/medipen/deforest/demoneye
 	cost = PAYCHECK_COMMAND * 3

--- a/monkestation/code/modules/blueshift/opfor/equipment/medical.dm
+++ b/monkestation/code/modules/blueshift/opfor/equipment/medical.dm
@@ -4,6 +4,8 @@
 /datum/opposing_force_equipment/medical/twitch
 	name = "TWitch Sensory Stimulant Injector"
 	item_type = /obj/item/reagent_containers/hypospray/medipen/deforest/twitch
+	description = "A special type of injector containing 10u of TWitch alongside some other chems. Overdosing on this can lead to heart implosion, but give you super speed and bullet immortality."
+	admin_note = "TWITCH IS VERY OVERPOWERED IF OD'D ON. Overdosing gives them a MASSIVE speed boost, with the ability to dodge 100% of ALL projectiles. OD limit is 15u."
 
 /datum/opposing_force_equipment/medical/demoneye
 	name = "DemonEye Steroid Injector"

--- a/monkestation/code/modules/blueshift/reagents/deforest.dm
+++ b/monkestation/code/modules/blueshift/reagents/deforest.dm
@@ -213,11 +213,11 @@
 // Reaction to make twitch, makes 10u from 17u input reagents
 /datum/chemical_reaction/twitch
 	results = list(
-		/datum/reagent/drug/twitch = 1,
+		/datum/reagent/drug/twitch = 5,
 	)
 	required_reagents = list(
 		/datum/reagent/medicine/adminordrazine = 30,
-		/datum/reagent/bluespace = 30 //why? because fuck you thats why. , im gonna leave it at this. Good luck making it.
+		/datum/reagent/bluespace = 30 //why? because fuck you thats why. Im gonna leave it at this. Good luck making it.
 	)
 	mob_react = FALSE
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG | REACTION_TAG_ORGAN | REACTION_TAG_DAMAGING

--- a/monkestation/code/modules/blueshift/reagents/deforest.dm
+++ b/monkestation/code/modules/blueshift/reagents/deforest.dm
@@ -213,12 +213,11 @@
 // Reaction to make twitch, makes 10u from 17u input reagents
 /datum/chemical_reaction/twitch
 	results = list(
-		/datum/reagent/drug/twitch = 10,
+		/datum/reagent/drug/twitch = 1,
 	)
 	required_reagents = list(
-		/datum/reagent/impedrezene = 5,
-		/datum/reagent/bluespace = 10,
-		/datum/reagent/consumable/liquidelectricity = 2,
+		/datum/reagent/medicine/adminordrazine = 30,
+		/datum/reagent/bluespace = 30 //why? because fuck you thats why. , im gonna leave it at this. Good luck making it.
 	)
 	mob_react = FALSE
 	reaction_tags = REACTION_TAG_EASY | REACTION_TAG_DRUG | REACTION_TAG_ORGAN | REACTION_TAG_DAMAGING
@@ -228,10 +227,12 @@
 	name = "TWitch"
 	description = "A drug originally developed by and for plutonians to assist them during raids. \
 		Does not see wide use due to the whole reality-disassociation and heart disease thing afterwards. \
-		Can be intentionally overdosed to increase the drug's effects"
+		However, the gods came to an agreement, and banished it from the realms. \
+		If the gods catch you using this, expect a swift and painful death."
+
 	reagent_state = LIQUID
 	color = "#c22a44"
-	taste_description = "television static"
+	taste_description = "television static, and the gods wrath"
 	metabolization_rate = 0.65 * REAGENTS_METABOLISM
 	ph = 3
 	overdose_threshold = 15


### PR DESCRIPTION
>Be me
>Admin shift, time to pull up big boy pants
>Observe some people with sandevistan effect
>Examine more and realize its TWitch chem
>Test with TWitch chem, realize OD'ing gives you a 100% projectile dodge chance, while giving meth speed, that IS stackable with meth.
>You can create it pretty easily, and strange seed it.
>MFW
![thisshiteveryday](https://github.com/user-attachments/assets/0942a1c5-752e-4dae-a770-eaec65e8dca1)
## About The Pull Request
As the story implies, nerfs strange seeds by adding a blacklist for certain chemicals. And makes TWitch an admin only chemical.
## Why It's Good For The Game
I dont think i need to explain how meth speed + projectile immunity is inherently unhealthy, especially with little downsides and easy (with some smarts) access. Also, we dont need botany to grow adminordrazine banana's. They're already strong as is. This doesnt remove it, nor the autoinjector form the game, but makes it admin only.
## Changelog
:cl:
balance: Blacklisted spesific antag and admin reagents from strange seeds.
balance: Changed the recipe for TWitch, making it effectivly impossible to get. If you somehow make it, you earned it.
del: Removed the TWitch injector from a hacked ordering computer.
admin: Added a warning to the TWitch autoinjector OPFOR item.
/:cl:
