### PR TITLE
Readds CQC for Assault Operatives

### DIFF
--- a/monkestation/code/modules/assault_ops/code/armaments/_base.dm
+++ b/monkestation/code/modules/assault_ops/code/armaments/_base.dm
@@ -192,6 +192,9 @@
 /datum/armament_entry/assault_operatives/secondary/martial/krav_implanter
 	item_type = /obj/item/implanter/krav_maga
 
+/datum/armament_entry/assault_operatives/secondary/martial/cqc
+	item_type = /obj/item/book/granter/martial/cqc
+
 #undef OPS_SUBCATEGORY_LETHAL_SIDE
 #undef OPS_SUBCATEGORY_NONLETHAL_SIDE
 #undef OPS_SUBCATEGORY_MARTIAL_SIDE


### PR DESCRIPTION

## About The Pull Request

Title, partial revert of #4780
## Why It's Good For The Game

There was no point to removing it, the PR got 2 thumbs down and complaints in comments.
CQC was the biggest stealth ability assops had, period. They can't do without CQC.
Why can't they do without it? BECAUSE THEY CAN'T DO EVEN WITH IT.
If anything, these guys need buffs, not fucking nerfs.

Maybe take a look at their winrate and compare it to nukies who are an equivalent threat.
You miiiiiight notice that assops have a winrate closer to 1% than you might think.
If even that.

And one of the reasons it was removed is that it can be used in conjunction with the Krav Maga implant.
And the answer to that is... kind of. You can't have two martial arts at once, you have to switch.
So overall it's not of too much utility if you get both.
## Changelog
:cl:
balance: Readded CQC for Assault Operatives, because it should've never been removed to begin with.
/:cl:
