### PR TITLE
Wizard mass mind/species/name swap now only affects the station

### DIFF
--- a/code/modules/events/wizard/race.dm
+++ b/code/modules/events/wizard/race.dm
@@ -23,6 +23,11 @@
 
 	for(var/i in GLOB.human_list) //yes, even the dead
 		var/mob/living/carbon/human/H = i
+		// monkestation start: ignore off-station mobs
+		var/turf/human_turf = get_turf(H)
+		if(!human_turf || !is_station_level(human_turf.z))
+			continue
+		// monkestation end
 		H.set_species(new_species)
 		H.dna.unique_enzymes = H.dna.generate_unique_enzymes()
 		to_chat(H, span_notice("You feel somehow... different?"))

--- a/code/modules/events/wizard/shuffle.dm
+++ b/code/modules/events/wizard/shuffle.dm
@@ -53,6 +53,11 @@
 	var/list/mobs = list()
 
 	for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)
+		// monkestation start: ignore off-station mobs
+		var/turf/human_turf = get_turf(H)
+		if(!human_turf || !is_station_level(human_turf.z))
+			continue
+		// monkestation end
 		mobnames += H.real_name
 		mobs += H
 
@@ -89,6 +94,11 @@
 	for(var/mob/living/carbon/human/alive_human in GLOB.alive_mob_list)
 		if(alive_human.stat != CONSCIOUS || isnull(alive_human.mind) || IS_WIZARD(alive_human) || HAS_TRAIT(alive_human, TRAIT_NO_MINDSWAP))
 			continue //the wizard(s) are spared on this one
+		// monkestation start: ignore off-station mobs
+		var/turf/human_turf = get_turf(alive_human)
+		if(!human_turf || !is_station_level(human_turf.z))
+			continue
+		// monkestation end
 		mobs_to_swap += alive_human
 
 	if(!length(mobs_to_swap))


### PR DESCRIPTION

## About The Pull Request

This makes it so the wizard Change Minds, Change Names, and Race Swap events only affect mobs on the station's z-level(s).

Off-station mobs will be ignored - i.e ghost roles and such.

## Why It's Good For The Game

A big appeal of off-station ghost roles is not really having to worry about what's going on with the station - you're doing your own thing. The wizard events kind of fuck that up - and it doesn't make any sense as the wizard is really only targeting the station.

## Changelog
:cl:
qol: Wizard mass mind/species/name swap now only affects the station - no more random ghost roles being swapped onto the station.
/:cl:
