### PR TITLE
Removes empowering the spoon until it can actually be balanced

### DIFF
--- a/monkestation/code/game/objects/items/comically_large_spoon.dm
+++ b/monkestation/code/game/objects/items/comically_large_spoon.dm
@@ -26,8 +26,10 @@
 	var/block_chance_wielded = 15
 	/// The demolition_mod the spoon has when wielded.
 	var/demolition_mod_wielded = 2 // IT'S A BIG METAL SPOON.
+/*
 	/// Is this spoon currently empowered?
 	var/empowered = FALSE
+*/
 
 /obj/item/comically_large_spoon/Initialize(mapload)
 	. = ..()
@@ -38,14 +40,16 @@
 		wield_callback = CALLBACK(src, PROC_REF(on_wield)), \
 		unwield_callback = CALLBACK(src, PROC_REF(on_unwield)), \
 	)
-	AddComponent(/datum/component/liquids_interaction, TYPE_PROC_REF(/obj/item/comically_large_spoon, try_scoop_liquids))
+	//AddComponent(/datum/component/liquids_interaction, TYPE_PROC_REF(/obj/item/comically_large_spoon, try_scoop_liquids))
 
+/*
 /obj/item/comically_large_spoon/examine(mob/user)
 	. = ..()
 	if(empowered)
 		. += span_big(span_warning("It seems to be unusually powerful!"))
 	else
 		. += span_smallnoticeital("Something special may happen if you scoop oil or blood off the floor with it.")
+*/
 
 /obj/item/comically_large_spoon/update_icon_state()
 	inhand_icon_state = "[base_icon_state][HAS_TRAIT(src, TRAIT_WIELDED) ? "_wielded" : ""]"
@@ -72,6 +76,7 @@
 	block_chance = src::block_chance
 	demolition_mod = src::demolition_mod
 
+/* REMOVED UNTIL I CAN ACTUALLY BALANCE THIS
 // touhou hijack lol
 // also i know this is a spoon and not a spork, i don't care
 /obj/item/comically_large_spoon/proc/try_scoop_liquids(obj/item/comically_large_spoon/spoon, turf/target, mob/user, obj/effect/abstract/liquid_turf/liquids)
@@ -127,3 +132,4 @@
 	remove_atom_colour(TEMPORARY_COLOUR_PRIORITY)
 	update_inhand_icon()
 	empowered = FALSE
+*/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

exactly what it says on the tin.

i left the code in, just commented out, so it can easily be restored if someone actually figures out how to balance the thing, bc i do enjoy the funny touhou reference

## Why It's Good For The Game

this shit's a bit OP - it got merged before I could properly balance it...

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: You can no longer empower the comically large spoon with oil or blood.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
