### PR TITLE
Ook's antag weight change requests

### DIFF
--- a/monkestation/code/modules/storytellers/converted_events/solo/blob_infection.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/blob_infection.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/antagonist/solo/blob_infection
 	name = "Blob Infection"
-	weight = 4
+	weight = 6
 	antag_flag = ROLE_BLOB_INFECTION
 	antag_datum = /datum/antagonist/blob/infection
 	min_players = 35

--- a/monkestation/code/modules/storytellers/converted_events/solo/bloodsuckers.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/bloodsuckers.dm
@@ -23,7 +23,7 @@
 		JOB_CYBORG,
 	)
 	min_players = 20
-	weight = 10
+	weight = 8
 	maximum_antags = 2
 	event_icon_state = "vampires"
 

--- a/monkestation/code/modules/storytellers/converted_events/solo/brother.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/brother.dm
@@ -32,7 +32,7 @@
 		JOB_SECURITY_ASSISTANT,
 	)
 	required_enemies = 1
-	weight = 12
+	weight = 10
 	maximum_antags = 2
 	denominator = 30
 	cost = 0.45 // so it doesn't eat up threat for a relatively low-threat antag

--- a/monkestation/code/modules/storytellers/converted_events/solo/changeling.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/changeling.dm
@@ -23,7 +23,7 @@
 		JOB_CYBORG,
 	)
 	min_players = 20
-	weight = 9
+	weight = 10
 	shared_occurence_type = SHARED_CHANGELING
 	event_icon_state = "changeling"
 

--- a/monkestation/code/modules/storytellers/converted_events/solo/malf.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/malf.dm
@@ -19,7 +19,7 @@
 	maximum_antags = 1
 	exclusive_roles = list(JOB_AI)
 	required_enemies = 4
-	weight = 6
+	weight = 8
 	min_players = 35
 	max_occurrences = 1
 

--- a/monkestation/code/modules/storytellers/converted_events/solo/obsessed.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/obsessed.dm
@@ -19,7 +19,7 @@
 		JOB_CYBORG,
 		ROLE_POSITRONIC_BRAIN,
 	)
-	weight = 6
+	weight = 4
 	max_occurrences = 3
 
 /datum/round_event_control/antagonist/solo/obsessed/midround

--- a/monkestation/code/modules/storytellers/converted_events/solo/traitor.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/traitor.dm
@@ -22,7 +22,7 @@
 		JOB_AI,
 		JOB_CYBORG,
 	)
-	weight = 15
+	weight = 13
 	event_icon_state = "traitor"
 
 /datum/round_event_control/antagonist/solo/traitor/roundstart


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/user-attachments/assets/4246d8aa-7e91-4ddc-8aff-8871fa1c29cb)
## Why It's Good For The Game
Messing around with weights
## Changelog
:cl:
:balance: Blob, changeling, and malf ai are now more common.
:balance: Blood brother, heretic, bloodsucker, obsessed, and traitor are now rarer.
:cl:
