### PR TITLE
Fixes and balances some problems with satyrs

### DIFF
--- a/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
+++ b/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
@@ -9,7 +9,7 @@
 
 	var/drunk_state = 0
 
-/datum/component/living_drunk/Initialize(grace_period = 5 MINUTES, booze_per_drunkness = 10)
+/datum/component/living_drunk/Initialize(grace_period = 5 MINUTES, booze_per_drunkness = 2)
 	. = ..()
 	src.grace_period = grace_period
 	src.booze_per_drunkness = booze_per_drunkness

--- a/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
+++ b/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
@@ -6,11 +6,11 @@
 
 	COOLDOWN_DECLARE(drank_grace)
 	var/grace_period = 5 MINUTES
-	var/booze_per_drunkness = 2
+	var/booze_per_drunkness = 1
 
 	var/drunk_state = 0
 
-/datum/component/living_drunk/Initialize(grace_period = 5 MINUTES, booze_per_drunkness = 2)
+/datum/component/living_drunk/Initialize(grace_period = 5 MINUTES, booze_per_drunkness = 1)
 	. = ..()
 	src.grace_period = grace_period
 	src.booze_per_drunkness = booze_per_drunkness

--- a/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
+++ b/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
@@ -2,6 +2,7 @@
 /datum/component/living_drunk
 	var/current_drunkness = 100
 	var/max_drunkness = 100
+	var/min_drunkness = 0
 
 	COOLDOWN_DECLARE(drank_grace)
 	var/grace_period = 5 MINUTES
@@ -46,7 +47,7 @@
 /datum/component/living_drunk/process(seconds_per_tick)
 	if(!COOLDOWN_FINISHED(src, drank_grace))
 		return
-	current_drunkness -= 0.2
+	current_drunkness = min(min_drunkness, (current_drunkness -= 0.2))
 	drunkness_change_effects()
 
 /datum/component/living_drunk/proc/drunkness_change_effects()

--- a/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
+++ b/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
@@ -9,7 +9,7 @@
 
 	var/drunk_state = 0
 
-/datum/component/living_drunk/Initialize(grace_period = 5 MINUTES, booze_per_drunkness = 100)
+/datum/component/living_drunk/Initialize(grace_period = 5 MINUTES, booze_per_drunkness = 10)
 	. = ..()
 	src.grace_period = grace_period
 	src.booze_per_drunkness = booze_per_drunkness
@@ -39,7 +39,7 @@
 	var/metabolized_amount = living.metabolism_efficiency * reagent.metabolization_rate * seconds_per_tick
 
 	var/drunk_increase = metabolized_amount / booze_per_drunkness
-	current_drunkness = min(max_drunkness, (current_drunkness + drunk_increase) * 100)
+	current_drunkness = min(max_drunkness, current_drunkness + drunk_increase)
 	COOLDOWN_START(src, drank_grace, grace_period)
 	drunkness_change_effects()
 

--- a/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
+++ b/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
@@ -39,14 +39,14 @@
 	var/metabolized_amount = living.metabolism_efficiency * reagent.metabolization_rate * seconds_per_tick
 
 	var/drunk_increase = metabolized_amount / booze_per_drunkness
-	current_drunkness = min(max_drunkness, current_drunkness + drunk_increase)
+	current_drunkness = min(max_drunkness, (current_drunkness + drunk_increase) * 100)
 	COOLDOWN_START(src, drank_grace, grace_period)
 	drunkness_change_effects()
 
 /datum/component/living_drunk/process(seconds_per_tick)
 	if(!COOLDOWN_FINISHED(src, drank_grace))
 		return
-	current_drunkness -= 0.1
+	current_drunkness -= 0.2
 	drunkness_change_effects()
 
 /datum/component/living_drunk/proc/drunkness_change_effects()
@@ -55,11 +55,10 @@
 		living.apply_status_effect(/datum/status_effect/inebriated/drunk, 80)
 		drunk_state = 2
 		return
-	if((current_drunkness <= 30) && (drunk_state != 1 || drunk_state != 2))
+	if((current_drunkness <= 30) && drunk_state != 1 && drunk_state != 2)
 		living.apply_status_effect(/datum/status_effect/inebriated/tipsy, 5)
 		drunk_state = 1
 		return
-
 	if(current_drunkness > 30)
 		drunk_state = 0
 		living.remove_status_effect(/datum/status_effect/inebriated/tipsy)

--- a/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
+++ b/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
@@ -5,7 +5,7 @@
 
 	COOLDOWN_DECLARE(drank_grace)
 	var/grace_period = 5 MINUTES
-	var/booze_per_drunkness = 100
+	var/booze_per_drunkness = 2
 
 	var/drunk_state = 0
 


### PR DESCRIPTION
## About The Pull Request
Satyrs sober up two times faster now, also satyrs now get drunk much faster now also fixes this bug: https://github.com/Monkestation/Monkestation2.0/issues/4593
also figured out there is nothing stopping current_drunkness from going into the negatives so added a minimum

## Why It's Good For The Game
Makes satyrs less annoying to play also fixes some bugs

## Changelog
:cl:
balance: Satyrs get sober faster now
balance: Satyrs don't take a few centuries to get drunk again
fix: Satyrs don't flicker between being drunk and not anymore
fix: Satyrs drunkness can no longer go negative
/:cl: