### PR TITLE
Gives Assault ops more AP ammo

### DIFF
--- a/monkestation/code/modules/assault_ops/code/armaments/_base.dm
+++ b/monkestation/code/modules/assault_ops/code/armaments/_base.dm
@@ -73,8 +73,11 @@
 /datum/armament_entry/assault_operatives/primary/submachinegun_ammo/c35sol_disabler
 	item_type = /obj/item/ammo_box/c35sol/incapacitator
 
-/datum/armament_entry/assault_operatives/primary/submachinegun_ammo/c35sol_pierce
+/datum/armament_entry/assault_operatives/primary/submachinegun_ammo/c35sol_ripper
 	item_type = /obj/item/ammo_box/c35sol/ripper
+
+/datum/armament_entry/assault_operatives/primary/submachinegun_ammo/c35sol_pierce
+	item_type = /obj/item/ammo_box/c35sol/pierce
 
 /datum/armament_entry/assault_operatives/primary/shotgun
 	subcategory = OPS_SUBCATEGORY_SHOTGUN
@@ -104,6 +107,9 @@
 
 /datum/armament_entry/assault_operatives/primary/shotgun_ammo/antitide
 	item_type = /obj/item/ammo_box/advanced/s12gauge/antitide
+
+/datum/armament_entry/assault_operatives/primary/shotgun_ammo/pierce
+	item_type = /obj/item/ammo_box/advanced/s12gauge/apds
 
 /datum/armament_entry/assault_operatives/primary/sniper
 	subcategory = OPS_SUBCATEGORY_SNIPER

--- a/monkestation/code/modules/blueshift/items/ammo.dm
+++ b/monkestation/code/modules/blueshift/items/ammo.dm
@@ -377,6 +377,26 @@
 	icon_state = "35box_shrapnel"
 	ammo_type = /obj/item/ammo_casing/c35sol/ripper
 
+//.35 sol pierce are the AP rounds for this weapon
+
+/obj/item/ammo_casing/c35sol/pierce
+	name = ".35 Sol Short armor piercing bullet casing"
+	desc = "A SolFed standard caseless armor piercing pistol round. Penetrates armor, but is rather weak against un-armored targets."
+	icon_state = "35sol_shrapnel"
+	projectile_type = /obj/projectile/bullet/c35sol/pierce
+
+/obj/projectile/bullet/c35sol/pierce
+	name = ".35 Sol Short armor piercing bullet"
+	damage = 13
+	bare_wound_bonus = -30
+	armour_penetration = 20
+
+/obj/item/ammo_box/c35sol/pierce
+	name = "ammo box (.35 Sol Short armor piercing)"
+	desc = "A box of .35 Sol Short pistol rounds, holds twenty-four rounds."
+	ammo_type = /obj/item/ammo_casing/c35sol/pierce
+
+
 // .40 Sol Long
 // Rifle caliber caseless ammo that kills people good
 


### PR DESCRIPTION

## About The Pull Request
Gives Assault ops AP ammo for the smg and shotgun.
## Why It's Good For The Game
Most of assault ops targets have some form of armor on them, whether that be from a modsuit or actual armor. Allowing them more choices of AP ammo besides the battle rifle will hopefully encourage picking those options more
## Changelog
:cl:
add: Gave assault ops access to AP ammo for their smgs and shotguns
add: Added c35sol AP ammo
/:cl:
