### PR TITLE
Update Medical cyborgs.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -666,17 +666,18 @@
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
 		/obj/item/healthanalyzer/cyborg, //MONKESTATION EDIT
+		/obj/item/device/antibody_scanner, // monkestation addition:
 		/obj/item/reagent_containers/borghypo/medical,
 		/obj/item/borg/apparatus/beaker,
 		/obj/item/reagent_containers/dropper,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/surgical_drapes,
-		/obj/item/retractor,
-		/obj/item/hemostat,
-		/obj/item/cautery,
-		/obj/item/surgicaldrill,
-		/obj/item/scalpel,
-		/obj/item/circular_saw,
+		/obj/item/retractor/augment, //monkestation edit start: Augmented tools
+		/obj/item/hemostat/augment,
+		/obj/item/cautery/augment,
+		/obj/item/surgicaldrill/augment,
+		/obj/item/scalpel/augment,
+		/obj/item/circular_saw/augment, //monkestation edit end: Augmented tools
 		/obj/item/bonesetter,
 		/obj/item/blood_filter,
 		/obj/item/extinguisher/mini,
@@ -886,11 +887,11 @@
 		/obj/item/shockpaddles/syndicate/cyborg,
 		/obj/item/healthanalyzer,
 		/obj/item/surgical_drapes,
-		/obj/item/retractor,
-		/obj/item/hemostat,
-		/obj/item/cautery,
-		/obj/item/surgicaldrill,
-		/obj/item/scalpel,
+		/obj/item/retractor/augment, //monkestation edit start: Augmented tools
+		/obj/item/hemostat/augment,
+		/obj/item/cautery/augment,
+		/obj/item/surgicaldrill/augment,
+		/obj/item/scalpel/augment, //monkestation edit: Augmented tools
 		/obj/item/melee/energy/sword/cyborg/saw,
 		/obj/item/bonesetter,
 		/obj/item/blood_filter,


### PR DESCRIPTION

## About The Pull Request
Gives medical cyborgs Immunity scanners
Gives medical and syndicate medical units augmented surgery tools instead of regular tools.
## Why It's Good For The Game
Medical units have no way to check on a crewmembers current health through any means, despite getting spaceallin in their hypo and having the tools to make antibody medicine. This should help give them some way to communicate what the patients' health hud is telling them.

Engineering cyborgs set the precedent that cyborgs are more highly specialized and good at what they do. Specifically getting augmented/cyborg tools. This updates the medical tools to use augmented tools rather than the standard toolkit. Making them twice as fast at surgery like engineering cyborgs are with their tools.
## Changelog
:cl:
add: Gave medical cyborgs a immunity scanner. 
balance: Medical and syndicate medical get augmented tools rather than normal tools.
/:cl:
