### PR TITLE
Adds DNA Recovery surgery

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -551,7 +551,7 @@
 		"surgery_heal_combo",
 		"surgery_lobotomy",
 		"surgery_wing_reconstruction",
-		"surgery_filter_upgrade_femto", // monke edit: advanced blood filter surgery
+		"surgery_filter_upgrade_femto", // monkestation edit: advanced blood filter surgery
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
 
@@ -572,6 +572,7 @@
 		"surgery_pacify",
 		"surgery_vein_thread",
 		"surgery_viral_bond",
+		"surgery_dna_recovery", // monkestation edit: dna recovery surgery
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 	discount_experiments = list(/datum/experiment/scanning/random/plants/traits = 4500)

--- a/monkestation/code/game/machinery/computer/cloning.dm
+++ b/monkestation/code/game/machinery/computer/cloning.dm
@@ -548,7 +548,7 @@
 		playsound(src, 'sound/machines/terminal_alert.ogg', 50, 0)
 		return
 	if(HAS_TRAIT(mob_occupant, TRAIT_BADDNA))
-		scantemp = "<font class='bad'>Subject's DNA is damaged beyond any hope of recovery.</font>"
+		scantemp = "<font class='bad'>Subject's DNA is too damaged to initiate cloning procedure.</font>"
 		playsound(src, 'sound/machines/terminal_alert.ogg', 50, 0)
 		return
 	if (!body_only && isnull(mob_occupant.mind))

--- a/monkestation/code/game/machinery/exp_cloner.dm
+++ b/monkestation/code/game/machinery/exp_cloner.dm
@@ -381,7 +381,7 @@
 		playsound(src, 'sound/machines/terminal_alert.ogg', 50, FALSE)
 		return
 	if(HAS_TRAIT(mob_occupant, TRAIT_BADDNA))
-		scantemp = "<font class='bad'>Subject's DNA is damaged beyond any hope of recovery.</font>"
+		scantemp = "<font class='bad'>Subject's DNA is too damaged to initiate cloning procedure.</font>"
 		playsound(src, 'sound/machines/terminal_alert.ogg', 50, FALSE)
 		return
 

--- a/monkestation/code/modules/research/designs/medical_designs.dm
+++ b/monkestation/code/modules/research/designs/medical_designs.dm
@@ -92,3 +92,10 @@
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL,
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
+
+/datum/design/surgery/dna_recovery
+	name = "DNA Recovery"
+	desc = "A surgical procedure which involves using rezadone to salvage a single strand of DNA from the patient, allowing them to be cloned."
+	id = "surgery_dna_recovery"
+	surgery = /datum/surgery/advanced/dna_recovery
+	research_icon_state = "surgery_head"

--- a/monkestation/code/modules/surgery/advanced/dna_recovery.dm
+++ b/monkestation/code/modules/surgery/advanced/dna_recovery.dm
@@ -1,0 +1,49 @@
+/datum/surgery/advanced/dna_recovery
+	name = "DNA Recovery"
+	desc = "An experimental surgical procedure that could fix the DNA from dead bodies. Requires rezadone, amanitin, or entropic polypnium."
+	possible_locs = list(BODY_ZONE_HEAD)
+	steps = list(
+		/datum/surgery_step/incise,
+		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/saw,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/dna_recovery,
+		/datum/surgery_step/close,
+	)
+
+/datum/surgery/advanced/dna_recovery/can_start(mob/user, mob/living/carbon/target)
+	if(!..())
+		return FALSE
+	return HAS_TRAIT_FROM(target, TRAIT_BADDNA, CHANGELING_DRAIN) || HAS_TRAIT(target, TRAIT_HUSK)
+
+/datum/surgery_step/dna_recovery
+	name = "recover DNA (syringe)"
+	implements = list(/obj/item/reagent_containers/syringe = 100, /obj/item/pen = 30)
+	time = 15 SECONDS
+	chems_needed = list(
+		/datum/reagent/medicine/rezadone,
+		/datum/reagent/toxin/amanitin,
+		/datum/reagent/consumable/entpoly,
+	)
+	require_all_chems = FALSE
+
+/datum/surgery_step/dna_recovery/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(
+		user,
+		target,
+		span_notice("You begin to mend what's left of [target]'s DNA..."),
+		span_notice("[user] begins to tinker with [target]'s brain..."),
+		span_notice("[user] begins to perform surgery on [target]'s brain.")
+	)
+
+/datum/surgery_step/dna_recovery/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(
+		user,
+		target,
+		span_notice("You succeed in fixing some of [target]'s DNA!"),
+		span_notice("[user] successfully repairs some of [target]'s DNA"),
+		span_notice("[user] completes the surgery on [target]'s brain."),
+	)
+	REMOVE_TRAIT(target, TRAIT_BADDNA, CHANGELING_DRAIN)
+	target.cure_husk()
+	return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8309,6 +8309,7 @@
 #include "monkestation\code\modules\surgery\robot_healing.dm"
 #include "monkestation\code\modules\surgery\steps.dm"
 #include "monkestation\code\modules\surgery\advanced\brainwashing.dm"
+#include "monkestation\code\modules\surgery\advanced\dna_recovery.dm"
 #include "monkestation\code\modules\surgery\advanced\lobotomy.dm"
 #include "monkestation\code\modules\surgery\advanced\pacification.dm"
 #include "monkestation\code\modules\surgery\bodyparts\arachnid_bodyparts.dm"


### PR DESCRIPTION

## About The Pull Request

Ports the following PRs:
- https://github.com/yogstation13/Yogstation/pull/6740
- https://github.com/yogstation13/Yogstation/pull/8110
- https://github.com/yogstation13/Yogstation/pull/13521

## Why It's Good For The Game

adds a somewhat reasonable way to revive ling victims while still requiring effort

## Changelog
:cl:
add: Added a new surgery, DNA Recovery, which can unhusk people, including changeling absorption victims. It's unlocked by experimental surgery node, and requires either rezadone, amanitin, or entropic polypnium.
/:cl:
