### PR TITLE
Fixes Table flipping 4ever (I hope)

### DIFF
--- a/monkestation/code/modules/blueshift/structures/flipped_table.dm
+++ b/monkestation/code/modules/blueshift/structures/flipped_table.dm
@@ -48,7 +48,7 @@
 		return COMPONENT_ATOM_BLOCK_EXIT
 
 /obj/structure/flippedtable/CtrlShiftClick(mob/user)
-	if(!istype(user) || iscorticalborer(user))
+	if(!iscarbon(user) && !is_admin(user.client))
 		return
 	if(isobserver(user) && !is_admin(user.client))  //prevent ghosts from unflipping tables but still allows admins to fuck around
 		return
@@ -72,13 +72,11 @@
 
 
 /obj/structure/table/CtrlShiftClick(mob/user)
-	if(!istype(user) || iscorticalborer(user))
-		return
-	if(!can_flip)
+	if(!iscarbon(user) && !is_admin(user.client))
 		return
 	if(isobserver(user) && !is_admin(user.client))  //prevent ghosts from flipping tables but still allows admins to fuck around
 		return
-	if(!user.CanReach(src)) //prevents certain kinds of fuckers on cameras from flipping tables THROUGH A FUCKING CAMERA. ... this is why we can't have nice things.
+	if(!can_flip || !user.CanReach(src))
 		return
 	user.balloon_alert_to_viewers("flipping table...")
 	if(!do_after(user, max_integrity * 0.25))


### PR DESCRIPTION

## About The Pull Request
Adds a iscarbon check to table flipping, hopefully forever fixing stupid things being able to flip tables. (Admins can still flip them as ghost)

Also cleans up table flipping checks a bit

## Why It's Good For The Game
Fixes bug, cleans up code
fixes https://github.com/Monkestation/Monkestation2.0/issues/4667

## Changelog

:cl:
fix: Adds carbon check to flipping tables, no more imaginary friends and roaches flipping tables
/:cl:

