### PR TITLE
Vitals display work with optable tables

### DIFF
--- a/monkestation/code/modules/blood_datum/vital_monitor/vital_reader.dm
+++ b/monkestation/code/modules/blood_datum/vital_monitor/vital_reader.dm
@@ -60,6 +60,7 @@
 		/obj/machinery/sleeper,
 		/obj/machinery/stasis,
 		/obj/machinery/health_scanner_floor,
+		/obj/structure/table/optable,
 	))
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/vitals_reader, 32)


### PR DESCRIPTION

## About The Pull Request
Adds Optable tables to the list of things vitals display work with
(Silver and alien tables)
## Why It's Good For The Game
Vitals display while a pretty cool item suffers from its weird list of allowed items to be used with. 
Adds some more use case of being an unremovable scanner.
## Changelog
:cl:
add: Optable tables now work with vitals displays
/:cl:
