### PR TITLE
Removes foreigner+bilingual quirk conflict

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -33,7 +33,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Social Anxiety", "Mute"),
 		list("Mute", "Soft-Spoken"),
 		list("Stormtrooper Aim", "Big Hands"),
-		list("Bilingual", "Foreigner"),
+		//list("Bilingual", "Foreigner"), //monkestation edit, commented out
 		//might be fun to change this in the future. you can be a body purist but be forced to use implants regardless for medical reasons
 		list("Body Purist", "Hosed"),
 		list("Body Purist", "Neuralinked"),


### PR DESCRIPTION

## About The Pull Request

Removes the quirk conflict between Foreigner and Bilingual, because I don't think it makes sense, as they technically don't counter each other, and both quirks seem to work as intended without the restriction.

## Why It's Good For The Game

it isn't

## Changelog

:cl:
del: Foreigner and Bilingual are no longer conflicting quirks
/:cl: