### PR TITLE
[PORT] Fixes things being statistically weighted to drop in security

### DIFF
--- a/code/__HELPERS/turfs.dm
+++ b/code/__HELPERS/turfs.dm
@@ -360,6 +360,35 @@ Turf and target are separate in case you want to teleport some distance from a t
 		if (target)
 			return target
 
+///Returns a random department of areas to pass into get_safe_random_station_turf() for more equal spawning.
+/proc/get_safe_random_station_turf_equal_weight()
+	// Big list of departments, each with lists of each area subtype.
+	var/static/list/department_areas
+	if(isnull(department_areas))
+		department_areas = list(
+				subtypesof(/area/station/engineering), \
+				subtypesof(/area/station/medical), \
+				subtypesof(/area/station/science), \
+				subtypesof(/area/station/security), \
+				subtypesof(/area/station/service), \
+				subtypesof(/area/station/command), \
+				subtypesof(/area/station/hallway), \
+				subtypesof(/area/station/ai_monitored), \
+				subtypesof(/area/station/cargo)
+			)
+
+	var/list/area/final_department = pick(department_areas) // Pick a department
+	var/list/area/final_area_list = list()
+
+	for(var/area/checked_area as anything in final_department) // Check each area to make sure it exists on the station
+		if(checked_area in GLOB.the_station_areas)
+			final_area_list += checked_area
+
+	if(!length(final_area_list)) // Failsafe
+		return get_safe_random_station_turf()
+
+	return get_safe_random_station_turf(final_area_list)
+
 /**
  * Checks whether the target turf is in a valid state to accept a directional construction
  * such as windows or railings.

--- a/code/controllers/subsystem/blackmarket.dm
+++ b/code/controllers/subsystem/blackmarket.dm
@@ -78,7 +78,7 @@ SUBSYSTEM_DEF(blackmarket)
 				pad.add_to_queue(purchase)
 			// Get random area, throw it somewhere there.
 			if(SHIPPING_METHOD_TELEPORT)
-				var/turf/targetturf = get_safe_random_station_turf()
+				var/turf/targetturf = get_safe_random_station_turf_equal_weight()
 				// This shouldn't happen.
 				if (!targetturf)
 					continue

--- a/code/game/objects/items/crab17.dm
+++ b/code/game/objects/items/crab17.dm
@@ -18,7 +18,7 @@
 	if(tgui_alert(user, "Are you sure you want to crash this market with no survivors?", "Protocol CRAB-17", list("Yes", "No")) == "Yes")
 		if(dumped || QDELETED(src)) //Prevents fuckers from cheesing alert
 			return FALSE
-		var/turf/targetturf = get_safe_random_station_turf()
+		var/turf/targetturf = get_safe_random_station_turf_equal_weight()
 		if (!targetturf)
 			return FALSE
 		var/list/accounts_to_rob = flatten_list(SSeconomy.bank_accounts_by_id)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -888,7 +888,7 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	set desc = "(\"Amount of mobs to create\") Populate the world with test mobs."
 
 	for (var/i in 1 to amount)
-		var/turf/tile = get_safe_random_station_turf()
+		var/turf/tile = get_safe_random_station_turf_equal_weight()
 		var/mob/living/carbon/human/hooman = new(tile)
 		hooman.equipOutfit(pick(subtypesof(/datum/outfit)))
 		testing("Spawned test mob at [get_area_name(tile, TRUE)] ([tile.x],[tile.y],[tile.z])")

--- a/code/modules/antagonists/heretic/influences.dm
+++ b/code/modules/antagonists/heretic/influences.dm
@@ -71,7 +71,7 @@
 
 	var/location_sanity = 0
 	while((length(smashes) + num_drained) < how_many_can_we_make && location_sanity < 100)
-		var/turf/chosen_location = get_safe_random_station_turf()
+		var/turf/chosen_location = get_safe_random_station_turf_equal_weight()
 
 		// We don't want them close to each other - at least 1 tile of seperation
 		var/list/nearby_things = range(1, chosen_location)

--- a/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
+++ b/code/modules/antagonists/wizard/grand_ritual/grand_rune.dm
@@ -259,7 +259,7 @@
 	var/location_sanity = 0
 	// Copied from the influences manager, but we don't want to obey the cap on influences per heretic.
 	while(created < to_create && location_sanity < 100)
-		var/turf/chosen_location = get_safe_random_station_turf()
+		var/turf/chosen_location = get_safe_random_station_turf_equal_weight()
 
 		// We don't want them close to each other - at least 1 tile of seperation
 		var/list/nearby_things = range(1, chosen_location)

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -90,10 +90,10 @@
 		number_of_hostiles += hostile_types[hostile]
 
 	while(number_of_bosses > boss_spawn.len)
-		boss_spawn += get_safe_random_station_turf() // monkestation edit: use [get_safe_random_station_turf] so they don't spawn in weird stupid places
+		boss_spawn += get_safe_random_station_turf_equal_weight() // monkestation edit: use [get_safe_random_station_turf_equal_weight] so they don't spawn in weird stupid places
 
 	while(number_of_hostiles > hostiles_spawn.len)
-		hostiles_spawn += get_safe_random_station_turf() // monkestation edit: use [get_safe_random_station_turf] so they don't spawn in weird stupid places
+		hostiles_spawn += get_safe_random_station_turf_equal_weight() // monkestation edit: use [get_safe_random_station_turf_equal_weight] so they don't spawn in weird stupid places
 
 	next_boss_spawn = start_when + CEILING(2 * number_of_hostiles / number_of_bosses, 1)
 	setup = TRUE //MONKESTATION ADDITION
@@ -107,7 +107,7 @@
 	sound_to_playing_players('sound/magic/lightningbolt.ogg')
 
 /datum/round_event/portal_storm/tick()
-	spawn_effects(get_safe_random_station_turf()) // monkestation edit: use [get_safe_random_station_turf] so they don't spawn in weird stupid places
+	spawn_effects(get_safe_random_station_turf_equal_weight()) // monkestation edit: use [get_safe_random_station_turf_equal_weight] so they don't spawn in weird stupid places
 
 	if(spawn_hostile() && length(hostile_types))
 		var/type = pick(hostile_types)

--- a/code/modules/events/wisdomcow.dm
+++ b/code/modules/events/wisdomcow.dm
@@ -27,7 +27,7 @@
 	if(spawn_location)
 		targetloc = spawn_location
 	else
-		targetloc = get_safe_random_station_turf()
+		targetloc = get_safe_random_station_turf_equal_weight()
 	var/mob/living/basic/cow/wisdom/wise = new(targetloc, selected_wisdom, selected_experience)
 	do_smoke(1, holder = wise, location = targetloc)
 	announce_to_ghosts(wise)

--- a/code/modules/explorer_drone/exodrone.dm
+++ b/code/modules/explorer_drone/exodrone.dm
@@ -170,7 +170,7 @@ GLOBAL_LIST_EMPTY(exodrone_launchers)
 
 /// Crashes the drone somewhere random if there's no launchpad to be found.
 /obj/item/exodrone/proc/drop_somewhere_on_station()
-	var/turf/random_spot = get_safe_random_station_turf()
+	var/turf/random_spot = get_safe_random_station_turf_equal_weight()
 
 	var/obj/structure/closet/supplypod/pod = podspawn(list(
 		"target" = random_spot,

--- a/code/modules/religion/hunt/hunting_rites.dm
+++ b/code/modules/religion/hunt/hunting_rites.dm
@@ -61,7 +61,7 @@ GLOBAL_LIST_EMPTY(sect_of_the_hunt_preys)
 /datum/religion_rites/call_the_hunt/invoke_effect(mob/living/user, atom/religious_tool)
 	. = ..()
 
-	var/turf/prey_location = get_safe_random_station_turf()
+	var/turf/prey_location = get_safe_random_station_turf_equal_weight()
 	GLOB.sect_of_the_hunt_preys += new /mob/living/basic/deer/prey(prey_location)
 
 

--- a/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -467,7 +467,7 @@
 		return
 
 	// Teleport them to a random safe coordinate on the station z level.
-	var/turf/open/floor/safe_turf = get_safe_random_station_turf()
+	var/turf/open/floor/safe_turf = get_safe_random_station_turf_equal_weight()
 	var/obj/effect/landmark/observer_start/backup_loc = locate(/obj/effect/landmark/observer_start) in GLOB.landmarks_list
 	if(!safe_turf)
 		safe_turf = get_turf(backup_loc)

--- a/monkestation/code/modules/antagonists/monster_hunters/events/wonderland_apocalypse.dm
+++ b/monkestation/code/modules/antagonists/monster_hunters/events/wonderland_apocalypse.dm
@@ -36,9 +36,9 @@
 /datum/round_event/wonderlandapocalypse/start()
 	SSshuttle.emergency_no_recall = TRUE
 	for(var/i = 1 to 16)
-		new /obj/effect/anomaly/dimensional/wonderland(get_safe_random_station_turf(), null, FALSE)
+		new /obj/effect/anomaly/dimensional/wonderland(get_safe_random_station_turf_equal_weight(), null, FALSE)
 	for(var/i = 1 to 4)
-		var/obj/structure/wonderland_rift/rift = new(get_safe_random_station_turf())
+		var/obj/structure/wonderland_rift/rift = new(get_safe_random_station_turf_equal_weight())
 		notify_ghosts(
 			"A doorway to the wonderland has been opened!",
 			source = rift,

--- a/monkestation/code/modules/antagonists/monster_hunters/hunter_datum.dm
+++ b/monkestation/code/modules/antagonists/monster_hunters/hunter_datum.dm
@@ -77,7 +77,7 @@
 	RegisterSignal(src, COMSIG_GAIN_INSIGHT, PROC_REF(insight_gained))
 	RegisterSignal(src, COMSIG_BEASTIFY, PROC_REF(turn_beast))
 	for(var/i in 1 to 5)
-		var/turf/rabbit_hole = get_safe_random_station_turf()
+		var/turf/rabbit_hole = get_safe_random_station_turf_equal_weight()
 		rabbits += new /obj/effect/bnnuy(rabbit_hole, src)
 	var/obj/effect/bnnuy/gun_holder = pick(rabbits)
 	gun_holder.drop_gun = TRUE

--- a/monkestation/code/modules/antagonists/traitor/objectives/kidnapping.dm
+++ b/monkestation/code/modules/antagonists/traitor/objectives/kidnapping.dm
@@ -293,7 +293,7 @@
 			continue
 		possible_turfs += open_turf
 
-	var/turf/return_turf = get_safe_random_station_turf()
+	var/turf/return_turf = get_safe_random_station_turf_equal_weight()
 	if(!return_turf) //SOMEHOW
 		to_chat(sent_mob, span_hypnophrase(span_reallybig("A million voices echo in your head... <i>\"Seems where you got sent here from won't \
 			be able to handle our pod... You will die here instead.\"</i></span>")))

--- a/monkestation/code/modules/art_sci_overrides/faults/warps.dm
+++ b/monkestation/code/modules/art_sci_overrides/faults/warps.dm
@@ -2,16 +2,11 @@
 	name = "Warping Fault"
 	trigger_chance = 12
 	visible_message = "warps space sending everyone away."
-	var/list/warp_areas = list()
-
 	research_value = 250
-
 	weight = ARTIFACT_UNCOMMON
 
 /datum/artifact_fault/warp/on_trigger()
-	if(!length(warp_areas))
-		warp_areas = GLOB.the_station_areas
-	var/turf/safe_turf = get_safe_random_station_turf(warp_areas)
+	var/turf/safe_turf = get_safe_random_station_turf_equal_weight()
 	var/center_turf = get_turf(our_artifact.parent)
 
 	if(!center_turf)

--- a/monkestation/code/modules/assault_ops/code/interrogator.dm
+++ b/monkestation/code/modules/assault_ops/code/interrogator.dm
@@ -257,7 +257,7 @@
 
 ///This proc attempts to return the head of staff back to the station after the interrogator finishes
 /obj/machinery/interrogator/proc/return_victim()
-	var/turf/open/floor/safe_turf = get_safe_random_station_turf()
+	var/turf/open/floor/safe_turf = get_safe_random_station_turf_equal_weight()
 	var/obj/effect/landmark/observer_start/backup_loc = locate(/obj/effect/landmark/observer_start) in GLOB.landmarks_list
 	if(!safe_turf)
 		safe_turf = get_turf(backup_loc)

--- a/monkestation/code/modules/assault_ops/code/sunbeam.dm
+++ b/monkestation/code/modules/assault_ops/code/sunbeam.dm
@@ -165,7 +165,7 @@
 
 /datum/round_event/icarus_sunbeam/start()
 	var/startside = pick(GLOB.cardinals)
-	var/turf/end_turf = get_edge_target_turf(get_safe_random_station_turf(), turn(startside, 180))
+	var/turf/end_turf = get_edge_target_turf(get_safe_random_station_turf_equal_weight(), turn(startside, 180))
 	var/turf/start_turf = spaceDebrisStartLoc(startside, end_turf.z)
 	new /obj/effect/sunbeam(start_turf, end_turf)
 


### PR DESCRIPTION

## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/88788

> Hey, fun fact, `get_safe_random_station_turf()` is not as random as it seems. The more areas a department has (blame security), there is a much bigger chance for it to land in that department.
> 
> Creates a `get_safe_random_station_turf_equal_weight()` which first picks a department, creates a list of areas from that department, to then pass into `get_safe_random_station_turf()`

## Why It's Good For The Game

> Here's get_safe_random_station_turf() ran 1000 times.
```
204 - Security
105 - Science
106 - Engineering
101 - Medical
61 - Cargo 
118 - Service
7 - Maintenance (This is only the xenobio cuck room, so it doesn't matter)
85 - Command
79 - Hallway
84 - AI Monitored (Vault, AI sat, etc)
```
> As you can see, the probability for choosing a place like security is much higher. Yes, this is funny for things like the CRAB. But the probability for choosing anywhere else (like command) can be less then 10 percent.
> 
> Here's with this proc.
```
Security - 107
Science - 107
Engineering - 105
Hallway - 94
Command - 104
Medical - 109
Service - 106
Cargo - 105
AI_monitored - 127
```

## Changelog
:cl: Absolucy, StrangeWeirdKitten
fix: Things that drop in random places are no longer statistically weighted to drop in security.
/:cl:
