### PR TITLE
Increases the shuttle stall time for assault operatives.

### DIFF
--- a/monkestation/code/modules/assault_ops/code/interrogator.dm
+++ b/monkestation/code/modules/assault_ops/code/interrogator.dm
@@ -213,7 +213,7 @@
 		disk_pinpointers.switch_mode_to(TRACK_GOLDENEYE) //Pinpointer will track the newly created goldeneye key.
 
 	if(SSshuttle.emergency.mode == SHUTTLE_CALL)
-		var/delaytime = 3 MINUTES
+		var/delaytime = 5 MINUTES
 		var/timer = SSshuttle.emergency.timeLeft(1) + delaytime
 		var/surplus = timer - (SSshuttle.emergency_call_time)
 		SSshuttle.emergency.setTimer(timer)


### PR DESCRIPTION

## About The Pull Request
Increases the time they stall the shuttle from 3 minutes to 5 minutes.
## Why It's Good For The Game
I had originally given them 3 minutes because I thought that's how long the interrogator takes. Turns out, it takes closer to 6 minutes. So this will give the operatives more leeway when it comes to getting the other keycards.
## Changelog
:cl:
balance: Assault operatives shuttle stall time increased from 3 to 5 minutes.
/:cl:
