### PR TITLE
Fixes Revolution

### DIFF
--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -52,6 +52,7 @@
 /datum/antagonist/rev/apply_innate_effects(mob/living/mob_override)
 	var/mob/living/M = mob_override || owner.current
 	handle_clown_mutation(M, mob_override ? null : "Your training has allowed you to overcome your clownish nature, allowing you to wield weapons without harming yourself.")
+	M.apply_status_effect(/datum/status_effect/agent_pinpointer/hunt_command)
 	add_team_hud(M, /datum/antagonist/rev)
 
 /datum/antagonist/rev/remove_innate_effects(mob/living/mob_override)
@@ -73,6 +74,8 @@
 
 /datum/antagonist/rev/on_removal()
 	remove_objectives()
+	var/mob/living/M = owner.current
+	M.remove_status_effect(/datum/status_effect/agent_pinpointer/hunt_command)
 	. = ..()
 
 /datum/antagonist/rev/greet()
@@ -733,6 +736,36 @@
 	gloves = /obj/item/clothing/gloves/color/black
 	l_hand = /obj/item/spear
 	r_hand = /obj/item/assembly/flash
+
+//MONKE
+/atom/movable/screen/alert/status_effect/agent_pinpointer/hunt_command
+	name = "Hunt Command"
+	desc = "You have an odd sense where command is."
+
+
+/datum/status_effect/agent_pinpointer/hunt_command
+	id = "agent_pinpointer"
+	alert_type = /atom/movable/screen/alert/status_effect/agent_pinpointer/hunt_command
+	//minimum_range = HUNTER_MINIMUM_RANGE
+	//tick_interval = HUNTER_PING_TIME
+	//duration = STATUS_EFFECT_PERMANENT
+	//range_fuzz_factor = HUNTER_FUZZ_FACTOR
+
+///Attempting to locate a nearby target to scan and point towards.
+/datum/status_effect/agent_pinpointer/hunt_command/scan_for_target()
+
+	scan_target = null
+	if(!owner && !owner.mind)
+		return
+	var/dist = 1000
+	var/mob/living/command
+	for(var/mob/living/located as anything in SSjob.get_all_heads())
+		if(get_dist(owner, located) < dist && considered_alive(located.mind))
+			dist = get_dist(owner, located)
+			command = located
+	if(QDELETED(command))
+		return
+	scan_target = command
 
 #undef DECONVERTER_REVS_WIN
 #undef DECONVERTER_STATION_WIN

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -758,14 +758,17 @@
 	if(!owner && !owner.mind)
 		return
 	var/dist = 1000
-	var/mob/living/command
-	for(var/mob/living/located as anything in SSjob.get_all_heads())
-		if(get_dist(owner, located) < dist && considered_alive(located.mind))
-			dist = get_dist(owner, located)
-			command = located
-	if(QDELETED(command))
+	var/mob/living/body
+	var/mob/living/target
+	var/list/heads_list = SSjob.get_all_heads()
+	for(var/datum/mind/command_mind as anything in heads_list)
+		body = command_mind.current
+		if(get_dist(owner, body) < dist && considered_alive(command_mind))
+			dist = get_dist(owner, body)
+			target = body
+	if(QDELETED(body))
 		return
-	scan_target = command
+	scan_target = target
 
 #undef DECONVERTER_REVS_WIN
 #undef DECONVERTER_STATION_WIN


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Attempts to fix revolution by fixing some of the issues inherent in the antag, while preserving the "spirit" of the antagonist being a violent crew uprising against command.
Finished:
-Giving revolutionaries
## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Revs are fun but have some issues that need to be fixed.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Revolutionaries now have a pinpointer towards the nearest command member.
config: Enables Revolution
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
