### PR TITLE
You can no longer "cheese" killing bloodsuckers via beheading

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
@@ -126,6 +126,8 @@
 		return FALSE
 	for(var/missing_limb in missing) //Find ONE Limb and regenerate it.
 		user.regenerate_limb(missing_limb, FALSE)
+		if(missing_limb == BODY_ZONE_HEAD)
+			ensure_brain_nonvital()
 		AddBloodVolume(-limb_regen_cost)
 		var/obj/item/bodypart/missing_bodypart = user.get_bodypart(missing_limb) // 2) Limb returns Damaged
 		missing_bodypart.brute_dam = 60
@@ -151,6 +153,7 @@
 
 	bloodsuckeruser.cure_husk()
 	bloodsuckeruser.regenerate_organs(regenerate_existing = FALSE)
+	ensure_brain_nonvital()
 
 	for(var/obj/item/organ/organ as anything in bloodsuckeruser.organs)
 		organ.set_organ_damage(0)


### PR DESCRIPTION
## About The Pull Request

Staking is supposed to be the way to "properly" kill off a bloodsucker - beheading currently kills them in a buggy way, which does not actually trigger Final Death, which avoids triggering the revenge vassal (and also doesn't result in the rest of the vassals being deconverted like they should)

I'm considering this as a fix instead of a balance change due to how buggy beheading them is.

Since bloodsucker code is _awful_, really the only "solution" that isn't just rewriting half the code from scratch is just making their brains "decoys", just like changelings, so they can still regenerate and revive from being beheaded. Janky solution? Yes. Does it work? Also yes.

Stake them like you're supposed to, and suck it up and deal with the revenge vassal.

[Refer to this clip for clarification.](https://www.youtube.com/watch?v=aYrL0Kq2gFI)

## Why It's Good For The Game

avoids cheesing, and maybe finally allows revenge vassals to actually be useful (bc I rarely see them trigger due to sec mostly just blowing the bloodsucker's head off with shotguns 99% of the time)

## Changelog
:cl:
fix: You can no longer "cheese" killing a bloodsucker by beheading them (which would avoid triggering the revenge vassal and such). Stake them like you're supposed to.
/:cl:
