### PR TITLE
A little disease, as a treat

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -23,7 +23,7 @@
 	name = "Disease Outbreak: Classic"
 	typepath = /datum/round_event/disease_outbreak
 	max_occurrences = 2
-	min_players = 10
+	min_players = 15
 	weight = 2
 	track = EVENT_TRACK_MAJOR //monkie edit
 	earliest_start = 20 MINUTES
@@ -112,12 +112,12 @@
 	var/virus_choice = pick(subtypesof(/datum/disease/advanced)- typesof(/datum/disease/advanced/premade))
 	var/list/anti = list(
 		ANTIGEN_BLOOD	= 1,
-		ANTIGEN_COMMON	= 1,
+		ANTIGEN_COMMON	= 2,
 		ANTIGEN_RARE	= 2,
 		ANTIGEN_ALIEN	= 0,
 		)
 	var/list/bad = list(
-		EFFECT_DANGER_HELPFUL	= 1,
+		EFFECT_DANGER_HELPFUL	= 2,
 		EFFECT_DANGER_FLAVOR	= 2,
 		EFFECT_DANGER_ANNOYING	= 2,
 		EFFECT_DANGER_HINDRANCE	= 3,

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -24,9 +24,9 @@
 	typepath = /datum/round_event/disease_outbreak
 	max_occurrences = 2
 	min_players = 10
-	weight = 0
+	weight = 2
 	track = EVENT_TRACK_MAJOR //monkie edit
-	earliest_start = 55 MINUTES
+	earliest_start = 20 MINUTES
 	category = EVENT_CATEGORY_HEALTH
 	description = "A 'classic' virus will infect some members of the crew."
 	min_wizard_trigger_potency = 2
@@ -117,8 +117,8 @@
 		ANTIGEN_ALIEN	= 0,
 		)
 	var/list/bad = list(
-		EFFECT_DANGER_HELPFUL	= 0,
-		EFFECT_DANGER_FLAVOR	= 1,
+		EFFECT_DANGER_HELPFUL	= 1,
+		EFFECT_DANGER_FLAVOR	= 2,
 		EFFECT_DANGER_ANNOYING	= 2,
 		EFFECT_DANGER_HINDRANCE	= 3,
 		EFFECT_DANGER_HARMFUL	= 0,
@@ -145,9 +145,10 @@
 	name = "Disease Outbreak: Advanced"
 	typepath = /datum/round_event/disease_outbreak/advanced
 	category = EVENT_CATEGORY_HEALTH
-	weight = 0 //monkestation change 15 ==> 5
+	weight = 4 //monkestation change 15 ==> 4
 	min_players = 35 // To avoid shafting lowpop
-	earliest_start = 55 MINUTES // give the chemist a chance
+	earliest_start = 40 MINUTES // give the chemist a chance
+	max_occurrences = 1
 	description = "An 'advanced' disease will infect some members of the crew."
 	min_wizard_trigger_potency = 2
 	max_wizard_trigger_potency = 6
@@ -227,11 +228,11 @@
 		)
 	var/list/bad = list(
 		EFFECT_DANGER_HELPFUL	= 0,
-		EFFECT_DANGER_FLAVOR	= 0,
+		EFFECT_DANGER_FLAVOR	= 2,
 		EFFECT_DANGER_ANNOYING	= 2,
 		EFFECT_DANGER_HINDRANCE	= 3,
 		EFFECT_DANGER_HARMFUL	= 3,
-		EFFECT_DANGER_DEADLY	= 1,
+		EFFECT_DANGER_DEADLY	= 0,
 		)
 	var/datum/disease/advanced/new_disease = new virus_choice
 	new_disease.makerandom(list(50,90),list(50,100),anti,bad,src)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -148,7 +148,6 @@
 	weight = 3 //monkestation change 15 ==> 3
 	min_players = 35 // To avoid shafting lowpop
 	earliest_start = 40 MINUTES // give the chemist a chance
-	max_occurrences = 1
 	description = "An 'advanced' disease will infect some members of the crew."
 	min_wizard_trigger_potency = 2
 	max_wizard_trigger_potency = 6

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -24,7 +24,7 @@
 	typepath = /datum/round_event/disease_outbreak
 	max_occurrences = 2
 	min_players = 15
-	weight = 2
+	weight = 4
 	track = EVENT_TRACK_MAJOR //monkie edit
 	earliest_start = 20 MINUTES
 	category = EVENT_CATEGORY_HEALTH
@@ -145,7 +145,7 @@
 	name = "Disease Outbreak: Advanced"
 	typepath = /datum/round_event/disease_outbreak/advanced
 	category = EVENT_CATEGORY_HEALTH
-	weight = 4 //monkestation change 15 ==> 4
+	weight = 3 //monkestation change 15 ==> 3
 	min_players = 35 // To avoid shafting lowpop
 	earliest_start = 40 MINUTES // give the chemist a chance
 	max_occurrences = 1

--- a/monkestation/code/modules/events/fake_virus.dm
+++ b/monkestation/code/modules/events/fake_virus.dm
@@ -1,2 +1,3 @@
-/datum/round_event_control/fake_virus
-	earliest_start = 55 MINUTES
+/datum/round_event_control/fake_virus //Matching earliest possible disease
+	earliest_start = 20 MINUTES
+	min_players = 15

--- a/monkestation/code/modules/virology/disease/plague_rat/event.dm
+++ b/monkestation/code/modules/virology/disease/plague_rat/event.dm
@@ -1,11 +1,11 @@
 /datum/round_event_control/plague_rat
 	name = "Spawn Plague Rats"
 	typepath = /datum/round_event/ghost_role/plague_rat
-	weight = 1
+	weight = 2
 	max_occurrences = 1
 	track = EVENT_TRACK_MAJOR
 	min_players = 30 //monke edit: 20 to 30
-	earliest_start = 55 MINUTES //monke edit: 20 to 60
+	earliest_start = 55 MINUTES //monke edit: 20 to 55
 	//dynamic_should_hijack = TRUE
 	category = EVENT_CATEGORY_ENTITIES
 	description = "Spawns a horde of plague rats."

--- a/monkestation/code/modules/virology/disease/plague_rat/event.dm
+++ b/monkestation/code/modules/virology/disease/plague_rat/event.dm
@@ -4,7 +4,7 @@
 	weight = 2
 	max_occurrences = 1
 	track = EVENT_TRACK_MAJOR
-	min_players = 30 //monke edit: 20 to 30
+	min_players = 35 //monke edit: 20 to 35
 	earliest_start = 55 MINUTES //monke edit: 20 to 55
 	//dynamic_should_hijack = TRUE
 	category = EVENT_CATEGORY_ENTITIES


### PR DESCRIPTION
## About The Pull Request
***Who's hiring all these plague doctors anywho?***
Reintroduces negative diseases back into the game in a meaningful form.

In #2766 disease related events were all effectively removed from the game without much notice. The only remaining real diseases are Plague rats, at a timer of 55 minutes and weight of 1. And if someone contracted a mouse disease by eating it. Which often will self-cure. 
Its to the point I don't need medical equipment to even consider if someone has been hit with the fake virus event.

This Pr reintroduces disease events to be hear the ever-so-present, 'Level 7 biohazard' again.
Three types of disease events are the main real sources of disease.

- Disease outbreak: Classic
- Disease outbreak: Advanced
- Plague Rats.

Each one of these is in increasing severity and affects the rounds more impactfully, but rarer and takes longer to spawn as they do.
To summarize each.

### Disease outbreak: Classic
Weight: 4
Earliest start? 20 minutes.
Max occurrences: 2 (Unchanged)
The earliest, least impactful and most common form of outbreak.
Classic diseases will now include chances for helpful disease effects. Decreasing the annoyingness of them overall.
Could easily be cured through any means.

### Disease outbreak: Advanced
Weight: 3
Earliest start? 40 minutes
Max occurrences: 2 (Unchanged)
Medium severity. These are a lot more impactful but notably will no longer be round ending. As they can now no longer hold deadly symptoms. (Looking at magnetism for this one). Theses should no longer be the reason for shuttle calls.
These need some assistance from medical to cure but aren't insane to deal with. 

### Plague rats.
***Rats rats we are the rats***
Wieght: 2
Earliest start: 55 minutes (Unchanged)
Max occurrences: 1 (Unchanged)
The highest severity. When folks have plague rats they will be known as everyone screams about the bloody rats. These are the only events that can carry deadly symptoms. (As they work now). The only notable change from me here is the weight change. As having a single weight for an antag preference role seems ridiculous and silly. 
Their infections as before are guaranteed to be hard to deal with and highly infectious. It is the plague after all.

### The idea behind the balance passes
To reduce the effect on the rounds overall we keep diseases
- Rarer overall than before
- Less impactful/more interesting overall 
- Make each event feel more unique compared to each other.

## Why It's Good For The Game
### The why
Virology does not have much meat to it currently
As mentioned above the only real disease is plague rats, and heartworms while a disease can be cured by doctors and chemists quite easily. (Aetercilde from chemists or Muscle membrane surgery, which removes the need for a heart)
This means except for once in a blue moon Viro is left all shift to farm out positive diseases without need to focus on anything else. Hence we see them make constant positive diseases with minimum impact.
To add more meat/impact to the job I want to add diseases back, and hopefully make them less of a pain.
### What's changed since September?
Diseases were annoying enough that people wanted them gone, since then we've added had changes that improve the QOL and tools of viro to seriously help in arguing in their return.

- #4931 (A current testmerge) Added in disease severity back to medical huds, allowing them to easily spot a good vs a bad disease at a glance. In addition adding maintenance panels/adjusting the disease incubator speed which allows for easier curing of diseases.
- #4161 Added Amber Alert level, a medical-specific alert level allowing the crew to be notified if theirs a serious medical issue onboard the station.
- #4061 Helps sort out viro's starting position making sure they have all the tools they need to get their job done. For better and worse
- Experience with pathology. This is mostly subjective and based on what I've seen but between the increasing population of monkeystation and time to understand pathology folks are much more familiar with diseases. Pathology as a department is much more likely to have at least one if not filled pathology each round. And even more folks who know how to cure a disease. Whether that be chemicals, vaccines, soup and sleep, or just burning the disease out of you.

## Changelog
:cl:
balance: Disease: Classic, Advanced, and plague rats are all more common. (From 0:0:1) to (4:3:2)
balance: Disease: Classic, and Advanced can occur earlier in the round. (55 mins:55 mins) to (20 mins:40mins)
balance: Disease: Classic will now have an additional chance to contain helpful and flavour symptoms. (0:1) to (2:2) chances respectively
balance: Disease: Advanced will no longer contain deadly symptoms and a small chance for flavour. (1:0) to (0:2) chances respectively
balance: Minimum players required for a Disease/plague outbreak are all increased
balance: Fake virus's will now share starting conditions with Disease: Classic rather than Plague rats.
/:cl:
