### PR TITLE
Make heart worms a preset dangerous disease

### DIFF
--- a/monkestation/code/modules/virology/disease/premades/heart_attack.dm
+++ b/monkestation/code/modules/virology/disease/premades/heart_attack.dm
@@ -13,3 +13,4 @@
 	infectionchance = 0
 	infectionchance_base = 0
 	stage_variance = 0
+	severity = DISEASE_SEVERITY_DANGEROUS


### PR DESCRIPTION

## About The Pull Request
Predefines heart worms as a 'dangerous' disease.
## Why It's Good For The Game
Since currently the disease hud status do not work, if virology is doing their job heart worms can easily blend in with a positive virus. This insures medical huds still can catch the worms early.
## Changelog
:cl:
qol: Predefined heartworms as a dangerous disease.
/:cl:
