### PR TITLE
Fixes Power Gloves combat logging

### DIFF
--- a/monkestation/code/modules/clothing/gloves/power_gloves.dm
+++ b/monkestation/code/modules/clothing/gloves/power_gloves.dm
@@ -47,10 +47,10 @@
 
 	if(power >= dust_power) //Dusts if there's enough in the grid
 		electrocute_victim.dust(TRUE, FALSE, TRUE)
-		log_combat(owner, target, "zapped", /obj/item/clothing/gloves/color/yellow/power_gloves, "[power] watts were used resulting in [shock_damage] damage.")
+		log_combat(owner, target, "zapped", /obj/item/clothing/gloves/color/yellow/power_gloves, "[power] watts were used resulting in the target dusting.")
 	else
 		electrocute_victim.electrocute_act(shock_damage, source, 1, SHOCK_TESLA | ((zap_flags & ZAP_MOB_STUN) ? NONE : SHOCK_NOSTUN))
-		log_combat(owner, target, "zapped", /obj/item/clothing/gloves/color/yellow/power_gloves, "[power] watts were used resulting in the target dusting.")
+		log_combat(owner, target, "zapped", /obj/item/clothing/gloves/color/yellow/power_gloves, "[power] watts were used resulting in [shock_damage] damage.")
 		return
 
 


### PR DESCRIPTION

## About The Pull Request
switched the places of the logs, so dusting says you dusted someone, and shocking someone regularly just says you shocked them when viewing admin logs.
## Why It's Good For The Game
Admins shouldnt be falsely told you dusted someone, when said one is still alive (or at the very least, not in a pile of dust on the ground.)
## Changelog
:cl: Tractor Mann
admin: Admins will no longer be told you dusted someone with power gloves when you didnt, and that you shocked someone with power gloves when you dust them.
/:cl:
