### PR TITLE
Makes advanced factories possible -- Bunch of changes to mech component and the assembler

### DIFF
--- a/monkestation/code/modules/bloodsuckers/structures/bloodsucker_recipes.dm
+++ b/monkestation/code/modules/bloodsuckers/structures/bloodsucker_recipes.dm
@@ -112,12 +112,3 @@
 	time = 8 SECONDS
 	category = CAT_WEAPON_MELEE
 	always_available = FALSE
-
-/datum/crafting_recipe/coffin
-	name = "Coffin"
-	result = /obj/structure/closet/crate/coffin
-	reqs = list(
-		/obj/item/stack/sheet/mineral/wood = 5,
-	)
-	time = 15 SECONDS
-	category = CAT_STRUCTURE

--- a/monkestation/code/modules/factory_type_beat/machinery/assembler.dm
+++ b/monkestation/code/modules/factory_type_beat/machinery/assembler.dm
@@ -13,7 +13,6 @@
 	icon = 'monkestation/code/modules/factory_type_beat/icons/mining_machines.dmi'
 	icon_state = "assembler"
 
-
 /obj/machinery/assembler/Initialize(mapload)
 	. = ..()
 

--- a/monkestation/code/modules/mech_comp/objects/_object.dm
+++ b/monkestation/code/modules/mech_comp/objects/_object.dm
@@ -15,6 +15,7 @@
 	configs = list()
 	inputs = list()
 	update_icon_state()
+	register_context()
 
 	MC_ADD_CONFIG(MC_CFG_LINK, add_linker)
 	MC_ADD_CONFIG(MC_CFG_UNLINK, unlink)
@@ -28,6 +29,17 @@
 	. = ..()
 	. += span_notice("You can left-click with a multitool to put up a list of options available for linking.")
 	. += span_notice("You can right-click with a multitool to quickly start linking the device as an output.")
+
+/obj/item/mcobject/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	. = ..()
+	if(isnull(held_item) || held_item.tool_behaviour != TOOL_MULTITOOL)
+		return NONE
+
+	context[SCREENTIP_CONTEXT_LMB] = "View available operations"
+	if(anchored)
+		context[SCREENTIP_CONTEXT_RMB] = "Start linking"
+
+	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/item/mcobject/update_icon_state()
 	. = ..()

--- a/monkestation/code/modules/mech_comp/objects/_object.dm
+++ b/monkestation/code/modules/mech_comp/objects/_object.dm
@@ -16,13 +16,18 @@
 	inputs = list()
 	update_icon_state()
 
-	MC_ADD_CONFIG(MC_CFG_UNLINK_ALL, unlink_all)
-	MC_ADD_CONFIG(MC_CFG_UNLINK, unlink)
 	MC_ADD_CONFIG(MC_CFG_LINK, add_linker)
+	MC_ADD_CONFIG(MC_CFG_UNLINK, unlink)
+	MC_ADD_CONFIG(MC_CFG_UNLINK_ALL, unlink_all)
 
 /obj/item/mcobject/Destroy(force)
 	QDEL_NULL(interface)
 	return ..()
+
+/obj/item/mcobject/examine(mob/user)
+	. = ..()
+	. += span_notice("You can left-click with a multitool to put up a list of options available for linking.")
+	. += span_notice("You can right-click with a multitool to quickly start linking the device as an output.")
 
 /obj/item/mcobject/update_icon_state()
 	. = ..()
@@ -63,6 +68,14 @@
 		return
 
 	call(src, configs[action])(user, tool)
+
+/obj/item/mcobject/multitool_act_secondary(mob/living/user, obj/item/tool)
+	var/datum/component/mclinker/link = tool.GetComponent(/datum/component/mclinker)
+	if(link)
+		to_chat(user, span_warning("Previous link deleted."))
+		qdel(link)
+
+	add_linker(user, tool)
 
 /obj/item/mcobject/proc/unlink(mob/user, obj/item/tool)
 	var/list/options = list()

--- a/monkestation/code/modules/mech_comp/objects/interactor.dm
+++ b/monkestation/code/modules/mech_comp/objects/interactor.dm
@@ -12,6 +12,8 @@
 	var/mob/living/carbon/human/dummy/dummy_human
 	///image of the held item displayed over the component to see whats going on
 	var/obj/item/held_item
+	///The object we specifically look for when clicking
+	var/atom/desired_path = null
 	///the connected storage component to act as an inventory to grab from
 	var/obj/item/mcobject/messaging/storage/connected_storage
 	///the current stored direction used for interaction
@@ -24,6 +26,7 @@
 	MC_ADD_CONFIG("Swap Click", swap_click)
 	MC_ADD_CONFIG("Swap Range", set_range)
 	MC_ADD_CONFIG("Change Direction", change_dir)
+	MC_ADD_CONFIG("Reset Desired Object", reset_desired_path)
 	MC_ADD_INPUT("swap click", swap_click_input)
 	MC_ADD_INPUT("replace", replace_from_storage)
 	MC_ADD_INPUT("drop", drop)
@@ -43,14 +46,32 @@
 	QDEL_NULL(dummy_human)
 	return ..()
 
+/obj/item/mcobject/examine(mob/user)
+	. = ..()
+	. += span_notice("You can right-click with a multitool whilst having a storage component in your buffer to link it.")
+	. += span_notice("You can drag [src] over an object whilst you're adjacent to both [src] and the object to make it only click objects of the same type as it.")
+
 /obj/item/mcobject/interactor/multitool_act_secondary(mob/living/user, obj/item/tool)
 	var/obj/item/multitool/multitool = tool
 	if(!multitool.component_buffer)
-		return
+		return ..()
 	if(!istype(multitool.component_buffer, /obj/item/mcobject/messaging/storage))
-		return
+		return ..()
 	connected_storage = multitool.component_buffer
 	say("Successfully linked to storage component")
+
+/obj/item/mcobject/interactor/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params)
+	. = ..()
+	if(!over || !istype(over) || over == src)
+		return
+
+	var/mob/living/carbon/human/user = usr
+	if(!istype(user))
+		return
+
+	if(Adjacent(user, src) && Adjacent(over, user))
+		say("Desired object set to [over]")
+		desired_path = over.type
 
 /obj/item/mcobject/interactor/proc/drop(datum/mcmessage/input)
 	if(!input)
@@ -110,6 +131,11 @@
 	stored_dir = directions_listed[direction_choice]
 	return TRUE
 
+/obj/item/mcobject/interactor/proc/reset_desired_path(mob/user, obj/item/tool)
+	say("Desired object [desired_path ? "reset" : "not set"]!")
+	desired_path = null
+	return TRUE
+
 /obj/item/mcobject/interactor/proc/swap_click_input(datum/mcmessage/input)
 	if(!input)
 		return
@@ -127,6 +153,9 @@
 		selected_turf = get_step(src, stored_dir)
 
 	for(var/atom/movable/listed_atom in selected_turf)
+		if(desired_path && (desired_path != listed_atom.type))
+			continue
+
 		if(dummy_human == listed_atom || src == listed_atom)
 			continue
 


### PR DESCRIPTION
## About The Pull Request

- Adds examine text telling you that you that using a multitool on mech components is how you interact with them
- Makes it so right-clicking with a multitool on a component automatically sets your multitool buffer to the link
- Makes interaction components capable of only choosing a specific type of item instead of all items on a tile (AKA, a filter)
- Makes assemblers actually have ALL the recipes in the crafting book by taking it from `GLOB.crafting_recipes` (except restricted ones)
- Removes the 10x longer coffin crafting recipe that bloodsuckers added for no reason

## Why It's Good For The Game

> Adds examine text telling you that you that using a multitool on mech components is how you interact with them
- Somehow we didnt have that, was also needed for the next point
> Makes it so right-clicking with a multitool on a component automatically sets your multitool buffer to the link
- Speeds up the repetiveness a bit
> Makes interaction components capable of only choosing a specific type of item instead of all items on a tile (AKA, a filter)
- Ever wanted to make a conveyorbelt with items and only interact with the items? Now is your chance to do so!
> Makes assemblers actually have ALL the recipes in the crafting book by taking it from `GLOB.crafting_recipes` (except restricted ones)
-  They didnt have the recipes from sheets of items, now they do, so a lot more is possible combined with the interaction comp filter.
- ((This does mean cargo can make coffins 10 times faster now, since that recipe is also taken into account. Can be slowed on request))
> Removes the 10x longer coffin crafting recipe that bloodsuckers added for no reason
- Bug :3

## Changelog

:cl:
add: Interaction components can now have a filter that only interacts with specific items.
qol: Mech components can now have themselfes quickly put into the multitool buffer as a device to link if you right-click them.
balance: automatic assemblers can now make any* crafting recipe thats made using sheets in your hand
fix: There is no longer a coffin recipe that takes 10 times as long to craft in the crafting menu.
/:cl:
