### PR TITLE
Prevents recall/security level change on assault operative shuttle

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -188,7 +188,7 @@
 				return
 			//monkestation edit start:
 			if (is_type_in_list(get_area(src), typesof(/area/shuttle/syndicate/cruiser))) // Prevents assault ops from modifying the alert level from thier shuttle
-			to_chat(usr, span_warning("Unable to connect to security level systems due to local interference"))
+				to_chat(usr, span_warning("Unable to connect to security level systems due to local interference"))
 				return
 			//monkestation edit end
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -307,7 +307,7 @@
 //monkestation edit start:
 			if(clock_user)
 				GLOB.main_clock_cult?.member_recalled = TRUE
-			if (is_type_in_list(get_area(src), typesof(/area/shuttle/syndicate/cruiser))) // Prevents assault ops from recalling from their shuttle
+			if(istype(get_area(src), /area/shuttle/syndicate/cruiser)) // monkestation edit: Prevents assault ops from recalling from their shuttle
 				to_chat(usr, span_warning("Unable to connect to shuttle systems due to local interference"))
 				return
 //monkestation edit end

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -188,6 +188,7 @@
 				return
 			//monkestation edit start:
 			if (is_type_in_list(get_area(src), typesof(/area/shuttle/syndicate/cruiser))) // Prevents assault ops from modifying the alert level from thier shuttle
+			to_chat(usr, span_warning("Unable to connect to security level systems due to local interference"))
 				return
 			//monkestation edit end
 
@@ -307,6 +308,7 @@
 			if(clock_user)
 				GLOB.main_clock_cult?.member_recalled = TRUE
 			if (is_type_in_list(get_area(src), typesof(/area/shuttle/syndicate/cruiser))) // Prevents assault ops from recalling from their shuttle
+				to_chat(usr, span_warning("Unable to connect to shuttle systems due to local interference"))
 				return
 //monkestation edit end
 			SSshuttle.cancelEvac(usr)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -187,7 +187,7 @@
 			if (!authenticated_as_silicon_or_captain(usr))
 				return
 			//monkestation edit start:
-			if (is_type_in_list(get_area(src), typesof(/area/shuttle/syndicate/cruiser))) // Prevents assault ops from modifying the alert level from thier shuttle
+			if(istype(get_area(src), /area/shuttle/syndicate/cruiser)) // monkestation edit: Prevents assault ops from modifying the alert level from their shuttle
 				to_chat(usr, span_warning("Unable to connect to security level systems due to local interference"))
 				return
 			//monkestation edit end

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -186,6 +186,10 @@
 		if ("changeSecurityLevel")
 			if (!authenticated_as_silicon_or_captain(usr))
 				return
+			//monkestation edit start:
+			if (is_type_in_list(get_area(src), typesof(/area/shuttle/syndicate/cruiser))) // Prevents assault ops from modifying the alert level from thier shuttle
+				return
+			//monkestation edit end
 
 			// Check if they have
 			if (!issilicon(usr))
@@ -299,9 +303,11 @@
 			var/clock_user = IS_CLOCK(usr) //monkestation edit
 			if (!authenticated(usr) || issilicon(usr) || syndicate || (clock_user && GLOB.main_clock_cult?.member_recalled)) //monkestation edit: adds the CWC check
 				return
-//monkestation edit start
+//monkestation edit start:
 			if(clock_user)
 				GLOB.main_clock_cult?.member_recalled = TRUE
+			if (is_type_in_list(get_area(src), typesof(/area/shuttle/syndicate/cruiser))) // Prevents assault ops from recalling from their shuttle
+				return
 //monkestation edit end
 			SSshuttle.cancelEvac(usr)
 		if ("requestNukeCodes")


### PR DESCRIPTION

## About The Pull Request
Prevents communication consoles on the assault operative ship from being able to recall the shuttle and change the security level.
## Why It's Good For The Game
Antags using an on-station communication console to stall the shuttle is already annoying, being able to do this from a fortified ship in some location off station that can teleport somewhere is  extremely annoying. If the operatives want to recall the shuttle/change the security level, they are gonna need to at least do so from on station/with the AIs help.
## Changelog
:cl:
balance: Communication consoles on assault operative ships can no longer recall the shuttle or change the security levels.
/:cl:
