### PR TITLE
fix: stop friers from frying if there's nothing in the basket

### DIFF
--- a/monkestation/code/modules/brewin_and_chewin/chewing/fryer_overhaul.dm
+++ b/monkestation/code/modules/brewin_and_chewin/chewing/fryer_overhaul.dm
@@ -75,6 +75,11 @@
 	if(istype(weapon, /obj/item/reagent_containers/cooking_container/deep_basket) && !basket)
 		weapon.forceMove(src)
 		basket = weapon
+		if (!length(basket.contents))
+			frying = FALSE
+			icon_state = "fryer_off"
+			return
+
 		icon_state = "fryer_on"
 		frying = TRUE
 		for(var/obj/item/item as anything in basket.contents)


### PR DESCRIPTION

## About The Pull Request

i am tired of putting an empty basket back into the deepfrier and it fries anyway.

## Why It's Good For The Game

## Changelog
:cl:
fix: make deepfryers not dry if there's nothing in the basket
/:cl:
