### PR TITLE
Port various UX improvements from tg

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -3,6 +3,7 @@
 	var/datum/hud/our_hud
 	var/actiontooltipstyle = ""
 	screen_loc = null
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 	/// The icon state of our active overlay, used to prevent re-applying identical overlays
 	var/active_overlay_icon_state
@@ -267,6 +268,7 @@
 	icon = 'icons/hud/64x16_actions.dmi'
 	icon_state = "screen_gen_palette"
 	screen_loc = ui_action_palette
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/datum/hud/our_hud
 	var/expanded = FALSE
 	/// Id of any currently running timers that set our color matrix
@@ -392,6 +394,7 @@ GLOBAL_LIST_INIT(palette_removed_matrix, list(1.4,0,0,0, 0.7,0.4,0,0, 0.4,0,0.6,
 /atom/movable/screen/palette_scroll
 	icon = 'icons/hud/screen_gen.dmi'
 	screen_loc = ui_palette_scroll
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	/// How should we move the palette's actions?
 	/// Positive scrolls down the list, negative scrolls back
 	var/scroll_direction = 0

--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -1,5 +1,6 @@
 /atom/movable/screen/ai
 	icon = 'icons/hud/screen_ai.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/ai/Click()
 	if(isobserver(usr) || usr.incapacitated())

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -117,6 +117,7 @@
 	. = ..()
 	if(clickable_glow)
 		add_filter("clickglow", 2, outline_filter(color = COLOR_GOLD, size = 1))
+		mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/alert/MouseEntered(location,control,params)
 	. = ..()

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -1207,7 +1207,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		return FALSE
 	var/list/modifiers = params2list(params)
 	if(LAZYACCESS(modifiers, SHIFT_CLICK)) // screen objects don't do the normal Click() stuff so we'll cheat
-		to_chat(usr, examine_block(jointext(examine(usr), "\n")))
+		to_chat(usr, boxed_message(jointext(examine(usr), "\n")))
 		return FALSE
 	if(master && click_master)
 		return usr.client.Click(master, location, control, params)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -102,6 +102,8 @@
 	name = "Alert"
 	desc = "Something seems to have gone wrong with this alert, so report this bug please"
 	mouse_opacity = MOUSE_OPACITY_ICON
+	/// do we glow to represent we do stuff when clicked
+	var/clickable_glow = FALSE
 	var/timeout = 0 //If set to a number, this alert will clear itself after that many deciseconds
 	var/severity = 0
 	var/alerttooltipstyle = ""
@@ -111,6 +113,10 @@
 	/// Boolean. If TRUE, the Click() proc will attempt to Click() on the master first if there is a master.
 	var/click_master = TRUE
 
+/atom/movable/screen/alert/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	if(clickable_glow)
+		add_filter("clickglow", 2, outline_filter(color = COLOR_GOLD, size = 1))
 
 /atom/movable/screen/alert/MouseEntered(location,control,params)
 	. = ..()
@@ -289,6 +295,7 @@
 	name = "Mind Control"
 	desc = "Your mind has been hijacked! Click to view the mind control command."
 	icon_state = ALERT_MIND_CONTROL
+	clickable_glow = TRUE
 	var/command
 
 /atom/movable/screen/alert/mind_control/Click()
@@ -302,6 +309,7 @@
 	desc = "Something got lodged into your flesh and is causing major bleeding. It might fall out with time, but surgery is the safest way. \
 		If you're feeling frisky, examine yourself and click the underlined item to pull the object out."
 	icon_state = ALERT_EMBEDDED_OBJECT
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/embeddedobject/Click()
 	. = ..()
@@ -339,6 +347,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	name = "On Fire"
 	desc = "You're on fire. Stop, drop and roll to put the fire out or move to a vacuum area."
 	icon_state = "fire"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/fire/Click()
 	. = ..()
@@ -357,6 +366,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/give // information set when the give alert is made
 	icon_state = "default"
+	clickable_glow = TRUE
 	/// The offer we're linked to, yes this is suspiciously like a status effect alert
 	var/datum/status_effect/offering/offer
 	/// Additional text displayed in the description of the alert.
@@ -531,6 +541,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	name = "Succumb"
 	desc = "Shuffle off this mortal coil."
 	icon_state = ALERT_SUCCUMB
+	clickable_glow = TRUE
 	var/static/list/death_titles = list(
 		"Goodnight, Sweet Prince",
 		"Game Over, Man",
@@ -857,6 +868,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		additional processing time to unlock more malfunction abilities."
 	icon_state = ALERT_HACKING_APC
 	timeout = 60 SECONDS
+	clickable_glow = TRUE
 	var/atom/target = null
 
 /atom/movable/screen/alert/hackingapc/Click()
@@ -884,6 +896,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	desc = "Someone is trying to revive you. Re-enter your corpse if you want to be revived!"
 	icon_state = "template"
 	timeout = 300
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/notify_cloning/Click()
 	. = ..()
@@ -897,6 +910,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	desc = "This can be clicked on to perform an action."
 	icon_state = "template"
 	timeout = 30 SECONDS
+	clickable_glow = TRUE
 	/// The target to use the action on
 	var/atom/target
 	/// Which on click action to use
@@ -1081,6 +1095,10 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	name = "Buckled"
 	desc = "You've been buckled to something. Click the alert to unbuckle unless you're handcuffed."
 	icon_state = ALERT_BUCKLED
+	clickable_glow = TRUE
+
+/atom/movable/screen/alert/restrained
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/restrained/handcuffed
 	name = "Handcuffed"
@@ -1128,6 +1146,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	name = "Knotted Shoes"
 	desc = "Someone tied your shoelaces together! Click the alert or your shoes to undo the knot."
 	icon_state = ALERT_SHOES_KNOT
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/shoes/Click()
 	. = ..()

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -360,11 +360,24 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	/// The offer we're linked to, yes this is suspiciously like a status effect alert
 	var/datum/status_effect/offering/offer
 	/// Additional text displayed in the description of the alert.
-	var/additional_desc_text = "Click this alert to take it."
+	var/additional_desc_text = "Click this alert to take it, or shift click it to examiante it."
+	/// Text to override what appears in screentips for the alert
+	var/screentip_override_text
+	/// Whether the offered item can be examined by shift-clicking the alert
+	var/examinable = TRUE
+
+/atom/movable/screen/alert/give/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	register_context()
 
 /atom/movable/screen/alert/give/Destroy()
 	offer = null
 	return ..()
+
+/atom/movable/screen/alert/give/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	context[SCREENTIP_CONTEXT_LMB] = screentip_override_text || "Take [offer.offered_item.name]"
+	context[SCREENTIP_CONTEXT_SHIFT_LMB] = "Examine"
+	return CONTEXTUAL_SCREENTIP_SET
 
 /**
  * Handles assigning most of the variables for the alert that pops up when an item is offered
@@ -416,6 +429,16 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 	handle_transfer()
 
+/atom/movable/screen/alert/give/examine(mob/user)
+	if(!examinable)
+		return ..()
+
+	return list(
+		span_boldnotice(name),
+		span_info("[offer.owner] is offering you the following item (click the alert to take it!):"),
+		"<hr>[jointext(offer.offered_item.examine(user), "\n")]",
+	)
+
 /// An overrideable proc used simply to hand over the item when claimed, this is a proc so that high-fives can override them since nothing is actually transferred
 /atom/movable/screen/alert/give/proc/handle_transfer(visible_message = TRUE)
 	var/mob/living/taker = owner
@@ -429,6 +452,8 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/give/highfive
 	additional_desc_text = "Click this alert to slap it."
+	screentip_override_text = "High Five"
+	examinable = FALSE
 	/// Tracks active "to slow"ing so we can't spam click
 	var/too_slowing_this_guy = FALSE
 
@@ -486,6 +511,10 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 	if(QDELETED(offer.offered_item))
 		examine_list += span_warning("[source]'s arm appears tensed up, as if [source.p_they()] plan on pulling it back suddenly...")
+
+/atom/movable/screen/alert/give/hand
+	screentip_override_text = "Take Hand"
+	examinable = FALSE
 
 /atom/movable/screen/alert/give/hand/get_receiving_name(mob/living/carbon/taker, mob/living/carbon/offerer, obj/item/receiving)
 	additional_desc_text = "Click this alert to take it and let [offerer.p_them()] pull you around!"
@@ -1156,7 +1185,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 		return FALSE
 	var/list/modifiers = params2list(params)
 	if(LAZYACCESS(modifiers, SHIFT_CLICK)) // screen objects don't do the normal Click() stuff so we'll cheat
-		to_chat(usr, span_boldnotice("[name]</span> - <span class='info'>[desc]"))
+		to_chat(usr, examine_block(jointext(examine(usr), "\n")))
 		return FALSE
 	if(master && click_master)
 		return usr.client.Click(master, location, control, params)
@@ -1169,3 +1198,9 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	master = null
 	owner = null
 	screen_loc = ""
+
+/atom/movable/screen/alert/examine(mob/user)
+	return list(
+		span_boldnotice(name),
+		span_info(desc),
+	)

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -944,6 +944,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	icon_state = "template"
 	timeout = 30 SECONDS
 	ghost_screentips = TRUE
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	/// If true you need to call START_PROCESSING manually
 	var/show_time_left = FALSE
 	/// MA for maptext showing time left for poll

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -919,9 +919,6 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/notify_action/Click()
 	. = ..()
-	if(!.)
-		return
-
 	if(isnull(target))
 		return
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -360,7 +360,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	/// The offer we're linked to, yes this is suspiciously like a status effect alert
 	var/datum/status_effect/offering/offer
 	/// Additional text displayed in the description of the alert.
-	var/additional_desc_text = "Click this alert to take it, or shift click it to examiante it."
+	var/additional_desc_text = "Click this alert to take it, or shift click it to examine it."
 	/// Text to override what appears in screentips for the alert
 	var/screentip_override_text
 	/// Whether the offered item can be examined by shift-clicking the alert

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -502,24 +502,62 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	name = "Succumb"
 	desc = "Shuffle off this mortal coil."
 	icon_state = ALERT_SUCCUMB
+	var/static/list/death_titles = list(
+		"Goodnight, Sweet Prince",
+		"Game Over, Man",
+		"End Of The Road",
+		"Live Long And Prosper",
+		"See You Space Cowboy...",
+		"It's Been An Honor",
+		"The Curtains Close",
+		"All Good Things Must End"
+	)
 
-/atom/movable/screen/alert/succumb/Click()
+/atom/movable/screen/alert/succumb/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	register_context()
+
+/atom/movable/screen/alert/succumb/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	context[SCREENTIP_CONTEXT_LMB] = "Succumb With Last Words"
+	context[SCREENTIP_CONTEXT_RMB] = "Succumb Silently"
+	return CONTEXTUAL_SCREENTIP_SET
+
+#define FASTSUCCUMB_YES "Yes"
+#define FASTSUCCUMB_WAIT "Wait, I have last words!"
+#define FASTSUCCUMB_NO "No"
+
+/atom/movable/screen/alert/succumb/Click(location, control, params)
 	. = ..()
 	if(!.)
 		return
 	var/mob/living/living_owner = owner
-	var/last_whisper
-	if(!HAS_TRAIT(living_owner, TRAIT_SUCCUMB_OVERRIDE))
-		last_whisper = tgui_input_text(usr, "Do you have any last words?", "Goodnight, Sweet Prince", encode = FALSE) // saycode already handles sanitization
+	if(!CAN_SUCCUMB(living_owner) && !HAS_TRAIT(living_owner, TRAIT_SUCCUMB_OVERRIDE)) //checked again in [mob/living/verb/succumb()]
+		return
+
+	var/title = pick(death_titles)
+
+	if(LAZYACCESS(params2list(params), RIGHT_CLICK))
+		//Succumbing without a message
+		var/choice = tgui_alert(living_owner, "Are you sure you want to succumb?", title, list(FASTSUCCUMB_YES, FASTSUCCUMB_WAIT, FASTSUCCUMB_NO))
+		switch(choice)
+			if(FASTSUCCUMB_NO, null)
+				return
+			if(FASTSUCCUMB_YES)
+				living_owner.succumb()
+				return
+			//if(FASTSUCCUMB_WAIT), we continue to last words
+
+	//Succumbing with a message
+	var/last_whisper = tgui_input_text(usr, "Do you have any last words?", title, max_length = CHAT_MESSAGE_MAX_LENGTH, encode = FALSE) // saycode already handles sanitization
 	if(isnull(last_whisper))
-		if(HAS_TRAIT(living_owner, TRAIT_SUCCUMB_OVERRIDE))
-			return
-	if(!CAN_SUCCUMB(living_owner) && !HAS_TRAIT(living_owner, TRAIT_SUCCUMB_OVERRIDE))
 		return
 	if(length(last_whisper))
 		living_owner.say("#[last_whisper]")
 	living_owner.succumb(whispered = length(last_whisper) > 0)
 
+#undef FASTSUCCUMB_NO
+#undef FASTSUCCUMB_WAIT
+#undef FASTSUCCUMB_YES
 //ALIENS
 
 /atom/movable/screen/alert/alien_plas

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -904,6 +904,9 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 
 /atom/movable/screen/alert/notify_action/Click()
 	. = ..()
+	if(!.)
+		return
+
 	if(isnull(target))
 		return
 

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -512,7 +512,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	if(!HAS_TRAIT(living_owner, TRAIT_SUCCUMB_OVERRIDE))
 		last_whisper = tgui_input_text(usr, "Do you have any last words?", "Goodnight, Sweet Prince", encode = FALSE) // saycode already handles sanitization
 	if(isnull(last_whisper))
-		if(!HAS_TRAIT(living_owner, TRAIT_SUCCUMB_OVERRIDE))
+		if(HAS_TRAIT(living_owner, TRAIT_SUCCUMB_OVERRIDE))
 			return
 	if(!CAN_SUCCUMB(living_owner) && !HAS_TRAIT(living_owner, TRAIT_SUCCUMB_OVERRIDE))
 		return

--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -1,6 +1,7 @@
 
 /atom/movable/screen/blob
 	icon = 'icons/hud/blob.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/blob/MouseEntered(location,control,params)
 	. = ..()

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -1,5 +1,6 @@
 /atom/movable/screen/ghost
 	icon = 'icons/hud/screen_ghost.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/ghost/MouseEntered(location, control, params)
 	. = ..()
@@ -115,4 +116,3 @@
 	if (istype(O) && O.observetarget)
 		return
 	. = ..()
-

--- a/code/_onclick/hud/guardian.dm
+++ b/code/_onclick/hud/guardian.dm
@@ -117,6 +117,7 @@
 
 /atom/movable/screen/guardian
 	icon = 'icons/hud/guardian.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/guardian/manifest
 	icon_state = "manifest"

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -4,6 +4,7 @@
 /atom/movable/screen/human/toggle
 	name = "toggle"
 	icon_state = "toggle"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/human/toggle/Click()
 
@@ -26,6 +27,7 @@
 /atom/movable/screen/human/equip
 	name = "equip"
 	icon_state = "act_equip"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/human/equip/Click()
 	if(ismecha(usr.loc)) // stops inventory actions in a mech
@@ -45,6 +47,7 @@
 	name = "current sting"
 	screen_loc = ui_lingstingdisplay
 	invisibility = INVISIBILITY_ABSTRACT
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/ling/sting/Click()
 	if(isobserver(usr))

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -501,8 +501,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/lobby/button/server)
 
 /atom/movable/screen/lobby/button/server/Initialize(mapload)
 	. = ..()
-	if(is_available())
-		set_button_status(TRUE)
+	set_button_status(is_available())
 	update_appearance(UPDATE_ICON_STATE)
 
 /atom/movable/screen/lobby/button/server/proc/is_available()

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -262,6 +262,7 @@
 	icon = 'icons/hud/lobby/observe.dmi'
 	icon_state = "observe_disabled"
 	base_icon_state = "observe"
+	enabled = FALSE
 
 /atom/movable/screen/lobby/button/observe/Initialize(mapload)
 	. = ..()

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -42,8 +42,9 @@
 
 /atom/movable/screen/lobby/button
 	abstract_type = /atom/movable/screen/lobby/button
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	///Is the button currently enabled?
-	var/enabled = TRUE
+	VAR_PROTECTED/enabled = TRUE
 	///Is the button currently being hovered over with the mouse?
 	var/highlighted = FALSE
 	/// The ref of the mob that owns this button. Only the owner can click on it.
@@ -104,7 +105,8 @@
 	if(status == enabled)
 		return FALSE
 	enabled = status
-	update_appearance(UPDATE_ICON_STATE)
+	update_appearance(UPDATE_ICON)
+	mouse_over_pointer = enabled ? MOUSE_HAND_POINTER : MOUSE_INACTIVE_POINTER
 	return TRUE
 
 ///Prefs menu
@@ -185,10 +187,10 @@
 	icon = 'icons/hud/lobby/join.dmi'
 	icon_state = "" //Default to not visible
 	base_icon_state = "join_game"
-	enabled = FALSE
 
 /atom/movable/screen/lobby/button/join/Initialize(mapload)
 	. = ..()
+	set_button_status(FALSE)
 	switch(SSticker.current_state)
 		if(GAME_STATE_PREGAME, GAME_STATE_STARTUP)
 			RegisterSignal(SSticker, COMSIG_TICKER_ENTER_SETTING_UP, PROC_REF(show_join_button))
@@ -260,13 +262,13 @@
 	icon = 'icons/hud/lobby/observe.dmi'
 	icon_state = "observe_disabled"
 	base_icon_state = "observe"
-	enabled = FALSE
 
 /atom/movable/screen/lobby/button/observe/Initialize(mapload)
 	. = ..()
 	if(SSticker.current_state > GAME_STATE_STARTUP)
 		set_button_status(TRUE)
 	else
+		set_button_status(FALSE)
 		RegisterSignal(SSticker, COMSIG_TICKER_ENTER_PREGAME, PROC_REF(enable_observing))
 
 /atom/movable/screen/lobby/button/observe/Click(location, control, params)

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -1,5 +1,6 @@
 /atom/movable/screen/robot
 	icon = 'icons/hud/screen_cyborg.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/robot/module
 	name = "cyborg module"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -73,6 +73,7 @@
 /atom/movable/screen/swap_hand
 	plane = HUD_PLANE
 	name = "swap hand"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/swap_hand/Click()
 	// At this point in client Click() code we have passed the 1/10 sec check and little else
@@ -93,6 +94,7 @@
 	icon = 'icons/hud/screen_midnight.dmi'
 	icon_state = "navigate"
 	screen_loc = ui_navigate_menu
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/navigate/Click()
 	if(!isliving(usr))
@@ -111,6 +113,7 @@
 	icon = 'icons/hud/screen_midnight.dmi'
 	icon_state = "area_edit"
 	screen_loc = ui_building
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/area_creator/Click()
 	if(usr.incapacitated() || (isobserver(usr) && !isAdminGhostAI(usr)))
@@ -126,6 +129,7 @@
 	icon = 'icons/hud/screen_midnight.dmi'
 	icon_state = "talk_wheel"
 	screen_loc = ui_language_menu
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/language_menu/Click()
 	var/mob/M = usr
@@ -255,6 +259,7 @@
 	name = "close"
 	plane = ABOVE_HUD_PLANE
 	icon_state = "backpack_close"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/close/Initialize(mapload, new_master)
 	. = ..()
@@ -270,6 +275,7 @@
 	icon = 'icons/hud/screen_midnight.dmi'
 	icon_state = "act_drop"
 	plane = HUD_PLANE
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/drop/Click()
 	if(usr.stat == CONSCIOUS)
@@ -280,6 +286,7 @@
 	icon = 'icons/hud/screen_midnight.dmi'
 	icon_state = "combat_off"
 	screen_loc = ui_combat_toggle
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/datum/interaction_mode/combat_mode/combat_mode
 
 /atom/movable/screen/combattoggle/Initialize(mapload)
@@ -330,6 +337,7 @@
 	name = "intent"
 	icon_state = "help"
 	screen_loc = ui_acti
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/datum/interaction_mode/intents3/intents
 
 /atom/movable/screen/act_intent3/Click(location, control, params)
@@ -356,6 +364,7 @@
 	name = "run/walk toggle"
 	icon = 'icons/hud/screen_midnight.dmi'
 	icon_state = "running"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/mov_intent/Click()
 	toggle(usr)
@@ -383,6 +392,7 @@
 	icon = 'icons/hud/screen_midnight.dmi'
 	icon_state = "pull"
 	base_icon_state = "pull"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/pull/Click()
 	if(isobserver(usr))
@@ -398,6 +408,7 @@
 	icon = 'icons/hud/screen_midnight.dmi'
 	icon_state = "act_resist"
 	plane = HUD_PLANE
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/resist/Click()
 	if(isliving(usr))
@@ -410,6 +421,7 @@
 	icon_state = "act_rest"
 	base_icon_state = "act_rest"
 	plane = HUD_PLANE
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/rest/Click()
 	if(isliving(usr))
@@ -455,6 +467,7 @@
 	name = "throw/catch"
 	icon = 'icons/hud/screen_midnight.dmi'
 	icon_state = "act_throw_off"
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/throw_catch/Click()
 	if(iscarbon(usr))
@@ -465,6 +478,7 @@
 	name = "damage zone"
 	icon_state = "zone_sel"
 	screen_loc = ui_zonesel
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/overlay_icon = 'icons/hud/screen_gen.dmi'
 	var/static/list/hover_overlays_cache = list()
 	var/hovering
@@ -642,6 +656,7 @@
 /atom/movable/screen/healthdoll
 	name = "health doll"
 	screen_loc = ui_healthdoll
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/healthdoll/Click()
 	if (iscarbon(usr))
@@ -657,6 +672,7 @@
 	name = "mood"
 	icon_state = "mood5"
 	screen_loc = ui_mood
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 /atom/movable/screen/splash
 	icon = 'icons/blanks/blank_title.png'
@@ -706,6 +722,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/splash)
 
 
 /atom/movable/screen/component_button
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/atom/movable/screen/parent
 
 /atom/movable/screen/component_button/Initialize(mapload, atom/movable/screen/parent)

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -856,6 +856,7 @@
 	name = "Ants!"
 	desc = span_warning("JESUS FUCKING CHRIST! CLICK TO GET THOSE THINGS OFF!")
 	icon_state = "antalert"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/ants/Click()
 	. = ..()

--- a/code/datums/status_effects/debuffs/strandling.dm
+++ b/code/datums/status_effects/debuffs/strandling.dm
@@ -85,6 +85,7 @@
 	desc = "Strands of Durathread are wrapped around your neck, preventing you from breathing! Click this icon to remove the strand."
 	icon_state = "his_grace"
 	alerttooltipstyle = "hisgrace"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/strandling/Click(location, control, params)
 	. = ..()

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -149,6 +149,7 @@
 	name = "Holding Up"
 	desc = "You're currently pointing a gun at someone."
 	icon_state = "aimed"
+	clickable_glow = TRUE
 
 // this status effect is used to negotiate the high-fiving capabilities of all concerned parties
 /datum/status_effect/offering
@@ -325,6 +326,7 @@
 	name = "Surrender"
 	desc = "Looks like you're in trouble now, bud. Click here to surrender. (Warning: You will be incapacitated.)"
 	icon_state = "surrender"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/surrender/Click(location, control, params)
 	. = ..()

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -5,6 +5,7 @@
 	icon_state = "doorctrl"
 	var/skin = "doorctrl"
 	power_channel = AREA_USAGE_ENVIRON
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/obj/item/assembly/device
 	var/obj/item/electronics/airlock/board
 	var/device_type = null

--- a/code/game/machinery/embedded_controller/access_controller.dm
+++ b/code/game/machinery/embedded_controller/access_controller.dm
@@ -10,6 +10,7 @@
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.05
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.04
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/idSelf
 
 /obj/machinery/door_buttons/attackby(obj/O, mob/user)
@@ -106,6 +107,7 @@
 	base_icon_state = "access_control"
 	name = "access console"
 	desc = "A small console that can cycle opening between two airlocks."
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/obj/machinery/door/airlock/interiorAirlock
 	var/obj/machinery/door/airlock/exteriorAirlock
 	var/idInterior

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -22,6 +22,7 @@
 	max_integrity = 250
 	integrity_failure = 0.4
 	armor_type = /datum/armor/machinery_firealarm
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.05
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.02
 	power_channel = AREA_USAGE_ENVIRON

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -7,6 +7,7 @@
 	desc = "Make dark."
 	power_channel = AREA_USAGE_LIGHT
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.02
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	/// Set this to a string, path, or area instance to control that area
 	/// instead of the switch's location.
 	var/area/area = null

--- a/code/modules/bitrunning/alerts.dm
+++ b/code/modules/bitrunning/alerts.dm
@@ -7,6 +7,7 @@
 	name = "Domain Completed"
 	desc = "The domain is completed. Activate to exit."
 	timeout = 20 SECONDS
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/bitrunning/qserver_domain_complete/Click(location, control, params)
 	if(..())

--- a/code/modules/buildmode/buttons.dm
+++ b/code/modules/buildmode/buttons.dm
@@ -1,5 +1,6 @@
 /atom/movable/screen/buildmode
 	icon = 'icons/misc/buildmode.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/datum/buildmode/bd
 	// If we don't do this, we get occluded by item action buttons
 	plane = ABOVE_HUD_PLANE

--- a/code/modules/escape_menu/home_page.dm
+++ b/code/modules/escape_menu/home_page.dm
@@ -107,6 +107,7 @@
 
 /atom/movable/screen/escape_menu/home_button
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 	VAR_PRIVATE
 		atom/movable/screen/escape_menu/home_button_text/home_button_text

--- a/code/modules/escape_menu/leave_body.dm
+++ b/code/modules/escape_menu/leave_body.dm
@@ -76,6 +76,7 @@
 	icon_state = "template"
 	maptext_width = 96
 	maptext_y = -32
+	mouse_over_pointer = MOUSE_HAND_POINTER
 
 	VAR_PRIVATE
 		datum/callback/on_click_callback

--- a/code/modules/industrial_lift/elevator/elevator_panel.dm
+++ b/code/modules/industrial_lift/elevator/elevator_panel.dm
@@ -19,6 +19,7 @@
 	icon_state = "elevpanel0"
 	base_icon_state = "elevpanel"
 
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	power_channel = AREA_USAGE_ENVIRON
 	// Indestructible until someone wants to make these constructible, with all the chaos that implies
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -498,10 +498,10 @@
 	if (!CAN_SUCCUMB(src))
 		if(HAS_TRAIT(src, TRAIT_SUCCUMB_OVERRIDE))
 			if(whispered)
-				to_chat(src, text="You are unable to succumb to death! Unless you just press the UI button.", type=MESSAGE_TYPE_INFO)
+				to_chat(src, span_notice("Your immortal body is keeping you alive. If you want to accept death, you must do so [span_bold("quietly")]."), type=MESSAGE_TYPE_INFO)
 				return
 		else
-			to_chat(src, text="You are unable to succumb to death! This life continues.", type=MESSAGE_TYPE_INFO)
+			to_chat(src, span_warning("You are unable to succumb to death! This life continues."), type=MESSAGE_TYPE_INFO)
 			return
 	log_message("Has [whispered ? "whispered his final words" : "succumbed to death"] with [round(health, 0.1)] points of health!", LOG_ATTACK)
 	adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)

--- a/code/modules/pai/hud.dm
+++ b/code/modules/pai/hud.dm
@@ -2,6 +2,7 @@
 
 /atom/movable/screen/pai
 	icon = 'icons/hud/screen_pai.dmi'
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/required_software
 
 /atom/movable/screen/pai/Click()

--- a/code/modules/spells/spell_types/shapeshift/_shape_status.dm
+++ b/code/modules/spells/spell_types/shapeshift/_shape_status.dm
@@ -230,6 +230,7 @@
 	desc = "Your form is not your own... you're shapeshifted into another creature! \
 		A wizard could turn you back - or maybe you're stuck like this for good?"
 	icon_state = "shapeshifted"
+	clickable_glow = TRUE
 
 /atom/movable/screen/alert/status_effect/shapeshifted/Click(location, control, params)
 	. = ..()

--- a/code/modules/tutorials/_tutorial.dm
+++ b/code/modules/tutorials/_tutorial.dm
@@ -14,8 +14,7 @@
 /datum/tutorial/New(mob/user)
 	src.user = user
 
-	RegisterSignal(user, COMSIG_QDELETING, PROC_REF(destroy_self))
-	RegisterSignal(user.client, COMSIG_QDELETING, PROC_REF(destroy_self))
+	RegisterSignals(user, list(COMSIG_QDELETING, COMSIG_MOB_LOGOUT), PROC_REF(destroy_self))
 
 /datum/tutorial/Destroy(force)
 	user.client?.screen -= instruction_screen
@@ -249,7 +248,13 @@
 /// Dismisses the tutorial, not marking it as completed in the database.
 /// Call `/datum/tutorial/proc/dismiss()` instead.
 /datum/tutorial_manager/proc/dismiss(mob/user)
-	performing_ckeys -= user.ckey
+	// this can be null in some disconnect/mob logout cases so we use some fallbacks
+	var/user_ckey = user.ckey
+	if(!user_ckey && user.canon_client)
+		user_ckey = user.canon_client.ckey
+	if(!user_ckey && user.mind?.key)
+		user_ckey = ckey(user.mind.key)
+	performing_ckeys -= user_ckey
 
 /// Given a ckey, will mark them as being completed without affecting the database.
 /// Call `/datum/tutorial/proc/complete()` instead.

--- a/code/modules/tutorials/_tutorial.dm
+++ b/code/modules/tutorials/_tutorial.dm
@@ -9,6 +9,7 @@
 	VAR_PROTECTED/mob/user
 
 	VAR_PRIVATE/atom/movable/screen/tutorial_instruction/instruction_screen
+	VAR_PRIVATE/atom/movable/screen/tutorial_skip/skip_button
 
 /datum/tutorial/New(mob/user)
 	src.user = user
@@ -18,10 +19,11 @@
 
 /datum/tutorial/Destroy(force)
 	user.client?.screen -= instruction_screen
+	user.client?.screen -= skip_button
 	QDEL_NULL(instruction_screen)
+	QDEL_NULL(skip_button)
 
 	user = null
-
 	return ..()
 
 /// Gets the [`/datum/tutorial_manager`] that owns this tutorial.
@@ -71,6 +73,7 @@
 
 	if (!isnull(instruction_screen))
 		animate(instruction_screen, time = INSTRUCTION_SCREEN_DELAY, alpha = 0, easing = SINE_EASING)
+		animate(skip_button, time = INSTRUCTION_SCREEN_DELAY, alpha = 0, easing = SINE_EASING)
 		delay += INSTRUCTION_SCREEN_DELAY
 
 	QDEL_IN(src, delay)
@@ -98,6 +101,10 @@
 /// If a message already exists, will fade it out and replace it.
 /datum/tutorial/proc/show_instruction(message)
 	PROTECTED_PROC(TRUE)
+	if(isnull(skip_button))
+		skip_button = new
+		user.client?.screen += skip_button
+		RegisterSignal(skip_button, COMSIG_SCREEN_ELEMENT_CLICK, PROC_REF(dismiss))
 
 	if (isnull(instruction_screen))
 		instruction_screen = new(null, message, user.client)

--- a/code/modules/tutorials/tutorial_instruction.dm
+++ b/code/modules/tutorials/tutorial_instruction.dm
@@ -7,7 +7,6 @@
 	layer = TUTORIAL_INSTRUCTIONS_LAYER
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
-	var/client/client
 	var/atom/movable/screen/tutorial_instruction_text/instruction_text
 
 /atom/movable/screen/tutorial_instruction/Initialize(mapload, message, client/client)
@@ -15,14 +14,12 @@
 
 	transform = transform.Scale(36, 2.5)
 
-	src.client = client
 	animate(src, alpha = 245, time = 0.8 SECONDS, easing = SINE_EASING)
 
 	instruction_text = new(src, message, client)
 	vis_contents += instruction_text
 
 /atom/movable/screen/tutorial_instruction/Destroy()
-	client = null
 	QDEL_NULL(instruction_text)
 
 	return ..()

--- a/code/modules/tutorials/tutorial_skip.dm
+++ b/code/modules/tutorials/tutorial_skip.dm
@@ -6,6 +6,7 @@
 	alpha = 0
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	layer = TUTORIAL_INSTRUCTIONS_LAYER
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/atom/movable/screen/tutorial_skip_text/skip_text
 
 /atom/movable/screen/tutorial_skip/Initialize(mapload, datum/hud/hud_owner)

--- a/code/modules/tutorials/tutorial_skip.dm
+++ b/code/modules/tutorials/tutorial_skip.dm
@@ -1,0 +1,35 @@
+/atom/movable/screen/tutorial_skip
+	icon = 'icons/effects/alphacolors.dmi'
+	icon_state = "white"
+	screen_loc = "TOP,LEFT"
+	color = COLOR_NEARLY_ALL_BLACK
+	alpha = 0
+	mouse_opacity = MOUSE_OPACITY_OPAQUE
+	layer = TUTORIAL_INSTRUCTIONS_LAYER
+	var/atom/movable/screen/tutorial_skip_text/skip_text
+
+/atom/movable/screen/tutorial_skip/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	transform = transform.Scale(9, 1)
+	skip_text = new(null, hud_owner)
+	vis_contents += skip_text
+	maptext = MAPTEXT_VCR_OSD_MONO("<span style='font-size: 10px; text-align: left'>Remind me later</span>")
+	animate(src, alpha = 245, time = 0.8 SECONDS, easing = SINE_EASING)
+
+/atom/movable/screen/tutorial_skip/Destroy()
+	QDEL_NULL(skip_text)
+	return ..()
+
+/atom/movable/screen/tutorial_skip_text
+	alpha = 0
+	layer = TUTORIAL_INSTRUCTIONS_LAYER
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	maptext_height = 32
+	maptext_width = 200
+	maptext_x = 20
+	maptext_y = 9
+
+/atom/movable/screen/tutorial_skip_text/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	var/newtext = MAPTEXT_VCR_OSD_MONO("<span style='font-size: 10px; text-align: left'>Remind me later</span>")
+	animate(src, alpha = 255, time = 0.5 SECONDS, maptext=newtext)

--- a/monkestation/code/modules/trading/box_rolling.dm
+++ b/monkestation/code/modules/trading/box_rolling.dm
@@ -25,6 +25,7 @@
 	plane = ABOVE_HUD_PLANE
 
 /atom/movable/screen/fullscreen/lootbox_overlay/main
+	mouse_over_pointer = MOUSE_HAND_POINTER
 	///have we already opened? prevents spam clicks
 	var/opened = FALSE
 	///are we a guarenteed roll for lootboxes.
@@ -37,6 +38,7 @@
 	if(opened)
 		return
 	opened = TRUE
+	mouse_over_pointer = MOUSE_INACTIVE_POINTER
 	playsound(usr, pick('goon/sounds/misc/openlootcrate.ogg', 'goon/sounds/misc/openlootcrate2.ogg'), 100, 0)
 	icon_state = "lootb2"
 	flick("lootb1", src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5658,6 +5658,7 @@
 #include "code\modules\tooltip\tooltip.dm"
 #include "code\modules\tutorials\_tutorial.dm"
 #include "code\modules\tutorials\tutorial_instruction.dm"
+#include "code\modules\tutorials\tutorial_skip.dm"
 #include "code\modules\tutorials\tutorials\drop.dm"
 #include "code\modules\tutorials\tutorials\switch_hands.dm"
 #include "code\modules\unit_tests\_unit_tests.dm"


### PR DESCRIPTION

## About The Pull Request

Ports the following PRs from tg:
- https://github.com/tgstation/tgstation/pull/83065
- https://github.com/tgstation/tgstation/pull/83066
- https://github.com/tgstation/tgstation/pull/83180
- https://github.com/tgstation/tgstation/pull/87490
- https://github.com/tgstation/tgstation/pull/87683
- https://github.com/tgstation/tgstation/pull/87830
- https://github.com/tgstation/tgstation/pull/87902
- https://github.com/tgstation/tgstation/pull/88470
- https://github.com/tgstation/tgstation/pull/88742

## Why It's Good For The Game
## Changelog
:cl:
fix: (TiviPlus) Fixed clients being seen as stuck doing tutorials in some cases when changing mobs.
qol: (Melbert) When you are offered something, you can shift-click the alert to examine the item rather than take it.
qol: (Melbert) Examine blocks for screen alert examining.
qol: (Melbert) Screentips for offer alerts.
fix: (grungussuss) It is now possible to succumb without speaking.
qol: (tontyGH) You can now right-click the succumb action button to succumb silently.
qol: (tontyGH) The succumb inputs have a few more titles to choose from now.
fix: (tontyGH) The succumb text input now shows the actual correct number of characters you can say.
fix: (tontyGH) Attempting to cancel a succumb will no longer kill you.
spellcheck: (tontyGH) The text for failing to succumb is now spanned.
fix: (harryob) Ghosts observing ghosts can no longer click on their screen alerts.
qol: (mc-oofert) Alerts that do stuff when clicked glow gold.
qol: (Melbert) Hovering over clickable screen elements will now update your mouse cursor to indicate they're clickable.
qol: (Melbert) Hovering over small wall mounts (light switches, buttons, fire alarms) will now update to mouse cursor indicating you're hovering them.
/:cl:
