### PR TITLE
Reduces BSA crystal price

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -23,7 +23,7 @@
 	greyscale_colors = CIRCUIT_COLOR_COMMAND
 	build_path = /obj/machinery/bsa/middle
 	req_components = list(
-		/obj/item/stack/ore/bluespace_crystal = 20,
+		/obj/item/stack/ore/bluespace_crystal = 10,
 		/obj/item/stack/cable_coil = 2)
 
 /obj/item/circuitboard/machine/dna_vault


### PR DESCRIPTION

## About The Pull Request
Reduces the amount of BS crystals needed for the BSA from 20 to 10
## Why It's Good For The Game
This project is rarely ever finished, partly due to how expensive the machine parts are. While the manipulators and capacitors are somewhat hard to get, 20 BS crystals is incredibly expensive, especially when considering the rest of the crew will also use those crystals. This will hopefully make this project completed more often with it being too easy to build.
## Changelog
:cl:
balance: The BSA now requires only 10 BS crystals, down from 20
/:cl:
