### PR TITLE
Adds tinyfans to arrivals on Blueshift

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -4701,6 +4701,10 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"aWw" = (
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/station/hallway/secondary/entry)
 "aWA" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/hangover,
@@ -55519,6 +55523,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
 "kKp" = (
@@ -170231,7 +170236,7 @@ ahn
 cXo
 cXo
 rMe
-ivx
+aWw
 rMe
 gLc
 gLc


### PR DESCRIPTION

## About The Pull Request

note: doors are just hidden in strongdmm, i didn't remove them - the arrivals shuttle tinyfans are below the doors, as they look really ugly below the floor lights in the middle

![2024-12-20 (1734740300) ~ StrongDMM](https://github.com/user-attachments/assets/ed4ca96b-141d-4d46-8739-4b86a93a5fdb)

## Why It's Good For The Game

so arrivals doesn't get spaced constantly and ook wanted it

## Changelog
:cl:
add: Added tinyfans to the arrivals shuttle and public mining shuttle doors on Blueshift.
/:cl:
