### PR TITLE
what if fire was deadlier + halves burning damage component

### DIFF
--- a/code/datums/components/burning.dm
+++ b/code/datums/components/burning.dm
@@ -55,7 +55,7 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 	if(atom_parent.resistance_flags & FIRE_PROOF)
 		atom_parent.extinguish()
 		return
-	atom_parent.take_damage(10 * seconds_per_tick, BURN, FIRE, FALSE)
+	atom_parent.take_damage(5 * seconds_per_tick, BURN, FIRE, FALSE) //monkestation edit: 10 to 5 damage
 
 /// Alerts any examiners that the parent is on fire (even though it should be rather obvious)
 /datum/component/burning/proc/on_examine(atom/source, mob/user, list/examine_list)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -111,3 +111,13 @@
 	// Tissues die without blood circulation
 	adjustBruteLoss(1 * seconds_per_tick)
 
+/mob/living/carbon/human/proc/get_thermal_protection()
+	var/thermal_protection = 0 //Simple check to estimate how protected we are against multiple temperatures
+	if(wear_suit)
+		if(wear_suit.max_heat_protection_temperature >= FIRE_SUIT_MAX_TEMP_PROTECT)
+			thermal_protection += wear_suit.max_heat_protection_temperature
+	if(head)
+		if((head.max_heat_protection_temperature >= FIRE_HELM_MAX_TEMP_PROTECT))
+			thermal_protection += head.max_heat_protection_temperature
+	thermal_protection = thermal_protection * 0.5
+	return thermal_protection


### PR DESCRIPTION
## About The Pull Request

Fire stacks apply direct damage and raise body temp instead of just using a hotspot to heat the victim up. Halved burning component damage (items take longer to burn). Husks lose fire stacks faster.
## Why It's Good For The Game
Fire is pretty weak. Someone can survive being on fire with max stacks for 4 minutes, now it's about 45 seconds with max stacks.

## Changelog

:cl:
balance: Fire (status effect) is deadlier. Husked bodies go out faster.
fix: Fixed husked bodies not losing fire stacks.
balance: Halved the burning damage for flammable items.
/:cl:

