### PR TITLE
Stampderization (Approval and Denied stamps in all head offices.)

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -19372,13 +19372,9 @@
 	pixel_y = 2
 	},
 /obj/item/folder/blue,
-/obj/item/stamp/centcom{
-	pixel_y = 8;
-	pixel_x = -6
-	},
 /obj/item/stamp/denied{
 	pixel_x = -6;
-	pixel_y = 4
+	pixel_y = 9
 	},
 /obj/item/stamp{
 	pixel_x = -6

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -19372,6 +19372,10 @@
 	pixel_y = 2
 	},
 /obj/item/folder/blue,
+/obj/item/stamp/centcom{
+	pixel_y = 8;
+	pixel_x = -6
+	},
 /obj/item/stamp/denied{
 	pixel_x = -6;
 	pixel_y = 4
@@ -32167,8 +32171,14 @@
 	pixel_y = 6
 	},
 /obj/item/folder/white,
+/obj/item/stamp/granted{
+	pixel_y = 11
+	},
+/obj/item/stamp/denied{
+	pixel_y = 6
+	},
 /obj/item/stamp/head/cmo{
-	pixel_y = 5
+	pixel_y = 1
 	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
@@ -75759,8 +75769,14 @@
 	},
 /obj/item/folder/yellow,
 /obj/item/lighter,
-/obj/item/stamp/head/ce,
 /obj/effect/turf_decal/tile/yellow/full,
+/obj/item/stamp/granted{
+	pixel_y = 11
+	},
+/obj/item/stamp/denied{
+	pixel_y = 6
+	},
+/obj/item/stamp/head/ce,
 /turf/open/floor/iron/large,
 /area/station/command/heads_quarters/ce)
 "oKi" = (
@@ -77255,7 +77271,6 @@
 	dir = 4
 	},
 /obj/item/folder/yellow,
-/obj/item/stamp/head/qm,
 /obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
 	pixel_x = 6;
 	pixel_y = 16
@@ -77269,6 +77284,13 @@
 	pixel_y = -8
 	},
 /obj/structure/disposalpipe/segment,
+/obj/item/stamp/granted{
+	pixel_y = 11
+	},
+/obj/item/stamp/denied{
+	pixel_y = 6
+	},
+/obj/item/stamp/head/qm,
 /turf/open/floor/wood/parquet,
 /area/station/cargo/quartermaster)
 "oYT" = (
@@ -77432,7 +77454,6 @@
 /obj/structure/table/reinforced,
 /obj/item/folder/red,
 /obj/item/pen/red,
-/obj/item/stamp/head/hos,
 /obj/machinery/keycard_auth{
 	pixel_x = 15
 	},
@@ -77440,6 +77461,15 @@
 	pixel_x = -7;
 	pixel_y = 9
 	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/head/hos,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
 "paq" = (
@@ -108442,6 +108472,14 @@
 "uYq" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
 /obj/item/stamp/head/rd,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -48749,6 +48749,15 @@
 /obj/item/clothing/neck/stethoscope,
 /obj/item/flashlight/pen,
 /obj/item/clothing/glasses/hud/health,
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/head/cmo,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "pSn" = (
@@ -54583,9 +54592,17 @@
 	pixel_x = 7;
 	pixel_y = 5
 	},
+/obj/item/stamp/granted{
+	pixel_y = 11;
+	pixel_x = 7
+	},
 /obj/item/stamp/head/hos{
 	pixel_x = 7;
-	pixel_y = 6
+	pixel_y = 7
+	},
+/obj/item/stamp/denied{
+	pixel_x = 7;
+	pixel_y = 3
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
@@ -67375,6 +67392,10 @@
 /obj/item/toy/figure/rd{
 	pixel_x = -13
 	},
+/obj/item/stamp/denied{
+	pixel_y = 5
+	},
+/obj/item/stamp/granted,
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/rd)
 "vSE" = (
@@ -67466,6 +67487,14 @@
 /obj/item/paper_bin,
 /obj/item/folder/blue,
 /obj/item/pen/fountain,
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
 /obj/item/stamp/head/captain,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
@@ -72451,6 +72480,14 @@
 	},
 /obj/item/pen{
 	pixel_y = 4
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
 	},
 /obj/item/stamp/head/ce,
 /turf/open/floor/iron,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -37042,10 +37042,6 @@
 	pixel_y = 6
 	},
 /obj/structure/table/wood,
-/obj/item/stamp/centcom{
-	pixel_x = 8;
-	pixel_y = 12
-	},
 /obj/item/stamp/granted{
 	pixel_y = 6;
 	pixel_x = 8

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -68462,13 +68462,9 @@
 	},
 /obj/item/folder/blue,
 /obj/item/paper_bin/carbon,
-/obj/item/stamp/centcom{
-	pixel_y = 8;
-	pixel_x = -6
-	},
 /obj/item/stamp/denied{
 	pixel_x = -6;
-	pixel_y = 4
+	pixel_y = 8
 	},
 /obj/item/stamp{
 	pixel_x = -6

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -11211,6 +11211,14 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
 /obj/item/stamp/head/ce,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
@@ -44151,10 +44159,15 @@
 /obj/item/pen/red{
 	pixel_x = 1
 	},
-/obj/item/stamp/head/hos{
-	pixel_x = 1;
-	pixel_y = -1
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
 	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/head/hos,
 /turf/open/floor/iron/grimy,
 /area/station/command/heads_quarters/hos)
 "kri" = (
@@ -55458,7 +55471,6 @@
 "nbs" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin/carbon,
-/obj/item/stamp/head/hop,
 /obj/machinery/requests_console/directional/north{
 	anon_tips_receiver = 1;
 	assistance_requestable = 1;
@@ -55466,6 +55478,15 @@
 	name = "Head of Personnel's Requests Console";
 	can_send_announcements = 1
 	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/head/hop,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "nbv" = (
@@ -68441,12 +68462,16 @@
 	},
 /obj/item/folder/blue,
 /obj/item/paper_bin/carbon,
-/obj/item/stamp{
+/obj/item/stamp/centcom{
+	pixel_y = 8;
 	pixel_x = -6
 	},
 /obj/item/stamp/denied{
 	pixel_x = -6;
 	pixel_y = 4
+	},
+/obj/item/stamp{
+	pixel_x = -6
 	},
 /obj/item/pen/fountain{
 	pixel_y = 10
@@ -72102,6 +72127,14 @@
 /obj/item/folder/yellow,
 /obj/item/stamp/head/qm,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/cargo/quartermaster)
 "rfH" = (
@@ -79212,6 +79245,14 @@
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/pen/fourcolor,
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
 /obj/item/stamp/head/captain,
 /obj/machinery/door/window/brigdoor/left/directional/north{
 	name = "Captain's Desk";
@@ -85523,13 +85564,21 @@
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue/opposingcorners,
 /obj/item/paper_bin,
-/obj/item/stamp/head/cmo,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/head/cmo,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "upB" = (
@@ -99273,6 +99322,14 @@
 "xEe" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
 /obj/item/stamp/head/rd,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -5784,10 +5784,15 @@
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/pen,
-/obj/item/stamp/head/rd{
-	pixel_x = 3;
-	pixel_y = -2
+/obj/item/stamp/granted{
+	pixel_x = 5;
+	pixel_y = 4
 	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/head/rd,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/rd)
 "bOg" = (
@@ -13427,6 +13432,14 @@
 /area/station/engineering/main)
 "efV" = (
 /obj/structure/table,
+/obj/item/stamp/granted{
+	pixel_x = 5;
+	pixel_y = 4
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
 /obj/item/stamp/head/qm,
 /turf/open/floor/carpet,
 /area/station/cargo/quartermaster)
@@ -30894,6 +30907,14 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -6;
+	pixel_y = 4
+	},
 /obj/item/stamp/head/hop,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
@@ -32044,9 +32065,17 @@
 /obj/machinery/light/directional/east,
 /obj/structure/table/glass,
 /obj/item/folder/white,
-/obj/item/stamp/head/cmo,
 /obj/item/clothing/neck/stethoscope,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/item/stamp/denied{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/obj/item/stamp/granted{
+	pixel_x = 4;
+	pixel_y = 5
+	},
+/obj/item/stamp/head/cmo,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "klk" = (
@@ -42876,6 +42905,10 @@
 	pixel_y = 2
 	},
 /obj/item/folder/blue,
+/obj/item/stamp/centcom{
+	pixel_x = -6;
+	pixel_y = 8
+	},
 /obj/item/stamp/denied{
 	pixel_x = -6;
 	pixel_y = 4
@@ -51148,6 +51181,14 @@
 	},
 /obj/item/folder/blue{
 	pixel_x = 10
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
 	},
 /obj/item/stamp/head/captain,
 /turf/open/floor/carpet,
@@ -65899,6 +65940,10 @@
 	pixel_x = 8;
 	pixel_y = 3
 	},
+/obj/item/stamp/granted{
+	pixel_y = 10;
+	pixel_x = 10
+	},
 /obj/item/stamp/head/hos{
 	pixel_x = 10;
 	pixel_y = 6
@@ -65911,6 +65956,10 @@
 /obj/item/phone{
 	pixel_x = -9;
 	pixel_y = 7
+	},
+/obj/item/stamp/denied{
+	pixel_x = 10;
+	pixel_y = 2
 	},
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hos)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -42905,13 +42905,9 @@
 	pixel_y = 2
 	},
 /obj/item/folder/blue,
-/obj/item/stamp/centcom{
-	pixel_x = -6;
-	pixel_y = 8
-	},
 /obj/item/stamp/denied{
 	pixel_x = -6;
-	pixel_y = 4
+	pixel_y = 10
 	},
 /obj/item/stamp{
 	pixel_x = -6

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -4452,6 +4452,10 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
+/obj/item/stamp/granted{
+	pixel_y = 10;
+	pixel_x = 8
+	},
 /obj/item/stamp/head/captain{
 	pixel_x = 8;
 	pixel_y = 6
@@ -4459,6 +4463,10 @@
 /obj/item/pen/fountain/captain,
 /obj/item/radio/intercom/directional/south,
 /obj/structure/table/wood,
+/obj/item/stamp/denied{
+	pixel_y = 2;
+	pixel_x = 8
+	},
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
 "bvR" = (
@@ -19500,13 +19508,17 @@
 "ggK" = (
 /obj/structure/cable,
 /obj/structure/table/wood,
-/obj/item/stamp/head/hos,
+/obj/item/clipboard,
+/obj/item/folder/red,
 /obj/item/stamp/denied{
-	pixel_x = 4;
+	pixel_x = -5;
 	pixel_y = 4
 	},
-/obj/item/folder/red,
-/obj/item/clipboard,
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/head/hos,
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
 "ggN" = (
@@ -22729,8 +22741,16 @@
 	},
 /obj/item/lighter,
 /obj/item/clothing/mask/cigarette/cigar/cohiba,
-/obj/item/stamp/head/ce,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/head/ce,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "hhG" = (
@@ -31354,6 +31374,10 @@
 	pixel_y = 6
 	},
 /obj/item/pen/fourcolor,
+/obj/item/stamp/granted{
+	pixel_y = 10;
+	pixel_x = 8
+	},
 /obj/item/stamp/head/hop{
 	pixel_x = 8;
 	pixel_y = 6
@@ -31365,6 +31389,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/item/stamp/denied{
+	pixel_y = 2;
+	pixel_x = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "jGU" = (
@@ -34397,10 +34425,18 @@
 "kGZ" = (
 /obj/structure/table,
 /obj/effect/turf_decal/bot,
+/obj/item/stamp/granted{
+	pixel_y = 11;
+	pixel_x = -8
+	},
 /obj/machinery/recharger{
 	pixel_x = -3
 	},
 /obj/structure/cable,
+/obj/item/stamp/denied{
+	pixel_x = 2;
+	pixel_y = 11
+	},
 /obj/item/toy/figure/rd{
 	pixel_x = 8;
 	pixel_y = 8
@@ -34408,8 +34444,8 @@
 /obj/item/stamp/head/rd{
 	pixel_x = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "kHe" = (
@@ -62257,8 +62293,11 @@
 	pixel_x = -5
 	},
 /obj/item/stamp{
-	pixel_x = -6;
-	pixel_y = -2
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/stamp/centcom{
+	pixel_x = 6
 	},
 /obj/item/stamp/denied{
 	pixel_x = 6;
@@ -73403,6 +73442,14 @@
 	pixel_y = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
 /obj/item/stamp/head/cmo,
 /turf/open/floor/iron/showroomfloor,
 /area/station/command/heads_quarters/cmo)

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -62296,9 +62296,6 @@
 	pixel_x = 6;
 	pixel_y = 4
 	},
-/obj/item/stamp/centcom{
-	pixel_x = 6
-	},
 /obj/item/stamp/denied{
 	pixel_x = 6;
 	pixel_y = -3

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -9205,7 +9205,6 @@
 "dso" = (
 /obj/structure/chair/office/light,
 /obj/structure/cable,
-/obj/item/stamp/head/cmo,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "dsq" = (
@@ -11254,6 +11253,17 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/cmo,
 /obj/structure/cable,
+/obj/item/stamp/head/cmo{
+	pixel_y = 12
+	},
+/obj/item/stamp/denied{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/item/stamp/granted{
+	pixel_y = 12;
+	pixel_x = 8
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "edu" = (
@@ -19699,6 +19709,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stamp/centcom{
+	pixel_y = 10;
+	pixel_x = -1
+	},
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/nt_rep)
 "hdx" = (
@@ -33162,6 +33176,14 @@
 /obj/item/radio/intercom/directional/east,
 /obj/item/folder/blue,
 /obj/item/hand_tele,
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
 /obj/item/stamp/head/captain,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
@@ -56231,6 +56253,10 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
+/obj/item/stamp/granted{
+	pixel_y = 9;
+	pixel_x = -4
+	},
 /obj/item/stamp/head/hop{
 	pixel_x = -4;
 	pixel_y = 4
@@ -56251,6 +56277,10 @@
 	pixel_x = -6;
 	pixel_y = -34;
 	req_access = list("hop")
+	},
+/obj/item/stamp/denied{
+	pixel_x = -4;
+	pixel_y = -1
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -58717,10 +58747,18 @@
 "uoO" = (
 /obj/structure/table,
 /obj/item/folder/white,
-/obj/item/stamp/head/rd,
 /obj/item/toy/figure/rd{
 	pixel_y = 10
 	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/head/rd,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "upe" = (
@@ -60232,9 +60270,22 @@
 "uOy" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
-/obj/item/stamp/head/ce,
+/obj/item/stamp/head/ce{
+	pixel_y = 11
+	},
 /obj/item/reagent_containers/pill/patch/aiuri,
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
+/obj/item/stamp/head/ce{
+	pixel_y = 11
+	},
+/obj/item/stamp/denied{
+	pixel_x = -9;
+	pixel_y = 11
+	},
+/obj/item/stamp/granted{
+	pixel_x = 9;
+	pixel_y = 11
+	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
 "uOH" = (
@@ -66485,6 +66536,14 @@
 /obj/item/folder/red{
 	pixel_x = -7;
 	pixel_y = 6
+	},
+/obj/item/stamp/denied{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
 	},
 /obj/item/stamp/head/hos,
 /turf/open/floor/wood,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -19709,10 +19709,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/stamp/centcom{
-	pixel_y = 10;
-	pixel_x = -1
-	},
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/nt_rep)
 "hdx" = (

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -13123,10 +13123,6 @@
 	pixel_x = -7;
 	pixel_y = 9
 	},
-/obj/item/stamp/centcom{
-	pixel_x = -7;
-	pixel_y = 4
-	},
 /obj/item/stamp{
 	pixel_x = -7;
 	pixel_y = -1

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -13123,9 +13123,13 @@
 	pixel_x = -7;
 	pixel_y = 9
 	},
+/obj/item/stamp/centcom{
+	pixel_x = -7;
+	pixel_y = 4
+	},
 /obj/item/stamp{
 	pixel_x = -7;
-	pixel_y = 1
+	pixel_y = -1
 	},
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/requests_console/auto_name/directional/south,
@@ -14269,13 +14273,21 @@
 "ekC" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/folder/white,
+/obj/item/stamp/granted{
+	pixel_y = 11;
+	pixel_x = 8
+	},
 /obj/item/stamp/head/cmo{
-	pixel_y = 7;
+	pixel_y = 6;
 	pixel_x = 8
 	},
 /obj/item/flashlight/pen,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/item/stamp/denied{
+	pixel_x = 8;
+	pixel_y = 1
 	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
@@ -35608,6 +35620,14 @@
 /obj/item/folder/yellow{
 	pixel_x = -3
 	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
 /obj/item/stamp/head/ce,
 /obj/machinery/button/door/directional/west{
 	id = "CEShutter";
@@ -52173,8 +52193,16 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/item/stamp/head/rd,
 /obj/machinery/light/cold/directional/west,
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/head/rd,
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/rd)
 "ptD" = (
@@ -55790,6 +55818,14 @@
 	pixel_x = 7;
 	pixel_y = 2
 	},
+/obj/item/stamp/denied{
+	pixel_x = -10;
+	pixel_y = 12
+	},
+/obj/item/stamp/granted{
+	pixel_y = 12;
+	pixel_x = -2
+	},
 /turf/open/floor/carpet/royalblue,
 /area/station/command/heads_quarters/captain)
 "qur" = (
@@ -56161,11 +56197,19 @@
 	dir = 1
 	},
 /obj/item/folder/red,
-/obj/item/stamp/head/hos,
 /obj/item/paper_bin{
 	pixel_x = 16;
 	pixel_y = 7
 	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/head/hos,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hos)
 "qyQ" = (

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -43855,10 +43855,6 @@
 	pixel_y = 10;
 	pixel_x = 7
 	},
-/obj/item/stamp/centcom{
-	pixel_x = -6;
-	pixel_y = 3
-	},
 /obj/item/stamp/granted{
 	pixel_y = 4
 	},

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -16702,6 +16702,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_y = 4;
+	pixel_x = -4
+	},
 /obj/item/stamp/head/hop,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
@@ -21234,6 +21242,14 @@
 	pixel_y = 15;
 	pixel_x = 4
 	},
+/obj/item/stamp/granted{
+	pixel_y = 11;
+	pixel_x = -6
+	},
+/obj/item/stamp/denied{
+	pixel_x = -14;
+	pixel_y = 11
+	},
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain/private)
 "gsZ" = (
@@ -24826,6 +24842,14 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/item/folder/blue,
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
 /obj/item/stamp/head/rd,
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/rd)
@@ -41521,6 +41545,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
 /obj/item/stamp/head/ce,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
@@ -43826,6 +43858,12 @@
 /obj/item/stamp/centcom{
 	pixel_x = -6;
 	pixel_y = 3
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4
+	},
+/obj/item/stamp/denied{
+	pixel_y = -1
 	},
 /obj/structure/cable,
 /obj/item/radio/intercom/command/directional/north,
@@ -58943,10 +58981,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/table/reinforced/rglass,
-/obj/item/stamp/head/cmo{
-	pixel_y = 12;
-	pixel_x = -23
-	},
 /obj/item/paperwork/medical,
 /obj/item/toy/figure/cmo,
 /turf/open/floor/iron/dark,
@@ -68111,6 +68145,17 @@
 /obj/item/clothing/glasses/hud/health{
 	pixel_x = 6
 	},
+/obj/item/stamp/head/cmo{
+	pixel_y = 12;
+	pixel_x = 9
+	},
+/obj/item/stamp/granted{
+	pixel_y = 6;
+	pixel_x = 9
+	},
+/obj/item/stamp/denied{
+	pixel_x = 9
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/cmo)
 "ucF" = (
@@ -69411,15 +69456,23 @@
 	pixel_y = 2;
 	pixel_x = -7
 	},
-/obj/item/stamp/head/hos{
-	pixel_x = 10;
-	pixel_y = -1
-	},
 /obj/machinery/recharger{
 	pixel_y = 7;
 	pixel_x = 6
 	},
 /obj/structure/closet/firecloset/wall/directional/north,
+/obj/item/stamp/granted{
+	pixel_y = 6;
+	pixel_x = 9
+	},
+/obj/item/stamp/denied{
+	pixel_x = 10;
+	pixel_y = 5
+	},
+/obj/item/stamp/head/hos{
+	pixel_x = 10;
+	pixel_y = -1
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "uwF" = (

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -30092,9 +30092,13 @@
 	pixel_x = -7;
 	pixel_y = 9
 	},
+/obj/item/stamp/centcom{
+	pixel_y = 6;
+	pixel_x = -7
+	},
 /obj/item/stamp{
 	pixel_x = -7;
-	pixel_y = 1
+	pixel_y = 2
 	},
 /obj/item/folder/red{
 	pixel_x = 11;
@@ -39009,10 +39013,18 @@
 	pixel_x = -4;
 	pixel_y = 3
 	},
+/obj/structure/table/reinforced/rglass,
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
 /obj/item/stamp/head/cmo{
 	pixel_y = 3
 	},
-/obj/structure/table/reinforced/rglass,
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "kXw" = (
@@ -44503,6 +44515,14 @@
 /obj/structure/table/reinforced/rglass,
 /obj/structure/cable,
 /obj/item/folder/white{
+	pixel_y = 4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
 	pixel_y = 4
 	},
 /obj/item/stamp/head/rd{
@@ -71967,13 +71987,20 @@
 	pixel_x = -2;
 	pixel_y = 3
 	},
-/obj/item/stamp/head/ce{
-	pixel_x = -2;
-	pixel_y = 3
-	},
 /obj/item/computer_disk/engineering{
 	pixel_x = 13;
 	pixel_y = 2
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/head/ce{
+	pixel_y = 3
 	},
 /turf/open/floor/carpet/orange,
 /area/station/command/heads_quarters/ce)

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -30092,10 +30092,6 @@
 	pixel_x = -7;
 	pixel_y = 9
 	},
-/obj/item/stamp/centcom{
-	pixel_y = 6;
-	pixel_x = -7
-	},
 /obj/item/stamp{
 	pixel_x = -7;
 	pixel_y = 2

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -7848,13 +7848,20 @@
 /obj/item/folder/white{
 	pixel_x = 5
 	},
+/obj/item/pen/fountain{
+	pixel_x = -9;
+	pixel_y = 7
+	},
+/obj/item/stamp/granted{
+	pixel_y = 11;
+	pixel_x = 8
+	},
+/obj/item/stamp/denied{
+	pixel_y = 6
+	},
 /obj/item/stamp/head/rd{
 	pixel_x = 6;
 	pixel_y = 2
-	},
-/obj/item/pen/fountain{
-	pixel_x = -4;
-	pixel_y = 7
 	},
 /turf/open/floor/glass/reinforced,
 /area/station/command/heads_quarters/rd)
@@ -12253,6 +12260,14 @@
 /obj/item/paper_bin,
 /obj/item/pen,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/item/stamp/denied{
+	pixel_y = 5;
+	pixel_x = -4
+	},
+/obj/item/stamp/granted{
+	pixel_x = 4;
+	pixel_y = 5
+	},
 /obj/item/stamp/head/cmo,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
@@ -25991,6 +26006,14 @@
 "hkU" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
 /obj/item/stamp/head/hos,
 /obj/item/food/spaghetti/pastatomato/soulful,
 /turf/open/floor/carpet,
@@ -35964,6 +35987,14 @@
 	pixel_x = 5
 	},
 /obj/machinery/light/directional/west,
+/obj/item/stamp/granted{
+	pixel_y = 11;
+	pixel_x = -6
+	},
+/obj/item/stamp/denied{
+	pixel_x = -6;
+	pixel_y = 4
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)
 "kqT" = (
@@ -68371,7 +68402,7 @@
 	},
 /obj/item/stamp/denied{
 	pixel_x = -6;
-	pixel_y = 4
+	pixel_y = 9
 	},
 /obj/item/stamp{
 	pixel_x = -6

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -31004,6 +31004,14 @@
 "iQx" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/granted{
+	pixel_y = 4;
+	pixel_x = 5
+	},
 /obj/item/stamp/head/captain,
 /obj/machinery/door/window{
 	base_state = "right";
@@ -55725,10 +55733,18 @@
 "qEv" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
-/obj/item/stamp/head/ce,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
+/obj/item/stamp{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/stamp/denied{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/stamp/head/ce,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "qEw" = (


### PR DESCRIPTION

## About The Pull Request

Adds approval and denied stamps to every head office, adds head stamps to offices that dont have any.  Tries to keep them looking kinda natural. Adds Centcom stamps to NTrep offices because it's kinda inconistent if they get one or nott.

## Why It's Good For The Game

More paperwork and RP tools. Having these roundstart should help encourage paperwork and roleplaying. Also, the stamps are nice and more people should use em more. 

## Changelog

:cl:

qol: Stamps in head offices are more consitent across the stations.
/:cl:

