### PR TITLE
Fixes Knock path not getting Relentless Heartbeat

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/knock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/knock_lore.dm
@@ -147,6 +147,7 @@
 	adds_sidepath_points = 1
 	next_knowledge = list(
 		/datum/heretic_knowledge/spell/opening_blast,
+		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/blade_upgrade/flesh/knock,
 		/datum/heretic_knowledge/unfathomable_curio,
 		/datum/heretic_knowledge/painting,


### PR DESCRIPTION
## About The Pull Request

port of https://github.com/tgstation/tgstation/pull/80962

fixes https://github.com/Monkestation/Monkestation2.0/issues/4963

## Why It's Good For The Game

Not being able to reroll targets as Knock kinda sucks.

## Changelog
:cl: Absolucy, the-orange-cow
fix: Knock heretics may once again access The Relentless Heartbeat after purchasing Burglar's Finesse.
/:cl:
