### PR TITLE
All ghosts now see PDA messages, not just observers

### DIFF
--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -608,7 +608,7 @@
 
 	// Show it to ghosts
 	var/ghost_message = span_name("[sender] [rigged ? "(as [fake_name]) Rigged " : ""]PDA Message --> [span_name("[signal.format_target()]")]: \"[signal.format_message()]\"")
-	for(var/mob/player_mob as anything in GLOB.current_observers_list)
+	for(var/mob/player_mob as anything in GLOB.dead_mob_list)
 		if(player_mob.client && !player_mob.client?.prefs)
 			stack_trace("[player_mob] ([player_mob.ckey]) had null prefs, which shouldn't be possible!")
 			continue


### PR DESCRIPTION

## About The Pull Request

This makes it so _all_ ghosts see PDA messages, not just those who observed from the lobby.

## Why It's Good For The Game

this was a dumb restriction. it also affected people who cryoed, and admins.

## Changelog
:cl:
qol: All ghosts now see PDA messages, not just observers.
/:cl:
