### PR TITLE
The shot gun

### DIFF
--- a/code/modules/projectiles/ammunition/special/syringe.dm
+++ b/code/modules/projectiles/ammunition/special/syringe.dm
@@ -32,6 +32,7 @@
 		qdel(loaded_syringe)
 	return ..()
 
+
 /obj/item/ammo_casing/chemgun
 	name = "dart synthesiser"
 	desc = "A high-power spring, linked to an energy-based piercing dart synthesiser."

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -63,6 +63,7 @@
 	var/pinless = FALSE
 
 	var/can_bayonet = FALSE //if a bayonet can be added or removed if it already has one.
+	var/has_manufacturer = TRUE // Set to true by default. This didn't exist until Brad needed to make a new pipe-gun esque weapon.
 	var/obj/item/knife/bayonet
 	var/knife_x_offset = 0
 	var/knife_y_offset = 0
@@ -78,7 +79,9 @@
 		pin = new pin(src)
 
 	add_seclight_point()
-	give_manufacturer_examine()
+
+	if(has_manufacturer)
+		give_manufacturer_examine()
 
 /obj/item/gun/Destroy()
 	if(isobj(pin)) //Can still be the initial path, then we skip

--- a/code/modules/projectiles/guns/special/syringe_gun.dm
+++ b/code/modules/projectiles/guns/special/syringe_gun.dm
@@ -200,3 +200,37 @@
 	user.stamina.adjust(-20)
 	user.adjustOxyLoss(20)
 	return ..()
+
+//Prepare thy coders for a PSYCHIC ATTACK.
+
+/obj/item/gun/syringe/shot_gun
+	name = "double-barreled 'shot' gun"
+	desc = "Fuck yeah, cheers bro! \n\nThis bad-boy is loaded with shot glasses! Just make sure they're full unless you want your patrons swallowing shards of broken glass."
+	icon = 'icons/obj/weapons/guns/ballistic.dmi'
+	icon_state = "dshotgun"
+	inhand_icon_state = "shotgun_db"
+	fire_sound = 'sound/weapons/gun/shotgun/shot.ogg'
+	has_syringe_overlay = FALSE
+	max_syringes = 2
+
+/obj/item/gun/syringe/shot_gun/attackby(obj/item/A, mob/user, params, show_msg = TRUE) // Needs to be overridden so it can be loaded w/ shotglasses instead.
+	if(istype(A, /obj/item/reagent_containers/cup/glass/drinkingglass/shotglass))
+		if(syringes.len < max_syringes)
+			if(!user.transferItemToLoc(A, src))
+				return FALSE
+			balloon_alert(user, "[A.name] loaded")
+			syringes += A
+			recharge_newshot()
+			playsound(loc, load_sound, 40)
+			return TRUE
+		else
+			balloon_alert(user, "it's already full!")
+	return FALSE
+
+/obj/item/gun/syringe/shot_gun/handle_chamber(mob/living/user, empty_chamber = TRUE, from_firing = TRUE, chamber_next_round = TRUE) // Exclusively overridden so it doesn't update appearance.
+	if(chambered && !chambered.loaded_projectile)
+		recharge_newshot()
+
+/obj/item/gun/syringe/shot_gun/examine(mob/user)
+	. = ..()
+	. = "Can hold [max_syringes] shot glasses. Has [syringes.len] shot glasses remaining."

--- a/code/modules/projectiles/guns/special/syringe_gun.dm
+++ b/code/modules/projectiles/guns/special/syringe_gun.dm
@@ -58,7 +58,8 @@
 
 /obj/item/gun/syringe/examine(mob/user)
 	. = ..()
-	. += "Can hold [max_syringes] syringe\s. Has [syringes.len] syringe\s remaining."
+	if(has_syringe_overlay)
+		. += "Can hold [max_syringes] syringe\s. Has [syringes.len] syringe\s remaining."
 
 /obj/item/gun/syringe/attack_self(mob/living/user)
 	if(!syringes.len)
@@ -211,7 +212,8 @@
 	inhand_icon_state = "shotgun_db"
 	fire_sound = 'sound/weapons/gun/shotgun/shot.ogg'
 	has_syringe_overlay = FALSE
-	max_syringes = 2
+	max_syringes = 2 // Technically makes it a better syringe gun, but at least you have to work for this one.
+	has_manufacturer = FALSE
 
 /obj/item/gun/syringe/shot_gun/attackby(obj/item/A, mob/user, params, show_msg = TRUE) // Needs to be overridden so it can be loaded w/ shotglasses instead.
 	if(istype(A, /obj/item/reagent_containers/cup/glass/drinkingglass/shotglass))
@@ -231,6 +233,15 @@
 	if(chambered && !chambered.loaded_projectile)
 		recharge_newshot()
 
-/obj/item/gun/syringe/shot_gun/examine(mob/user)
-	. = ..()
-	. = "Can hold [max_syringes] shot glasses. Has [syringes.len] shot glasses remaining."
+/datum/crafting_recipe/shot_gun // Crafting recipe to make the dumb gun. Could be modified to require more annoying materials or a recipe book if people complain.
+	name = "'Shot' gun"
+	result = /obj/item/gun/syringe/shot_gun
+	reqs = list(
+		/obj/item/gun/ballistic/shotgun/doublebarrel = 1,
+		/obj/item/stack/sticky_tape = 1,
+		/obj/item/pipe = 3,
+		/obj/item/stack/sheet/iron = 5,
+	)
+	tool_behaviors = list(TOOL_SCREWDRIVER, TOOL_DRILL, TOOL_CROWBAR, TOOL_WELDER, TOOL_SAW)
+	time = 15 SECONDS
+	category = CAT_WEAPON_RANGED

--- a/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinkingglass.dm
@@ -66,6 +66,7 @@
 	volume = 15
 	custom_materials = list(/datum/material/glass=SMALL_MATERIAL_AMOUNT)
 	custom_price = PAYCHECK_CREW * 0.4
+	var/inject_flags = NONE // Pay no mind that I (Brad) put this variable here for ONE gun.
 
 /obj/item/reagent_containers/cup/glass/drinkingglass/shotglass/update_name(updates)
 	if(renamedByPlayer)


### PR DESCRIPTION
## About The Pull Request

Adds a new 'weapon' to the game; the **double-barrel shot gun**, which is actually just a play on words for a double-barrel shotgun that shoots shots. The kind of shots you drink.

We can finally weaponize liver death.

## Why It's Good For The Game

It's not. I thought it was funny whilst I was delirious at 5 AM and making puns in #spess-admin and got goaded into actually making it a reality.

## Changelog

:cl:
add: Added the SHOT gun... I have no regrets for my decisions.
add: Created the respective crafting recipe for said shot gun, requiring the bartender's DB shotgun, some misc items and an assortment of tools.
add: Added new variable for guns "has_manufacturer" to override if a manufacturer's label should be slapped onto the description of a gun or not from as far down the inheritance chain as you want.
change: Tampered slightly with the syringe gun's "has_syringe_overlay" variable to include whether or not to display in its examine text how many syringes are currently loaded into it, since the shot gun has no screen to show how much is loaded into it anyhow.
\:cl:
