### PR TITLE
Space Hotel machine frames!

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
@@ -243,7 +243,8 @@
 /obj/machinery/button/door/directional/south{
 	id = "a6";
 	name = "privacy button";
-	specialfunctions = 4
+	specialfunctions = 4;
+	normaldoorcontrol = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet/orange,

--- a/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
@@ -488,7 +488,7 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/airlock{
-	id_tag = "a2";
+	id_tag = "Cabina2";
 	name = "Guest Room A2"
 	},
 /obj/machinery/door/firedoor,
@@ -957,7 +957,7 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/airlock{
-	id_tag = "a5";
+	id_tag = "Cabina5";
 	name = "Guest Room A5"
 	},
 /obj/machinery/door/firedoor,
@@ -1186,7 +1186,7 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/airlock{
-	id_tag = "a4";
+	id_tag = "Cabina4";
 	name = "Guest Room A4"
 	},
 /obj/machinery/door/firedoor,
@@ -1279,9 +1279,11 @@
 	dir = 4
 	},
 /obj/machinery/button/door/directional/south{
-	id = "a3";
+	id = "Cabina3";
 	name = "privacy button";
-	pixel_y = 24
+	pixel_y = 24;
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/hotel/guestroom/room_3)
@@ -1590,7 +1592,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/window{
-	id = "htsec"
+	id = "hotelsecshutter"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/security)
@@ -1686,7 +1688,7 @@
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/window{
-	id = "htsec"
+	id = "hotelsecshutter"
 	},
 /turf/open/floor/iron/dark/textured,
 /area/ruin/space/has_grav/hotel/security)
@@ -2491,7 +2493,7 @@
 "zx" = (
 /obj/structure/chair/office/tactical,
 /obj/machinery/button{
-	id = "htsec";
+	id = "hotelsecshutter";
 	name = "shutters control";
 	pixel_x = -25;
 	pixel_y = -1
@@ -2712,7 +2714,7 @@
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters/window{
-	id = "htsec"
+	id = "hotelsecshutter"
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/hotel/security)
@@ -3155,9 +3157,10 @@
 	dir = 4
 	},
 /obj/machinery/button/door/directional/south{
-	id = "a4";
+	id = "Cabina4";
 	name = "privacy button";
-	normaldoorcontrol = 1
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -4109,9 +4112,11 @@
 	dir = 8
 	},
 /obj/machinery/button/door/directional/south{
-	id = "a5";
+	id = "Cabina5";
 	name = "privacy button";
-	pixel_y = 24
+	pixel_y = 24;
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -4294,9 +4299,11 @@
 /obj/structure/table/wood/fancy/red,
 /obj/structure/window/reinforced/tinted/frosted/spawner/directional/east,
 /obj/machinery/button/door/directional/north{
-	id = "a2";
+	id = "Cabina2";
 	name = "privacy button";
-	pixel_y = -24
+	pixel_y = -24;
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
 /turf/open/floor/carpet/green,
 /area/ruin/space/has_grav/hotel/guestroom/room_2)
@@ -4340,7 +4347,7 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/airlock{
-	id_tag = "a3";
+	id_tag = "Cabina3";
 	name = "Guest Room A3"
 	},
 /obj/machinery/door/firedoor,
@@ -4666,8 +4673,10 @@
 	dir = 8
 	},
 /obj/machinery/button/door/directional/north{
-	id = "a1";
-	name = "privacy button"
+	id = "Cabina1";
+	name = "privacy button";
+	normaldoorcontrol = 1;
+	specialfunctions = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -5200,7 +5209,7 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/airlock{
-	id_tag = "a1";
+	id_tag = "Cabina1";
 	name = "Guest Room A1"
 	},
 /obj/machinery/door/firedoor,

--- a/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
@@ -242,7 +242,8 @@
 	},
 /obj/machinery/button/door/directional/south{
 	id = "a6";
-	name = "privacy button"
+	name = "privacy button";
+	specialfunctions = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/carpet/orange,

--- a/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
@@ -2492,11 +2492,11 @@
 /area/ruin/space/has_grav/hotel/workroom)
 "zx" = (
 /obj/structure/chair/office/tactical,
-/obj/machinery/button{
-	id = "hotelsecshutter";
-	name = "shutters control";
-	pixel_x = -25;
-	pixel_y = -1
+/obj/machinery/button/door{
+	pixel_x = -24;
+	pixel_y = 1;
+	name = "shutter control";
+	id = "hotelsecshutter"
 	},
 /turf/open/floor/glass/reinforced,
 /area/ruin/space/has_grav/hotel/security)

--- a/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
@@ -241,7 +241,7 @@
 	dir = 8
 	},
 /obj/machinery/button/door/directional/south{
-	id = "a6";
+	id = "Cabina6";
 	name = "privacy button";
 	specialfunctions = 4;
 	normaldoorcontrol = 1
@@ -320,7 +320,7 @@
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/airlock{
-	id_tag = "a6";
+	id_tag = "Cabina6";
 	name = "Guest Room A6"
 	},
 /obj/machinery/door/firedoor,
@@ -3156,7 +3156,8 @@
 	},
 /obj/machinery/button/door/directional/south{
 	id = "a4";
-	name = "privacy button"
+	name = "privacy button";
+	normaldoorcontrol = 1
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{

--- a/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
@@ -1335,7 +1335,7 @@
 /turf/open/floor/wood/tile,
 /area/ruin/space/has_grav/hotel)
 "oW" = (
-/obj/structure/frame,
+/obj/structure/frame/machine,
 /obj/item/stack/cable_coil/five,
 /obj/item/stock_parts/micro_laser/quadultra,
 /turf/open/floor/circuit/green,
@@ -2062,7 +2062,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/ruin/space/has_grav/hotel/security)
 "vL" = (
-/obj/structure/frame,
+/obj/structure/frame/machine,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/circuitboard/machine/announcement_system,
 /obj/item/stock_parts/micro_laser/quadultra,
@@ -3559,7 +3559,7 @@
 /turf/template_noop,
 /area/ruin/space/has_grav/hotel)
 "Ko" = (
-/obj/structure/frame,
+/obj/structure/frame/machine,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/circuitboard/machine/pacman,
 /obj/item/stack/cable_coil/five,
@@ -5022,7 +5022,7 @@
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/hotel)
 "WA" = (
-/obj/structure/frame,
+/obj/structure/frame/machine,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/circuitboard/machine/emitter,
 /obj/item/stack/cable_coil/five,

--- a/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
@@ -1631,7 +1631,8 @@
 /obj/machinery/button/door{
 	pixel_x = 24;
 	name = "shutter button";
-	id = "hotelcb1"
+	id = "hotelcb1";
+	normaldoorcontrol = 1
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3409,7 +3410,8 @@
 	pixel_y = 8;
 	pixel_x = -24;
 	id = "hotelcb2";
-	name = "shutter button"
+	name = "shutter button";
+	normaldoorcontrol = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/hotel/dock)
@@ -4661,7 +4663,8 @@
 	pixel_y = -24;
 	pixel_x = -24;
 	id = "hotelcb2";
-	name = "shutter button"
+	name = "shutter button";
+	normaldoorcontrol = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -5260,7 +5263,8 @@
 /obj/machinery/button/door{
 	pixel_x = -24;
 	name = "shutter button";
-	id = "hotelcb1"
+	id = "hotelcb1";
+	normaldoorcontrol = 1
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1

--- a/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacerealhotel.dmm
@@ -1628,11 +1628,10 @@
 /turf/open/floor/wood/tile,
 /area/ruin/space/has_grav/hotel)
 "rN" = (
-/obj/machinery/button{
-	id = "hcb1";
-	name = "shutters control";
-	pixel_x = 26;
-	pixel_y = 8
+/obj/machinery/button/door{
+	pixel_x = 24;
+	name = "shutter button";
+	id = "hotelcb1"
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2631,7 +2630,7 @@
 "AX" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
-	id = "hcb2";
+	id = "hotelcb2";
 	name = "Cargo Bay Shutters"
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -2889,7 +2888,7 @@
 "Dk" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor{
-	id = "hcd1";
+	id = "hotelcd1";
 	name = "Cargo Dock"
 	},
 /turf/open/floor/plating,
@@ -3406,11 +3405,11 @@
 /area/ruin/space/has_grav/hotel/pool)
 "IJ" = (
 /obj/effect/turf_decal/loading_area,
-/obj/machinery/button{
-	id = "hcb2";
-	name = "shutters control";
-	pixel_x = -25;
-	pixel_y = 8
+/obj/machinery/button/door{
+	pixel_y = 8;
+	pixel_x = -24;
+	id = "hotelcb2";
+	name = "shutter button"
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/hotel/dock)
@@ -4102,7 +4101,7 @@
 "OQ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
-	id = "hcb2";
+	id = "hotelcb2";
 	name = "Cargo Bay Shutters"
 	},
 /turf/open/floor/plating,
@@ -4636,11 +4635,11 @@
 /turf/template_noop,
 /area/template_noop)
 "Te" = (
-/obj/machinery/button{
-	id = "hcd1";
-	name = "shutters control";
-	pixel_x = -25;
-	pixel_y = -25
+/obj/machinery/button/door{
+	pixel_x = -24;
+	pixel_y = -24;
+	id = "hotelcd1";
+	name = "shutter button"
 	},
 /turf/open/floor/iron/dark/side,
 /area/ruin/space/has_grav/hotel/dock)
@@ -4652,17 +4651,17 @@
 "Th" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
-	id = "hcb1";
+	id = "hotelcb1";
 	name = "Cargo Bay Shutters"
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/ruin/space/has_grav/hotel/dock)
 "Tk" = (
-/obj/machinery/button{
-	id = "hcb2";
-	name = "shutters control";
-	pixel_x = -25;
-	pixel_y = -25
+/obj/machinery/button/door{
+	pixel_y = -24;
+	pixel_x = -24;
+	id = "hotelcb2";
+	name = "shutter button"
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -5258,11 +5257,10 @@
 /turf/open/floor/carpet/black,
 /area/ruin/space/has_grav/hotel)
 "YT" = (
-/obj/machinery/button{
-	id = "hcb1";
-	name = "shutters control";
-	pixel_x = -25;
-	pixel_y = 8
+/obj/machinery/button/door{
+	pixel_x = -24;
+	name = "shutter button";
+	id = "hotelcb1"
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1


### PR DESCRIPTION
## About The Pull Request

replaced obj/structure/frame with obj/structure/frame/machine so that players can immediately work on repairs or construction of tcomm.

Also redoes every single button and most door/shutter IDs on the map so it actually works right in the first place.

## Why It's Good For The Game

Fixes #4668. You like fixes dont you?
## Changelog

:cl:
fix: changed frames for machine frames on the ghost variant of the Space Hotel.
fix: fixed all the doors and shutters. the buttons should actually do what they say they do.
/:cl:
