### PR TITLE
regal rat minions are now immune to viruses

### DIFF
--- a/monkestation/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
+++ b/monkestation/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
@@ -1,0 +1,3 @@
+/datum/action/cooldown/mob_cooldown/riot/make_minion(mob/living/new_minion, minion_desc, list/command_list = mouse_commands)
+	. = ..()
+	ADD_TRAIT(new_minion, TRAIT_VIRUSIMMUNE, REF(owner))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7576,6 +7576,7 @@
 #include "monkestation\code\modules\mob\living\basic\pets\parrot\_parrot.dm"
 #include "monkestation\code\modules\mob\living\basic\pets\parrot\parrot_ai\parroting_action.dm"
 #include "monkestation\code\modules\mob\living\basic\space_fauna\carp\carp.dm"
+#include "monkestation\code\modules\mob\living\basic\space_fauna\regal_rat\regal_rat_actions.dm"
 #include "monkestation\code\modules\mob\living\basic\space_fauna\slugcat\slugcat.dm"
 #include "monkestation\code\modules\mob\living\basic\trooper\syndicate.dm"
 #include "monkestation\code\modules\mob\living\basic\vermin\frog.dm"


### PR DESCRIPTION

## About The Pull Request

this adds `TRAIT_VIRUSIMMUNE` to all regal rat minions, so they don't kill the server from 5 morbillion rats trying to spread a disease.

## Why It's Good For The Game

![2024-12-26 (1735235809) ~ %pn](https://github.com/user-attachments/assets/9ebcfe77-cec8-44bf-a36e-e9a583560323)

## Changelog
:cl:
fix: Regal rat minions are now immune to viruses, to prevent Lag'sie from being summoned with large rat swarms.
/:cl:
