### PR TITLE
Fix crew transfer votes being spammed if nobody votes on them

### DIFF
--- a/monkestation/code/controllers/subsystem/autotransfer.dm
+++ b/monkestation/code/controllers/subsystem/autotransfer.dm
@@ -15,7 +15,6 @@ SUBSYSTEM_DEF(autotransfer)
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/autotransfer/Recover()
-	doing_transfer_vote = SSautotransfer.doing_transfer_vote
 	next_transfer_vote = SSautotransfer.next_transfer_vote
 
 /datum/controller/subsystem/autotransfer/fire()

--- a/monkestation/code/controllers/subsystem/autotransfer.dm
+++ b/monkestation/code/controllers/subsystem/autotransfer.dm
@@ -14,6 +14,10 @@ SUBSYSTEM_DEF(autotransfer)
 	SSticker.OnRoundstart(CALLBACK(src, PROC_REF(crew_transfer_setup)))
 	return SS_INIT_SUCCESS
 
+/datum/controller/subsystem/autotransfer/Recover()
+	doing_transfer_vote = SSautotransfer.doing_transfer_vote
+	next_transfer_vote = SSautotransfer.next_transfer_vote
+
 /datum/controller/subsystem/autotransfer/fire()
 	if(can_run_transfer_vote())
 		SSvote.initiate_vote(/datum/vote/shuttle_call, "automatic shuttle vote", forced = TRUE)

--- a/monkestation/code/controllers/subsystem/autotransfer.dm
+++ b/monkestation/code/controllers/subsystem/autotransfer.dm
@@ -17,6 +17,14 @@ SUBSYSTEM_DEF(autotransfer)
 /datum/controller/subsystem/autotransfer/fire()
 	if(can_run_transfer_vote())
 		SSvote.initiate_vote(/datum/vote/shuttle_call, "automatic shuttle vote", forced = TRUE)
+		start_subsequent_vote_cooldown()
+
+/datum/controller/subsystem/autotransfer/proc/start_subsequent_vote_cooldown()
+	var/subsequent_transfer_vote_time = CONFIG_GET(number/subsequent_transfer_vote_time)
+	if(subsequent_transfer_vote_time)
+		COOLDOWN_START(src, next_transfer_vote, subsequent_transfer_vote_time + CONFIG_GET(number/vote_period))
+	else
+		next_transfer_vote = 0
 
 /datum/controller/subsystem/autotransfer/proc/can_run_transfer_vote()
 	. = TRUE
@@ -50,8 +58,3 @@ SUBSYSTEM_DEF(autotransfer)
 
 /datum/controller/subsystem/autotransfer/proc/crew_transfer_continue()
 	SSgamemode.point_gain_multipliers[EVENT_TRACK_ROLESET]++
-	var/subsequent_transfer_vote_time = CONFIG_GET(number/subsequent_transfer_vote_time)
-	if(!subsequent_transfer_vote_time)
-		next_transfer_vote = 0
-		return
-	COOLDOWN_START(src, next_transfer_vote, subsequent_transfer_vote_time)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/5194

i made it so the cooldown timer is started after initiating the vote (and just adding the vote duration to it) rather than _after_, to account for any sort of issues with the vote finishing

## Changelog
:cl:
fix: Fixed crew transfer votes being spammed if nobody votes on them.
/:cl:
