### PR TITLE
Don't spawn artifacts during unit tests

### DIFF
--- a/monkestation/code/modules/art_sci_overrides/generic_artifact_objects.dm
+++ b/monkestation/code/modules/art_sci_overrides/generic_artifact_objects.dm
@@ -18,9 +18,12 @@ ARTIFACT_SETUP(/obj/structure/artifact, SSobj, null, forced_effect, null)
 	icon_state = "wiznerd-1"
 
 /obj/effect/artifact_spawner/Initialize(mapload)
-	. = ..()
+	..()
+// don't want artifacts exploding during unit tests or something
+#ifndef UNIT_TESTS
 	spawn_artifact(loc)
-	qdel(src)
+#endif
+	return INITIALIZE_HINT_QDEL
 
 /obj/structure/artifact/bonk
 	forced_effect = /datum/artifact_effect/bonk


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Sometimes there's flaky unit test failures like this:
```
  Error: Space turf found in non-allowed area (/area/station/science/explab) at Experimentation Lab (164,72,2)! Please ensure that all space turfs are in an /area/space!
  	FAILURE #1: Space turf found in non-allowed area (/area/station/science/explab) at Experimentation Lab (164,72,2)! Please ensure that all space turfs are in an /area/space! at code/modules/unit_tests/mapload_space_verification.dm:37
Error: FAIL /datum/unit_test/mapload_space_verification 0.4s
```
and they're almost certainly related to artifacts exploding or something dumb like that.

So this just makes it so artifact spawners self-delete without spawning anything during unit tests.

Also changed them to just properly return `INITIALIZE_HINT_QDEL` instead of doing `qdel(src)` in Initialize

## Why It's Good For The Game

flaky unit tests suck. and this is also a slight code improvement

## Changelog

No player-facing changes.