### PR TITLE
Makes reagent explosions obey the max cap.

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -173,7 +173,7 @@ SUBSYSTEM_DEF(explosions)
  * * flame_range: Flame range. Equal to the equivalent of the light impact range multiplied by this value.
  * * flash_range: The range at which the explosion flashes people. Equal to the equivalent of the light impact range multiplied by this value.
  * * adminlog: Whether to log the explosion/report it to the administration.
- * * ignorecap: Whether to ignore the relevant bombcap. Defaults to FALSE.
+ * * ignorecap: Whether to ignore the relevant bombcap. Defaults to TRUE. Re: ignorecap = TRUE. If you call dyn_explosion, ensure that you set it false or want it to ignore cap.
  * * flame_range: The range at which the explosion should produce hotspots.
  * * silent: Whether to generate/execute sound effects.
  * * smoke: Whether to generate a smoke cloud provided the explosion is powerful enough to warrant it.

--- a/code/game/objects/effects/effect_system/effects_other.dm
+++ b/code/game/objects/effects/effect_system/effects_other.dm
@@ -111,4 +111,4 @@
 	if(explosion_message)
 		location.visible_message(span_danger("The solution violently explodes!"), span_hear("You hear an explosion!"))
 
-	dyn_explosion(location, amount, flash_range = flashing_factor, explosion_cause = explosion_source)
+	dyn_explosion(location, amount, flash_range = flashing_factor, ignorecap = FALSE, explosion_cause = explosion_source)  //monke edit: ignorecap set to FALSE, can't belive it took till 2025

--- a/code/game/objects/effects/effect_system/effects_other.dm
+++ b/code/game/objects/effects/effect_system/effects_other.dm
@@ -91,6 +91,7 @@
 	var/flashing = FALSE // does explosion creates flash effect?
 	var/flashing_factor = 0 // factor of how powerful the flash effect relatively to the explosion
 	var/explosion_message = 1 //whether we show a message to mobs.
+	var/ignore_explosion_cap = FALSE
 
 /datum/effect_system/reagents_explosion/set_up(amt, loca, flash = FALSE, flash_fact = 0, message = TRUE)
 	amount = amt
@@ -111,4 +112,4 @@
 	if(explosion_message)
 		location.visible_message(span_danger("The solution violently explodes!"), span_hear("You hear an explosion!"))
 
-	dyn_explosion(location, amount, flash_range = flashing_factor, ignorecap = FALSE, explosion_cause = explosion_source)  //monke edit: ignorecap set to FALSE, can't belive it took till 2025
+	dyn_explosion(location, amount, flash_range = flashing_factor, ignorecap = ignore_explosion_cap, explosion_cause = explosion_source)  //monke edit: ignorecap set to FALSE, can't belive it took till 2025


### PR DESCRIPTION

## About The Pull Request
Does what it says on the tin. Despite being commented as defaulting to false, dyn_explosion ignorecap currently defaults to true.

## Why It's Good For The Game
Explosions are capped for a reason. This change will fix exploits like using dead monkies filled with meth to bypass said cap, instead limiting them to the same size as TTVs are limited to. Includes a variable in case a reagent that SPECIFICALLY ignores the cap is added at a later date.
Also, the comments were wrong.
## Changelog
:cl:
fix: Reagent explosions now obey the explosion cap, like all other editable explosions do by default.
/:cl:
