### PR TITLE
Move fake virus event later into the round

### DIFF
--- a/monkestation/code/modules/events/fake_virus.dm
+++ b/monkestation/code/modules/events/fake_virus.dm
@@ -1,0 +1,2 @@
+/datum/round_event_control/fake_virus
+	earliest_start = 55 MINUTES

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7274,6 +7274,7 @@
 #include "monkestation\code\modules\events\_event_admin_setup.dm"
 #include "monkestation\code\modules\events\artifact_spawn.dm"
 #include "monkestation\code\modules\events\brand_intelligence.dm"
+#include "monkestation\code\modules\events\fake_virus.dm"
 #include "monkestation\code\modules\events\gravity_generator_blackout.dm"
 #include "monkestation\code\modules\events\portal_storm.dm"
 #include "monkestation\code\modules\events\radiation_storm.dm"


### PR DESCRIPTION

## About The Pull Request
Fake virus wont trigger until 55 minutes into the round
## Why It's Good For The Game
A disease outbreak event (the real one) has been crept in time from no time in March of 2023, to a time limit to 55 minutes. Alongside many other virus's events. Ex Sentient virus's nonexistence under the new virus system. Meanwhile fake virus, an event I'd argue relies on the potentiality of real viruses being about has not been crept in the same way. As it mostly just causes an unneeded medical trip that wastes the infected time as nothing interesting really occurs.

This allows the weight to be spent on more interesting and lasting things throughout the round rather than bombarding three people's chats how their throat feels sore.

They walk to medical, get told they aren't sick, and then return to whatever their doing assuming they even notice/react to it.
## Changelog
:cl:
balance: Makes fake disease events trigger as early as a normal disease outbreak would.
/:cl:
