### PR TITLE
Gary no longer randomly dies for seemingly no reason

### DIFF
--- a/monkestation/code/modules/ranching/chickens/misc/gary.dm
+++ b/monkestation/code/modules/ranching/chickens/misc/gary.dm
@@ -57,6 +57,9 @@
 	. = ..()
 	Write_Memory(TRUE)
 
+/mob/living/basic/chicken/gary/unhappy_death()
+	return
+
 /mob/living/basic/chicken/gary/proc/drop_held_item()
 	if(QDELETED(held_item))
 		return


### PR DESCRIPTION

## About The Pull Request

Gary no longer dies from unhappiness - he's only a chicken subtype for code reasons, and likely isn't meant to die from unhappiness. Plus, people picking up anything from his stash pisses him off a bit, which would contribute to him dying for seemingly no reason.

## Why It's Good For The Game

bugfix

## Changelog
:cl:
fix: Gary no longer randomly dies for seemingly no reason.
/:cl:
