### PR TITLE
Sneaky cybernetics

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -539,6 +539,7 @@
 
 /obj/item/storage/box/syndie_kit/laser_arm/PopulateContents()
 	new /obj/item/autosurgeon/organ/cyberlink_syndicate(src)
+	new /obj/item/autosurgeon/syndicate/organ/cyberlink_syndicate(src)
 	new /obj/item/autosurgeon/syndicate/laser_arm (src)
 
 /obj/item/storage/box/syndie_kit/nodrop/PopulateContents()

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -537,22 +537,21 @@
 		new /obj/item/food/croissant/throwing(src)
 	new /obj/item/book/granter/crafting_recipe/combat_baking(src)
 
-/obj/item/storage/box/syndie_kit/laser_arm/PopulateContents()
-	new /obj/item/autosurgeon/organ/cyberlink_syndicate(src)
-	new /obj/item/autosurgeon/syndicate/organ/cyberlink_syndicate(src)
+/obj/item/storage/box/syndie_kit/laser_arm/PopulateContents()  // monkestation edit begin: Syndicate implants
+	new /obj/item/autosurgeon/syndicate/cyberlink_syndicate(src)
 	new /obj/item/autosurgeon/syndicate/laser_arm (src)
 
 /obj/item/storage/box/syndie_kit/nodrop/PopulateContents()
-	new /obj/item/autosurgeon/organ/cyberlink_nt_high(src)
+	new /obj/item/autosurgeon/syndicate/cyberlink_syndicate(src)
 	new /obj/item/autosurgeon/syndicate/nodrop(src)
 
 /obj/item/storage/box/syndie_kit/anti_stun/PopulateContents()
-	new /obj/item/autosurgeon/organ/cyberlink_nt_high(src)
+	new /obj/item/autosurgeon/syndicate/cyberlink_syndicate(src)
 	new /obj/item/autosurgeon/syndicate/anti_stun(src)
 
 /obj/item/storage/box/syndie_kit/reviver/PopulateContents()
-	new /obj/item/autosurgeon/organ/cyberlink_nt_high(src)
-	new /obj/item/autosurgeon/syndicate/reviver(src)
+	new /obj/item/autosurgeon/syndicate/cyberlink_syndicate(src)
+	new /obj/item/autosurgeon/syndicate/reviver(src) //monkestation edit end: Syndicate implants
 
 /obj/item/storage/box/syndie_kit/centcom_costume/PopulateContents()
 	new /obj/item/clothing/under/rank/centcom/officer(src)

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -415,7 +415,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_HEALTH
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY //monkestation edit
 
 /datum/design/cyberimp_surgical
 	name = "Surgical Arm Implant"
@@ -467,7 +467,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY // monkestation edit
 
 /datum/design/cyberimp_diagnostic_hud
 	name = "Diagnostic HUD Implant"
@@ -493,7 +493,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_COMBAT
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY // monkestation edit
 
 /datum/design/cyberimp_thermals
 	name = "Thermal Eyes"
@@ -506,7 +506,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_COMBAT
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY // monkestation edit
 
 /datum/design/cyberimp_antidrop
 	name = "Anti-Drop Implant"
@@ -519,7 +519,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY //  monkestation edit
 
 /datum/design/cyberimp_antistun
 	name = "CNS Rebooter Implant"
@@ -532,7 +532,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_COMBAT
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY // monkestation edit
 
 /datum/design/cyberimp_nutriment
 	name = "Nutriment Pump Implant"
@@ -571,7 +571,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_HEALTH
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY // monkestation edit
 
 /datum/design/cyberimp_thrusters
 	name = "Thrusters Set Implant"
@@ -584,7 +584,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY // monkestation edit
 
 /////////////////////////////////////////
 ////////////Regular Implants/////////////

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -148,17 +148,17 @@
 	uses = 1
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/gun/laser
 
-/obj/item/autosurgeon/syndicate/thermal_eyes
-	starting_organ = /obj/item/organ/internal/eyes/robotic/thermals
+/obj/item/autosurgeon/syndicate/thermal_eyes //monkestation edit start: Syndicate cybernetics
+	starting_organ = /obj/item/organ/internal/eyes/robotic/thermals/syndicate
 
 /obj/item/autosurgeon/syndicate/xray_eyes
-	starting_organ = /obj/item/organ/internal/eyes/robotic/xray
+	starting_organ = /obj/item/organ/internal/eyes/robotic/xray/syndicate
 
 /obj/item/autosurgeon/syndicate/anti_stun
-	starting_organ = /obj/item/organ/internal/cyberimp/brain/anti_stun
+	starting_organ = /obj/item/organ/internal/cyberimp/brain/anti_stun/syndicate
 
 /obj/item/autosurgeon/syndicate/reviver
-	starting_organ = /obj/item/organ/internal/cyberimp/chest/reviver
+	starting_organ = /obj/item/organ/internal/cyberimp/chest/reviver/syndicate //monkestation edit end: Syndicate cybernetics
 
 /obj/item/autosurgeon/syndicate/commsagent
 	desc = "A device that automatically - painfully - inserts an implant. It seems someone's specially \

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -148,13 +148,13 @@
 	uses = 1
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/gun/laser
 
-/obj/item/autosurgeon/syndicate/thermal_eyes //monkestation edit start: Syndicate cybernetics
-	starting_organ = /obj/item/organ/internal/eyes/robotic/thermals/syndicate
+/obj/item/autosurgeon/syndicate/thermal_eyes
+	starting_organ = /obj/item/organ/internal/eyes/robotic/thermals
 
 /obj/item/autosurgeon/syndicate/xray_eyes
-	starting_organ = /obj/item/organ/internal/eyes/robotic/xray/syndicate
+	starting_organ = /obj/item/organ/internal/eyes/robotic/xray
 
-/obj/item/autosurgeon/syndicate/anti_stun
+/obj/item/autosurgeon/syndicate/anti_stun //monkestation edit start: Syndicate cybernetics
 	starting_organ = /obj/item/organ/internal/cyberimp/brain/anti_stun/syndicate
 
 /obj/item/autosurgeon/syndicate/reviver

--- a/monkestation/code/modules/assault_ops/code/armaments/implants.dm
+++ b/monkestation/code/modules/assault_ops/code/armaments/implants.dm
@@ -1,6 +1,11 @@
+#define OPS_SUBCATEGORY_IMPLANTS "Implants"
+
+#define OPS_SUBCATEGORY_CYBERNETICS "Cybernetic Enhancements"
+
 /datum/armament_entry/assault_operatives/implants
 	category = "Cybernetic Implants"
 	category_item_limit = 3
+	subcategory = OPS_SUBCATEGORY_IMPLANTS
 
 /datum/armament_entry/assault_operatives/implants/deathrattle
 	name = "Deathrattle Implant Kit"
@@ -32,17 +37,20 @@
 /datum/armament_entry/assault_operatives/implants/freedom
 	name = "Freedom Implant"
 	description = "Releases the user from common restraints like handcuffs and legcuffs. Comes with four charges."
-	item_type = /obj/item/storage/box/syndie_kit/imp_freedom
+	item_type = /obj/item/implanter/freedom
 	cost = 3
 
-/datum/armament_entry/assault_operatives/implants/thermal
-	name = "Thermal Vision Implant"
-	description = "These cybernetic eyes will give you thermal vision."
-	item_type = /obj/item/autosurgeon/syndicate/thermal_eyes
-	cost = 5
+/datum/armament_entry/assault_operatives/implants/cybernetic
+	subcategory = OPS_SUBCATEGORY_CYBERNETICS
 
-/datum/armament_entry/assault_operatives/implants/nodrop
+/datum/armament_entry/assault_operatives/implants/cybernetic/nodrop
 	name = "Anti-Drop Implant"
 	description = "When activated forces your hand muscles to tightly grip the object you are holding, preventing you from dropping it involuntarily."
 	item_type = /obj/item/storage/box/syndie_kit/nodrop
+	cost = 5
+
+/datum/armament_entry/assault_operatives/implants/cybernetic/thermal
+	name = "Thermal Vision Implant"
+	description = "These cybernetic eyes will give you thermal vision."
+	item_type = /obj/item/autosurgeon/syndicate/thermal_eyes
 	cost = 5

--- a/monkestation/code/modules/blueshift/items/implants.dm
+++ b/monkestation/code/modules/blueshift/items/implants.dm
@@ -19,7 +19,7 @@
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/esword
 
 /obj/item/autosurgeon/syndicate/nodrop
-	starting_organ = /obj/item/organ/internal/cyberimp/brain/anti_drop
+	starting_organ = /obj/item/organ/internal/cyberimp/brain/anti_drop/syndicate
 
 /obj/item/autosurgeon/syndicate/baton
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/baton

--- a/monkestation/code/modules/blueshift/opfor/equipment/implants.dm
+++ b/monkestation/code/modules/blueshift/opfor/equipment/implants.dm
@@ -16,6 +16,17 @@
 	admin_note = "Needed to run any non illegal cyberware"
 	item_type = /obj/item/autosurgeon/organ/cyberlink_nt_high
 
+
+/datum/opposing_force_equipment/implants/xray
+	name = "Contraband X-Ray Eyes"
+	item_type = /obj/item/autosurgeon/syndicate/xray_eyes
+	description = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
+
+/datum/opposing_force_equipment/implants/thermal
+	name = "Contraband Thermal Eyes"
+	item_type = /obj/item/autosurgeon/syndicate/thermal_eyes
+	description = "These cybernetic eye implants will give you thermal vision. Vertical slit pupil included."
+
 /datum/opposing_force_equipment/implants/sad_trombone
 	name = "Sad Trombone Implant"
 	item_type = /obj/item/implanter/sad_trombone
@@ -88,16 +99,6 @@
 	item_type = /obj/item/implanter/emp
 	admin_note = "Gives the user a big EMP on an action button. Has three uses after which it becomes useless."
 	description = "An implanter that grants you the ability to create several EMP pulses, centered on you."
-
-/datum/opposing_force_equipment/implants_illegal/xray
-	name = "Contraband X-Ray Eyes"
-	item_type = /obj/item/autosurgeon/syndicate/xray_eyes
-	description = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
-
-/datum/opposing_force_equipment/implants_illegal/thermal
-	name = "Contraband Thermal Eyes"
-	item_type = /obj/item/autosurgeon/syndicate/thermal_eyes
-	description = "These cybernetic eye implants will give you thermal vision. Vertical slit pupil included."
 
 /datum/opposing_force_equipment/implants_illegal/armlaser
 	name = "Arm-mounted Laser Implant"

--- a/monkestation/code/modules/blueshift/opfor/equipment/implants.dm
+++ b/monkestation/code/modules/blueshift/opfor/equipment/implants.dm
@@ -11,23 +11,10 @@
 	description = "A skillchip that, when installed, allows the user to recognise cyborg wire layouts and understand their functionality at a glance."
 
 //Implants
-/datum/opposing_force_equipment/implants/Cybersun
-	item_type = /obj/item/autosurgeon/syndicate/
-/datum/opposing_force_equipment/implants/nodrop
-	item_type = /obj/item/autosurgeon/syndicate/nodrop
-	name = "Anti Drop Implant"
-	admin_note = "Allows the user to tighten their grip, their held items unable to be dropped by any cause. Hardstuns user for a longtime if hit with EMP."
-	description = "An implant that prevents you from dropping items in your hand involuntarily. Comes loaded in a syndicate autosurgeon."
-
-/datum/opposing_force_equipment/implants/cns
-	name = "CNS Rebooter Implant"
-	item_type = /obj/item/autosurgeon/syndicate/anti_stun
-	description = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned."
-
-/datum/opposing_force_equipment/implants/reviver
-	name = "Reviver Implant"
-	item_type = /obj/item/autosurgeon/syndicate/reviver
-	description = "This implant will attempt to revive and heal you if you lose consciousness. For the faint of heart!"
+/datum/opposing_force_equipment/implants/cyberlink_nt_high
+	name = "NT-High Cyberlink"
+	admin_note = "Needed to run any non illegal cyberware"
+	item_type = /obj/item/autosurgeon/cyberlink_nt_high
 
 /datum/opposing_force_equipment/implants/sad_trombone
 	name = "Sad Trombone Implant"
@@ -52,10 +39,6 @@
 	name = "Janitor Arm Implant"
 	item_type = /obj/item/autosurgeon/janitor
 
-/datum/opposing_force_equipment/implants/armblade
-	name = "Mantis Blade Arm Implant"
-	admin_note = "Force 30 IF emagged."
-	item_type = /obj/item/autosurgeon/organ/syndicate/syndie_mantis
 
 /datum/opposing_force_equipment/implants/muscle
 	name = "Muscle Arm Implant"
@@ -94,6 +77,11 @@
 	item_type = /obj/item/implanter/explosive
 	description = "An implanter that will make you explode on death in a decent-sized explosion."
 */
+/datum/opposing_force_equipment/implants_illegal/cybersun
+	item_type = /obj/item/autosurgeon/syndicate/cyberlink_syndicate
+	name = "Cybersun Cybernetics Access System"
+	admin_note = "Needed to use any illegal cybernetics."
+	description = "Cybersun's patented cyberlink, equipped to run more nefarious and dangerous cyberware. Invisible to medical huds, and comes with a single use autosurgeon."
 
 /datum/opposing_force_equipment/implants_illegal/emp
 	name = "EMP Implant"
@@ -130,3 +118,25 @@
 /datum/opposing_force_equipment/implants_illegal/flash
 	name = "Flash Arm Implant"
 	item_type = /obj/item/autosurgeon/syndicate/flash
+
+/datum/opposing_force_equipment/implants_illegal/armblade
+	name = "Mantis Blade Arm Implant"
+	admin_note = "Force 30 IF emagged. Acts as a power crowbar (Opens airlock after delay)."
+	description = "A pair of armblades, can be used to cut and pry objects open, and pry open airlocks."
+	item_type = /obj/item/autosurgeon/organ/syndicate/syndie_mantis
+
+/datum/opposing_force_equipment/implants_illegal/nodrop
+	item_type = /obj/item/autosurgeon/syndicate/nodrop
+	name = "Anti Drop Implant"
+	admin_note = "Allows the user to tighten their grip, their held items unable to be dropped by any cause. Hardstuns user for a longtime if hit with EMP."
+	description = "An implant that prevents you from dropping items in your hand involuntarily. Comes loaded in a syndicate autosurgeon."
+
+/datum/opposing_force_equipment/implants_illegal/cns
+	name = "CNS Rebooter Implant"
+	item_type = /obj/item/autosurgeon/syndicate/anti_stun
+	description = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned. Comes loaded in a syndicate autosurgeon."
+
+/datum/opposing_force_equipment/implants_illegal/reviver
+	name = "Reviver Implant"
+	item_type = /obj/item/autosurgeon/syndicate/reviver
+	description = "This implant will attempt to revive and heal you if you lose consciousness. For the faint of heart! Comes loaded in a syndicate autosurgeon."

--- a/monkestation/code/modules/blueshift/opfor/equipment/implants.dm
+++ b/monkestation/code/modules/blueshift/opfor/equipment/implants.dm
@@ -14,7 +14,7 @@
 /datum/opposing_force_equipment/implants/cyberlink_nt_high
 	name = "NT-High Cyberlink"
 	admin_note = "Needed to run any non illegal cyberware"
-	item_type = /obj/item/autosurgeon/cyberlink_nt_high
+	item_type = /obj/item/autosurgeon/organ/cyberlink_nt_high
 
 /datum/opposing_force_equipment/implants/sad_trombone
 	name = "Sad Trombone Implant"

--- a/monkestation/code/modules/blueshift/opfor/equipment/implants.dm
+++ b/monkestation/code/modules/blueshift/opfor/equipment/implants.dm
@@ -122,21 +122,23 @@
 /datum/opposing_force_equipment/implants_illegal/armblade
 	name = "Mantis Blade Arm Implant"
 	admin_note = "Force 30 IF emagged. Acts as a power crowbar (Opens airlock after delay)."
-	description = "A pair of armblades, can be used to cut and pry objects open, and pry open airlocks."
+	description = "A pair of armblades, can be used to cut and pry objects and people open alike."
 	item_type = /obj/item/autosurgeon/organ/syndicate/syndie_mantis
 
 /datum/opposing_force_equipment/implants_illegal/nodrop
 	item_type = /obj/item/autosurgeon/syndicate/nodrop
-	name = "Anti Drop Implant"
-	admin_note = "Allows the user to tighten their grip, their held items unable to be dropped by any cause. Hardstuns user for a longtime if hit with EMP."
+	name = "Contraband Anti Drop Implant"
+	admin_note = "Allows the user to tighten their grip, their held items unable to be dropped by any cause. Hardstuns user for a longtime if hit with EMP. Will not show on health analyzers."
 	description = "An implant that prevents you from dropping items in your hand involuntarily. Comes loaded in a syndicate autosurgeon."
 
 /datum/opposing_force_equipment/implants_illegal/cns
-	name = "CNS Rebooter Implant"
+	name = "Contraband CNS Rebooter Implant"
 	item_type = /obj/item/autosurgeon/syndicate/anti_stun
 	description = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned. Comes loaded in a syndicate autosurgeon."
+	admin_note = "Will not show on health analyzers."
 
 /datum/opposing_force_equipment/implants_illegal/reviver
-	name = "Reviver Implant"
+	name = "Contraband Reviver Implant"
 	item_type = /obj/item/autosurgeon/syndicate/reviver
 	description = "This implant will attempt to revive and heal you if you lose consciousness. For the faint of heart! Comes loaded in a syndicate autosurgeon."
+	admin_note = "Will not show on health analyzers."

--- a/monkestation/code/modules/blueshift/opfor/equipment/implants.dm
+++ b/monkestation/code/modules/blueshift/opfor/equipment/implants.dm
@@ -11,6 +11,8 @@
 	description = "A skillchip that, when installed, allows the user to recognise cyborg wire layouts and understand their functionality at a glance."
 
 //Implants
+/datum/opposing_force_equipment/implants/Cybersun
+	item_type = /obj/item/autosurgeon/syndicate/
 /datum/opposing_force_equipment/implants/nodrop
 	item_type = /obj/item/autosurgeon/syndicate/nodrop
 	name = "Anti Drop Implant"
@@ -100,12 +102,12 @@
 	description = "An implanter that grants you the ability to create several EMP pulses, centered on you."
 
 /datum/opposing_force_equipment/implants_illegal/xray
-	name = "X-Ray Eyes"
+	name = "Contraband X-Ray Eyes"
 	item_type = /obj/item/autosurgeon/syndicate/xray_eyes
 	description = "These cybernetic eyes will give you X-ray vision. Blinking is futile."
 
 /datum/opposing_force_equipment/implants_illegal/thermal
-	name = "Thermal Eyes"
+	name = "Contraband Thermal Eyes"
 	item_type = /obj/item/autosurgeon/syndicate/thermal_eyes
 	description = "These cybernetic eye implants will give you thermal vision. Vertical slit pupil included."
 

--- a/monkestation/code/modules/cybernetics/augments/_base_changes.dm
+++ b/monkestation/code/modules/cybernetics/augments/_base_changes.dm
@@ -200,7 +200,7 @@
 	starting_organ = /obj/item/organ/internal/cyberimp/cyberlink/terragov
 	uses = 1
 
-/obj/item/autosurgeon/organ/cyberlink_syndicate
+/obj/item/autosurgeon/syndicate/organ/cyberlink_syndicate
 	starting_organ = /obj/item/organ/internal/cyberimp/cyberlink/syndicate
 	uses = 1
 

--- a/monkestation/code/modules/cybernetics/augments/_base_changes.dm
+++ b/monkestation/code/modules/cybernetics/augments/_base_changes.dm
@@ -200,7 +200,7 @@
 	starting_organ = /obj/item/organ/internal/cyberimp/cyberlink/terragov
 	uses = 1
 
-/obj/item/autosurgeon/syndicate/organ/cyberlink_syndicate
+/obj/item/autosurgeon/syndicate/cyberlink_syndicate
 	starting_organ = /obj/item/organ/internal/cyberimp/cyberlink/syndicate
 	uses = 1
 

--- a/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
+++ b/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
@@ -47,7 +47,9 @@
 		var/obj/potential_knife = created_item.resolve()
 		if(istype(/obj/item/knife/combat/cyborg, potential_knife))
 			return FALSE
-
+	balloon_alert(user, "integrated knife unlocked")
+	items_list += WEAKREF(new /obj/item/knife/combat/cyborg(src))
+	return TRUE
 /obj/item/organ/internal/cyberimp/arm/item_set/surgery/emagged
 	name = "hacked surgical toolset implant"
 	desc = "A set of surgical tools hidden behind a concealed panel on the user's arm. This one seems to have been tampered with."
@@ -190,3 +192,6 @@
 		var/obj/potential_chainsaw = created_item.resolve()
 		if(istype(/obj/item/chainsaw, potential_chainsaw))
 			return FALSE
+	balloon_alert(user, "integrated chainsaw unlocked")
+	items_list += WEAKREF(new /obj/item/chainsaw(src))
+	return TRUE

--- a/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
+++ b/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
@@ -42,6 +42,12 @@
 	)
 	encode_info = AUGMENT_NT_HIGHLEVEL
 
+/obj/item/organ/internal/cyberimp/arm/item_set/surgery/emag_act(mob/user, obj/item/card/emag/emag_card)
+	for(var/datum/weakref/created_item in items_list)
+		var/obj/potential_knife = created_item.resolve()
+		if(istype(/obj/item/knife/combat/cyborg, potential_knife))
+			return FALSE
+
 /obj/item/organ/internal/cyberimp/arm/item_set/surgery/emagged
 	name = "hacked surgical toolset implant"
 	desc = "A set of surgical tools hidden behind a concealed panel on the user's arm. This one seems to have been tampered with."
@@ -178,3 +184,9 @@
 		/obj/item/storage/bag/plants/portaseeder
 	)
 	encode_info = AUGMENT_NT_LOWLEVEL
+
+/obj/item/organ/internal/cyberimp/arm/item_set/botany/emag_act(mob/user, obj/item/card/emag/emag_card)
+	for(var/datum/weakref/created_item in items_list)
+		var/obj/potential_chainsaw = created_item.resolve()
+		if(istype(/obj/item/chainsaw, potential_chainsaw))
+			return FALSE

--- a/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
+++ b/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
@@ -190,8 +190,8 @@
 /obj/item/organ/internal/cyberimp/arm/item_set/botany/emag_act(mob/user, obj/item/card/emag/emag_card)
 	for(var/datum/weakref/created_item in items_list)
 		var/obj/potential_chainsaw = created_item.resolve()
-		if(istype(/obj/item/chainsaw, potential_chainsaw))
+		if(istype(/obj/item/chainsaw/mounted_chainsaw, potential_chainsaw))
 			return FALSE
 	balloon_alert(user, "integrated chainsaw unlocked")
-	items_list += WEAKREF(new /obj/item/chainsaw(src))
+	items_list += WEAKREF(new /obj/item/chainsaw/mounted_chainsaw(src))
 	return TRUE

--- a/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
+++ b/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/jobs.dm
@@ -187,11 +187,3 @@
 	)
 	encode_info = AUGMENT_NT_LOWLEVEL
 
-/obj/item/organ/internal/cyberimp/arm/item_set/botany/emag_act(mob/user, obj/item/card/emag/emag_card)
-	for(var/datum/weakref/created_item in items_list)
-		var/obj/potential_chainsaw = created_item.resolve()
-		if(istype(/obj/item/chainsaw/mounted_chainsaw, potential_chainsaw))
-			return FALSE
-	balloon_alert(user, "integrated chainsaw unlocked")
-	items_list += WEAKREF(new /obj/item/chainsaw/mounted_chainsaw(src))
-	return TRUE

--- a/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/weapons.dm
+++ b/monkestation/code/modules/cybernetics/augments/arm_augments/item_sets/weapons.dm
@@ -18,6 +18,7 @@
 	icon_state = "arm_laser"
 	items_to_create = list(/obj/item/gun/energy/laser/mounted/augment)
 	encode_info = AUGMENT_SYNDICATE_LEVEL
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
 
 /obj/item/organ/internal/cyberimp/arm/item_set/gun/laser/l
 	zone = BODY_ZONE_L_ARM

--- a/monkestation/code/modules/cybernetics/augments/chest_augments.dm
+++ b/monkestation/code/modules/cybernetics/augments/chest_augments.dm
@@ -376,6 +376,10 @@
 	if(human_owner.stat == CONSCIOUS)
 		to_chat(human_owner, span_notice("You feel your heart beating again!"))
 
+/obj/item/organ/internal/cyberimp/chest/reviver/syndicate
+	name = "contraband reviver implant"
+	encode_info = AUGMENT_SYNDICATE_LEVEL
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
 
 /obj/item/organ/internal/cyberimp/chest/thrusters
 	name = "implantable thrusters set"

--- a/monkestation/code/modules/cybernetics/augments/eye_implants.dm
+++ b/monkestation/code/modules/cybernetics/augments/eye_implants.dm
@@ -80,5 +80,5 @@
 	name = "Contraband Security HUD Implant"
 	desc = "A Cybersun Industries brand Security HUD Implant. These illicit cybernetic eye implants will display a security HUD over everything you see."
 	icon_state = "eye_implant_syndicate"
-	organ_flags = ORGAN_SYNTHETIC | ORGAN_HIDDEN
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
 	encode_info = AUGMENT_SYNDICATE_LEVEL

--- a/monkestation/code/modules/cybernetics/augments/internal_implants.dm
+++ b/monkestation/code/modules/cybernetics/augments/internal_implants.dm
@@ -105,6 +105,11 @@
 	UnregisterSignal(source, COMSIG_ITEM_DROPPED)
 	stored_items -= source
 
+/obj/item/organ/internal/cyberimp/brain/anti_drop/syndicate
+	name = "contraband anti-drop implant"
+	encode_info = AUGMENT_SYNDICATE_LEVEL
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
+
 /obj/item/organ/internal/cyberimp/brain/anti_stun
 	name = "CNS rebooter implant"
 	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned."
@@ -157,6 +162,11 @@
 
 /obj/item/organ/internal/cyberimp/brain/anti_stun/proc/reboot()
 	organ_flags &= ~ORGAN_FAILING
+
+/obj/item/organ/internal/cyberimp/brain/anti_stun/syndicate
+	name = "contraband CNS rebooter implant"
+	encode_info = AUGMENT_SYNDICATE_LEVEL
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
 
 //[[[[MOUTH]]]]
 /obj/item/organ/internal/cyberimp/mouth

--- a/monkestation/code/modules/cybernetics/augments/internal_implants.dm
+++ b/monkestation/code/modules/cybernetics/augments/internal_implants.dm
@@ -41,7 +41,8 @@
 	icon_state = "brain_implant_antidrop"
 	var/active = FALSE
 	var/list/stored_items = list()
-	implant_color = "#DE7E00"
+	implant_overlay = null
+	implant_color = null
 	slot = ORGAN_SLOT_BRAIN_ANTIDROP
 	actions_types = list(/datum/action/item_action/organ_action/toggle)
 	encode_info = AUGMENT_NT_HIGHLEVEL
@@ -108,7 +109,8 @@
 	name = "CNS rebooter implant"
 	desc = "This implant will automatically give you back control over your central nervous system, reducing downtime when stunned."
 	icon_state = "brain_implant_rebooter"
-	implant_color = "#FFFF00"
+	implant_overlay = null
+	implant_color = null
 	slot = ORGAN_SLOT_BRAIN_ANTISTUN
 
 	var/static/list/signalCache = list(

--- a/monkestation/code/modules/cybernetics/augments/uplink/uplink.dm
+++ b/monkestation/code/modules/cybernetics/augments/uplink/uplink.dm
@@ -6,7 +6,7 @@
 	purchasable_from = UPLINK_TRAITORS
 
 /obj/item/storage/box/syndie_kit/sandy/PopulateContents()
-	new /obj/item/autosurgeon/syndicate/organ/cyberlink_syndicate(src)
+	new /obj/item/autosurgeon/syndicate/cyberlink_syndicate(src)
 	new /obj/item/autosurgeon/organ/syndicate/sandy(src)
 
 
@@ -18,7 +18,7 @@
 	purchasable_from = UPLINK_TRAITORS
 
 /obj/item/storage/box/syndie_kit/mantis/PopulateContents()
-	new /obj/item/autosurgeon/syndicate/organ/cyberlink_syndicate(src)
+	new /obj/item/autosurgeon/syndicate/cyberlink_syndicate(src)
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis(src)
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis/l(src)
 
@@ -30,5 +30,5 @@
 	purchasable_from = UPLINK_TRAITORS
 
 /obj/item/storage/box/syndie_kit/dualwield/PopulateContents()
-	new /obj/item/autosurgeon/syndicate/organ/cyberlink_syndicate(src)
+	new /obj/item/autosurgeon/syndicate/cyberlink_syndicate(src)
 	new /obj/item/autosurgeon/organ/syndicate/dualwield(src)

--- a/monkestation/code/modules/cybernetics/augments/uplink/uplink.dm
+++ b/monkestation/code/modules/cybernetics/augments/uplink/uplink.dm
@@ -6,7 +6,7 @@
 	purchasable_from = UPLINK_TRAITORS
 
 /obj/item/storage/box/syndie_kit/sandy/PopulateContents()
-	new /obj/item/autosurgeon/organ/cyberlink_syndicate(src)
+	new /obj/item/autosurgeon/syndicate/organ/cyberlink_syndicate(src)
 	new /obj/item/autosurgeon/organ/syndicate/sandy(src)
 
 
@@ -18,7 +18,7 @@
 	purchasable_from = UPLINK_TRAITORS
 
 /obj/item/storage/box/syndie_kit/mantis/PopulateContents()
-	new /obj/item/autosurgeon/organ/cyberlink_syndicate(src)
+	new /obj/item/autosurgeon/syndicate/organ/cyberlink_syndicate(src)
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis(src)
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis/l(src)
 
@@ -30,5 +30,5 @@
 	purchasable_from = UPLINK_TRAITORS
 
 /obj/item/storage/box/syndie_kit/dualwield/PopulateContents()
-	new /obj/item/autosurgeon/organ/cyberlink_syndicate(src)
+	new /obj/item/autosurgeon/syndicate/organ/cyberlink_syndicate(src)
 	new /obj/item/autosurgeon/organ/syndicate/dualwield(src)

--- a/monkestation/code/modules/cybernetics/designs/item_sets.dm
+++ b/monkestation/code/modules/cybernetics/designs/item_sets.dm
@@ -61,7 +61,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_UTILITY
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
 /datum/design/itemset_janitor
 	name = "Janitorial Arm Implant"

--- a/monkestation/code/modules/cybernetics/premade_storages/antags.dm
+++ b/monkestation/code/modules/cybernetics/premade_storages/antags.dm
@@ -5,4 +5,4 @@
 	..()
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis(src)
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis/l(src)
-	new /obj/item/autosurgeon/syndicate/organ/cyberlink_syndicate(src)
+	new /obj/item/autosurgeon/syndicate/cyberlink_syndicate(src)

--- a/monkestation/code/modules/cybernetics/premade_storages/antags.dm
+++ b/monkestation/code/modules/cybernetics/premade_storages/antags.dm
@@ -5,4 +5,4 @@
 	..()
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis(src)
 	new /obj/item/autosurgeon/organ/syndicate/syndie_mantis/l(src)
-	new /obj/item/autosurgeon/organ/cyberlink_syndicate(src)
+	new /obj/item/autosurgeon/syndicate/organ/cyberlink_syndicate(src)

--- a/monkestation/code/modules/cybernetics/tech_nodes.dm
+++ b/monkestation/code/modules/cybernetics/tech_nodes.dm
@@ -12,7 +12,7 @@
 	display_name = "Advanced Cybernetic Application"
 	description = "Creation of NT-secure advanced cyberlinks for high-grade cybernetic augmentation"
 	prereq_ids = list("ntlink_low", "adv_cyber_implants","high_efficiency")
-	design_ids = list("ci-nt_high", "ci-cyberconnector")
+	design_ids = list("ci-nt_high", "ci-tg", "ci-cyberconnector")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/job_approved_item_set
@@ -34,12 +34,10 @@
 /datum/techweb_node/security_authorized_implants
 	id = "job_itemsets-sec"
 	display_name = "NT Approved Security Implants"
-	description = "A list of approved item sets that can be implanted into the crew to allow easier access to their tools."
-	prereq_ids = "A list of approved implants for security officers."
+	description = "A list of approved implants for security officers."
 	prereq_ids = list("ntlink_high")
 	design_ids = list(
 		"ci-set-mantis",
 		"ci-set-combat",
-		"ci-tg",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)

--- a/monkestation/code/modules/cybernetics/tech_nodes.dm
+++ b/monkestation/code/modules/cybernetics/tech_nodes.dm
@@ -4,7 +4,7 @@
 	display_name = "Cybernetic Application"
 	description = "Creation of NT-secure basic cyberlinks for low-grade cybernetic augmentation"
 	prereq_ids = list("adv_biotech","adv_biotech", "datatheory")
-	design_ids = list("ci-nt_low", "ci-cyberconnector", "nif_standard")
+	design_ids = list("ci-nt_low", "ci-set-connector", "nif_standard")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 
 /datum/techweb_node/ntlink_high
@@ -12,7 +12,7 @@
 	display_name = "Advanced Cybernetic Application"
 	description = "Creation of NT-secure advanced cyberlinks for high-grade cybernetic augmentation"
 	prereq_ids = list("ntlink_low", "adv_cyber_implants","high_efficiency")
-	design_ids = list("ci-nt_high")
+	design_ids = list("ci-nt_high", "ci-cyberconnector")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/job_approved_item_set
@@ -26,7 +26,6 @@
 		"ci-set-detective",
 		"ci-set-paramedic",
 		"ci-set-atmospherics",
-		"ci-set-connector",
 		"ci-set-botany",
 		"ci-set-mining",
 	)

--- a/monkestation/code/modules/research/designs/mechfabricator_designs.dm
+++ b/monkestation/code/modules/research/designs/mechfabricator_designs.dm
@@ -84,7 +84,7 @@
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/design/power_cord
-	name = "power cord implant"
+	name = "Power Cord Implant"
 	desc = "An internal power cord hooked up to a battery. Useful if you run on volts."
 	id = "power_cord"
 	build_type = MECHFAB
@@ -92,7 +92,7 @@
 	materials = list(/datum/material/iron = 2500, /datum/material/glass = 2000)
 	build_path = /obj/item/organ/internal/cyberimp/arm/item_set/power_cord
 	category = list(
-		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_MISC
+		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_IMPLANTS_MISC
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 

--- a/monkestation/code/modules/surgery/organs/augments.dm
+++ b/monkestation/code/modules/surgery/organs/augments.dm
@@ -1,5 +1,5 @@
 /obj/item/organ/internal/cyberimp/arm/item_set/power_cord
-	name = "power cord implant"
+	name = "Power Cord Implant"
 	desc = "An internal power cord hooked up to a battery. Useful if you run on volts."
 	contents = newlist(/obj/item/apc_powercord)
 	zone = "l_arm"

--- a/monkestation/code/modules/surgery/organs/internal/eyes.dm
+++ b/monkestation/code/modules/surgery/organs/internal/eyes.dm
@@ -101,3 +101,11 @@
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_1
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
+
+/obj/item/organ/internal/eyes/robotic/xray/syndicate
+	name = "contraband x-ray eyes"
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
+
+/obj/item/organ/internal/eyes/robotic/thermals/syndicate
+	name = "contraband thermal eyes"
+	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN

--- a/monkestation/code/modules/surgery/organs/internal/eyes.dm
+++ b/monkestation/code/modules/surgery/organs/internal/eyes.dm
@@ -102,10 +102,3 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
 
-/obj/item/organ/internal/eyes/robotic/xray/syndicate
-	name = "contraband x-ray eyes"
-	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN
-
-/obj/item/organ/internal/eyes/robotic/thermals/syndicate
-	name = "contraband thermal eyes"
-	organ_flags = parent_type::organ_flags | ORGAN_HIDDEN

--- a/monkestation/code/modules/surgery/organs/internal/tongue.dm
+++ b/monkestation/code/modules/surgery/organs/internal/tongue.dm
@@ -57,7 +57,6 @@
 	modifies_speech = TRUE
 	taste_sensitivity = 25 // not as good as an organic tongue
 	maxHealth = 100 //RoboTongue!
-	zone = BODY_ZONE_HEAD
 	slot = ORGAN_SLOT_TONGUE
 	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
 


### PR DESCRIPTION

## About The Pull Request
### Contraband Cybernetics
Cybersun now has exclusive deals with all syndicate organizations. All traitors, nuclear and assault operatives, and whatever the hell a 'opfor' is, will now use contraband cybernetics, which use a cybersun link and are invisible to health scans.

### Security printable cybernetics
Brig physicans have complained and the research directors were motivated enough to adjust how designs are sent out. Now the following implants are printable by security lathes

- Security hud implants
- Antidrops
- Rebooters
- X-ray eyes
- Thermal eyes
- Detective toolset arms
- Revivers
- Breathing tubes

And to follow suit Terran cyberlinks have been moved to Advanced cybernetic implantation research to follow suit.

### Civilian restrictions
To follow suit we've restricted some of the combat/security cybernetics.

- Anti-drops
- Rebooters
- Detective Toolset arms

These will remain printable by robotics but no longer by medical lathes. So if you really need one you can contact your local ripperdoc.

### Emag Fix
Override specialists finally got around to subverting surgical
Now knifes are producable by surgery arms

### Research/hacking balancing
Universal connectors were moved to cybernetic implentation (NT Low cybernetics)
Wireless connectors are now unlocked with Advanced cybernetic implantation (NT High cybernetics)
## Why It's Good For The Game

- Contraband cybernetics help address the weirdness around what cybernetic link you need and keep evil cybernetics to the evildoers. In addition not outing an assault operative because they have a anti-drop 10 minutes into the round and were scanned once by a doctor after stubbing their toe.
- Security implants were already printable at the security lathe. But only the final ones. With brig physicians losing med access this makes them have to beg someone in medical to be able to print a security implant or three to upgrade their team. Which frankly sucks.
In addition their link was unlocked that I moved it down some so installations can be made before they get all the tools.
So I gave them cybernetics that dont use any link, (Breathing tubes) and anything useful for security thats NT High or terran access.

- Medical lathe restrictions. As the name suggests these are combat implants. There's not much use for antidrops and antistuns for civilian use. X-rays and thermals can actually be useful for paramedics for finding folks and thrusters are helpful for engineers and other z g situations. So I gave them a pass for now.
- Surgical arms are supposed to get knifes, they have even a emag subtype but no way to emag it. Its been so frustrating and AGKJN. Gives the knife they deserve.
- The worse version of a tool should be unlocked before the better one. This currently is inverse for connectors; you get universal connectors AFTER wireless connectors. This gives some reason to install a universal connector at least.
## Changelog
:cl:
add: Added more contraband cybernetics (Invisible to health huds and use syndicate access)
add: Added NT high link and Cybersun link to OPFOR equipment
qol: added categories and cleaned up assault operatives cybernetics implantation category
balance: Syndicate themed groups will now all use cybersun cyberlinks and contraband cybernetics
balance: Wireless connectors are later in research and universal connectors are later in research.
balance: Terran cyberlinks are now unlocked alongside NT High cybernetics.
balance: Combat and security related/useable implants are now printable at security lathe
balance: Antidrops, Antistuns, and detective arms are now no longer printable at the medical lathe,
fix: Surgical set arms are now properly emagable.
/:cl:
