### PR TITLE
Prison loaves no longer decompose

### DIFF
--- a/monkestation/code/modules/loafing/code/loaf.dm
+++ b/monkestation/code/modules/loafing/code/loaf.dm
@@ -4,9 +4,11 @@
 	icon = 'monkestation/code/modules/loafing/icons/obj.dmi'
 	icon_state = "loaf"
 	food_reagents = list(/datum/reagent/consumable/nutraslop = 10)
+	force_feed_on_aggression = TRUE
+	preserved_food = TRUE
+
 	var/loaf_density = 1 //base loaf density
 	var/can_condense = TRUE //for special loaves, make false
-	force_feed_on_aggression = TRUE
 	//vars for high level loafs
 
 	var/critical = FALSE


### PR DESCRIPTION

## About The Pull Request

This makes it so prison loaves don't decompose. Exactly what it says on the ten.

also I'm unsure if this is balance or just qol, marking as balance just to be safe

## Why It's Good For The Game

it's a crime against both food and physics, it shouldn't decompose

## Changelog
:cl:
balance: Prison loaves no longer decompose.
/:cl:
