### PR TITLE
Fixes laser carbines being able to akimbo and rounds their firing delay to 0.2 seconds

### DIFF
--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -263,7 +263,7 @@
 	if(HAS_TRAIT(shooter, TRAIT_DOUBLE_TAP))
 		next_delay = round(next_delay * 0.5)
 	COOLDOWN_START(src, next_shot_cd, next_delay)
-	if(SEND_SIGNAL(parent, COMSIG_AUTOFIRE_SHOT, target, shooter, mouse_parameters) & COMPONENT_AUTOFIRE_SHOT_SUCCESS)
+	if(SEND_SIGNAL(parent, COMSIG_AUTOFIRE_SHOT, target, shooter, allow_akimbo, mouse_parameters) & COMPONENT_AUTOFIRE_SHOT_SUCCESS)
 		return TRUE
 	stop_autofiring()
 	return FALSE

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -31,7 +31,7 @@
 
 /obj/item/gun/energy/laser/carbine/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/automatic_fire, 0.15 SECONDS, allow_akimbo = FALSE)
+	AddComponent(/datum/component/automatic_fire, 0.2 SECONDS, allow_akimbo = FALSE)
 
 /obj/item/gun/energy/laser/retro/old
 	name ="laser gun"


### PR DESCRIPTION

## About The Pull Request

Title, previously allow_akimbo was fucked by the power of argument shifting and badly done ports.
Now it works and you can't get 100 DPS with 700 credits roundstart. Woe is security.
Rounding the firing delay doesn't affect anything. Just for consistency.
## Why It's Good For The Game

I don't know how to break this to you but a 1 second TTK is unhealthy for the game.
## Changelog
:cl:
fix: Laser carbines can no longer akimbo. They were never supposed to.
/:cl:
