### PR TITLE
`TRAIT_NO_TRANSFORMATION_STING` now actually prevents transformation stings

### DIFF
--- a/code/datums/status_effects/debuffs/dna_transformation.dm
+++ b/code/datums/status_effects/debuffs/dna_transformation.dm
@@ -67,8 +67,8 @@
 
 /datum/status_effect/temporary_transformation/trans_sting/on_apply()
 	. = ..()
-	if(!.)
-		return
+	if(!. || HAS_TRAIT(owner, TRAIT_NO_TRANSFORMATION_STING))
+		return FALSE
 	RegisterSignals(owner, update_on_signals, PROC_REF(pause_effect))
 	pause_effect(owner) // for if we sting a dead guy
 

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -112,6 +112,7 @@
 		|| !target.has_dna() \
 		|| HAS_TRAIT(target, TRAIT_HUSK) \
 		|| HAS_TRAIT(target, TRAIT_BADDNA) \
+		|| HAS_TRAIT(target, TRAIT_NO_TRANSFORMATION_STING) \
 		|| (HAS_TRAIT(target, TRAIT_NO_DNA_COPY) && !ismonkey(target))) // sure, go ahead, make a monk-clone
 		user.balloon_alert(user, "incompatible DNA!")
 		return FALSE


### PR DESCRIPTION
## Changelog
:cl:
fix: Species that are supposed to be immune to transformation stings are now actually immune to transformation stings.
/:cl:
