### PR TITLE
[DNM] try to fix passive vents dividing by zero

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -265,7 +265,7 @@ GLOBAL_LIST_INIT(gaslist_cache, init_gaslist_cache())
 		. = TRUE
 		var/self_heat_cap = heat_capacity()
 		var/other_heat_cap = other.heat_capacity()
-		var/new_temp = (temperature * self_heat_cap + other.temperature * other_heat_cap) / (self_heat_cap + other_heat_cap)
+		var/new_temp = max((temperature * self_heat_cap + other.temperature * other_heat_cap) / (self_heat_cap + other_heat_cap), TCMB)
 		temperature = new_temp
 		other.temperature = new_temp
 


### PR DESCRIPTION

## About The Pull Request
## Why It's Good For The Game
## Changelog
:cl:
fix: Fixed passive vents getting zero temperature and dividing by zero as a result. Probably.
/:cl:
