### PR TITLE
Fix borers sometimes losing Galactic Common

### DIFF
--- a/code/datums/mind/_mind.dm
+++ b/code/datums/mind/_mind.dm
@@ -168,7 +168,8 @@
 	SIGNAL_HANDLER
 	set_current(null)
 
-/datum/mind/proc/get_language_holder()
+/datum/mind/proc/get_language_holder() as /datum/language_holder
+	RETURN_TYPE(/datum/language_holder)
 	if(!language_holder)
 		language_holder = new (src)
 	return language_holder

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1485,7 +1485,8 @@
 */
 
 /// Gets or creates the relevant language holder. For mindless atoms, gets the local one. For atom with mind, gets the mind one.
-/atom/movable/proc/get_language_holder(get_minds = TRUE)
+/atom/movable/proc/get_language_holder(get_minds = TRUE) as /datum/language_holder
+	RETURN_TYPE(/datum/language_holder)
 	if(!language_holder)
 		language_holder = new initial_language_holder(src)
 	return language_holder

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -540,6 +540,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	say("#[message]", bubble_type, spans, sanitize, language, ignore_spam, forced, filterproof)
 
 /mob/living/get_language_holder(get_minds = TRUE)
+	RETURN_TYPE(/datum/language_holder)
 	if(get_minds && mind)
 		return mind.get_language_holder()
 	. = ..()

--- a/monkestation/code/modules/antagonists/borers/code/abilities/enter_host.dm
+++ b/monkestation/code/modules/antagonists/borers/code/abilities/enter_host.dm
@@ -114,8 +114,6 @@
 	if(!(cortical_owner.upgrade_flags & BORER_STEALTH_MODE))
 		to_chat(cortical_owner.human_host, span_notice("A chilling sensation goes down your spine..."))
 
-	cortical_owner.copy_languages(cortical_owner.human_host)
-
 	var/obj/item/organ/internal/borer_body/borer_organ = new(cortical_owner.human_host)
 	borer_organ.borer = owner
 	borer_organ.Insert(cortical_owner.human_host)

--- a/monkestation/code/modules/antagonists/borers/code/mobs/cortical_borer.dm
+++ b/monkestation/code/modules/antagonists/borers/code/mobs/cortical_borer.dm
@@ -89,6 +89,8 @@ GLOBAL_LIST_INIT(borer_second_name, world.file2list("monkestation/code/modules/a
 	icon_dead = "brainslug_dead"
 	maxHealth = 25
 	health = 25
+	// Allows them to understand any language their current host can.
+	initial_language_holder = /datum/language_holder/borer
 	// They need to be able to pass tables and mobs
 	pass_flags = PASSTABLE | PASSMOB
 	density = FALSE

--- a/monkestation/code/modules/language/language_holder.dm
+++ b/monkestation/code/modules/language/language_holder.dm
@@ -1,0 +1,10 @@
+/// Language holder for borers, that let them understand any language their host understands.
+/datum/language_holder/borer
+
+/datum/language_holder/borer/has_language(language, spoken = FALSE)
+	. = ..()
+	if(.)
+		return
+	var/mob/living/basic/cortical_borer/cortical_owner = get_atom()
+	if(istype(cortical_owner))
+		return cortical_owner.human_host?.get_language_holder()?.has_language(language, spoken)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7428,6 +7428,7 @@
 #include "monkestation\code\modules\jobs\job_types\virologist.dm"
 #include "monkestation\code\modules\jobs\job_types\yellowclown.dm"
 #include "monkestation\code\modules\jobs\job_types\spawner\bar_drone.dm"
+#include "monkestation\code\modules\language\language_holder.dm"
 #include "monkestation\code\modules\library\bookcase.dm"
 #include "monkestation\code\modules\library\skill_learning\job_skillchips\shaft_miner.dm"
 #include "monkestation\code\modules\liquids\drains.dm"


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/4946
Fixes https://github.com/Monkestation/Monkestation2.0/issues/4681

This changes borers from just using `copy_languages` on their host (which also copies blocked languages), to giving them a new language holder subtype, `/datum/language_holder/borer`, which allows them to _also_ understand any language their current host understands, without blocking any languages if they have any.

## Why It's Good For The Game

bugfix :3

## Changelog
:cl:
fix: Borers will no longer lose Galactic Common upon entering someone who can't speak it - instead, they will always be able to understand any languages their host does, in addition to common.
/:cl:
