### PR TITLE
Makes blueshift departures airlock not security exclusive

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -85820,26 +85820,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/white/side,
 /area/station/science/xenobiology)
-"qHM" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes{
-	dir = 8
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Docking Port";
-	space_dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/exit/departure_lounge)
 "qHR" = (
 /obj/item/weldingtool/mini,
 /turf/open/floor/plating,
@@ -90716,24 +90696,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/science/ordnance)
-"rEg" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/door/airlock/external{
-	name = "External Docking Port"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/general,
-/turf/open/floor/iron/dark,
-/area/station/hallway/secondary/exit/departure_lounge)
 "rEj" = (
 /obj/structure/hedge,
 /turf/open/floor/glass/reinforced,
@@ -142447,7 +142409,7 @@ fZI
 dTd
 stH
 dTd
-qHM
+lzr
 nKo
 fZI
 fZI
@@ -143218,7 +143180,7 @@ dTd
 dTd
 iZi
 cFU
-rEg
+wiF
 nKo
 cOE
 iqG


### PR DESCRIPTION
## About The Pull Request
Makes the public airlock not security exclusive for no reason on blueshift
![image](https://github.com/user-attachments/assets/61e7079e-9e08-4edb-9007-649aca493360)

## Why It's Good For The Game
Not in line with any of our other maps and causes unnecessary cramming into the bottom two airlocks. Especially since the security section typically arrives at the bottommost airlock on blueshift.
## Changelog
:cl:
fix: Removed unneeded security access on Blueshift departures.
/:cl:
