### PR TITLE
[PORT] fix: add support for multibyte chars for `truncate`, `stripped_input`, `tgui_input_text`

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -123,7 +123,7 @@
 	if(isnull(user_input)) // User pressed cancel
 		return
 	if(no_trim)
-		return copytext(html_encode(user_input), 1, max_length)
+		return copytext_char(html_encode(user_input), 1, max_length)
 	else
 		return trim(html_encode(user_input), max_length) //trim is "outside" because html_encode can expand single symbols into multiple symbols (such as turning < into &lt;)
 
@@ -142,7 +142,7 @@
 	if(isnull(user_input)) // User pressed cancel
 		return
 	if(no_trim)
-		return copytext(html_encode(user_input), 1, max_length)
+		return copytext_char(html_encode(user_input), 1, max_length)
 	else
 		return trim(html_encode(user_input), max_length)
 
@@ -324,7 +324,7 @@
  */
 /proc/truncate(text, max_length)
 	if(length(text) > max_length)
-		return copytext(text, 1, max_length)
+		return copytext_char(text, 1, max_length)
 	return text
 
 //Returns a string with reserved characters and spaces before the first word and after the last word removed.

--- a/code/modules/tgui_input/text.dm
+++ b/code/modules/tgui_input/text.dm
@@ -132,9 +132,9 @@
 	switch(action)
 		if("submit")
 			if(max_length)
-				if(length(params["entry"]) > max_length)
+				if(length_char(params["entry"]) > max_length)
 					CRASH("[usr] typed a text string longer than the max length")
-				if(encode && (length(html_encode(params["entry"])) > max_length))
+				if(encode && (length_char(html_encode(params["entry"])) > max_length))
 					to_chat(usr, span_notice("Your message was clipped due to special character usage."))
 			set_entry(params["entry"])
 			closed = TRUE


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/85313

> Add support for multibyte chars for `truncate`, `stripped_input`, `tgui_input_text`.
> 
> Right now, on UI of `tgui_input_text` chars are counted, but on back-end - bytes. So I made it consistent. Also fixed that for `stripped_input`, which is used in case of disabled `tgui input`.
> While I was here, made `truncate` proc consistent too

## Why It's Good For The Game

> Tgui text input won't lie about the size of input

## Changelog

N/A