### PR TITLE
Prevent Life and similar reactions from occuring in plants

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -111,6 +111,8 @@
 #define REACTION_REAL_TIME_SPLIT (1<<7)
 ///Should this reaction use purity
 #define REACTION_USES_PURITY (1<<8)
+/// This reaction should never occur in grown plants (monkestation addition)
+#define REACTION_NOT_IN_PLANTS (1<<9)
 
 ///Used for overheat_temp - This sets the overheat so high it effectively has no overheat temperature.
 #define NO_OVERHEAT 99999

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -913,6 +913,12 @@
 			if((reaction.reaction_flags & REACTION_NON_INSTANT))
 				granularity = CHEMICAL_VOLUME_MINIMUM
 
+			// monkestation start
+			var/banned_due_to_plant = FALSE
+			if((reaction.reaction_flags & REACTION_NOT_IN_PLANTS) && istype(cached_my_atom, /obj/item/food/grown))
+				banned_due_to_plant = TRUE
+			// monkestation end
+
 			for(var/req_reagent in cached_required_reagents)
 				if(!has_reagent(req_reagent, (cached_required_reagents[req_reagent]*granularity)))
 					break
@@ -947,7 +953,7 @@
 			else
 				meets_ph_requirement = TRUE
 
-			if(total_matching_reagents == total_required_reagents && total_matching_catalysts == total_required_catalysts && matching_container && matching_other)
+			if(total_matching_reagents == total_required_reagents && total_matching_catalysts == total_required_catalysts && matching_container && matching_other && !banned_due_to_plant)
 				if(meets_temp_requirement && meets_ph_requirement)
 					possible_reactions += reaction
 				else

--- a/monkestation/code/modules/reagents/chemistry/recipes/others.dm
+++ b/monkestation/code/modules/reagents/chemistry/recipes/others.dm
@@ -1,0 +1,17 @@
+/datum/chemical_reaction/life
+	reaction_flags = parent_type::reaction_flags | REACTION_NOT_IN_PLANTS
+
+/datum/chemical_reaction/life_friendly
+	reaction_flags = parent_type::reaction_flags | REACTION_NOT_IN_PLANTS
+
+/datum/chemical_reaction/corgium
+	reaction_flags = parent_type::reaction_flags | REACTION_NOT_IN_PLANTS
+
+/datum/chemical_reaction/monkey
+	reaction_flags = parent_type::reaction_flags | REACTION_NOT_IN_PLANTS
+
+/datum/chemical_reaction/butterflium
+	reaction_flags = parent_type::reaction_flags | REACTION_NOT_IN_PLANTS
+
+/datum/chemical_reaction/ant_slurry
+	reaction_flags = parent_type::reaction_flags | REACTION_NOT_IN_PLANTS

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7922,6 +7922,7 @@
 #include "monkestation\code\modules\reagents\chemistry\reagents\drug_reagents.dm"
 #include "monkestation\code\modules\reagents\chemistry\reagents\other_reagents.dm"
 #include "monkestation\code\modules\reagents\chemistry\reagents\drinks\glass_styles\mixed_drinks.dm"
+#include "monkestation\code\modules\reagents\chemistry\recipes\others.dm"
 #include "monkestation\code\modules\reagents\fun\austrialium.dm"
 #include "monkestation\code\modules\reagents\fun\liquid_justice.dm"
 #include "monkestation\code\modules\reagents\fun\shakeium.dm"


### PR DESCRIPTION

## About The Pull Request

This adds a new chemical reagent flag, `REACTION_NOT_IN_PLANTS`, that bans the reaction from occurring inside plants.

## Why It's Good For The Game

OH GOD THE LAG

## Changelog
:cl:
fix: Reactions such as Life, Corgium, etc are now banned from occuring in grown plants, to prevent massive lag.
/:cl:
