### PR TITLE
Removes CC comms from blueshield and rep

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -368,6 +368,14 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	worn_icon_state = "cent_headset_alt"
 	keyslot2 = null
 
+//monkestation addition start:
+/obj/item/radio/headset/headset_cent/representative
+	name = "\improper Representative headset"
+	desc = "A headset used by the lower ranking members of Central Command."
+	keyslot = /obj/item/encryptionkey/headset_com
+	keyslot2 = null
+//monkestation addition end
+
 /obj/item/radio/headset/headset_cent/alt/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))

--- a/monkestation/code/modules/blueshield/clothing.dm
+++ b/monkestation/code/modules/blueshield/clothing.dm
@@ -209,7 +209,7 @@
 	icon_state = "bshield_headset"
 	worn_icon_state = "bshield_headset"
 	keyslot = /obj/item/encryptionkey/heads/blueshield
-	keyslot2 = /obj/item/encryptionkey/headset_cent
+	keyslot2 = null
 
 /obj/item/radio/headset/headset_bs/alt
 	name = "\proper the blueshield's bowman headset"

--- a/monkestation/code/modules/jobs/job_types/nanotrasen_representative.dm
+++ b/monkestation/code/modules/jobs/job_types/nanotrasen_representative.dm
@@ -76,7 +76,7 @@
 	r_pocket = /obj/item/modular_computer/pda/heads/ntrep
 	l_hand = /obj/item/storage/secure/briefcase/cash
 	glasses = /obj/item/clothing/glasses/sunglasses
-	ears = /obj/item/radio/headset/headset_cent
+	ears = /obj/item/radio/headset/headset_cent/representative
 	gloves = /obj/item/clothing/gloves/color/black
 	shoes = /obj/item/clothing/shoes/laceup
 


### PR DESCRIPTION

## About The Pull Request
Title
## Why It's Good For The Game
CC comms was never designed with it being accessible to non-admin roles, being able to bypass several restrictions normal comms would have and being able to eavesdrop on admin communication. If admins want the rep/blueshield to have CC comms for some kind of event, they can send them a pod with the encryption key for it.
## Changelog
:cl:
del: Removed CC comms from the blueshield and nanotrasen representative
/:cl:
