### PR TITLE
Replaces the syndie base's passive vent with an injector

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_inevitable.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_inevitable.dmm
@@ -197,8 +197,8 @@
 /turf/open/floor/engine,
 /area/ruin/syndicate_lava_base/testlab)
 "rX" = (
-/obj/machinery/atmospherics/components/unary/passive_vent,
 /obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/template_noop,
 /area/ruin/syndicate_lava_base/testlab)
 "sa" = (


### PR DESCRIPTION

## About The Pull Request
Title, replaces the passive vent in the syndie base's SM with an injector on.
## Why It's Good For The Game
Should stop the station from delamming due to the passive vent getting clogged
## Changelog
:cl:
fix: Fixed the syndicate lavaland base delamming if they spawned with an SM
/:cl:
