### PR TITLE
Phobias should not prevent forced says

### DIFF
--- a/code/datums/brain_damage/phobia.dm
+++ b/code/datums/brain_damage/phobia.dm
@@ -104,10 +104,16 @@
 	if(HAS_TRAIT(owner, TRAIT_FEARLESS))
 		return
 	if(trigger_regex.Find(speech_args[SPEECH_MESSAGE]) != 0)
+		//MONKESTATION EDIT START - Phobias should not prevent forced speech (such as through tourettes)
+		if(speech_args[SPEECH_FORCED])
+			// Freak out
+			addtimer(CALLBACK(src, PROC_REF(freak_out), null, trigger_regex.group[2], TRUE), 10)
+			return
+		//MONKESTATION EDIT END
 		to_chat(owner, span_warning("You can't bring yourself to say the word \"[span_phobia("[trigger_regex.group[2]]")]\"!"))
 		speech_args[SPEECH_MESSAGE] = ""
 
-/datum/brain_trauma/mild/phobia/proc/freak_out(atom/reason, trigger_word)
+/datum/brain_trauma/mild/phobia/proc/freak_out(atom/reason, trigger_word, said_not_heard = FALSE)
 	COOLDOWN_START(src, scare_cooldown, 12 SECONDS)
 	if(owner.stat == DEAD)
 		return
@@ -115,7 +121,10 @@
 	if(reason)
 		to_chat(owner, span_userdanger("Seeing [reason] [message]!"))
 	else if(trigger_word)
-		to_chat(owner, span_userdanger("Hearing \"[trigger_word]\" [message]!"))
+		if(said_not_heard)
+			to_chat(owner, span_userdanger("Saying \"[trigger_word]\" [message]!"))
+		else
+			to_chat(owner, span_userdanger("Hearing \"[trigger_word]\" [message]!"))
 	else
 		to_chat(owner, span_userdanger("Something [message]!"))
 	var/reaction = rand(1,4)


### PR DESCRIPTION
## About The Pull Request
I found that phobias could prevent a character from being forced to say something. For example, the anime phobia would prevent a character from yelling "ANIME" even if the yell was forced by something else (i.e. a spell).

This PR fixes this, preventing forced says from being blocked by phobias... in exchange for making them freak out anyways.

Note that this is currently not an issue in tgstation's codebase, as none of the phobias appear to overlap with things that characters can be forced to say, but I am sending in a PR anyways, in the event that downstream forks are affected by this.

## Why It's Good For The Game
Bug fixes. Give me some good coder cookies, please?

## Changelog
:cl: MichiRecRoom
add: Being forced to say something (i.e. through Tourettes) that would normally be blocked by your phobia will now cause your character to freak out.
fix: Your phobias can no longer prevent you from being forced to say something by an admin.
/:cl: