### PR TITLE
Mark of Rust can no longer damage indestructible items

### DIFF
--- a/monkestation/code/modules/antagonists/heretic/status_effects/mark_effects.dm
+++ b/monkestation/code/modules/antagonists/heretic/status_effects/mark_effects.dm
@@ -22,7 +22,7 @@
 			if(QDELETED(thing) || prob(50))
 				continue
 			// ignore abstract items and such
-			if(thing.item_flags & (ABSTRACT | EXAMINE_SKIP | HAND_ITEM))
+			if((thing.item_flags & (ABSTRACT | EXAMINE_SKIP | HAND_ITEM)) || (thing.resistance_flags & INDESTRUCTIBLE))
 				continue
 			// don't delete people's ID cards
 			if(istype(thing, /obj/item/card/id))


### PR DESCRIPTION

## About The Pull Request

indestructible means, well, indestructible, dammit.

## Why It's Good For The Game

bug fix

## Changelog
:cl:
fix: Mark of Rust can no longer damage indestructible items.
/:cl:
