### PR TITLE
Ensures the Tenacity trauma now properly negates all pain as intended

### DIFF
--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -255,6 +255,7 @@
 /datum/brain_trauma/special/psychotic_brawling/bath_salts
 	name = "Chemical Violent Psychosis"
 
+/* monkestation removal: reimplemented in [monkestation/code/datums/brain_damage/special.dm]
 /datum/brain_trauma/special/tenacity
 	name = "Tenacity"
 	desc = "Patient is psychologically unaffected by pain and injuries, and can remain standing far longer than a normal person."
@@ -269,6 +270,7 @@
 /datum/brain_trauma/special/tenacity/on_lose()
 	owner.remove_traits(list(TRAIT_NOSOFTCRIT, TRAIT_NOHARDCRIT, TRAIT_ANALGESIA), TRAUMA_TRAIT)
 	..()
+monkestation end */
 
 /datum/brain_trauma/special/death_whispers
 	name = "Functional Cerebral Necrosis"

--- a/monkestation/code/datums/brain_damage/special.dm
+++ b/monkestation/code/datums/brain_damage/special.dm
@@ -1,0 +1,24 @@
+/datum/brain_trauma/special/tenacity
+	name = "Tenacity"
+	desc = "Patient is psychologically unaffected by pain and injuries, and can remain standing far longer than a normal person."
+	scan_desc = "traumatic neuropathy"
+	gain_text = span_warning("You suddenly stop feeling pain.")
+	lose_text = span_warning("You realize you can feel pain again.")
+	/// Traits given to the owner of the trauma.
+	var/static/list/traits_to_apply = list(
+		TRAIT_NOSOFTCRIT,
+		TRAIT_NOHARDCRIT,
+		TRAIT_ABATES_SHOCK,
+		TRAIT_ANALGESIA,
+		TRAIT_NO_PAIN_EFFECTS,
+		TRAIT_NO_SHOCK_BUILDUP,
+	)
+
+/datum/brain_trauma/special/tenacity/on_gain()
+	. = ..()
+	owner.pain_controller?.remove_all_pain()
+	owner.add_traits(traits_to_apply, TRAUMA_TRAIT)
+
+/datum/brain_trauma/special/tenacity/on_lose()
+	. = ..()
+	owner.remove_traits(traits_to_apply, TRAUMA_TRAIT)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5954,6 +5954,7 @@
 #include "monkestation\code\datums\brain_damage\creepy_trauma.dm"
 #include "monkestation\code\datums\brain_damage\magic.dm"
 #include "monkestation\code\datums\brain_damage\phobia.dm"
+#include "monkestation\code\datums\brain_damage\special.dm"
 #include "monkestation\code\datums\changelog\changelog.dm"
 #include "monkestation\code\datums\components\basic_inhands.dm"
 #include "monkestation\code\datums\components\carbon_sprint.dm"


### PR DESCRIPTION

## About The Pull Request

This makes it so the Tenacity brain trauma removes all existing pain whenever it's gained, and fully prevents all pain by applying all four pain-related traits (`TRAIT_ABATES_SHOCK`, `TRAIT_ANALGESIA`, `TRAIT_NO_PAIN_EFFECTS`, and `TRAIT_NO_SHOCK_BUILDUP`)

## Why It's Good For The Game

If it specifically says "You suddenly stop feeling pain.", you should stop feeling pain.

## Changelog
:cl:
fix: The tenacity brain trauma now properly removes and prevents all pain, like it says it does.
/:cl:
