### PR TITLE
properly disable memstat during init if the dll isn't there

### DIFF
--- a/monkestation/code/controllers/master.dm
+++ b/monkestation/code/controllers/master.dm
@@ -5,6 +5,9 @@
 	if(no_memstat)
 		return
 	try
+		if(!rustg_file_exists(MEMORYSTATS_DLL_PATH))
+			no_memstat = TRUE
+			return
 		var/memory_summary = trimtext(replacetext(call_ext(MEMORYSTATS_DLL_PATH, "memory_stats")(), "Server mem usage:", ""))
 		if(memory_summary)
 			rustg_file_append("=== [subsystem.name] ===\n[memory_summary]\n", "[GLOB.log_directory]/profiler/memstat-init.txt")


### PR DESCRIPTION
apparently causing issues locally

this does not have any visible effect whatsoever for players