### PR TITLE
Adds Job Title "Hellminer" to Shaft Miner

### DIFF
--- a/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
+++ b/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
@@ -343,6 +343,7 @@
 		"Spelunker",
 		"Drill Technician",
 		"Prospector",
+		"Hellminer",
 	)
 
 /datum/job/station_engineer

--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -280,6 +280,7 @@ const ALTTITLES = {
   Spelunker: BASEICONS['Shaft Miner'],
   'Drill Technician': BASEICONS['Shaft Miner'],
   Prospector: BASEICONS['Shaft Miner'],
+  Hellminer: BASEICONS['Shaft Miner'],
   // Station Engineer - gears
   'Emergency Damage Control Technician': BASEICONS['Station Engineer'],
   Electrician: BASEICONS['Station Engineer'],


### PR DESCRIPTION

## About The Pull Request

Adds Hellminer alt job title

## Why It's Good For The Game

A Halo *and* a Helldivers reference in one! More job titles are fun too. 

## Changelog

:cl:
add: Adds a new alt title to Miners, called Hellminer. Drop pods not included. 
/:cl:

