### PR TITLE
Fix latejoin cyborgs sometimes ending up in walls and such

### DIFF
--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -36,16 +36,14 @@
 
 /datum/job/cyborg/proc/get_random_open_turf_in_area()
 	var/list/turfs = get_area_turfs(/area/station/ai_monitored/turret_protected/ai_upload)
-	var/turf/open/target_turf
 	while(length(turfs))
 		var/turf/turf = pick_n_take(turfs)
 		if(!isfloorturf(turf) || turf.is_blocked_turf(exclude_mobs = TRUE))
 			continue
-		target_turf = turf
-		break
-	if(!target_turf)
-		CRASH("Failed to find eligible spawn turf for a cyborg!")
-	return target_turf
+		return turf
+	stack_trace("Failed to find eligible spawn turf for a cyborg, using observer start landmark instead.")
+	var/obj/effect/landmark/observer_start/target = locate(/obj/effect/landmark/observer_start) in GLOB.landmarks_list
+	return get_turf(target)
 
 /datum/job/cyborg/after_spawn(mob/living/spawned, client/player_client)
 	. = ..()

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -36,11 +36,15 @@
 
 /datum/job/cyborg/proc/get_random_open_turf_in_area()
 	var/list/turfs = get_area_turfs(/area/station/ai_monitored/turret_protected/ai_upload)
-	var/turf/open/target_turf = null
-	while(!target_turf)
-		var/turf/turf = pick(turfs)
-		if(!turf.density)
-			target_turf = turf
+	var/turf/open/target_turf
+	while(length(turfs))
+		var/turf/turf = pick_n_take(turfs)
+		if(!isfloorturf(turf) || turf.is_blocked_turf(exclude_mobs = TRUE))
+			continue
+		target_turf = turf
+		break
+	if(!target_turf)
+		CRASH("Failed to find eligible spawn turf for a cyborg!")
 	return target_turf
 
 /datum/job/cyborg/after_spawn(mob/living/spawned, client/player_client)


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/3964
Fixes https://github.com/Monkestation/Monkestation2.0/issues/4982

This makes it so latejoin cyborgs will always be podded onto a floor turf that isn't blocked - using `turf.is_blocked_turf()` instead of just checking for turf density.

## Why It's Good For The Game

bugfix

## Changelog
:cl:
fix: Latejoin cyborgs will now only spawn on non-blocked floors in the AI upload, so they'll no longer end up stuck in a wall or something.
/:cl:
