### PR TITLE
Fix cybernetic hacking for others

### DIFF
--- a/monkestation/code/modules/cybernetics/implant_items/cyberlink_connector.dm
+++ b/monkestation/code/modules/cybernetics/implant_items/cyberlink_connector.dm
@@ -42,8 +42,6 @@
 	if(ishuman(target))
 		if(!QDELETED(linked_target) && (target != linked_target))
 			return
-		if(target != user)
-			return
 
 		var/mob/living/carbon/human/human = target
 		var/list/implants = list()


### PR DESCRIPTION
## About The Pull Request
Fixes the ability to hack others cybernetics while 'plugging'

It had a check which made sure the target of the hack was the user which just prevented hacking for others
## Why It's Good For The Game
Makes cyberlink connectors and universal connectors actually more useful, rather than a joke item.

The only issue with this fix is leashing is not required to hack for others. But Ill take what I can get
## Changelog
:cl:
fix: Roboticists finally figured out the cybernetic connectors purpose is and will now be able to hack cybernetics for others.
/:cl:
