### PR TITLE
Plushie Loadout Fix 

### DIFF
--- a/code/__DEFINES/clothing_paths.dm
+++ b/code/__DEFINES/clothing_paths.dm
@@ -18,7 +18,8 @@
 #define INFO_NAMED "name"
 
 /// Max amonut of misc / backpack items that are allowed.
-#define MAX_ALLOWED_MISC_ITEMS 3
+#define MAX_ALLOWED_MISC_ITEMS
+#define MAX_ALLOWED_PLUSHIES 3
 
 /// Defines for extra info blurbs, for loadout items.
 #define TOOLTIP_NO_ARMOR "ARMORLESS - This item has no armor and is entirely cosmetic."

--- a/code/__DEFINES/clothing_paths.dm
+++ b/code/__DEFINES/clothing_paths.dm
@@ -18,7 +18,7 @@
 #define INFO_NAMED "name"
 
 /// Max amonut of misc / backpack items that are allowed.
-#define MAX_ALLOWED_MISC_ITEMS
+#define MAX_ALLOWED_MISC_ITEMS 3
 #define MAX_ALLOWED_PLUSHIES 3
 
 /// Defines for extra info blurbs, for loadout items.

--- a/monkestation/code/modules/loadouts/loadout_middleware.dm
+++ b/monkestation/code/modules/loadouts/loadout_middleware.dm
@@ -101,7 +101,7 @@
 	if(params["deselect"])
 		deselect_item(interacted_item, user)
 		return
-
+	var/num_plushies = 0
 	var/num_misc_items = 0
 	var/datum/loadout_item/first_misc_found
 	for(var/datum/loadout_item/item as anything in loadout_list_to_datums(preferences.loadout_list))

--- a/monkestation/code/modules/loadouts/loadout_middleware.dm
+++ b/monkestation/code/modules/loadouts/loadout_middleware.dm
@@ -37,7 +37,7 @@
 	loadout_tabs += list(list("name" = "Accessory", "title" = "Uniform Accessory Slot Items", "contents" = list_to_data(GLOB.loadout_accessory)))
 	loadout_tabs += list(list("name" = "Inhand", "title" = "In-hand Items", "contents" = list_to_data(GLOB.loadout_inhand_items)))
 	loadout_tabs += list(list("name" = "Toys", "title" = "Toys! ([MAX_ALLOWED_MISC_ITEMS] max)", "contents" = list_to_data(GLOB.loadout_toys)))
-	loadout_tabs += list(list("name" = "Plushies", "title" = "Adorable little plushies! ([MAX_ALLOWED_MISC_ITEMS] max)", "contents" = list_to_data(GLOB.loadout_plushies)))
+	loadout_tabs += list(list("name" = "Plushies", "title" = "Adorable little plushies! ([MAX_ALLOWED_PLUSHIES] max)", "contents" = list_to_data(GLOB.loadout_plushies)))
 	loadout_tabs += list(list("name" = "Other", "title" = "Backpack Items ([MAX_ALLOWED_MISC_ITEMS] max)", "contents" = list_to_data(GLOB.loadout_pocket_items)))
 	loadout_tabs += list(list("name" = "Effects", "title" = "Unique Effects", "contents" = list_to_data(GLOB.loadout_effects)))
 	loadout_tabs += list(list("name" = "Unusuals", "title" = "Unusual Hats", "contents" = convert_stored_unusuals_to_data()))
@@ -106,7 +106,7 @@
 	var/datum/loadout_item/first_misc_found
 	for(var/datum/loadout_item/item as anything in loadout_list_to_datums(preferences.loadout_list))
 		if(item.category == interacted_item.category)
-			if((item.category == LOADOUT_ITEM_MISC || item.category == LOADOUT_ITEM_TOYS) && ++num_misc_items < MAX_ALLOWED_MISC_ITEMS)
+			if((item.category == LOADOUT_ITEM_PLUSHIES || item.category == LOADOUT_ITEM_MISC || item.category == LOADOUT_ITEM_TOYS) && ++num_misc_items < MAX_ALLOWED_MISC_ITEMS || ++num_plushies < MAX_ALLOWED_PLUSHIES)
 				if(!first_misc_found)
 					first_misc_found = item
 				continue


### PR DESCRIPTION

## About The Pull Request

Updates loadout code to allow for 3 plushies & 3 misc items.

## Why It's Good For The Game

More plushies more fun. And it means I get to see more veth plushies.

## Changelog
:cl:
add: You can now carry 3 plushies in your loadout in addition to 3 misc items.
/:cl:
