### PR TITLE
[bounty] adds immobilization implant to depot syndies

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -263,7 +263,6 @@
 				var/obj/item/implant/I = SSwardrobe.provide_type(implant_type, H)
 				I.implant(H, null, TRUE)
 
-
 		// Insert the skillchips associated with this outfit into the target.
 		if(skillchips)
 			for(var/skillchip_path in skillchips)

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -269,6 +269,8 @@
 				var/activate_msg = skillchip_instance.try_activate_skillchip(TRUE, TRUE)
 				if(activate_msg)
 					CRASH("Failed to activate [H]'s [skillchip_instance], on job [src]. Failure message: [activate_msg]")
+
+
 	H.update_body()
 	return TRUE
 

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -114,6 +114,13 @@
 	  */
 	var/list/skillchips = null
 
+	/**
+	  * Any organs the mob should have upon spawn.
+	  *
+	  * Format of this list is (typepath, typepath, typepath)
+	  */
+	var/list/organs = null
+
 	///Should we preload some of this job's items?
 	var/preload = FALSE
 
@@ -256,6 +263,7 @@
 				var/obj/item/implant/I = SSwardrobe.provide_type(implant_type, H)
 				I.implant(H, null, TRUE)
 
+
 		// Insert the skillchips associated with this outfit into the target.
 		if(skillchips)
 			for(var/skillchip_path in skillchips)
@@ -270,6 +278,10 @@
 				if(activate_msg)
 					CRASH("Failed to activate [H]'s [skillchip_instance], on job [src]. Failure message: [activate_msg]")
 
+		if(organs)
+			for(var/organ_path in organs)
+				var/obj/item/organ/organ = SSwardrobe.provide_type(organ_path)
+				organ.Insert(H, special = TRUE, drop_if_replaced = FALSE)
 
 	H.update_body()
 	return TRUE
@@ -363,6 +375,8 @@
 		preload += implant_type
 	for(var/skillpath in skillchips)
 		preload += skillpath
+	for(var/organ_type in organs)
+		preload += organ_type
 
 	return preload
 
@@ -394,6 +408,7 @@
 	.["box"] = box
 	.["implants"] = implants
 	.["accessory"] = accessory
+	.["organs"] = organs
 
 /// Copy most vars from another outfit to this one
 /datum/outfit/proc/copy_from(datum/outfit/target)
@@ -421,6 +436,7 @@
 	box = target.box
 	implants = target.implants
 	accessory = target.accessory
+	organs = target.organs
 
 /// Prompt the passed in mob client to download this outfit as a json blob
 /datum/outfit/proc/save_to_file(mob/admin)
@@ -469,6 +485,12 @@
 		if(imptype)
 			implants += imptype
 	accessory = text2path(outfit_data["accessory"])
+	var/list/orgn = outfit_data["organs"]
+	organs = list()
+	for(var/organ in orgn)
+		var/organ_type = text2path(organ)
+		if(organ_type)
+			organs += organ_type
 	return TRUE
 
 /datum/outfit/vv_get_dropdown()

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -114,13 +114,6 @@
 	  */
 	var/list/skillchips = null
 
-	/**
-	  * Any organs the mob should have upon spawn.
-	  *
-	  * Format of this list is (typepath, typepath, typepath)
-	  */
-	var/list/organs = null
-
 	///Should we preload some of this job's items?
 	var/preload = FALSE
 
@@ -277,11 +270,6 @@
 				if(activate_msg)
 					CRASH("Failed to activate [H]'s [skillchip_instance], on job [src]. Failure message: [activate_msg]")
 
-		if(organs)
-			for(var/organ_path in organs)
-				var/obj/item/organ/organ = SSwardrobe.provide_type(organ_path)
-				organ.Insert(H, special = TRUE, drop_if_replaced = FALSE)
-
 	H.update_body()
 	return TRUE
 
@@ -374,8 +362,6 @@
 		preload += implant_type
 	for(var/skillpath in skillchips)
 		preload += skillpath
-	for(var/organ_type in organs)
-		preload += organ_type
 
 	return preload
 
@@ -407,7 +393,6 @@
 	.["box"] = box
 	.["implants"] = implants
 	.["accessory"] = accessory
-	.["organs"] = organs
 
 /// Copy most vars from another outfit to this one
 /datum/outfit/proc/copy_from(datum/outfit/target)
@@ -435,7 +420,6 @@
 	box = target.box
 	implants = target.implants
 	accessory = target.accessory
-	organs = target.organs
 
 /// Prompt the passed in mob client to download this outfit as a json blob
 /datum/outfit/proc/save_to_file(mob/admin)
@@ -484,12 +468,6 @@
 		if(imptype)
 			implants += imptype
 	accessory = text2path(outfit_data["accessory"])
-	var/list/orgn = outfit_data["organs"]
-	organs = list()
-	for(var/organ in orgn)
-		var/organ_type = text2path(organ)
-		if(organ_type)
-			organs += organ_type
 	return TRUE
 
 /datum/outfit/vv_get_dropdown()

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -269,7 +269,6 @@
 				var/activate_msg = skillchip_instance.try_activate_skillchip(TRUE, TRUE)
 				if(activate_msg)
 					CRASH("Failed to activate [H]'s [skillchip_instance], on job [src]. Failure message: [activate_msg]")
-
 	H.update_body()
 	return TRUE
 

--- a/monkestation/code/modules/cybernetics/augments/chest_augments.dm
+++ b/monkestation/code/modules/cybernetics/augments/chest_augments.dm
@@ -670,6 +670,9 @@
 	. = ..()
 	//so deleting the implant doesn't actually explode the owner
 	if(QDELETED(src))
+		//if the target was paralyzed, remove it
+		if(set_off)
+			owner.remove_traits(list(TRAIT_PARALYSIS_L_LEG, TRAIT_PARALYSIS_R_LEG), type)
 		return
 	//no removing implant!
 	playsound(owner, 'sound/machines/beep.ogg', 50, FALSE)

--- a/monkestation/code/modules/cybernetics/augments/chest_augments.dm
+++ b/monkestation/code/modules/cybernetics/augments/chest_augments.dm
@@ -651,17 +651,15 @@
 		arm?.receive_damage(brute = 10, wound_bonus = 10, sharpness = NONE) // You can get away with like 5 spazzes before you get a dislocation.
 
 /obj/item/organ/internal/cyberimp/chest/spinal_bomb
-	name = "Spinal immobilization implant"
+	name = "Immobilization implant"
 	desc = "Implant inserted into one's spine to prevent them leaving certain space, and will permamently immobilize them if they do. Do not attempt removal."
 	encode_info = AUGMENT_NO_REQ
 	///starting z of when it was inserted, also counts as a zlvl that a person can't leave
 	var/z_restriction = null
-	///is the implant currently activated
-	var/on = TRUE
 	///our timer
 	var/detonation_timer = 5
 	///determines if the implant is set off
-	var/not_set_off = TRUE
+	var/set_off = FALSE
 
 /obj/item/organ/internal/cyberimp/chest/spinal_bomb/on_insert(mob/living/carbon/owner)
 	. = ..()
@@ -670,16 +668,16 @@
 
 /obj/item/organ/internal/cyberimp/chest/spinal_bomb/on_remove(mob/living/carbon/owner)
 	. = ..()
+	//so deleting the implant doesn't actually explode the owner
+	if(QDELETED(src))
+		return
 	//no removing implant!
 	playsound(owner, 'sound/machines/beep.ogg', 50, FALSE)
 	explosion(owner, 1, 2, 4, 2, explosion_cause = src)
 
-/obj/item/organ/internal/cyberimp/chest/spinal_bomb/Destroy()
-	. = ..()
-
 /obj/item/organ/internal/cyberimp/chest/spinal_bomb/on_life()
 	. = ..()
-	if (!on || !not_set_off)
+	if (set_off)
 		return
 	var/turf/owner_turf = get_turf(owner)
 	if (z_restriction == owner_turf.z)
@@ -696,6 +694,7 @@
 			to_chat(owner, span_userdanger("FUCK!!!!!"))
 			playsound(owner, 'sound/effects/snap.ogg', 75)
 			playsound(owner, 'sound/effects/splat.ogg', 50)
+			owner.emote("scream")
 			owner.add_traits(list(TRAIT_PARALYSIS_L_LEG, TRAIT_PARALYSIS_R_LEG), type)
 			owner.cause_pain(list(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG), 60, BRUTE)
-			not_set_off = FALSE
+			set_off = TRUE

--- a/monkestation/code/modules/cybernetics/augments/chest_augments.dm
+++ b/monkestation/code/modules/cybernetics/augments/chest_augments.dm
@@ -655,7 +655,14 @@
 	desc = "WIP"
 	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
 	encode_info = AUGMENT_NO_REQ
+	//starting z of when it was inserted, also counts as a zlvl that a person can't leave
 	var/starter_z = null
+	//is the implant currently activated
+	var/on = TRUE
+	//our timer
+	var/detonation_timer = 5
+	//determines if the implant is set off
+	var/not_set_off = TRUE
 
 /obj/item/organ/internal/cyberimp/chest/spinal_bomb/on_insert(mob/living/carbon/owner)
 	. = ..()
@@ -664,8 +671,21 @@
 
 /obj/item/organ/internal/cyberimp/chest/spinal_bomb/on_life()
 	. = ..()
-	var/turf/owner_turf = get_turf(owner)
-	if (starter_z == owner_turf.z)
-		return
-	else
-		owner.add_traits(list(TRAIT_PARALYSIS_L_LEG, TRAIT_PARALYSIS_R_LEG), src)
+	if (on && not_set_off)
+		var/turf/owner_turf = get_turf(owner)
+		if (starter_z == owner_turf.z)
+			//reset the timer if it started ticking
+			if (detonation_timer != 5)
+				detonation_timer = 5
+			return
+		else
+			if (detonation_timer != 0)
+				detonation_timer -= 1
+				to_chat(owner, span_warning("Implant will immobilize you in [detonation_timer] seconds. Please, return to the bounds."))
+				playsound(owner, 'sound/items/timer.ogg', 50, FALSE)
+			else
+				to_chat(owner, span_warning("FUCK!!!!!"))
+				playsound(owner, 'sound/machines/beep.ogg', 100, FALSE)
+				owner.add_traits(list(TRAIT_PARALYSIS_L_LEG, TRAIT_PARALYSIS_R_LEG), src)
+				owner.cause_pain(list(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG), 40, BRUTE)
+				not_set_off = FALSE

--- a/monkestation/code/modules/cybernetics/augments/chest_augments.dm
+++ b/monkestation/code/modules/cybernetics/augments/chest_augments.dm
@@ -650,7 +650,7 @@
 		var/obj/item/bodypart/arm = owner.get_holding_bodypart_of_item(item)
 		arm?.receive_damage(brute = 10, wound_bonus = 10, sharpness = NONE) // You can get away with like 5 spazzes before you get a dislocation.
 
-/obj/item/organ/internal/cyberimp/chest/spinal_bomb
+/obj/item/organ/internal/cyberimp/chest/immobilization
 	name = "Immobilization implant"
 	desc = "Implant inserted into one's spine to prevent them leaving certain space, and will permamently immobilize them if they do. Do not attempt removal."
 	encode_info = AUGMENT_NO_REQ
@@ -661,12 +661,12 @@
 	///determines if the implant is set off
 	var/set_off = FALSE
 
-/obj/item/organ/internal/cyberimp/chest/spinal_bomb/on_insert(mob/living/carbon/owner)
+/obj/item/organ/internal/cyberimp/chest/immobilization/on_insert(mob/living/carbon/owner)
 	. = ..()
 	var/turf/owner_turf = get_turf(owner)
 	z_restriction = owner_turf.z
 
-/obj/item/organ/internal/cyberimp/chest/spinal_bomb/on_remove(mob/living/carbon/owner)
+/obj/item/organ/internal/cyberimp/chest/immobilization/on_remove(mob/living/carbon/owner)
 	. = ..()
 	//so deleting the implant doesn't actually explode the owner
 	if(QDELETED(src))
@@ -675,10 +675,10 @@
 	playsound(owner, 'sound/machines/beep.ogg', 50, FALSE)
 	explosion(owner, 1, 2, 4, 2, explosion_cause = src)
 
-/obj/item/organ/internal/cyberimp/chest/spinal_bomb/emp_act(severity)
+/obj/item/organ/internal/cyberimp/chest/immobilization/emp_act(severity)
 	return
 
-/obj/item/organ/internal/cyberimp/chest/spinal_bomb/on_life()
+/obj/item/organ/internal/cyberimp/chest/immobilization/on_life()
 	. = ..()
 	if (set_off)
 		return

--- a/monkestation/code/modules/cybernetics/augments/chest_augments.dm
+++ b/monkestation/code/modules/cybernetics/augments/chest_augments.dm
@@ -657,10 +657,10 @@
 	///starting z of when it was inserted, also counts as a zlvl that a person can't leave
 	var/z_restriction = null
 	///our timer
-	var/detonation_timer = 15
+	var/activation_timer = 15
 	///determines if the implant is set off
 	var/set_off = FALSE
-	//ticking
+	//ticking of timer
 	var/ticking = FALSE
 
 /obj/item/organ/internal/cyberimp/chest/immobilization/on_insert(mob/living/carbon/owner)
@@ -689,9 +689,9 @@
 	. = ..()
 	if (set_off || !ticking)
 		return
-	if (detonation_timer != 0)
-		to_chat(owner, span_warning("Implant will immobilize you in [detonation_timer] seconds. Please, return to the bounds."))
-		detonation_timer -= 1
+	if (activation_timer != 0)
+		to_chat(owner, span_warning("Implant will immobilize you in [activation_timer] seconds. Please, return to the bounds."))
+		activation_timer -= 1
 		playsound(owner, 'sound/items/timer.ogg', 50, FALSE)
 	else
 		to_chat(owner, span_userdanger("FUCK!!!!!"))
@@ -707,8 +707,8 @@
 	var/turf/owner_turf = get_turf(owner)
 	if (z_restriction == owner_turf.z)
 		//reset the timer if it started ticking
-		if (detonation_timer != initial(detonation_timer))
-			detonation_timer = initial(detonation_timer)
+		if (activation_timer != initial(activation_timer))
+			activation_timer = initial(activation_timer)
 			ticking = FALSE
 		return
 	else

--- a/monkestation/code/modules/cybernetics/augments/chest_augments.dm
+++ b/monkestation/code/modules/cybernetics/augments/chest_augments.dm
@@ -649,3 +649,23 @@
 		)
 		var/obj/item/bodypart/arm = owner.get_holding_bodypart_of_item(item)
 		arm?.receive_damage(brute = 10, wound_bonus = 10, sharpness = NONE) // You can get away with like 5 spazzes before you get a dislocation.
+
+/obj/item/organ/internal/cyberimp/chest/spinal_bomb
+	name = "Spinal self-destruct implant"
+	desc = "WIP"
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
+	encode_info = AUGMENT_NO_REQ
+	var/starter_z = null
+
+/obj/item/organ/internal/cyberimp/chest/spinal_bomb/on_insert(mob/living/carbon/owner)
+	. = ..()
+	var/turf/owner_turf = get_turf(owner)
+	starter_z = owner_turf.z
+
+/obj/item/organ/internal/cyberimp/chest/spinal_bomb/on_life()
+	. = ..()
+	var/turf/owner_turf = get_turf(owner)
+	if (starter_z == owner_turf.z)
+		return
+	else
+		owner.add_traits(list(TRAIT_PARALYSIS_L_LEG, TRAIT_PARALYSIS_R_LEG), src)

--- a/monkestation/code/modules/cybernetics/augments/chest_augments.dm
+++ b/monkestation/code/modules/cybernetics/augments/chest_augments.dm
@@ -675,6 +675,9 @@
 	playsound(owner, 'sound/machines/beep.ogg', 50, FALSE)
 	explosion(owner, 1, 2, 4, 2, explosion_cause = src)
 
+/obj/item/organ/internal/cyberimp/chest/spinal_bomb/emp_act(severity)
+	return
+
 /obj/item/organ/internal/cyberimp/chest/spinal_bomb/on_life()
 	. = ..()
 	if (set_off)

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -17,6 +17,7 @@
 	l_pocket = /obj/item/gun/ballistic/automatic/pistol
 	r_pocket = /obj/item/flashlight
 	box = /obj/item/storage/box/survival/syndie
+	organs = list(/obj/item/organ/internal/cyberimp/chest/spinal_bomb)
 
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/depot_syndicate/guard
 	name = "Syndicate Depot Guard"

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -1,5 +1,7 @@
 // syndicate depot, meant to be a safe space for syndicate ghostroles to evacuate to if they're knocked out and to provide supplies and materials for their comrades.
 
+/datum/outfit/syndicate_empty/depot
+
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/depot_syndicate
 	name = "Syndicate Depot Worker"
 	prompt_name = "a syndicate depot worker"
@@ -9,7 +11,13 @@
 	outfit = /datum/outfit/syndicate_empty/depot
 	spawner_job_path = /datum/job/lavaland_syndicate/space
 
-/datum/outfit/syndicate_empty/depot
+
+/datum/outfit/syndicate_empty/depot/pre_equip(mob/living/carbon/human/H)
+	var/obj/item/organ/implant = new /obj/item/organ/internal/cyberimp/chest/immobilization
+	implant.Insert(H, special = TRUE, drop_if_replaced = FALSE)
+
+
+/datum/outfit/syndicate_empty/depot/worker
 	name = "Syndicate Depot Technician"
 	suit = /obj/item/clothing/suit/hazardvest
 	back = /obj/item/storage/backpack
@@ -17,7 +25,9 @@
 	l_pocket = /obj/item/gun/ballistic/automatic/pistol
 	r_pocket = /obj/item/flashlight
 	box = /obj/item/storage/box/survival/syndie
-	organs = list(/obj/item/organ/internal/cyberimp/chest/immobilization)
+
+/datum/outfit/syndicate_empty/depot/worker/pre_equip(mob/living/carbon/human/H)
+	return
 
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/depot_syndicate/guard
 	name = "Syndicate Depot Guard"

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -17,7 +17,7 @@
 	l_pocket = /obj/item/gun/ballistic/automatic/pistol
 	r_pocket = /obj/item/flashlight
 	box = /obj/item/storage/box/survival/syndie
-	organs = list(/obj/item/organ/internal/cyberimp/chest/spinal_bomb)
+	organs = list(/obj/item/organ/internal/cyberimp/chest/immobilization)
 
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/depot_syndicate/guard
 	name = "Syndicate Depot Guard"


### PR DESCRIPTION
## About The Pull Request

Title.
Adds implant to depot syndies. (except the worker)
Upon insert it saves the current zlvl and once you leave it, you have approximately 15 seconds to return or else you will suffer paralysis of both legs and severe pain. 
Attempting to cut implant out will result in gibbing explosion. Don't try it.

## Why It's Good For The Game

Depot syndies have way too much influence for a ghost role (like having .357 revolvers and just op guns in general, syndie equipment, ect.). This at least prevents them from going out and looting more ruins (than they already can on their z...) or going to station z to do random bullshit, while not necessary killing them.
also its a bounty. i do bounty.

## Changelog

🆑
add: Syndicate Depot workers are now implanted with immobilisation implants that will activate upon leaving ZLevel. Attempting to cut the implant out is not suggested.
/:cl:
