### PR TITLE
Britarnya's Admin Office

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -5572,7 +5572,9 @@
 /turf/open/floor/grass,
 /area/centcom/wizard_station)
 "apc" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/coffee{
+	dir = 4
+	},
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 4
 	},
@@ -18971,6 +18973,13 @@
 "aZc" = (
 /turf/open/floor/iron/dark/small,
 /area/centcom/central_command_areas/adminroom)
+"aZd" = (
+/obj/machinery/light/directional/east{
+	dir = 1
+	},
+/obj/machinery/computer/message_monitor,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "aZe" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
@@ -19571,6 +19580,11 @@
 	},
 /turf/open/misc/sandy_dirt,
 /area/centcom/central_command_areas/adminroom)
+"bzE" = (
+/obj/item/radio/headset/headset_cent,
+/obj/structure/table/reinforced,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "bAl" = (
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/mineral/plastitanium,
@@ -20088,11 +20102,11 @@
 /turf/open/floor/carpet/neon/simple/blue/nodots,
 /area/centcom/central_command_areas/prison)
 "cMo" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/tile,
+/obj/machinery/light/directional/east,
+/turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/admin)
 "cMW" = (
 /obj/structure/railing/wooden_fence{
@@ -20388,6 +20402,10 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
+"dzO" = (
+/obj/structure/showcase/machinery/tv,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "dAJ" = (
 /obj/machinery/photocopier/gratis,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
@@ -20473,6 +20491,17 @@
 /obj/structure/flora/bush/reed/style_2,
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
+"dMp" = (
+/obj/structure/table/wood/fancy,
+/obj/item/storage/box/coffeepack,
+/obj/item/reagent_containers/cup/coffeepot/bluespace{
+	pixel_y = 9;
+	pixel_x = 5
+	},
+/obj/item/reagent_containers/cup/glass/mug/nanotrasen,
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "dNQ" = (
 /obj/structure/table/greyscale,
 /obj/machinery/fax/messageadmins{
@@ -20544,6 +20573,13 @@
 /obj/item/storage/medkit/tactical/premium,
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
+"dSe" = (
+/obj/item/language_manual{
+	language = /datum/language/machine
+	},
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "dSg" = (
 /turf/closed/indestructible/opsglass,
 /area/centcom/syndicate_mothership/expansion_bulldozer)
@@ -20671,7 +20707,9 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
 "elw" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/coffee{
+	dir = 4
+	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/centcom/central_command_areas/adminroom)
@@ -21009,6 +21047,10 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/cruiser_dock)
+"fkK" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "flv" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -21140,6 +21182,14 @@
 /obj/item/mop,
 /turf/open/floor/iron/dark/small,
 /area/centcom)
+"fCJ" = (
+/obj/structure/closet/cabinet,
+/obj/item/clothing/suit/jacket/tailcoat/centcom,
+/obj/item/clothing/head/hats/centcom_cap,
+/obj/machinery/light/directional/north,
+/obj/item/flashlight,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "fDz" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -21802,6 +21852,18 @@
 /obj/structure/table/reinforced/titaniumglass,
 /turf/open/floor/mineral/titanium/tiled/white,
 /area/centcom/central_command_areas/adminroom)
+"gYk" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin{
+	pixel_y = 5
+	},
+/obj/item/pen{
+	pixel_y = 8
+	},
+/obj/item/stamp/centcom,
+/obj/item/stamp/denied,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "gYo" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 1
@@ -21945,6 +22007,15 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
+"hlT" = (
+/obj/machinery/button/door/directional/north{
+	name = "Emergency Assistants Fuck Off Button";
+	id = "donutstealthisid";
+	req_access = "cent_captain"
+	},
+/obj/machinery/computer/communications,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "hna" = (
 /obj/structure/closet/secure_closet{
 	name = "contraband locker";
@@ -22160,6 +22231,12 @@
 	dir = 4
 	},
 /area/cruiser_dock)
+"hCG" = (
+/obj/structure/ai_core/deactivated{
+	name = "MATRIARCH"
+	},
+/turf/open/floor/circuit/green/anim,
+/area/centcom/central_command_areas/admin)
 "hCH" = (
 /obj/structure/mineral_door/wood{
 	color = "543e27"
@@ -22488,19 +22565,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/admin)
-"ioX" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8;
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/structure/railing/wooden_fencing{
-	pixel_y = 16
-	},
-/turf/open/floor/sandy_dirt,
-/area/centcom/central_command_areas/admin)
 "ipJ" = (
 /obj/effect/mapping_helpers/airlock/access/any/admin/captain,
 /obj/effect/turf_decal/trimline/red/real_red/filled/line{
@@ -22789,6 +22853,12 @@
 /obj/structure/marker_beacon/teal,
 /turf/open/misc/asteroid,
 /area/cruiser_dock)
+"jhT" = (
+/obj/machinery/light/directional/east,
+/obj/structure/bed/double,
+/obj/item/bedsheet/hos/double,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "jhU" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L2"
@@ -23066,6 +23136,11 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/textured,
 /area/centcom/central_command_areas/prison)
+"jPq" = (
+/obj/machinery/computer,
+/obj/machinery/light/directional/north,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/admin)
 "jQu" = (
 /obj/machinery/door/puzzle/keycard/syndicate_suit_storage,
 /turf/open/floor/iron/smooth_half{
@@ -23508,6 +23583,11 @@
 /mob/living/basic/cow,
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
+"lfR" = (
+/obj/structure/table/reinforced,
+/obj/item/aicard,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/admin)
 "lgW" = (
 /turf/open/misc/sandy_dirt,
 /area/centcom/central_command_areas/admin)
@@ -23560,6 +23640,13 @@
 	dir = 4
 	},
 /turf/open/floor/plastic,
+/area/centcom/central_command_areas/admin)
+"lng" = (
+/obj/structure/table/reinforced,
+/obj/machinery/fax{
+	name = "Beverly's Fax Machine"
+	},
+/turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/admin)
 "lpd" = (
 /obj/machinery/modular_computer/preset/id/centcom{
@@ -23853,6 +23940,11 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating/rust,
 /area/centcom/central_command_areas/adminroom)
+"muc" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/coffeemaker,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "mvd" = (
 /obj/effect/decal/cleanable/blood/gibs/limb{
 	dir = 8;
@@ -23860,6 +23952,10 @@
 	},
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/sandy_dirt,
+/area/centcom/central_command_areas/admin)
+"mxM" = (
+/obj/item/language_manual,
+/turf/closed/indestructible/event/rock,
 /area/centcom/central_command_areas/admin)
 "myi" = (
 /obj/machinery/light/directional/east{
@@ -24118,6 +24214,9 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
+"npI" = (
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "npK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/flora/grass/brown/style_random,
@@ -24291,6 +24390,11 @@
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
+"nMl" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "nNA" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Vault G-07"
@@ -24616,6 +24720,13 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
+"oID" = (
+/obj/machinery/door/airlock/vault{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/admin)
 "oJi" = (
 /obj/structure/mirror/magic{
 	pixel_y = 28
@@ -24644,12 +24755,26 @@
 	},
 /turf/open/floor/mineral/titanium/tiled/yellow,
 /area/centcom/syndicate_mothership/expansion_bioterrorism)
+"oMR" = (
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/cup/glass/flask,
+/obj/item/reagent_containers/cup/glass/drinkingglass,
+/obj/item/clothing/mask/cigarette/rollie/cannabis,
+/obj/item/lighter/bright,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "oMX" = (
 /obj/machinery/door/poddoor/shutters/indestructible/preopen{
 	id = "donutstealthisid";
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/admin)
+"oND" = (
+/obj/machinery/modular_computer/preset/id/centcom{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/admin)
 "oNH" = (
 /obj/machinery/light/neon_lining{
@@ -24795,6 +24920,10 @@
 "pkc" = (
 /obj/structure/flora/bush/stalky/style_3,
 /turf/open/floor/sandy_dirt,
+/area/centcom/central_command_areas/admin)
+"pkm" = (
+/obj/machinery/computer/camera_advanced,
+/turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/admin)
 "pkn" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
@@ -25373,6 +25502,15 @@
 	},
 /turf/open/misc/asteroid,
 /area/centcom/central_command_areas/admin)
+"qIy" = (
+/obj/item/bodypart/chest/ipc,
+/obj/item/bodypart/arm/left/ipc,
+/obj/item/bodypart/arm/right/ipc,
+/obj/item/bodypart/head/ipc,
+/obj/item/bodypart/leg/left/ipc,
+/obj/item/bodypart/leg/right/ipc,
+/turf/open/floor/circuit/green/anim,
+/area/centcom/central_command_areas/admin)
 "qIZ" = (
 /obj/structure/railing/wooden_fence{
 	dir = 8
@@ -25477,6 +25615,10 @@
 	dir = 8
 	},
 /area/cruiser_dock)
+"qUy" = (
+/obj/item/toy/plush/pooba_bee_plush,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/admin)
 "qVW" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark,
 /turf/open/floor/iron/dark/textured_edge,
@@ -25520,6 +25662,10 @@
 "qZk" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/sandy_dirt,
+/area/centcom/central_command_areas/admin)
+"qZy" = (
+/obj/machinery/computer/upload/ai,
+/turf/open/floor/circuit/green/anim,
 /area/centcom/central_command_areas/admin)
 "rcc" = (
 /obj/machinery/chem_master,
@@ -25713,6 +25859,10 @@
 /obj/structure/shipping_container/kosmologistika,
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
+"rJm" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/admin)
 "rJt" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark,
 /turf/open/floor/iron/smooth_edge{
@@ -25851,6 +26001,11 @@
 	},
 /turf/open/indestructible/plating,
 /area/centcom/central_command_areas/admin)
+"rVj" = (
+/obj/structure/table/wood/fancy,
+/obj/item/pai_card,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "rVD" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -25897,6 +26052,12 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/adminroom)
+"rZf" = (
+/obj/structure/sign/paint{
+	name = "RIP Karissa Sep '99 - Apr '16"
+	},
+/turf/open/floor/sandy_dirt,
+/area/centcom/central_command_areas/admin)
 "sae" = (
 /obj/machinery/door/airlock/centcom{
 	dir = 8;
@@ -26098,6 +26259,14 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
+"sJO" = (
+/obj/machinery/door/airlock/maintenance_hatch{
+	dir = 4;
+	name = "Pooba's Coder Closet"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/admin)
 "sKl" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/machinery/medical_kiosk,
@@ -26188,6 +26357,13 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
+"sWP" = (
+/obj/machinery/door/airlock/vault{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "sYg" = (
 /obj/machinery/light/neon_lining{
 	icon_state = "pink2_1"
@@ -26209,6 +26385,10 @@
 "tcJ" = (
 /turf/open/floor/iron/dark,
 /area/cruiser_dock)
+"tdK" = (
+/obj/structure/chair/comfy/black,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "tez" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Raziel's Theatre"
@@ -26338,6 +26518,10 @@
 	},
 /obj/structure/flora/bush/stalky/style_2,
 /turf/open/water/arena,
+/area/centcom/central_command_areas/admin)
+"tsx" = (
+/obj/structure/decorative/shelf/alcohol,
+/turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/admin)
 "tsH" = (
 /obj/effect/turf_decal/siding/white{
@@ -26637,11 +26821,11 @@
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
 "ued" = (
-/obj/structure/mineral_door/wood{
-	color = "543e27";
-	name = "empty office"
+/obj/machinery/door/airlock/gold{
+	name = "Beverly Valon's Office"
 	},
-/turf/open/floor/sandy_dirt,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/turf/open/floor/wood/tile,
 /area/centcom/central_command_areas/admin)
 "uei" = (
 /obj/effect/turf_decal/stripes/box,
@@ -26652,6 +26836,12 @@
 	dir = 1
 	},
 /turf/open/floor/plastic,
+/area/centcom/central_command_areas/admin)
+"ufS" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/admin)
 "uhK" = (
 /obj/structure/window/reinforced/spawner/directional/west{
@@ -27188,6 +27378,10 @@
 	},
 /turf/open/floor/iron/dark/corner,
 /area/centcom/central_command_areas/prison)
+"vzt" = (
+/obj/item/kirbyplants/organic/plant23,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "vAz" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -27613,13 +27807,6 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin)
 "wrH" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4;
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
 /obj/structure/railing/wooden_fencing{
 	pixel_y = 16
 	},
@@ -27738,6 +27925,11 @@
 	},
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
+"wFA" = (
+/obj/item/flashlight/lamp,
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "wGr" = (
 /obj/structure/table/wood,
 /obj/item/modular_computer/laptop,
@@ -27834,7 +28026,9 @@
 /turf/open/floor/iron/vaporwave,
 /area/centcom/central_command_areas/adminroom)
 "wTZ" = (
-/obj/machinery/vending/coffee,
+/obj/machinery/vending/coffee{
+	dir = 4
+	},
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron/dark/textured_large,
 /area/cruiser_dock)
@@ -27926,6 +28120,12 @@
 	dir = 8
 	},
 /turf/open/floor/grass,
+/area/centcom/central_command_areas/admin)
+"xgZ" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/admin)
 "xih" = (
 /obj/structure/railing/wood{
@@ -65424,11 +65624,11 @@ aaa
 aaa
 aaa
 aaa
-aOn
-lgW
-lgW
-lgW
-lgW
+blK
+jPq
+qUy
+qGw
+blK
 lgW
 lgW
 lgW
@@ -65684,7 +65884,7 @@ aaa
 blK
 blK
 blK
-blK
+sJO
 blK
 blK
 blK
@@ -65939,12 +66139,12 @@ aaa
 aaa
 aaa
 blK
-kFQ
-tVr
-nPn
-kdH
-gXp
-bHb
+lng
+gYk
+npI
+npI
+muc
+dMp
 blK
 aMc
 jRn
@@ -66196,17 +66396,17 @@ aaa
 aaa
 aaa
 blK
-cnR
-vPE
-cmN
-ijQ
-cKq
-jJO
+pkm
+npI
+npI
+npI
+npI
+rVj
 blK
 cdN
 aMc
 kPZ
-eTJ
+exa
 exa
 exa
 exa
@@ -66453,17 +66653,17 @@ aaa
 aaa
 aaa
 blK
-qKa
-lpd
-flv
-ijQ
-cKq
-jJO
+aZd
+tdK
+oND
+npI
+npI
+npI
 ued
 aMc
 aMc
 kPZ
-eTJ
+exa
 exa
 exa
 mIn
@@ -66710,17 +66910,17 @@ aaa
 aaa
 aaa
 blK
-fex
-vPE
-cmN
-ijQ
-cKq
-jJO
+hlT
+npI
+bzE
+npI
+npI
+npI
 blK
 cdN
 aMc
 kPZ
-eTJ
+exa
 jbR
 exa
 rRY
@@ -66967,16 +67167,16 @@ aaa
 aaa
 aaa
 blK
-wJw
-vBV
-jwN
-iwc
-dIy
+nMl
+npI
+npI
+npI
+xgZ
 cMo
 blK
 aMc
 jRn
-ioX
+duN
 exa
 exa
 exa
@@ -67225,7 +67425,7 @@ aaa
 aaa
 blK
 blK
-blK
+sWP
 vyT
 blK
 blK
@@ -67480,14 +67680,14 @@ aaa
 aaa
 aaa
 aaa
-aOn
-exa
-exa
-exa
-exa
-exa
-exa
-exa
+blK
+fCJ
+npI
+npI
+npI
+fkK
+vzt
+blK
 exa
 exa
 exa
@@ -67737,14 +67937,14 @@ aaa
 aaa
 aaa
 aaa
-aOn
-exa
-exa
-exa
-exa
-exa
-exa
-exa
+blK
+blK
+oID
+blK
+npI
+npI
+oMR
+blK
 exa
 exa
 exa
@@ -67994,14 +68194,14 @@ aaa
 aaa
 aaa
 aaa
-aOn
-exa
-exa
-exa
-exa
-exa
-exa
-exa
+blK
+qIy
+kWs
+blK
+dzO
+npI
+ufS
+blK
 exa
 exa
 exa
@@ -68251,14 +68451,14 @@ aaa
 aaa
 aaa
 aaa
-aOn
-exa
-exa
-exa
-exa
-exa
-exa
-exa
+blK
+qZy
+rJm
+blK
+npI
+npI
+tsx
+blK
 exa
 aeB
 aeB
@@ -68508,14 +68708,14 @@ aaa
 aaa
 aaa
 aaa
-aOn
-exa
-exa
-exa
-exa
-exa
-exa
-exa
+blK
+hCG
+lfR
+blK
+wFA
+jhT
+dSe
+blK
 aeB
 aeB
 exa
@@ -68765,14 +68965,14 @@ aaa
 aaa
 aaa
 aaa
-aOn
-exa
-exa
-exa
-exa
-exa
-aeB
-exa
+blK
+blK
+blK
+blK
+blK
+blK
+blK
+blK
 exa
 aeB
 aeB
@@ -69024,7 +69224,7 @@ aaa
 aaa
 aOn
 aeB
-exa
+rZf
 exa
 exa
 exa
@@ -70318,7 +70518,7 @@ exa
 exa
 aeB
 aeB
-aeB
+mxM
 aeB
 aeB
 exa


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/4fefe726-a28e-4ba0-a04b-94884d04cd57)


This takes one of the empty wooden offices and turns it into a workspace for Beverly Valon, Centcom Official, along with her work on the MATRIARCH AI and IPC programming.
## About The Pull Request

Add In-Character Decoration and Furnishing for Centcom Official Beverly Valon, played by yours truly. This office is simply an in-character visual story of what Beverly works on and how she lives while under employment by Nanotrasen.

## Why It's Good For The Game

Because it leaves my own mark on the Monkestation server and is a nice Easter Egg for other players to find.

## Changelog
:cl:
admin: Furnished an Empty Office in Centcom Admin area into workspace and office for Beverly Valon, MATRIARCH AI, and PORG IPCs. This also adds a coder closet as requested by Pooba.
/:cl:
