### PR TITLE
Slipping and Smashing.

### DIFF
--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -129,7 +129,7 @@
 
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_POSTPROCESS, result, delay * visual_delay)
 
-	if(isliving(src.moving) && istype(src, /datum/move_loop/has_target/move_towards)) // Tell the mob we slipped and what happened
+	if(ishuman(src.moving) && istype(src, /datum/move_loop/has_target/move_towards)) // Tell the mob we slipped and what happened
 		var/datum/move_loop/has_target/move_towards/collide_move = src
 		SEND_SIGNAL(src.moving, COMSIG_MOVELOOP_POSTPROCESS, result, delay * visual_delay, collide_move.moving_towards, src)
 

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -129,6 +129,10 @@
 
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_POSTPROCESS, result, delay * visual_delay)
 
+	if(isliving(src.moving) && istype(src, /datum/move_loop/has_target/move_towards)) // Tell the mob we slipped and what happened
+		var/datum/move_loop/has_target/move_towards/collide_move = src
+		SEND_SIGNAL(src.moving, COMSIG_MOVELOOP_POSTPROCESS, result, delay * visual_delay, collide_move.moving_towards, src)
+
 	if(QDELETED(src) || result != MOVELOOP_SUCCESS) //Can happen
 		return
 

--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -129,7 +129,7 @@
 
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_POSTPROCESS, result, delay * visual_delay)
 
-	if(ishuman(src.moving) && istype(src, /datum/move_loop/has_target/move_towards)) // Tell the mob we slipped and what happened
+	if(result == MOVELOOP_FAILURE && ishuman(src.moving) && istype(src, /datum/move_loop/has_target/move_towards)) // Tell the mob we slipped and what happened
 		var/datum/move_loop/has_target/move_towards/collide_move = src
 		SEND_SIGNAL(src.moving, COMSIG_MOVELOOP_POSTPROCESS, result, delay * visual_delay, collide_move.moving_towards, src)
 

--- a/code/datums/components/force_move.dm
+++ b/code/datums/components/force_move.dm
@@ -12,6 +12,7 @@
 	var/datum/move_loop/loop = SSmove_manager.move_towards(mob_parent, target, delay = 1, timeout = dist)
 	RegisterSignal(mob_parent, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, PROC_REF(stop_move))
 	RegisterSignal(mob_parent, COMSIG_ATOM_PRE_PRESSURE_PUSH, PROC_REF(stop_pressure))
+	RegisterSignal(mob_parent, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(slip_crash))
 	if(spin)
 		RegisterSignal(loop, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(slip_spin))
 	RegisterSignal(loop, COMSIG_QDELETING, PROC_REF(loop_ended))
@@ -28,6 +29,18 @@
 	SIGNAL_HANDLER
 	var/mob/mob_parent = parent
 	mob_parent.spin(1, 1)
+
+/datum/component/force_move/proc/slip_crash(datum/source, var/result, var/delay, turf/target_turf, /datum/move_loop/blocked)
+	SIGNAL_HANDLER
+	if(!result) // Something prevented us from moving into the space.
+		var/obj/machinery/vending/heavy_weight = (locate(/obj/machinery/vending) in target_turf)
+		var/obj/structure/table/tabled = (locate(/obj/structure/table) in target_turf)
+		if(istype(heavy_weight))
+			heavy_weight.tilt(parent)
+
+		if(istype(tabled))
+			var/mob/mob_parent = parent
+			mob_parent.throw_at(target_turf, 1, 1)
 
 /datum/component/force_move/proc/loop_ended(datum/source)
 	SIGNAL_HANDLER

--- a/code/datums/components/force_move.dm
+++ b/code/datums/components/force_move.dm
@@ -30,7 +30,7 @@
 	var/mob/mob_parent = parent
 	mob_parent.spin(1, 1)
 
-/datum/component/force_move/proc/slip_crash(datum/source, var/result, var/delay, turf/target_turf, datum/blocked)
+/datum/component/force_move/proc/slip_crash(datum/source, result, delay, turf/target_turf, datum/blocked)
 	SIGNAL_HANDLER
 	if(!result && ishuman(parent) && istype(blocked, /datum/move_loop/has_target/move_towards)) // Something prevented us from moving into the space.
 		var/obj/machinery/heavy_weight = (locate(/obj/machinery/vending) in target_turf)
@@ -42,7 +42,7 @@
 		else
 			// We hit a structure and we need to keep going.
 			var/mob/living/mob_parent = parent
-			mob_parent.Immobilize(800) // Prevent them from throw bending around objects.
+			mob_parent.Immobilize(0.8 SECONDS) // Prevent them from throw bending around objects.
 			// We don't exactly know what stopped us. So throw us at the turf and let physics handle it.
 			blocked_move.lifetime = -1
 			INVOKE_ASYNC(mob_parent, /atom/movable/proc/throw_at, target_turf, 1, 1)

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -408,6 +408,9 @@
 		else
 			visible_message(span_notice("[AM] bounces off of [src]'s rim!"))
 			return ..()
+	if(ishuman(AM) && AM.CanEnterDisposals())
+		AM.forceMove(src)
+		flush() // Might need to use do_flush if this causes problems.
 	else
 		return ..()
 


### PR DESCRIPTION

## About The Pull Request
This adds the ability for things like lube to smash the person into anything "solid" that blocks their path as they slide. This means walls turfs and machines on that turf. This mechanic can be seen through lube and comes with a fun video to demonstrate. A lot of objects seem to have interactions to being hit by stuff. Disposals will also activate and flush living mobs tossed into the disposal. So now lube will throw the person at that direction and allow hit by to handle it. Things that don't really react causes a curious bug where you roll 90 degrees to the direction of the throw. Minor bug but just so it's mentioned.

## Why It's Good For The Game
A video showing why it might be good for the game. [Funny Clown Accidents.](https://cdn.discordapp.com/attachments/1325885241243467868/1325885242048905367/Honkmotherhasgift.mp4?ex=677d6a5b&is=677c18db&hm=260aa5b8deaea932defea14dd1dcf2dc3873b28daa4c324f8337d667732c2280&)

Honestly, not sure why this wasn't in sooner. A staple to one of clowns funny arsenal and potential trap makers addition to the tool box. Might cause some weird issues with all slipping effects.
## Changelog
:cl:
add: Lube and other similar sliding materials throwing human mobs into turfs if their slide was blocked.
add: Disposal Bin flushes living mobs tossed into it.
code: Ends move_loop early if human movement was blocked. Sends signal to mob that it was blocked.
/:cl:
