### PR TITLE
anti-kudzu measures for centcom + goat fix

### DIFF
--- a/code/modules/events/space_vines/vine_structure.dm
+++ b/code/modules/events/space_vines/vine_structure.dm
@@ -30,6 +30,12 @@
 
 /obj/structure/spacevine/Initialize(mapload)
 	. = ..()
+	var/area/area = get_area(src)
+	if(istype(area, /area/centcom))
+		do_sparks(rand(3, 4), FALSE, src)
+		visible_message(span_warning("AUTOMATIC BLUESPACE HEDGE TRIMMING PROTOCOL ACTIVATED!"))
+		qdel(src)
+
 	add_atom_colour("#ffffff", FIXED_COLOUR_PRIORITY)
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),

--- a/code/modules/events/space_vines/vine_structure.dm
+++ b/code/modules/events/space_vines/vine_structure.dm
@@ -30,12 +30,13 @@
 
 /obj/structure/spacevine/Initialize(mapload)
 	. = ..()
+	//MONKESTATION EDIT START
 	var/area/area = get_area(src)
 	if(istype(area, /area/centcom))
 		do_sparks(rand(3, 4), FALSE, src)
 		visible_message(span_warning("AUTOMATIC BLUESPACE HEDGE TRIMMING PROTOCOL ACTIVATED!"))
 		qdel(src)
-
+	//MONKESTATION EDIT STOP
 	add_atom_colour("#ffffff", FIXED_COLOUR_PRIORITY)
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),

--- a/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
+++ b/code/modules/mob/living/basic/farm_animals/goat/_goat.dm
@@ -125,7 +125,7 @@
 
 /// Proc that handles dealing with the various types of plants we might eat. Assumes that a valid list of type(s) will be passed in.
 /mob/living/basic/goat/proc/eat_plant(list/plants)
-	if(health == 0) //monkestation edit
+	if(health <= 0) //monkestation edit
 		return
 	var/eaten = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Kudzu auto-deletes if grown in CentCom. Made doubly sure goats don't eat stuff if dead.
fix: https://github.com/Monkestation/Monkestation2.0/issues/3266
## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Anti-grief measures for CentCom and a bug fix
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Kudzu can't be grown in CentCom.
fix: Let go of fully of Pete's servitude in death contract. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
