### PR TITLE
[PORT] Group Integration Tests together on the left side of each CI Suite run

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -189,31 +189,20 @@ jobs:
     name: Integration Tests
     needs: collect_data
 
-    strategy:
-      fail-fast: false
-      matrix:
-        map: ${{ fromJSON(needs.collect_data.outputs.maps).paths }}
-
-    uses: ./.github/workflows/run_integration_tests.yml
+    uses: ./.github/workflows/perform_regular_version_tests.yml
     with:
-      map: ${{ matrix.map }}
+      maps: ${{ needs.collect_data.outputs.maps }}
       max_required_byond_client: ${{needs.collect_data.outputs.max_required_byond_client}}
 
   run_alternate_tests:
     if: needs.collect_data.outputs.alternate_tests != '[]'
     name: Alternate Tests
     needs: collect_data
-    strategy:
-      fail-fast: false
-      matrix:
-        setup: ${{ fromJSON(needs.collect_data.outputs.alternate_tests) }}
 
-    uses: ./.github/workflows/run_integration_tests.yml
+    uses: ./.github/workflows/perform_alternate_version_tests.yml
     with:
-      map: ${{ matrix.setup.map }}
-      major: ${{ matrix.setup.major }}
-      minor: ${{ matrix.setup.minor }}
-      max_required_byond_client: ${{ matrix.setup.max_client_version || needs.collect_data.outputs.max_required_byond_client }}
+      alternate_tests: ${{ needs.collect_data.outputs.alternate_tests }}
+      default_max_required_byond_client: ${{ needs.collect_data.outputs.max_required_byond_client }}
 
   compare_screenshots:
     if: needs.collect_data.outputs.alternate_tests == '[]' || needs.run_alternate_tests.result == 'success'

--- a/.github/workflows/perform_alternate_version_tests.yml
+++ b/.github/workflows/perform_alternate_version_tests.yml
@@ -1,0 +1,25 @@
+name: Run Alternate BYOND Version Tests
+on:
+  workflow_call:
+    inputs:
+      alternate_tests:
+        required: true
+        type: string
+      default_max_required_byond_client:
+        required: true
+        type: string
+
+jobs:
+  run:
+    uses: ./.github/workflows/run_integration_tests.yml
+
+    strategy:
+      fail-fast: false
+      matrix:
+        setup: ${{ fromJSON(inputs.alternate_tests) }}
+
+    with:
+      map: ${{ matrix.setup.map }}
+      major: ${{ matrix.setup.major }}
+      minor: ${{ matrix.setup.minor }}
+      max_required_byond_client: ${{ matrix.setup.max_client_version || inputs.default_max_required_byond_client }}

--- a/.github/workflows/perform_regular_version_tests.yml
+++ b/.github/workflows/perform_regular_version_tests.yml
@@ -1,0 +1,23 @@
+name: Run Regular BYOND Version Tests
+on:
+  workflow_call:
+    inputs:
+      maps:
+        required: true
+        type: string
+      max_required_byond_client:
+        required: true
+        type: string
+
+jobs:
+  run:
+    uses: ./.github/workflows/run_integration_tests.yml
+
+    strategy:
+      fail-fast: false
+      matrix:
+        map: ${{ fromJSON(inputs.maps).paths }}
+
+    with:
+      map: ${{ matrix.map }}
+      max_required_byond_client: ${{ inputs.max_required_byond_client }}

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -19,6 +19,12 @@ on:
 
 jobs:
   run_integration_tests:
+    # If `inputs.major` is specified, this will output `Run Tests (major.minor; map; max)`.
+    # For example, `Run Tests (515.1627; runtimestation; 515)`.
+    #
+    # Otherwise, it will output `Run Tests (map; max)`.
+    # For example, `Run Tests (runtimestation; 515)`.
+    name: Run Tests (${{ inputs.major && format('{0}.{1}; ', inputs.major, inputs.minor) || '' }}${{ inputs.map }}; ${{ inputs.max_required_byond_client }})
     runs-on: ubuntu-latest
     timeout-minutes: 30 # Monkestation edit: Our CI takes nearly twice as long, so the timeout is twice as long
     services:


### PR DESCRIPTION
NOTE: This PR description is taken from https://github.com/tgstation/tgstation/pull/89191, where I initially PR'd it to, with some small edits.

## About The Pull Request
Hi again! I'm messing around with the workflow files again.

One of my main issues with viewing the logs for workflows, is that all the integration tests are listed under separate dropdowns. It's not so bad in the node-based view (the [visualization graph](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/about-monitoring-workflows#using-the-visualization-graph), as github call it), but it's still a pain to navigate between different integration tests' logs. This problem can only get worse when more maps are added, too (such as on Monkestation, which tests on 13 maps!).

However, I managed to figure out a way to group them together, which makes navigating them (and hiding them, if you don't need them!) much better. See the difference yourself:

<details><summary>Screenshots</summary>

| Before | After |
|--------|-------|
| ![406283558-f9391f63-41be-4115-86c7-992be3e28e18](https://github.com/user-attachments/assets/d6977281-c52f-44cb-9bec-e57e45b8c43d) | ![image](https://github.com/user-attachments/assets/9252f3cc-b384-4d7e-b7b8-26b02dc3e243) |
</details>

Note the name attached to each map - I had to do this to make it possible to figure out which one is for which map. If I didn't do this, all the entries in the "After" image would just say "run_integration_tests".

Also note that doesn't apply to alternate tests. However, we have so few alternate tests that I don't think it's worth taking the time to group them together.

A side effect of how I implemented this: the checks list (attached to PRs and commits) is now a little denser than before. However, I don't think this is too much of an issue.

<details><summary>Screenshots</summary>

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/93f34a9b-6702-4f83-9d81-eb7e5a57a6c9) | ![image](https://github.com/user-attachments/assets/5c769051-2c4c-4967-81d5-76b0578fb35b) |
</details>

I hope this makes navigating the workflow logs a little easier. :)