### PR TITLE
Some small `SSparticle_weather` fixes

### DIFF
--- a/monkestation/code/modules/outdoors/code/controllers/subsystem/particle_weather.dm
+++ b/monkestation/code/modules/outdoors/code/controllers/subsystem/particle_weather.dm
@@ -142,7 +142,7 @@ SUBSYSTEM_DEF(particle_weather)
 		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_WEATHER_CHANGE)
 		running_eclipse_weather = weather_datum_type
 		running_eclipse_weather.start()
-		weather_datum_type = null
+		next_hit_eclipse = null
 	else
 		if(!QDELETED(running_weather))
 			if(!force)
@@ -154,7 +154,7 @@ SUBSYSTEM_DEF(particle_weather)
 		SEND_GLOBAL_SIGNAL(COMSIG_GLOB_WEATHER_CHANGE)
 		running_weather = weather_datum_type
 		running_weather.start()
-		weather_datum_type = null
+		next_hit = null
 
 /datum/controller/subsystem/particle_weather/proc/make_eligible(datum/particle_weather/possible_weather, probability = 10)
 	eligible_weathers[possible_weather] = probability

--- a/monkestation/code/modules/outdoors/code/datum/particle_weathers/_particle_weather.dm
+++ b/monkestation/code/modules/outdoors/code/datum/particle_weathers/_particle_weather.dm
@@ -277,13 +277,14 @@ GLOBAL_LIST_EMPTY(siren_objects)
 	switch(plane_type)
 		if("Default")
 			SSparticle_weather.particle_effect?.animate_severity(severity_mod())
+			//Wait for the last particle to fade, then qdel yourself
+			addtimer(CALLBACK(src, PROC_REF(end)), SSparticle_weather.particle_effect.lifespan + SSparticle_weather.particle_effect.fade)
 		if("Eclipse")
 			SSparticle_weather.particle_effect_eclipse?.animate_severity(severity_mod())
+			//Wait for the last particle to fade, then qdel yourself
+			addtimer(CALLBACK(src, PROC_REF(end)), SSparticle_weather.particle_effect_eclipse.lifespan + SSparticle_weather.particle_effect_eclipse.fade)
 		else
 			stack_trace("[src] had invalid plane_type [plane_type]")
-
-	//Wait for the last particle to fade, then qdel yourself
-	addtimer(CALLBACK(src, PROC_REF(end)), SSparticle_weather.particle_effect.lifespan + SSparticle_weather.particle_effect.fade)
 
 /datum/particle_weather/proc/end()
 	running = FALSE


### PR DESCRIPTION
## About The Pull Request
This PR should fix a hard-del that's been repeatedly reported, regarding particle weather stuff.

Additionally, I happened to notice that `/datum/controller/subsystem/particle_weather/proc/run_weather` was trying to nullify `next_hit(_eclipse)`... but seemed to instead nullify the parameter. So I fixed that too.

As an aside... I do think that SSparticle_weather should be rewritten. Right now, it seems to duplicate much of its functionality to have both regular weather and eclipse weather running at once.

## Why It's Good For The Game
Bugs!

edit: and hard-dels!

## Changelog
I don't believe SSparticle_weather even runs on any of our active maps, so this probably isn't a player-facing change.

That said, I'm going to put these here so the relevant flaky test reports automatically close when this is merged:

Fixes https://github.com/Monkestation/Monkestation2.0/issues/5265
Fixes https://github.com/Monkestation/Monkestation2.0/issues/5254
Fixes https://github.com/Monkestation/Monkestation2.0/issues/5252
