### PR TITLE
[PORT] Datumizes pAI screen images

### DIFF
--- a/code/modules/pai/card.dm
+++ b/code/modules/pai/card.dm
@@ -14,8 +14,8 @@
 
 	/// Spam alert prevention
 	var/alert_cooldown
-	/// The emotion icon displayed.
-	var/emotion_icon = "off"
+	/// The icon displayed on the card's screen.
+	var/datum/pai_screen_image/screen_image = /datum/pai_screen_image/off
 	/// Any pAI personalities inserted
 	var/mob/living/silicon/pai/pai
 	/// Prevents a crew member from hitting "request pAI" repeatedly
@@ -60,7 +60,7 @@
 /obj/item/pai_card/handle_atom_del(atom/thing)
 	if(thing == pai) //double check /mob/living/silicon/pai/Destroy() if you change these.
 		pai = null
-		emotion_icon = initial(emotion_icon)
+		screen_image = initial(screen_image)
 		update_appearance()
 	return ..()
 
@@ -76,13 +76,13 @@
 
 /obj/item/pai_card/update_overlays()
 	. = ..()
-	. += "pai-[emotion_icon]"
+	. += image(icon = screen_image.icon, icon_state = screen_image.icon_state)
 	if(pai?.hacking_cable)
 		. += "[initial(icon_state)]-connector"
 
 /obj/item/pai_card/vv_edit_var(vname, vval)
 	. = ..()
-	if(vname == NAMEOF(src, emotion_icon))
+	if(vname == NAMEOF(src, screen_image))
 		update_appearance()
 
 /obj/item/pai_card/ui_interact(mob/user, datum/tgui/ui)
@@ -268,7 +268,7 @@
 	if(pai)
 		return FALSE
 	pai = downloaded
-	emotion_icon = "null"
+	screen_image = /datum/pai_screen_image/neutral
 	update_appearance()
 	playsound(src, 'sound/effects/pai_boot.ogg', 50, TRUE, -1)
 	audible_message("[src] plays a cheerful startup noise!")

--- a/code/modules/pai/datums/screen_icon.dm
+++ b/code/modules/pai/datums/screen_icon.dm
@@ -1,0 +1,67 @@
+// Datums describing an icon that is overlaid on a pAI card, to make its screen show something. The
+// player can select between any of these at any time. These are usually faces, but can
+// realistically be anything (similar to an AI's display).
+
+/datum/pai_screen_image
+	// The name to show in the radial menu.
+	var/name
+	// The icon and icon state that is applied to the pAI device when this screen image is selected.
+	var/icon/icon = 'icons/obj/aicards.dmi'
+	var/icon_state
+	// The FontAwesome icon to use next to the "Display" button in the pAI's tgui interface window.
+	var/interface_icon
+
+/datum/pai_screen_image/angry
+	name = "Angry"
+	icon_state = "pai-angry"
+	interface_icon = "angry"
+
+/datum/pai_screen_image/cat
+	name = "Cat"
+	icon_state = "pai-cat"
+	interface_icon = "cat"
+
+/datum/pai_screen_image/extremely_happy
+	name = "Extremely Happy"
+	icon_state = "pai-extremely-happy"
+	interface_icon = "grin-beam"
+
+/datum/pai_screen_image/face
+	name = "Face"
+	icon_state = "pai-face"
+	interface_icon = "grin-alt"
+
+/datum/pai_screen_image/happy
+	name = "Happy"
+	icon_state = "pai-happy"
+	interface_icon = "smile"
+
+/datum/pai_screen_image/laugh
+	name = "Laugh"
+	icon_state = "pai-laugh"
+	interface_icon = "grin-tears"
+
+/datum/pai_screen_image/neutral
+	name = "Neutral"
+	icon_state = "pai-null"
+	interface_icon = "meh"
+
+/datum/pai_screen_image/off
+	name = "None"
+	icon_state = "pai-off"
+	interface_icon = "meh-blank"
+
+/datum/pai_screen_image/sad
+	name = "Sad"
+	icon_state = "pai-sad"
+	interface_icon = "sad-cry"
+
+/datum/pai_screen_image/sunglasses
+	name = "Sunglasses"
+	icon_state = "pai-sunglasses"
+	interface_icon = "sun"
+
+/datum/pai_screen_image/what
+	name = "What"
+	icon_state = "pai-what"
+	interface_icon = "frown-open"

--- a/code/modules/pai/death.dm
+++ b/code/modules/pai/death.dm
@@ -13,7 +13,7 @@
 	if (!QDELETED(card) && loc != card)
 		card.forceMove(drop_location())
 		card.pai = null
-		card.emotion_icon = initial(card.emotion_icon)
+		card.screen_image = initial(card.screen_image)
 		card.update_appearance()
 
 	qdel(src)

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -124,20 +124,6 @@
 		"puppy" = FALSE,
 		"spider" = FALSE,
 	)
-	/// List of all available card overlays.
-	var/static/list/possible_overlays = list(
-		"null",
-		"angry",
-		"cat",
-		"extremely-happy",
-		"face",
-		"happy",
-		"laugh",
-		"off",
-		"sad",
-		"sunglasses",
-		"what"
-	)
 
 /mob/living/silicon/pai/add_sensors() //pAIs have to buy their HUDs
 	return

--- a/code/modules/pai/software.dm
+++ b/code/modules/pai/software.dm
@@ -8,7 +8,7 @@
 /mob/living/silicon/pai/ui_data(mob/user)
 	var/list/data = list()
 	data["door_jack"] = hacking_cable
-	data["image"] = card.emotion_icon
+	data["screen_image_interface_icon"] = card.screen_image.interface_icon
 	data["installed"] = installed_software
 	data["ram"] = ram
 	return data
@@ -135,16 +135,16 @@
  */
 /mob/living/silicon/pai/proc/change_image()
 	var/list/possible_choices = list()
-	for(var/face_option in possible_overlays)
+	for(var/datum/pai_screen_image/screen_option as anything in subtypesof(/datum/pai_screen_image))
 		var/datum/radial_menu_choice/choice = new
-		choice.name = face_option
-		choice.image = image(icon = card.icon, icon_state = "pai-[face_option]")
-		possible_choices[face_option] += choice
+		choice.name = screen_option.name
+		choice.image = image(icon = screen_option.icon, icon_state = screen_option.icon_state)
+		possible_choices[screen_option] += choice
 	var/atom/anchor = get_atom_on_turf(src)
 	var/new_image = show_radial_menu(src, anchor, possible_choices, custom_check = CALLBACK(src, PROC_REF(check_menu), anchor), radius = 40, require_near = TRUE)
 	if(isnull(new_image))
 		return FALSE
-	card.emotion_icon = new_image
+	card.screen_image = new_image
 	card.update_appearance()
 	return TRUE
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4996,6 +4996,7 @@
 #include "code\modules\pai\say.dm"
 #include "code\modules\pai\shell.dm"
 #include "code\modules\pai\software.dm"
+#include "code\modules\pai\datums\screen_icon.dm"
 #include "code\modules\paperwork\carbonpaper.dm"
 #include "code\modules\paperwork\clipboard.dm"
 #include "code\modules\paperwork\contract.dm"

--- a/tgui/packages/tgui/interfaces/PaiInterface/System.tsx
+++ b/tgui/packages/tgui/interfaces/PaiInterface/System.tsx
@@ -1,6 +1,5 @@
 import { useBackend } from 'tgui/backend';
 import { Box, Button, LabeledList, Section, Stack } from 'tgui/components';
-import { ICON_MAP } from './constants';
 import { PaiData } from './types';
 
 export const SystemDisplay = (props) => {
@@ -64,7 +63,7 @@ const SystemWallpaper = (props) => {
  */
 const SystemInfo = (props) => {
   const { act, data } = useBackend<PaiData>();
-  const { image, master_dna, master_name } = data;
+  const { screen_image_interface_icon, master_dna, master_name } = data;
 
   return (
     <Section
@@ -79,7 +78,7 @@ const SystemInfo = (props) => {
             Verify
           </Button>
           <Button
-            icon={ICON_MAP[image]}
+            icon={screen_image_interface_icon}
             onClick={() => act('change image')}
             tooltip="Change your display image."
           >

--- a/tgui/packages/tgui/interfaces/PaiInterface/constants.ts
+++ b/tgui/packages/tgui/interfaces/PaiInterface/constants.ts
@@ -23,20 +23,6 @@ export enum HOST_SCAN {
   Master,
 }
 
-export const ICON_MAP = {
-  angry: 'angry',
-  cat: 'cat',
-  'extremely-happy': 'grin-beam',
-  face: 'grin-alt',
-  happy: 'smile',
-  laugh: 'grin-tears',
-  null: 'meh',
-  off: 'meh-blank',
-  sad: 'sad-cry',
-  sunglasses: 'sun',
-  what: 'frown-open',
-} as const;
-
 export enum PHOTO_MODE {
   Camera,
   Printer,

--- a/tgui/packages/tgui/interfaces/PaiInterface/types.ts
+++ b/tgui/packages/tgui/interfaces/PaiInterface/types.ts
@@ -5,7 +5,7 @@ export type PaiData = {
   directives: string;
   door_jack: string | null;
   emagged: BooleanLike;
-  image: string;
+  screen_image_interface_icon: string;
   installed: ReadonlyArray<string>;
   languages: BooleanLike;
   master_dna: string | null;


### PR DESCRIPTION
NOTE: This PR description is copied from https://github.com/tgstation/tgstation/pull/89208, where I originally submitted it.

## About The Pull Request
This PR changes pAI screen images (previously called "emotion icon" or "card overlay") to be datums.

In doing so, I made some changes in how screen images are handled:
* A screen image's name and icon state are separate now, whereas before the name determined the icon state used.
* Something useful for downstreams: The icon file that a screen image pulls from default's to tg's icon file for pAI screen images, but can be overridden if you don't want to put the new screen image in the same file.
* The FA icon for each screen image is now selected in the datum, rather than as part of a constant in some far-off TS file.

Additionally, the codebase previously used inconsistent terminology to refer to these - "card overlay" in one place, "emotion icon" in another, "image" somewhere else... Now, all of them are called "screen image" or some variant thereof. "Screen image" is more accurate to what it is anyways, since it doesn't need to be a face (although 99% of the time, it will be).

One last thing: The new datum is in its own directory, all by its lonesome. If you're wondering why I don't just move it out and put it next to the rest of the pAI module, it's because I plan to datumize some other pAI stuff (in particular, software and holochassis) in a future PR. (Though I'll admit, I'm not sure of the current folder location.)

## Why It's Good For The Game
Datumizes some items that really should've been datums in the first place.

## Changelog
No player-facing changes (hopefully).