### PR TITLE
Some minor bloodsucker fixes

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_moodlets.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_moodlets.dm
@@ -1,40 +1,40 @@
 /datum/mood_event/drankblood
-	description = "<span class='nicegreen'>I have fed greedly from that which nourishes me.</span>\n"
+	description = span_nicegreen("I have fed greedly from that which nourishes me.")
 	mood_change = 10
 	timeout = 8 MINUTES
 
 /datum/mood_event/drankblood_bad
-	description = "<span class='boldwarning'>I drank the blood of a lesser creature. Disgusting.</span>\n"
+	description = span_boldwarning("I drank the blood of a lesser creature. Disgusting.")
 	mood_change = -4
 	timeout = 3 MINUTES
 
 /datum/mood_event/drankblood_dead
-	description = "<span class='boldwarning'>I drank dead blood. I am better than this.</span>\n"
+	description = span_boldwarning("I drank dead blood. I am better than this.")
 	mood_change = -7
 	timeout = 8 MINUTES
 
 /datum/mood_event/drankblood_synth
-	description = "<span class='boldwarning'>I drank synthetic blood. What is wrong with me?</span>\n"
+	description = span_boldwarning("I drank synthetic blood. What is wrong with me?")
 	mood_change = -7
 	timeout = 8 MINUTES
 
 /datum/mood_event/drankkilled
-	description = "<span class='boldwarning'>I fed off of a dead person. I feel... less human.</span>\n"
+	description = span_boldwarning("I fed off of a dead person. I feel... less human.")
 	mood_change = -15
 	timeout = 10 MINUTES
 
 /datum/mood_event/madevamp
-	description = "<span class='boldwarning'>A mortal has reached an apotheosis- undeath- by my own hand.</span>\n"
+	description = span_boldwarning("A mortal has reached an apotheosis- undeath- by my own hand.")
 	mood_change = 15
 	timeout = 20 MINUTES
 
 /datum/mood_event/coffinsleep
-	description = "<span class='nicegreen'>I slept in a coffin during the day. I feel whole again.</span>\n"
+	description = span_nicegreen("I slept in a coffin during the day. I feel whole again.")
 	mood_change = 10
 	timeout = 6 MINUTES
 
 ///Candelabrum's mood event to non Bloodsucker/Vassals
 /datum/mood_event/vampcandle
-	description = "<span class='boldwarning'>Something is making your mind feel... loose.</span>\n"
+	description = span_boldwarning("Something is making your mind feel... loose.")
 	mood_change = -15
 	timeout = 5 MINUTES

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_objectives.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_objectives.dm
@@ -278,7 +278,7 @@
 // EXPLANATION
 /datum/objective/bloodsucker/embrace/update_explanation_text()
 	. = ..()
-	explanation_text = "Use the persuassion rack to Rank your Favorite Vassal up enough to become a Bloodsucker."
+	explanation_text = "Use the persuasion rack to Rank your Favorite Vassal up enough to become a Bloodsucker."
 
 // WIN CONDITIONS?
 /datum/objective/bloodsucker/embrace/check_completion()

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_objectives.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_objectives.dm
@@ -278,7 +278,7 @@
 // EXPLANATION
 /datum/objective/bloodsucker/embrace/update_explanation_text()
 	. = ..()
-	explanation_text = "Use the Candelabrum to Rank your Favorite Vassal up enough to become a Bloodsucker."
+	explanation_text = "Use the persuassion rack to Rank your Favorite Vassal up enough to become a Bloodsucker."
 
 // WIN CONDITIONS?
 /datum/objective/bloodsucker/embrace/check_completion()

--- a/monkestation/code/modules/bloodsuckers/clans/_clan_base.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/_clan_base.dm
@@ -246,7 +246,7 @@
 		return
 
 	to_chat(bloodsuckerdatum.owner.current, span_notice("You can change who this Vassal is, who are they to you?"))
-	var/vassal_response = show_radial_menu(bloodsuckerdatum.owner.current, vassaldatum.owner.current, radial_display)
+	var/vassal_response = show_radial_menu(bloodsuckerdatum.owner.current, vassaldatum.owner.current, radial_display, autopick_single_option = FALSE)
 	if(!vassal_response)
 		return
 	vassal_response = options[vassal_response]

--- a/monkestation/code/modules/bloodsuckers/clans/venture.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/venture.dm
@@ -108,7 +108,7 @@
 	return TRUE
 
 /datum/bloodsucker_clan/ventrue/on_favorite_vassal(datum/source, datum/antagonist/vassal/vassaldatum, mob/living/bloodsucker)
-	to_chat(bloodsucker, span_announce("* Bloodsucker Tip: You can now upgrade your Favorite Vassal by buckling them onto a Candelabrum!"))
+	to_chat(bloodsucker, span_announce("* Bloodsucker Tip: You can now upgrade your Favorite Vassal by buckling them onto a persuassion rack!"))
 	vassaldatum.BuyPower(new /datum/action/cooldown/bloodsucker/distress)
 
 #undef BLOODSUCKER_BLOOD_RANKUP_COST

--- a/monkestation/code/modules/bloodsuckers/clans/venture.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/venture.dm
@@ -108,7 +108,7 @@
 	return TRUE
 
 /datum/bloodsucker_clan/ventrue/on_favorite_vassal(datum/source, datum/antagonist/vassal/vassaldatum, mob/living/bloodsucker)
-	to_chat(bloodsucker, span_announce("* Bloodsucker Tip: You can now upgrade your Favorite Vassal by buckling them onto a persuassion rack!"))
+	to_chat(bloodsucker, span_announce("* Bloodsucker Tip: You can now upgrade your Favorite Vassal by buckling them onto a persuasion rack!"))
 	vassaldatum.BuyPower(new /datum/action/cooldown/bloodsucker/distress)
 
 #undef BLOODSUCKER_BLOOD_RANKUP_COST

--- a/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
+++ b/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
@@ -292,6 +292,9 @@
 	if(!ishuman(target))
 		balloon_alert(user, "you can't torture an animal or basic mob!")
 		return FALSE
+	if(disloyalty_offered)
+		balloon_alert(user, "wait a moment!")
+		return FALSE
 	var/disloyalty_requires = RequireDisloyalty(user, target)
 
 	if(disloyalty_requires == VASSALIZATION_BANNED)


### PR DESCRIPTION
Fixes https://github.com/Monkestation/Monkestation2.0/issues/3355

## Changelog
:cl:
spellcheck: The flavor text for the bloodsucker Venture clan now properly says to use a persuasion rack instead of a candelabrum to level their favorite vassal up.
spellcheck: Fixed bloodsucker-related moodlets having blank lines after them.
fix: Clicking on the persuasion rack while a vassal is buckled after a revenge or favorite vassal has been selected won't automatically make the buckled vassal into the other without prompting.
fix: Fixed being able to vassalize antags/mindshielded people regardless of whether they accepted the prompt or not.
/:cl:
