### PR TITLE
Add an extra CI check for BYOND 516

### DIFF
--- a/.github/alternate_byond_versions.txt
+++ b/.github/alternate_byond_versions.txt
@@ -7,3 +7,4 @@
 # 500.1337: runtimestation
 
 515.1627: runtimestation
+516.1651: runtimestation


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This adds an extra CI check using `alternate_byond_versions.txt`, to run a runtimestation CI check on BYOND 516.1651.

## Why It's Good For The Game

Good to ensure we're ready for 516 as much as possible

## Changelog

no user-facing changes