### PR TITLE
Ashwalker Longbow Spawn fix

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker2.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker2.dmm
@@ -1265,9 +1265,8 @@
 /obj/item/storage/bag/quiver{
 	pixel_x = -10
 	},
-/obj/item/gun/ballistic/bow,
-/obj/item/gun/ballistic/bow{
-	pixel_y = 0;
+/obj/item/gun/ballistic/bow/longbow,
+/obj/item/gun/ballistic/bow/longbow{
 	pixel_x = 5
 	},
 /turf/open/misc/asteroid/basalt/lava_land_surface,


### PR DESCRIPTION

## About The Pull Request

Makes the bows in Ashieland actually bows and not the parent object.
## Why It's Good For The Game

Fixes #3469 
## Changelog
:cl:
fix: made the bows in ashieland actually longbows like they should be.
/:cl:
