### PR TITLE
Fix things deathgasping twice

### DIFF
--- a/code/__DEFINES/living.dm
+++ b/code/__DEFINES/living.dm
@@ -1,3 +1,6 @@
 // living_flags
 /// Simple mob trait, indicating it may follow continuous move actions controlled by code instead of by user input.
 #define MOVES_ON_ITS_OWN (1<<0)
+/// Always does *deathgasp when they die
+/// If unset mobs will only deathgasp if supplied a death sound or custom death message
+#define ALWAYS_DEATHGASP (1<<1)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -11,6 +11,7 @@
 	usable_hands = 0 //Populated on init through list/bodyparts
 	mobility_flags = MOBILITY_FLAGS_CARBON_DEFAULT
 	blocks_emissive = EMISSIVE_BLOCK_NONE
+	living_flags = ALWAYS_DEATHGASP
 	///List of [/obj/item/organ]s in the mob. They don't go in the contents for some reason I don't want to know.
 	var/list/obj/item/organ/organs = list()
 	///Same as [above][/mob/living/carbon/var/organs], but stores "slot ID" - "organ" pairs for easy access.

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -5,7 +5,6 @@
 	losebreath = 0
 
 	if(!gibbed)
-		INVOKE_ASYNC(src, PROC_REF(emote), "deathgasp")
 		add_memory_in_range(src, 7, /datum/memory/witnessed_death, protagonist = src)
 	reagents.end_metabolization(src)
 

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -83,7 +83,7 @@
 	if(stat == DEAD)
 		return FALSE
 
-	if(!gibbed && (death_sound || death_message))
+	if(!gibbed && (death_sound || death_message || (living_flags & ALWAYS_DEATHGASP)))
 		INVOKE_ASYNC(src, TYPE_PROC_REF(/mob, emote), "deathgasp")
 
 	set_stat(DEAD)
@@ -96,8 +96,9 @@
 	var/player_mob_check = mind && mind.name && mind.active
 	// and, display a death message if the area allows it (or if they're in nullspace)
 	var/valid_area_check = !death_area || !(death_area.area_flags & NO_DEATH_MESSAGE)
-	if(player_mob_check && valid_area_check)
-		deadchat_broadcast(" has died at <b>[get_area_name(death_turf)]</b>.", "<b>[mind.name]</b>", follow_target = src, turf_target = death_turf, message_type=DEADCHAT_DEATHRATTLE)
+	if(player_mob_check)
+		if(valid_area_check)
+			deadchat_broadcast(" has died at <b>[get_area_name(death_turf)]</b>.", "<b>[mind.name]</b>", follow_target = src, turf_target = death_turf, message_type=DEADCHAT_DEATHRATTLE)
 		if(SSlag_switch.measures[DISABLE_DEAD_KEYLOOP] && !client?.holder)
 			to_chat(src, span_deadsay(span_big("Observer freelook is disabled.\nPlease use Orbit, Teleport, and Jump to look around.")))
 			ghostize(TRUE)

--- a/code/modules/mob/living/silicon/death.dm
+++ b/code/modules/mob/living/silicon/death.dm
@@ -5,8 +5,6 @@
 	new /obj/effect/decal/remains/robot(loc)
 
 /mob/living/silicon/death(gibbed)
-	if(!gibbed)
-		emote("deathgasp")
 	diag_hud_set_status()
 	diag_hud_set_health()
 	update_health_hud()

--- a/code/modules/wiremod/shell/drone.dm
+++ b/code/modules/wiremod/shell/drone.dm
@@ -9,7 +9,7 @@
 	icon_state = "setup_medium_med"
 	maxHealth = 300
 	health = 300
-	living_flags = 0
+	living_flags = NONE
 	light_system = OVERLAY_LIGHT_DIRECTIONAL
 	light_on = FALSE
 


### PR DESCRIPTION

## About The Pull Request

Ports the following PRs from /tg/:
- https://github.com/tgstation/tgstation/pull/80671
- https://github.com/tgstation/tgstation/pull/84347

## Why It's Good For The Game

mmm bug bad

## Changelog
:cl: Absolucy
fix: (uaioy) Cyborgs do not deathgasp twice when dying anymore
fix: (Melbert) Lizards and Moths don't deathgasp twice when they die
/:cl:
