### PR TITLE
Blueshift Balance Pass

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -70865,11 +70865,9 @@
 "nNn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/contraband/narcotics,
-/obj/effect/spawner/random/sakhno,
 /obj/structure/safe{
 	name = "stinking safe"
 	},
-/obj/effect/spawner/random/sakhno/ammo,
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/department/medical/central)
 "nNt" = (
@@ -82628,7 +82626,6 @@
 /obj/structure/safe/floor{
 	name = "frozen safe"
 	},
-/obj/item/hilbertshotel,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "qaV" = (
@@ -110246,7 +110243,6 @@
 	name = "glowing safe"
 	},
 /obj/item/book/granter/crafting_recipe/trash_cannon,
-/obj/item/gun/ballistic/rifle/boltaction/pipegun/prime,
 /obj/item/book/granter/crafting_recipe/maint_gun/pipegun_prime,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
@@ -165520,9 +165516,9 @@ aRP
 mhN
 jtX
 mjE
-jxo
-jxo
-jxo
+cLX
+cLX
+cLX
 cLX
 rKX
 rHQ
@@ -168363,9 +168359,9 @@ cLX
 cLX
 cLX
 cLX
-tnw
-tnw
-tnw
+wPS
+wPS
+wPS
 wPS
 hrK
 ldF

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -37407,6 +37407,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "hkb" = (
@@ -70838,6 +70841,9 @@
 	pixel_y = 13
 	},
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/recharger{
+	pixel_y = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "nMW" = (


### PR DESCRIPTION
## About The Pull Request

Apparently, missed some things when being balanced in the first place.

## Why It's Good For The Game

Restores perfect balance. As all things should be.

## Changelog
:cl:
balance: Blueshift: all prison 'exterior' walls are now properly rwalls.
balance: Blueshift: Removed several items that were comically easy to get and ruin the balance of the map.
balance: Blueshift: added two additional chargers to sec's meeting room as there is a comically short number of available chargers outside of the armory for officers to use while in the brig.
/:cl:
