### PR TITLE
[PORT] Removes the arbitrary limit of 10 maximum chat highlights

### DIFF
--- a/tgui/packages/tgui-panel/settings/SettingsPanel.jsx
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.jsx
@@ -14,11 +14,12 @@ import {
   Collapsible,
   ColorBox,
   Divider,
-  Stack,
+  Icon,
   Input,
   LabeledList,
   NumberInput,
   Section,
+  Stack,
   Tabs,
   TextArea,
 } from 'tgui/components';
@@ -32,7 +33,7 @@ import {
   removeHighlightSetting,
   updateHighlightSetting,
 } from './actions';
-import { SETTINGS_TABS, FONTS, MAX_HIGHLIGHT_SETTINGS } from './constants';
+import { SETTINGS_TABS, FONTS, WARN_AFTER_HIGHLIGHT_AMT } from './constants';
 import {
   selectActiveTab,
   selectSettings,
@@ -236,8 +237,8 @@ const TextHighlightSettings = (props, context) => {
             mb={i + 1 === highlightSettings.length ? 0 : '10px'}
           />
         ))}
-        {highlightSettings.length < MAX_HIGHLIGHT_SETTINGS && (
-          <Stack.Item>
+        <Stack.Item>
+          <Box>
             <Button
               color="transparent"
               icon="plus"
@@ -246,8 +247,15 @@ const TextHighlightSettings = (props, context) => {
                 dispatch(addHighlightSetting());
               }}
             />
-          </Stack.Item>
-        )}
+            {highlightSettings.length >= WARN_AFTER_HIGHLIGHT_AMT && (
+              <Box inline fontSize="0.9em" ml={1} color="red">
+                <Icon mr={1} name="triangle-exclamation" />
+                Large amounts of highlights can potentially cause performance
+                issues!
+              </Box>
+            )}
+          </Box>
+        </Stack.Item>
       </Stack>
       <Divider />
       <Box>

--- a/tgui/packages/tgui-panel/settings/constants.js
+++ b/tgui/packages/tgui-panel/settings/constants.js
@@ -36,4 +36,4 @@ export const FONTS = [
   'Lucida Console',
 ];
 
-export const MAX_HIGHLIGHT_SETTINGS = 10;
+export const WARN_AFTER_HIGHLIGHT_AMT = 10;

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -15,7 +15,7 @@ import {
   updateHighlightSetting,
 } from './actions';
 import { createDefaultHighlightSetting } from './model';
-import { SETTINGS_TABS, FONTS, MAX_HIGHLIGHT_SETTINGS } from './constants';
+import { SETTINGS_TABS, FONTS } from './constants';
 
 const defaultHighlightSetting = createDefaultHighlightSetting();
 
@@ -119,9 +119,6 @@ export const settingsReducer = (state = initialState, action) => {
   }
   if (type === addHighlightSetting.type) {
     const highlightSetting = payload;
-    if (state.highlightSettings.length >= MAX_HIGHLIGHT_SETTINGS) {
-      return state;
-    }
     return {
       ...state,
       highlightSettings: [...state.highlightSettings, highlightSetting.id],


### PR DESCRIPTION

## About The Pull Request

Ports my own upstream PR, https://github.com/tgstation/tgstation/pull/89166

> this removes the arbitrary maximum of 10 chat highlights. no clue why this was limited in the first place.

![2025-01-25 (1737860821) ~ dreamseeker](https://github.com/user-attachments/assets/25b5d70c-65fc-43de-90b4-def0056b0b78)

## Why It's Good For The Game

> it is my god-given right to have a morbillion chat highlights and make IE on my own computer slow to a crawl doing so

## Changelog
:cl:
qol: Removed the arbitrary limit of 10 maximum chat highlights.
/:cl:
