### PR TITLE
Doubles lionhunter range, Eldritch and Unholy water painkiller

### DIFF
--- a/code/modules/antagonists/heretic/items/hunter_rifle.dm
+++ b/code/modules/antagonists/heretic/items/hunter_rifle.dm
@@ -1,5 +1,5 @@
 /// The max range we can zoom in on people from.
-#define MAX_LIONHUNTER_RANGE 30
+#define MAX_LIONHUNTER_RANGE 60 // MONKESTATIN EDIT ORG: 30
 
 // The Lionhunter, a gun for heretics
 // The ammo it uses takes time to "charge" before firing,

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2736,6 +2736,7 @@
 		drinker.adjustOxyLoss(-2 * REM * seconds_per_tick, FALSE)
 		drinker.adjustBruteLoss(-2 * REM * seconds_per_tick, FALSE)
 		drinker.adjustFireLoss(-2 * REM * seconds_per_tick, FALSE)
+		drinker.cause_pain(BODY_ZONES_ALL, -5 * REM * seconds_per_tick)
 		if(drinker.blood_volume < BLOOD_VOLUME_NORMAL)
 			drinker.blood_volume += 3 * REM * seconds_per_tick
 	else

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -480,6 +480,7 @@
 		affected_mob.adjustOxyLoss(-2 * REM * seconds_per_tick, 0)
 		affected_mob.adjustBruteLoss(-2 * REM * seconds_per_tick, 0)
 		affected_mob.adjustFireLoss(-2 * REM * seconds_per_tick, 0)
+		affected_mob.cause_pain(BODY_ZONES_ALL, -8 * REM * seconds_per_tick)
 		if(ishuman(affected_mob) && affected_mob.blood_volume < BLOOD_VOLUME_NORMAL)
 			affected_mob.blood_volume += 3 * REM * seconds_per_tick
 	else  // Will deal about 90 damage when 50 units are thrown

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -480,7 +480,7 @@
 		affected_mob.adjustOxyLoss(-2 * REM * seconds_per_tick, 0)
 		affected_mob.adjustBruteLoss(-2 * REM * seconds_per_tick, 0)
 		affected_mob.adjustFireLoss(-2 * REM * seconds_per_tick, 0)
-		affected_mob.cause_pain(BODY_ZONES_ALL, -8 * REM * seconds_per_tick)
+		affected_mob.cause_pain(BODY_ZONES_ALL, -8 * REM * seconds_per_tick) //MONKESTATION ADDITION
 		if(ishuman(affected_mob) && affected_mob.blood_volume < BLOOD_VOLUME_NORMAL)
 			affected_mob.blood_volume += 3 * REM * seconds_per_tick
 	else  // Will deal about 90 damage when 50 units are thrown
@@ -2736,7 +2736,7 @@
 		drinker.adjustOxyLoss(-2 * REM * seconds_per_tick, FALSE)
 		drinker.adjustBruteLoss(-2 * REM * seconds_per_tick, FALSE)
 		drinker.adjustFireLoss(-2 * REM * seconds_per_tick, FALSE)
-		drinker.cause_pain(BODY_ZONES_ALL, -5 * REM * seconds_per_tick)
+		drinker.cause_pain(BODY_ZONES_ALL, -5 * REM * seconds_per_tick) // MONKESTATION ADDITION
 		if(drinker.blood_volume < BLOOD_VOLUME_NORMAL)
 			drinker.blood_volume += 3 * REM * seconds_per_tick
 	else


### PR DESCRIPTION
## About The Pull Request
Doubles Lionhunter max lock on range from 30 tiles to 60

Eldritch Essence now painkills heretics
Unholy water now painkills cultist

## Why It's Good For The Game
The lionhunter is a terrible weapon. It is such high effort to make yet it holds 3 bullets, and does 30 damage a bullet, with lock on it does 60 damage a shot which takes several seconds to preform and isn't really worth it considering the time to make the gun and ammo.
While this doesn't fix that, it allows some of the gimmicks it used to allow by increasing range allowing heretics to snipe people from far away harassing them or making threats. Giving it some use to be made again

Cultist take damage from using runes and using spells. This can cause them to suffocate to the point of death, get stunned, or otherwise purely for making runes. This isn't a great fix but it allows them a way to treat this without getting opiate addictions.

Eldritch Essence is a all around healer for heretics, it doesn't make much sense for it to not help pain at all. Gives heretics a way to fight off pain.

## Changelog

:cl:
balance: Unholy water and Eldritch now heal pain
balance: Doubled lion hunter max range
/:cl:

