### PR TITLE
[#4901] Prevent drones from interacting with fireaxe cabinets.

### DIFF
--- a/monkestation/code/game/objects/structures/fireaxe.dm
+++ b/monkestation/code/game/objects/structures/fireaxe.dm
@@ -1,0 +1,11 @@
+/obj/structure/fireaxecabinet/attackby(obj/item/attacking_item, mob/living/user, params)
+	if (isdrone(user) && attacking_item.tool_behaviour == TOOL_MULTITOOL)
+		to_chat(src, span_warning("Using [src] could break your laws."))
+		return
+	. = ..()
+
+/obj/structure/fireaxecabinet/attack_hand(mob/user, list/modifiers)
+	if (isdrone(user))
+		to_chat(src, span_warning("Using [src] could break your laws."))
+		return
+	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6168,6 +6168,7 @@
 #include "monkestation\code\game\objects\items\storage\boxes\boxes.dm"
 #include "monkestation\code\game\objects\items\storage\boxes\security_boxes.dm"
 #include "monkestation\code\game\objects\structures\elevation.dm"
+#include "monkestation\code\game\objects\structures\fireaxe.dm"
 #include "monkestation\code\game\objects\structures\gravestones.dm"
 #include "monkestation\code\game\objects\structures\tables_racks.dm"
 #include "monkestation\code\game\objects\structures\trash_pile.dm"


### PR DESCRIPTION

## About The Pull Request

Fixes #4901 
Prevents drones from interacting with fireaxe cabinets, or at least trying to take the axe out.
## Why It's Good For The Game
## Changelog
:cl:
fix: Prevent drones from interacting with fireaxe cabinets, or at least trying to take the axe out.
/:cl:
