### PR TITLE
Fix food buffs potentially resulting in negative stamina

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -552,18 +552,19 @@ Behavior that's still missing from this component that original food items had t
 
 	on_consume?.Invoke(eater, feeder)
 
+	// monkestation start: food buffs
 	if(food_buffs && ishuman(eater))
 		var/mob/living/carbon/consumer = eater
+		var/food_quality
+		if(isitem(parent))
+			var/obj/item/parent_item = parent
+			food_quality = parent_item.food_quality
 		if(consumer.applied_food_buffs < consumer.max_food_buffs)
-			eater.apply_status_effect(food_buffs)
-			consumer.applied_food_buffs ++
+			eater.apply_status_effect(food_buffs, food_quality)
+			consumer.applied_food_buffs++
 		else if(food_buffs in consumer.status_effects)
-			eater.apply_status_effect(food_buffs)
-		var/datum/status_effect/food/effect = locate(food_buffs) in consumer.status_effects
-		if(effect)
-			var/obj/item/food = parent
-			if(food.food_quality != 1) //if we are not the default value
-				effect.apply_quality(food.food_quality)
+			eater.apply_status_effect(food_buffs, food_quality)
+	// monkestation end
 
 	to_chat(feeder, span_warning("There is nothing left of [parent], oh no!"))
 	if(isturf(parent))

--- a/monkestation/code/datums/stamina_container.dm
+++ b/monkestation/code/datums/stamina_container.dm
@@ -1,7 +1,8 @@
 /datum/stamina_container
 	///Daddy?
 	var/mob/living/parent
-	///The maximum amount of stamina this container has
+	/// The maximum amount of stamina this container has.
+	/// Don't touch this directly, it is set using set_maximum().
 	var/maximum = 0
 	///How much stamina we have right now
 	var/current = 0
@@ -24,6 +25,9 @@
 	COOLDOWN_DECLARE(paused_stamina)
 
 /datum/stamina_container/New(parent, maximum = STAMINA_MAX, regen_rate = STAMINA_REGEN)
+	if(maximum <= 0)
+		stack_trace("Attempted to initialize stamian container with an invalid maximum limit of [maximum], defaulting to [STAMINA_MAX]")
+		maximum = STAMINA_MAX
 	src.parent = parent
 	src.maximum = maximum
 	src.regen_rate = regen_rate
@@ -36,7 +40,7 @@
 	STOP_PROCESSING(SSstamina, src)
 	return ..()
 
-/datum/stamina_container/proc/update(seconds_per_tick)
+/datum/stamina_container/proc/update(seconds_per_tick = 1)
 	if(process_stamina == TRUE)
 		if(!is_regenerating)
 			if(!COOLDOWN_FINISHED(src, paused_stamina))
@@ -83,7 +87,7 @@
 	if(base_modify)
 		modify = amt
 	current = round(clamp(current + modify, 0, maximum), DAMAGE_PRECISION)
-	update(1)
+	update()
 	if((amt < 0) && is_regenerating)
 		pause(STAMINA_REGEN_TIME)
 	return amt
@@ -101,7 +105,20 @@
 		amount = current - lowest_stamina_value
 
 	current = round(clamp(current + amount, 0, maximum), DAMAGE_PRECISION)
-	update(1)
+	update()
 	if((amount < 0) && is_regenerating)
 		pause(STAMINA_REGEN_TIME)
 	return amount
+
+/// Sets the maximum amount of stamina.
+/// Always use this instead of directly setting the stamina var, as this has sanity checks, and immediately updates afterwards.
+/datum/stamina_container/proc/set_maximum(value = STAMINA_MAX)
+	if(!IS_SAFE_NUM(value) || value <= 0)
+		maximum = STAMINA_MAX
+		update()
+		CRASH("Attempted to set maximum stamina to invalid value ([value]), resetting to the default maximum of [STAMINA_MAX]")
+	if(value == maximum)
+		return
+	maximum = value
+	update()
+	return TRUE

--- a/monkestation/code/datums/stamina_container.dm
+++ b/monkestation/code/datums/stamina_container.dm
@@ -26,7 +26,7 @@
 
 /datum/stamina_container/New(parent, maximum = STAMINA_MAX, regen_rate = STAMINA_REGEN)
 	if(maximum <= 0)
-		stack_trace("Attempted to initialize stamian container with an invalid maximum limit of [maximum], defaulting to [STAMINA_MAX]")
+		stack_trace("Attempted to initialize stamina container with an invalid maximum limit of [maximum], defaulting to [STAMINA_MAX]")
 		maximum = STAMINA_MAX
 	src.parent = parent
 	src.maximum = maximum

--- a/monkestation/code/datums/status_effects/food_buffs.dm
+++ b/monkestation/code/datums/status_effects/food_buffs.dm
@@ -111,14 +111,14 @@
 /datum/status_effect/food/fire_burps/on_apply()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		ADD_TRAIT(user, TRAIT_FOOD_FIRE_BURPS, type)
+		ADD_TRAIT(user, TRAIT_FOOD_FIRE_BURPS, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
 /datum/status_effect/food/fire_burps/on_remove()
 	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		REMOVE_TRAIT(user, TRAIT_FOOD_FIRE_BURPS, type)
+		REMOVE_TRAIT(user, TRAIT_FOOD_FIRE_BURPS, TRAIT_STATUS_EFFECT(id))
 
 
 /datum/status_effect/food/fire_burps/proc/Burp()
@@ -261,12 +261,12 @@
 /datum/status_effect/food/belly_slide/on_apply()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		ADD_TRAIT(user, TRAIT_FOOD_SLIDE, type)
+		ADD_TRAIT(user, TRAIT_FOOD_SLIDE, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
 /datum/status_effect/food/belly_slide/on_remove()
 	. = ..()
-	REMOVE_TRAIT(owner, TRAIT_FOOD_SLIDE, type)
+	REMOVE_TRAIT(owner, TRAIT_FOOD_SLIDE, TRAIT_STATUS_EFFECT(id))
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/belly_slide)
 
 
@@ -331,14 +331,14 @@
 /datum/status_effect/food/botanist/on_apply()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		ADD_TRAIT(user, TRAIT_FOOD_JOB_BOTANIST, type)
+		ADD_TRAIT(user, TRAIT_FOOD_JOB_BOTANIST, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
 /datum/status_effect/food/botanist/on_remove()
 	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		REMOVE_TRAIT(user, TRAIT_FOOD_JOB_BOTANIST, type)
+		REMOVE_TRAIT(user, TRAIT_FOOD_JOB_BOTANIST, TRAIT_STATUS_EFFECT(id))
 
 
 /datum/status_effect/food/miner
@@ -353,11 +353,11 @@
 /datum/status_effect/food/miner/on_apply()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		ADD_TRAIT(user, TRAIT_FOOD_JOB_MINER, type)
+		ADD_TRAIT(user, TRAIT_FOOD_JOB_MINER, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
 /datum/status_effect/food/miner/on_remove()
 	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		REMOVE_TRAIT(user, TRAIT_FOOD_JOB_MINER, type)
+		REMOVE_TRAIT(user, TRAIT_FOOD_JOB_MINER, TRAIT_STATUS_EFFECT(id))

--- a/monkestation/code/datums/status_effects/food_buffs.dm
+++ b/monkestation/code/datums/status_effects/food_buffs.dm
@@ -4,7 +4,13 @@
 	status_type = STATUS_EFFECT_REPLACE
 	show_duration = TRUE
 
+/datum/status_effect/food/on_creation(mob/living/new_owner, quality)
+	if(!isnull(quality) && quality != 1)
+		apply_quality(quality)
+	return ..()
+
 /datum/status_effect/food/proc/apply_quality(quality)
+	PROTECTED_PROC(TRUE)
 	return
 
 /datum/status_effect/food/on_apply()
@@ -15,7 +21,7 @@
 /datum/status_effect/food/on_remove()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		user.applied_food_buffs --
+		user.applied_food_buffs--
 
 /datum/status_effect/food/stamina_increase
 	id = "t1_stamina"
@@ -23,7 +29,7 @@
 	var/stam_increase = 10
 
 /datum/status_effect/food/stamina_increase/apply_quality(quality)
-	stam_increase = stam_increase * (1 + (quality / 50))
+	stam_increase *= 1 + (quality / 50)
 
 /atom/movable/screen/alert/status_effect/food/stamina_increase_t1
 	name = "Tiny Stamina Increase"
@@ -51,14 +57,15 @@
 	icon_state = "stam_t3"
 
 /datum/status_effect/food/stamina_increase/on_apply()
-	if(ishuman(owner))
-		owner.stamina.maximum += stam_increase
+	if(ishuman(owner) && !owner.stamina.set_maximum(owner.stamina.maximum + stam_increase))
+		stam_increase = 0 // Ensure we don't ADD more than we need to maximum upon removal
+		return FALSE
 	return ..()
 
 /datum/status_effect/food/stamina_increase/on_remove()
-	.=..()
+	. = ..()
 	if(ishuman(owner))
-		owner.stamina.maximum -= stam_increase
+		owner.stamina?.set_maximum(owner.stamina.maximum - stam_increase)
 
 
 /datum/status_effect/food/resistance
@@ -78,7 +85,7 @@
 	return ..()
 
 /datum/status_effect/food/resistance/on_remove()
-	.=..()
+	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
 		for(var/obj/item/bodypart/limbs in user.bodyparts)
@@ -94,7 +101,7 @@
 	var/duration_loss = DURATION_LOSS
 
 /datum/status_effect/food/fire_burps/apply_quality(quality)
-	range = range + round((quality / 40))
+	range += round((quality / 40))
 
 /atom/movable/screen/alert/status_effect/food/fire_burps
 	name = "Firey Burps"
@@ -104,14 +111,14 @@
 /datum/status_effect/food/fire_burps/on_apply()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		ADD_TRAIT(user, TRAIT_FOOD_FIRE_BURPS, "food_buffs")
+		ADD_TRAIT(user, TRAIT_FOOD_FIRE_BURPS, type)
 	return ..()
 
 /datum/status_effect/food/fire_burps/on_remove()
-	.=..()
+	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		REMOVE_TRAIT(user, TRAIT_FOOD_FIRE_BURPS, "food_buffs")
+		REMOVE_TRAIT(user, TRAIT_FOOD_FIRE_BURPS, type)
 
 
 /datum/status_effect/food/fire_burps/proc/Burp()
@@ -185,7 +192,7 @@
 	return ..()
 
 /datum/status_effect/food/sweaty/on_remove()
-	.=..()
+	. = ..()
 	owner.metabolism_efficiency -= metabolism_increase
 
 
@@ -201,7 +208,7 @@
 	var/health_increase = 10
 
 /datum/status_effect/food/health_increase/apply_quality(quality)
-	health_increase = health_increase * (1 + (quality / 50))
+	health_increase *= (1 + (quality / 50))
 
 /atom/movable/screen/alert/status_effect/food/health_increase_t1
 	name = "Small Health Increase"
@@ -235,7 +242,7 @@
 	return ..()
 
 /datum/status_effect/food/health_increase/on_remove()
-	.=..()
+	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
 		user.maxHealth -= health_increase
@@ -254,15 +261,13 @@
 /datum/status_effect/food/belly_slide/on_apply()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		ADD_TRAIT(user, TRAIT_FOOD_SLIDE, "food_buffs")
+		ADD_TRAIT(user, TRAIT_FOOD_SLIDE, type)
 	return ..()
 
 /datum/status_effect/food/belly_slide/on_remove()
-	.=..()
-	if(HAS_TRAIT(owner, TRAIT_FOOD_SLIDE))
-		REMOVE_TRAIT(owner, TRAIT_FOOD_SLIDE, "food_buffs")
-		if(owner.has_movespeed_modifier(/datum/movespeed_modifier/belly_slide))
-			owner.remove_movespeed_modifier(/datum/movespeed_modifier/belly_slide)
+	. = ..()
+	REMOVE_TRAIT(owner, TRAIT_FOOD_SLIDE, type)
+	owner.remove_movespeed_modifier(/datum/movespeed_modifier/belly_slide)
 
 
 /datum/status_effect/food/stam_regen
@@ -271,7 +276,7 @@
 	var/regen_increase = 0.5
 
 /datum/status_effect/food/stam_regen/apply_quality(quality)
-	regen_increase = regen_increase * (1 + (quality / 20))
+	regen_increase *= (1 + (quality / 20))
 
 /atom/movable/screen/alert/status_effect/food/stam_regen_t1
 	name = "Small Stamina Regeneration Increase"
@@ -312,8 +317,6 @@
 		user.stamina.regen_rate += regen_increase
 
 
-
-
 /////JOB BUFFS
 
 /datum/status_effect/food/botanist
@@ -328,14 +331,14 @@
 /datum/status_effect/food/botanist/on_apply()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		ADD_TRAIT(user, TRAIT_FOOD_JOB_BOTANIST, "food_buffs")
+		ADD_TRAIT(user, TRAIT_FOOD_JOB_BOTANIST, type)
 	return ..()
 
 /datum/status_effect/food/botanist/on_remove()
-	.=..()
+	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		REMOVE_TRAIT(user, TRAIT_FOOD_JOB_BOTANIST, "food_buffs")
+		REMOVE_TRAIT(user, TRAIT_FOOD_JOB_BOTANIST, type)
 
 
 /datum/status_effect/food/miner
@@ -350,11 +353,11 @@
 /datum/status_effect/food/miner/on_apply()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		ADD_TRAIT(user, TRAIT_FOOD_JOB_MINER, "food_buffs")
+		ADD_TRAIT(user, TRAIT_FOOD_JOB_MINER, type)
 	return ..()
 
 /datum/status_effect/food/miner/on_remove()
-	.=..()
+	. = ..()
 	if(ishuman(owner))
 		var/mob/living/carbon/user = owner
-		REMOVE_TRAIT(user, TRAIT_FOOD_JOB_MINER, "food_buffs")
+		REMOVE_TRAIT(user, TRAIT_FOOD_JOB_MINER, type)


### PR DESCRIPTION

## About The Pull Request

I somehow ended up with a maximum stamina of _-650_, and after code diving - the only thing that ever sets `stamina.maximum` is food buffs. So I decided to clean up some of that code a bit, and add a new wrapper, `/datum/stamina_container/proc/set_maximum`, which ensures that the maximum value is never 0 or below.

## Why It's Good For The Game

mrrrp mrrp mrrow :3

## Changelog
:cl:
fix: Fixed food buffs potentially resulting in negative maximum stamina, resulting in permanent slowdown.
/:cl:
