### PR TITLE
Fix not being able to build several vendors (+ unit test to prevent similar issues)

### DIFF
--- a/_maps/multiz_debug.json
+++ b/_maps/multiz_debug.json
@@ -4,7 +4,8 @@
 	"map_path": "map_files/debug",
 	"map_file": "multiz.dmm",
 	"ignored_unit_tests": [
-		"/datum/unit_test/required_map_items"
+		"/datum/unit_test/required_map_items",
+		"/datum/unit_test/vendor_boards"
 	],
 	"traits": [
 		{

--- a/_maps/runtimestation.json
+++ b/_maps/runtimestation.json
@@ -5,7 +5,8 @@
 	"map_file": "runtimestation.dmm",
 	"space_ruin_levels": 1,
 	"ignored_unit_tests": [
-		"/datum/unit_test/required_map_items"
+		"/datum/unit_test/required_map_items",
+		"/datum/unit_test/vendor_boards"
 	],
 	"shuttles": {
 		"cargo": "cargo_delta"

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -645,11 +645,17 @@
 		/obj/machinery/vending/modularpc = "Deluxe Silicate Selections",
 		/obj/machinery/vending/tool = "YouTool",
 		/obj/machinery/vending/custom = "Custom Vendor",
+		// monkestation start
+		/obj/machinery/vending/access/command = "Command Outfitting Station",
+		/obj/machinery/vending/barbervend = "Fab-O-Vend",
 		/obj/machinery/vending/imported = "NT Sustenance Supplier",
-		/obj/machinery/vending/imported/yangyu = "Fudobenda",
 		/obj/machinery/vending/imported/mothic = "Nomad Fleet Ration Chit Exchange",
 		/obj/machinery/vending/imported/tizirian = "Tizirian Imported Delicacies",
-		/obj/machinery/vending/plushvendor = "Plushie Vendor",)
+		/obj/machinery/vending/imported/yangyu = "Fudobenda",
+		/obj/machinery/vending/mechcomp = "ThinkTronic MechComp Dispenser",
+		/obj/machinery/vending/plushvendor = "Plushie Vendor",
+		// monkestation end
+	)
 
 /obj/item/circuitboard/machine/vendor/screwdriver_act(mob/living/user, obj/item/tool)
 	var/static/list/display_vending_names_paths

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -236,6 +236,7 @@
 #include "trick_weapon_icons.dm"
 #include "tutorial_sanity.dm"
 #include "unit_test.dm"
+#include "vendor_boards.dm"
 #include "verify_config_tags.dm"
 #include "verify_emoji_names.dm"
 #include "wizard_loadout.dm"

--- a/code/modules/unit_tests/vendor_boards.dm
+++ b/code/modules/unit_tests/vendor_boards.dm
@@ -1,0 +1,26 @@
+/// This test ensures that all vendors that spawn on-station can be constructed via a vendor circuit board.
+/datum/unit_test/vendor_boards
+
+/datum/unit_test/vendor_boards/Run()
+	var/obj/item/circuitboard/machine/vendor/dummy_board = new
+	var/list/vending_names_paths = dummy_board.vending_names_paths.Copy()
+	QDEL_NULL(dummy_board)
+
+	// 'cuz there's various subtypes of the same vendor which are pretty much the same thing,
+	// we're gonna check refill canister types rather than vendor types.
+	var/list/valid_vendor_refills = list()
+	for(var/obj/machinery/vending/vendor_type as anything in vending_names_paths)
+		if(isnull(vendor_type::refill_canister))
+			TEST_FAIL("[vendor_type] ([vendor_type::name]) does not have a refill_canister set, despite the fact it can be constructed from a vendor board!")
+		else
+			valid_vendor_refills |= vendor_type::refill_canister
+
+	var/list/checked_types = list() // just to avoid duplicate errors for the same exact vendor type.
+	for(var/obj/machinery/vending/vendor as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/vending))
+		if(!is_station_level(vendor.loc?.z) || checked_types[vendor.type])
+			continue
+		if(vendor.circuit != /obj/machinery/vending::circuit) // skip anything using its own different board
+			continue
+		checked_types[vendor.type] = TRUE
+		if(!(vendor.refill_canister in valid_vendor_refills))
+			TEST_FAIL("[vendor.type] (using [vendor.refill_canister]) not found in possible constructible vending machines, despite being mapped on-station!")

--- a/monkestation/code/modules/mech_comp/vending_machine.dm
+++ b/monkestation/code/modules/mech_comp/vending_machine.dm
@@ -6,9 +6,9 @@
 	name = "\improper ThinkTronic MechComp Dispenser"
 	desc = "A rather plain vendor for ThinkTronic's line of field-assemblable components."
 	product_ads = "At least it's not Circuits!;95% GPL Compatible!;Source Exists, Somewhere!;Semi-Standards Compliant!;IETF Cleared!"
-
 	default_price = 0
 	extra_price = 0
+	refill_canister = /obj/item/vending_refill/mechcomp
 
 	products = list(
 		/obj/item/mcobject/signal_output = STANDARD_COMPONENT_SUPPLY,


### PR DESCRIPTION
## About The Pull Request

this adds the mechcomp, barber, and command clothing vendors as valid options when screwdrivering a vendor board.

also adds a unit test to ensure all vendors that are mapped on-station are a valid option when screwdrivering the vendor board.

## Why It's Good For The Game

you can get a mechcomp vendor refill unit... but not a board. kinda dumb.

## Changelog
:cl:
fix: You can now properly select "Command Outfitting Station", "Fab-O-Vend", and "ThinkTronic MechComp Dispenser" when screwdrivering a vendor board.
/:cl:
