### PR TITLE
Update BarDrone Rule GUI to Match Correct Laws and Guidelines

### DIFF
--- a/tgui/packages/tgui/interfaces/BarDrone.tsx
+++ b/tgui/packages/tgui/interfaces/BarDrone.tsx
@@ -3,23 +3,37 @@ import { Window } from '../layouts';
 
 export const BarDrone = () => {
   return (
-    <Window title="Drone Information" width={600} height={320}>
+    // MONKESTATION EDIT START
+    // <Window title="Drone Information" width={600} height={320}>
+    <Window title="Bar Drone Information" width={600} height={522}>
+      {/* MONKESTATION EDIT END */}
       <Section title="">
         <Box color="red" fontSize="18px" margin="5px 0">
           <b>
-            DO NOT INTERFERE WITH THE ROUND AS A DRONE OR YOU WILL BE DRONE
-            BANNED
+            {/* MONKESTATION EDIT START */}
+            {/* DO NOT INTERFERE WITH THE ROUND AS A DRONE OR YOU WILL BE DRONE
+            BANNED */}
+            DO NOT INTERFERE WITH THE ROUND OUTSIDE OF YOUR LAWS AS A BARDRONE
+            OR YOU WILL BE DRONE BANNED
+            {/* MONKESTATION EDIT END */}
           </b>
         </Box>
         <Box fontSize="14px" margin="5px 0" color="#ffffff">
-          Drones are a ghost role that are allowed to fix the station and build
-          things. Interfering with the round as a drone is against the rules.
+          {/* MONKESTATION EDIT START */}
+          {/* Drones are a ghost role that are allowed to fix the station and build
+          things. Interfering with the round as a drone is against the rules. */}
+          Bar Drones are a ghost role designed to serve drinks, entertain
+          patrons, and maintain their bar. Actions outside of your laws and
+          guidelines are against the rules.
+          {/* MONKESTATION EDIT END */}
         </Box>
         <Box fontSize="14px" color="#ffffff" margin="5px 0">
           Actions that constitute interference include, but are not limited to:
         </Box>
         <LabeledList>
-          <LabeledList.Item label="">
+          {/* MONKESTATION EDIT START*/}
+          {/*
+           <LabeledList.Item label="">
             <Box fontSize="14px" color="#ffffff">
               - Interacting with round-critical objects (IDs, weapons,
               contraband, powersinks, bombs, etc.)
@@ -37,6 +51,60 @@ export const BarDrone = () => {
               bodies, etc.)
             </Box>
           </LabeledList.Item>
+           */}
+          <LabeledList.Item label="">
+            <Box fontSize="14px" color="#ffffff">
+              - Harming sapient creatures (attacking, poisoning, or any form of
+              intentional harm).
+            </Box>
+          </LabeledList.Item>
+          <LabeledList.Item label="">
+            <Box fontSize="14px" color="#ffffff">
+              - Interacting with non-conscious individuals (dead, passed out, or
+              SSD). Call for medical assistance instead.
+            </Box>
+          </LabeledList.Item>
+          <LabeledList.Item label="">
+            <Box fontSize="14px" color="#ffffff">
+              - Getting involved in altercations (fights, disputes, or
+              conflicts). Remove yourself from these situations.
+            </Box>
+          </LabeledList.Item>
+          <LabeledList.Item label="">
+            <Box fontSize="14px" color="#ffffff">
+              - Protecting the bar from aggressors (do not play security or
+              attempt to defend the bar).
+            </Box>
+          </LabeledList.Item>
+        </LabeledList>
+        <Box fontSize="14px" margin="10px 0" color="#ffffff">
+          <b>Guidelines for Bar Drones:</b>
+        </Box>
+        <LabeledList>
+          <LabeledList.Item label="">
+            <Box fontSize="14px" color="#ffffff">
+              - Serve drinks and interact with patrons.
+            </Box>
+          </LabeledList.Item>
+          <LabeledList.Item label="">
+            <Box fontSize="14px" color="#ffffff">
+              - Operate only at a bar with the permission of its users or
+              owners.
+            </Box>
+          </LabeledList.Item>
+          <LabeledList.Item label="">
+            <Box fontSize="14px" color="#ffffff">
+              - You may create your own bar if you have permission from a
+              relevant head of staff. Do not monopolize station resources.
+            </Box>
+          </LabeledList.Item>
+          <LabeledList.Item label="">
+            <Box fontSize="14px" color="#ffffff">
+              - Focus on maintaining the integrity of the bar. Keep it clean,
+              operational, and welcoming.
+            </Box>
+          </LabeledList.Item>
+          {/* MONKESTATION EDIT END */}
         </LabeledList>
         <Box color="red" fontSize="14px" margin="10px 0">
           These rules are at admin discretion and will be heavily enforced.
@@ -48,8 +116,11 @@ export const BarDrone = () => {
           textDecoration="underline, bold"
         >
           <b>
-            If you do not have the regular drone laws, follow your laws to the
-            best of your ability.
+            {/* MONKESTATION EDIT START */}
+            {/* If you do not have the regular drone laws, follow your laws to the
+            best of your ability. */}
+            If you have questions about these rules, AHELP for clarification.
+            {/* MONKESTATION EDIT END */}
           </b>
         </Box>
         <Box fontSize="14px" color="#ffffff" margin="5px 0">


### PR DESCRIPTION
## About The Pull Request

This PR updates the Bar Drone Information GUI to show the correct laws and guidelines for Bar Drones instead of the rules for Maintenance Drones. The new text matches with Bar Drone laws, focusing on their role as interactive bartenders and clarifying their guidelines.

Old GUI:

![image](https://github.com/user-attachments/assets/36084e3d-3d4a-43d8-9700-0a41345f4b91)

New GUI:

![image](https://github.com/user-attachments/assets/83c14112-4958-482d-8499-30519794d694)

## Why It's Good For The Game

The update improves the quality of life for players using the Bar Drone role by allowing them to easily access the correct guidelines for Bar Drones, which reduces confusion and potential rule violations.

## Changelog

:cl:
fix: Changed the Bar Drone Information GUI to match laws and guidelines for Bar Drones rather than Maintenance Drones.
/:cl: