### PR TITLE
[PORT] Changes mob height from getter -> updater

### DIFF
--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -86,7 +86,7 @@
 			if(ismob(loc))
 				if(ishuman(loc))
 					var/mob/living/carbon/human/user = loc
-					hat_adding.pixel_y -= GLOB.human_heights_to_offsets[num2text(user.get_mob_height())][1]
+					hat_adding.pixel_y -= GLOB.human_heights_to_offsets[num2text(user.mob_height)][1]
 			hat_adding.pixel_x = (rand(-1, 1))
 			current_hat++
 			. += hat_adding

--- a/code/modules/mob/living/carbon/carbon_update_icons.dm
+++ b/code/modules/mob/living/carbon/carbon_update_icons.dm
@@ -516,7 +516,7 @@
 		. += "-[jointext(overlay.generate_icon_cache(), "-")]"
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_owner = owner
-		. += "-[human_owner.get_mob_height()]"
+		. += "-[human_owner.mob_height]"
 	return .
 
 ///Generates a cache key specifically for husks
@@ -528,7 +528,7 @@
 	. += "-[body_zone]"
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_owner = owner
-		. += "-[human_owner.get_mob_height()]"
+		. += "-[human_owner.mob_height]"
 	return .
 
 /obj/item/bodypart/head/generate_icon_key()

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1931,3 +1931,14 @@ GLOBAL_LIST_EMPTY(features_by_species)
 
 /datum/species/proc/spec_revival(mob/living/carbon/human/H)
 	return
+
+/**
+ * Calculates the expected height values for this species
+ *
+ * Return a height value corresponding to a specific height filter
+ * Return null to just use the mob's base height
+ */
+/datum/species/proc/update_species_heights(mob/living/carbon/human/holder)
+	if(HAS_TRAIT(holder, TRAIT_DWARF))
+		return HUMAN_HEIGHT_DWARF
+	return null

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -729,31 +729,13 @@
 
 /mob/living/carbon/human/vv_edit_var(var_name, var_value)
 	if(var_name == NAMEOF(src, mob_height))
-		var/static/list/monkey_heights = list(
-			MONKEY_HEIGHT_DWARF,
-			MONKEY_HEIGHT_MEDIUM,
-		)
-		var/static/list/heights = list(
-			HUMAN_HEIGHT_SHORTEST,
-			HUMAN_HEIGHT_SHORT,
-			HUMAN_HEIGHT_MEDIUM,
-			HUMAN_HEIGHT_TALL,
-			HUMAN_HEIGHT_TALLER,
-			HUMAN_HEIGHT_TALLEST
-		)
-		if(ismonkey(src))
-			if(!(var_value in monkey_heights))
-				return
-		else if(!(var_value in heights))
-			return
-
-		. = set_mob_height(var_value)
-
-	if(!isnull(.))
-		datum_flags |= DF_VAR_EDITED
-		return
-
-	return ..()
+		// you wanna edit this one not that one
+		var_name = NAMEOF(src, base_mob_height)
+	. = ..()
+	if(!.)
+		return .
+	if(var_name == NAMEOF(src, base_mob_height))
+		update_mob_height()
 
 /mob/living/carbon/human/vv_get_dropdown()
 	. = ..()

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -86,5 +86,7 @@
 	/// When an braindead player has their equipment fiddled with, we log that info here for when they come back so they know who took their ID while they were DC'd for 30 seconds
 	var/list/afk_thefts
 
-	/// Height of the mob
-	VAR_PROTECTED/mob_height = HUMAN_HEIGHT_MEDIUM
+	/// Base height of the mob, modified by stuff like dwarfism or species
+	VAR_PRIVATE/base_mob_height = HUMAN_HEIGHT_MEDIUM
+	/// Actual height of the mob. Don't touch this one, it is set via update_mob_height()
+	VAR_FINAL/mob_height = HUMAN_HEIGHT_MEDIUM

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -254,39 +254,25 @@
 			preference.apply_to_human(src, preference.create_random_value(preferences))
 
 /**
- * Setter for mob height
+ * Setter for mob height - updates the base height of the mob (which is then adjusted by traits or species)
  *
  * Exists so that the update is done immediately
  *
  * Returns TRUE if changed, FALSE otherwise
  */
 /mob/living/carbon/human/proc/set_mob_height(new_height)
-	if(mob_height == new_height)
-		return FALSE
-	if(new_height == HUMAN_HEIGHT_DWARF || new_height == MONKEY_HEIGHT_DWARF)
-		CRASH("Don't set height to dwarf height directly, use dwarf trait instead.")
-	if(new_height == MONKEY_HEIGHT_MEDIUM)
-		CRASH("Don't set height to monkey height directly, use monkified gene/species instead.")
-
-	mob_height = new_height
-	regenerate_icons()
-	return TRUE
+	base_mob_height = new_height
+	update_mob_height()
 
 /**
- * Getter for mob height
+ * Updates the mob's height
  *
  * Mainly so that dwarfism can adjust height without needing to override existing height
  *
  * Returns a mob height num
  */
-/mob/living/carbon/human/proc/get_mob_height()
-	if(HAS_TRAIT(src, TRAIT_DWARF))
-		if(ismonkey(src))
-			return MONKEY_HEIGHT_DWARF
-		else
-			return HUMAN_HEIGHT_DWARF
-
-	else if(ismonkey(src))
-		return MONKEY_HEIGHT_MEDIUM
-
-	return mob_height
+/mob/living/carbon/human/proc/update_mob_height()
+	var/old_height = mob_height
+	mob_height = dna?.species?.update_species_heights(src) || base_mob_height
+	if(old_height != mob_height)
+		regenerate_icons()

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -885,8 +885,8 @@ generate/load female uniform sprites matching all previously decided variables
 /mob/living/carbon/human/apply_overlay(cache_index)
 	/* MONKESTATION EDIT: made it so that MUTATIONS_LAYER and FRONT_MUTATIONS_LAYER always get their filters updated
 		This is required because they use cached / shared appearences
-	if(get_mob_height() == HUMAN_HEIGHT_MEDIUM) - original */
-	if(get_mob_height() == HUMAN_HEIGHT_MEDIUM && cache_index != MUTATIONS_LAYER && cache_index != FRONT_MUTATIONS_LAYER)
+	if(mob_height == HUMAN_HEIGHT_MEDIUM) - original */
+	if(mob_height == HUMAN_HEIGHT_MEDIUM && cache_index != MUTATIONS_LAYER && cache_index != FRONT_MUTATIONS_LAYER)
 		return ..()
 
 	var/raw_applied = overlays_standing[cache_index]
@@ -914,7 +914,7 @@ generate/load female uniform sprites matching all previously decided variables
  * higher up things (hats for example) need to be offset more due to the location of the filter displacement
  */
 /mob/living/carbon/human/proc/apply_height_offsets(image/appearance, upper_torso)
-	var/height_to_use = num2text(get_mob_height())
+	var/height_to_use = num2text(mob_height)
 	var/final_offset = 0
 	switch(upper_torso)
 		if(UPPER_BODY)
@@ -981,7 +981,7 @@ generate/load female uniform sprites matching all previously decided variables
 		"Monkey_Gnome_Cut_Legs",
 	), update = FALSE) // note: the add_filter(s) calls after this will call update_filters on their own. so by not calling it here, we avoid calling it twice.
 
-	switch(get_mob_height())
+	switch(mob_height)
 		// Don't set this one directly, use TRAIT_DWARF
 		if(MONKEY_HEIGHT_DWARF)
 			appearance.add_filters(list(

--- a/code/modules/mob/living/carbon/human/init_signals.dm
+++ b/code/modules/mob/living/carbon/human/init_signals.dm
@@ -17,8 +17,7 @@
 /mob/living/carbon/human/proc/on_dwarf_trait(datum/source)
 	SIGNAL_HANDLER
 
-	// We need to regenerate everything for height
-	regenerate_icons()
+	update_mob_height()
 /* //Non-Modular change - Remove passtable from dwarves.
 	if(HAS_TRAIT(src, TRAIT_DWARF))
 		passtable_on(src, TRAIT_DWARF)

--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -67,12 +67,14 @@
 		passtable_on(human_who_gained_species, SPECIES_TRAIT)
 		human_who_gained_species.dna.add_mutation(/datum/mutation/human/race, MUT_NORMAL)
 		human_who_gained_species.dna.activate_mutation(/datum/mutation/human/race)
+	human_who_gained_species.update_mob_height()
 
 /datum/species/monkey/on_species_loss(mob/living/carbon/human/C)
 	. = ..()
 	if(give_monkey_species_effects)
 		passtable_off(C, SPECIES_TRAIT)
 		C.dna.remove_mutation(/datum/mutation/human/race)
+	C.update_mob_height()
 
 /datum/species/monkey/randomize_features(mob/living/carbon/human/human_mob)
 	randomize_external_organs(human_mob)
@@ -244,5 +246,10 @@
 
 /obj/item/organ/internal/brain/primate/get_attacking_limb(mob/living/carbon/human/target)
 	return owner.get_bodypart(BODY_ZONE_HEAD)
+
+/datum/species/monkey/update_species_heights(mob/living/carbon/human/holder)
+	if(HAS_TRAIT(holder, TRAIT_DWARF))
+		return MONKEY_HEIGHT_DWARF
+	return MONKEY_HEIGHT_MEDIUM
 
 #undef MONKEY_SPEC_ATTACK_BITE_MISS_CHANCE

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -871,7 +871,7 @@
 	var/breath_dir = breather.dir
 
 	var/list/particle_grav = list(0, 0.1, 0)
-	var/list/particle_pos = list(0, breather.get_mob_height() + 2, 0)
+	var/list/particle_pos = list(0, breather.mob_height + 2, 0)
 	if(breath_dir & NORTH)
 		particle_grav[2] = 0.2
 		breath_particle.rotation = pick(-45, 45)


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/88953

> `get_mob_height()` is called a lot a lot, and frequently ended up over-timing when it amounted to the same value 98% of the time.
> Instead we can defer it to only update when we actually change height, or when we pick up a trait or species that changes our height.
> 
> I also moved the monkey checks out. Made it into a species procs. I know species procs are lame but it seems fine unless we wanna tie to the monkey's chest or limbs or something.

## Why It's Good For The Game

better performance