### PR TITLE
Update VoidRaptor.dmm

### DIFF
--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -41279,7 +41279,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/mob/living/basic/pet/dog/corgi,
+/mob/living/basic/pet/dog/corgi{
+	name = "Dirk"
+	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/robotics/lab)
 "lDP" = (
@@ -70070,14 +70072,6 @@
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/engineering/transit_tube)
-"tuJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/chair,
-/obj/effect/landmark/start/depsec/engineering,
-/turf/open/floor/iron/textured_edge,
-/area/station/security/checkpoint/engineering)
 "tuU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -82887,6 +82881,14 @@
 "wWQ" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/security/warden)
+"wWR" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/chair,
+/obj/effect/landmark/start/depsec/engineering,
+/turf/open/floor/iron/textured_edge,
+/area/station/security/checkpoint/engineering)
 "wXc" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -118788,7 +118790,7 @@ uWW
 gXL
 erh
 sxd
-tuJ
+wWR
 hpe
 qks
 hOM

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -20540,6 +20540,14 @@
 	dir = 6
 	},
 /area/station/service/chapel)
+"fWZ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/chair,
+/obj/effect/landmark/start/depsec/engineering,
+/turf/open/floor/iron/textured_edge,
+/area/station/security/checkpoint/engineering)
 "fXi" = (
 /obj/structure/railing/wood{
 	dir = 8
@@ -22331,6 +22339,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/mob/living/basic/bot/cleanbot/medbay,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/storage)
 "gvO" = (
@@ -82881,14 +82890,6 @@
 "wWQ" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/security/warden)
-"wWR" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/chair,
-/obj/effect/landmark/start/depsec/engineering,
-/turf/open/floor/iron/textured_edge,
-/area/station/security/checkpoint/engineering)
 "wXc" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -118790,7 +118791,7 @@ uWW
 gXL
 erh
 sxd
-wWR
+fWZ
 hpe
 qks
 hOM

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -954,9 +954,6 @@
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/fore)
 "amZ" = (
-/obj/machinery/modular_computer/preset/civilian{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -966,6 +963,39 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/cold/directional/west,
+/obj/structure/table,
+/obj/item/storage/medkit{
+	pixel_x = -3;
+	pixel_y = 8
+	},
+/obj/item/healthanalyzer{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/storage/medkit{
+	pixel_x = -3;
+	pixel_y = 0
+	},
+/obj/item/healthanalyzer{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 10;
+	pixel_y = 14
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 11;
+	pixel_y = 8
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/assembly/prox_sensor{
+	pixel_x = 11;
+	pixel_y = -4
+	},
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
@@ -2588,7 +2618,6 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "aMf" = (
-/obj/machinery/mechpad,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
@@ -2596,6 +2625,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "aMk" = (
@@ -3809,7 +3839,6 @@
 /area/station/engineering/lobby)
 "bbW" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -3825,6 +3854,7 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Shared Engineering Storage"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/storage_shared)
 "bcf" = (
@@ -7974,15 +8004,11 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cuq" = (
-/obj/structure/table,
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/stripes/line,
-/obj/item/storage/belt/utility{
-	pixel_y = 2
-	},
-/obj/item/storage/belt/utility{
-	pixel_y = 6
+/obj/machinery/modular_computer/preset/civilian{
+	dir = 4
 	},
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
@@ -10311,6 +10337,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/sink/directional/south,
 /turf/open/floor/iron/white/textured_edge,
 /area/station/science/genetics)
 "dcJ" = (
@@ -11719,13 +11746,13 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
-/obj/machinery/dna_scannernew,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/requests_console/directional/north{
 	department = "Genetics";
 	name = "Genetics Requests console"
 	},
+/obj/machinery/clonepod,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
 "dwH" = (
@@ -15573,7 +15600,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/sink/directional/west,
+/obj/machinery/vending/wardrobe/gene_wardrobe,
+/obj/item/toy/figure/geneticist{
+	pixel_y = 18
+	},
 /turf/open/floor/iron/white/textured_edge{
 	dir = 8
 	},
@@ -17648,6 +17678,7 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
+/obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/freezer,
 /area/station/security/checkpoint/medical)
 "fci" = (
@@ -23133,11 +23164,11 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/machinery/computer/scan_consolenew{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/cold/directional/west,
+/obj/machinery/computer/cloning{
+	dir = 4
+	},
 /turf/open/floor/iron/white/textured_edge{
 	dir = 4
 	},
@@ -23324,10 +23355,8 @@
 "gKY" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/suit/apron/surgical,
-/obj/item/clothing/mask/surgical,
 /obj/effect/turf_decal/tile/dark_red/anticorner/contrasted,
+/obj/item/surgery_tray,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "gKZ" = (
@@ -29932,6 +29961,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
+/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 4
 	},
@@ -30292,7 +30322,6 @@
 /area/station/maintenance/starboard/lesser)
 "iGc" = (
 /obj/effect/landmark/start/roboticist,
-/obj/structure/sink/directional/east,
 /obj/effect/turf_decal/tile/dark_red{
 	dir = 4
 	},
@@ -31217,6 +31246,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
+/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron/white/textured_edge,
 /area/station/security/checkpoint/science/research)
 "iTS" = (
@@ -31661,6 +31691,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron/textured_large,
 /area/station/security/checkpoint/engineering)
 "iZa" = (
@@ -31839,7 +31870,6 @@
 /turf/open/floor/pod/dark,
 /area/station/service/chapel/funeral)
 "jbi" = (
-/obj/structure/filingcabinet/chestdrawer,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -31850,6 +31880,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/autolathe,
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 8
 	},
@@ -37341,6 +37372,7 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
+/obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron/textured_edge{
 	dir = 4
 	},
@@ -38018,7 +38050,6 @@
 "kJi" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/obj/machinery/autolathe,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/robotics/lab)
 "kJk" = (
@@ -41107,6 +41138,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
 	},
+/obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron/textured_edge{
 	dir = 8
 	},
@@ -42659,6 +42691,7 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/effect/landmark/start/research_director,
 /turf/open/floor/wood/large,
 /area/station/science/research)
 "lWr" = (
@@ -43340,7 +43373,9 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/box,
-/obj/structure/reagent_dispensers/fueltank/large,
+/obj/machinery/computer/mechpad{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/mechbay)
 "mhx" = (
@@ -43438,7 +43473,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/research_director,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "miZ" = (
@@ -45843,13 +45877,12 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/entry)
 "mSx" = (
-/obj/machinery/recharge_station,
 /obj/item/radio/intercom/directional/south,
-/obj/effect/landmark/start/cyborg,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
 /obj/effect/turf_decal/box,
+/obj/machinery/mechpad,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/mechbay)
 "mSI" = (
@@ -48778,6 +48811,7 @@
 /area/station/commons/dorms)
 "nJe" = (
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/freezer,
 /area/station/security/checkpoint/medical)
 "nJj" = (
@@ -48916,7 +48950,6 @@
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/sorting)
 "nLM" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -48926,6 +48959,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/rnd/production/circuit_imprinter/department/science,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "nMf" = (
@@ -49898,6 +49932,7 @@
 	network = list("rd","toxins","minisat","xeno","test");
 	pixel_x = 32
 	},
+/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 8
 	},
@@ -53262,6 +53297,7 @@
 	network = list("ss13","rd")
 	},
 /obj/item/pai_card,
+/obj/effect/landmark/start/depsec/science,
 /turf/open/floor/wood/large,
 /area/station/science/research)
 "oVM" = (
@@ -56071,6 +56107,7 @@
 /area/station/hallway/primary/aft)
 "pHC" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/landmark/start/depsec/supply,
 /turf/open/floor/iron/textured_edge{
 	dir = 1
 	},
@@ -65470,6 +65507,7 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/item/radio/intercom/directional/west,
 /obj/structure/sink/directional/east,
+/obj/effect/landmark/start/depsec/medical,
 /turf/open/floor/iron/freezer,
 /area/station/security/checkpoint/medical)
 "snO" = (
@@ -70032,6 +70070,14 @@
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/dark/diagonal,
 /area/station/engineering/transit_tube)
+"tuJ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/chair,
+/obj/effect/landmark/start/depsec/engineering,
+/turf/open/floor/iron/textured_edge,
+/area/station/security/checkpoint/engineering)
 "tuU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -74272,6 +74318,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron/textured_corner{
 	dir = 8
 	},
@@ -75913,7 +75960,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/item/kirbyplants/monkey,
+/obj/machinery/vending/mechcomp,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 8
 	},
@@ -76735,17 +76782,14 @@
 /turf/open/floor/iron/textured,
 /area/station/maintenance/aft/lesser)
 "vmI" = (
-/obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
-	},
-/obj/item/toy/figure/geneticist{
-	pixel_y = 18
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/dna_scannernew,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 4
 	},
@@ -78795,12 +78839,11 @@
 /turf/open/floor/iron/freezer,
 /area/station/medical/pharmacy)
 "vRB" = (
-/obj/structure/table,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/tile/dark_red/half/contrasted{
 	dir = 8
 	},
-/obj/item/surgery_tray,
+/obj/structure/sink/directional/south,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 4
 	},
@@ -82775,7 +82818,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot_red,
-/obj/machinery/vending/mechcomp,
+/obj/structure/table,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/suit/apron/surgical,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/robotics/lab)
 "wVD" = (
@@ -85543,7 +85589,6 @@
 /area/station/command/heads_quarters/rd)
 "xNl" = (
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -85559,6 +85604,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/main)
 "xNE" = (
@@ -86583,9 +86629,6 @@
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos)
 "ybV" = (
-/obj/machinery/computer/mechpad{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
@@ -86594,6 +86637,8 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/cold/directional/east,
+/obj/effect/landmark/start/cyborg,
+/obj/machinery/recharge_station,
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 8
 	},
@@ -118743,7 +118788,7 @@ uWW
 gXL
 erh
 sxd
-hFa
+tuJ
 hpe
 qks
 hOM


### PR DESCRIPTION
## About The Pull Request

- Adds a cloner to genectics
- Adds equipment for medbots to robotics
- Shifted equipment in robotics to create more space. (and not place a orbital mech pad next to the sofa.)
- Added spawn locations for all departmental security
- Added Dr. Scrubs to medical
- Named robotics dog Dirk.
## Why It's Good For The Game
Genetics having cloning is a given for maps and I wasn't a big fan of robotics here. Way to cramped and had supplies they didn't need in their room. (Mainly the mech chomp)
Dr. Scrubs is effectively medical teams pet.
Gave name to robotics dog
Super important
## Changelog
:cl:
add: Added cloning to Void Raptor
add: Added medbot supplies to Void Raptor Robotics
add: Added departmental security spawns to voidraptor.
add: Dr. Scrubs is now on voidraptor
add: Robotics dog is now named Dirk. (Thank Britarnya)
fix: Adjusted the layout of voidraptor robotics to create more space
/:cl:
