### PR TITLE
I fixed cant breathe mood bug

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -56,6 +56,7 @@
 	if(HAS_TRAIT(src, TRAIT_NOBREATH))
 		setOxyLoss(0) //idk how because spec life should cover this
 		losebreath = 0
+		failed_last_breath = 0
 		return
 
 	var/next_breath = 4

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -274,7 +274,6 @@
 		lung_pop_tick = 0
 		breather.clear_alert(ALERT_NOT_ENOUGH_OXYGEN)
 
-
 	breathe_gas_volume(breath, /datum/gas/oxygen, /datum/gas/carbon_dioxide)
 	// Heal mob if not in crit.
 	if(breather.health >= breather.crit_threshold && breather.oxyloss)
@@ -629,6 +628,7 @@
 
 	if(HAS_TRAIT(breather, TRAIT_NOBREATH))
 		return FALSE
+
 	// If the breath is null, it's actually a failed breath
 	var/no_breath = isnull(breath) || skip_breath
 	if(no_breath)

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -644,7 +644,7 @@
 		// Breath has more than 0 moles of gas.
 		//checks if the last breath was one of the not- this fucking breaths so it can clear it
 		if(failed_last_breath_checker)
-			failed_last_breath  = FALSE
+			breather.failed_last_breath = FALSE
 			failed_last_breath_checker = FALSE
 		// Route gases through mask filter if breather is wearing one.
 		if(istype(breather.wear_mask) && (breather.wear_mask.clothing_flags & GAS_FILTERING) && breather.wear_mask.has_filter)
@@ -683,8 +683,8 @@
 	// Robot, don't care lol
 	else if((owner && !HAS_TRAIT(owner, TRAIT_ASSISTED_BREATHING)))
 		// Can't breathe!
-			breather.failed_last_breath = TRUE
-			failed_last_breath_checker = TRUE
+		breather.failed_last_breath = TRUE
+		failed_last_breath_checker = TRUE
 
 	// The list of gases in the breath.
 	var/list/breath_gases = breath.gases


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
this fucking SUCKS, if you need to fix annother moodlet buyg you need to set failed_last_breath_checker in lungs to true in the part that is causing it FUCK

there was nothing checking for if 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixes the CANT... BREATH... moodlet but when you could breathe fine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
