### PR TITLE
Ghost runechat now shows to anyone who can both see and hear ghosts

### DIFF
--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -147,7 +147,7 @@
 	for(var/mob/M in GLOB.player_list)
 		if(M == src)
 			continue
-		if(!isdead(M))
+		if(SSticker.current_state != GAME_STATE_FINISHED && (M.see_invisible < invisibility || (!isdead(M) && !HAS_TRAIT(M, TRAIT_SIXTHSENSE))))
 			continue
 		if (M.client?.prefs.read_preference(/datum/preference/toggle/enable_runechat))
 			M.create_chat_message(src, /datum/language/common, message)


### PR DESCRIPTION

## About The Pull Request

this allows dchat runechat to be seen by everyone after roundend, and also by anyone who can both hear and see ghosts, even if they aren't a ghost themselves.

## Why It's Good For The Game

makes more sense. also it's kinda silly you can see looc runechat at roundend (and everyone can looc regardless of status after the round ends) but not deadchat

## Changelog
:cl:
qol: Ghost runechat now shows to anyone who can both see and hear ghosts, rather than ONLY to ghosts.
/:cl:
