### PR TITLE
Adds NT frontier and NT Science Hub to Sci PDAs; NT Frontier to RD PDA

### DIFF
--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -102,6 +102,7 @@
 		/datum/computer_file/program/robocontrol,
 		/datum/computer_file/program/budgetorders,
 		/datum/computer_file/program/signal_commander,
+		/datum/computer_file/program/scipaper_program,
 	)
 
 /obj/item/modular_computer/pda/heads/quartermaster
@@ -187,6 +188,8 @@
 	starting_programs = list(
 		/datum/computer_file/program/atmosscan,
 		/datum/computer_file/program/signal_commander,
+		/datum/computer_file/program/science,
+		/datum/computer_file/program/scipaper_program,
 	)
 
 /obj/item/modular_computer/pda/roboticist


### PR DESCRIPTION

## About The Pull Request

Title.
Scientists now have science hub and nt frontier installed on their PDAs
RD now has nt frontier too

## Why It's Good For The Game

QoL stuff. Weird that scientists dont start with the sci hub considering they are THE RnD guys. You can install it yourself anyway.
NT frontier is for people that dont know how to send files for ordnance experiments and cant be bothered to open downloading app. Hopefully people will see it and think "wow thats how you do it".   (absolute cope) (please do ordnance experiments)

## Changelog

:cl:
add: Added NT frontier and NT Science Hub to Scientist PDAs
add: Added NT frontier to RD PDAs
/:cl:
