### PR TITLE
Beepsky stuns are now closer to a stunbaton rather than an instant hardstun

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -51,6 +51,8 @@
 	///The department the secbot will deposit collected money into
 	var/payment_department = ACCOUNT_SEC
 
+	var/stamina_damage = 95 //3 hit stam crit from full, but they most likely wont be due to running a bit
+
 /mob/living/simple_animal/bot/secbot/beepsky
 	name = "Commander Beep O'sky"
 	desc = "It's Commander Beep O'sky! Officially the superior officer of all bots on station, Beepsky remains as humble and dedicated to the law as the day he was first fabricated."
@@ -329,15 +331,17 @@
 
 	if(harm)
 		weapon.attack(current_target, src)
+
+	// monkestation start: check shields and baton resistance, deal stamina damage
 	if(ishuman(current_target))
-		current_target.set_stutter(10 SECONDS)
-		current_target.Paralyze(100)
 		var/mob/living/carbon/human/human_target = current_target
-		threat = human_target.assess_threat(judgement_criteria, weaponcheck = CALLBACK(src, PROC_REF(check_for_weapons)))
+		if(human_target.check_shields(src, 0, "\the [name]", MELEE_ATTACK))
+			return
+	if(HAS_TRAIT(current_target, TRAIT_BATON_RESISTANCE))
+		current_target.stamina.adjust_to(-stamina_damage, current_target.stamina.maximum * 0.29)
 	else
-		current_target.Paralyze(100)
-		current_target.set_stutter(10 SECONDS)
-		threat = current_target.assess_threat(judgement_criteria, weaponcheck = CALLBACK(src, PROC_REF(check_for_weapons)))
+		current_target.stamina.adjust(-stamina_damage)
+	// monkestation end
 
 	log_combat(src, current_target, "stunned")
 	if(security_mode_flags & SECBOT_DECLARE_ARRESTS)

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -323,7 +323,7 @@
 		back_to_idle()
 
 /mob/living/simple_animal/bot/secbot/proc/stun_attack(mob/living/carbon/current_target, harm = FALSE)
-	var/judgement_criteria = judgement_criteria()
+	//var/judgement_criteria = judgement_criteria()
 	playsound(src, 'sound/weapons/egloves.ogg', 50, TRUE, -1)
 	icon_state = "[initial(icon_state)]-c"
 	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, update_appearance)), 0.2 SECONDS)


### PR DESCRIPTION
## About The Pull Request

this makes it so beepsky's stun attack is practically identical to a normal stunbaton (albeit one with unlimited charge), including allowing the target to block it if they have a shield or something.

## Why It's Good For The Game

beepsky is basically a stunbaton on wheels. they should act like a stunbaton.

sec should have to arrest people themselves, rather than relying on a batong taped to a toaster.

## Changelog
:cl:
balance: Securitrons/Beepsky now only deal stamina damage instead of instantly hardstunning someone.
balance: Having baton resistance now also provides resistance against beepsky.
balance: Beepsky can now be blocked/parried with shields and such.
/:cl:
