### PR TITLE
Removes Stolen CC Clothes and Paperwork Guys Inventory Update

### DIFF
--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -58,6 +58,8 @@
 	backpack_contents = list(
 		/obj/item/melee/baton/telescopic = 1,
 		/obj/item/storage/box/ids = 1,
+		/obj/item/stamp = 1,
+		/obj/item/stamp/denied = 1,
 		)
 	belt = /obj/item/storage/belt/sabre/cargo
 	l_pocket = /obj/item/modular_computer/pda/heads/hop

--- a/code/modules/jobs/job_types/head_of_personnel.dm
+++ b/code/modules/jobs/job_types/head_of_personnel.dm
@@ -59,7 +59,8 @@
 		/obj/item/melee/baton/telescopic = 1,
 		/obj/item/storage/box/ids = 1,
 		)
-	belt = /obj/item/modular_computer/pda/heads/hop
+	belt = /obj/item/storage/belt/sabre/cargo
+	l_pocket = /obj/item/modular_computer/pda/heads/hop
 	ears = /obj/item/radio/headset/heads/hop
 	head = /obj/item/clothing/head/hats/hopcap
 	shoes = /obj/item/clothing/shoes/laceup

--- a/monkestation/code/game/objects/structures/crates_lockers/closets/secure/nanotrasen_rep.dm
+++ b/monkestation/code/game/objects/structures/crates_lockers/closets/secure/nanotrasen_rep.dm
@@ -6,7 +6,6 @@
 
 /obj/structure/closet/secure_closet/nanotrasen_representative/PopulateContents()
 	..()
-	new /obj/item/storage/bag/garment/stolen(src)
 	new /obj/item/storage/backpack/satchel/leather(src)
 	new /obj/item/storage/photo_album/personal(src)
 	new /obj/item/assembly/flash(src)

--- a/monkestation/code/modules/NTrep/clothing/NTrep_clothing.dm
+++ b/monkestation/code/modules/NTrep/clothing/NTrep_clothing.dm
@@ -77,16 +77,5 @@
 	new /obj/item/clothing/gloves/color/black(src)
 	new /obj/item/clothing/shoes/laceup(src)
 
-/obj/item/storage/bag/garment/stolen
-	name = "stolen garment bag"
-	desc = "Somewhere a CentCom commander is livid about their drycleaning going missing."
-
-/obj/item/storage/bag/garment/stolen/PopulateContents()
-	new /obj/item/clothing/head/hats/centhat(src)
-	new /obj/item/clothing/under/rank/centcom/commander(src)
-	new /obj/item/clothing/suit/armor/centcom_formal(src)
-	new /obj/item/clothing/gloves/tackler/combat(src)
-	new /obj/item/clothing/shoes/laceup(src)
-
 
 

--- a/monkestation/code/modules/blueshift/structures/locker.dm
+++ b/monkestation/code/modules/blueshift/structures/locker.dm
@@ -24,7 +24,6 @@
 
 /obj/structure/closet/secure_closet/nanotrasen_consultant/PopulateContents()
 	..()
-	new /obj/item/storage/bag/garment/stolen(src)
 	new /obj/item/storage/backpack/satchel/leather(src)
 	new /obj/item/storage/photo_album/personal(src)
 	new /obj/item/assembly/flash(src)

--- a/monkestation/code/modules/jobs/job_types/nanotrasen_representative.dm
+++ b/monkestation/code/modules/jobs/job_types/nanotrasen_representative.dm
@@ -71,7 +71,8 @@
 		/obj/item/melee/baton/telescopic = 1,
 		/obj/item/folder/blue = 1,
 	)
-	belt = /obj/item/gun/energy/laser/plasmacore
+	belt = /obj/item/storage/belt/sabre/cargo
+	back = /obj/item/gun/energy/laser/plasmacore
 	shoes = /obj/item/clothing/shoes/laceup
 	r_pocket = /obj/item/modular_computer/pda/heads/ntrep
 	l_hand = /obj/item/storage/secure/briefcase/cash

--- a/monkestation/code/modules/jobs/job_types/nanotrasen_representative.dm
+++ b/monkestation/code/modules/jobs/job_types/nanotrasen_representative.dm
@@ -70,9 +70,9 @@
 		/obj/item/stamp/centcom = 1,
 		/obj/item/melee/baton/telescopic = 1,
 		/obj/item/folder/blue = 1,
+		/obj/item/gun/energy/laser/plasmacore = 1,
 	)
 	belt = /obj/item/storage/belt/sabre/cargo
-	back = /obj/item/gun/energy/laser/plasmacore
 	shoes = /obj/item/clothing/shoes/laceup
 	r_pocket = /obj/item/modular_computer/pda/heads/ntrep
 	l_hand = /obj/item/storage/secure/briefcase/cash


### PR DESCRIPTION
## About The Pull Request

I have heard a recurring issue with NT Reps is that they try to act like a captain when they very much should not. Having admin only CC gear does not help with this, and should be removed to help stem "command rep"

While I was going through it, I decided to compensate for the loss of drip/armor by giving them a cool sword. Swords are cool, and make up for the lost style.

I figured I should give the HoP one too (it looks cool), and also gave them approved/denied stamps in their backpack, since they aren't on every map and the HoP not having them is very silly. Also ensures in the case of overflow on a map that *does* have them that they can always do the paperwork :)

## Why It's Good For The Game

Helps stem "Command Rep", and removes admin only gear from NT Rep's locker to prevent confusion.

Swords feel fitting on them and HoP, so they both get one

HoP gets approved/denied stamps, basically required for the job and it not being something they get by default in some cases is absurd

## Changelog

:cl:
del: Removed NT Rep stolen CC admiral clothing bag
add: Added a roundstart sword to NT Rep and HoP
add: Added roundstart stamps to the HoP's bag
change: Moved NT Rep's gun to their bag roundstart
/:cl:
