### PR TITLE
Oxygen Tank Refills

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -97970,10 +97970,6 @@
 /mob/living/carbon/human/species/monkey,
 /turf/open/floor/iron/white,
 /area/station/medical/pathology)
-"xop" = (
-/obj/machinery/atmospherics/components/tank,
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance/storage)
 "xoI" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/stripes/line{
@@ -133206,8 +133202,8 @@ qMB
 wtS
 dQq
 hIB
-xop
-xop
+pGi
+pGi
 eam
 rHp
 rSR
@@ -133463,8 +133459,8 @@ vUe
 sav
 pNH
 hIB
-xop
-xop
+pGi
+pGi
 ehk
 kLi
 kLi
@@ -133721,7 +133717,7 @@ eNE
 xXR
 hIB
 pGi
-xop
+pGi
 ehk
 agq
 hbA

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -28909,7 +28909,9 @@
 /area/station/security/prison)
 "jlj" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "jlq" = (
@@ -29607,7 +29609,9 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "jxJ" = (
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -39566,7 +39570,9 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "mHu" = (
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "mHw" = (
@@ -52711,7 +52717,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "qKx" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -51273,7 +51273,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "qfn" = (
-/obj/machinery/atmospherics/components/tank{
+/obj/machinery/atmospherics/components/tank/oxygen{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple/half/contrasted{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -18392,7 +18392,9 @@
 /turf/open/floor/iron,
 /area/station/security/holding_cell)
 "gHw" = (
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 9
 	},
@@ -25881,7 +25883,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "jcw" = (
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "jcy" = (
@@ -39384,7 +39388,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "nDw" = (
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
@@ -44452,13 +44458,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"pth" = (
-/obj/machinery/atmospherics/components/tank,
-/obj/effect/turf_decal/siding/purple{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/ordnance/storage)
 "pti" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
@@ -99942,7 +99941,7 @@ kzQ
 gwf
 pJl
 rYI
-pth
+ltm
 jcw
 uBF
 iyc

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -3917,12 +3917,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/port/aft)
-"biD" = (
-/obj/machinery/atmospherics/components/tank{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/science/ordnance)
 "biO" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 8
@@ -5512,10 +5506,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/evidence)
-"bEJ" = (
-/obj/machinery/atmospherics/components/tank,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/science/ordnance)
 "bEK" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners{
 	dir = 1
@@ -20333,8 +20323,8 @@
 /area/station/hallway/secondary/command)
 "gcs" = (
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/components/tank{
-	dir = 1
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
 	},
 /obj/machinery/light/cold/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
@@ -59272,7 +59262,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/safe)
 "rzH" = (
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/ordnance)
@@ -103258,9 +103250,9 @@ vhx
 uZB
 con
 bev
-bEJ
-biD
-bEJ
+ebQ
+ebQ
+ebQ
 bev
 qlO
 laO

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -17142,7 +17142,9 @@
 /turf/open/floor/wood/tile,
 /area/station/service/barber)
 "ffQ" = (
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 8
 	},
@@ -29513,7 +29515,9 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "iPL" = (
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
 "iPQ" = (
@@ -41049,7 +41053,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "mfE" = (
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
 	},
@@ -76518,7 +76524,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "wCN" = (
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/purple{
 	dir = 9
 	},

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -27266,7 +27266,9 @@
 	},
 /area/station/security/checkpoint/customs)
 "hQk" = (
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Science - Ordnance Storage";
 	name = "science camera";
@@ -40833,7 +40835,9 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/aft/upper)
 "lxx" = (
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /obj/structure/sign/warning/no_smoking/circle/directional/east,
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/engine,
@@ -69761,7 +69765,9 @@
 	},
 /area/station/security/prison)
 "trl" = (
-/obj/machinery/atmospherics/components/tank,
+/obj/machinery/atmospherics/components/tank/oxygen{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
 "tru" = (


### PR DESCRIPTION
## About The Pull Request

Reorganized all tank systems for ordnance to be full of oxygen.
## Why It's Good For The Game

Gives sci just a tad bit longer to work off their stored oxygen supply before needing to go to Atmos. Also greatly increases the risk of HILARIOUS fires in Ordnance when the rod hits sci!

Fixes #4672 btw
## Changelog
:cl:
balance: all maps excluding Blueshift and Tramstation have their ordnance oxygen tanks contain even more oxygen. Not for assistant use.
/:cl:
