### PR TITLE
Tells you the amount of donator tokens

### DIFF
--- a/monkestation/code/modules/client/verbs.dm
+++ b/monkestation/code/modules/client/verbs.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(antag_token_config, load_antag_token_config())
 	var/tier = tgui_input_list(src, "High: [client_token_holder.total_high_threat_tokens] | \
 									Med: [client_token_holder.total_medium_threat_tokens] | \
 									Low: [client_token_holder.total_low_threat_tokens] | \
-									Donator: [client_token_holder.donator_token ? "Yes" : "No"]", "Choose A Tier To Spend", list(HIGH_THREAT, MEDIUM_THREAT, LOW_THREAT))
+									Donator: [client_token_holder.donator_token]", "Choose A Tier To Spend", list(HIGH_THREAT, MEDIUM_THREAT, LOW_THREAT))
 	if(!tier)
 		return
 


### PR DESCRIPTION

## About The Pull Request
Changes the antag token menu to tell you how many donator tokens you have instead of a yes/no
## Why It's Good For The Game
We made it so donator tokens save between months some time ago, so telling players how many they have is better than just saying whether they have any or none
## Changelog
:cl:
qol: The antag token menu will now tell you how many donator tokens you have
/:cl:
