### PR TITLE
Syndicate Depot Updates and Shipbreaking Is Now Ruin-Friendly

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -448,10 +448,10 @@
 /area/ruin/space/has_grav/listeningstation/medical)
 "mh" = (
 /obj/docking_port/stationary{
-	height = 8;
+	height = 16;
 	shuttle_id = "syndicate_listening_post";
 	name = "Syndicate Listening Post";
-	width = 12;
+	width = 16;
 	dwidth = 6
 	},
 /turf/template_noop,

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -1117,7 +1117,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/effect/turf_decal/floorsign/medical,
+/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 "mr" = (
@@ -1412,6 +1413,9 @@
 "qM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 "qP" = (
@@ -1856,6 +1860,8 @@
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/storage/bag/plants,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/hatchet/wooden,
+/obj/item/clothing/gloves/botanic_leather,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/hydroponics)
 "vT" = (
@@ -2362,6 +2368,7 @@
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/effect/mapping_helpers/apc/cut_AI_wire,
 /obj/structure/closet/emcloset,
+/obj/structure/sign/warning/no_smoking/circle/directional/west,
 /turf/open/floor/iron/smooth_half,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "AB" = (
@@ -2404,6 +2411,9 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4,
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/orange{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 "Bx" = (
@@ -2724,6 +2734,7 @@
 "FS" = (
 /obj/machinery/computer/station_alert,
 /obj/machinery/light/directional/north,
+/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "FY" = (
@@ -3027,6 +3038,17 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"JX" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/effect/turf_decal/floorsign/engineering,
+/obj/effect/turf_decal/tile/orange{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/syndicate_depot/hallway)
 "Kb" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer2{
 	dir = 9
@@ -3369,7 +3391,7 @@
 /obj/item/storage/toolbox/syndicate,
 /obj/item/storage/toolbox/syndicate,
 /obj/item/storage/toolbox/syndicate,
-/obj/machinery/firealarm/directional/north,
+/obj/structure/sign/warning/fire/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "NO" = (
@@ -3984,8 +4006,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/brown/half/contrasted{
-	dir = 8
+/obj/effect/turf_decal/floorsign/cargo,
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
@@ -5252,7 +5275,7 @@ BF
 BF
 et
 et
-PN
+tr
 xz
 Ap
 tg
@@ -5332,7 +5355,7 @@ BF
 BF
 BF
 et
-PN
+tr
 xz
 Ap
 Nq
@@ -6951,7 +6974,7 @@ SO
 rg
 Se
 Bn
-vZ
+JX
 qM
 RS
 iD

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -1329,7 +1329,11 @@
 	icon_screen = "seclaptop";
 	icon_keyboard = "laptop_key";
 	name = "communications laptop";
-	desc = "A laptop that can announce over wideband frequencies. Be careful."
+	desc = "A laptop that can make announcements to the local quadrant. Good for waking up crew."
+	},
+/obj/item/stack/spacecash/c500{
+	pixel_x = -7;
+	pixel_y = 20
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_depot/control_room)
@@ -2960,7 +2964,7 @@
 "JG" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/syndicate/shipbreaking,
-/obj/item/melee/sledgehammer,
+/obj/item/melee/sledgehammer/syndicate_depot,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "JN" = (
@@ -3055,7 +3059,7 @@
 	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/syndicate/shipbreaking,
-/obj/item/melee/sledgehammer,
+/obj/item/melee/sledgehammer/syndicate_depot,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "KL" = (

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -203,6 +203,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/atm/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 "cv" = (

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -407,6 +407,14 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
+"eW" = (
+/obj/machinery/light/small/directional/west,
+/obj/machinery/camera/directional/west{
+	network = list("syndicate_depot");
+	c_tag = "Exterior: Hydroponics East"
+	},
+/turf/open/misc/asteroid/airless,
+/area/ruin/space/has_grav/syndicate_depot)
 "eY" = (
 /obj/machinery/growing/tray,
 /obj/machinery/light_switch/directional/south,
@@ -1106,6 +1114,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"mh" = (
+/obj/machinery/plantgenes,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/syndicate_depot/hydroponics)
 "mk" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1537,6 +1549,19 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple/layer4,
 /turf/open/floor/engine/airless,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"sf" = (
+/obj/structure/closet/syndicate,
+/obj/item/cultivator,
+/obj/item/shovel/spade,
+/obj/item/storage/bag/plants/portaseeder,
+/obj/item/storage/bag/plants,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/hatchet/wooden,
+/obj/item/clothing/gloves/botanic_leather,
+/obj/item/secateurs,
+/obj/item/plant_analyzer,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/syndicate_depot/hydroponics)
 "si" = (
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/fax{
@@ -1854,14 +1879,8 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
 "vM" = (
-/obj/structure/closet/syndicate,
-/obj/item/cultivator,
-/obj/item/shovel/spade,
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/storage/bag/plants,
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/hatchet/wooden,
-/obj/item/clothing/gloves/botanic_leather,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/hydroponics)
 "vT" = (
@@ -4171,6 +4190,10 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/item/storage/box/plant_gene{
+	pixel_x = -10;
+	pixel_y = 11
+	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/hydroponics)
 "WE" = (
@@ -8677,7 +8700,7 @@ hq
 yo
 RN
 wh
-zd
+vM
 eY
 yo
 hq
@@ -8755,10 +8778,10 @@ lH
 hq
 hq
 yo
-yo
-vM
-WC
-yo
+mh
+wh
+zd
+lz
 yo
 hq
 bc
@@ -8834,16 +8857,16 @@ et
 RB
 et
 hq
-hq
 yo
 yo
+sf
+WC
 yo
 yo
-hq
 hq
 et
 et
-BF
+et
 BF
 BF
 BF
@@ -8913,17 +8936,17 @@ et
 et
 et
 et
-zl
 hq
 hq
-hq
-hq
+yo
+yo
+yo
+yo
 hq
 hq
 et
 et
 et
-BF
 BF
 BF
 BF
@@ -8993,16 +9016,16 @@ BF
 et
 et
 et
+zl
+hq
+hq
+hq
+lH
+hq
+hq
 et
 et
 et
-et
-et
-et
-et
-et
-et
-BF
 BF
 BF
 BF
@@ -9075,13 +9098,13 @@ BF
 et
 et
 et
-BF
-BF
+et
+et
+eW
 et
 et
 et
-BF
-BF
+et
 BF
 BF
 BF
@@ -9156,10 +9179,10 @@ BF
 BF
 BF
 BF
-BF
-BF
-BF
-BF
+et
+et
+et
+et
 BF
 BF
 BF

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -115,6 +115,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "bD" = (
@@ -1126,6 +1127,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "mz" = (
@@ -1204,6 +1206,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "nM" = (
@@ -1224,6 +1227,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/recharge_station,
 /obj/effect/turf_decal/box/red,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "nR" = (
@@ -1239,6 +1243,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "og" = (
@@ -1687,6 +1692,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "tp" = (
@@ -1907,6 +1913,7 @@
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "wD" = (
 /obj/machinery/vending/snack/orange,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "wJ" = (
@@ -2052,6 +2059,10 @@
 /obj/machinery/door/poddoor{
 	id = "syndicate_depot_shipbreaking_gate"
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "xD" = (
@@ -2322,6 +2333,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
+"Ap" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "Au" = (
 /obj/machinery/syndicatebomb/self_destruct,
 /obj/structure/cable,
@@ -2786,6 +2804,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
+"HN" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "HU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -2965,6 +2987,7 @@
 /obj/structure/rack,
 /obj/item/storage/toolbox/syndicate/shipbreaking,
 /obj/item/melee/sledgehammer/syndicate_depot,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "JN" = (
@@ -3060,6 +3083,10 @@
 /obj/structure/rack,
 /obj/item/storage/toolbox/syndicate/shipbreaking,
 /obj/item/melee/sledgehammer/syndicate_depot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "KL" = (
@@ -3269,11 +3296,13 @@
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/loading_area,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "Nq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "Nu" = (
@@ -3284,6 +3313,7 @@
 	dir = 9;
 	id = "depot_shipbreak"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "Nz" = (
@@ -3333,6 +3363,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "Oe" = (
@@ -3458,6 +3489,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"PN" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/asteroid/line,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/syndicate_depot)
 "PQ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -3611,6 +3650,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "RB" = (
@@ -3817,6 +3857,7 @@
 /obj/machinery/computer/security/telescreen{
 	network = list("syndicate_depot")
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "TR" = (
@@ -4000,6 +4041,10 @@
 "VR" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/computer/shipbreaker/syndicate_depot,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "VY" = (
@@ -4404,6 +4449,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "ZQ" = (
@@ -5102,7 +5148,7 @@ IM
 Xc
 KG
 JG
-wk
+HN
 Nk
 Nw
 Xc
@@ -5178,12 +5224,12 @@ Je
 BF
 BF
 et
-tr
+PN
 xz
-wk
+Ap
 tg
-wk
-wk
+HN
+HN
 Ym
 Xc
 et
@@ -5258,9 +5304,9 @@ Je
 BF
 BF
 et
-tr
+PN
 xz
-wk
+Ap
 Nq
 nJ
 Cj

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -1836,6 +1836,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"uV" = (
+/obj/machinery/smartfridge/food,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/area/ruin/space/has_grav/syndicate_depot/crew_quarters)
 "uW" = (
 /obj/structure/cable,
 /obj/machinery/cell_charger_multi/wall_mounted/directional/east,
@@ -8297,7 +8301,7 @@ fy
 Ix
 up
 Gv
-DQ
+uV
 fc
 Kp
 bG

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -1575,6 +1575,8 @@
 /obj/item/ammo_box/advanced/s12gauge/buckshot,
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/stripes/corner,
+/obj/item/melee/baton,
+/obj/item/holosign_creator/security,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/security)
 "sA" = (

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -513,6 +513,11 @@
 	},
 /turf/open/misc/asteroid/airless,
 /area/ruin/space/has_grav/syndicate_depot)
+"fR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "fS" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
@@ -708,6 +713,13 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
+"hV" = (
+/obj/machinery/power/smes/engineering{
+	output_attempt = 0
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "hZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/west,
@@ -1284,6 +1296,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"oy" = (
+/obj/structure/closet/generic/wall/directional/east,
+/obj/item/stack/sheet/mineral/plasma/thirty,
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "oz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1582,6 +1600,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/security)
+"sK" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "sR" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/syndicate_depot/security)
@@ -2028,6 +2050,13 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
+"xD" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "xM" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -2075,6 +2104,8 @@
 /mob/living/basic/bot/cleanbot{
 	faction = list("neutral","silicon","turret","Syndicate")
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "yD" = (
@@ -2381,6 +2412,11 @@
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"BE" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/layer4,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "BF" = (
 /turf/closed/mineral/random/high_chance,
 /area/ruin/space/has_grav/syndicate_depot)
@@ -2917,6 +2953,8 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "JG" = (
@@ -3085,6 +3123,14 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
+"LS" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "LW" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering"
@@ -6927,10 +6973,10 @@ dx
 Fc
 hq
 hq
+hq
+hq
 et
 et
-BF
-BF
 BF
 BF
 BF
@@ -7005,12 +7051,12 @@ Nu
 Me
 PU
 Fc
+et
+et
 hq
 hq
 et
 et
-BF
-BF
 BF
 BF
 BF
@@ -7085,12 +7131,12 @@ Fc
 Fc
 Fc
 Fc
+Fc
+et
 hq
 hq
 et
 et
-BF
-BF
 BF
 BF
 BF
@@ -7161,16 +7207,16 @@ iL
 Dl
 JB
 yB
+xD
+fR
+fR
+fR
 Fc
 et
-et
-hq
 hq
 hq
 et
 et
-BF
-BF
 BF
 BF
 BF
@@ -7243,15 +7289,15 @@ mz
 mz
 mz
 mz
+BE
+fR
+Fc
 et
 hq
 hq
-hq
 et
 et
 et
-BF
-BF
 BF
 BF
 BF
@@ -7323,15 +7369,15 @@ on
 nH
 Nb
 mz
+hV
+sK
+Fc
 dZ
-hq
 hq
 hq
 Vj
 et
 et
-BF
-BF
 BF
 BF
 BF
@@ -7403,15 +7449,15 @@ HW
 Au
 AJ
 mz
+LS
+oy
+Fc
 YP
 hq
 hq
 hq
-hq
 et
 et
-BF
-BF
 BF
 BF
 BF
@@ -7488,8 +7534,8 @@ Oe
 Oe
 Oe
 hq
-et
-et
+hq
+hq
 et
 BF
 BF

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -238,6 +238,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/syndicate_depot)
+"cC" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "cM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -569,6 +575,13 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/security)
+"gm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "gs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mech_bay_recharge_port,
@@ -1451,6 +1464,7 @@
 /obj/item/choice_beacon/pet,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/crowbar/red,
+/obj/item/clothing/head/hats/hos/beret/syndicate,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_depot/control_room)
 "rj" = (
@@ -1796,6 +1810,12 @@
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"ux" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "uL" = (
 /obj/machinery/atmospherics/components/binary/pump/on/general/visible/layer2{
 	dir = 8
@@ -1821,13 +1841,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
-"vp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "vu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2134,10 +2147,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "yD" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering Airlock";
-	network = list("syndicate_depot")
-	},
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/smooth_half,
@@ -2550,12 +2559,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/security)
-"Dk" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Dl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5166,7 +5169,7 @@ IM
 Xc
 KG
 JG
-HN
+ux
 Nk
 Nw
 Xc
@@ -7196,7 +7199,7 @@ NO
 NO
 AB
 Nu
-Dk
+cC
 Nu
 Fc
 Fc
@@ -7358,7 +7361,7 @@ mz
 mz
 mz
 BE
-vp
+gm
 Fc
 et
 hq

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -238,12 +238,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/syndicate_depot)
-"cC" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "cM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -575,13 +569,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/security)
-"gm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "gs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/mech_bay_recharge_port,
@@ -963,6 +950,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/syndicate_depot)
+"kC" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "kH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -1465,6 +1458,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/crowbar/red,
 /obj/item/clothing/head/hats/hos/beret/syndicate,
+/obj/item/clothing/suit/armor/vest/capcarapace/syndicate/winter,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_depot/control_room)
 "rj" = (
@@ -1810,12 +1804,6 @@
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
-"ux" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/west,
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "uL" = (
 /obj/machinery/atmospherics/components/binary/pump/on/general/visible/layer2{
 	dir = 8
@@ -2494,6 +2482,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/syndicate_depot)
+"CA" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "CD" = (
 /obj/machinery/computer/operating{
 	dir = 1
@@ -4241,6 +4235,13 @@
 /obj/effect/mapping_helpers/apc/cut_AI_wire,
 /turf/open/misc/asteroid/airless,
 /area/ruin/space/has_grav/syndicate_depot)
+"XH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "XK" = (
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/machinery/door/firedoor,
@@ -5169,7 +5170,7 @@ IM
 Xc
 KG
 JG
-ux
+CA
 Nk
 Nw
 Xc
@@ -7199,7 +7200,7 @@ NO
 NO
 AB
 Nu
-cC
+kC
 Nu
 Fc
 Fc
@@ -7361,7 +7362,7 @@ mz
 mz
 mz
 BE
-gm
+XH
 Fc
 et
 hq

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -2774,6 +2774,16 @@
 /obj/item/clothing/head/soft/black,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
+"Gh" = (
+/obj/docking_port/stationary{
+	height = 16;
+	shuttle_id = "syndicate_depot";
+	name = "Syndicate Depot";
+	width = 16;
+	dwidth = 6
+	},
+/turf/template_noop,
+/area/template_noop)
 "Gj" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -7512,7 +7522,7 @@ Je
 Je
 Je
 Je
-Je
+Gh
 et
 et
 et

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -950,12 +950,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/syndicate_depot)
-"kC" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "kH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -2457,6 +2451,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/eva_storage)
+"BZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Cj" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -2482,12 +2483,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/syndicate_depot)
-"CA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/directional/west,
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
-/turf/open/floor/mineral/plastitanium,
-/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "CD" = (
 /obj/machinery/computer/operating{
 	dir = 1
@@ -2800,6 +2795,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
+"Hn" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
+"Ht" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/directional/west,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "Hx" = (
 /obj/machinery/camera/directional/south{
 	network = list("syndicate_depot");
@@ -3002,6 +3009,7 @@
 /obj/item/storage/toolbox/syndicate/shipbreaking,
 /obj/item/melee/sledgehammer/syndicate_depot,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/pushbroom,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "JN" = (
@@ -3101,6 +3109,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/item/pushbroom,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "KL" = (
@@ -4235,13 +4244,6 @@
 /obj/effect/mapping_helpers/apc/cut_AI_wire,
 /turf/open/misc/asteroid/airless,
 /area/ruin/space/has_grav/syndicate_depot)
-"XH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "XK" = (
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/machinery/door/firedoor,
@@ -4687,7 +4689,7 @@ Je
 Je
 Je
 Je
-Je
+BF
 BF
 BF
 BF
@@ -4766,7 +4768,7 @@ Je
 Je
 Je
 Je
-Je
+BF
 BF
 BF
 BF
@@ -4845,7 +4847,7 @@ Je
 Je
 Je
 Je
-Je
+BF
 BF
 BF
 BF
@@ -4924,7 +4926,7 @@ hd
 Je
 Je
 Je
-Je
+BF
 BF
 BF
 BF
@@ -5003,8 +5005,8 @@ hd
 hd
 Je
 Je
-Je
-Je
+BF
+BF
 BF
 BF
 BF
@@ -5083,7 +5085,7 @@ hd
 hd
 Je
 Je
-Je
+BF
 BF
 BF
 Tv
@@ -5163,14 +5165,14 @@ hd
 hd
 Je
 Je
-Je
+BF
 BF
 et
 IM
 Xc
 KG
 JG
-CA
+Ht
 Nk
 Nw
 Xc
@@ -5242,9 +5244,9 @@ hd
 hd
 hd
 Je
-Je
 BF
 BF
+et
 et
 PN
 xz
@@ -5321,8 +5323,8 @@ hd
 hd
 hd
 hd
-Je
-Je
+BF
+BF
 BF
 BF
 et
@@ -5401,8 +5403,8 @@ hd
 hd
 hd
 hd
-Je
-Je
+BF
+BF
 BF
 et
 et
@@ -5481,8 +5483,8 @@ hd
 hd
 hd
 hd
-Je
-Je
+PN
+et
 et
 et
 et
@@ -5561,9 +5563,9 @@ hd
 hd
 hd
 hd
-Je
-Je
-BF
+PN
+et
+et
 BF
 BF
 BF
@@ -5641,8 +5643,8 @@ hd
 hd
 hd
 hd
-Je
-Je
+PN
+et
 BF
 BF
 BF
@@ -5721,9 +5723,9 @@ hd
 hd
 hd
 hd
-Je
-Je
-Je
+BF
+BF
+BF
 BF
 BF
 BF
@@ -5802,8 +5804,8 @@ hd
 hd
 hd
 Je
-Je
-Je
+BF
+BF
 BF
 BF
 BF
@@ -5882,8 +5884,8 @@ hd
 hd
 hd
 Je
-Je
-Je
+BF
+BF
 BF
 BF
 BF
@@ -5962,7 +5964,7 @@ hd
 hd
 hd
 Je
-Je
+BF
 BF
 BF
 BF
@@ -6042,7 +6044,7 @@ hd
 hd
 hd
 Je
-Je
+BF
 BF
 BF
 BF
@@ -7200,7 +7202,7 @@ NO
 NO
 AB
 Nu
-kC
+Hn
 Nu
 Fc
 Fc
@@ -7362,7 +7364,7 @@ mz
 mz
 mz
 BE
-XH
+BZ
 Fc
 et
 hq

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -2078,6 +2078,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "xM" = (
@@ -2132,8 +2133,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "yD" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron/smooth_half,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "yI" = (
@@ -2358,9 +2359,9 @@
 "AA" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/closet/radiation,
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/effect/mapping_helpers/apc/cut_AI_wire,
+/obj/structure/closet/emcloset,
 /turf/open/floor/iron/smooth_half,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "AB" = (

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -1515,12 +1515,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
-"sc" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/effect/mapping_helpers/airlock/cutaiwire,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "sd" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -1827,6 +1821,13 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"vp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "vu" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2549,6 +2550,12 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/security)
+"Dk" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Dl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3270,6 +3277,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/vending/mechcomp,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Nb" = (
@@ -3656,13 +3664,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
-"Ru" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Rv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -7195,7 +7196,7 @@ NO
 NO
 AB
 Nu
-sc
+Dk
 Nu
 Fc
 Fc
@@ -7357,7 +7358,7 @@ mz
 mz
 mz
 BE
-Ru
+vp
 Fc
 et
 hq

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -111,6 +111,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
+"bC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "bD" = (
 /obj/item/gps{
 	pixel_x = -5;
@@ -133,10 +139,6 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "bG" = (
-/obj/machinery/camera/directional/south{
-	network = list("syndicate_depot");
-	c_tag = "Kitchen"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/oven/range,
 /turf/open/floor/iron/kitchen/small,
@@ -178,6 +180,7 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/syndicate_depot/control_room)
 "cj" = (
@@ -353,6 +356,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"ef" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 5
+	},
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/syndicate_depot)
 "ej" = (
 /turf/closed/mineral/random/stationside/asteroid,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
@@ -370,6 +382,7 @@
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 "eF" = (
 /obj/structure/fence/door,
+/obj/structure/cable,
 /turf/open/misc/asteroid/airless,
 /area/ruin/space/has_grav/syndicate_depot)
 "eO" = (
@@ -442,10 +455,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "fw" = (
-/obj/machinery/camera/directional/south{
-	network = list("syndicate_depot");
-	c_tag = "Infirmary"
-	},
 /obj/structure/table/optable,
 /obj/machinery/defibrillator_mount/loaded/directional/south,
 /turf/open/floor/iron/white/small,
@@ -467,6 +476,7 @@
 	pixel_x = -5;
 	pixel_y = 9
 	},
+/obj/effect/spawner/random/food_or_drink/donkpockets,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
 "fF" = (
@@ -496,6 +506,13 @@
 /obj/item/watertank/atmos,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
+"fP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 1
+	},
+/turf/open/misc/asteroid/airless,
+/area/ruin/space/has_grav/syndicate_depot)
 "fS" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
@@ -589,6 +606,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "gS" = (
@@ -600,6 +618,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/kitchen/small,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
 "gU" = (
@@ -607,12 +626,13 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 "ha" = (
-/obj/machinery/camera/directional/west{
+/obj/machinery/camera/directional/south{
 	network = list("syndicate_depot");
-	c_tag = "Hallway South"
+	c_tag = "Exterior: Northnortheast"
 	},
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/syndicate_depot/hallway)
+/obj/machinery/light/small/directional/south,
+/turf/open/misc/asteroid/airless,
+/area/ruin/space/has_grav/syndicate_depot)
 "hc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -623,6 +643,9 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
+"hd" = (
+/turf/template_noop,
+/area/shipbreak/syndicate_depot)
 "hl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -633,6 +656,7 @@
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
 "hq" = (
@@ -641,6 +665,14 @@
 "hw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
+/obj/effect/spawner/random/food_or_drink/donkpockets{
+	pixel_x = -5;
+	pixel_y = 14
+	},
+/obj/effect/spawner/random/food_or_drink/donkpockets{
+	pixel_x = 6;
+	pixel_y = 8
+	},
 /turf/open/floor/iron/kitchen/small,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
 "hB" = (
@@ -735,10 +767,6 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "iL" = (
-/obj/machinery/camera/directional/east{
-	network = list("syndicate_depot");
-	c_tag = "Cargo Bay"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -746,6 +774,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
+"iN" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "iO" = (
 /obj/machinery/sleeper/syndie/fullupgrade{
 	dir = 8
@@ -857,6 +889,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
+"jR" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/effect/turf_decal/sand/plating,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/syndicate_depot)
 "jU" = (
 /obj/machinery/button/door/directional/south{
 	req_access = list("syndicate_leader");
@@ -937,6 +975,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/security)
 "kY" = (
@@ -1071,9 +1110,24 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/kitchen/small,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
+"mu" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "mz" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/syndicate_depot/vault)
+"mS" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 6
+	},
+/obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/syndicate_depot)
 "mX" = (
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1131,8 +1185,15 @@
 /obj/structure/safe,
 /obj/item/stack/telecrystal/five,
 /obj/item/stack/telecrystal/twenty,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
 /turf/open/floor/circuit/red/anim,
 /area/ruin/space/has_grav/syndicate_depot/vault)
+"nJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "nM" = (
 /obj/machinery/button/door/directional/west{
 	id = "syndicate_depot_vault";
@@ -1147,6 +1208,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
+"nO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "nR" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/seed_extractor,
@@ -1154,6 +1219,14 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/hydroponics)
+"oe" = (
+/obj/structure/chair/office/tactical{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "og" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -1169,6 +1242,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood/end,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
 "om" = (
@@ -1263,6 +1337,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/misc/asteroid/airless,
 /area/ruin/space/has_grav/syndicate_depot)
 "ps" = (
@@ -1370,10 +1445,6 @@
 /turf/open/floor/iron/kitchen/small,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
 "rE" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Hallway North";
-	network = list("syndicate_depot")
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -1396,6 +1467,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "rQ" = (
@@ -1419,6 +1491,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "se" = (
@@ -1467,10 +1540,6 @@
 /obj/item/ammo_box/advanced/s12gauge/buckshot,
 /obj/item/ammo_box/advanced/s12gauge/buckshot,
 /obj/machinery/light_switch/directional/east,
-/obj/machinery/camera/directional/east{
-	network = list("syndicate_depot");
-	c_tag = "Security Room"
-	},
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/security)
@@ -1524,6 +1593,7 @@
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
 "sT" = (
@@ -1562,6 +1632,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "sY" = (
@@ -1584,6 +1655,12 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
+"tg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "tp" = (
 /obj/structure/fence{
 	dir = 4
@@ -1622,15 +1699,18 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "tO" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "EVA Storage";
-	network = list("syndicate_depot")
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/eva_storage)
+"tQ" = (
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "depot_shipbreak"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "tU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -1640,9 +1720,13 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_depot/control_room)
 "uf" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/syndicate_depot/hallway)
+/obj/machinery/camera/directional/north{
+	c_tag = "Exterior: Southeast";
+	network = list("syndicate_depot")
+	},
+/obj/machinery/light/small/directional/north,
+/turf/open/misc/asteroid/airless,
+/area/ruin/space/has_grav/syndicate_depot)
 "ui" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/orange/visible,
 /obj/structure/closet/firecloset/full,
@@ -1655,10 +1739,12 @@
 /obj/machinery/microwave,
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/effect/mapping_helpers/apc/cell_5k,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
 "uq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "ut" = (
@@ -1670,6 +1756,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "uL" = (
@@ -1678,11 +1765,11 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"uW" = (
+/obj/structure/cable,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "uX" = (
-/obj/machinery/camera/directional/south{
-	network = list("syndicate_depot");
-	c_tag = "Manufacturing"
-	},
 /obj/machinery/rnd/production/protolathe/offstation,
 /obj/structure/railing{
 	dir = 8
@@ -1721,10 +1808,6 @@
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
 "vM" = (
 /obj/structure/closet/syndicate,
-/obj/machinery/camera/directional/east{
-	network = list("syndicate_depot");
-	c_tag = "Hydroponics"
-	},
 /obj/item/cultivator,
 /obj/item/shovel/spade,
 /obj/item/storage/bag/plants/portaseeder,
@@ -1774,6 +1857,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/hydroponics)
+"wk" = (
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "wn" = (
 /obj/machinery/atmospherics/components/tank/carbon_dioxide,
 /obj/effect/turf_decal/sand/plating,
@@ -1790,6 +1876,10 @@
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"wD" = (
+/obj/machinery/vending/snack/orange,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "wJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -1850,10 +1940,6 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
 "wU" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Generator Core Chamber";
-	network = list("syndicate_depot")
-	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
 	},
@@ -1861,13 +1947,10 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "wY" = (
-/obj/machinery/camera/directional/east{
-	network = list("syndicate_depot");
-	c_tag = "Hallway East"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/syndicate_depot/hallway)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/railing,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "wZ" = (
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
@@ -1935,6 +2018,13 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/smooth_half,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"xz" = (
+/obj/structure/fans/tiny/forcefield,
+/obj/machinery/door/poddoor{
+	id = "syndicate_depot_shipbreaking_gate"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "xM" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -1945,6 +2035,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
 "ym" = (
@@ -1968,10 +2059,6 @@
 /area/ruin/space/has_grav/syndicate_depot/hydroponics)
 "yt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/camera/directional/south{
-	network = list("syndicate_depot");
-	c_tag = "Atmospherics Lobby"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced/plastitaniumglass,
 /obj/machinery/firealarm/directional/south,
@@ -2071,6 +2158,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/hydroponics)
 "zl" = (
@@ -2164,6 +2252,7 @@
 /area/ruin/space/has_grav/syndicate_depot/security)
 "zU" = (
 /obj/machinery/light/small/directional/north,
+/obj/structure/railing,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "zV" = (
@@ -2211,6 +2300,7 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/closet/radiation,
 /obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
 /turf/open/floor/iron/smooth_half,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "AB" = (
@@ -2221,10 +2311,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "AJ" = (
-/obj/machinery/camera/directional/south{
-	network = list("syndicate_depot");
-	c_tag = "Vault"
-	},
 /obj/machinery/button/door/directional/south{
 	req_access = list("syndicate_leader");
 	name = "Emergency Base Lockdown";
@@ -2239,6 +2325,7 @@
 "AS" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Bc" = (
@@ -2253,6 +2340,9 @@
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "Bn" = (
 /obj/machinery/firealarm/directional/west,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer4,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 "Bx" = (
@@ -2298,6 +2388,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/eva_storage)
+"Cj" = (
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "Cq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/machinery/atmospherics/components/trinary/mixer/flipped/layer4{
@@ -2314,6 +2410,7 @@
 /obj/effect/turf_decal/stripes/asteroid/line{
 	dir = 1
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/syndicate_depot)
 "CD" = (
@@ -2323,10 +2420,6 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
 "CE" = (
-/obj/machinery/camera/directional/west{
-	network = list("syndicate_depot");
-	c_tag = "Cargo Entrance"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -2368,6 +2461,7 @@
 	pixel_x = -12;
 	pixel_y = 22
 	},
+/obj/structure/railing,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "CX" = (
@@ -2487,6 +2581,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/security)
+"Fa" = (
+/obj/item/wrench,
+/turf/open/misc/asteroid/airless,
+/area/ruin/space/has_grav/syndicate_depot)
 "Fc" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
@@ -2510,6 +2608,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "Fz" = (
@@ -2545,6 +2644,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
 "FS" = (
@@ -2622,6 +2722,7 @@
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
 "He" = (
 /obj/machinery/firealarm/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 "Hx" = (
@@ -2674,10 +2775,6 @@
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
 "Ix" = (
 /obj/structure/table/wood,
-/obj/machinery/camera/directional/east{
-	network = list("syndicate_depot");
-	c_tag = "Canteen"
-	},
 /obj/machinery/light/small/directional/east,
 /obj/machinery/light_switch/directional/east,
 /obj/item/toy/cards/deck/cas{
@@ -2716,6 +2813,21 @@
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
+"IM" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 5
+	},
+/obj/machinery/porta_turret/syndicate/depot{
+	dir = 5
+	},
+/obj/machinery/camera/directional/west{
+	network = list("syndicate_depot");
+	c_tag = "Exterior: Shipbreaking Access"
+	},
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/syndicate_depot)
 "IZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/bag/trash/filled,
@@ -2734,7 +2846,9 @@
 /turf/template_noop,
 /area/template_noop)
 "Jm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2,
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 "Jn" = (
@@ -2750,6 +2864,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Jt" = (
@@ -2774,6 +2889,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/security)
 "Ju" = (
@@ -2800,11 +2916,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
+"JG" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/syndicate/shipbreaking,
+/obj/item/melee/sledgehammer,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "JN" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Control Room";
-	network = list("syndicate_depot")
-	},
 /obj/machinery/computer/message_monitor,
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
@@ -2854,6 +2972,10 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
+"Ku" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "KA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -2881,12 +3003,31 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/security)
+"KG" = (
+/obj/machinery/button/door/directional/north{
+	id = "syndicate_depot_shipbreaking_gate";
+	req_access = list("syndicate");
+	name = "Shipbreaking Gate"
+	},
+/obj/structure/rack,
+/obj/item/storage/toolbox/syndicate/shipbreaking,
+/obj/item/melee/sledgehammer,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "KL" = (
 /obj/item/circuitboard/machine/stasis,
 /obj/effect/turf_decal/delivery/white,
-/obj/structure/closet/crate/medical,
+/obj/structure/closet/crate/engineering/electrical,
+/obj/item/circuitboard/machine/quantumpad,
+/obj/item/circuitboard/machine/quantumpad,
+/obj/item/circuitboard/machine/quantumpad,
+/obj/item/circuitboard/machine/quantumpad,
+/obj/item/circuitboard/machine/quantumpad,
+/obj/item/circuitboard/machine/quantumpad,
+/obj/item/storage/toolbox/electrical,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "KP" = (
@@ -2931,6 +3072,7 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "LH" = (
@@ -2953,6 +3095,7 @@
 	dir = 4
 	},
 /obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "Me" = (
@@ -2968,6 +3111,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/hydroponics)
 "Mi" = (
@@ -2987,13 +3131,17 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/vault)
 "Mk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
+/obj/machinery/camera/directional/south{
+	network = list("syndicate_depot");
+	c_tag = "Exterior: Northwest"
+	},
+/obj/machinery/light/small/directional/south,
+/turf/open/misc/asteroid/airless,
+/area/ruin/space/has_grav/syndicate_depot)
 "Mz" = (
 /obj/machinery/biogenerator,
 /obj/item/reagent_containers/cup/beaker/large,
@@ -3061,9 +3209,30 @@
 /obj/item/stack/sheet/plastic/fifty,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/syndicate_depot/vault)
+"Nk" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "depot_shipbreak";
+	pixel_x = -12;
+	pixel_y = 1
+	},
+/obj/effect/turf_decal/loading_area,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
+"Nq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "Nu" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
+"Nw" = (
+/obj/machinery/conveyor/inverted{
+	dir = 9;
+	id = "depot_shipbreak"
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "Nz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3084,10 +3253,6 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "NG" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering Kit Storage";
-	network = list("syndicate_depot")
-	},
 /obj/structure/closet/toolcloset,
 /obj/item/storage/toolbox/syndicate,
 /obj/item/storage/toolbox/syndicate,
@@ -3103,6 +3268,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
+"NW" = (
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/door/airlock/external/glass{
+	name = "Shipbreaking Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "Oe" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
@@ -3208,7 +3387,6 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "PG" = (
-/obj/machinery/rnd/production/circuit_imprinter,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3216,6 +3394,8 @@
 	},
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/machinery/firealarm/directional/east,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
+/obj/machinery/rnd/production/circuit_imprinter/offstation,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
 "PL" = (
@@ -3248,6 +3428,7 @@
 /obj/item/reagent_containers/blood/o_minus,
 /obj/item/reagent_containers/blood/o_minus,
 /obj/item/reagent_containers/blood/o_minus,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
 "PU" = (
@@ -3327,6 +3508,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "QU" = (
@@ -3343,6 +3525,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/control_room)
 "Ra" = (
@@ -3371,6 +3554,12 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
+"Rv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "RB" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/camera/directional/west{
@@ -3389,6 +3578,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/grimy,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
 "RH" = (
@@ -3408,6 +3598,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 "RN" = (
@@ -3442,6 +3633,7 @@
 	id = "syndicate_depot_lockdown";
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
 "So" = (
@@ -3510,6 +3702,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "SU" = (
@@ -3558,22 +3751,21 @@
 /area/ruin/space/has_grav/syndicate_depot)
 "TD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
-/obj/machinery/camera/directional/south{
-	network = list("syndicate_depot");
-	c_tag = "Atmospherics"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "TH" = (
 /obj/effect/turf_decal/sand/plating,
-/obj/machinery/camera/directional/west{
-	network = list("syndicate_depot");
-	c_tag = "Atmospherics Burn Chamber"
-	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"TK" = (
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/computer/security/telescreen{
+	network = list("syndicate_depot")
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "TR" = (
 /obj/effect/turf_decal/sand/plating,
 /obj/structure/cable,
@@ -3752,6 +3944,11 @@
 /obj/machinery/duct,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"VR" = (
+/obj/machinery/computer/shipbreaker/syndicate_depot,
+/obj/machinery/light/directional/north,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "VY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/engine/o2,
@@ -3769,6 +3966,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/control_room)
 "Wd" = (
@@ -3861,6 +4059,9 @@
 /obj/structure/cable,
 /turf/open/misc/asteroid/airless,
 /area/ruin/space/has_grav/syndicate_depot)
+"Xc" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "Xd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3901,6 +4102,16 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
+"Xz" = (
+/obj/effect/turf_decal/sand/plating,
+/obj/effect/turf_decal/stripes/asteroid/line{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/syndicate_depot)
 "XD" = (
 /obj/effect/turf_decal/stripes/asteroid/line,
 /obj/structure/cable,
@@ -3908,6 +4119,7 @@
 /obj/effect/mapping_helpers/apc/cell_10k,
 /obj/effect/mapping_helpers/apc/full_charge,
 /obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
 /turf/open/misc/asteroid/airless,
 /area/ruin/space/has_grav/syndicate_depot)
 "XK" = (
@@ -3922,6 +4134,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "XO" = (
@@ -3939,12 +4152,29 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
+"XU" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
+/obj/structure/reagent_dispensers/fueltank/large,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "XX" = (
 /obj/effect/turf_decal/vg_decals/atmos/plasma{
 	dir = 8
 	},
 /turf/open/floor/engine/plasma,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"Ym" = (
+/obj/machinery/shipbreaker,
+/obj/machinery/conveyor{
+	id = "depot_shipbreak";
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "Yo" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -4043,6 +4273,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "Zh" = (
@@ -4108,6 +4339,20 @@
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
+"ZM" = (
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/door/airlock/external/glass{
+	name = "Shipbreaking Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "ZQ" = (
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 4
@@ -4129,6 +4374,34 @@
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 
 (1,1,1) = {"
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 Je
 Je
 Je
@@ -4187,6 +4460,34 @@ Je
 Je
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
@@ -4233,6 +4534,34 @@ Je
 Je
 "}
 (3,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 Je
 Je
 Je
@@ -4286,6 +4615,34 @@ Je
 "}
 (4,1,1) = {"
 Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
+Je
 Je
 Je
 Je
@@ -4337,6 +4694,34 @@ Je
 Je
 "}
 (5,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 Je
 Je
 Je
@@ -4390,6 +4775,34 @@ Je
 "}
 (6,1,1) = {"
 Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
+Je
 Je
 BF
 BF
@@ -4441,6 +4854,34 @@ Je
 Je
 "}
 (7,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 Je
 Je
 BF
@@ -4494,11 +4935,44 @@ Je
 "}
 (8,1,1) = {"
 Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
+Je
 BF
 BF
-BF
-BF
-BF
+Tv
+Xc
+Xc
+Xc
+Xc
+Xc
+Xc
+Xc
 et
 et
 et
@@ -4509,18 +4983,13 @@ et
 et
 et
 et
-et
-et
-et
-et
-et
-et
-et
-et
-et
-et
-et
-et
+Xb
+Xb
+Xb
+Xb
+Xb
+Xb
+Xb
 et
 et
 et
@@ -4546,35 +5015,63 @@ Je
 "}
 (9,1,1) = {"
 Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
+Je
 BF
-BF
-BF
-BF
+et
+IM
+Xc
+KG
+JG
+wk
+Nk
+Nw
+Xc
 et
 et
 et
 et
 et
 et
+Xb
+Xb
+Xb
+Xb
+Xb
 et
 et
 et
 et
 et
-et
-et
-et
-et
-et
-et
-et
-et
-et
-et
-et
-et
-et
-et
+Xb
+Xb
+Xb
 et
 et
 et
@@ -4597,24 +5094,52 @@ Je
 Je
 "}
 (10,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
 BF
-BF
-BF
+et
+tr
+xz
+wk
+tg
+wk
+wk
+Ym
+Xc
 et
 et
 et
-et
-et
-et
-et
-et
-et
-et
-et
-et
-et
-et
+Xb
+Xb
+Xb
+Xb
 et
 et
 et
@@ -4626,9 +5151,9 @@ et
 et
 et
 et
-et
-et
-et
+Xb
+Xb
+Xb
 et
 et
 et
@@ -4649,21 +5174,49 @@ Je
 Je
 "}
 (11,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
 BF
-BF
-BF
+et
+tr
+xz
+wk
+Nq
+nJ
+Cj
+tQ
+Xc
 et
 et
 et
-et
-et
-et
-et
-et
-et
-et
-et
+Xb
 et
 et
 et
@@ -4680,8 +5233,8 @@ Vj
 et
 et
 et
-et
-et
+Xb
+Xb
 et
 et
 et
@@ -4701,21 +5254,49 @@ Je
 Je
 "}
 (12,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
+et
+et
 BF
-BF
-BF
+Xc
+VR
+oe
+wk
+iN
+Xc
+Xc
 et
-et
-et
-et
-et
-et
-et
-et
-et
-et
-et
+Xb
+Xb
+Xb
 et
 et
 et
@@ -4733,8 +5314,8 @@ hq
 et
 et
 et
-et
-et
+Xb
+Xb
 et
 et
 et
@@ -4753,19 +5334,47 @@ Je
 Je
 "}
 (13,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
+et
+et
+et
 BF
-BF
-BF
-BF
+Xc
+TK
+Nq
+wk
+Ku
+Xc
 et
-et
-et
-et
-et
-et
-et
-et
-et
+Xb
+Xb
 et
 et
 et
@@ -4786,7 +5395,7 @@ hq
 et
 et
 et
-et
+Xb
 et
 et
 et
@@ -4805,18 +5414,46 @@ Je
 Je
 "}
 (14,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
 BF
 BF
 BF
+Xc
+wD
+mu
+uW
+XU
+Xc
 et
-et
-et
-et
-et
-et
-et
-et
+Xb
 et
 et
 et
@@ -4838,8 +5475,8 @@ hq
 hq
 et
 et
-et
-et
+Xb
+Xb
 et
 et
 et
@@ -4857,22 +5494,50 @@ Je
 Je
 "}
 (15,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
 BF
 BF
 BF
+Xc
+Xc
+ZM
+Xc
+Xc
+Xc
+Xb
+Xb
 et
 et
-et
-et
-et
-et
-et
-et
-et
-et
-et
-hq
+Mk
+lH
 hq
 lH
 lH
@@ -4891,7 +5556,7 @@ hq
 et
 et
 et
-et
+Xb
 et
 et
 et
@@ -4910,16 +5575,44 @@ Je
 "}
 (16,1,1) = {"
 Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
+Je
 BF
 BF
 BF
+Xc
+nO
+bC
+Rv
+Xc
 et
-et
-et
-et
-et
-et
-et
+Xb
 et
 et
 et
@@ -4943,7 +5636,7 @@ hq
 hq
 Xn
 et
-et
+Xb
 et
 et
 et
@@ -4962,16 +5655,44 @@ Je
 "}
 (17,1,1) = {"
 Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
+Je
 BF
 BF
 BF
-et
-et
-et
-et
-et
-et
-et
+Xc
+Xc
+NW
+Xc
+Xc
+Xb
+Xb
 et
 kl
 hq
@@ -4995,7 +5716,7 @@ hq
 hq
 lH
 hq
-et
+Xb
 hq
 Vj
 et
@@ -5014,15 +5735,43 @@ Je
 "}
 (18,1,1) = {"
 Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
+Je
 BF
 BF
 BF
-et
-et
-et
-et
-et
-et
+jR
+ef
+Xz
+mS
+fP
+Xb
 et
 et
 hq
@@ -5046,8 +5795,8 @@ Tv
 JA
 et
 tp
-et
-et
+Xb
+Xb
 hq
 hq
 et
@@ -5065,15 +5814,43 @@ Je
 Je
 "}
 (19,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
 BF
 BF
 BF
+Fa
 et
-et
-et
-et
-et
+Xb
+Xb
+Xb
 et
 et
 et
@@ -5096,9 +5873,9 @@ SU
 XD
 Cs
 pl
-et
+Xb
 eF
-et
+Xb
 et
 hq
 hq
@@ -5117,6 +5894,34 @@ BF
 Je
 "}
 (20,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
 BF
 BF
@@ -5169,6 +5974,34 @@ BF
 Je
 "}
 (21,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
 BF
 BF
@@ -5221,6 +6054,34 @@ BF
 Je
 "}
 (22,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
 BF
 BF
@@ -5273,6 +6134,34 @@ BF
 BF
 "}
 (23,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
 BF
 BF
@@ -5325,6 +6214,34 @@ BF
 BF
 "}
 (24,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
 BF
 BF
@@ -5377,6 +6294,34 @@ BF
 BF
 "}
 (25,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
 BF
 BF
@@ -5429,6 +6374,34 @@ BF
 Je
 "}
 (26,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
 BF
 BF
@@ -5481,6 +6454,34 @@ BF
 Je
 "}
 (27,1,1) = {"
+Je
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+hd
+Je
+Je
 BF
 BF
 BF
@@ -5533,6 +6534,34 @@ BF
 Je
 "}
 (28,1,1) = {"
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
@@ -5586,6 +6615,34 @@ Je
 "}
 (29,1,1) = {"
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
@@ -5623,7 +6680,7 @@ mk
 yn
 Nu
 UW
-Mk
+PU
 Fc
 hq
 lH
@@ -5637,6 +6694,34 @@ BF
 Je
 "}
 (30,1,1) = {"
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 Je
 BF
 BF
@@ -5674,7 +6759,7 @@ MM
 mk
 cM
 AS
-PU
+wY
 dx
 Fc
 hq
@@ -5689,6 +6774,34 @@ BF
 Je
 "}
 (31,1,1) = {"
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 Je
 BF
 BF
@@ -5742,6 +6855,34 @@ Je
 "}
 (32,1,1) = {"
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
@@ -5793,6 +6934,34 @@ BF
 Je
 "}
 (33,1,1) = {"
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 Je
 BF
 BF
@@ -5847,13 +7016,41 @@ BF
 (34,1,1) = {"
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
-BF
-BF
-BF
+et
+et
+et
 et
 et
 hq
@@ -5899,14 +7096,42 @@ BF
 (35,1,1) = {"
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+BF
+BF
+BF
+BF
+BF
 BF
 BF
 et
-et
-et
-et
-BF
-BF
 et
 hq
 SU
@@ -5950,6 +7175,34 @@ BF
 "}
 (36,1,1) = {"
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 et
@@ -5957,8 +7210,8 @@ et
 et
 et
 et
-et
 BF
+et
 et
 hq
 SU
@@ -6002,15 +7255,43 @@ BF
 "}
 (37,1,1) = {"
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 et
 et
 BF
 BF
-BF
 et
 BF
+et
 et
 hq
 hq
@@ -6054,14 +7335,42 @@ BF
 "}
 (38,1,1) = {"
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 et
 et
 et
 et
 BF
 BF
-BF
 et
+BF
 et
 et
 et
@@ -6106,12 +7415,40 @@ BF
 "}
 (39,1,1) = {"
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 et
 et
 et
 BF
 BF
-et
+BF
 et
 et
 et
@@ -6158,12 +7495,40 @@ BF
 "}
 (40,1,1) = {"
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
 BF
-et
+BF
 et
 et
 et
@@ -6211,11 +7576,39 @@ BF
 (41,1,1) = {"
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
-et
-et
+BF
+BF
 et
 et
 et
@@ -6242,7 +7635,7 @@ qt
 UO
 xg
 Yy
-ha
+Ay
 nM
 wb
 pk
@@ -6262,12 +7655,40 @@ BF
 "}
 (42,1,1) = {"
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
-et
-et
+BF
+BF
 et
 et
 et
@@ -6314,12 +7735,40 @@ BF
 "}
 (43,1,1) = {"
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
-et
-et
+BF
+BF
 et
 et
 et
@@ -6336,9 +7785,9 @@ kR
 Nz
 LH
 Uf
-uf
+Eq
 xM
-wY
+Am
 ln
 kc
 Ay
@@ -6365,12 +7814,40 @@ BF
 Je
 "}
 (44,1,1) = {"
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
-et
-et
+BF
+BF
 et
 et
 et
@@ -6417,12 +7894,40 @@ BF
 Je
 "}
 (45,1,1) = {"
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
-et
-et
+BF
+BF
 et
 et
 et
@@ -6469,13 +7974,41 @@ BF
 BF
 "}
 (46,1,1) = {"
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
 BF
-et
-et
+BF
+BF
 et
 et
 et
@@ -6522,13 +8055,41 @@ BF
 "}
 (47,1,1) = {"
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
 BF
-et
-et
+BF
+BF
 et
 et
 et
@@ -6575,20 +8136,48 @@ Je
 (48,1,1) = {"
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
+BF
+BF
 et
 et
 et
 et
 et
 et
-et
-et
-et
-hq
+ha
+lH
 sR
 sR
 sR
@@ -6628,12 +8217,40 @@ Je
 Je
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
-et
-et
+BF
+BF
 et
 et
 et
@@ -6665,8 +8282,8 @@ OW
 yo
 Oe
 hq
-hq
-et
+lH
+uf
 et
 et
 BF
@@ -6680,12 +8297,40 @@ Je
 Je
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
 BF
-et
+BF
 et
 et
 et
@@ -6733,12 +8378,40 @@ Je
 Je
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
-et
-et
+BF
+BF
 et
 et
 et
@@ -6785,12 +8458,40 @@ Je
 Je
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
-et
-et
+BF
+BF
 et
 et
 et
@@ -6837,13 +8538,41 @@ Je
 Je
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
 BF
-et
-et
+BF
+BF
 et
 et
 et
@@ -6890,12 +8619,40 @@ Je
 Je
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
-et
-et
+BF
+BF
 et
 et
 et
@@ -6942,10 +8699,41 @@ Je
 Je
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
+BF
+BF
+BF
 et
 et
 et
@@ -6965,10 +8753,7 @@ et
 et
 et
 et
-et
-et
-et
-et
+zl
 hq
 hq
 hq
@@ -6994,13 +8779,41 @@ Je
 Je
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
 BF
 BF
-et
-et
+BF
+BF
 BF
 BF
 BF
@@ -7041,6 +8854,34 @@ Je
 Je
 "}
 (57,1,1) = {"
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 Je
 Je
 Je
@@ -7093,6 +8934,34 @@ Je
 Je
 "}
 (58,1,1) = {"
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 Je
 Je
 Je
@@ -7153,6 +9022,34 @@ Je
 Je
 Je
 Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 BF
 BF
 BF
@@ -7197,6 +9094,34 @@ Je
 Je
 "}
 (60,1,1) = {"
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
+Je
 Je
 Je
 Je

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -517,6 +517,7 @@
 "fR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "fS" = (
@@ -1305,6 +1306,7 @@
 /obj/structure/closet/generic/wall/directional/east,
 /obj/item/stack/sheet/mineral/plasma/thirty,
 /obj/item/storage/toolbox/emergency,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "oz" = (
@@ -1513,6 +1515,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
+"sc" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
+/obj/effect/mapping_helpers/airlock/cutaiwire,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "sd" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -1611,6 +1619,7 @@
 /area/ruin/space/has_grav/syndicate_depot/security)
 "sK" = (
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "sR" = (
@@ -2437,6 +2446,7 @@
 "BE" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4,
 /obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "BF" = (
@@ -3646,6 +3656,13 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
+"Ru" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/light/small/directional/south,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Rv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -7177,9 +7194,9 @@ mk
 NO
 NO
 AB
-Fc
-Fc
-Fc
+Nu
+sc
+Nu
 Fc
 Fc
 et
@@ -7340,7 +7357,7 @@ mz
 mz
 mz
 BE
-fR
+Ru
 Fc
 et
 hq

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -645,7 +645,7 @@
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 "hd" = (
 /turf/template_noop,
-/area/shipbreak/syndicate_depot)
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking)
 "hl" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -1210,6 +1210,8 @@
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "nO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/box/red,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "nR" = (
@@ -1767,6 +1769,7 @@
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "uW" = (
 /obj/structure/cable,
+/obj/machinery/cell_charger_multi/wall_mounted/directional/east,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "uX" = (
@@ -3945,8 +3948,8 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "VR" = (
-/obj/machinery/computer/shipbreaker/syndicate_depot,
 /obj/machinery/light/directional/north,
+/obj/machinery/computer/shipbreaker/syndicate_depot,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "VY" = (

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/black_peregrine.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/black_peregrine.dmm
@@ -1,21 +1,21 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aV" = (
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "bY" = (
 /obj/structure/chair/comfy/shuttle/tactical{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/dark_red,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "cS" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 8
 	},
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "dR" = (
 /obj/machinery/door/airlock/security,
 /obj/structure/cable,
@@ -23,33 +23,33 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "ef" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 4
 	},
 /obj/machinery/vending/cigarette/syndicate,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "es" = (
 /obj/structure/transit_tube/curved{
 	dir = 4
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "eS" = (
 /obj/structure/lattice,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "eY" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "fd" = (
 /obj/structure/cable,
 /obj/machinery/power/smes/engineering,
@@ -57,7 +57,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "fX" = (
 /obj/machinery/door/airlock/engineering,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -65,43 +65,43 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "ha" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "hq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/titanium/tiled/yellow,
-/area/shipbreak)
+/area/template_noop)
 "hy" = (
 /obj/machinery/power/turbine/inlet_compressor/constructed,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "io" = (
 /obj/structure/transit_tube/station/dispenser/reverse{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "iI" = (
 /obj/machinery/computer/old,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "jz" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "jG" = (
 /obj/structure/dresser,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "kt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "lk" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
@@ -109,12 +109,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "lx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "ly" = (
 /obj/machinery/door/airlock{
 	dir = 8
@@ -124,7 +124,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "mi" = (
 /obj/structure/transit_tube{
 	dir = 4
@@ -134,7 +134,7 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "nk" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 4
@@ -143,7 +143,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/armory/laser_gun,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "nv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -152,13 +152,13 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "nw" = (
 /obj/structure/transit_tube{
 	dir = 4
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "ny" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 8
@@ -170,7 +170,7 @@
 /obj/item/pizzabox,
 /obj/item/reagent_containers/cup/glass/bottle/beer,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "og" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 1;
@@ -178,23 +178,23 @@
 	},
 /obj/machinery/light/red/dim/directional/west,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "oA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "oF" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "pc" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "ph" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -203,41 +203,41 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "pQ" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "qq" = (
 /obj/machinery/shower/directional/east,
 /obj/structure/drain,
 /obj/structure/curtain/bounty/start_closed,
 /turf/open/floor/iron/freezer,
-/area/shipbreak)
+/area/template_noop)
 "qO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "qT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "rf" = (
 /obj/machinery/computer/old{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "sg" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "sk" = (
 /obj/structure/sign/departments/engineering/directional/south,
 /obj/effect/turf_decal/siding/dark_red{
@@ -250,18 +250,18 @@
 	pixel_x = -3
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "sE" = (
 /obj/structure/transit_tube/station/dispenser/reverse/flipped,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "uj" = (
 /obj/machinery/door/airlock/security,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "ur" = (
 /obj/machinery/door/airlock{
 	dir = 8
@@ -272,13 +272,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "uV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "vh" = (
 /obj/effect/turf_decal/caution/stand_clear{
 	dir = 1;
@@ -286,12 +286,12 @@
 	},
 /obj/machinery/light/red/dim/directional/east,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "vA" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "we" = (
 /obj/structure/bed{
 	dir = 4
@@ -304,31 +304,31 @@
 	},
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "wo" = (
 /obj/structure/lattice/catwalk/mining,
 /obj/structure/marker_beacon/burgundy,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "wK" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "xJ" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "yf" = (
 /obj/structure/chair/comfy/shuttle/tactical{
 	dir = 1
 	},
 /obj/machinery/light/warm/dim/directional/south,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "yC" = (
 /obj/machinery/door/airlock/public,
 /obj/structure/cable,
@@ -337,7 +337,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "yN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/command,
@@ -346,42 +346,42 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate,
 /obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "zb" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "zu" = (
 /obj/structure/transit_tube/curved{
 	dir = 8
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Ap" = (
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/suit_storage_unit,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "At" = (
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/suit_storage_unit,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "Bo" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "BW" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Ce" = (
 /obj/structure/sign/departments/engineering/directional/south,
 /obj/effect/turf_decal/siding/dark_red{
@@ -389,12 +389,12 @@
 	},
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Cj" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Ek" = (
 /obj/structure/bed{
 	dir = 4
@@ -403,13 +403,13 @@
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "FH" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 4
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "IA" = (
 /obj/structure/transit_tube{
 	dir = 4
@@ -419,13 +419,13 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Kw" = (
 /obj/effect/turf_decal/siding/dark_red{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Lh" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/structure/cable,
@@ -433,24 +433,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Lt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "ME" = (
 /obj/machinery/shower/directional/west,
 /obj/structure/drain,
 /obj/structure/curtain/bounty/start_closed,
 /turf/open/floor/iron/freezer,
-/area/shipbreak)
+/area/template_noop)
 "MN" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /obj/machinery/power/shuttle_engine/heater,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "NF" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -464,25 +464,25 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "NN" = (
 /obj/machinery/power/shuttle_engine/large,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Pm" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "PQ" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Qm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Qv" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
@@ -491,12 +491,12 @@
 	},
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "QE" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "QS" = (
 /obj/structure/cable,
 /obj/item/stack/sheet/mineral/uranium/five,
@@ -507,7 +507,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Te" = (
 /obj/effect/turf_decal/siding/dark_red/corner{
 	dir = 1
@@ -516,7 +516,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/red/dim/directional/south,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "UE" = (
 /obj/effect/turf_decal/siding/dark_red/corner{
 	dir = 4
@@ -527,49 +527,49 @@
 	},
 /obj/machinery/light/red/dim/directional/south,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "UJ" = (
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "Vg" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 8
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Wb" = (
 /obj/machinery/power/turbine/core_rotor/constructed,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "WK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "XK" = (
 /obj/structure/transit_tube/station/dispenser/flipped,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Yv" = (
 /obj/machinery/computer/old{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "YM" = (
 /obj/machinery/power/turbine/turbine_outlet/constructed,
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "Zu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb/red,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "Zy" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 Zy

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/gasstation.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/gasstation.dmm
@@ -1,159 +1,1398 @@
-"ag" = (/obj/structure/railing{dir = 4},/turf/open/floor/holofloor/stairs,/area/shipbreak)
-"ah" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/shipbreak)
-"ak" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/carpet/black,/area/shipbreak)
-"as" = (/obj/machinery/power/shuttle_engine/heater{dir = 1},/obj/structure/window/reinforced/spawner/directional/south,/turf/open/floor/plating/airless,/area/shipbreak)
-"aW" = (/obj/structure/lattice/catwalk,/obj/structure/cable,/obj/effect/spawner/random/engineering/toolbox,/turf/template_noop,/area/shipbreak)
-"aX" = (/obj/effect/decal/cleanable/dirt,/obj/effect/spawner/random/entertainment/wallet_storage,/turf/open/floor/carpet/black,/area/shipbreak)
-"aZ" = (/obj/effect/decal/cleanable/blood/drip,/obj/machinery/computer/accounting{dir = 1},/obj/effect/turf_decal/bot,/turf/open/floor/carpet/black,/area/shipbreak)
-"bk" = (/obj/effect/mapping_helpers/broken_floor,/turf/open/floor/iron/dark/smooth_large/airless,/area/shipbreak)
-"bU" = (/obj/structure/table,/obj/item/food/hotdog{pixel_y = 7; pixel_x = -2},/obj/structure/rack,/obj/item/food/hotdog,/obj/effect/turf_decal/tile/dark/anticorner{dir = 4},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"ce" = (/obj/machinery/griddle,/obj/item/food/raw_sausage{pixel_y = 11},/obj/item/food/raw_sausage{pixel_y = 2; pixel_x = 2},/obj/effect/turf_decal/tile/dark/half{dir = 4},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"cD" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/shipbreak)
-"cK" = (/obj/structure/lattice/catwalk,/obj/machinery/power/tracker,/obj/structure/cable,/turf/template_noop,/area/shipbreak)
-"cT" = (/obj/effect/decal/cleanable/dirt,/obj/effect/mapping_helpers/broken_floor,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"dz" = (/obj/machinery/light/directional/south,/obj/effect/turf_decal/tile/dark/half,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"dU" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/garbage,/turf/open/floor/iron/dark,/area/shipbreak)
-"eg" = (/obj/effect/mapping_helpers/broken_floor,/obj/effect/spawner/random/trash/grime,/turf/open/floor/plating,/area/shipbreak)
-"er" = (/turf/open/floor/holofloor/stairs/right,/area/shipbreak)
-"fk" = (/turf/template_noop,/area/shipbreak)
-"fB" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/blood/drip,/obj/structure/sign/poster/contraband/donk_co/directional/north,/obj/effect/turf_decal/tile/dark/half{dir = 1},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"fK" = (/obj/machinery/door/airlock/titanium{name = "Storeroom"},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/dark,/area/shipbreak)
-"he" = (/obj/machinery/power/solar{id = "forestarboard"; name = "Fore-Starboard Solar Array"},/obj/structure/cable,/turf/open/floor/iron/solarpanel,/area/shipbreak)
-"ht" = (/turf/open/space/basic,/area/shipbreak)
-"hU" = (/obj/effect/decal/cleanable/food/tomato_smudge,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/plastic,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"ic" = (/turf/open/floor/plating,/area/shipbreak)
-"if" = (/obj/machinery/light/directional/east,/obj/effect/turf_decal/tile/dark/half{dir = 4},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"io" = (/obj/machinery/light/directional/north,/obj/effect/turf_decal/bot,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"ip" = (/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/tile/dark/half,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"iz" = (/obj/structure/cable,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"iG" = (/obj/effect/decal/cleanable/dirt,/obj/effect/spawner/random/trash/grime,/turf/open/floor/iron/dark/smooth_large/airless,/area/shipbreak)
-"iL" = (/obj/machinery/door/airlock/titanium{name = "Storeroom"},/obj/effect/decal/cleanable/dirt,/turf/open/floor/iron/dark,/area/shipbreak)
-"iX" = (/obj/machinery/light/directional/west,/turf/open/floor/carpet/black,/area/shipbreak)
-"jk" = (/obj/structure/rack/shelf,/obj/item/food/canned/tomatoes,/obj/item/food/canned/tomatoes,/obj/item/food/canned/tomatoes,/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/bot,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"jW" = (/obj/structure/table,/obj/effect/decal/cleanable/glass,/obj/effect/spawner/random/maintenance/three,/turf/open/floor/iron/dark,/area/shipbreak)
-"jX" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"kb" = (/obj/machinery/door/airlock/external{name = "Getcher Gas'n'Go"},/obj/structure/cable,/turf/open/space/basic,/area/shipbreak)
-"ki" = (/obj/structure/rack/shelf,/obj/item/food/peanuts/random,/obj/item/food/peanuts/random,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/bot,/obj/effect/turf_decal/tile/dark/half{dir = 8},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"km" = (/obj/machinery/power/shuttle_engine/propulsion{dir = 1},/turf/open/floor/plating/airless,/area/shipbreak)
-"kR" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/extinguisher_cabinet/directional/west,/obj/effect/turf_decal/tile/dark/anticorner{dir = 1},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"li" = (/obj/effect/mapping_helpers/broken_floor,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/shipbreak)
-"lx" = (/obj/effect/mapping_helpers/burnt_floor,/turf/open/floor/iron/dark,/area/shipbreak)
-"lU" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/random/structure/crate,/turf/open/floor/iron/dark,/area/shipbreak)
-"mX" = (/obj/structure/railing{dir = 4},/obj/structure/cable,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"nn" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/iron/white/textured_large/airless,/area/shipbreak)
-"ow" = (/obj/structure/cable,/obj/effect/decal/cleanable/dirt,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"oA" = (/obj/effect/spawner/structure/window/reinforced/shuttle,/turf/open/floor/plating,/area/shipbreak)
-"oD" = (/obj/machinery/vending/cigarette,/obj/structure/sign/poster/contraband/have_a_puff/directional/north,/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/bot,/obj/effect/turf_decal/tile/dark/half{dir = 1},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"pI" = (/obj/structure/rack/shelf,/obj/item/storage/box/donkpockets,/obj/item/storage/box/donkpockets/donkpocketberry,/obj/item/storage/box/donkpockets/donkpocketgondola,/obj/item/storage/box/donkpockets/donkpockethonk,/obj/effect/turf_decal/bot,/obj/effect/turf_decal/tile/dark/half{dir = 8},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"pY" = (/obj/structure/lattice/catwalk,/turf/template_noop,/area/shipbreak)
-"qh" = (/obj/effect/turf_decal/tile/dark{dir = 4},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"qk" = (/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/glass,/turf/open/floor/iron/dark,/area/shipbreak)
-"qF" = (/obj/structure/railing{dir = 8},/turf/open/floor/holofloor/stairs,/area/shipbreak)
-"ra" = (/turf/open/floor/holofloor/stairs/left,/area/shipbreak)
-"rb" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/coffeemaker/impressa{pixel_y = 5; pixel_x = 9},/obj/structure/table,/obj/item/storage/box/coffeepack{pixel_x = -4; pixel_y = 3},/obj/effect/turf_decal/tile/dark/half,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"rs" = (/obj/effect/decal/cleanable/dirt,/obj/effect/spawner/random/trash/grille_or_waste,/turf/open/floor/plating,/area/shipbreak)
-"rA" = (/obj/structure/cable,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating,/area/shipbreak)
-"rK" = (/obj/structure/sign/poster/random/directional/east,/obj/structure/lattice,/turf/open/space/basic,/area/shipbreak)
-"rL" = (/turf/open/floor/mineral/titanium,/area/shipbreak)
-"sn" = (/obj/effect/mapping_helpers/broken_floor,/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/random/trash/hobo_squat{atom_integrity = 100},/turf/open/floor/plating,/area/shipbreak)
-"tk" = (/obj/structure/table,/obj/item/kitchen/fork/plastic{pixel_x = 10},/obj/item/kitchen/spoon/plastic{pixel_x = 7},/obj/item/kitchen/fork/plastic{pixel_x = 10},/obj/item/kitchen/fork/plastic{pixel_x = 10},/obj/item/kitchen/fork/plastic{pixel_x = 10},/obj/item/kitchen/spoon/plastic{pixel_x = 7},/obj/item/kitchen/spoon/plastic{pixel_x = 7},/obj/item/kitchen/spoon/plastic{pixel_x = 7},/obj/item/knife/plastic{pixel_x = -4},/obj/item/knife/plastic{pixel_x = -4},/obj/effect/turf_decal/tile/dark/half,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"tn" = (/obj/effect/mapping_helpers/broken_floor,/obj/effect/decal/cleanable/ants,/turf/open/floor/iron/dark,/area/shipbreak)
-"tp" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt,/obj/effect/spawner/random/entertainment/money_small,/turf/open/floor/carpet/black,/area/shipbreak)
-"tO" = (/obj/effect/decal/cleanable/dirt/dust,/obj/machinery/light/directional/south,/turf/open/floor/iron/freezer,/area/shipbreak)
-"up" = (/obj/effect/mapping_helpers/broken_floor,/turf/open/floor/plating,/area/shipbreak)
-"uv" = (/obj/structure/cable,/obj/effect/decal/cleanable/dirt,/obj/effect/mapping_helpers/broken_floor,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/shipbreak)
-"uH" = (/turf/open/floor/iron/dark/smooth_large/airless,/area/shipbreak)
-"uL" = (/obj/structure/rack/shelf,/obj/effect/spawner/random/food_or_drink/booze,/obj/effect/spawner/random/food_or_drink/booze,/obj/effect/spawner/random/food_or_drink/booze,/obj/effect/spawner/random/food_or_drink/booze,/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/bot,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"vc" = (/obj/structure/lattice,/obj/structure/lattice,/turf/template_noop,/area/shipbreak)
-"vg" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/plastic,/obj/effect/turf_decal/tile/dark/half,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"vn" = (/obj/effect/turf_decal/tile/dark/half{dir = 1},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"wc" = (/obj/effect/turf_decal/bot,/obj/effect/spawner/random/vending/colavend,/obj/effect/decal/cleanable/dirt,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"wd" = (/obj/effect/turf_decal/bot,/obj/effect/spawner/random/vending/snackvend,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"wf" = (/obj/structure/sink/directional/south,/obj/structure/mirror{pixel_y = 32},/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/hair,/turf/open/floor/iron/freezer,/area/shipbreak)
-"xu" = (/obj/effect/decal/cleanable/dirt,/obj/effect/spawner/random/trash/moisture,/turf/open/floor/iron/freezer,/area/shipbreak)
-"xP" = (/turf/open/floor/iron/solarpanel,/area/shipbreak)
-"ye" = (/obj/structure/lattice/catwalk,/obj/structure/cable,/turf/template_noop,/area/shipbreak)
-"yR" = (/turf/open/floor/iron/white/textured_large/airless,/area/shipbreak)
-"za" = (/obj/structure/window/reinforced/tinted/spawner/directional/west,/obj/structure/toilet{pixel_y = 16},/obj/machinery/door/window/right/directional/south,/obj/item/knife/shiv,/obj/effect/decal/cleanable/dirt,/turf/open/floor/iron/freezer,/area/shipbreak)
-"zQ" = (/obj/structure/closet/crate/bin,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/garbage,/obj/effect/turf_decal/bot,/obj/machinery/light/small/directional/north,/turf/open/floor/iron/dark,/area/shipbreak)
-"Aa" = (/obj/structure/closet/crate/cardboard/mothic,/obj/structure/rack/shelf,/obj/effect/turf_decal/bot,/obj/machinery/light/small/directional/north,/turf/open/floor/iron/dark,/area/shipbreak)
-"Ag" = (/obj/structure/rack/shelf,/obj/effect/spawner/random/food_or_drink/refreshing_beverage,/obj/effect/spawner/random/food_or_drink/refreshing_beverage,/obj/effect/spawner/random/food_or_drink/refreshing_beverage,/obj/effect/spawner/random/food_or_drink/refreshing_beverage,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/plastic,/obj/effect/turf_decal/bot,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"As" = (/obj/structure/rack/shelf,/obj/item/food/cnds/random,/obj/item/food/cnds/random,/obj/item/food/cnds/random,/obj/item/food/cnds/random,/obj/effect/turf_decal/bot,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"AV" = (/obj/structure/railing{dir = 1},/turf/open/floor/iron/white/textured_large/airless,/area/shipbreak)
-"BT" = (/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/tile/dark/anticorner{dir = 4},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"BY" = (/obj/effect/decal/cleanable/piss_stain,/obj/item/food/urinalcake,/turf/open/floor/iron/freezer,/area/shipbreak)
-"DC" = (/obj/machinery/door/airlock/bathroom{name = "Restroom"},/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/vomit,/turf/open/floor/iron/freezer,/area/shipbreak)
-"DO" = (/obj/effect/spawner/random/trash/graffiti,/obj/structure/cable,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"Ei" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/iron/dark/smooth_large/airless,/area/shipbreak)
-"GT" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating,/area/shipbreak)
-"Ha" = (/obj/structure/lattice,/obj/structure/marker_beacon/burgundy,/turf/template_noop,/area/shipbreak)
-"Hx" = (/obj/structure/rack/shelf,/obj/item/food/syndicake,/obj/item/food/syndicake,/obj/item/food/syndicake,/obj/effect/turf_decal/bot,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"HC" = (/obj/structure/sign/poster/random/directional/east,/turf/open/floor/plating,/area/shipbreak)
-"HJ" = (/obj/structure/lattice,/turf/template_noop,/area/shipbreak)
-"HR" = (/obj/structure/lattice,/turf/closed/wall/mineral/titanium,/area/shipbreak)
-"Iv" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/dark/smooth_large/airless,/area/shipbreak)
-"Jc" = (/obj/structure/table,/obj/item/reagent_containers/condiment/ketchup{pixel_y = 18; pixel_x = 11},/obj/item/reagent_containers/condiment/hotsauce{pixel_y = 15},/obj/item/reagent_containers/condiment/saltshaker{pixel_x = -8; pixel_y = 5},/obj/item/reagent_containers/condiment/peppermill{pixel_x = -8},/obj/effect/turf_decal/tile/dark/half{dir = 1},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"Je" = (/obj/structure/railing{dir = 1},/obj/structure/reagent_dispensers/fueltank,/obj/effect/turf_decal/bot,/turf/open/floor/iron/white/textured_large/airless,/area/shipbreak)
-"Ji" = (/obj/effect/decal/cleanable/dirt,/obj/effect/spawner/random/trash/food_packaging,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"Jv" = (/obj/structure/window/reinforced/tinted/spawner/directional/west,/obj/structure/toilet{pixel_y = 16},/obj/machinery/door/window/right/directional/south,/obj/effect/decal/cleanable/piss_stain,/obj/effect/decal/cleanable/blood/drip,/turf/open/floor/iron/freezer,/area/shipbreak)
-"JR" = (/obj/machinery/door/airlock/external{name = "Getcher Gas'n'Go"},/obj/effect/decal/cleanable/dirt,/turf/open/space/basic,/area/shipbreak)
-"Kg" = (/obj/machinery/atm/directional/north,/obj/effect/mapping_helpers/broken_floor,/turf/open/floor/plating,/area/shipbreak)
-"Kv" = (/turf/closed/wall/mineral/titanium,/area/shipbreak)
-"KH" = (/obj/effect/spawner/random/vending/snackvend,/obj/effect/turf_decal/bot,/obj/effect/decal/cleanable/dirt,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"Ln" = (/obj/structure/table,/obj/effect/spawner/random/entertainment/cigarette_pack,/obj/effect/spawner/random/entertainment/cigarette,/turf/open/floor/carpet/black,/area/shipbreak)
-"Ls" = (/obj/structure/railing{dir = 4},/obj/structure/reagent_dispensers/watertank,/obj/effect/turf_decal/bot,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"LR" = (/obj/structure/cable,/obj/effect/mapping_helpers/broken_floor,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/plating,/area/shipbreak)
-"Mg" = (/obj/effect/decal/cleanable/dirt,/obj/effect/spawner/random/trash/cigbutt,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"Nb" = (/obj/effect/spawner/random/vending/colavend,/obj/effect/turf_decal/bot,/obj/effect/decal/cleanable/dirt,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"Nj" = (/obj/structure/table,/obj/item/food/syndicake,/turf/open/floor/carpet/black,/area/shipbreak)
-"NL" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/iron/dark,/area/shipbreak)
-"Om" = (/obj/effect/turf_decal/tile/dark/anticorner{dir = 8},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"OJ" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt/dust,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"Pd" = (/obj/structure/closet/crate/bin{pixel_y = 13},/obj/effect/turf_decal/bot,/obj/effect/turf_decal/tile/dark/half{dir = 1},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"Ps" = (/obj/machinery/door/window/right/directional/east,/obj/effect/decal/cleanable/dirt/dust,/obj/effect/turf_decal/tile/dark/half{dir = 1},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"QJ" = (/obj/machinery/light/directional/north,/obj/effect/turf_decal/bot,/obj/structure/sign/poster/random/directional/north,/obj/effect/decal/cleanable/dirt,/obj/effect/spawner/random/trash/food_packaging,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"QP" = (/obj/effect/turf_decal/tile/dark/half{dir = 4},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"Sj" = (/obj/structure/railing{dir = 1},/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/random/trash/garbage,/turf/open/floor/iron/white/textured_large/airless,/area/shipbreak)
-"Sy" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt/dust,/obj/structure/sign/poster/contraband/pizza_imperator/directional/north,/obj/effect/turf_decal/tile/dark/half{dir = 1},/turf/open/floor/mineral/titanium,/area/shipbreak)
-"TP" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/carpet/black,/area/shipbreak)
-"Up" = (/obj/structure/railing{dir = 1},/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/white/textured_large/airless,/area/shipbreak)
-"Ux" = (/obj/effect/spawner/random/trash/graffiti,/obj/effect/decal/cleanable/dirt,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"UR" = (/obj/structure/railing{dir = 8},/obj/effect/turf_decal/bot,/obj/structure/closet/crate/bin{pixel_y = 13},/obj/effect/decal/cleanable/dirt,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"Vx" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/iron/dark,/area/shipbreak)
-"VJ" = (/obj/effect/decal/cleanable/dirt,/obj/effect/spawner/random/trash/caution_sign,/turf/open/floor/carpet/black,/area/shipbreak)
-"Wc" = (/obj/structure/rack/shelf,/obj/item/food/canned/beans,/obj/item/food/canned/beans,/obj/item/food/canned/beans,/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/bot,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"Ws" = (/obj/effect/mapping_helpers/broken_floor,/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/dark/smooth_large/airless,/area/shipbreak)
-"Wy" = (/obj/effect/spawner/random/trash/grime,/turf/open/floor/iron/dark/smooth_large/airless,/area/shipbreak)
-"WD" = (/obj/structure/railing{dir = 8},/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt/dust,/obj/effect/spawner/random/trash/bacteria,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"XY" = (/obj/structure/closet/cardboard,/turf/open/floor/iron/dark,/area/shipbreak)
-"Yi" = (/obj/effect/decal/cleanable/dirt/dust,/turf/open/floor/iron/white/textured_large/airless,/area/shipbreak)
-"YA" = (/obj/structure/table,/obj/structure/rack,/obj/item/food/taco{pixel_y = 7; pixel_x = 1},/obj/item/food/taco,/obj/effect/turf_decal/tile/dark/anticorner,/turf/open/floor/mineral/titanium,/area/shipbreak)
-"YP" = (/obj/structure/rack/shelf,/obj/structure/closet/crate/cardboard,/obj/effect/decal/cleanable/cobweb,/obj/effect/turf_decal/bot,/turf/open/floor/iron/dark,/area/shipbreak)
-"YY" = (/obj/effect/spawner/random/structure/billboard/roadsigns,/turf/open/floor/plating,/area/shipbreak)
-"Zs" = (/obj/structure/rack,/obj/effect/decal/cleanable/garbage,/obj/effect/turf_decal/bot,/obj/effect/spawner/random/structure/crate,/turf/open/floor/iron/dark,/area/shipbreak)
-"ZF" = (/obj/structure/cable,/turf/open/floor/iron/solarpanel,/area/shipbreak)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ag" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/holofloor/stairs,
+/area/template_noop)
+"ah" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"ak" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/template_noop)
+"as" = (
+/obj/machinery/power/shuttle_engine/heater{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"aW" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/effect/spawner/random/engineering/toolbox,
+/turf/template_noop,
+/area/template_noop)
+"aX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/entertainment/wallet_storage,
+/turf/open/floor/carpet/black,
+/area/template_noop)
+"aZ" = (
+/obj/effect/decal/cleanable/blood/drip,
+/obj/machinery/computer/accounting{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/carpet/black,
+/area/template_noop)
+"bk" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/iron/dark/smooth_large/airless,
+/area/template_noop)
+"bU" = (
+/obj/structure/table,
+/obj/item/food/hotdog{
+	pixel_y = 7;
+	pixel_x = -2
+	},
+/obj/structure/rack,
+/obj/item/food/hotdog,
+/obj/effect/turf_decal/tile/dark/anticorner{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"ce" = (
+/obj/machinery/griddle,
+/obj/item/food/raw_sausage{
+	pixel_y = 11
+	},
+/obj/item/food/raw_sausage{
+	pixel_y = 2;
+	pixel_x = 2
+	},
+/obj/effect/turf_decal/tile/dark/half{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"cD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"cK" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/power/tracker,
+/obj/structure/cable,
+/turf/template_noop,
+/area/template_noop)
+"cT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"dz" = (
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/tile/dark/half,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"dU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"eg" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/plating,
+/area/template_noop)
+"er" = (
+/turf/open/floor/holofloor/stairs/right,
+/area/template_noop)
+"fk" = (
+/turf/template_noop,
+/area/template_noop)
+"fB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood/drip,
+/obj/structure/sign/poster/contraband/donk_co/directional/north,
+/obj/effect/turf_decal/tile/dark/half{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"fK" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Storeroom"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"he" = (
+/obj/machinery/power/solar{
+	id = "forestarboard";
+	name = "Fore-Starboard Solar Array"
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel,
+/area/template_noop)
+"ht" = (
+/turf/open/space/basic,
+/area/template_noop)
+"hU" = (
+/obj/effect/decal/cleanable/food/tomato_smudge,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plastic,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"ic" = (
+/turf/open/floor/plating,
+/area/template_noop)
+"if" = (
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/tile/dark/half{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"io" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"ip" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark/half,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"iz" = (
+/obj/structure/cable,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"iG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/iron/dark/smooth_large/airless,
+/area/template_noop)
+"iL" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Storeroom"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"iX" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/carpet/black,
+/area/template_noop)
+"jk" = (
+/obj/structure/rack/shelf,
+/obj/item/food/canned/tomatoes,
+/obj/item/food/canned/tomatoes,
+/obj/item/food/canned/tomatoes,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"jW" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/spawner/random/maintenance/three,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"jX" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"kb" = (
+/obj/machinery/door/airlock/external{
+	name = "Getcher Gas'n'Go"
+	},
+/obj/structure/cable,
+/turf/open/space/basic,
+/area/template_noop)
+"ki" = (
+/obj/structure/rack/shelf,
+/obj/item/food/peanuts/random,
+/obj/item/food/peanuts/random,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/dark/half{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"km" = (
+/obj/machinery/power/shuttle_engine/propulsion{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"kR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/dark/anticorner{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"li" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"lx" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"lU" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"mX" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"nn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/white/textured_large/airless,
+/area/template_noop)
+"ow" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"oA" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/plating,
+/area/template_noop)
+"oD" = (
+/obj/machinery/vending/cigarette,
+/obj/structure/sign/poster/contraband/have_a_puff/directional/north,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/dark/half{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"pI" = (
+/obj/structure/rack/shelf,
+/obj/item/storage/box/donkpockets,
+/obj/item/storage/box/donkpockets/donkpocketberry,
+/obj/item/storage/box/donkpockets/donkpocketgondola,
+/obj/item/storage/box/donkpockets/donkpockethonk,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/dark/half{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"pY" = (
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/template_noop)
+"qh" = (
+/obj/effect/turf_decal/tile/dark{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"qk" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/glass,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"qF" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/holofloor/stairs,
+/area/template_noop)
+"ra" = (
+/turf/open/floor/holofloor/stairs/left,
+/area/template_noop)
+"rb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/coffeemaker/impressa{
+	pixel_y = 5;
+	pixel_x = 9
+	},
+/obj/structure/table,
+/obj/item/storage/box/coffeepack{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/tile/dark/half,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"rs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/grille_or_waste,
+/turf/open/floor/plating,
+/area/template_noop)
+"rA" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/template_noop)
+"rK" = (
+/obj/structure/sign/poster/random/directional/east,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/template_noop)
+"rL" = (
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"sn" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/hobo_squat{
+	atom_integrity = 100
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"tk" = (
+/obj/structure/table,
+/obj/item/kitchen/fork/plastic{
+	pixel_x = 10
+	},
+/obj/item/kitchen/spoon/plastic{
+	pixel_x = 7
+	},
+/obj/item/kitchen/fork/plastic{
+	pixel_x = 10
+	},
+/obj/item/kitchen/fork/plastic{
+	pixel_x = 10
+	},
+/obj/item/kitchen/fork/plastic{
+	pixel_x = 10
+	},
+/obj/item/kitchen/spoon/plastic{
+	pixel_x = 7
+	},
+/obj/item/kitchen/spoon/plastic{
+	pixel_x = 7
+	},
+/obj/item/kitchen/spoon/plastic{
+	pixel_x = 7
+	},
+/obj/item/knife/plastic{
+	pixel_x = -4
+	},
+/obj/item/knife/plastic{
+	pixel_x = -4
+	},
+/obj/effect/turf_decal/tile/dark/half,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"tn" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/ants,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"tp" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/entertainment/money_small,
+/turf/open/floor/carpet/black,
+/area/template_noop)
+"tO" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/directional/south,
+/turf/open/floor/iron/freezer,
+/area/template_noop)
+"up" = (
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/template_noop)
+"uv" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"uH" = (
+/turf/open/floor/iron/dark/smooth_large/airless,
+/area/template_noop)
+"uL" = (
+/obj/structure/rack/shelf,
+/obj/effect/spawner/random/food_or_drink/booze,
+/obj/effect/spawner/random/food_or_drink/booze,
+/obj/effect/spawner/random/food_or_drink/booze,
+/obj/effect/spawner/random/food_or_drink/booze,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"vc" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"vg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plastic,
+/obj/effect/turf_decal/tile/dark/half,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"vn" = (
+/obj/effect/turf_decal/tile/dark/half{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"wc" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/vending/colavend,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"wd" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"wf" = (
+/obj/structure/sink/directional/south,
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/hair,
+/turf/open/floor/iron/freezer,
+/area/template_noop)
+"xu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/moisture,
+/turf/open/floor/iron/freezer,
+/area/template_noop)
+"xP" = (
+/turf/open/floor/iron/solarpanel,
+/area/template_noop)
+"ye" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/template_noop,
+/area/template_noop)
+"yR" = (
+/turf/open/floor/iron/white/textured_large/airless,
+/area/template_noop)
+"za" = (
+/obj/structure/window/reinforced/tinted/spawner/directional/west,
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/machinery/door/window/right/directional/south,
+/obj/item/knife/shiv,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/freezer,
+/area/template_noop)
+"zQ" = (
+/obj/structure/closet/crate/bin,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"Aa" = (
+/obj/structure/closet/crate/cardboard/mothic,
+/obj/structure/rack/shelf,
+/obj/effect/turf_decal/bot,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"Ag" = (
+/obj/structure/rack/shelf,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
+/obj/effect/spawner/random/food_or_drink/refreshing_beverage,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/plastic,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"As" = (
+/obj/structure/rack/shelf,
+/obj/item/food/cnds/random,
+/obj/item/food/cnds/random,
+/obj/item/food/cnds/random,
+/obj/item/food/cnds/random,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"AV" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured_large/airless,
+/area/template_noop)
+"BT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/dark/anticorner{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"BY" = (
+/obj/effect/decal/cleanable/piss_stain,
+/obj/item/food/urinalcake,
+/turf/open/floor/iron/freezer,
+/area/template_noop)
+"DC" = (
+/obj/machinery/door/airlock/bathroom{
+	name = "Restroom"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/vomit,
+/turf/open/floor/iron/freezer,
+/area/template_noop)
+"DO" = (
+/obj/effect/spawner/random/trash/graffiti,
+/obj/structure/cable,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"Ei" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark/smooth_large/airless,
+/area/template_noop)
+"GT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/template_noop)
+"Ha" = (
+/obj/structure/lattice,
+/obj/structure/marker_beacon/burgundy,
+/turf/template_noop,
+/area/template_noop)
+"Hx" = (
+/obj/structure/rack/shelf,
+/obj/item/food/syndicake,
+/obj/item/food/syndicake,
+/obj/item/food/syndicake,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"HC" = (
+/obj/structure/sign/poster/random/directional/east,
+/turf/open/floor/plating,
+/area/template_noop)
+"HJ" = (
+/obj/structure/lattice,
+/turf/template_noop,
+/area/template_noop)
+"HR" = (
+/obj/structure/lattice,
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"Iv" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/smooth_large/airless,
+/area/template_noop)
+"Jc" = (
+/obj/structure/table,
+/obj/item/reagent_containers/condiment/ketchup{
+	pixel_y = 18;
+	pixel_x = 11
+	},
+/obj/item/reagent_containers/condiment/hotsauce{
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/condiment/saltshaker{
+	pixel_x = -8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/condiment/peppermill{
+	pixel_x = -8
+	},
+/obj/effect/turf_decal/tile/dark/half{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"Je" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/white/textured_large/airless,
+/area/template_noop)
+"Ji" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"Jv" = (
+/obj/structure/window/reinforced/tinted/spawner/directional/west,
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/machinery/door/window/right/directional/south,
+/obj/effect/decal/cleanable/piss_stain,
+/obj/effect/decal/cleanable/blood/drip,
+/turf/open/floor/iron/freezer,
+/area/template_noop)
+"JR" = (
+/obj/machinery/door/airlock/external{
+	name = "Getcher Gas'n'Go"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/space/basic,
+/area/template_noop)
+"Kg" = (
+/obj/machinery/atm/directional/north,
+/obj/effect/mapping_helpers/broken_floor,
+/turf/open/floor/plating,
+/area/template_noop)
+"Kv" = (
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"KH" = (
+/obj/effect/spawner/random/vending/snackvend,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"Ln" = (
+/obj/structure/table,
+/obj/effect/spawner/random/entertainment/cigarette_pack,
+/obj/effect/spawner/random/entertainment/cigarette,
+/turf/open/floor/carpet/black,
+/area/template_noop)
+"Ls" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"LR" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/template_noop)
+"Mg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/cigbutt,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"Nb" = (
+/obj/effect/spawner/random/vending/colavend,
+/obj/effect/turf_decal/bot,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"Nj" = (
+/obj/structure/table,
+/obj/item/food/syndicake,
+/turf/open/floor/carpet/black,
+/area/template_noop)
+"NL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"Om" = (
+/obj/effect/turf_decal/tile/dark/anticorner{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"OJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"Pd" = (
+/obj/structure/closet/crate/bin{
+	pixel_y = 13
+	},
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/dark/half{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"Ps" = (
+/obj/machinery/door/window/right/directional/east,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/turf_decal/tile/dark/half{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"QJ" = (
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/poster/random/directional/north,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"QP" = (
+/obj/effect/turf_decal/tile/dark/half{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"Sj" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/garbage,
+/turf/open/floor/iron/white/textured_large/airless,
+/area/template_noop)
+"Sy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sign/poster/contraband/pizza_imperator/directional/north,
+/obj/effect/turf_decal/tile/dark/half{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"TP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/carpet/black,
+/area/template_noop)
+"Up" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white/textured_large/airless,
+/area/template_noop)
+"Ux" = (
+/obj/effect/spawner/random/trash/graffiti,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"UR" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/bin{
+	pixel_y = 13
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"Vx" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"VJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/caution_sign,
+/turf/open/floor/carpet/black,
+/area/template_noop)
+"Wc" = (
+/obj/structure/rack/shelf,
+/obj/item/food/canned/beans,
+/obj/item/food/canned/beans,
+/obj/item/food/canned/beans,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"Ws" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/dark/smooth_large/airless,
+/area/template_noop)
+"Wy" = (
+/obj/effect/spawner/random/trash/grime,
+/turf/open/floor/iron/dark/smooth_large/airless,
+/area/template_noop)
+"WD" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/spawner/random/trash/bacteria,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"XY" = (
+/obj/structure/closet/cardboard,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"Yi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/iron/white/textured_large/airless,
+/area/template_noop)
+"YA" = (
+/obj/structure/table,
+/obj/structure/rack,
+/obj/item/food/taco{
+	pixel_y = 7;
+	pixel_x = 1
+	},
+/obj/item/food/taco,
+/obj/effect/turf_decal/tile/dark/anticorner,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
+"YP" = (
+/obj/structure/rack/shelf,
+/obj/structure/closet/crate/cardboard,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"YY" = (
+/obj/effect/spawner/random/structure/billboard/roadsigns,
+/turf/open/floor/plating,
+/area/template_noop)
+"Zs" = (
+/obj/structure/rack,
+/obj/effect/decal/cleanable/garbage,
+/obj/effect/turf_decal/bot,
+/obj/effect/spawner/random/structure/crate,
+/turf/open/floor/iron/dark,
+/area/template_noop)
+"ZF" = (
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel,
+/area/template_noop)
 
 (1,1,1) = {"
-fkfkfkfkHJHJHJHJHJHJfkHJfkfkfkfkfkfkfkfkfkfk
-fkfkfkHJHRKvKvKvKvicHJHJfkfkfkfkfkfkfkfkfkfk
-fkfkfkHJHRYPAaZsKvKvKvKvfkfkfkfkfkfkcKfkfkfk
-fkHJHJicHRlUtndUKvjWzQKvkmkmkmkmfkHaaWHafkfk
-fkYYupGTHRXYVxlxiLNLqkKvasasasasHJHJyeHJHJfk
-fkHJliupKvKvKvKvKvKvfKKvKvKvKvKvyeyeyeyeyeHJ
-fkfkHJHJKvkRSyfBPsvnBTKvwfJvzaKvheheyeheheHJ
-fkhthtrKKvaZtpLnNjrLQPDCxutOBYKvheheyexPheHJ
-HJYYcDHCKviXTPaXakjXifKvKvKvKvKvhexPyeheZFHJ
-HJcDGTsnoApIAsWcuLrLqhPdoDJcbUoAyeyeyeyeyeHJ
-fkHJHJHJoAkiHxjkAgTPVJOJMghUceoAhexPyexPheHJ
-fkfkfkHJoAOmipvgdzakTPdzrbtkYAoAxPheyexPheHJ
-fkfkfkHJKvoAoAoAKvJRkbKvoAoAoAKvpYpYyepYpYHJ
-fkfkfkfkKgURNbKHQJjXowiowdwcLsrAyeLRyepYpYHJ
-fkfkfkfkahWDUxJicTjXowowizDOmXuvcDrsHJHJHJvc
-fkfkfkfkahqFJeAVUpraerUpAVSjagicfkfkfkfkfkfk
-fkfkfkfkuHHJYiEinnWyIvnnEiyRIvEifkfkfkfkfkfk
-fkfkfkfkfkuHYiEiHJEiuHYiWsIvEifkfkfkfkfkfkfk
-fkfkfkfkfkEiIvIvHJEibkYiuHuHiGfkfkfkfkfkfkfk
-fkfkfkfkfkfkfkcDIvuHIvicHJfkfkfkfkfkfkfkfkfk
-fkfkfkfkfkfkfkHJuHuHegHJfkfkfkfkfkfkfkfkfkfk
-fkfkfkfkfkfkfkfkbkHJfkfkfkfkfkfkfkfkfkfkfkfk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+HJ
+HJ
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+"}
+(2,1,1) = {"
+fk
+fk
+fk
+HJ
+YY
+HJ
+fk
+ht
+YY
+cD
+HJ
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+"}
+(3,1,1) = {"
+fk
+fk
+fk
+HJ
+up
+li
+HJ
+ht
+cD
+GT
+HJ
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+"}
+(4,1,1) = {"
+fk
+HJ
+HJ
+ic
+GT
+up
+HJ
+rK
+HC
+sn
+HJ
+HJ
+HJ
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+"}
+(5,1,1) = {"
+HJ
+HR
+HR
+HR
+HR
+Kv
+Kv
+Kv
+Kv
+oA
+oA
+oA
+Kv
+Kg
+ah
+ah
+uH
+fk
+fk
+fk
+fk
+fk
+"}
+(6,1,1) = {"
+HJ
+Kv
+YP
+lU
+XY
+Kv
+kR
+aZ
+iX
+pI
+ki
+Om
+oA
+UR
+WD
+qF
+HJ
+uH
+Ei
+fk
+fk
+fk
+"}
+(7,1,1) = {"
+HJ
+Kv
+Aa
+tn
+Vx
+Kv
+Sy
+tp
+TP
+As
+Hx
+ip
+oA
+Nb
+Ux
+Je
+Yi
+Yi
+Iv
+fk
+fk
+fk
+"}
+(8,1,1) = {"
+HJ
+Kv
+Zs
+dU
+lx
+Kv
+fB
+Ln
+aX
+Wc
+jk
+vg
+oA
+KH
+Ji
+AV
+Ei
+Ei
+Iv
+cD
+HJ
+fk
+"}
+(9,1,1) = {"
+HJ
+Kv
+Kv
+Kv
+iL
+Kv
+Ps
+Nj
+ak
+uL
+Ag
+dz
+Kv
+QJ
+cT
+Up
+nn
+HJ
+HJ
+Iv
+uH
+bk
+"}
+(10,1,1) = {"
+HJ
+ic
+Kv
+jW
+NL
+Kv
+vn
+rL
+jX
+rL
+TP
+ak
+JR
+jX
+jX
+ra
+Wy
+Ei
+Ei
+uH
+uH
+HJ
+"}
+(11,1,1) = {"
+fk
+HJ
+Kv
+zQ
+qk
+fK
+BT
+QP
+if
+qh
+VJ
+TP
+kb
+ow
+ow
+er
+Iv
+uH
+bk
+Iv
+eg
+fk
+"}
+(12,1,1) = {"
+HJ
+HJ
+Kv
+Kv
+Kv
+Kv
+Kv
+DC
+Kv
+Pd
+OJ
+dz
+Kv
+io
+ow
+Up
+nn
+Yi
+Yi
+ic
+HJ
+fk
+"}
+(13,1,1) = {"
+fk
+fk
+fk
+km
+as
+Kv
+wf
+xu
+Kv
+oD
+Mg
+rb
+oA
+wd
+iz
+AV
+Ei
+Ws
+uH
+HJ
+fk
+fk
+"}
+(14,1,1) = {"
+fk
+fk
+fk
+km
+as
+Kv
+Jv
+tO
+Kv
+Jc
+hU
+tk
+oA
+wc
+DO
+Sj
+yR
+Iv
+uH
+fk
+fk
+fk
+"}
+(15,1,1) = {"
+fk
+fk
+fk
+km
+as
+Kv
+za
+BY
+Kv
+bU
+ce
+YA
+oA
+Ls
+mX
+ag
+Iv
+Ei
+iG
+fk
+fk
+fk
+"}
+(16,1,1) = {"
+fk
+fk
+fk
+km
+as
+Kv
+Kv
+Kv
+Kv
+oA
+oA
+oA
+Kv
+rA
+uv
+ic
+Ei
+fk
+fk
+fk
+fk
+fk
+"}
+(17,1,1) = {"
+fk
+fk
+fk
+fk
+HJ
+ye
+he
+he
+he
+ye
+he
+xP
+pY
+ye
+cD
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+"}
+(18,1,1) = {"
+fk
+fk
+fk
+Ha
+HJ
+ye
+he
+he
+xP
+ye
+xP
+he
+pY
+LR
+rs
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+"}
+(19,1,1) = {"
+fk
+fk
+cK
+aW
+ye
+ye
+ye
+ye
+ye
+ye
+ye
+ye
+ye
+ye
+HJ
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+"}
+(20,1,1) = {"
+fk
+fk
+fk
+Ha
+HJ
+ye
+he
+xP
+he
+ye
+xP
+xP
+pY
+pY
+HJ
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+"}
+(21,1,1) = {"
+fk
+fk
+fk
+fk
+HJ
+ye
+he
+he
+ZF
+ye
+he
+he
+pY
+pY
+HJ
+fk
+fk
+fk
+fk
+fk
+fk
+fk
+"}
+(22,1,1) = {"
+fk
+fk
+fk
+fk
+fk
+HJ
+HJ
+HJ
+HJ
+HJ
+HJ
+HJ
+HJ
+HJ
+vc
+fk
+fk
+fk
+fk
+fk
+fk
+fk
 "}

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/goonshuttlesmall.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/goonshuttlesmall.dmm
@@ -4,19 +4,19 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "b" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/mineral/titanium/yellow,
-/area/shipbreak)
+/area/template_noop)
 "c" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 8
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "d" = (
 /obj/item/clothing/suit/hazardvest{
 	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
@@ -98,69 +98,69 @@
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "e" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /obj/effect/gibspawner/human,
 /turf/open/floor/mineral/titanium/yellow,
-/area/shipbreak)
+/area/template_noop)
 "f" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "g" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Escape Shuttle Infirmary"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "i" = (
 /turf/closed/wall/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "k" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Cockpit"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium/yellow,
-/area/shipbreak)
+/area/template_noop)
 "l" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "m" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "n" = (
 /obj/machinery/stasis{
 	dir = 4
 	},
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "o" = (
 /obj/machinery/computer/old{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/shipbreak)
+/area/template_noop)
 "p" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular,
 /turf/open/floor/mineral/titanium/yellow,
-/area/shipbreak)
+/area/template_noop)
 "s" = (
 /obj/effect/gibspawner/human,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "t" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -168,11 +168,11 @@
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "u" = (
 /obj/structure/sign/warning/no_smoking,
 /turf/closed/wall/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "w" = (
 /obj/structure/table,
 /obj/item/storage/medkit/toxin{
@@ -190,24 +190,24 @@
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "x" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "y" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/shipbreak)
+/area/template_noop)
 "z" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "A" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Emergency Shuttle Airlock"
@@ -217,98 +217,98 @@
 	name = "G00N-S emergency shuttle"
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "B" = (
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "C" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "D" = (
 /obj/item/organ/internal/butt,
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "F" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "G" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "H" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /obj/effect/gibspawner/human,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "I" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "K" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "N" = (
 /obj/machinery/vending/wallmed/directional/west{
 	products = null;
 	products_monke = null
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "P" = (
 /obj/machinery/stasis,
 /obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "Q" = (
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "R" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/machinery/light/directional/north,
 /obj/machinery/computer/old,
 /turf/open/floor/mineral/titanium/yellow,
-/area/shipbreak)
+/area/template_noop)
 "T" = (
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "U" = (
 /turf/open/floor/mineral/titanium/yellow,
-/area/shipbreak)
+/area/template_noop)
 "W" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/computer/old{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/shipbreak)
+/area/template_noop)
 "X" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "Y" = (
 /obj/item/clothing/head/utility/bomb_hood/security,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 I

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/gorlex_cruiser.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/gorlex_cruiser.dmm
@@ -4,7 +4,7 @@
 /obj/structure/cable,
 /obj/structure/sign/warning/electric_shock/directional/west,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "aT" = (
 /obj/structure/table,
 /obj/item/storage/box{
@@ -23,7 +23,7 @@
 	},
 /obj/structure/sign/poster/contraband/donk_co/directional/west,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "bs" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -32,28 +32,28 @@
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "bE" = (
 /obj/machinery/computer/atmos_control/fixed{
 	atmos_chambers = list("gorlex_ship_burner" = "Burn Chamber");
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "bT" = (
 /obj/machinery/vending/boozeomat/syndicate_access,
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "bU" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "bW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "bZ" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Master at Arms"
@@ -65,48 +65,48 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "cw" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
 	id = "gorlex_cruiser_cargo"
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "cx" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "cG" = (
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/box/white/corners,
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "dc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "dy" = (
 /obj/structure/fluff/oldturret{
 	icon_state = "syndie_off";
 	dir = 10
 	},
 /turf/closed/wall/r_wall/syndicate,
-/area/shipbreak)
+/area/template_noop)
 "dD" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "dH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "dM" = (
 /obj/structure/shipping_container/vitezstvi{
 	desc = "A standard-measure shipping container for bulk transport of goods. This one is from Vítězství Arms, proudly proclaiming that Vítězství weapons mean victory. A large gaping hole is in its door, which is welded shut at the remaining sections."
@@ -115,7 +115,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "dZ" = (
 /obj/structure/tank_dispenser/oxygen,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -123,13 +123,13 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/shipbreak)
+/area/template_noop)
 "ea" = (
 /obj/structure/fluff/metalpole/end/right{
 	dir = 4
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "eu" = (
 /obj/structure/closet/syndicate,
 /obj/machinery/light/small/dim/directional/east,
@@ -144,14 +144,14 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "ex" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "eJ" = (
 /obj/structure/fluff/metalpole{
 	dir = 8
@@ -160,20 +160,20 @@
 	dir = 4
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "eW" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "fn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
 /obj/structure/cable/multilayer/connected,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "fo" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/structure/cable,
@@ -181,28 +181,28 @@
 	id = "gorlex_cruiser_bridge"
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "fr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "fC" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/five,
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "gd" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "gm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "gn" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -211,30 +211,30 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "gu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "gv" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "ho" = (
 /obj/structure/closet/secure_closet/medical1{
 	req_access = list("syndicate")
 	},
 /obj/structure/closet/firecloset/wall/directional/south,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "hK" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "hO" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
@@ -244,7 +244,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "io" = (
 /obj/structure/fluff/metalpole{
 	dir = 4
@@ -253,7 +253,7 @@
 	dir = 4
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "it" = (
 /obj/structure/reflector/box/mapping{
 	dir = 1
@@ -262,16 +262,16 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "iH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "iK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "jh" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering{
@@ -284,20 +284,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "jj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "jo" = (
 /obj/structure/closet/crate/freezer,
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "ju" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "jx" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -306,7 +306,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "kA" = (
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
@@ -319,17 +319,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "kB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "kM" = (
 /obj/machinery/atmospherics/components/tank/oxygen,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "kY" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable,
@@ -347,34 +347,34 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "li" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "lu" = (
 /obj/effect/turf_decal/box/white/corners,
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "lF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "lH" = (
 /obj/machinery/igniter/on{
 	id = "gorlex_cruiser_igniter"
 	},
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold4w,
 /turf/open/floor/engine/airless,
-/area/shipbreak)
+/area/template_noop)
 "lL" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "lX" = (
 /obj/item/paper{
 	default_raw_text = "Evacuation has been authorised. I've opened the spacesuit locker. If you wake up; take a suit and leave this place. Wake up anyone else, too."
@@ -382,13 +382,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "mh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "mr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -398,47 +398,47 @@
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/item/storage/medkit/regular,
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "mC" = (
 /obj/structure/shipping_container/cybersun,
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "mE" = (
 /obj/machinery/door/poddoor{
 	id = "gorlex_cruiser_engine_vent"
 	},
 /turf/open/floor/engine/airless,
-/area/shipbreak)
+/area/template_noop)
 "mX" = (
 /obj/structure/cable/layer1,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "nt" = (
 /obj/machinery/light/small/dim/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "nB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "nG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "nS" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "ot" = (
 /obj/machinery/computer/old{
 	dir = 4
@@ -447,7 +447,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "oz" = (
 /obj/structure/cable/multilayer/connected,
 /obj/effect/turf_decal/stripes/line{
@@ -455,7 +455,7 @@
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "oE" = (
 /obj/machinery/door/airlock{
 	name = "Quartermaster's Bunk"
@@ -467,7 +467,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "oH" = (
 /obj/structure/filingcabinet/chestdrawer/wheeled,
 /obj/item/paper{
@@ -476,15 +476,15 @@
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "oP" = (
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "pi" = (
 /obj/structure/sign/poster/contraband/cybersun_six_hundred/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "px" = (
 /obj/structure/table/wood,
 /obj/item/food/donkpocket{
@@ -497,11 +497,11 @@
 	pixel_y = -2
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "pC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "pF" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Munitions Bay Access"
@@ -516,22 +516,22 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "pQ" = (
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "qh" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "qr" = (
 /obj/structure/table,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "qR" = (
 /obj/structure/closet/syndicate,
 /obj/machinery/light/small/dim/directional/east,
@@ -543,13 +543,13 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "rc" = (
 /obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "rf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -558,17 +558,17 @@
 	dir = 5
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "rt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "sh" = (
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "so" = (
 /obj/structure/fluff/metalpole/anchor{
 	dir = 4
@@ -577,28 +577,28 @@
 	dir = 8
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "sJ" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped/on{
 	dir = 4
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "sO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "sP" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "tf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "tg" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
@@ -618,7 +618,7 @@
 	pixel_y = -22
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "tw" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -628,13 +628,13 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "tS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "ua" = (
 /obj/machinery/button/door/directional/east{
 	id = "gorlex_cruiser_engine_vent";
@@ -651,19 +651,19 @@
 	dir = 8
 	},
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "un" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "uy" = (
 /obj/structure/cable,
 /obj/structure/chair/office/tactical{
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "uM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -674,11 +674,11 @@
 	},
 /obj/structure/sign/warning/no_smoking/circle/directional/south,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "uY" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "vb" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "gorlex_cruiser_eva"
@@ -688,7 +688,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
-/area/shipbreak)
+/area/template_noop)
 "vc" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Master at Arms"
@@ -699,20 +699,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "vp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "vq" = (
 /obj/structure/fluff/oldturret{
 	icon_state = "syndie_off";
 	dir = 9
 	},
 /turf/closed/wall/r_wall/syndicate,
-/area/shipbreak)
+/area/template_noop)
 "vD" = (
 /obj/structure/guncase,
 /obj/item/gun/ballistic/revolver/c38{
@@ -724,24 +724,24 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "wd" = (
 /obj/structure/closet/secure_closet/freezer/empty/open,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "wq" = (
 /obj/machinery/light/small/dim/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "wv" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
 /turf/open/floor/engine/airless,
-/area/shipbreak)
+/area/template_noop)
 "wK" = (
 /obj/structure/table/reinforced,
 /obj/item/paper{
@@ -750,20 +750,20 @@
 	default_raw_text = "The Captain just declared a state of rationing due to undersupply. Most of us are rail-thin already, we can't take this for long. We're outside of range from a friendly port too, and the listening posts we were meant to supply have all either evacuated or run out and gone under a mutiny."
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "xb" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "xd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "xn" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "xp" = (
 /obj/machinery/door/airlock{
 	name = "Crew Bunks"
@@ -778,7 +778,7 @@
 	invisibility = 101
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "xr" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -786,7 +786,7 @@
 	},
 /obj/structure/sign/warning/deathsposal/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "xO" = (
 /obj/machinery/door/airlock{
 	name = "Engineer's Bunk"
@@ -798,7 +798,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "xT" = (
 /obj/structure/closet/syndicate,
 /obj/item/clothing/suit/hooded/wintercoat/nova/syndicate,
@@ -808,13 +808,13 @@
 	dir = 8
 	},
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "xY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "ye" = (
 /obj/structure/fluff/metalpole{
 	dir = 8
@@ -823,11 +823,11 @@
 	dir = 4
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "yi" = (
 /obj/machinery/computer/old,
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "yw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -835,7 +835,7 @@
 	dir = 6
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "yF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/bathroom,
@@ -844,7 +844,7 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
-/area/shipbreak)
+/area/template_noop)
 "yH" = (
 /obj/structure/table/reinforced,
 /obj/item/stamp/syndicate{
@@ -860,7 +860,7 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "yQ" = (
 /obj/structure/closet/syndicate,
 /obj/item/clothing/under/syndicate/sniper,
@@ -873,18 +873,18 @@
 	req_access = list("syndicate")
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "zb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "zl" = (
 /obj/machinery/computer/old,
 /obj/structure/cable,
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "zy" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Munitions Bay Access"
@@ -899,19 +899,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "Ac" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
 	},
 /turf/closed/wall/r_wall/syndicate,
-/area/shipbreak)
+/area/template_noop)
 "Ah" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "AS" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -925,7 +925,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Bb" = (
 /obj/structure/fluff/metalpole/anchor{
 	dir = 4
@@ -934,41 +934,41 @@
 	dir = 8
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Bq" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "Br" = (
 /obj/structure/sign/poster/contraband/eat/directional/south,
 /obj/structure/table,
 /obj/structure/closet/emcloset/wall/directional/east,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "BU" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Ca" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Cl" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall/syndicate,
-/area/shipbreak)
+/area/template_noop)
 "Cs" = (
 /obj/machinery/atmospherics/components/tank/nitrogen{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "CT" = (
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
 /obj/machinery/door/airlock/command{
@@ -983,7 +983,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "CU" = (
 /obj/structure/table/reinforced,
 /obj/machinery/fax{
@@ -1001,12 +1001,12 @@
 /obj/machinery/airalarm/directional/north,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Dp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Dt" = (
 /obj/structure/table,
 /obj/machinery/firealarm/directional/west,
@@ -1014,37 +1014,37 @@
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Du" = (
 /obj/machinery/atmospherics/components/tank/nitrogen{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Dx" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /turf/open/floor/engine/airless,
-/area/shipbreak)
+/area/template_noop)
 "DB" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "DL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "DV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Eg" = (
 /obj/machinery/button/door/directional/east{
 	id = "gorlex_cruiser_eva";
@@ -1059,22 +1059,22 @@
 	dir = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "EM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "EV" = (
 /obj/structure/cable,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "EX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Fl" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/syndicate{
@@ -1082,24 +1082,24 @@
 	pixel_y = 9
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Fp" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
 	},
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Fz" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "FI" = (
 /obj/structure/closet/firecloset/wall/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "FN" = (
 /obj/structure/fluff/metalpole{
 	dir = 4
@@ -1108,7 +1108,7 @@
 	dir = 8
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "FQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1117,7 +1117,7 @@
 	invisibility = 101
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "Gl" = (
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/leader,
 /obj/machinery/door/airlock/command{
@@ -1130,7 +1130,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "Gn" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Service Bay"
@@ -1140,25 +1140,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "GF" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
 /turf/open/floor/engine/airless,
-/area/shipbreak)
+/area/template_noop)
 "GH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /obj/structure/sign/warning/fire/directional/south,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "GR" = (
 /obj/structure/fluff/metalpole{
 	dir = 4
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Hm" = (
 /obj/structure/fluff/metalpole/end/right{
 	dir = 8
@@ -1167,19 +1167,19 @@
 	dir = 8
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Ib" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Ig" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "Ix" = (
 /obj/machinery/power/emitter/welded{
 	projectile_type = /obj/projectile/beam/laser/accelerator;
@@ -1190,7 +1190,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "IG" = (
 /obj/structure/rack,
 /obj/item/storage/box/syndie_kit/space_suit{
@@ -1228,7 +1228,7 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/engine,
-/area/shipbreak)
+/area/template_noop)
 "IL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1239,17 +1239,17 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "Ji" = (
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "Kc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "Kf" = (
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "Kg" = (
 /obj/machinery/light/directional/east,
 /obj/structure/table,
@@ -1258,49 +1258,49 @@
 	pixel_y = 6
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Kk" = (
 /obj/machinery/firealarm/directional/south,
 /obj/structure/bookcase/manuals/engineering,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "Ky" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "KC" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold{
 	dir = 8
 	},
 /turf/open/floor/engine/airless,
-/area/shipbreak)
+/area/template_noop)
 "KF" = (
 /obj/machinery/light/small/dim/directional/south,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
-/area/shipbreak)
+/area/template_noop)
 "KM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "KT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "Lg" = (
 /obj/structure/fluff/oldturret{
 	icon_state = "syndie_off";
 	dir = 5
 	},
 /turf/closed/wall/r_wall/syndicate,
-/area/shipbreak)
+/area/template_noop)
 "Lx" = (
 /obj/machinery/door/airlock{
 	name = "Munitions Officer's Bunk"
@@ -1312,22 +1312,22 @@
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "LY" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "LZ" = (
 /obj/structure/fluff/oldturret{
 	icon_state = "syndie_off";
 	dir = 6
 	},
 /turf/closed/wall/r_wall/syndicate,
-/area/shipbreak)
+/area/template_noop)
 "Mf" = (
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "MJ" = (
 /obj/machinery/light/small/dim/directional/north,
 /obj/structure/closet/syndicate,
@@ -1339,14 +1339,14 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "ML" = (
 /obj/structure/closet/crate,
 /obj/item/lightreplacer,
 /obj/item/storage/box/lights/mixed,
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "MT" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -1356,13 +1356,13 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "Nf" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 10
 	},
 /turf/closed/wall/r_wall/syndicate,
-/area/shipbreak)
+/area/template_noop)
 "Od" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -1372,20 +1372,20 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "On" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
 	},
 /turf/closed/wall/r_wall/syndicate,
-/area/shipbreak)
+/area/template_noop)
 "OA" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
 	dir = 1
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "OK" = (
 /obj/machinery/atmospherics/components/unary/passive_vent{
 	dir = 1
@@ -1393,14 +1393,14 @@
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
 /turf/open/floor/engine/airless,
-/area/shipbreak)
+/area/template_noop)
 "Pm" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
 /turf/open/floor/engine/airless,
-/area/shipbreak)
+/area/template_noop)
 "Pq" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -1411,7 +1411,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "PJ" = (
 /obj/machinery/button/door/directional/east{
 	id = "gorlex_cruiser_cargo";
@@ -1420,20 +1420,20 @@
 	},
 /obj/structure/chair/office/tactical,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "PX" = (
 /obj/machinery/light/small/dim/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "Qc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Qo" = (
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /obj/effect/mapping_helpers/airlock/cutaiwire,
@@ -1446,20 +1446,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "Qs" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Sy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/hidden,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "SC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "Th" = (
 /obj/structure/sink/directional/west,
 /obj/machinery/light/small/directional/west,
@@ -1472,25 +1472,25 @@
 /obj/item/soap/syndie,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
-/area/shipbreak)
+/area/template_noop)
 "TD" = (
 /obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/visible/layer4{
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "TU" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "UN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "UP" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Service Bay"
@@ -1502,32 +1502,32 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "UX" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "UZ" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Vj" = (
 /turf/closed/wall/r_wall/syndicate,
-/area/shipbreak)
+/area/template_noop)
 "Wc" = (
 /obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "Wy" = (
 /obj/structure/fluff/metalpole/end/left{
 	dir = 4
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "WA" = (
 /obj/structure/table/reinforced,
 /obj/item/stamp/head/qm{
@@ -1543,7 +1543,7 @@
 	pixel_y = 7
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "WL" = (
 /obj/machinery/power/stirling_generator{
 	dir = 1
@@ -1551,13 +1551,13 @@
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /obj/structure/cable,
 /turf/open/floor/engine/airless,
-/area/shipbreak)
+/area/template_noop)
 "WM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "WQ" = (
 /obj/structure/bed,
 /obj/item/bedsheet/syndie,
@@ -1567,35 +1567,35 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
-/area/shipbreak)
+/area/template_noop)
 "Xb" = (
 /obj/structure/sign/poster/contraband/mothic_rations/directional/north{
 	desc = "A Mothic ration chart. The information on it has been drawn over in crude handwriting, listing what food has been allocated to which crewmembers. You can't recognise any of the names on here."
 	},
 /obj/structure/closet/secure_closet/freezer/empty/open,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Xe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 "Xu" = (
 /obj/vehicle/sealed/mecha/working/ripley/cargo,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Xv" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "XQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "XX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1605,7 +1605,7 @@
 	invisibility = 101
 	},
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "Yq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1613,7 +1613,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "YP" = (
 /obj/structure/table,
 /obj/item/pen{
@@ -1626,21 +1626,21 @@
 	pixel_y = 4
 	},
 /turf/open/floor/iron/grimy,
-/area/shipbreak)
+/area/template_noop)
 "Za" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/mineral/wood/fifty,
 /obj/item/hatchet/wooden,
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/iron/dark/smooth_large,
-/area/shipbreak)
+/area/template_noop)
 "Zo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 UZ

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/mcsail.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/mcsail.dmm
@@ -3,28 +3,28 @@
 /obj/structure/cable,
 /obj/machinery/power/solar,
 /turf/open/floor/iron/solarpanel/airless,
-/area/shipbreak)
+/area/template_noop)
 "j" = (
 /turf/closed/wall,
-/area/shipbreak)
+/area/template_noop)
 "k" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/cable,
 /obj/machinery/power/solar_control,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "p" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "s" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "u" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "x" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/table/reinforced,
@@ -32,70 +32,70 @@
 	pixel_y = 4
 	},
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "z" = (
 /obj/structure/cable,
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "B" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "D" = (
 /obj/structure/cable,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "E" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "F" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "P" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Q" = (
 /obj/machinery/door/airlock/external,
 /obj/structure/cable,
 /obj/structure/fans/tiny,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "R" = (
 /obj/machinery/power/tracker,
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "S" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "V" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/computer/old,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "W" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/computer/old,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "Y" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 u

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/mcsteal_sloop.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/mcsteal_sloop.dmm
@@ -1,48 +1,48 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/closed/wall,
-/area/shipbreak)
+/area/template_noop)
 "b" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "d" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "e" = (
 /obj/machinery/autolathe,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "h" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/airlock/external,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "i" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "l" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "m" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "q" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/medkit/regular,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "r" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54,29 +54,29 @@
 	amount = 30
 	},
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "u" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "v" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "y" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/olive,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "B" = (
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "C" = (
 /obj/structure/cable,
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "D" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -84,20 +84,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "E" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "G" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "I" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -106,28 +106,28 @@
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "K" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "L" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "M" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "O" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall,
-/area/shipbreak)
+/area/template_noop)
 "P" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Q" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -136,7 +136,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "S" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -146,12 +146,12 @@
 	dir = 4
 	},
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "T" = (
 /obj/machinery/atmospherics/components/unary/passive_vent/layer2,
 /obj/structure/lattice,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "U" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -160,24 +160,24 @@
 	dir = 8
 	},
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "W" = (
 /obj/machinery/airalarm/directional/west,
 /obj/structure/table/reinforced,
 /obj/item/storage/medkit/surgery,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "Y" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/comfy/shuttle,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 "Z" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/iron/smooth,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 L

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/mess.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/mess.dmm
@@ -6,17 +6,17 @@
 	},
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "ac" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "aC" = (
 /obj/effect/decal/cleanable/plastic,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "aY" = (
 /obj/projectile/bullet/reusable/foam_dart{
 	pixel_x = 14;
@@ -24,224 +24,221 @@
 	},
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "br" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "ck" = (
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "dc" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/material/meat,
-/area/shipbreak)
-"ds" = (
-/turf/open/space/basic,
-/area/shipbreak)
+/area/template_noop)
 "eu" = (
 /obj/item/paper/employment_contract{
 	pixel_x = 1;
 	pixel_y = -14
 	},
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "fu" = (
 /turf/open/floor/bronze,
-/area/shipbreak)
+/area/template_noop)
 "fA" = (
 /obj/machinery/vending/donksofttoyvendor,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "fD" = (
 /obj/machinery/light/floor/has_bulb/red,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "fG" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "fM" = (
 /obj/machinery/light/blacklight/directional/south,
 /turf/open/floor/vault/alien,
-/area/shipbreak)
+/area/template_noop)
 "fW" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "gC" = (
 /obj/machinery/power/smes/full,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "gS" = (
 /obj/machinery/power/apc/worn_out/directional/south,
 /obj/effect/decal/cleanable/robot_debris/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "gY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/goldeneye_upload_terminal,
 /obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/computer/old,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "ha" = (
 /obj/effect/decal/cleanable/vomit/old/black_bile,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "ih" = (
 /turf/open/floor/glass/plasma,
-/area/shipbreak)
+/area/template_noop)
 "il" = (
 /obj/item/stack/sheet/bronze,
 /turf/open/floor/bronze,
-/area/shipbreak)
+/area/template_noop)
 "iz" = (
 /obj/item/reagent_containers/cup/glass/bottle/cognac,
 /obj/structure/table/wood/fancy/blue,
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "iS" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "iV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/vault/alien,
-/area/shipbreak)
+/area/template_noop)
 "jf" = (
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "jX" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "kp" = (
 /mob/living/basic/flesh_spider,
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "kO" = (
 /obj/effect/decal/remains/human{
 	pixel_x = 11;
 	pixel_y = -5
 	},
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "kY" = (
 /obj/structure/table,
 /obj/item/food/ready_donk/warm,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "la" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "lc" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "mm" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "mL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/bronze,
-/area/shipbreak)
+/area/template_noop)
 "mX" = (
 /obj/structure/alien/egg/burst,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "ni" = (
 /obj/effect/spawner/random/decoration/showcase,
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "nF" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/vault/alien,
-/area/shipbreak)
+/area/template_noop)
 "oh" = (
 /obj/item/trash/ready_donk{
 	pixel_x = -4;
 	pixel_y = -7
 	},
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "op" = (
 /obj/structure/table/bronze,
 /obj/item/storage/toolbox/brass/surgery,
 /turf/open/floor/bronze,
-/area/shipbreak)
+/area/template_noop)
 "oy" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/effect/spawner/random/entertainment/coin,
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "oF" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "pe" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "po" = (
 /obj/structure/flippedtable,
 /obj/effect/spawner/random/trash/bacteria,
 /obj/machinery/light/small/dim/directional/east,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "pq" = (
 /obj/machinery/power/shuttle_engine/propulsion,
-/turf/open/space/basic,
-/area/shipbreak)
+/turf/template_noop,
+/area/template_noop)
 "px" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "pZ" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "qo" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "qN" = (
 /obj/machinery/chem_dispenser/abductor,
 /turf/open/floor/glass/plasma,
-/area/shipbreak)
+/area/template_noop)
 "rl" = (
 /obj/structure/table/bronze,
 /turf/open/floor/bronze,
-/area/shipbreak)
+/area/template_noop)
 "rq" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "rE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "rF" = (
 /obj/structure/alien/egg/burst,
 /obj/machinery/light/small/dim/directional/north,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "rY" = (
 /obj/effect/decal/remains/human{
 	pixel_x = -6;
 	pixel_y = 10
 	},
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "sd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "su" = (
 /obj/effect/spawner/random/food_or_drink/donkpockets{
 	pixel_x = -5;
@@ -260,60 +257,60 @@
 	pixel_y = -10
 	},
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "sV" = (
 /obj/structure/window/fulltile/colony_fabricator,
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "tw" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/spawner/random/bureaucracy/paper,
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "vO" = (
 /obj/structure/sign/poster/contraband/donk_co/directional/west,
 /obj/effect/spawner/costume/sexyclown,
 /obj/structure/rack,
 /obj/effect/spawner/random/entertainment/musical_instrument,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "wc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "wh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "ww" = (
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "wA" = (
 /obj/structure/table/optable,
 /turf/open/floor/bronze,
-/area/shipbreak)
+/area/template_noop)
 "wC" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "wX" = (
 /obj/machinery/door/airlock/plasma,
 /turf/open/floor/glass/plasma,
-/area/shipbreak)
+/area/template_noop)
 "xd" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/effect/spawner/random/entertainment/cigar,
 /obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "xk" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "xr" = (
 /obj/item/paperplane{
 	pixel_x = 19;
@@ -321,33 +318,33 @@
 	dir = 1
 	},
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "xB" = (
 /turf/open/floor/vault/alien,
-/area/shipbreak)
+/area/template_noop)
 "xD" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "xY" = (
 /turf/closed/wall/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "yA" = (
 /obj/structure/broken_flooring,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "yI" = (
 /obj/structure/fluff/paper/stack{
 	pixel_x = 0;
 	pixel_y = 0
 	},
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "zj" = (
 /obj/machinery/plumbing/synthesizer/colony_hydroponics,
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "zq" = (
 /obj/item/chair/plastic{
 	pixel_x = -98;
@@ -358,88 +355,88 @@
 	pixel_y = 4
 	},
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "zB" = (
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "Ab" = (
 /obj/effect/decal/cleanable/leaper_sludge,
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "Aj" = (
 /obj/machinery/fat_sucker,
 /turf/open/floor/vault/alien,
-/area/shipbreak)
+/area/template_noop)
 "As" = (
 /obj/effect/decal/cleanable/ants/fire,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "Ay" = (
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "Bm" = (
 /obj/structure/window/fulltile/colony_fabricator,
-/turf/open/space/basic,
-/area/shipbreak)
+/turf/template_noop,
+/area/template_noop)
 "BI" = (
 /obj/machinery/sleeper/clockwork{
 	dir = 1
 	},
 /turf/open/floor/bronze,
-/area/shipbreak)
+/area/template_noop)
 "Ci" = (
 /obj/structure/chair/comfy/shuttle/tactical{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "Cn" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/bronze,
-/area/shipbreak)
+/area/template_noop)
 "CF" = (
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "CH" = (
 /obj/structure/alien_tank/filled/hugger,
 /turf/open/floor/mineral/abductor,
-/area/shipbreak)
+/area/template_noop)
 "Ds" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "DC" = (
 /obj/machinery/abductor/experiment,
 /turf/open/floor/vault/alien,
-/area/shipbreak)
+/area/template_noop)
 "DO" = (
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "Eu" = (
 /obj/machinery/light/floor/has_bulb/red,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "Ey" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/effect/spawner/random/trash/bacteria,
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "EA" = (
 /obj/effect/spawner/random/contraband/prison,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "EF" = (
 /obj/machinery/colony_recycler,
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "EI" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "ER" = (
 /turf/closed/wall/prefab_plastic,
-/area/shipbreak)
+/area/template_noop)
 "EX" = (
 /obj/structure/table,
 /obj/item/toy/foamfinger,
@@ -448,84 +445,84 @@
 	pixel_y = -18
 	},
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "Fl" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "FH" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "FQ" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "FS" = (
 /obj/effect/decal/cleanable/robot_debris/limb{
 	pixel_x = -20;
 	pixel_y = -8
 	},
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "Gh" = (
 /obj/structure/sign/warning/vacuum/directional/north,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "Gj" = (
 /obj/machinery/power/shuttle_engine/heater,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "Gl" = (
 /turf/closed/wall/clockwork,
-/area/shipbreak)
+/area/template_noop)
 "Gx" = (
 /obj/structure/bed/abductor,
 /obj/effect/spawner/random/bedsheet,
 /turf/open/floor/vault/alien,
-/area/shipbreak)
+/area/template_noop)
 "GD" = (
 /obj/machinery/holopad/secure,
 /obj/machinery/light/small/dim/directional/east,
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "GZ" = (
 /obj/structure/bed/abductor,
 /turf/open/floor/vault/alien,
-/area/shipbreak)
+/area/template_noop)
 "Hi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "Hj" = (
 /turf/closed/wall/metal_foam_base,
-/area/shipbreak)
+/area/template_noop)
 "Hn" = (
 /turf/closed/wall/rust,
-/area/shipbreak)
+/area/template_noop)
 "Hz" = (
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "IA" = (
 /obj/machinery/ore_silo/colony_lathe,
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "ID" = (
 /obj/effect/decal/cleanable/oil/streak,
 /turf/open/floor/bronze,
-/area/shipbreak)
+/area/template_noop)
 "IQ" = (
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Jj" = (
 /obj/machinery/computer/operating/clockwork,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/bronze,
-/area/shipbreak)
+/area/template_noop)
 "Js" = (
 /obj/structure/chair/plastic{
 	dir = 1;
@@ -538,15 +535,15 @@
 	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "Jw" = (
 /obj/machinery/power/shuttle_engine/propulsion/burst/cargo,
-/turf/open/space/basic,
-/area/shipbreak)
+/turf/template_noop,
+/area/template_noop)
 "JI" = (
 /obj/machinery/light/small/dim/directional/east,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "JL" = (
 /obj/item/storage/box/metalfoam,
 /obj/structure/rack,
@@ -555,123 +552,123 @@
 /obj/item/stack/sticky_tape,
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "KA" = (
 /obj/structure/bed/abductor,
 /obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/mineral/abductor,
-/area/shipbreak)
+/area/template_noop)
 "KZ" = (
 /obj/structure/bed/abductor,
 /obj/effect/spawner/random/bedsheet/any,
 /turf/open/floor/plating/abductor2,
-/area/shipbreak)
+/area/template_noop)
 "Lj" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/light/floor/has_bulb/warm,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "Ll" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "Lr" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "LA" = (
-/turf/open/space/basic,
-/area/space)
+/turf/template_noop,
+/area/template_noop)
 "LH" = (
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "LZ" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/bronze,
-/area/shipbreak)
+/area/template_noop)
 "Mh" = (
 /obj/machinery/power/shuttle_engine/large,
-/turf/open/space/basic,
-/area/shipbreak)
+/turf/template_noop,
+/area/template_noop)
 "Mt" = (
 /obj/machinery/power/shuttle_engine/huge,
-/turf/open/space/basic,
-/area/shipbreak)
+/turf/template_noop,
+/area/template_noop)
 "Mv" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
-/turf/open/space/basic,
-/area/shipbreak)
+/turf/open/floor/plating,
+/area/template_noop)
 "MR" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "Nk" = (
 /obj/item/flatpacked_machine/co2_cracker,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "No" = (
 /obj/item/paperwork/ancient,
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "Nx" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "NN" = (
 /obj/machinery/door/airlock/bronze/clock,
 /turf/closed/wall/clockwork,
-/area/shipbreak)
+/area/template_noop)
 "NY" = (
 /turf/open/floor/mineral/abductor,
-/area/shipbreak)
+/area/template_noop)
 "OT" = (
 /obj/structure/meateor_fluff/flesh_pod_open,
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "Pf" = (
 /obj/effect/decal/cleanable/crayon,
 /obj/machinery/light/directional/west,
 /turf/open/floor/bronze,
-/area/shipbreak)
+/area/template_noop)
 "Pv" = (
 /turf/closed/wall/vault/alien,
-/area/shipbreak)
+/area/template_noop)
 "PE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "PF" = (
 /obj/machinery/door/airlock/grunge,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "Ql" = (
 /obj/effect/spawner/random/medical/two_percent_xeno_egg_spawner,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "Qz" = (
 /obj/machinery/hypnochair,
 /turf/open/floor/glass/plasma,
-/area/shipbreak)
+/area/template_noop)
 "QC" = (
 /obj/structure/table/bronze,
 /obj/item/stack/sheet/bronze,
 /turf/open/floor/bronze,
-/area/shipbreak)
+/area/template_noop)
 "QT" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "Rw" = (
 /obj/machinery/portable_atmospherics/canister/water_vapor,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "RL" = (
 /obj/structure/alien_tank/broken,
 /turf/open/floor/mineral/abductor,
-/area/shipbreak)
+/area/template_noop)
 "Se" = (
 /obj/projectile/bullet/reusable/foam_dart{
 	pixel_x = -24;
@@ -687,23 +684,23 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "Sj" = (
 /obj/machinery/door/airlock/colony_prefab,
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "SA" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Tk" = (
 /obj/machinery/computer/old,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Tl" = (
 /obj/machinery/rnd/production/colony_lathe,
 /turf/open/floor/iron/colony/white,
-/area/shipbreak)
+/area/template_noop)
 "Tn" = (
 /obj/projectile/bullet/reusable/foam_dart{
 	pixel_x = 6;
@@ -712,47 +709,47 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "Tp" = (
 /obj/structure/alien_tank/broken,
 /turf/open/floor/plating/abductor2,
-/area/shipbreak)
+/area/template_noop)
 "TX" = (
 /turf/closed/wall/mineral/wood/nonmetal,
-/area/shipbreak)
+/area/template_noop)
 "Us" = (
 /obj/structure/artifact/smoke/flesh,
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "UA" = (
 /obj/effect/decal/cleanable/insectguts,
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "Vr" = (
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "VE" = (
 /turf/open/floor/plating/abductor2,
-/area/shipbreak)
+/area/template_noop)
 "VI" = (
 /obj/structure/meateor_fluff/flesh_pod,
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "VR" = (
 /obj/effect/decal/cleanable/shreds{
 	pixel_x = -1;
 	pixel_y = -5
 	},
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "Wr" = (
 /obj/structure/foamedmetal/iron,
-/turf/open/space/basic,
-/area/shipbreak)
+/turf/template_noop,
+/area/template_noop)
 "WO" = (
 /mob/living/basic/xenofauna/meatbeast,
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "XF" = (
 /obj/item/chair/plastic,
 /obj/item/chair/plastic{
@@ -764,18 +761,18 @@
 	pixel_y = 9
 	},
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "XH" = (
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "XU" = (
 /obj/effect/decal/remains/human{
 	pixel_x = 3;
 	pixel_y = 15
 	},
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "Yh" = (
 /obj/projectile/bullet/reusable/foam_dart{
 	pixel_x = 6;
@@ -783,23 +780,23 @@
 	},
 /obj/structure/sign/poster/official/foam_force_ad/directional/north,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "YL" = (
 /obj/projectile/bullet/reusable/foam_dart,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "YU" = (
 /turf/open/floor/carpet/executive,
-/area/shipbreak)
+/area/template_noop)
 "Zf" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "Zq" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/plating/foam,
-/area/shipbreak)
+/area/template_noop)
 "ZH" = (
 /obj/projectile/bullet/reusable/foam_dart{
 	pixel_x = -40;
@@ -807,17 +804,17 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 "ZU" = (
 /obj/machinery/abductor/console,
 /turf/open/floor/vault/alien,
-/area/shipbreak)
+/area/template_noop)
 "ZX" = (
 /obj/structure/chair/plastic{
 	dir = 4
 	},
 /turf/open/floor/carpet/donk,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 LA
@@ -867,8 +864,8 @@ Bm
 Bm
 ER
 Gj
-ds
-ds
+LA
+LA
 Mt
 LA
 LA
@@ -894,9 +891,9 @@ FS
 mm
 ER
 Gj
-ds
-ds
-ds
+LA
+LA
+LA
 LA
 LA
 "}
@@ -921,9 +918,9 @@ px
 Nk
 ER
 Gj
-ds
-ds
-ds
+LA
+LA
+LA
 LA
 LA
 "}
@@ -1312,7 +1309,7 @@ LA
 LA
 Hn
 Gj
-ds
+LA
 Mh
 Wr
 Wr
@@ -1339,8 +1336,8 @@ Hn
 Hn
 Hn
 Gj
-ds
-ds
+LA
+LA
 LA
 Wr
 Wr

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/mule.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/mule.dmm
@@ -1,47 +1,47 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ah" = (
 /turf/closed/wall/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "bY" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/engineering/canister,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "cg" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "dd" = (
 /obj/structure/shipping_container/donk_co,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "dt" = (
 /obj/effect/spawner/random/structure/crate_loot,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/warm/directional/south,
 /turf/open/floor/iron/dark/side,
-/area/shipbreak)
+/area/template_noop)
 "eg" = (
 /obj/effect/spawner/random/contraband,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "gc" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/warm/directional/south,
 /turf/open/floor/iron/dark/side,
-/area/shipbreak)
+/area/template_noop)
 "gq" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/very_dim/directional/north,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "gx" = (
 /obj/machinery/button/door/directional/west{
 	id = 2
@@ -51,18 +51,18 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "gC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "gD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "gY" = (
 /obj/structure/window/spawner/directional/south,
 /obj/structure/window/spawner/directional/west,
@@ -70,26 +70,26 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/bush/flowers_pp,
 /turf/open/floor/grass,
-/area/shipbreak)
+/area/template_noop)
 "hc" = (
 /obj/effect/spawner/random/structure/closet_empty/crate,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/shipbreak)
+/area/template_noop)
 "hq" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/artifact_spawner,
 /turf/open/floor/iron/dark/side,
-/area/shipbreak)
+/area/template_noop)
 "iI" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/artifact_spawner,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/shipbreak)
+/area/template_noop)
 "iO" = (
 /obj/structure/chair/sofa/right/brown{
 	dir = 4
@@ -97,7 +97,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/light/very_dim/directional/west,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "iZ" = (
 /obj/machinery/power/port_gen/pacman/super,
 /obj/structure/cable,
@@ -105,21 +105,22 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "jz" = (
 /obj/effect/spawner/random/structure/closet_empty/crate/with_loot,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/side,
-/area/shipbreak)
+/area/template_noop)
 "jJ" = (
 /obj/effect/turf_decal/bot,
+/mob/living/basic/mimic/crate,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "kf" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/critter,
 /turf/open/floor/iron/dark/side,
-/area/shipbreak)
+/area/template_noop)
 "kp" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -129,16 +130,16 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/shipbreak)
+/area/template_noop)
 "kT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/light/very_dim/directional/east,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "kW" = (
 /obj/effect/artifact_spawner,
 /turf/open/floor/catwalk_floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "lW" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/crate/critter,
@@ -149,7 +150,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 6
 	},
-/area/shipbreak)
+/area/template_noop)
 "mG" = (
 /obj/machinery/button/door/directional/east{
 	id = 4
@@ -158,78 +159,71 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "mU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "mW" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/engineering/canister,
 /obj/machinery/light/small/warm/directional/south,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "nm" = (
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "oP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "pj" = (
 /obj/structure/chair/sofa/middle/brown{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/shipbreak)
-"pI" = (
-/obj/effect/turf_decal/bot,
-/mob/living/basic/mimic/crate/crate,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/shipbreak)
+/area/template_noop)
 "qk" = (
 /obj/structure/cable,
 /obj/machinery/light/small/warm/directional/north,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "rj" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/critter,
 /obj/machinery/light/small/warm/directional/south,
 /turf/open/floor/iron/dark/side,
-/area/shipbreak)
+/area/template_noop)
 "rl" = (
 /obj/structure/closet/crate/critter,
 /mob/living/basic/pet/dog/breaddog,
 /turf/open/floor/catwalk_floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "sb" = (
 /obj/effect/spawner/random/engineering/canister,
 /turf/open/floor/catwalk_floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "sC" = (
 /obj/structure/chair/sofa/corner/brown{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "sW" = (
 /obj/machinery/power/shuttle_engine/huge,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "tn" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "tO" = (
 /obj/structure/falsewall/titanium,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "tQ" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -238,7 +232,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "ul" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/structure/closet_empty/crate/with_loot,
@@ -248,7 +242,7 @@
 /turf/open/floor/iron/dark/side{
 	dir = 6
 	},
-/area/shipbreak)
+/area/template_noop)
 "uA" = (
 /obj/machinery/button/door/directional/west{
 	id = 2
@@ -257,36 +251,36 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "vo" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /obj/structure/window/reinforced/plasma/spawner/directional/west,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "vA" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "vX" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /turf/open/floor/carpet/neon/simple/black/nodots,
-/area/shipbreak)
+/area/template_noop)
 "xw" = (
 /obj/machinery/computer/old,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "yh" = (
 /obj/structure/chair/plastic{
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "yR" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "zH" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/window/spawner/directional/north,
@@ -294,7 +288,7 @@
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/bush/flowers_br,
 /turf/open/floor/grass,
-/area/shipbreak)
+/area/template_noop)
 "zO" = (
 /obj/structure/bed/double{
 	dir = 4
@@ -304,13 +298,13 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Bq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Bz" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -320,18 +314,18 @@
 /turf/open/floor/iron/half{
 	dir = 1
 	},
-/area/shipbreak)
+/area/template_noop)
 "BK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/warm/directional/north,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "BN" = (
 /obj/structure/chair/sofa/left/brown,
 /obj/machinery/light/very_dim/directional/north,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "BW" = (
 /obj/effect/spawner/random/structure/crate_loot,
 /obj/effect/turf_decal/loading_area{
@@ -342,16 +336,16 @@
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
-/area/shipbreak)
+/area/template_noop)
 "CB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/light/very_dim/directional/east,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "CZ" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "DL" = (
 /obj/effect/turf_decal/delivery,
 /obj/item/toy/plush/slimeplushie,
@@ -359,25 +353,25 @@
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
-/area/shipbreak)
+/area/template_noop)
 "Fg" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "GZ" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/engineering/canister,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/shipbreak)
+/area/template_noop)
 "HS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "IR" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck/syndicate/holographic,
@@ -387,10 +381,10 @@
 	},
 /obj/effect/spawner/random/entertainment/wallet_lighter,
 /turf/open/floor/carpet/orange,
-/area/shipbreak)
+/area/template_noop)
 "JE" = (
 /turf/open/floor/catwalk_floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "Kb" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/window/spawner/directional/east,
@@ -398,26 +392,26 @@
 /obj/structure/flora/bush/style_4,
 /obj/structure/flora/grass/green/style_3,
 /turf/open/floor/grass,
-/area/shipbreak)
+/area/template_noop)
 "KG" = (
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "Lm" = (
 /obj/effect/spawner/random/contraband/landmine,
 /turf/open/floor/catwalk_floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "Lt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/glass,
-/area/shipbreak)
+/area/template_noop)
 "LQ" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /obj/structure/window/reinforced/plasma/spawner/directional/east,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "MM" = (
 /obj/machinery/button/door/directional/east{
 	id = 4
@@ -426,23 +420,23 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "Nx" = (
 /obj/structure/table/greyscale,
 /obj/item/storage/backpack/satchel/flat,
 /obj/effect/spawner/random/exotic/syndie,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "NF" = (
 /obj/machinery/power/smes/engineering,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "OQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/neon/simple/black/nodots,
-/area/shipbreak)
+/area/template_noop)
 "Pe" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/engineering/canister,
@@ -450,7 +444,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "QE" = (
 /obj/machinery/button/door/directional/south{
 	id = 5
@@ -460,17 +454,17 @@
 	},
 /obj/machinery/light/very_dim/directional/south,
 /turf/open/floor/carpet/neon/simple/black/nodots,
-/area/shipbreak)
+/area/template_noop)
 "QZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Rw" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Rz" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/vending/donksofttoyvendor,
@@ -478,52 +472,52 @@
 /turf/open/floor/iron/dark/side{
 	dir = 5
 	},
-/area/shipbreak)
+/area/template_noop)
 "RA" = (
 /obj/machinery/door/airlock/qm,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "RN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/light/very_dim/directional/west,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "RX" = (
 /obj/effect/spawner/random/contraband/prison,
 /obj/effect/spawner/random/contraband,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Sf" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/side,
-/area/shipbreak)
+/area/template_noop)
 "Sh" = (
 /obj/effect/spawner/random/contraband/plus,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Sn" = (
 /obj/effect/spawner/random/structure/crate_loot,
 /turf/open/floor/catwalk_floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "Su" = (
 /obj/machinery/atmospherics/components/tank/air,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "SO" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/side,
-/area/shipbreak)
+/area/template_noop)
 "Uo" = (
 /obj/structure/table/wood/poker,
 /obj/item/toy/cards/deck/syndicate/holographic,
 /turf/open/floor/carpet/orange,
-/area/shipbreak)
+/area/template_noop)
 "VT" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/structure/table/greyscale,
@@ -538,17 +532,17 @@
 	},
 /obj/item/reagent_containers/cup/glass/bottle/beer,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Wl" = (
 /turf/open/floor/glass,
-/area/shipbreak)
+/area/template_noop)
 "Wm" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/shipbreak)
+/area/template_noop)
 "Wq" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate/critter,
@@ -556,32 +550,32 @@
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/shipbreak)
+/area/template_noop)
 "Ww" = (
 /obj/machinery/vending/cigarette/syndicate,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "WM" = (
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Xa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "XH" = (
 /obj/structure/window/spawner/directional/west,
 /obj/structure/window/spawner/directional/east,
 /obj/structure/flora/grass/jungle,
 /obj/structure/flora/bush/leavy,
 /turf/open/floor/grass,
-/area/shipbreak)
+/area/template_noop)
 "Yo" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
-/area/shipbreak)
+/area/template_noop)
 "Zv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -590,7 +584,7 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light/very_dim/directional/south,
 /turf/open/floor/carpet/neon/simple/black/nodots,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 yR
@@ -791,7 +785,7 @@ yR
 ah
 tn
 ah
-pI
+Yo
 JE
 rj
 ah

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_altar.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_altar.dmm
@@ -2,13 +2,13 @@
 "c" = (
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/cult,
-/area/shipbreak)
+/area/template_noop)
 "d" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "g" = (
 /turf/closed/wall/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "j" = (
 /obj/machinery/door/airlock/shuttle{
 	welded = 1
@@ -20,14 +20,14 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "n" = (
 /obj/structure/chair/pew{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/cult,
-/area/shipbreak)
+/area/template_noop)
 "u" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/siding/wood,
@@ -39,30 +39,30 @@
 	},
 /obj/structure/altar_of_gods,
 /obj/item/toy/toy_dagger,
-/turf/open/space/basic,
-/area/shipbreak)
+/turf/open/floor/cult,
+/area/template_noop)
 "w" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "x" = (
 /obj/structure/fluff/drake_statue{
 	pixel_x = 0
 	},
 /turf/open/floor/cult,
-/area/shipbreak)
+/area/template_noop)
 "y" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/cult,
-/area/shipbreak)
+/area/template_noop)
 "B" = (
 /obj/structure/statue/bone/rib,
 /turf/open/floor/cult,
-/area/shipbreak)
+/area/template_noop)
 "C" = (
 /turf/open/floor/cult,
-/area/shipbreak)
+/area/template_noop)
 "D" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor/border_only{
@@ -70,16 +70,16 @@
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "I" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/cult,
-/area/shipbreak)
+/area/template_noop)
 "M" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "N" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/siding/wood,
@@ -90,42 +90,42 @@
 /obj/structure/altar_of_gods,
 /obj/item/flashlight/flare/candle,
 /obj/item/organ/internal/heart/freedom,
-/turf/open/space/basic,
-/area/shipbreak)
+/turf/open/floor/cult,
+/area/template_noop)
 "R" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
 /obj/machinery/power/shuttle_engine/heater,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "V" = (
 /obj/structure/chair/pew/left{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/cult,
-/area/shipbreak)
+/area/template_noop)
 "W" = (
 /obj/structure/statue/bone/rib{
 	dir = 8
 	},
 /turf/open/floor/cult,
-/area/shipbreak)
+/area/template_noop)
 "X" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Y" = (
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/cult,
-/area/shipbreak)
+/area/template_noop)
 "Z" = (
 /obj/item/storage/box/holy/follower,
 /turf/open/floor/cult,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 X

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_banana.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_banana.dmm
@@ -1,14 +1,14 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/closed/wall/mineral/bananium,
-/area/shipbreak)
+/area/template_noop)
 "k" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "q" = (
 /turf/open/floor/mineral/bananium/airless,
-/area/shipbreak)
+/area/template_noop)
 "u" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -16,15 +16,15 @@
 /obj/structure/grille,
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "x" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
 /turf/open/floor/mineral/bananium/airless,
-/area/shipbreak)
+/area/template_noop)
 "B" = (
 /obj/machinery/vending/autodrobe/all_access,
 /turf/open/floor/mineral/bananium/airless,
-/area/shipbreak)
+/area/template_noop)
 "M" = (
 /obj/machinery/door/airlock/bananium/glass,
 /obj/machinery/door/firedoor/border_only{
@@ -33,7 +33,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/mine/sound/bwoink,
 /turf/open/floor/mineral/bananium/airless,
-/area/shipbreak)
+/area/template_noop)
 "P" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -46,22 +46,22 @@
 	},
 /obj/machinery/power/shuttle_engine/heater,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "R" = (
 /obj/machinery/computer{
 	dir = 8
 	},
 /turf/open/floor/mineral/bananium/airless,
-/area/shipbreak)
+/area/template_noop)
 "T" = (
 /obj/item/bikehorn,
 /obj/structure/table/wood/fancy,
 /obj/item/food/burger/clown,
 /turf/open/floor/mineral/bananium/airless,
-/area/shipbreak)
+/area/template_noop)
 "Y" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 Y

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_bathroom.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_bathroom.dmm
@@ -1,28 +1,28 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "c" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "d" = (
 /obj/machinery/door/airlock/highsecurity,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "g" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
 /obj/machinery/power/shuttle_engine/heater,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "h" = (
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "j" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "s" = (
 /obj/structure/toilet{
 	dir = 8
@@ -33,12 +33,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/curtain,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "x" = (
 /obj/structure/bedsheetbin,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "y" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/urinal{
@@ -46,11 +46,11 @@
 	pixel_x = 32
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "A" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "E" = (
 /obj/structure/toilet{
 	dir = 8
@@ -62,11 +62,11 @@
 /obj/structure/curtain,
 /obj/item/food/urinalcake,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "G" = (
 /obj/structure/mirror,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "J" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -77,7 +77,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "K" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
@@ -85,30 +85,30 @@
 	pixel_x = -12
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "O" = (
 /obj/item/bikehorn/rubberducky,
 /obj/item/soap/deluxe,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "P" = (
 /obj/machinery/shower,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "W" = (
 /turf/closed/wall/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "X" = (
 /obj/machinery/shower,
 /obj/item/soap,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "Z" = (
 /obj/machinery/shower,
 /obj/item/soap/nanotrasen,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 a

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_chapel.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_chapel.dmm
@@ -2,113 +2,113 @@
 "a" = (
 /obj/item/food/headcheese,
 /turf/open/floor/holofloor/chapel,
-/area/shipbreak)
+/area/template_noop)
 "c" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "h" = (
 /turf/open/floor/carpet/purple,
-/area/shipbreak)
+/area/template_noop)
 "m" = (
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/carpet/purple,
-/area/shipbreak)
+/area/template_noop)
 "n" = (
 /obj/item/food/sustenance_bar/cheese,
 /turf/open/floor/carpet/purple,
-/area/shipbreak)
+/area/template_noop)
 "q" = (
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/holofloor/chapel,
-/area/shipbreak)
+/area/template_noop)
 "r" = (
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
 /turf/open/floor/carpet/purple,
-/area/shipbreak)
+/area/template_noop)
 "s" = (
 /obj/structure/chair/pew/left{
 	dir = 1
 	},
 /obj/item/food/baked_cheese_platter,
 /turf/open/floor/carpet/purple,
-/area/shipbreak)
+/area/template_noop)
 "t" = (
 /obj/structure/chair/pew/left{
 	dir = 1
 	},
 /obj/item/food/burger/cheese,
 /turf/open/floor/carpet/purple,
-/area/shipbreak)
+/area/template_noop)
 "A" = (
 /obj/item/food/cheese/cheese_curds,
 /turf/open/floor/holofloor/chapel{
 	dir = 1
 	},
-/area/shipbreak)
+/area/template_noop)
 "B" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "C" = (
 /turf/open/floor/holofloor/chapel{
 	dir = 1
 	},
-/area/shipbreak)
+/area/template_noop)
 "E" = (
 /obj/structure/chair/pew/left{
 	dir = 1
 	},
 /turf/open/floor/carpet/purple,
-/area/shipbreak)
+/area/template_noop)
 "G" = (
 /turf/open/floor/holofloor/chapel{
 	dir = 8
 	},
-/area/shipbreak)
+/area/template_noop)
 "I" = (
 /obj/item/food/herby_cheese,
 /turf/open/floor/holofloor/chapel,
-/area/shipbreak)
+/area/template_noop)
 "L" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "N" = (
 /turf/open/floor/holofloor/chapel{
 	dir = 4
 	},
-/area/shipbreak)
+/area/template_noop)
 "P" = (
 /obj/item/food/pizza/mothic_five_cheese,
 /turf/open/floor/holofloor/chapel,
-/area/shipbreak)
+/area/template_noop)
 "R" = (
 /obj/item/food/sandwich/cheese,
 /turf/open/floor/holofloor/chapel{
 	dir = 1
 	},
-/area/shipbreak)
+/area/template_noop)
 "S" = (
 /obj/structure/window/reinforced/shuttle,
 /obj/structure/grille,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "U" = (
 /obj/item/food/cake/cheese,
 /turf/open/floor/carpet/purple,
-/area/shipbreak)
+/area/template_noop)
 "W" = (
 /obj/structure/fluff/divine/convertaltar,
 /obj/item/food/bread/creamcheese,
 /turf/open/floor/holofloor/chapel{
 	dir = 4
 	},
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 B

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_diner.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_diner.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "b" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -9,8 +9,8 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/clothing/suit/apron/chef,
 /obj/item/kitchen/rollingpin,
-/turf/open/space/basic,
-/area/shipbreak)
+/turf/open/floor/wood/airless,
+/area/template_noop)
 "c" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -18,14 +18,14 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 "d" = (
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "f" = (
 /obj/structure/table/glass,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "g" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -35,24 +35,24 @@
 	},
 /obj/machinery/power/shuttle_engine/heater,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "i" = (
 /obj/structure/table/glass,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "j" = (
 /obj/machinery/jukebox,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "l" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 "m" = (
 /obj/machinery/door/airlock/glass_large{
 	doorOpen = 'sound/machines/defib_success.ogg'
@@ -63,19 +63,19 @@
 	},
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 "n" = (
 /obj/structure/chair/sofa/right/maroon,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "o" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "p" = (
 /obj/item/kirbyplants,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "q" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
@@ -83,35 +83,35 @@
 /obj/machinery/coffeemaker/impressa,
 /obj/item/reagent_containers/cup/coffeepot/bluespace,
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 "t" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/sofa/right/maroon{
 	dir = 1
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "u" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 "w" = (
 /obj/structure/chair/sofa/left/maroon,
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "y" = (
 /obj/machinery/oven,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 "z" = (
 /obj/machinery/griddle,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/reagent_containers/cooking_container/pan,
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 "A" = (
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -124,14 +124,14 @@
 /obj/item/reagent_containers/condiment/flour,
 /obj/item/reagent_containers/condiment/flour,
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 "B" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "C" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "E" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -141,45 +141,45 @@
 	},
 /obj/machinery/power/shuttle_engine/heater,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "H" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 "J" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/chair/sofa/left/maroon{
 	dir = 1
 	},
 /turf/open/floor/iron/kitchen/small,
-/area/shipbreak)
+/area/template_noop)
 "K" = (
 /obj/machinery/door/window,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 "L" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 "T" = (
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 "V" = (
 /obj/structure/window/reinforced/shuttle,
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 "W" = (
 /turf/closed/wall/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "X" = (
 /obj/machinery/deepfryer,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/item/food/deadmouse,
 /turf/open/floor/wood/airless,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 C

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_escape_pod.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_escape_pod.dmm
@@ -1,13 +1,13 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "g" = (
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "h" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Escape Pod Airlock"
@@ -19,17 +19,17 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "i" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue/airless,
-/area/shipbreak)
+/area/template_noop)
 "k" = (
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "l" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/item/radio/intercom{
@@ -39,22 +39,22 @@
 /obj/item/clothing/suit/space/fragile,
 /obj/effect/decal/cleanable/blood/innards,
 /turf/open/floor/mineral/titanium/blue/airless,
-/area/shipbreak)
+/area/template_noop)
 "m" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "q" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /obj/item/pickaxe/emergency,
 /turf/open/floor/mineral/titanium/blue/airless,
-/area/shipbreak)
+/area/template_noop)
 "s" = (
 /turf/closed/wall/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "A" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -64,11 +64,11 @@
 	},
 /obj/item/clothing/head/helmet/space/fragile,
 /turf/open/floor/mineral/titanium/blue/airless,
-/area/shipbreak)
+/area/template_noop)
 "D" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "F" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Escape Pod Airlock"
@@ -78,7 +78,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "L" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Escape Pod Airlock"
@@ -88,17 +88,17 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "M" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "P" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /obj/item/kinetic_crusher/spear,
 /turf/open/floor/mineral/titanium/blue/airless,
-/area/shipbreak)
+/area/template_noop)
 "Y" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -109,7 +109,7 @@
 /obj/item/tank/internals/emergency_oxygen/double/empty,
 /obj/effect/decal/cleanable/blood/innards,
 /turf/open/floor/mineral/titanium/blue/airless,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 a

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_repair.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/old_repair.dmm
@@ -2,25 +2,25 @@
 "a" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "c" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "d" = (
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "e" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "g" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "j" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "k" = (
 /obj/effect/turf_decal{
 	dir = 1
@@ -31,7 +31,7 @@
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "l" = (
 /obj/machinery/door/airlock/external/glass,
 /obj/machinery/door/firedoor/border_only{
@@ -42,18 +42,18 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "m" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "n" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "o" = (
 /obj/effect/turf_decal/stripes/full,
 /obj/machinery/door/firedoor/border_only{
@@ -67,13 +67,13 @@
 	id = "shipbreaker_repair"
 	},
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "p" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue/airless,
-/area/shipbreak)
+/area/template_noop)
 "r" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -81,7 +81,7 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "s" = (
 /obj/effect/turf_decal{
 	dir = 1
@@ -91,7 +91,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "u" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Escape Pod Airlock"
@@ -103,11 +103,11 @@
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "v" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "w" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -115,13 +115,13 @@
 	id = "shipbreaker_repair"
 	},
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "x" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "z" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/color/fyellow{
@@ -132,7 +132,7 @@
 /obj/item/storage/belt/utility,
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "C" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -141,19 +141,19 @@
 	pixel_y = 27
 	},
 /turf/open/floor/mineral/titanium/blue/airless,
-/area/shipbreak)
+/area/template_noop)
 "D" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "E" = (
 /obj/effect/turf_decal,
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "F" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical{
@@ -163,7 +163,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "H" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -173,31 +173,31 @@
 	},
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "I" = (
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "L" = (
 /turf/closed/wall/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "M" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "N" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "O" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Q" = (
 /obj/effect/turf_decal{
 	dir = 1
@@ -208,13 +208,13 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "R" = (
 /obj/effect/turf_decal,
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "S" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -224,13 +224,13 @@
 	},
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "U" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "X" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -240,7 +240,7 @@
 	},
 /obj/item/storage/box/metalfoam,
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 "Y" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -254,7 +254,7 @@
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/titanium/airless,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 e

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/robotics.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/robotics.dmm
@@ -6,35 +6,35 @@
 	id = "mothership_right"
 	},
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "bG" = (
 /turf/closed/wall/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "cE" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "mothership_right"
 	},
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "cH" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "dk" = (
 /obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "dB" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced/spawner/directional/north{
 	layer = 2.9
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "ev" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "fi" = (
 /obj/machinery/light/cold/no_nightlight/directional/west,
 /obj/machinery/button/door/directional/west{
@@ -42,17 +42,17 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "fA" = (
 /obj/item/stack/sheet/mineral/titanium,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "ht" = (
 /obj/structure/lattice,
 /obj/item/stack/sheet/mineral/titanium,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "hQ" = (
 /obj/structure/spacevine,
 /obj/machinery/conveyor{
@@ -61,20 +61,20 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "hZ" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "ib" = (
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "jp" = (
 /obj/structure/sign/warning/vacuum/external/directional/west,
 /obj/structure/closet/emcloset/anchored,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "jH" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced/spawner/directional/north{
@@ -82,25 +82,25 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "ka" = (
 /obj/structure/lattice,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "mj" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "mC" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "nJ" = (
 /obj/item/radio/intercom/directional/south,
 /obj/structure/ai_core,
 /turf/open/floor/circuit/green/airless,
-/area/shipbreak)
+/area/template_noop)
 "pL" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/conveyor{
@@ -109,64 +109,64 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "qg" = (
 /obj/item/organ/internal/brain,
 /obj/structure/cable,
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "qN" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
 	id = "mothership_main"
 	},
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "rI" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "we" = (
 /obj/machinery/power/smes,
 /obj/structure/cable,
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "wg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "wB" = (
-/obj/machinery/computer/camera_advanced/shuttle_docker/cyborg_mothership{
+/obj/machinery/computer/old{
 	dir = 1
 	},
 /turf/open/floor/circuit/green/airless,
-/area/shipbreak)
+/area/template_noop)
 "xg" = (
 /obj/machinery/mineral/stacking_machine{
 	input_dir = 2
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/shipbreak)
+/area/template_noop)
 "xX" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "mothership_left"
 	},
 /obj/structure/cable,
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "ys" = (
 /obj/machinery/light/cold/no_nightlight/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "yL" = (
 /obj/machinery/conveyor/inverted{
 	dir = 6;
 	id = "mothership_main"
 	},
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "zp" = (
 /obj/machinery/space_heater{
 	anchored = 1
@@ -177,7 +177,7 @@
 /obj/effect/mapping_helpers/airalarm/all_access,
 /obj/item/wrench,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "AL" = (
 /obj/machinery/mecha_part_fabricator/maint{
 	name = "forgotten exosuit fabricator";
@@ -188,13 +188,7 @@
 	id = "mothership_left"
 	},
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
-"AY" = (
-/obj/machinery/computer/shuttle/cyborg_mothership{
-	dir = 1
-	},
-/turf/open/floor/circuit/green/airless,
-/area/shipbreak)
+/area/template_noop)
 "BI" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced/spawner/directional/north{
@@ -202,7 +196,7 @@
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Cj" = (
 /obj/machinery/door/airlock/hatch,
 /obj/structure/cable,
@@ -210,7 +204,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "DF" = (
 /obj/item/stack/rods,
 /obj/machinery/light/broken/directional/east,
@@ -218,25 +212,25 @@
 	id = "mothership_right"
 	},
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "Ea" = (
 /obj/machinery/recharge_station,
 /obj/structure/sign/warning/vacuum/external/directional/east,
 /obj/machinery/camera/directional/east,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "FK" = (
 /obj/machinery/conveyor{
 	id = "Recycler"
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "FL" = (
 /obj/structure/lattice,
 /obj/structure/marker_beacon/cerulean,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Ga" = (
 /obj/structure/spacevine,
 /obj/machinery/conveyor{
@@ -245,21 +239,21 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "Hr" = (
 /obj/item/mmi,
 /turf/open/floor/circuit/green/airless,
-/area/shipbreak)
+/area/template_noop)
 "HO" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/power/tracker,
 /obj/structure/cable,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Ja" = (
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "Jk" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/conveyor_switch{
@@ -267,30 +261,30 @@
 	name = "Recycler"
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Jn" = (
 /obj/item/circuitboard/aicore,
 /obj/structure/cable,
 /turf/open/floor/circuit/green/airless,
-/area/shipbreak)
+/area/template_noop)
 "Js" = (
 /obj/machinery/holopad/secure,
 /obj/structure/cable,
 /turf/open/floor/circuit/green/airless,
-/area/shipbreak)
+/area/template_noop)
 "JW" = (
 /obj/structure/cable,
 /obj/machinery/power/terminal{
 	dir = 4
 	},
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "LS" = (
 /obj/item/stack/sheet/rglass{
 	amount = 2
 	},
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "Mf" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -300,20 +294,20 @@
 	},
 /obj/effect/turf_decal/stripes/asteroid/line,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "NY" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 4
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/shipbreak)
+/area/template_noop)
 "OR" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera/directional/north,
 /obj/machinery/ore_silo,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Pc" = (
 /obj/machinery/conveyor/inverted{
 	dir = 6;
@@ -321,14 +315,14 @@
 	},
 /obj/structure/cable,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Qd" = (
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "mothership_main"
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Qm" = (
 /obj/machinery/conveyor{
 	id = "mothership_main";
@@ -336,23 +330,23 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "RU" = (
 /obj/item/disk/holodisk/ruin/cyborg_mothership,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "Th" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "UU" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/conveyor_switch/oneway{
 	id = "mothership_main"
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "Vf" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -360,7 +354,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "VU" = (
 /obj/structure/table,
 /obj/item/toy/talking/ai{
@@ -370,7 +364,7 @@
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/circuit/green/airless,
-/area/shipbreak)
+/area/template_noop)
 "VW" = (
 /obj/machinery/camera/directional/south,
 /obj/structure/cable,
@@ -381,7 +375,7 @@
 	},
 /obj/effect/mapping_helpers/apc/unlocked,
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "Wf" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -389,14 +383,14 @@
 	},
 /obj/structure/cable,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "WC" = (
 /obj/structure/cable,
 /obj/structure/table_frame,
 /obj/item/aicard,
 /obj/item/ai_module/core/full/overlord,
 /turf/open/floor/circuit/green/airless,
-/area/shipbreak)
+/area/template_noop)
 "WH" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -407,7 +401,7 @@
 	eat_dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "XU" = (
 /obj/structure/spacevine,
 /obj/machinery/conveyor{
@@ -415,16 +409,16 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "Ya" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Yj" = (
 /obj/machinery/light/cold/no_nightlight/directional/west,
 /turf/open/floor/circuit/airless,
-/area/shipbreak)
+/area/template_noop)
 "ZL" = (
 /obj/machinery/conveyor{
 	id = "mothership_main";
@@ -432,7 +426,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 rI
@@ -568,7 +562,7 @@ Ya
 cH
 RU
 Hr
-AY
+wB
 VU
 ib
 ib

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/squid.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/squid.dmm
@@ -5,7 +5,7 @@
 /area/template_noop)
 "bR" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "bZ" = (
 /obj/structure/bed,
@@ -331,9 +331,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/template_noop)
-"ur" = (
-/turf/open/space/basic,
-/area/template_noop)
 "uC" = (
 /turf/closed/wall/mineral/titanium,
 /area/template_noop)
@@ -396,14 +393,14 @@
 /obj/machinery/power/shuttle_engine/propulsion/burst{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "yi" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional,
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "zj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -552,7 +549,7 @@
 	dir = 1
 	},
 /obj/effect/spawner/structure/window/hollow/reinforced/directional,
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "Ll" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer2{
@@ -594,7 +591,7 @@
 /obj/machinery/power/shuttle_engine/large{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "Ol" = (
 /obj/structure/reagent_dispensers/foamtank,
@@ -660,7 +657,7 @@
 /obj/machinery/atmospherics/components/unary/passive_vent/layer4{
 	dir = 8
 	},
-/turf/open/space/basic,
+/turf/template_noop,
 /area/template_noop)
 "TR" = (
 /obj/machinery/door/airlock/highsecurity,
@@ -1057,7 +1054,7 @@ nZ
 nZ
 nZ
 nZ
-ur
+nZ
 NJ
 Lj
 Px
@@ -1084,8 +1081,8 @@ nZ
 nZ
 nZ
 nZ
-ur
-ur
+nZ
+nZ
 Lj
 Px
 cF
@@ -1138,7 +1135,7 @@ nZ
 nZ
 nZ
 nZ
-ur
+nZ
 NJ
 Lj
 Px
@@ -1165,8 +1162,8 @@ nZ
 nZ
 nZ
 nZ
-ur
-ur
+nZ
+nZ
 Lj
 Px
 mL

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/squid.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/squid.dmm
@@ -1,145 +1,1458 @@
-"aO" = (/obj/machinery/camera/directional/west,/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"bR" = (/obj/structure/lattice,/turf/open/space/basic,/area/shipbreak)
-"bZ" = (/obj/structure/bed,/obj/structure/curtain,/obj/item/bedsheet/dorms,/obj/structure/sign/poster/contraband/lusty_xenomorph/directional/east,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"cB" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/obj/machinery/smartfridge,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"cF" = (/obj/structure/cable,/obj/structure/table/reinforced/rglass,/obj/item/modular_computer/laptop/preset,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"cI" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"dd" = (/obj/structure/cable,/obj/machinery/holopad/secure,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"dq" = (/obj/structure/window/reinforced/tinted/spawner/directional/east,/obj/effect/spawner/random/vending/snackvend,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"dC" = (/obj/machinery/light/cold/directional/west,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"dF" = (/obj/structure/bed,/obj/item/bedsheet/dorms,/obj/structure/curtain,/obj/structure/sign/poster/contraband/interdyne_gene_clinics/directional/south{pixel_x = -1; pixel_y = -24},/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"dU" = (/obj/structure/table/reinforced/rglass,/obj/item/paper/fluff/awaymissions/moonoutpost19/research/xeno_hivemind{pixel_x = -4; pixel_y = 5},/obj/item/pen/fountain{pixel_x = 8; pixel_y = 4},/obj/item/organ/internal/alien/hivenode{pixel_x = 4; pixel_y = -4},/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"eV" = (/obj/machinery/chem_heater{dir = 1; pixel_x = 0; pixel_y = -4},/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"gh" = (/obj/structure/bed,/obj/item/bedsheet/blue,/obj/structure/curtain,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"gw" = (/obj/structure/tank_dispenser/oxygen,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"hy" = (/obj/machinery/door/airlock/external/glass,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"hM" = (/obj/structure/statue/plasma/xeno,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"hQ" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/obj/machinery/smoke_machine,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"hV" = (/turf/closed/wall/mineral/titanium/interior,/area/shipbreak)
-"ih" = (/obj/structure/cable,/obj/machinery/camera/directional/west,/obj/machinery/light/cold/directional/east,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"is" = (/obj/structure/cable,/obj/machinery/light/cold/directional/east,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"jk" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"jn" = (/obj/structure/cable,/obj/machinery/photocopier/gratis,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"km" = (/obj/structure/cable,/obj/structure/sink/directional/west,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"kK" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"kS" = (/obj/structure/cable,/obj/machinery/camera/directional/east,/obj/machinery/light/cold/directional/west,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"lc" = (/obj/structure/cable,/obj/structure/sign/warning/vacuum/directional/east,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"lD" = (/obj/machinery/door/airlock/titanium/glass,/obj/machinery/door/poddoor/shuttledock{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"lG" = (/obj/structure/cable,/obj/structure/sign/warning/vacuum/directional/west,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"lT" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"mG" = (/obj/structure/chair/office{dir = 8},/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"mJ" = (/obj/structure/cable,/obj/structure/sign/departments/evac/directional/west,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"mK" = (/obj/machinery/door/airlock/highsecurity,/obj/machinery/door/poddoor/shuttledock,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"mL" = (/obj/structure/cable,/obj/structure/table/reinforced/rglass,/obj/effect/spawner/random/vendor_meal_sides/nt,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"nJ" = (/obj/machinery/door/poddoor/shuttledock,/obj/machinery/door/airlock/highsecurity,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"nY" = (/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"nZ" = (/turf/template_noop,/area/shipbreak)
-"oa" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"pi" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/closed/wall/mineral/titanium,/area/shipbreak)
-"py" = (/obj/structure/reagent_dispensers/watertank/high,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"pz" = (/obj/machinery/light/cold/directional/east,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"pL" = (/obj/machinery/camera/directional/east,/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"pN" = (/obj/structure/sign/calendar/directional/west{pixel_x = -29; pixel_y = 1},/obj/structure/cable,/obj/machinery/light/cold/directional/west,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"qc" = (/obj/structure/table/reinforced/rglass,/obj/structure/closet/mini_fridge{name = "mini-fridge"; pixel_x = 9; pixel_y = 9},/obj/item/reagent_containers/condiment/soymilk{pixel_x = -2; pixel_y = 2},/obj/item/reagent_containers/condiment/milk{pixel_x = 8; pixel_y = 2},/obj/item/reagent_containers/condiment/flour{pixel_x = -5; pixel_y = 11},/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"qw" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{dir = 8},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"qE" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/obj/machinery/computer/old{dir = 8},/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"rp" = (/obj/structure/table/reinforced/rglass,/obj/item/organ/internal/body_egg/alien_embryo{pixel_x = 70; pixel_y = 36},/obj/effect/spawner/random/medical/injector,/obj/effect/spawner/random/medical/injector{pixel_x = -1; pixel_y = 7},/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"rJ" = (/obj/machinery/computer/operating{dir = 4},/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"se" = (/obj/structure/reagent_dispensers/fueltank/large,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"sf" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{dir = 4},/obj/structure/cable,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"sg" = (/obj/machinery/suit_storage_unit,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"tl" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{dir = 1},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"ur" = (/turf/open/space/basic,/area/shipbreak)
-"uC" = (/turf/closed/wall/mineral/titanium,/area/shipbreak)
-"uO" = (/obj/structure/cable,/obj/structure/sign/warning/biohazard/directional/east,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"vN" = (/obj/structure/sign/directions/dorms/directional/south{pixel_x = -1; pixel_y = -21},/obj/machinery/light/cold/directional/east,/obj/machinery/oven/range,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"wY" = (/obj/structure/bed,/obj/structure/curtain,/obj/item/bedsheet/dorms,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"xl" = (/obj/structure/table/reinforced/rglass,/obj/item/reagent_containers/cooking_container/pan{pixel_x = -6; pixel_y = -2},/obj/item/kitchen/rollingpin{pixel_x = -3; pixel_y = 9},/obj/item/knife/kitchen{pixel_x = 8; pixel_y = 0},/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"xo" = (/obj/structure/rack,/obj/item/stack/scrap/plasma,/obj/item/stack/sheet/mineral/plasma,/obj/item/stack/sheet/mineral/plasma,/obj/machinery/light/cold/directional/east,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"xJ" = (/obj/structure/sign/directions/medical/directional/south{pixel_x = 4; pixel_y = -21},/obj/machinery/light/cold/directional/west,/obj/machinery/smartfridge,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"xN" = (/obj/machinery/power/shuttle_engine/propulsion/burst{dir = 1},/turf/open/space/basic,/area/shipbreak)
-"yi" = (/obj/effect/spawner/structure/window/hollow/reinforced/directional,/obj/machinery/power/shuttle_engine/heater{dir = 1},/turf/open/space/basic,/area/shipbreak)
-"zj" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{dir = 8},/obj/structure/cable,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"AJ" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/obj/machinery/computer/old{dir = 4},/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Bb" = (/obj/structure/cable,/obj/structure/table/reinforced/rglass,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Bc" = (/obj/structure/cable,/obj/machinery/computer/old{dir = 1},/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"BZ" = (/obj/machinery/sleeper{dir = 4},/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"CV" = (/obj/structure/cable,/obj/structure/sign/departments/evac/directional/east,/obj/structure/sink/directional/west,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"DU" = (/obj/machinery/shower{pixel_x = 0; pixel_y = 17},/obj/structure/drain,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Ep" = (/obj/structure/cable,/obj/machinery/suit_storage_unit,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"ED" = (/obj/structure/cable,/obj/machinery/light/cold/directional/east,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Fa" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{dir = 4},/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"Fj" = (/obj/structure/table/reinforced/rglass,/obj/effect/spawner/random/medical/surgery_tool_advanced,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"GC" = (/obj/structure/cable,/obj/machinery/power/smes/super/full,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"GY" = (/obj/structure/cable,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Hf" = (/obj/structure/cable,/obj/structure/chair/comfy/shuttle,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Hl" = (/obj/structure/cable,/obj/structure/table/reinforced/rglass,/obj/item/paper/fluff/awaymissions/moonoutpost19/research/larva_autopsy{pixel_x = -39; pixel_y = 6},/obj/item/paper/fluff/awaymissions/moonoutpost19/research/facehugger,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"HD" = (/obj/structure/table/reinforced/rglass,/obj/item/paper/fluff/awaymissions/moonoutpost19/research/xeno_queen{pixel_x = 0; pixel_y = 0},/obj/effect/spawner/random/vendor_meal_sides/yangyu,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"IK" = (/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"IV" = (/obj/structure/cable,/obj/structure/table/reinforced/rglass,/obj/item/plate,/obj/item/plate{pixel_y = 2; pixel_x = 0},/obj/item/plate{pixel_y = 4},/obj/item/plate{pixel_y = 6},/obj/item/plate{pixel_y = 8},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Kh" = (/obj/structure/table/reinforced/rglass,/obj/effect/spawner/random/exotic/technology,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Lj" = (/obj/machinery/power/shuttle_engine/heater{dir = 1},/obj/effect/spawner/structure/window/hollow/reinforced/directional,/turf/open/space/basic,/area/shipbreak)
-"Ll" = (/obj/machinery/atmospherics/components/unary/portables_connector/layer2{dir = 4},/obj/machinery/portable_atmospherics/canister/air,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"LP" = (/obj/machinery/light/cold/directional/east,/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"MR" = (/obj/structure/cable,/obj/machinery/light/cold/directional/west,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"MX" = (/obj/machinery/atmospherics/components/unary/portables_connector/layer2{dir = 8},/obj/machinery/portable_atmospherics/canister/air,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Np" = (/obj/machinery/door/airlock/external/glass,/obj/structure/cable,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Ny" = (/obj/structure/rack,/obj/item/storage/belt,/obj/item/stack/sheet/mineral/plasma,/obj/item/shard/plasma,/obj/machinery/light/cold/directional/west,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"NJ" = (/obj/machinery/power/shuttle_engine/large{dir = 1},/turf/open/space/basic,/area/shipbreak)
-"Ol" = (/obj/structure/reagent_dispensers/foamtank,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Ou" = (/obj/structure/cable,/obj/structure/sign/warning/biohazard/directional/west,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"ON" = (/obj/structure/cable,/obj/machinery/vending/wallmed/directional/east{pixel_x = 23; pixel_y = 2},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"OX" = (/obj/machinery/door/airlock/titanium/glass,/obj/machinery/door/poddoor/shuttledock{dir = 4},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Px" = (/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Pz" = (/obj/structure/chair/office{dir = 1},/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"PK" = (/obj/machinery/smartfridge,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"PY" = (/obj/machinery/power/port_gen/pacman/pre_loaded,/obj/structure/cable,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"QS" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"RY" = (/obj/machinery/light/cold/directional/west,/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"SV" = (/obj/structure/lattice,/obj/machinery/atmospherics/components/unary/passive_vent/layer4{dir = 8},/turf/open/space/basic,/area/shipbreak)
-"TR" = (/obj/machinery/door/airlock/highsecurity,/obj/machinery/door/poddoor/shuttledock,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"Ua" = (/obj/structure/cable,/obj/structure/table/reinforced/rglass,/obj/effect/spawner/random/exotic/tool,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Uf" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"UH" = (/obj/structure/cable,/obj/structure/table/reinforced/rglass,/obj/item/reagent_containers/cup/beaker{pixel_x = -7; pixel_y = -2},/obj/item/reagent_containers/cup/beaker/large/aiuri{pixel_x = 7; pixel_y = 7},/obj/item/reagent_containers/syringe/morphine,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Vi" = (/obj/structure/reagent_dispensers/fueltank/large,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"VS" = (/obj/structure/window/reinforced/tinted/spawner/directional/west,/obj/effect/spawner/random/vending/colavend,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"WH" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{dir = 1},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"Xq" = (/obj/machinery/door/airlock/titanium/glass,/obj/machinery/door/poddoor/shuttledock{dir = 1},/obj/structure/cable,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Xy" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{dir = 8},/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"XJ" = (/obj/structure/cable,/obj/machinery/light/cold/directional/north,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"XK" = (/obj/structure/chair/office,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Yp" = (/obj/structure/bed/medical,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Yr" = (/obj/structure/table/optable,/obj/machinery/iv_drip,/obj/machinery/light/cold/directional/west,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"YZ" = (/obj/structure/cable,/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6/directional/west{pixel_x = -27; pixel_y = 4},/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"Za" = (/obj/machinery/holopad/secure,/turf/open/floor/mineral/titanium/tiled/white,/area/shipbreak)
-"ZF" = (/obj/structure/bed,/obj/item/bedsheet/cosmos,/obj/structure/curtain,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"ZJ" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
-"ZV" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,/obj/structure/cable,/turf/open/floor/iron/showroomfloor,/area/shipbreak)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aO" = (
+/obj/machinery/camera/directional/west,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"bR" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/template_noop)
+"bZ" = (
+/obj/structure/bed,
+/obj/structure/curtain,
+/obj/item/bedsheet/dorms,
+/obj/structure/sign/poster/contraband/lusty_xenomorph/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"cB" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/smartfridge,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"cF" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced/rglass,
+/obj/item/modular_computer/laptop/preset,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"cI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"dd" = (
+/obj/structure/cable,
+/obj/machinery/holopad/secure,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"dq" = (
+/obj/structure/window/reinforced/tinted/spawner/directional/east,
+/obj/effect/spawner/random/vending/snackvend,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"dC" = (
+/obj/machinery/light/cold/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"dF" = (
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/obj/structure/curtain,
+/obj/structure/sign/poster/contraband/interdyne_gene_clinics/directional/south{
+	pixel_x = -1;
+	pixel_y = -24
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"dU" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/paper/fluff/awaymissions/moonoutpost19/research/xeno_hivemind{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/pen/fountain{
+	pixel_x = 8;
+	pixel_y = 4
+	},
+/obj/item/organ/internal/alien/hivenode{
+	pixel_x = 4;
+	pixel_y = -4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"eV" = (
+/obj/machinery/chem_heater{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"gh" = (
+/obj/structure/bed,
+/obj/item/bedsheet/blue,
+/obj/structure/curtain,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"gw" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"hy" = (
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"hM" = (
+/obj/structure/statue/plasma/xeno,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"hQ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/smoke_machine,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"hV" = (
+/turf/closed/wall/mineral/titanium/interior,
+/area/template_noop)
+"ih" = (
+/obj/structure/cable,
+/obj/machinery/camera/directional/west,
+/obj/machinery/light/cold/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"is" = (
+/obj/structure/cable,
+/obj/machinery/light/cold/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"jk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"jn" = (
+/obj/structure/cable,
+/obj/machinery/photocopier/gratis,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"km" = (
+/obj/structure/cable,
+/obj/structure/sink/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"kK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"kS" = (
+/obj/structure/cable,
+/obj/machinery/camera/directional/east,
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"lc" = (
+/obj/structure/cable,
+/obj/structure/sign/warning/vacuum/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"lD" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/machinery/door/poddoor/shuttledock{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"lG" = (
+/obj/structure/cable,
+/obj/structure/sign/warning/vacuum/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"lT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"mG" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"mJ" = (
+/obj/structure/cable,
+/obj/structure/sign/departments/evac/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"mK" = (
+/obj/machinery/door/airlock/highsecurity,
+/obj/machinery/door/poddoor/shuttledock,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"mL" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced/rglass,
+/obj/effect/spawner/random/vendor_meal_sides/nt,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"nJ" = (
+/obj/machinery/door/poddoor/shuttledock,
+/obj/machinery/door/airlock/highsecurity,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"nY" = (
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"nZ" = (
+/turf/template_noop,
+/area/template_noop)
+"oa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"pi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"py" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"pz" = (
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"pL" = (
+/obj/machinery/camera/directional/east,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"pN" = (
+/obj/structure/sign/calendar/directional/west{
+	pixel_x = -29;
+	pixel_y = 1
+	},
+/obj/structure/cable,
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"qc" = (
+/obj/structure/table/reinforced/rglass,
+/obj/structure/closet/mini_fridge{
+	name = "mini-fridge";
+	pixel_x = 9;
+	pixel_y = 9
+	},
+/obj/item/reagent_containers/condiment/soymilk{
+	pixel_x = -2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/condiment/milk{
+	pixel_x = 8;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/condiment/flour{
+	pixel_x = -5;
+	pixel_y = 11
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"qw" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"qE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/computer/old{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"rp" = (
+/obj/structure/table/reinforced/rglass,
+/obj/effect/spawner/random/medical/injector,
+/obj/effect/spawner/random/medical/injector{
+	pixel_x = -1;
+	pixel_y = 7
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"rJ" = (
+/obj/machinery/computer/operating{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"se" = (
+/obj/structure/reagent_dispensers/fueltank/large,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"sf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"sg" = (
+/obj/machinery/suit_storage_unit,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"tl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"ur" = (
+/turf/open/space/basic,
+/area/template_noop)
+"uC" = (
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"uO" = (
+/obj/structure/cable,
+/obj/structure/sign/warning/biohazard/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"vN" = (
+/obj/structure/sign/directions/dorms/directional/south{
+	pixel_x = -1;
+	pixel_y = -21
+	},
+/obj/machinery/light/cold/directional/east,
+/obj/machinery/oven/range,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"wY" = (
+/obj/structure/bed,
+/obj/structure/curtain,
+/obj/item/bedsheet/dorms,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"xl" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/reagent_containers/cooking_container/pan{
+	pixel_x = -6;
+	pixel_y = -2
+	},
+/obj/item/kitchen/rollingpin{
+	pixel_x = -3;
+	pixel_y = 9
+	},
+/obj/item/knife/kitchen{
+	pixel_x = 8;
+	pixel_y = 0
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"xo" = (
+/obj/structure/rack,
+/obj/item/stack/scrap/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"xJ" = (
+/obj/structure/sign/directions/medical/directional/south{
+	pixel_x = 4;
+	pixel_y = -21
+	},
+/obj/machinery/light/cold/directional/west,
+/obj/machinery/smartfridge,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"xN" = (
+/obj/machinery/power/shuttle_engine/propulsion/burst{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/template_noop)
+"yi" = (
+/obj/effect/spawner/structure/window/hollow/reinforced/directional,
+/obj/machinery/power/shuttle_engine/heater{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/template_noop)
+"zj" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"AJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/computer/old{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Bb" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced/rglass,
+/obj/item/organ/internal/body_egg/alien_embryo{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Bc" = (
+/obj/structure/cable,
+/obj/machinery/computer/old{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"BZ" = (
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"CV" = (
+/obj/structure/cable,
+/obj/structure/sign/departments/evac/directional/east,
+/obj/structure/sink/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"DU" = (
+/obj/machinery/shower{
+	pixel_x = 0;
+	pixel_y = 17
+	},
+/obj/structure/drain,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Ep" = (
+/obj/structure/cable,
+/obj/machinery/suit_storage_unit,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"ED" = (
+/obj/structure/cable,
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Fa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"Fj" = (
+/obj/structure/table/reinforced/rglass,
+/obj/effect/spawner/random/medical/surgery_tool_advanced,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"GC" = (
+/obj/structure/cable,
+/obj/machinery/power/smes/super/full,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"GY" = (
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Hf" = (
+/obj/structure/cable,
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Hl" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced/rglass,
+/obj/item/paper/fluff/awaymissions/moonoutpost19/research/larva_autopsy{
+	pixel_x = -39;
+	pixel_y = 6
+	},
+/obj/item/paper/fluff/awaymissions/moonoutpost19/research/facehugger,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"HD" = (
+/obj/structure/table/reinforced/rglass,
+/obj/item/paper/fluff/awaymissions/moonoutpost19/research/xeno_queen{
+	pixel_x = 0;
+	pixel_y = 0
+	},
+/obj/effect/spawner/random/vendor_meal_sides/yangyu,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"IK" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"IV" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced/rglass,
+/obj/item/plate,
+/obj/item/plate{
+	pixel_y = 2;
+	pixel_x = 0
+	},
+/obj/item/plate{
+	pixel_y = 4
+	},
+/obj/item/plate{
+	pixel_y = 6
+	},
+/obj/item/plate{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Kh" = (
+/obj/structure/table/reinforced/rglass,
+/obj/effect/spawner/random/exotic/technology,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Lj" = (
+/obj/machinery/power/shuttle_engine/heater{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/hollow/reinforced/directional,
+/turf/open/space/basic,
+/area/template_noop)
+"Ll" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"LP" = (
+/obj/machinery/light/cold/directional/east,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"MR" = (
+/obj/structure/cable,
+/obj/machinery/light/cold/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"MX" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/layer2{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Np" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Ny" = (
+/obj/structure/rack,
+/obj/item/storage/belt,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/shard/plasma,
+/obj/machinery/light/cold/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"NJ" = (
+/obj/machinery/power/shuttle_engine/large{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/template_noop)
+"Ol" = (
+/obj/structure/reagent_dispensers/foamtank,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Ou" = (
+/obj/structure/cable,
+/obj/structure/sign/warning/biohazard/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"ON" = (
+/obj/structure/cable,
+/obj/machinery/vending/wallmed/directional/east{
+	pixel_x = 23;
+	pixel_y = 2
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"OX" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/machinery/door/poddoor/shuttledock{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Px" = (
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Pz" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"PK" = (
+/obj/machinery/smartfridge,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"PY" = (
+/obj/machinery/power/port_gen/pacman/pre_loaded,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"QS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"RY" = (
+/obj/machinery/light/cold/directional/west,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"SV" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/components/unary/passive_vent/layer4{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/template_noop)
+"TR" = (
+/obj/machinery/door/airlock/highsecurity,
+/obj/machinery/door/poddoor/shuttledock,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"Ua" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced/rglass,
+/obj/effect/spawner/random/exotic/tool,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Uf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"UH" = (
+/obj/structure/cable,
+/obj/structure/table/reinforced/rglass,
+/obj/item/reagent_containers/cup/beaker{
+	pixel_x = -7;
+	pixel_y = -2
+	},
+/obj/item/reagent_containers/cup/beaker/large/aiuri{
+	pixel_x = 7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/syringe/morphine,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Vi" = (
+/obj/structure/reagent_dispensers/fueltank/large,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"VS" = (
+/obj/structure/window/reinforced/tinted/spawner/directional/west,
+/obj/effect/spawner/random/vending/colavend,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"WH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"Xq" = (
+/obj/machinery/door/airlock/titanium/glass,
+/obj/machinery/door/poddoor/shuttledock{
+	dir = 1
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Xy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"XJ" = (
+/obj/structure/cable,
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"XK" = (
+/obj/structure/chair/office,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Yp" = (
+/obj/structure/bed/medical,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Yr" = (
+/obj/structure/table/optable,
+/obj/machinery/iv_drip,
+/obj/machinery/light/cold/directional/west,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"YZ" = (
+/obj/structure/cable,
+/obj/structure/sign/poster/contraband/busty_backdoor_xeno_babes_6/directional/west{
+	pixel_x = -27;
+	pixel_y = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"Za" = (
+/obj/machinery/holopad/secure,
+/turf/open/floor/mineral/titanium/tiled/white,
+/area/template_noop)
+"ZF" = (
+/obj/structure/bed,
+/obj/item/bedsheet/cosmos,
+/obj/structure/curtain,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"ZJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
+"ZV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/showroomfloor,
+/area/template_noop)
 
 (1,1,1) = {"
-nZnZnZnZnZxNnZnZnZnZnZnZnZnZnZnZnZnZnZxNnZnZnZnZnZ
-nZnZnZnZuCLjuCuCnZnZnZnZnZnZnZnZnZuCuCyiuCnZnZnZnZ
-nZnZnZnZuCPxPYuCnZnZnZnZnZnZnZnZnZuCPYPxuCnZnZnZnZ
-nZnZnZnZuCPxGCuCnZnZnZnZnZnZnZnZnZuCGCPxuCnZnZnZnZ
-nZnZnZnZuCPxGYuCuCnZnZnZnZnZnZnZuCuCGYPxuCnZnZnZnZ
-nZnZnZnZuCNyQSsepiSVururnZururbRuCViZVxouCnZnZnZnZ
-nZnZnZnZuCLlUfOlhVuCNJurxNNJuruChVOlUfMXuCnZnZnZnZ
-nZnZnZnZuCLlIKpyhVdqLjLjLjLjLjVShVpyIKMXuCnZnZnZnZ
-nZnZnZnZuCuCIKIKhVdCPxPxXKPxPxpzhVIKIKuCuCnZnZnZnZ
-nZnZnZnZuCuCuClDhVPxUacFBbHlmLPxhVXquCuCuCnZnZnZnZ
-nZnZnZuCuCgwuCIKPxPxrpmGddPzdUPxPxIKuCgwuCuCnZnZnZ
-nZnZuCuCsgEDhVmJcIPxHDPxjnPxKhmGcICVhVMRsguCuCnZnZ
-nZuCuCsglTIKOXIKIKZJPzPxGYPxPxZJIKIKOXIKqwsguCuCnZ
-uCuCGYsfjkuChVPKIKUHIKcBhMhQIKIVIKqchVuCjkzjGYuCuC
-uChVNphVuCuCuCxJIKeVPxPxIKPxPxxlIKvNuCuCuChVNphVuC
-hyXJlcuCuCnZuCuCXqhVOuAJHfqEuOhVXquCuCnZuCuClGXJhy
-uCEpuCuCnZuCuCDUishVmKhVBchVnJhVpNghuCuCnZuCuCEpuC
-uCuCuCnZuCuCYpIKkmuCihhVuChVkSuCYZIKwYuCuCnZuCuCuC
-nZnZnZuCuCYpIKONuCuCTRuCnZuCmKuCuCIKIKwYuCuCnZnZnZ
-nZnZuCuCBZjktluCuCZaoauCnZuCoaZauCuCtljkZFuCuCnZnZ
-nZnZuCrJsfjkuCuCaOkKWHuCnZuCWHkKpLuCuCjkzjbZuCnZnZ
-nZnZuCYrGYuCuCuCRYkKuCuCnZuCuCkKLPuCuCuCGYpzuCnZnZ
-nZnZuCFjuCuCnZuCFakKuCnZnZnZuCkKXyuCnZuCuCdFuCnZnZ
-nZnZuCuCuCnZnZuCnYuCuCnZnZnZuCuCnYuCnZnZuCuCuCnZnZ
-nZnZnZnZnZnZnZuCuCuCnZnZnZnZnZuCuCuCnZnZnZnZnZnZnZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+uC
+uC
+hy
+uC
+uC
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+"}
+(2,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+uC
+uC
+hV
+XJ
+Ep
+uC
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+"}
+(3,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+uC
+uC
+GY
+Np
+lc
+uC
+uC
+nZ
+uC
+uC
+uC
+uC
+uC
+nZ
+"}
+(4,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+uC
+uC
+sg
+sf
+hV
+uC
+uC
+nZ
+uC
+uC
+rJ
+Yr
+Fj
+uC
+nZ
+"}
+(5,1,1) = {"
+nZ
+uC
+uC
+uC
+uC
+uC
+uC
+uC
+uC
+uC
+uC
+sg
+lT
+jk
+uC
+uC
+nZ
+uC
+uC
+BZ
+sf
+GY
+uC
+uC
+nZ
+"}
+(6,1,1) = {"
+xN
+Lj
+Px
+Px
+Px
+Ny
+Ll
+Ll
+uC
+uC
+gw
+ED
+IK
+uC
+uC
+nZ
+uC
+uC
+Yp
+jk
+jk
+uC
+uC
+nZ
+nZ
+"}
+(7,1,1) = {"
+nZ
+uC
+PY
+GC
+GY
+QS
+Uf
+IK
+IK
+uC
+uC
+hV
+OX
+hV
+uC
+uC
+uC
+Yp
+IK
+tl
+uC
+uC
+nZ
+nZ
+nZ
+"}
+(8,1,1) = {"
+nZ
+uC
+uC
+uC
+uC
+se
+Ol
+py
+IK
+lD
+IK
+mJ
+IK
+PK
+xJ
+uC
+DU
+IK
+ON
+uC
+uC
+uC
+uC
+uC
+uC
+"}
+(9,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+uC
+pi
+hV
+hV
+hV
+hV
+Px
+cI
+IK
+IK
+IK
+Xq
+is
+km
+uC
+uC
+aO
+RY
+Fa
+nY
+uC
+"}
+(10,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+SV
+uC
+dq
+dC
+Px
+Px
+Px
+ZJ
+UH
+eV
+hV
+hV
+uC
+uC
+Za
+kK
+kK
+kK
+uC
+uC
+"}
+(11,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+ur
+NJ
+Lj
+Px
+Ua
+rp
+HD
+Pz
+IK
+Px
+Ou
+mK
+ih
+TR
+oa
+WH
+uC
+uC
+uC
+nZ
+"}
+(12,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+ur
+ur
+Lj
+Px
+cF
+mG
+Px
+Px
+cB
+Px
+AJ
+hV
+hV
+uC
+uC
+uC
+uC
+nZ
+nZ
+nZ
+"}
+(13,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+xN
+Lj
+XK
+Bb
+dd
+jn
+GY
+hM
+IK
+Hf
+Bc
+uC
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+"}
+(14,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+ur
+NJ
+Lj
+Px
+Hl
+Pz
+Px
+Px
+hQ
+Px
+qE
+hV
+hV
+uC
+uC
+uC
+uC
+nZ
+nZ
+nZ
+"}
+(15,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+ur
+ur
+Lj
+Px
+mL
+dU
+Kh
+Px
+IK
+Px
+uO
+nJ
+kS
+mK
+oa
+WH
+uC
+uC
+uC
+nZ
+"}
+(16,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+bR
+uC
+VS
+pz
+Px
+Px
+mG
+ZJ
+IV
+xl
+hV
+hV
+uC
+uC
+Za
+kK
+kK
+kK
+uC
+uC
+"}
+(17,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+uC
+uC
+hV
+hV
+hV
+hV
+Px
+cI
+IK
+IK
+IK
+Xq
+pN
+YZ
+uC
+uC
+pL
+LP
+Xy
+nY
+uC
+"}
+(18,1,1) = {"
+nZ
+uC
+uC
+uC
+uC
+Vi
+Ol
+py
+IK
+Xq
+IK
+CV
+IK
+qc
+vN
+uC
+gh
+IK
+IK
+uC
+uC
+uC
+uC
+uC
+uC
+"}
+(19,1,1) = {"
+nZ
+uC
+PY
+GC
+GY
+ZV
+Uf
+IK
+IK
+uC
+uC
+hV
+OX
+hV
+uC
+uC
+uC
+wY
+IK
+tl
+uC
+uC
+nZ
+nZ
+nZ
+"}
+(20,1,1) = {"
+xN
+yi
+Px
+Px
+Px
+xo
+MX
+MX
+uC
+uC
+gw
+MR
+IK
+uC
+uC
+nZ
+uC
+uC
+wY
+jk
+jk
+uC
+uC
+nZ
+nZ
+"}
+(21,1,1) = {"
+nZ
+uC
+uC
+uC
+uC
+uC
+uC
+uC
+uC
+uC
+uC
+sg
+qw
+jk
+uC
+uC
+nZ
+uC
+uC
+ZF
+zj
+GY
+uC
+uC
+nZ
+"}
+(22,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+uC
+uC
+sg
+zj
+hV
+uC
+uC
+nZ
+uC
+uC
+bZ
+pz
+dF
+uC
+nZ
+"}
+(23,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+uC
+uC
+GY
+Np
+lG
+uC
+uC
+nZ
+uC
+uC
+uC
+uC
+uC
+nZ
+"}
+(24,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+uC
+uC
+hV
+XJ
+Ep
+uC
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+"}
+(25,1,1) = {"
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+uC
+uC
+hy
+uC
+uC
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
+nZ
 "}

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/torus.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/torus.dmm
@@ -4,37 +4,37 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "an" = (
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "aA" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "bj" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "bl" = (
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "bq" = (
 /obj/machinery/door/airlock/diamond,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/mineral/titanium/tiled/blue,
-/area/shipbreak)
+/area/template_noop)
 "bV" = (
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "cl" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
@@ -43,11 +43,11 @@
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "cO" = (
 /obj/machinery/door/airlock/uranium/safe,
 /turf/open/floor/mineral/uranium,
-/area/shipbreak)
+/area/template_noop)
 "da" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/miasma_output{
 	dir = 1
@@ -55,25 +55,25 @@
 /turf/open/floor/engine/halon{
 	initial_gas_mix = "halon=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "dc" = (
 /obj/machinery/door/airlock/security,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "dn" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "du" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/power/floodlight,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "ee" = (
 /obj/machinery/air_sensor/miasma_tank,
 /obj/machinery/light/floor/has_bulb,
@@ -83,11 +83,11 @@
 /turf/open/floor/engine/halon{
 	initial_gas_mix = "halon=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "eC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "eK" = (
 /obj/machinery/air_sensor/halon_tank,
 /obj/machinery/light/floor/has_bulb,
@@ -97,69 +97,69 @@
 /turf/open/floor/engine/healium{
 	initial_gas_mix = "healium=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "eU" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "fc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "fU" = (
 /obj/machinery/computer/atmos_control/miasma_tank{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "gt" = (
 /obj/effect/spawner/structure/window/reinforced/damaged,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "hb" = (
 /obj/effect/turf_decal/trimline/yellow/corner,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "iB" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "iC" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium/tiled/yellow,
-/area/shipbreak)
+/area/template_noop)
 "iH" = (
 /obj/machinery/power/shuttle_engine/large{
 	dir = 1
 	},
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "iZ" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium/tiled/blue,
-/area/shipbreak)
+/area/template_noop)
 "jb" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "jq" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "jP" = (
 /obj/structure/table/reinforced/titaniumglass,
 /obj/item/storage/belt/utility{
@@ -169,58 +169,58 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "jS" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "ls" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "lv" = (
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "lX" = (
 /obj/effect/turf_decal/trimline/neutral/corner{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "md" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "mo" = (
 /obj/structure/window/reinforced,
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "mG" = (
 /obj/machinery/door/airlock/security,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "mQ" = (
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "mU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "ne" = (
 /obj/machinery/air_sensor/tritium_tank,
 /obj/machinery/light/floor/has_bulb,
@@ -230,21 +230,21 @@
 /turf/open/floor/engine/tritium{
 	initial_gas_mix = "tritium=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "nm" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "nR" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 9
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "oK" = (
 /obj/machinery/air_sensor/zauker_tank,
 /obj/machinery/light/floor/has_bulb,
@@ -254,18 +254,18 @@
 /turf/open/floor/engine/zauker{
 	initial_gas_mix = "zauker=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "pi" = (
 /obj/effect/turf_decal/vg_decals/numbers/eight,
 /turf/open/floor/engine/healium{
 	initial_gas_mix = "healium=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "pJ" = (
 /turf/open/floor/engine/halon{
 	initial_gas_mix = "halon=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "qv" = (
 /obj/effect/turf_decal/trimline/green/corner{
 	dir = 1
@@ -273,11 +273,11 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "qC" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "qI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 7
@@ -285,16 +285,16 @@
 /obj/structure/cable,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "qR" = (
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "qX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "rl" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 1
@@ -304,25 +304,25 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "rs" = (
 /obj/structure/closet/firecloset/full,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "rt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/zauker_output,
 /turf/open/floor/engine/zauker{
 	initial_gas_mix = "zauker=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "rw" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "sK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/halon_output{
 	dir = 1
@@ -330,13 +330,13 @@
 /turf/open/floor/engine/healium{
 	initial_gas_mix = "healium=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "tp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "tz" = (
 /obj/item/grenade/chem_grenade/metalfoam{
 	pixel_x = 3;
@@ -355,7 +355,7 @@
 /obj/item/clothing/suit/utility/fire/atmos,
 /obj/item/holosign_creator/atmos,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "tS" = (
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 8
@@ -363,59 +363,59 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "uq" = (
 /obj/structure/window/reinforced,
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "uU" = (
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 5
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "uW" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "wj" = (
 /obj/effect/turf_decal/vg_decals/numbers/three,
 /turf/open/floor/engine/tritium{
 	initial_gas_mix = "tritium=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "wR" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "wV" = (
 /obj/effect/turf_decal/trimline/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium/tiled/yellow,
-/area/shipbreak)
+/area/template_noop)
 "wZ" = (
 /obj/machinery/portable_atmospherics/scrubber/huge/movable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "xt" = (
 /obj/structure/window/reinforced,
 /obj/structure/reagent_dispensers/foamtank,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "xN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/tritium_output,
 /turf/open/floor/engine/tritium{
 	initial_gas_mix = "tritium=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "xY" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
@@ -423,49 +423,49 @@
 /obj/structure/cable,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "yt" = (
 /turf/open/floor/mineral/titanium/tiled,
-/area/shipbreak)
+/area/template_noop)
 "yz" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 6
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "yL" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "yO" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "yZ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 4
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "zq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "zw" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "zM" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/uranium,
-/area/shipbreak)
+/area/template_noop)
 "AW" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 1
@@ -474,18 +474,18 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "AX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Ba" = (
 /turf/open/floor/engine/zauker{
 	initial_gas_mix = "zauker=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "Bj" = (
 /obj/effect/turf_decal/trimline/yellow,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -493,22 +493,22 @@
 	mob_name = "failed atmosian"
 	},
 /turf/open/floor/mineral/titanium/tiled/yellow,
-/area/shipbreak)
+/area/template_noop)
 "Bp" = (
 /obj/effect/turf_decal/trimline/red/filled/warning,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "By" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "BJ" = (
 /turf/open/floor/engine/healium{
 	initial_gas_mix = "healium=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "BN" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -537,27 +537,27 @@
 	pixel_y = -4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "BT" = (
 /obj/structure/fireaxecabinet,
 /obj/item/flashlight/spotlight,
 /obj/effect/holy,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shipbreak)
+/area/template_noop)
 "Cg" = (
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Cs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Df" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -570,45 +570,45 @@
 	},
 /obj/item/food/donkpocket/warm/spicy,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Dy" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "DV" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium/tiled/yellow,
-/area/shipbreak)
+/area/template_noop)
 "Ei" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium/tiled,
-/area/shipbreak)
+/area/template_noop)
 "Eq" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "ER" = (
 /turf/open/floor/engine/tritium{
 	initial_gas_mix = "tritium=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "EX" = (
 /obj/effect/turf_decal/trimline/red/filled/warning,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Fj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Fv" = (
 /obj/machinery/power/shuttle_engine/large,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "FG" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -616,24 +616,24 @@
 /obj/structure/cable,
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "FW" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/catwalk_floor/iron_dark/airless,
-/area/shipbreak)
+/area/template_noop)
 "GE" = (
 /obj/machinery/door/airlock/uranium/safe,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/mineral/uranium,
-/area/shipbreak)
+/area/template_noop)
 "Iv" = (
 /turf/open/floor/mineral/titanium/tiled/blue,
-/area/shipbreak)
+/area/template_noop)
 "JU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green,
 /obj/effect/spawner/structure/window/reinforced/damaged,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "JV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/warning{
 	dir = 1
@@ -643,28 +643,28 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "JY" = (
 /turf/open/floor/mineral/uranium,
-/area/shipbreak)
+/area/template_noop)
 "Kv" = (
 /obj/machinery/door/airlock/freezer,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/mineral/titanium/tiled,
-/area/shipbreak)
+/area/template_noop)
 "KM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Lz" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "LP" = (
 /obj/machinery/computer/atmos_control/tritium_tank,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "MM" = (
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 1
@@ -674,13 +674,13 @@
 	},
 /obj/item/wrench,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "MX" = (
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Na" = (
 /obj/machinery/computer/atmos_control/halon_tank{
 	dir = 1
@@ -688,7 +688,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "NF" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
@@ -696,21 +696,21 @@
 /obj/structure/cable,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "NH" = (
 /obj/structure/cable,
 /obj/structure/chair/comfy/shuttle/tactical{
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Ob" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "Pd" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -718,15 +718,15 @@
 /obj/structure/cable,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "PM" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Qk" = (
 /obj/machinery/door/airlock/diamond,
 /turf/open/floor/mineral/titanium/tiled/blue,
-/area/shipbreak)
+/area/template_noop)
 "QE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -735,12 +735,12 @@
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "QJ" = (
 /obj/effect/decal/cleanable/blood/splatter/over_window,
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "QV" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -749,58 +749,58 @@
 /obj/structure/sign/poster/contraband/donk_co/directional/north,
 /obj/machinery/computer/old,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "QY" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "RE" = (
 /obj/effect/turf_decal/trimline/blue/corner,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "RK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "RT" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "RV" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 8
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Sr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers,
 /obj/effect/spawner/structure/window/reinforced/damaged,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "SA" = (
 /turf/open/floor/mineral/titanium/tiled/yellow,
-/area/shipbreak)
+/area/template_noop)
 "Tm" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "TC" = (
 /turf/open/floor/mineral/plastitanium/red,
-/area/shipbreak)
+/area/template_noop)
 "UR" = (
 /obj/machinery/door/airlock/freezer,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/mineral/titanium/tiled,
-/area/shipbreak)
+/area/template_noop)
 "VU" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hazardvest,
@@ -810,7 +810,7 @@
 /obj/item/clothing/mask/gas/atmos,
 /obj/item/clothing/mask/gas/atmos,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Wd" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/suit_storage_unit/standard_unit{
@@ -818,7 +818,7 @@
 	pixel_y = 0
 	},
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Wx" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
@@ -826,15 +826,15 @@
 /obj/structure/cable,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Xj" = (
 /obj/effect/turf_decal/trimline/yellow,
 /turf/open/floor/mineral/titanium/tiled/yellow,
-/area/shipbreak)
+/area/template_noop)
 "Xq" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Xy" = (
 /obj/machinery/power/smes/full{
 	pixel_y = 5
@@ -842,7 +842,7 @@
 /obj/structure/cable,
 /obj/structure/window/reinforced,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "XY" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 8
@@ -850,35 +850,35 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "Yg" = (
 /obj/effect/turf_decal/vg_decals/numbers/zero,
 /turf/open/floor/engine/zauker{
 	initial_gas_mix = "zauker=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 "Yq" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "ZB" = (
 /obj/machinery/computer/atmos_control/zauker_tank,
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "ZF" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 10
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/plastitanium,
-/area/shipbreak)
+/area/template_noop)
 "ZG" = (
 /obj/effect/turf_decal/vg_decals/numbers/five,
 /turf/open/floor/engine/halon{
 	initial_gas_mix = "halon=500;TEMP=298.15"
 	},
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 iB

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/true_church.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/true_church.dmm
@@ -2,7 +2,7 @@
 "a" = (
 /obj/structure/meateor_fluff/abandoned_headcrab_egg,
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "b" = (
 /obj/structure/spirit_board{
 	pixel_y = -1
@@ -12,32 +12,32 @@
 	pixel_x = 2
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "c" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/reagent_containers/cup/glass/bottle/ritual_wine{
 	pixel_y = 7
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "d" = (
 /obj/structure/meateor_fluff/eyeball,
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "f" = (
 /obj/item/trash/candle,
 /turf/open/floor/carpet/royalblue,
-/area/shipbreak)
+/area/template_noop)
 "g" = (
 /obj/structure/chair/pew/left{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "h" = (
 /obj/structure/meateor_fluff/flesh_pod,
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "i" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/effect/turf_decal/siding/dark/corner{
@@ -48,29 +48,29 @@
 	pixel_y = 4
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "j" = (
 /obj/item/flashlight/flare/candle/infinite,
 /turf/open/floor/carpet/royalblue,
-/area/shipbreak)
+/area/template_noop)
 "k" = (
 /obj/structure/meateor_fluff/eyeball,
 /turf/open/floor/carpet/royalblue,
-/area/shipbreak)
+/area/template_noop)
 "l" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/shipbreak)
+/area/template_noop)
 "m" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/shipbreak)
+/area/template_noop)
 "n" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/storage/organbox/preloaded{
@@ -79,32 +79,32 @@
 	pixel_y = 6
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "o" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/flare/candle,
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "p" = (
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "q" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel"
 	},
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "r" = (
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "s" = (
 /obj/structure/altar_of_gods,
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "t" = (
 /obj/machinery/power/shuttle_engine/propulsion,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "u" = (
 /turf/template_noop,
 /area/template_noop)
@@ -138,18 +138,18 @@
 	on = 1
 	},
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "w" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/shipbreak)
+/area/template_noop)
 "x" = (
 /obj/machinery/computer/old,
 /turf/open/floor/carpet/royalblack,
-/area/shipbreak)
+/area/template_noop)
 "y" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -158,13 +158,13 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "z" = (
 /obj/machinery/door/airlock/public{
 	name = "Chapel"
 	},
 /turf/open/floor/carpet/royalblue,
-/area/shipbreak)
+/area/template_noop)
 "A" = (
 /obj/structure/statue/sandstone/venus{
 	anchored = 1;
@@ -181,25 +181,25 @@
 	pixel_x = -10
 	},
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "B" = (
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "C" = (
 /obj/machinery/power/shuttle_engine/heater,
 /obj/structure/window/reinforced/clockwork{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "D" = (
 /turf/closed/wall/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "E" = (
 /obj/structure/table/wood,
 /obj/item/trash/candle,
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "F" = (
 /obj/item/flashlight/flare/candle{
 	pixel_y = 7;
@@ -233,32 +233,32 @@
 	dir = 4
 	},
 /turf/open/floor/wood/large,
-/area/shipbreak)
+/area/template_noop)
 "G" = (
 /obj/structure/window/reinforced/clockwork/fulltile,
 /obj/structure/window_sill,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "H" = (
 /obj/item/flashlight/flare/candle/infinite,
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "I" = (
 /obj/structure/chair/pew{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "J" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "K" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/shipbreak)
+/area/template_noop)
 "L" = (
 /obj/machinery/power/shuttle_engine/heater{
 	pixel_y = 13
@@ -267,10 +267,10 @@
 	pixel_y = -19
 	},
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "M" = (
 /turf/closed/wall,
-/area/shipbreak)
+/area/template_noop)
 "N" = (
 /obj/item/flashlight/flare/candle{
 	pixel_y = -5;
@@ -299,10 +299,10 @@
 	pixel_x = -6
 	},
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "O" = (
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "P" = (
 /obj/item/flashlight/flare/candle{
 	pixel_y = 5;
@@ -334,32 +334,32 @@
 	dir = 1
 	},
 /turf/open/floor/wood/large,
-/area/shipbreak)
+/area/template_noop)
 "Q" = (
 /obj/structure/meateor_fluff/eyeball,
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "R" = (
 /obj/structure/chair/pew/right{
 	dir = 1
 	},
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "S" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/item/reagent_containers/cup/glass/bottle/holywater{
 	pixel_y = 5
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "T" = (
 /obj/structure/sign/painting/meat,
 /turf/closed/wall,
-/area/shipbreak)
+/area/template_noop)
 "U" = (
 /obj/structure/meateor_fluff/flesh_pod_open,
 /turf/open/floor/stone,
-/area/shipbreak)
+/area/template_noop)
 "V" = (
 /obj/structure/table/wood/fancy/royalblack,
 /obj/effect/turf_decal/siding/dark/corner{
@@ -369,24 +369,24 @@
 	pixel_y = 14
 	},
 /turf/open/floor/carpet/red,
-/area/shipbreak)
+/area/template_noop)
 "W" = (
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "X" = (
 /turf/open/floor/carpet/royalblue,
-/area/shipbreak)
+/area/template_noop)
 "Y" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Z" = (
 /obj/machinery/door/airlock/external{
 	name = "Airlock";
 	space_dir = 2
 	},
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 u

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/wanglius.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/wanglius.dmm
@@ -4,87 +4,87 @@
 	dir = 10
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "af" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 5
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "ak" = (
 /obj/structure/cable,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Wanglius Engineering"
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "aK" = (
 /turf/closed/wall/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "aL" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "be" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "bz" = (
 /obj/structure/cable,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "dF" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "dL" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "et" = (
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "eQ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "fr" = (
 /obj/machinery/door/window/brigdoor/security/cell/left/directional/east{
 	name = "Wanglius Brig"
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "fv" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/west,
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
 /obj/structure/bed,
 /obj/item/bedsheet/captain,
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "fz" = (
 /obj/machinery/power/shuttle_engine/propulsion{
 	dir = 8
 	},
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "fL" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "fN" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/mineral/plasma/five,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "fX" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/rglass{
@@ -98,32 +98,32 @@
 	},
 /obj/item/stack/sheet/iron,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "gB" = (
 /obj/machinery/door/window/left/directional/north{
 	name = "Captain's Sleeping Capsule"
 	},
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "hv" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "hE" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "hF" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/deck,
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "id" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "ig" = (
 /obj/structure/table,
 /obj/machinery/recharger{
@@ -134,36 +134,36 @@
 	},
 /obj/item/coin/iron,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "iw" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "lc" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "lK" = (
 /obj/structure/table/optable,
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "mb" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "mA" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "nk" = (
 /obj/structure/chair{
 	dir = 4
@@ -173,10 +173,10 @@
 	},
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "nN" = (
 /turf/open/floor/carpet/orange,
-/area/shipbreak)
+/area/template_noop)
 "pb" = (
 /obj/effect/spawner/liquids_spawner{
 	reagent_list = list(/datum/reagent/ammonia/urine=600)
@@ -192,7 +192,7 @@
 	},
 /obj/item/reagent_containers/cup/glass/waterbottle/large/empty,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "qh" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular{
@@ -201,31 +201,31 @@
 	},
 /obj/item/storage/medkit/brute,
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "qn" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency{
 	pixel_y = 3
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "qT" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
 /obj/effect/spawner/random/structure/closet_private,
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "rI" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "sB" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "tl" = (
 /obj/item/clothing/suit/hazardvest{
 	desc = "A high-visibility lifejacket complete with whistle and slot for oxygen tanks.";
@@ -306,7 +306,7 @@
 	name = "lifejackets"
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "tt" = (
 /obj/structure/closet/crate{
 	name = "emergency supplies crate"
@@ -326,179 +326,179 @@
 /obj/item/radio,
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron,
-/area/shipbreak)
+/area/template_noop)
 "tH" = (
 /obj/machinery/computer/old,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "tN" = (
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "uR" = (
 /obj/machinery/door/window/left/directional/east{
 	name = "Sleeping Capsule"
 	},
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "uW" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "wn" = (
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "wL" = (
 /obj/machinery/power/smes/full,
 /obj/structure/cable,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "yp" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "yt" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "yx" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "yO" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "zo" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "zD" = (
 /obj/structure/table,
 /obj/machinery/microwave{
 	pixel_y = 6
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "zK" = (
 /obj/machinery/light/directional/west,
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "AK" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Wanglius Sick Bay"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "BF" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Wanglius Cargo Bay"
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "Ca" = (
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "Ct" = (
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "CW" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "Dj" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "Eh" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 6
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "Er" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "EN" = (
 /obj/item/coin/iron,
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "Fq" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "FA" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/dark,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "FG" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "FY" = (
 /obj/machinery/button/door/directional/east{
 	id = "wangliusboardingdoor";
 	name = "Boarding Door Control"
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "Gv" = (
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "Hl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "HG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "HR" = (
 /obj/effect/spawner/random/structure/crate,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "HZ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "Ia" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "Jt" = (
 /obj/machinery/stasis,
 /obj/machinery/light/directional/south,
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "JO" = (
 /obj/machinery/door/airlock/external{
 	name = "Wanglius Airlock"
@@ -507,46 +507,46 @@
 	cycle_id = "wangliusairlock"
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "JZ" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "Kg" = (
 /obj/machinery/power/terminal{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "KL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "KT" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/structure/bed,
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "La" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "MS" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light/directional/north,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "MU" = (
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "Np" = (
 /obj/structure/closet/crate,
 /obj/item/coin/iron,
@@ -555,38 +555,38 @@
 /obj/item/coin/iron,
 /obj/item/coin/iron,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "Nt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "NJ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 9
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "Oc" = (
 /obj/effect/turf_decal/siding/dark/corner,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "Of" = (
 /obj/machinery/power/shuttle_engine/heater{
 	dir = 8
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "Oh" = (
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "OB" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "OI" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -601,17 +601,17 @@
 	pixel_y = -5
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "OP" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "PR" = (
 /obj/machinery/door/airlock/public{
 	name = "Wanglius Crew Quarters"
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "PV" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table,
@@ -619,11 +619,11 @@
 	pixel_y = 4
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "Qi" = (
 /obj/structure/cable,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "Qj" = (
 /obj/structure/rack,
 /obj/item/tank/internals/oxygen/red,
@@ -633,85 +633,85 @@
 /obj/item/extinguisher,
 /obj/item/extinguisher,
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "QE" = (
 /obj/structure/bed,
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "Se" = (
 /obj/effect/spawner/random/structure/closet_private,
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "SL" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "Tl" = (
 /obj/effect/spawner/random/maintenance,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 "TN" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
 	},
 /turf/open/floor/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "UO" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating/airless,
-/area/shipbreak)
+/area/template_noop)
 "Vb" = (
 /obj/structure/chair{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
-/area/shipbreak)
+/area/template_noop)
 "Vd" = (
 /obj/machinery/door/window/left/directional/south{
 	name = "Sleeping Capsule"
 	},
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "XN" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "XV" = (
 /obj/structure/bed,
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet/blue,
-/area/shipbreak)
+/area/template_noop)
 "XW" = (
 /obj/structure/table,
 /obj/item/defibrillator/loaded,
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "Yx" = (
 /obj/structure/table,
 /obj/machinery/light/directional/west,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/mineral/titanium/white,
-/area/shipbreak)
+/area/template_noop)
 "YZ" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "Zx" = (
 /obj/effect/spawner/random/trash,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
 /turf/open/floor/iron/dark/textured,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 Er

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/whale.dmm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ship_maps/whale.dmm
@@ -2,27 +2,27 @@
 "n" = (
 /obj/machinery/power/shuttle_engine/propulsion/burst,
 /turf/closed/wall/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 "q" = (
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "w" = (
 /obj/structure/alien/resin/wall/creature,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "z" = (
 /obj/effect/spawner/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
-/area/shipbreak)
+/area/template_noop)
 "E" = (
 /obj/structure/meateor_fluff/flesh_pod,
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "F" = (
 /obj/structure/meateor_fluff/eyeball,
 /obj/structure/alien/resin/membrane/creature,
 /turf/template_noop,
-/area/shipbreak)
+/area/template_noop)
 "G" = (
 /obj/machinery/door/airlock/titanium{
 	name = "Escape Pod Airlock"
@@ -31,19 +31,19 @@
 	port_direction = 2
 	},
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "N" = (
 /obj/structure/punji_sticks/spikes{
 	name = "jagged teeth"
 	},
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "O" = (
 /obj/structure/statue/bone/rib{
 	dir = 1
 	},
 /turf/open/floor/material/meat,
-/area/shipbreak)
+/area/template_noop)
 "R" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -53,7 +53,7 @@
 /obj/machinery/light/small/directional/west,
 /obj/effect/mob_spawn/corpse/human/assistant,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "S" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -64,10 +64,10 @@
 	},
 /obj/effect/mob_spawn/corpse/human/assistant,
 /turf/open/floor/mineral/titanium/blue,
-/area/shipbreak)
+/area/template_noop)
 "W" = (
 /turf/closed/wall/mineral/titanium,
-/area/shipbreak)
+/area/template_noop)
 
 (1,1,1) = {"
 q

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -113,15 +113,15 @@
 
 //shipbreaking features
 /obj/machinery/computer/shipbreaker/syndicate_depot
-	name = "shipbreaker magnet console"
+	name = "shipbreaking magnet console"
 	desc = "A computer linked to the depot's shipbreaking magnet, capable of pulling in abandoned ships from any location."
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
 	light_color = COLOR_SOFT_RED
-	mapped_start_area = /area/shipbreak/syndicate_depot
+	mapped_start_area = /area/ruin/space/has_grav/syndicate_depot/shipbreaking
 
-/area/shipbreak/syndicate_depot
-	name = "Syndicate Depot Shipbreaking Magnet"
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking
+	name = "Syndicate Depot Shipbreaking Zone"
 
 /obj/item/storage/toolbox/syndicate/shipbreaking
 	name = "suspicious salvage toolbox"

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -126,7 +126,7 @@
 /obj/item/storage/toolbox/syndicate/shipbreaking
 	name = "suspicious salvage toolbox"
 
-/obj/item/storage/toolbox/syndicate/PopulateContents()
+/obj/item/storage/toolbox/syndicate/shipbreaking/PopulateContents()
 	new /obj/item/screwdriver/nuke(src)
 	new /obj/item/wrench(src)
 	new /obj/item/weldingtool/electric/hacked_raynewelder(src)

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -99,6 +99,9 @@
 /area/ruin/space/has_grav/syndicate_depot/hydroponics
 	name = "Syndicate Depot Hydroponics"
 
+/area/ruin/space/has_grav/syndicate_depot/shipbreaking_control
+	name = "Syndicate Depot Shipbreaking Magnet Control"
+
 
 //misc things; fluff, stun-capable turrets
 
@@ -107,3 +110,44 @@
 	desc = "A ballistic machine-gun auto-turret. This one has had one of its barrels replaced with a taser."
 	stun_projectile = /obj/projectile/energy/electrode
 	stun_projectile_sound = 'sound/weapons/taser.ogg'
+
+//shipbreaking features
+/obj/machinery/computer/shipbreaker/syndicate_depot
+	name = "shipbreaker magnet console"
+	desc = "A computer linked to the depot's shipbreaking magnet, capable of pulling in abandoned ships from any location."
+	icon_screen = "syndishuttle"
+	icon_keyboard = "syndie_key"
+	light_color = COLOR_SOFT_RED
+	mapped_start_area = /area/shipbreak/syndicate_depot
+
+/area/shipbreak/syndicate_depot
+	name = "Syndicate Depot Shipbreaking Magnet"
+
+/obj/item/storage/toolbox/syndicate/shipbreaking
+	name = "suspicious salvage toolbox"
+
+/obj/item/storage/toolbox/syndicate/PopulateContents()
+	new /obj/item/screwdriver/nuke(src)
+	new /obj/item/wrench(src)
+	new /obj/item/weldingtool/electric/hacked_raynewelder(src)
+	new /obj/item/crowbar/red(src)
+	new /obj/item/wirecutters(src, "red")
+	new /obj/item/multitool(src)
+	new /obj/item/extinguisher/mini(src)
+
+/obj/item/weldingtool/electric/hacked_raynewelder //id make it a subtype of the rayne welder but then id have to override shit
+	name = "modified laser welding tool"
+	desc = "A Rayne corp laser cutter and welder. This one seems to have been refitted by the Syndicate for general salvage use, though the removal of its safety measures has slightly reduced its efficiency."
+	icon = 'monkestation/icons/obj/rayne_corp/rayne.dmi'
+	icon_state = "raynewelder"
+	inhand_icon_state = "raynewelder"
+	lefthand_file = 'monkestation/icons/mob/inhands/equipment/engineering_lefthand.dmi'
+	righthand_file = 'monkestation/icons/mob/inhands/equipment/engineering_righthand.dmi'
+	light_power = 1
+	light_color = LIGHT_COLOR_FLARE
+	tool_behaviour = NONE
+	toolspeed = 0.3
+	power_use_amount = 25
+	// We don't use fuel
+	change_icons = FALSE
+	max_fuel = 20

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -151,3 +151,28 @@
 	// We don't use fuel
 	change_icons = FALSE
 	max_fuel = 20
+
+/obj/item/melee/sledgehammer/syndicate_depot //fuck you
+
+/obj/item/melee/sledgehammer/syndicate_depot/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+	. = ..()
+	if(!HAS_TRAIT(src, TRAIT_WIELDED) && user)
+		/// This will already do low damage, so it doesn't need to be intercepted earlier
+		to_chat(user, span_danger("\The [src] is too heavy to attack effectively without being wielded!"))
+		return
+	if(istype(target, /mob/living/carbon/human))
+		var/mob/living/carbon/human/humantarget = target
+		if(!HAS_TRAIT(target, TRAIT_SPLEENLESS_METABOLISM) && humantarget.get_organ_slot(ORGAN_SLOT_SPLEEN) && !isnull(humantarget.dna.species.mutantspleen))
+			var/obj/item/organ/internal/spleen/target_spleen = humantarget.get_organ_slot(ORGAN_SLOT_SPLEEN)
+			target_spleen.apply_organ_damage(5)
+	if(!proximity_flag)
+		return
+
+	if(target.uses_integrity)
+		if(!QDELETED(target))
+			if(istype(get_area(target), /area/ruin/space/has_grav/syndicate_depot/shipbreaking))
+				if(isstructure(target))
+					target.take_damage(force * demolition_mod, BRUTE, MELEE, FALSE, null, 20) // Breaks "structures pretty good"
+				if(ismachinery(target))
+					target.take_damage(force * demolition_mod, BRUTE, MELEE, FALSE, null, 20) // A luddites friend, Sledghammer good at break machine
+			playsound(src, 'sound/effects/bang.ogg', 40, 1)


### PR DESCRIPTION

## About The Pull Request

- The Syndicate Depot has had its interior security cameras removed and its airlocks and APCs modified to keep nosy AIs from fucking with equipment. Johnson and Co refuses to admit any wrongdoing.
- The Depot has also been fitted with shipbreaking, both as a proof of concept to add to other ruins and because it's something for the techies to do.
- All shipbreaking templates have been modified to only have passthrough areas, as otherwise it would break depot shipbreaking (and ruin shipbreaking in general in the future)
- The depot's circuit imprinter has also been replaced with an ancient one to mirror some other PR that I don't have the number on hand for right now so that they can sod off from the depot to prevent merge conflicts

## Why It's Good For The Game

Shipbreaking is fucking cool, and extending access to it to ruins is good.

Also, AIs fucking with the depot is not good.

## Changelog
:cl:
add: The Syndicate depot now has shipbreaking!
add: Shipbreaking can now also be integrated into other space ghostroles with enough effort! (good luck lmao)
balance: The Syndicate depot's circuit imprinter is now the shit ancient one, but they have been provided quantum pad boards so they can still be buddy-buddy with other outposts.
fix: Nanotrasen AIs can no longer fuck with the syndicate depot, at least on the interior. They can still see the outside, but it's now much harder for them to do anything.
/:cl:
