### PR TITLE
Update tramstation robotics

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -11999,8 +11999,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
+"cGP" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/robot_suit,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "cHn" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/floor/grass,
@@ -24231,7 +24238,6 @@
 /turf/open/floor/wood/large,
 /area/station/service/library)
 "gFu" = (
-/obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -35238,15 +35244,13 @@
 "kcF" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/stripes/corner,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/clothing/mask/surgical,
-/obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -10;
-	pixel_y = -1
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/bodypart/arm/left/robot{
+	pixel_x = -3
+	},
+/obj/item/bodypart/arm/right/robot{
+	pixel_x = 3
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "kcQ" = (
@@ -35343,10 +35347,18 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/power/apc/auto_name/directional/west{
+	pixel_y = 5
+	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/button/door/directional/west{
+	pixel_y = -9;
+	id = "mechbay";
+	name = "Mech Bay Shutters Control";
+	req_access = list("robotics")
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "ken" = (
@@ -37562,6 +37574,10 @@
 	pixel_x = 7
 	},
 /obj/effect/turf_decal/tile/dark_green/fourcorners,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "genetics";
+	name = "Robotics Lab Shutters"
+	},
 /turf/open/floor/iron/white/side,
 /area/station/science/genetics)
 "kNn" = (
@@ -44383,6 +44399,10 @@
 	req_access = list("robotics")
 	},
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "robotics2";
+	name = "Robotics Lab Shutters"
+	},
 /turf/open/floor/iron/white/side{
 	dir = 1
 	},
@@ -45454,6 +45474,11 @@
 /area/station/command/heads_quarters/blueshield)
 "nns" = (
 /obj/structure/table/reinforced,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/bodybags,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "nny" = (
@@ -45883,17 +45908,13 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "nto" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "genetics";
+	name = "Robotics Lab Shutters"
 	},
-/obj/item/storage/box/bodybags,
-/obj/item/healthanalyzer,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
+/turf/open/floor/plating,
+/area/station/science/genetics)
 "ntp" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -50969,7 +50990,14 @@
 /obj/structure/table/reinforced,
 /obj/structure/window/spawner/directional/north,
 /obj/structure/window/spawner/directional/west,
-/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_x = -10;
+	pixel_y = -1
+	},
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/mask/surgical,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "pfh" = (
@@ -61720,11 +61748,12 @@
 	name = "Research and Development Shutter"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/left/directional/east{
-	name = "Research Lab Desk";
-	req_access = list("science")
-	},
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/item/paper_bin,
+/obj/machinery/door/window/left/directional/west{
+	name = "Research Lab Desk";
+	req_access = list("robotics")
+	},
 /turf/open/floor/iron/white/side{
 	dir = 4
 	},
@@ -61963,6 +61992,12 @@
 	req_access = list("robotics")
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/button/door/directional/north{
+	id = "mechbay";
+	name = "Mech Bay Shutters Control";
+	req_access = list("robotics");
+	pixel_x = -8
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "syH" = (
@@ -66904,7 +66939,9 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "uaJ" = (
-/obj/machinery/computer/mechpad,
+/obj/machinery/computer/mechpad{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "uaM" = (
@@ -67460,6 +67497,11 @@
 	c_tag = "Science - Robotics Surgery";
 	network = list("ss13","rd")
 	},
+/obj/item/healthanalyzer{
+	pixel_y = 5;
+	pixel_x = 5
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "ukT" = (
@@ -71273,7 +71315,14 @@
 	},
 /obj/machinery/requests_console/directional/west{
 	department = "Genetics";
-	name = "Genetics Requests Console"
+	name = "Genetics Requests Console";
+	pixel_y = 6
+	},
+/obj/machinery/button/door/directional/west{
+	pixel_y = -8;
+	id = "genetics";
+	name = "Genetics Privacy Shutters";
+	req_access = list("genetics")
 	},
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
@@ -187792,15 +187841,15 @@ bXG
 lVi
 kCF
 soq
-uzG
-wSi
+bvM
+icx
 moz
 gyP
 cdB
 tnU
 mAf
 dzu
-nto
+tFV
 uKv
 aLH
 hsR
@@ -188049,15 +188098,15 @@ aHn
 lVi
 kCF
 soq
-bvM
-icx
+uzG
+wSi
 wEQ
 gyP
 dZu
 xgO
 muZ
 dzu
-tFV
+doK
 uJH
 uJH
 peU
@@ -188569,7 +188618,7 @@ idO
 gyP
 fAA
 okn
-muZ
+cGP
 uSP
 jXr
 uKv
@@ -193963,7 +194012,7 @@ tXz
 iJW
 bHb
 sed
-dpB
+nto
 vpp
 gel
 knq
@@ -194477,7 +194526,7 @@ gAQ
 eoX
 fyc
 vwD
-dpB
+nto
 iqM
 nzk
 rle

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -14044,11 +14044,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/library/lounge)
-"dqE" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable,
-/turf/open/floor/iron/white,
-/area/station/science/lobby)
 "dqM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -19977,6 +19972,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"fkB" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/lobby)
 "fkD" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/bot,
@@ -28556,11 +28556,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/button/door/directional/north{
-	id = "mechbay";
-	name = "Mech Bay Shutters Control";
-	req_access = list("robotics")
-	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "ibt" = (
@@ -28630,9 +28625,13 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "icx" = (
-/obj/structure/chair/stool/directional/north,
-/turf/open/floor/iron,
-/area/station/science/robotics/mechbay)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "genetics";
+	name = "Robotics Lab Shutters"
+	},
+/turf/open/floor/plating,
+/area/station/science/genetics)
 "icH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -35351,11 +35350,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/button/door/directional/west{
-	id = "mechbay";
-	name = "Mech Bay Shutters Control";
-	req_access = list("robotics")
-	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "ken" = (
@@ -42521,6 +42515,9 @@
 /turf/open/floor/iron,
 /area/station/security/prison/workout)
 "moz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "moH" = (
@@ -45905,13 +45902,12 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "nto" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "genetics";
-	name = "Robotics Lab Shutters"
+/obj/structure/chair/stool/directional/north,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/science/genetics)
+/turf/open/floor/iron,
+/area/station/science/robotics/mechbay)
 "ntp" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -53690,6 +53686,12 @@
 /obj/item/clothing/under/rank/civilian/janitor/maid,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal/incinerator)
+"pRo" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/robot_suit,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "pRu" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "cargoupperbelt"
@@ -66939,6 +66941,7 @@
 /obj/machinery/computer/mechpad{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
 "uaM" = (
@@ -67559,6 +67562,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/station/engineering/atmospherics_engine)
+"ulp" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	id = "mechbay";
+	name = "Mech Bay"
+	},
+/obj/machinery/button/door/directional/north{
+	id = "mechbay";
+	name = "Mech Bay Shutters Control";
+	req_access = list("robotics")
+	},
+/turf/open/floor/plating,
+/area/station/science/robotics/mechbay)
 "ulz" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -68375,12 +68392,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"uxg" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/robot_suit,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
 "uxh" = (
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/light/directional/west,
@@ -187843,7 +187854,7 @@ lVi
 kCF
 soq
 bvM
-icx
+nto
 moz
 gyP
 cdB
@@ -188619,7 +188630,7 @@ idO
 gyP
 fAA
 okn
-uxg
+pRo
 uSP
 jXr
 uKv
@@ -189641,7 +189652,7 @@ rmH
 lVi
 uZX
 soq
-iws
+ulp
 urY
 iws
 dKM
@@ -191442,7 +191453,7 @@ aHQ
 tSr
 xrp
 slI
-dqE
+fkB
 rHj
 rcA
 doC
@@ -194013,7 +194024,7 @@ tXz
 iJW
 bHb
 sed
-nto
+icx
 vpp
 gel
 knq
@@ -194527,7 +194538,7 @@ gAQ
 eoX
 fyc
 vwD
-nto
+icx
 iqM
 nzk
 rle

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -10023,6 +10023,8 @@
 	c_tag = "Science - Front Lobby";
 	network = list("ss13","rd")
 	},
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "caK" = (
@@ -12002,12 +12004,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
-"cGP" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/robot_suit,
-/turf/open/floor/iron/dark,
-/area/station/science/robotics/lab)
 "cHn" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/floor/grass,
@@ -14048,6 +14044,11 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/service/library/lounge)
+"dqE" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/science/lobby)
 "dqM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -35347,14 +35348,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/west{
-	pixel_y = 5
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/button/door/directional/west{
-	pixel_y = -9;
 	id = "mechbay";
 	name = "Mech Bay Shutters Control";
 	req_access = list("robotics")
@@ -68378,6 +68375,12 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"uxg" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/item/robot_suit,
+/turf/open/floor/iron/dark,
+/area/station/science/robotics/lab)
 "uxh" = (
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/light/directional/west,
@@ -70066,7 +70069,6 @@
 "uXu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/navbeacon{
 	location = "easttram5";
 	codes_txt = "patrol;next_patrol=midtram2"
@@ -71985,7 +71987,6 @@
 "vyy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "vyD" = (
@@ -77679,7 +77680,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
@@ -80334,6 +80334,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "yjZ" = (
@@ -188618,7 +188619,7 @@ idO
 gyP
 fAA
 okn
-cGP
+uxg
 uSP
 jXr
 uKv
@@ -191441,7 +191442,7 @@ aHQ
 tSr
 xrp
 slI
-nUy
+dqE
 rHj
 rcA
 doC


### PR DESCRIPTION
## About The Pull Request
Updated tram station science robotics to improve flow and layout. Mainly for the robotics area.

- With in mind the garage door is the easiest and most straightforward way into robotics I added a shutter one more shutter control button near the desk so they open it for people without access. And readjusted the position of the outside one so its accessible from both sides

- Swapped the robotics sci windoor to require robotics access. 

- Moved some items to create additional space in robotics

- Added a starting endoskeleton and pair of robotic arms to bring it more in line with other robotics roundstart.

- Moved around recharging stations to help prevent a broken linkage between consoles

- Fixed the privacy shutters so it doesn't awkwardly leave the desk window open

- Also gave genetics privacy shutters

## Why It's Good For The Game
Alot of this is QOL improvements, moving things closer to where they should be, fixes for machines that dont work, or the like.
## Changelog
:cl:
add: added complete privacy shutters to tram robotics and genetics
qol: Adjusted the layout of tram station robotics 
fix: Tram station mech rechargers should now no longer incorrectly link with the opposite console.
/:cl:
