### PR TITLE
Fix a bunch of hard-dels; fix plumbing stuff being qdel'd before initialization; and make unit tests actually output `data/unit_tests.json` on CI

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -2638,7 +2638,6 @@
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "kB" = (
@@ -2855,7 +2854,6 @@
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "vs" = (

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -66575,7 +66575,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /mob/living/basic/pet/potty,
 /obj/structure/sink/directional/east,
-/obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/common/night_club/changing_room)
 "mTN" = (

--- a/_maps/map_files/Graveyard/Graveyard.dmm
+++ b/_maps/map_files/Graveyard/Graveyard.dmm
@@ -17052,7 +17052,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/grimy,
 /area/ruin/syndicate_lava_base)
 "gEx" = (
@@ -25736,8 +25735,6 @@
 /obj/structure/cable/multilayer/connected,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/layer3,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "kbt" = (
@@ -27810,7 +27807,6 @@
 /area/station/maintenance/aft)
 "kQn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
 /obj/structure/sink/directional/east,
 /turf/open/floor/iron/white,
 /area/graveyard/bunker/medical)

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -23809,7 +23809,6 @@
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
 "heQ" = (
-/obj/machinery/duct,
 /obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -26238,7 +26237,6 @@
 /obj/structure/mirror/directional/north{
 	pixel_y = 30
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms)
 "hRr" = (
@@ -54539,7 +54537,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons)
 "qhb" = (
@@ -66356,7 +66353,6 @@
 	dir = 8
 	},
 /obj/structure/sink/directional/south,
-/obj/machinery/duct,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "tAh" = (

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -70916,7 +70916,6 @@
 /area/station/maintenance/starboard/central)
 "vcp" = (
 /obj/structure/curtain,
-/obj/machinery/shower/directional/north,
 /obj/machinery/duct,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -213,7 +213,7 @@
 		move_packet = null
 
 	if(spatial_grid_key)
-		SSspatial_grid.force_remove_from_cell(src)
+		SSspatial_grid.force_remove_from_grid(src)
 
 	LAZYNULL(client_mobs_in_contents)
 

--- a/code/modules/unit_tests/unit_test.dm
+++ b/code/modules/unit_tests/unit_test.dm
@@ -353,9 +353,12 @@ GLOBAL_VAR_INIT(focused_tests, focused_tests())
 
 	var/list/test_results = list()
 
+	//Hell code, we're bound to end the round somehow so let's stop if from ending while we work
+	SSticker.delay_end = TRUE
 	for(var/unit_path in tests_to_run)
 		CHECK_TICK //We check tick first because the unit test we run last may be so expensive that checking tick will lock up this loop forever
 		RunUnitTest(unit_path, test_results)
+	SSticker.delay_end = FALSE
 
 	var/file_name = "data/unit_tests.json"
 	fdel(file_name)

--- a/monkestation/code/modules/botany/species/apid/hive/hive_object.dm
+++ b/monkestation/code/modules/botany/species/apid/hive/hive_object.dm
@@ -100,25 +100,25 @@ GLOBAL_LIST_INIT(hive_exits, list())
 	RegisterSignal(get_area(src), COMSIG_AREA_ENTERED, PROC_REF(enter_area))
 
 /obj/structure/hive_exit/Destroy()
-	. = ..()
-	if(!linked_hive || !get_turf(linked_hive))
-		return
-	var/turf/turf = get_turf(linked_hive)
-	for(var/atom/movable/listed in atoms_inside)
-		if(isnull(turf))
-			continue
-		listed.forceMove(turf)
-	var/area/area = get_area(src)
-	for(var/atom/movable/movable as anything in area)
-		if(isturf(movable))
-			continue
-		if(isnull(turf))
-			continue
-		movable.forceMove(turf)
+	if(linked_hive)
+		var/turf/turf = get_turf(linked_hive)
+		for(var/atom/movable/listed in atoms_inside)
+			if(isnull(turf))
+				continue
+			listed.forceMove(turf)
+		var/area/area = get_area(src)
+		for(var/atom/movable/movable as anything in area)
+			if(isturf(movable))
+				continue
+			if(isnull(turf))
+				continue
+			movable.forceMove(turf)
+
+		linked_hive.linked_exit = null
+		linked_hive = null
 
 	GLOB.hive_exits -= src
-	linked_hive?.linked_exit = null
-	linked_hive = null
+	return ..()
 
 /obj/structure/hive_exit/attack_hand(mob/living/user, list/modifiers)
 	. = ..()

--- a/monkestation/code/modules/map_gen_expansions/mushroom/extraction/structures/extractor/hub.dm
+++ b/monkestation/code/modules/map_gen_expansions/mushroom/extraction/structures/extractor/hub.dm
@@ -30,6 +30,20 @@ TODO LIST:
 	///The main pipe that owns us as part of our 3x3 machine.
 	var/obj/structure/plasma_extraction_hub/part/pipe/main/pipe_owner
 
+/obj/structure/plasma_extraction_hub/part/Destroy()
+	pipe_owner = null
+	return ..()
+
+/**
+ * A piece of the extractor itself, that otherwise does not act as a pipe.
+ */
+/obj/structure/plasma_extraction_hub/part/extractor
+
+/obj/structure/plasma_extraction_hub/part/extractor/Destroy()
+	if(pipe_owner)
+		pipe_owner.extractor_parts -= src
+	return ..()
+
 /**
  * Plasma extraction machine pipe
  * There's 3 of these on each plasma extraction machine, one of which is the owner of the rest.
@@ -48,9 +62,11 @@ TODO LIST:
 	AddComponent(/datum/component/pipe_laying, src)
 
 /obj/structure/plasma_extraction_hub/part/pipe/Destroy()
-	. = ..()
+	if(pipe_owner)
+		pipe_owner.hub_parts -= src
 	last_pipe = null
 	QDEL_LIST(connected_pipes)
+	return ..()
 
 /**
  * Called when a pipe with a reference to us is destroyed,

--- a/monkestation/code/modules/map_gen_expansions/mushroom/extraction/structures/extractor/main.dm
+++ b/monkestation/code/modules/map_gen_expansions/mushroom/extraction/structures/extractor/main.dm
@@ -13,7 +13,9 @@
 	///This is used to tell recently repaired pipes that they should get back to working.
 	var/drilling = FALSE
 	///List of all parts connected to the extraction hub, not including ourselves.
-	var/list/obj/structure/plasma_extraction_hub/hub_parts = list()
+	var/list/obj/structure/plasma_extraction_hub/part/pipe/hub_parts = list()
+	///List of all parts which make up the extractor's sprite. Excludes parts which act as pipes.
+	var/list/obj/structure/plasma_extraction_hub/part/extractor/extractor_parts = list()
 
 /obj/structure/plasma_extraction_hub/part/pipe/main/Initialize(mapload)
 	. = ..()
@@ -21,6 +23,7 @@
 
 /obj/structure/plasma_extraction_hub/part/pipe/main/Destroy()
 	QDEL_LIST(hub_parts)
+	QDEL_LIST(extractor_parts)
 	if(display_panel_ref)
 		QDEL_NULL(display_panel_ref)
 	return ..()
@@ -51,7 +54,8 @@
 				hub_parts += new_part
 				new_part.icon_state = "extractor-middle-left"
 			else
-				new_part = new/obj/structure/plasma_extraction_hub/part(spawned_turf)
+				new_part = new/obj/structure/plasma_extraction_hub/part/extractor(spawned_turf)
+				extractor_parts += new_part
 				switch(count)
 					if(9)
 						new_part.icon_state = "extractor-bottom-left"

--- a/monkestation/code/modules/slimecore/machines/extract_requestor.dm
+++ b/monkestation/code/modules/slimecore/machines/extract_requestor.dm
@@ -29,6 +29,12 @@
 			name_to_path |= list("[new_extract.name]" = new_extract.type)
 			qdel(new_extract)
 
+/obj/machinery/slime_extract_requestor/Destroy()
+	if(console?.request_pad == src)
+		console.request_pad = null
+	console = null
+	return ..()
+
 /obj/machinery/slime_extract_requestor/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
 	if(!console)

--- a/monkestation/code/modules/slimecore/machines/slime_market.dm
+++ b/monkestation/code/modules/slimecore/machines/slime_market.dm
@@ -26,6 +26,13 @@
 	. = ..()
 	link_console()
 
+/obj/machinery/slime_market_pad/Destroy()
+	var/consoles_market_pad = console?.market_pad
+	if(consoles_market_pad == src)
+		console.market_pad = null
+	console = null
+	return ..()
+
 /obj/machinery/slime_market_pad/AltClick(mob/user)
 	. = ..()
 	if(!.)

--- a/monkestation/code/modules/slimecore/machines/slime_market_computer.dm
+++ b/monkestation/code/modules/slimecore/machines/slime_market_computer.dm
@@ -24,7 +24,6 @@ GLOBAL_DATUM(default_slime_market, /obj/machinery/computer/slime_market)
 	link_market_pad()
 
 /obj/machinery/computer/slime_market/Destroy()
-	. = ..()
 	if(GLOB.default_slime_market == src)
 		GLOB.default_slime_market = null
 
@@ -35,6 +34,7 @@ GLOBAL_DATUM(default_slime_market, /obj/machinery/computer/slime_market)
 
 	request_pad = null
 	market_pad = null
+	return ..()
 
 /obj/machinery/computer/slime_market/proc/link_market_pad()
 	if(market_pad)


### PR DESCRIPTION
## About The Pull Request
Unit tests were not delaying the round end - this caused a number of issues, from hard-dels not being reported, to `data/unit_tests.json` not being output.

Once the above was fixed, several hard-dels relating to bees, the slime market pad, hive exit, and plasma extraction hub surfaced, which were also fixed.

There were additionally some qdel-before-initialization issues which surfaced, too. These issues arose when two fluid-duct-like objects, or two power-cable-like objects, were atop the same tile. Upon loading the map, one would attempt to deconstruct the others so that it could anchor itself - leading to a qdel-before-initialization.

## Please testmerge this for a few rounds before merging, to ensure that I didn't break anything.