### PR TITLE
Improve admin logging for antag/event tokens

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1781,8 +1781,12 @@
 		if(!IS_CLIENT_OR_MOCK(target))
 			return
 		var/client/user_client = target
-		user_client.client_token_holder.approve_antag_token()
-		log_admin("[user_client]'s token has been approved by [owner].")
+		var/datum/meta_token_holder/token_holder = user_client?.client_token_holder
+		if(!token_holder?.in_queue)
+			return
+		token_holder.approve_antag_token()
+		message_admins("[key_name_admin(owner)] approved a [token_holder.in_queue] token from [ADMIN_LOOKUPFLW(user_client)]")
+		log_admin("[user_client]'s [token_holder.in_queue] token has been approved by [owner].")
 
 	else if(href_list["reject_antag_token"])
 		if(!check_rights(R_ADMIN))
@@ -1791,8 +1795,12 @@
 		if(!IS_CLIENT_OR_MOCK(target))
 			return
 		var/client/user_client = target
-		user_client.client_token_holder.reject_antag_token()
-		log_admin("[user_client]'s token has been rejected by [owner].")
+		var/datum/meta_token_holder/token_holder = user_client?.client_token_holder
+		if(!token_holder?.in_queue)
+			return
+		token_holder.reject_antag_token()
+		message_admins("[key_name_admin(owner)] rejected a [token_holder.in_queue] token from [ADMIN_LOOKUPFLW(user_client)]")
+		log_admin("[user_client]'s [token_holder.in_queue] token has been rejected by [owner].")
 
 	else if(href_list["open_music_review"])
 		if(!check_rights(R_ADMIN))
@@ -1810,8 +1818,12 @@
 		if(!IS_CLIENT_OR_MOCK(target))
 			return
 		var/client/user_client = target
-		user_client.client_token_holder.approve_token_event()
-		log_admin("[user_client]'s token event has been approved by [owner].")
+		var/datum/meta_token_holder/token_holder = user_client?.client_token_holder
+		if(!token_holder?.queued_token_event)
+			return
+		token_holder.approve_token_event()
+		message_admins("[key_name_admin(owner)] approved a [token_holder.queued_token_event.event_name] event token from [ADMIN_LOOKUPFLW(user_client)]")
+		log_admin("[user_client]'s [token_holder.queued_token_event.event_name] event token has been approved by [owner].")
 
 	else if(href_list["reject_token_event"])
 		if(!check_rights(R_ADMIN))
@@ -1820,6 +1832,10 @@
 		if(!IS_CLIENT_OR_MOCK(target))
 			return
 		var/client/user_client = target
-		user_client.client_token_holder.reject_token_event()
-		log_admin("[user_client]'s token event has been rejected by [owner].")
+		var/datum/meta_token_holder/token_holder = user_client?.client_token_holder
+		if(!token_holder?.queued_token_event)
+			return
+		token_holder.reject_token_event()
+		message_admins("[key_name_admin(owner)] rejected a [token_holder.queued_token_event.event_name] event token from [ADMIN_LOOKUPFLW(user_client)]")
+		log_admin("[user_client]'s [token_holder.queued_token_event.event_name] event token has been rejected by [owner].")
 //monkestation edit end


### PR DESCRIPTION
## Changelog
:cl:
admin: Admins are actually notified when someone accepts/rejects a token, instead of there being no feedback whatsoever.
/:cl:
