### PR TITLE
Adds a second bartender slot

### DIFF
--- a/code/modules/jobs/job_types/bartender.dm
+++ b/code/modules/jobs/job_types/bartender.dm
@@ -3,8 +3,8 @@
 	description = "Serve booze, mix drinks, keep the crew drunk."
 	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
-	total_positions = 1
-	spawn_positions = 1
+	total_positions = 2  //monke edit
+	spawn_positions = 2  //monke edit
 	supervisors = SUPERVISOR_HOP
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "BARTENDER"


### PR DESCRIPTION

## About The Pull Request

Does what it says on the tin

## Why It's Good For The Game

Requested by Mothella, confirmed by a couple other people in discord. Our population is EXTREMELY high rn, having 2 bartenders is more reasonable for simply the quantity of players. In addition, 2 bartenders gives a lot more room for gimmicks/building stuff/RP when no-one comes to bar.

## Changelog
:cl:
balance: +1 bartender slot
/:cl:
