### PR TITLE
Your balance is no longer loose

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -192,7 +192,7 @@
 	if (!bulky && prob(50))
 		return
 	visible_message(span_danger("[src] looses [src.p_their()] balance."), \
-		span_danger("You loose your balance."))
+		span_danger("You lose your balance."))
 	Knockdown(2 SECONDS)
 
 	//MONKESTATION EDIT END


### PR DESCRIPTION

## About The Pull Request

Fixes a stupid typo when you throw a bulky object as a carbon
## Why It's Good For The Game

Bugfix good, yada yada
## Changelog
:cl:
spellcheck: You no longer loosen your balance, instead you lose it when throwing a bulky item.
/:cl:
