### PR TITLE
Sweetening Apids

### DIFF
--- a/monkestation/code/modules/botany/species/apid/hive/ability.dm
+++ b/monkestation/code/modules/botany/species/apid/hive/ability.dm
@@ -5,8 +5,10 @@
 	button_icon = 'icons/obj/hydroponics/equipment.dmi'
 	button_icon_state = "beebox"
 
-	cooldown_time = 25 MINUTES
+	cooldown_time = 5 MINUTES
 	spell_requirements = NONE
+//MONKESTATION EDIT : Reducing the cooldown from 25 to 10 minutes.
+// The time was extremely long before, almost twice as the time to **make** a hive. This is healthier, equating to double of the time of the beehive.
 
 	var/obj/structure/beebox/hive/created_hive
 
@@ -19,7 +21,7 @@
 	. = ..()
 	if(is_species(user, /datum/species/apid))
 		var/datum/species/apid/apid = user.dna.species
-		if(apid.stored_honey < 150)
+		if(apid.stored_honey < 70)
 			to_chat(user, span_notice("Not enough stored honey"))
 			addtimer(CALLBACK(src, PROC_REF(reset_spell_cooldown)), 2 SECONDS)
 			return
@@ -30,14 +32,16 @@
 
 	if(is_species(user, /datum/species/apid))
 		var/datum/species/apid/apid = user.dna.species
-		if(apid.stored_honey < 150)
+		if(apid.stored_honey < 70)
 			addtimer(CALLBACK(src, PROC_REF(reset_spell_cooldown)), 2 SECONDS)
 			return
 
-		apid.adjust_honeycount(-150)
+		apid.adjust_honeycount(-70)
 		created_hive = new(get_turf(user), user.real_name)
 		apid.owned_hive = created_hive
 		created_hive.current_stat = apid.current_stat
+		//MONKESTATION EDIT : Changed the total requirement from 15 minutes to a reasonable 7.
+		//The amount of time investment this required only incentivized an isolated style of gameplay, this should be healthier and incentivize the use of beehives earlier for interactions with crewmembers.
 
 	RegisterSignals(created_hive, list(COMSIG_QDELETING, COMSIG_PREQDELETED), PROC_REF(remove_hive))
 


### PR DESCRIPTION
# Sweetening Apids
_(Their pacience anyways)_

![image](https://github.com/user-attachments/assets/29f113ed-d132-4c6a-9a5d-60c13b432893)


## About The Pull Request

Changes how long beehives take to make, and how much honey is used, by reducing Apid honey count required 
from 150 to 50, while also reducing the cooldown for making beehives from **25 MINUTES** to a reasonable 5 minutes, in case 
your beehive is destroyed.

## Why It's Good For The Game

This comes as a complaint of many players about the time it takes for these beehives to be made, and as well, the problems involving having people stuck in the bee dimension.

### 1. The 15 Minutes Isolationist vs The 7 Minute Bee Chad

Firstly it used to take 15 minutes for a beehive to be made, but in reality, it takes more than this, considerably, because you`ll
often, as a player, be talking with other people, participating in conflitcs, as trying to socialize and have fun. 

However, because the beehive takes 15 minutes of **consistent** focus to be always pollinated on time, what ends up happening is players that will often isolate themselves and lose much of the round interactions due to it.

This also translates in apids having to always interact with botany due to how long it takes them to make a single beehive.

### 2. Beehive Dimension Hostages

Another positive effect of these changes is the reduction of the beehive cooldown itself, which due to past case scenarios, players got stuck inside a apid beehive only to discover the cooldown for those beehives to made again was **25 MINUTES**, effectively isolating players for over a 1/4 to 1/5 of the round.

## Conclusion

All in all, this should bring the apid gameplay to a more healthy style, allowing them to make their own bee homes more quickly and in turn creating little hubs of stores, tea parties, clubs, hospitals, ~organ trafficking operations~ or whatever else they might want to use to interact with crew.

![image](https://github.com/user-attachments/assets/3505c17d-d49d-478e-a7aa-d32a2c365661)
(The illustration of players stuck for 25 minutes in the bee dimension)

## Changelog

:cl:
balance: reduced minimum apid honey require to make beehives from 150 to 70
balance: reduced beehive cooldown from 25 minutes to 5 minutes. 
/:cl:

