### PR TITLE
Fixes issue #4664 by moving up sleep infliction in order

### DIFF
--- a/monkestation/code/datums/quirks/negative_quirks/stowaway.dm
+++ b/monkestation/code/datums/quirks/negative_quirks/stowaway.dm
@@ -7,7 +7,6 @@
 
 /datum/quirk/stowaway/add_unique()
 	var/mob/living/carbon/human/stowaway = quirk_holder
-	stowaway.Sleeping(5 SECONDS)
 	var/obj/item/card/id/trashed = stowaway.get_item_by_slot(ITEM_SLOT_ID) //No ID
 	qdel(trashed)
 
@@ -20,6 +19,7 @@
 	var/obj/structure/closet/selected_closet = get_unlocked_closed_locker() //Find your new home
 	if(selected_closet)
 		stowaway.forceMove(selected_closet) //Move in
+		stowaway.Sleeping(5 SECONDS)
 
 /datum/quirk/stowaway/post_add()
 	to_chat(quirk_holder, span_boldnotice("You've awoken to find yourself inside [GLOB.station_name] without real identification!"))


### PR DESCRIPTION
## About The Pull Request
Should fix issue #4664
the reasoning i gathered for the sleep was a flavorful way to hide the code working in game, but it seems about the same when i change it to this outside of the bugfix deal working, at least on localhost

## Why It's Good For The Game
The bug zoops away some of your possible starting equipment to where you would have spawned if you weren't a stowaway, which PROBABLY isn't intended

## Changelog
:cl:
fix: Stowaway's inhand starting equipment now is moved to their starting point with them correctly.
/:cl: