### PR TITLE
Minor fixes for Slime Grinder and Slime Market Pad

### DIFF
--- a/monkestation/code/modules/slimecore/machines/slime_grinder.dm
+++ b/monkestation/code/modules/slimecore/machines/slime_grinder.dm
@@ -91,7 +91,6 @@
 	. += mutable_appearance(icon, "slime_grinder_overlay", layer + 0.1, src)
 
 /obj/machinery/plumbing/slime_grinder/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
-	. = ..()
 	if(isslime(AM))
 		if(!poster_boy)
 			poster_boy = AM
@@ -102,3 +101,5 @@
 		soon_to_be_crushed |= AM
 		AM.forceMove(src)
 		update_appearance()
+		return // Stops slime from actually hitting the machine
+	return ..() // If it is anything else handle being hit normally.

--- a/monkestation/code/modules/slimecore/machines/slime_market.dm
+++ b/monkestation/code/modules/slimecore/machines/slime_market.dm
@@ -6,6 +6,7 @@
 	base_icon_state = "market_pad"
 	density = TRUE
 	use_power = IDLE_POWER_USE
+	interaction_flags_machine = INTERACT_MACHINE_OPEN|INTERACT_MACHINE_ALLOW_SILICON|INTERACT_MACHINE_OFFLINE|INTERACT_MACHINE_OPEN_SILICON|INTERACT_MACHINE_SET_MACHINE|INTERACT_MACHINE_WIRES_IF_OPEN
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION
 	circuit = /obj/item/circuitboard/machine/slime_market_pad
@@ -42,15 +43,16 @@
 			break
 
 /obj/machinery/slime_market_pad/attackby(obj/item/item, mob/living/user, params)
-	. = ..()
-	if(. || !can_interact(user))
-		return
+	if(HAS_TRAIT(user, TRAIT_CANT_ATTACK) || !can_interact(user))
+		return ..() // Little wasteful to call HAS_TRAIT twice here and parent but the parent will apply damage if we call it
 	if(default_deconstruction_screwdriver(user, icon_state, icon_state, item))
 		user.visible_message(span_notice("\The [user] [panel_open ? "opens" : "closes"] the hatch on \the [src]."), span_notice("You [panel_open ? "open" : "close"] the hatch on \the [src]."))
 		update_appearance()
 		return TRUE
 	if(default_unfasten_wrench(user, item) || default_deconstruction_crowbar(item))
 		return TRUE
+	if(machine_stat & (NOPOWER|BROKEN))
+		return ..()
 	if(QDELETED(console))
 		to_chat(user, span_warning("[src] does not have a console linked to it!"))
 		return
@@ -74,7 +76,8 @@
 			sold_extracts++
 		if(sold_extracts > 0)
 			user.balloon_alert_to_viewers("sold [sold_extracts] extracts")
-		return
+		return TRUE
+	return ..()
 
 /obj/machinery/slime_market_pad/proc/sell_extract(obj/item/slime_extract/extract)
 	SSresearch.xenobio_points += round(SSresearch.slime_core_prices[extract.type])

--- a/monkestation/code/modules/slimecore/machines/slime_market.dm
+++ b/monkestation/code/modules/slimecore/machines/slime_market.dm
@@ -46,7 +46,7 @@
 	if(HAS_TRAIT(user, TRAIT_CANT_ATTACK) || !can_interact(user))
 		return ..() // Little wasteful to call HAS_TRAIT twice here and parent but the parent will apply damage if we call it
 	if(default_deconstruction_screwdriver(user, icon_state, icon_state, item))
-		user.visible_message(span_notice("\The [user] [panel_open ? "opens" : "closes"] the hatch on \the [src]."), span_notice("You [panel_open ? "open" : "close"] the hatch on \the [src]."))
+		user.visible_message(span_notice("\The [user] [panel_open ? "opens" : "closes"] the hatch on \the [src]."))
 		update_appearance()
 		return TRUE
 	if(default_unfasten_wrench(user, item) || default_deconstruction_crowbar(item))


### PR DESCRIPTION
## About The Pull Request
This addresses a couple of annoying issues with the Xenobio market pad and the Slime grinder. 
The Market Pad will let you open it with a screwdriver but once open it cannot be closed. Also does not allow tool interactions if unpowered, These issues don't make sense for most machines and so these have been resolved. It also stops tools from hitting the machine even though you opened the panel or unanchored it etc.

Slime Grinder is a small bug but insanely annoying. When you fire slimes at the grinder they actually slam into the machine causing damage over time as they get pulled in. So if you are grinding many slimes eventually that machine gets destroyed. This just forces the machine to not take hitby damage from slimes.

Removes small double text sent to the user when opening and closing the hatch on the Slime Market Pad.
## Why It's Good For The Game
Only really fixes some issues with these machines bringing their operation more in line with what would be expected. Also prevents unnecessary machine destruction from normal operation. Small PR for small fixes.

## Changelog
:cl: Siro
fix: Successful tool use on the Market pad will not damage it.
fix: Allows maintenance on market pad while unpowered or broken. Fixes #3176
fix: Prevents slimes launched (usually by xenobio vacuum) from damaging the slime grinder when hitting it.
del: Removes double text when opening the Market Pad Maintenance hatch.
/:cl:
