### PR TITLE
Ghost can no longer trigger kudzu painting.,

### DIFF
--- a/code/modules/antagonists/heretic/items/eldritch_painting.dm
+++ b/code/modules/antagonists/heretic/items/eldritch_painting.dm
@@ -175,7 +175,7 @@
 
 /obj/structure/sign/painting/eldritch/vines/examine_effects(mob/living/carbon/examiner)
 	. = ..()
-	if(!IS_HERETIC(examiner))
+	if(!IS_HERETIC(examiner) && iscarbon(examiner))
 		new /datum/spacevine_controller(get_turf(examiner), mutations, 0, 10)
 		to_chat(examiner, span_notice("The thicket crawls through the frame, and you suddenly find vines beneath you..."))
 		return

--- a/code/modules/antagonists/heretic/items/eldritch_painting.dm
+++ b/code/modules/antagonists/heretic/items/eldritch_painting.dm
@@ -175,7 +175,9 @@
 
 /obj/structure/sign/painting/eldritch/vines/examine_effects(mob/living/carbon/examiner)
 	. = ..()
-	if(!IS_HERETIC(examiner) && iscarbon(examiner))
+	if(!iscarbon(examiner))
+		return
+	if(!IS_HERETIC(examiner))
 		new /datum/spacevine_controller(get_turf(examiner), mutations, 0, 10)
 		to_chat(examiner, span_notice("The thicket crawls through the frame, and you suddenly find vines beneath you..."))
 		return


### PR DESCRIPTION

## About The Pull Request
Title
Ghost can no longer inspect the heretic kudzu painting to spawn kudzu where-ever they currently are.

## Why It's Good For The Game
Fixes bug
Ghost can inspect it at long ranges and through walls constantly spawning kudzu in terrible spots.

## Changelog

:cl:
fix: ghost can no longer spawn kudzu via heretic painting
/:cl:

