### PR TITLE
Fixes infinite wand with duel wielding

### DIFF
--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -28,6 +28,11 @@
 	icon_state = "[base_icon_state][charges ? null : "-drained"]"
 	return ..()
 
+/obj/item/gun/magic/wand/can_trigger_gun(mob/living/user, akimbo_usage)
+	if(akimbo_usage)
+		return FALSE
+	return ..()
+
 /obj/item/gun/magic/wand/attack(atom/target, mob/living/user)
 	if(target == user)
 		return


### PR DESCRIPTION

## About The Pull Request
title
removes duel wielding from wand (hopefully only for now)

## Why It's Good For The Game
fixes bug

## Changelog

:cl:
fix: you can no longer akimbo and fire a wand forever
/:cl:

