### PR TITLE
Fix 3 stray "Vacant Office" tiles on MetaStation

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -27468,9 +27468,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
-"jzp" = (
-/turf/closed/wall,
-/area/station/commons/vacant_room/office)
 "jzw" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -86547,9 +86544,9 @@ crr
 qyT
 rZT
 lQW
-jzp
-jzp
-jzp
+fjD
+fjD
+fjD
 pOa
 pOa
 pOa


### PR DESCRIPTION

## About The Pull Request

fixes these 3 tiles on Meta being marked as "Vacant Office":

![image](https://github.com/user-attachments/assets/926987e1-edbb-4ee7-9c32-f48ff047a973)

they're now marked as being part of the bathroom:

![2025-02-03 (1738572790) ~ StrongDMM](https://github.com/user-attachments/assets/fef04d74-677e-460b-b484-770448a867e9)

## Why It's Good For The Game

it's confusing

## Changelog
:cl:
fix: Fixed 3 walls in the MetaStation arrivals bathroom being erroneously marked as the "Vacant Office"
/:cl:
