### PR TITLE
Prevent keycard auth from lowering alert to red during delta alert and such

### DIFF
--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -49,6 +49,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 	data["waiting"] = waiting
 	data["auth_required"] = event_source ? event_source.event : 0
 	data["red_alert"] = (SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED) ? 1 : 0
+	data["can_set_alert"] = SSsecurity_level.current_security_level?.can_crew_change_alert
 	data["emergency_maint"] = GLOB.emergency_access
 	data["bsa_unlock"] = GLOB.bsa_unlock
 	return data
@@ -70,7 +71,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 
 	switch(action)
 		if("red_alert")
-			if(!event_source)
+			if(!event_source && SSsecurity_level.current_security_level?.can_crew_change_alert)
 				sendEvent(KEYCARD_RED_ALERT)
 				. = TRUE
 		if("emergency_maint")
@@ -157,7 +158,8 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 	deadchat_broadcast(" confirmed [event] at [span_name("[A2.name]")].", span_name("[confirmer]"), confirmer, message_type=DEADCHAT_ANNOUNCEMENT)
 	switch(event)
 		if(KEYCARD_RED_ALERT)
-			SSsecurity_level.set_level(SEC_LEVEL_RED)
+			if(SSsecurity_level.current_security_level?.can_crew_change_alert)
+				SSsecurity_level.set_level(SEC_LEVEL_RED)
 		if(KEYCARD_EMERGENCY_MAINTENANCE_ACCESS)
 			make_maint_all_access()
 		if(KEYCARD_BSA_UNLOCK)

--- a/tgui/packages/tgui/interfaces/KeycardAuth.jsx
+++ b/tgui/packages/tgui/interfaces/KeycardAuth.jsx
@@ -35,7 +35,7 @@ export const KeycardAuth = (props) => {
                       disabled={!data.can_set_alert}
                       tooltip={
                         !data.can_set_alert &&
-                        'The current alert cannot be overriden by the crew!'
+                        'The current security level cannot be changed by the crew.'
                       }
                       onClick={() => {
                         return act('red_alert');

--- a/tgui/packages/tgui/interfaces/KeycardAuth.jsx
+++ b/tgui/packages/tgui/interfaces/KeycardAuth.jsx
@@ -32,6 +32,7 @@ export const KeycardAuth = (props) => {
                     <Button
                       icon="exclamation-triangle"
                       fluid
+                      disabled={!data.can_set_alert}
                       onClick={() => {
                         return act('red_alert');
                       }}

--- a/tgui/packages/tgui/interfaces/KeycardAuth.jsx
+++ b/tgui/packages/tgui/interfaces/KeycardAuth.jsx
@@ -33,6 +33,10 @@ export const KeycardAuth = (props) => {
                       icon="exclamation-triangle"
                       fluid
                       disabled={!data.can_set_alert}
+                      tooltip={
+                        !data.can_set_alert &&
+                        'The current alert cannot be overriden by the crew!'
+                      }
                       onClick={() => {
                         return act('red_alert');
                       }}


### PR DESCRIPTION
## About The Pull Request

self-explanatory bugfix

## Changelog
:cl:
fix: Swiping for red alert when it's already delta alert or such will no longer lower the alert to red.
/:cl:
