### PR TITLE
Even more various fixes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2446,7 +2446,7 @@
 /datum/reagent/pax
 	name = "Pax"
 	description = "A colorless liquid that suppresses violence in its subjects."
-	color = "#AAAAAA55"
+	color = "#aaaaaaff"
 	taste_description = "water"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	ph = 15

--- a/monkestation/code/modules/blueshift/items/deforest.dm
+++ b/monkestation/code/modules/blueshift/items/deforest.dm
@@ -606,7 +606,7 @@
 	desc = "A sealed patch with a small nanite swarm along with electrical coagulant reagents to repair small amounts of synthetic damage."
 	icon_state = "synth_patch"
 	list_reagents = list(
-		/datum/reagent/medicine/nanite_slurry = 10,
+		/datum/reagent/medicine/nanite_slurry = 9,
 		/datum/reagent/dinitrogen_plasmide = 5,
 		/datum/reagent/medicine/coagulant/fabricated = 10,
 	)
@@ -1020,6 +1020,7 @@
 /obj/item/storage/medkit/robotic_repair/stocked/PopulateContents()
 	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze = 1,
+		/obj/item/stack/cable_coil/five = 1,
 		/obj/item/reagent_containers/pill/robotic_patch/synth_repair = 2,
 		/obj/item/reagent_containers/hypospray/medipen/deforest/robot_system_cleaner = 1,
 		/obj/item/reagent_containers/hypospray/medipen/deforest/coagulants = 1, // Coagulants help electrical damage
@@ -1044,12 +1045,13 @@
 /obj/item/storage/medkit/robotic_repair/preemo/stocked/PopulateContents()
 	var/static/items_inside = list(
 		/obj/item/stack/medical/gauze/twelve = 1,
-		/obj/item/stack/cable_coil/five = 1,
+		/obj/item/stack/cable_coil/industrial = 1,
 		/obj/item/reagent_containers/pill/robotic_patch/synth_repair = 4,
 		/obj/item/reagent_containers/hypospray/medipen/deforest/robot_system_cleaner = 1,
 		/obj/item/reagent_containers/hypospray/medipen/deforest/robot_liquid_solder = 1,
 		/obj/item/reagent_containers/hypospray/medipen/deforest/coagulants = 1,
 		/obj/item/healthanalyzer/simple = 1,
+		/obj/item/reagent_containers/blood/oil = 1,
 	)
 	generate_items_inside(items_inside,src)
 


### PR DESCRIPTION

## About The Pull Request

- Robotic repair patches: 10 u of nanite slurry -> 9 u of nanite slurry

This brings it just under the threshhold for a overdose. You can either use one patch to heal some basic healing or apply two and heal organ damage.

- Robotic Repair bags. Added 5 cable coils. 
- Preemo Robotic repair bags 5 cable coils -> 30 cable coils.  --- Added A singular blood bag of oil.
Fixes: #4862 

- Increased the alpha levels for the colour of Pax.
Pax was nearly invisible due to having a alpha level mixed wtih the transparency of being in a beaker. This alleviates that issue
Fixes: #4923
## Why It's Good For The Game
## Changelog
:cl:
balance: A singular robotic repair patch wont trigger a overdose and now will heal.
balance: Blood bag and full coil roll has been added to the premium robotic repair bag. And 5 coil added to basic robotic repair bag
fix: Fixed pax functionally being invisible.
/:cl:
