### PR TITLE
Bump minimum compile version to 515.1642, dependencies.sh to 515 stable

### DIFF
--- a/.github/alternate_byond_versions.txt
+++ b/.github/alternate_byond_versions.txt
@@ -7,6 +7,6 @@
 # 500.1337: runtimestation
 # 516.1638: runtimestation;516
 # Lowest supported version
-515.1627: runtimestation
+515.1642: runtimestation
 # Beta version
-516.1651: runtimestation;516
+516.1652: runtimestation;516

--- a/.tgs.yml
+++ b/.tgs.yml
@@ -3,7 +3,7 @@
 version: 1
 # The BYOND version to use (kept in sync with dependencies.sh by the "TGS Test Suite" CI job)
 # Must be interpreted as a string, keep quoted
-byond: "515.1637"
+byond: "515.1647"
 # Folders to create in "<instance_path>/Configuration/GameStaticFiles/"
 static_files:
   # Config directory should be static

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -2,11 +2,11 @@
 
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 515
-#define MIN_COMPILER_BUILD 1627
+#define MIN_COMPILER_BUILD 1642
 #if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 515.1627 or higher
+#error You need version 515.1642 or higher
 #endif
 
 // Unable to compile this version thanks to mutable appearance changes

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -5,7 +5,7 @@
 
 # byond version
 export BYOND_MAJOR=515
-export BYOND_MINOR=1637
+export BYOND_MINOR=1647
 
 #rust_g git tag
 export RUST_G_VERSION=3.5.1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/89164 and https://github.com/tgstation/tgstation/pull/89171

> This bumps the minimum compile version to 515.1642, due to [this BYOND bug](https://www.byond.com/forum/post/2936624) where byondapi can corrupt vars, and dreamluau is called regardless of whether a Lua script is actually being ran (mostly via `DREAMLUAU_CLEAR_REF_USERDATA`), so it's best to get rid of any potential of this bug triggering.

## Why It's Good For The Game

> mrrrp mrrrp mrrrowww

## Changelog

No user-facing changes.
