### PR TITLE
Disable the storyteller during unit tests

### DIFF
--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -161,6 +161,9 @@ SUBSYSTEM_DEF(gamemode)
 	var/list/triggered_round_events = list()
 
 /datum/controller/subsystem/gamemode/Initialize(time, zlevel)
+#if defined(UNIT_TESTS) || defined(AUTOWIKI) // lazy way of doing this but idc
+	CONFIG_SET(flag/disable_storyteller, TRUE)
+#endif
 	// Populate event pools
 	for(var/track in event_tracks)
 		event_pools[track] = list()


### PR DESCRIPTION

## About The Pull Request

This prevents storytellers from running or ticking during unit tests, hopefully to reduce the chance of weird failures from randomly triggering events.

## Why It's Good For The Game

one less possibility for flaky unit tests

## Changelog

Only applies to unit tests, does not impact any actual gameplay at all.