### PR TITLE
Shock touch respects his grace

### DIFF
--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -51,7 +51,7 @@
 /datum/action/cooldown/spell/touch/shock/cast_on_hand_hit(obj/item/melee/touch_attack/hand, atom/victim, mob/living/carbon/caster)
 	if(iscarbon(victim))
 		var/mob/living/carbon/carbon_victim = victim
-		if(carbon_victim.electrocute_act(15, caster, 1, SHOCK_NOGLOVES | SHOCK_NOSTUN) && !HAS_TRAIT(carbon_victim, TRAIT_NO_SHOCK_BUILDUP))//doesnt stun. never let this stun MONKESTATION ADDITION: his grace check
+		if(carbon_victim.electrocute_act(15, caster, 1, SHOCK_NOGLOVES | SHOCK_NOSTUN) && !HAS_TRAIT(carbon_victim, TRAIT_NO_SHOCK_BUILDUP) && !HAS_TRAIT(carbon_victim, TRAIT_SHOCKIMMUNE))//doesnt stun. never let this stun MONKESTATION ADDITION: HAS TRAIT
 			carbon_victim.dropItemToGround(carbon_victim.get_active_held_item())
 			carbon_victim.dropItemToGround(carbon_victim.get_inactive_held_item())
 			carbon_victim.adjust_confusion(15 SECONDS)

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -51,7 +51,7 @@
 /datum/action/cooldown/spell/touch/shock/cast_on_hand_hit(obj/item/melee/touch_attack/hand, atom/victim, mob/living/carbon/caster)
 	if(iscarbon(victim))
 		var/mob/living/carbon/carbon_victim = victim
-		if(carbon_victim.electrocute_act(15, caster, 1, SHOCK_NOGLOVES | SHOCK_NOSTUN))//doesnt stun. never let this stun
+		if(carbon_victim.electrocute_act(15, caster, 1, SHOCK_NOGLOVES | SHOCK_NOSTUN) && !carbon_victim.has_status_effect(/datum/status_effect/his_grace))//doesnt stun. never let this stun MONKESTATION ADDITION: his grace check
 			carbon_victim.dropItemToGround(carbon_victim.get_active_held_item())
 			carbon_victim.dropItemToGround(carbon_victim.get_inactive_held_item())
 			carbon_victim.adjust_confusion(15 SECONDS)

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -51,7 +51,7 @@
 /datum/action/cooldown/spell/touch/shock/cast_on_hand_hit(obj/item/melee/touch_attack/hand, atom/victim, mob/living/carbon/caster)
 	if(iscarbon(victim))
 		var/mob/living/carbon/carbon_victim = victim
-		if(carbon_victim.electrocute_act(15, caster, 1, SHOCK_NOGLOVES | SHOCK_NOSTUN) && !carbon_victim.has_status_effect(/datum/status_effect/his_grace))//doesnt stun. never let this stun MONKESTATION ADDITION: his grace check
+		if(carbon_victim.electrocute_act(15, caster, 1, SHOCK_NOGLOVES | SHOCK_NOSTUN) && !HAS_TRAIT(carbon_victim, TRAIT_NO_SHOCK_BUILDUP))//doesnt stun. never let this stun MONKESTATION ADDITION: his grace check
 			carbon_victim.dropItemToGround(carbon_victim.get_active_held_item())
 			carbon_victim.dropItemToGround(carbon_victim.get_inactive_held_item())
 			carbon_victim.adjust_confusion(15 SECONDS)


### PR DESCRIPTION
## About The Pull Request
Makes shocktouch not force people with no shock buildup to drop their items

His grace is stun immune, but still droppable in early stages but only by holder or stripping, shocktouch bypasses this and makes them drop it anyways

## Why It's Good For The Game
Fixes bug/oversight. No screwing his grace or other things
fixes https://github.com/Monkestation/Monkestation2.0/issues/4339#issuecomment-2563691451

## Changelog

:cl:
fix: Shock Touch no longer forces people with no shock buildup to drop items
/:cl:

