### PR TITLE
Reduces the amount of banana peels from trash piles

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -73,9 +73,9 @@ GLOBAL_LIST_INIT(trash_loot, list(//junk: useless, very easy to get, or ghetto c
 
 // monkestation addition: just trash_loot with a chance of banana peels
 GLOBAL_LIST_INIT(trash_pile_loot, list(
-	GLOB.trash_loot = 150,
-	/obj/item/grown/bananapeel = 20,
-	/obj/item/grown/bananapeel/bluespace = 1, // I am SO going to regret this later ~Lucy
+	GLOB.trash_loot = 500,
+	/obj/item/grown/bananapeel = 10,
+	/obj/item/grown/bananapeel/bluespace = 0.1, // I am SO going to regret this later ~Lucy
 ))
 // monkestation end
 


### PR DESCRIPTION

## About The Pull Request

People have been saying that there's _too many_ banana peels coming from trash piles, so I've reduced the weight of banana peels - while also increasing the weight of non-banana peels.

## Why It's Good For The Game

the banana peels are seemingly annoying everyone from being too common

## Changelog
:cl:
qol: Reduces the amount of banana peels from trash piles.
/:cl:
