### PR TITLE
nerfs 45 long ammo

### DIFF
--- a/monkestation/code/game/objects/items/guns/long_guns.dm
+++ b/monkestation/code/game/objects/items/guns/long_guns.dm
@@ -45,7 +45,8 @@
 
 /obj/projectile/bullet/g45l
 	name = ".45 Long bullet"
-	damage = 35
+	damage = 25
+	weak_against_armour = TRUE // High fire rate
 	wound_bonus = -5
 	sharpness = SHARP_EDGED
 	embedding = list(embed_chance=25, fall_chance=2, jostle_chance=2, ignore_throwspeed_threshold=TRUE, pain_stam_pct=0.4, pain_mult=3, jostle_pain_mult=5, rip_time=1 SECONDS)

--- a/monkestation/code/game/objects/items/guns/long_guns.dm
+++ b/monkestation/code/game/objects/items/guns/long_guns.dm
@@ -45,7 +45,7 @@
 
 /obj/projectile/bullet/g45l
 	name = ".45 Long bullet"
-	damage = 25
+	damage = 30
 	weak_against_armour = TRUE // High fire rate
 	wound_bonus = -5
 	sharpness = SHARP_EDGED


### PR DESCRIPTION
## About The Pull Request
drops the damage of the 45 long, used by long revolver and bush rifle to 30 damage and makes it weak to armor

## Why It's Good For The Game
These two weapons had high fire rate, high damage, could be instantly reloaded, and the pistol dual wielded.

This makes the gun weaker, taking a unarmored person down in 4 shots and 8 in 30% bullet armor, which is a base vest, taking the gun down a noche and way more reasonable.

## Changelog

:cl:
balance: .45 long ammo now does 30 damage and is weaker to armor
/:cl:

