### PR TITLE
tot Kiboko starts with proper ammo

### DIFF
--- a/monkestation/code/modules/blueshift/items/company_guns.dm
+++ b/monkestation/code/modules/blueshift/items/company_guns.dm
@@ -325,8 +325,6 @@
 	worn_icon_state = "kiboko_evil"
 	inhand_icon_state = "kiboko_evil"
 
-	spawn_magazine_type = /obj/item/ammo_box/magazine/c980_grenade/drum
-
 /obj/item/gun/ballistic/automatic/sol_grenade_launcher/evil/no_mag
 	spawnwithmagazine = FALSE
 

--- a/monkestation/code/modules/blueshift/items/company_guns.dm
+++ b/monkestation/code/modules/blueshift/items/company_guns.dm
@@ -257,7 +257,7 @@
 	weapon_weight = WEAPON_HEAVY
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_SUITSTORE
 
-	spawn_magazine_type = /obj/item/ammo_box/magazine/c980_grenade/drum/thunderdome_shrapnel
+	spawn_magazine_type = /obj/item/ammo_box/magazine/c980_grenade/drum
 	accepted_magazine_type = /obj/item/ammo_box/magazine/c980_grenade
 
 	fire_sound = 'monkestation/code/modules/blueshift/sounds/grenade_launcher.ogg'
@@ -324,6 +324,8 @@
 	icon_state = "kiboko_evil"
 	worn_icon_state = "kiboko_evil"
 	inhand_icon_state = "kiboko_evil"
+
+	spawn_magazine_type = /obj/item/ammo_box/magazine/c980_grenade/drum
 
 /obj/item/gun/ballistic/automatic/sol_grenade_launcher/evil/no_mag
 	spawnwithmagazine = FALSE

--- a/monkestation/code/modules/blueshift/items/company_guns.dm
+++ b/monkestation/code/modules/blueshift/items/company_guns.dm
@@ -325,7 +325,7 @@
 	worn_icon_state = "kiboko_evil"
 	inhand_icon_state = "kiboko_evil"
 
-	spawn_magazine_type = /obj/item/ammo_box/magazine/c980_grenade/drum
+	spawn_magazine_type = /obj/item/ammo_box/magazine/c980_grenade/drum/thunderdome_shrapnel
 
 /obj/item/gun/ballistic/automatic/sol_grenade_launcher/evil/no_mag
 	spawnwithmagazine = FALSE

--- a/monkestation/code/modules/blueshift/items/company_guns.dm
+++ b/monkestation/code/modules/blueshift/items/company_guns.dm
@@ -257,6 +257,7 @@
 	weapon_weight = WEAPON_HEAVY
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_SUITSTORE
 
+	spawn_magazine_type = /obj/item/ammo_box/magazine/c980_grenade/drum/thunderdome_shrapnel
 	accepted_magazine_type = /obj/item/ammo_box/magazine/c980_grenade
 
 	fire_sound = 'monkestation/code/modules/blueshift/sounds/grenade_launcher.ogg'


### PR DESCRIPTION

## About The Pull Request
Traitor Kiboko starts with lethals instead of practice ammo

requested by pooba

## Why It's Good For The Game
It made no sense and was really just a noob trap, 0 reason for it to be that way not really a bug since it was intentional, more like a oversight maybe?

## Changelog

:cl:
qol: Traitor Kiboko starts with lethals
/:cl:

