### PR TITLE
Shockwave PKA Rebalance [temp]

### DIFF
--- a/monkestation/code/modules/mining/accelerators/shockwave.dm
+++ b/monkestation/code/modules/mining/accelerators/shockwave.dm
@@ -20,6 +20,7 @@
 
 /obj/projectile/kinetic/shockwave
 	name = "concussive kinetic force"
+	damage = 5 //turning this down since miners are using it to point blank enemies. might not be enough damage to break walls anymore but /shrug. until we can fix shitcode to prevent the shockwave from being able to do a point blank, this is all I can do.
 	range = 1
 
 /obj/item/firing_pin/explorer/unremovable


### PR DESCRIPTION

## About The Pull Request

Due to a serious usage of some supposed "chad miners" of the PKA Shockwave, this is unfortunately a necessary thing to be done because you are able to kill Bubblegum in approximately 7 attacks with this. And it will outright oneshot kill anyone that doesn't have serious BOMB armor if they are exposed to vacuum.

NOTE: THIS IS A TEMPORARY SOLUTION UNTIL WE CAN POSSIBLY REMOVE THE ABILITY FOR A WEAPON TO BE POINT BLANK FIRED AT MOBS. This is not something I want to be permanent.

## Why It's Good For The Game

This brings all the PKAs back in line with each other for their intended usage.

## Changelog
:cl:
balance: The PKA shockwave does 1/8th the damage from before, down from 40 to 5. Brings the point blank damage usage down to where it should be.
/:cl:
