### PR TITLE
Mark of Rust now arms grenades instead of instantly detonating them

### DIFF
--- a/code/__DEFINES/~monkestation/antagonists.dm
+++ b/code/__DEFINES/~monkestation/antagonists.dm
@@ -53,3 +53,6 @@
 #define BORER_HIDING (1<<3)
 /// If the borer can produce eggs without a host
 #define BORER_ALONE_PRODUCTION (1<<4)
+
+/// How much heretic Mark of Rust mark does to items
+#define RUST_MARK_DAMAGE	50

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -343,7 +343,7 @@
 	if(!istype(mark))
 		return FALSE
 
-	mark.on_effect()
+	mark.on_effect(source) // monkestation edit: add "activator" arg to /datum/status_effect/eldritch/proc/on_effect()
 	return TRUE
 
 /**

--- a/code/modules/antagonists/heretic/status_effects/mark_effects.dm
+++ b/code/modules/antagonists/heretic/status_effects/mark_effects.dm
@@ -44,7 +44,7 @@
 /**
  * Called when the mark is activated by the heretic.
  */
-/datum/status_effect/eldritch/proc/on_effect()
+/datum/status_effect/eldritch/proc/on_effect(mob/living/activator) // monkestation edit: add "activator" arg to /datum/status_effect/eldritch/proc/on_effect()
 	SHOULD_CALL_PARENT(TRUE)
 
 	playsound(owner, 'sound/magic/repulse.ogg', 75, TRUE)
@@ -57,7 +57,7 @@
 /datum/status_effect/eldritch/flesh
 	effect_icon_state = "emark1"
 
-/datum/status_effect/eldritch/flesh/on_effect()
+/datum/status_effect/eldritch/flesh/on_effect(mob/living/activator) // monkestation edit: add "activator" arg to /datum/status_effect/eldritch/proc/on_effect()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_owner = owner
 		var/obj/item/bodypart/bodypart = pick(human_owner.bodyparts)
@@ -76,7 +76,7 @@
 	. = ..()
 	src.repetitions = max(1, repetition)
 
-/datum/status_effect/eldritch/ash/on_effect()
+/datum/status_effect/eldritch/ash/on_effect(mob/living/activator) // monkestation edit: add "activator" arg to /datum/status_effect/eldritch/proc/on_effect()
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
 		carbon_owner.stamina.adjust(-6 * repetitions) // first one = 30 stam
@@ -94,6 +94,7 @@
 /datum/status_effect/eldritch/rust
 	effect_icon_state = "emark3"
 
+/* monkestation removal: reimplemented in [monkestation/code/modules/antagonists/heretic/status_effects/mark_effects.dm]
 /datum/status_effect/eldritch/rust/on_effect()
 	if(iscarbon(owner))
 		var/mob/living/carbon/carbon_owner = owner
@@ -119,13 +120,14 @@
 					thing.take_damage(50) //monkestation edit end
 
 	return ..()
+monkestation end */
 
 // MARK OF VOID
 
 /datum/status_effect/eldritch/void
 	effect_icon_state = "emark4"
 
-/datum/status_effect/eldritch/void/on_effect()
+/datum/status_effect/eldritch/void/on_effect(mob/living/activator) // monkestation edit: add "activator" arg to /datum/status_effect/eldritch/proc/on_effect()
 	owner.apply_status_effect(/datum/status_effect/void_chill/major)
 	owner.adjust_silence(10 SECONDS)
 	return ..()
@@ -235,7 +237,7 @@
 	QDEL_NULL(cosmic_diamond)
 	return ..()
 
-/datum/status_effect/eldritch/cosmic/on_effect()
+/datum/status_effect/eldritch/cosmic/on_effect(mob/living/activator) // monkestation edit: add "activator" arg to /datum/status_effect/eldritch/proc/on_effect()
 	owner.adjust_confusion(7 SECONDS) //monkestation edit
 	new teleport_effect(get_turf(owner))
 	new /obj/effect/forcefield/cosmic_field(get_turf(owner))
@@ -295,7 +297,7 @@
 	REMOVE_TRAIT(owner, TRAIT_PACIFISM, id)
 	owner.balloon_alert(owner, "you feel able to once again strike!")
 
-/datum/status_effect/eldritch/moon/on_effect()
+/datum/status_effect/eldritch/moon/on_effect(mob/living/activator) // monkestation edit: add "activator" arg to /datum/status_effect/eldritch/proc/
 	owner.adjust_confusion(30 SECONDS)
 	owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 25, 160)
 	owner.emote(pick("giggle", "laugh"))

--- a/monkestation/code/modules/antagonists/heretic/status_effects/mark_effects.dm
+++ b/monkestation/code/modules/antagonists/heretic/status_effects/mark_effects.dm
@@ -1,0 +1,50 @@
+/datum/status_effect/eldritch/rust/on_effect(mob/living/activator)
+	if(iscarbon(owner))
+		var/mob/living/carbon/carbon_owner = owner
+		var/static/list/organs_to_damage = list(
+			ORGAN_SLOT_BRAIN,
+			ORGAN_SLOT_EARS,
+			ORGAN_SLOT_EYES,
+			ORGAN_SLOT_LIVER,
+			ORGAN_SLOT_LUNGS,
+			ORGAN_SLOT_STOMACH,
+			ORGAN_SLOT_HEART,
+		)
+
+		// Roughly 25% of their organs will take a bit of damage
+		for(var/organ_slot in organs_to_damage)
+			if(prob(25))
+				carbon_owner.adjustOrganLoss(organ_slot, 20)
+
+		var/list/grenades = list()
+		// And roughly 50% of their items will take a smack, too
+		for(var/obj/item/thing in carbon_owner.get_all_gear())
+			if(QDELETED(thing) || prob(50))
+				continue
+			// ignore abstract items and such
+			if(thing.item_flags & (ABSTRACT | EXAMINE_SKIP | HAND_ITEM))
+				continue
+			// don't delete people's ID cards
+			if(istype(thing, /obj/item/card/id))
+				continue
+			// special handling for grenades
+			if(istype(thing, /obj/item/grenade))
+				var/obj/item/grenade/grenade = thing
+				if(grenade.active) // primed grenades are just turned into duds
+					grenade.dud_flags |= GRENADE_DUD
+					continue
+				if(!grenade.dud_flags)
+					grenades["[grenade::name]"]++ // so you can't name/label a grenade something stupidly long to annoy them
+					log_bomber(activator, "has primed a", grenade, "via damage from Mark of Rust")
+					grenade.arm_grenade(delayoverride = max(round(grenade.det_time * 0.75, 0.5 SECONDS), 2 SECONDS))
+					continue
+			thing.take_damage(RUST_MARK_DAMAGE)
+
+		var/grenade_amt = length(grenades)
+		if(grenade_amt)
+			var/list/msg = list()
+			for(var/name in grenades)
+				msg += "[grenades[name]]x [name]"
+			owner.balloon_alert(activator, "triggered [english_list(msg)]")
+			owner.balloon_alert_to_viewers("[grenade_amt > 1 ? "several grenades" : "grenade"] damaged and activated!", ignored_mobs = activator)
+	return ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6394,6 +6394,7 @@
 #include "monkestation\code\modules\antagonists\heretic\knowledge\rust_lore.dm"
 #include "monkestation\code\modules\antagonists\heretic\knowledge\sacrifice_knowledge\sacrifice_buff.dm"
 #include "monkestation\code\modules\antagonists\heretic\knowledge\sacrifice_knowledge\sacrifice_knowledge.dm"
+#include "monkestation\code\modules\antagonists\heretic\status_effects\mark_effects.dm"
 #include "monkestation\code\modules\antagonists\monster_hunters\hunter_datum.dm"
 #include "monkestation\code\modules\antagonists\monster_hunters\hunter_rulesets.dm"
 #include "monkestation\code\modules\antagonists\monster_hunters\hunting_contracts.dm"


### PR DESCRIPTION

## About The Pull Request

This was brought up as a potential solution by QB a few months ago, to the issue of "rust heretic mark can instantly detonate grenades" - which can easily result in a hardstun or damage/death, in a way you have no way of knowing about beforehand.

This still detonates the grenades, but they will still have a timer, and kind of forces the two parties to try to get away from each other for a moment

The grenade's timer will be 25% shorter than normal

Grenades activated by mark of rust will be specifically logged as such.

To prevent potential cheesing, already activated grenades will be turned into duds, and grenade timers will be reduced by 25%, but they will never below a minimum of 2 seconds.

## Why It's Good For The Game

prevents a shitty uncounterable loss condition, exchanging it for something that still allows the victim to ward off the attacking heretics.

## Changelog
:cl:
balance: Mark of Rust now arms grenades instead of instantly detonating them. A balloon alert indicates this to the victim and witnesses, altho the heretic will see which grenades were activated.
/:cl:
