### PR TITLE
Slightly raises beepsky's health

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -5,8 +5,10 @@
 	icon_state = "secbot"
 	density = FALSE
 	anchored = FALSE
-	health = 25
-	maxHealth = 25
+	// monkestation edit: slightly raise beepsky's health (25 -> 35)
+	health = 35
+	maxHealth = 35
+	// monkestation end
 	damage_coeff = list(BRUTE = 0.5, BURN = 0.7, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	pass_flags = PASSMOB | PASSFLAPS
 	istate = ISTATE_HARM|ISTATE_BLOCKING


### PR DESCRIPTION

## About The Pull Request

requested by @ThePooba:

> when you get a chance can you up beepskies health so the baton changes let him stun you before you kill him with a toolbox
> his curretn is 25 i think 35 would do it

## Changelog
:cl:
balance: Slightly raised the health of securitrons/beepsky. (From 25 to 35)
/:cl:
