### PR TITLE
Defer the asteroid magnet's initial map generation to LateInitialize

### DIFF
--- a/monkestation/code/modules/art_sci_overrides/asteroids/asteroid_magnet.dm
+++ b/monkestation/code/modules/art_sci_overrides/asteroids/asteroid_magnet.dm
@@ -61,7 +61,10 @@
 		else
 			available_templates[roid] = 100
 	templates_on_map = list()
+	return INITIALIZE_HINT_LATELOAD
 
+/obj/machinery/asteroid_magnet/LateInitialize()
+	. = ..()
 	GenerateMap()
 
 /obj/machinery/asteroid_magnet/proc/ping(coords_x, coords_y)


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/5234

LateInitialize is the proper place for this, as [maploading in Initialize leads to problems](https://github.com/tgstation/tgstation/pull/89024), and LateInitialize sets `waitfor = FALSE` anyways

## Why It's Good For The Game

more reliable code

## Changelog

no player-facing changes