### PR TITLE
Nerfs qarad

### DIFF
--- a/monkestation/code/modules/blueshift/items/company_guns.dm
+++ b/monkestation/code/modules/blueshift/items/company_guns.dm
@@ -135,6 +135,7 @@
 	wield_recoil = 0.5
 	spread = 12.5
 	projectile_wound_bonus = -20
+	projectile_damage_multiplier = 0.75
 
 /obj/item/gun/ballistic/automatic/sol_rifle/machinegun/examine_more(mob/user)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Gives the Qarad a 0.75 damage modifier.

## Why It's Good For The Game
Right now, the Qarad has 200 DPS, which is more than the Saw's 150 DPS. It's very odd for crew weapons to be comparable to literal nukie weaponry.

This brings the Qarad to 150 DPS, so it's basically a saw that's less accurate.

## Changelog
:cl:
balance: Qarad now has a 0.75 damage modifier.
/:cl:
