### PR TITLE
Roundstart Explorer

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -70,6 +70,7 @@
 #define JOB_QUARTERMASTER "Quartermaster"
 #define JOB_CARGO_TECHNICIAN "Cargo Technician"
 #define JOB_SHAFT_MINER "Shaft Miner"
+#define JOB_EXPLORER "Explorer"
 #define JOB_BITRUNNER "Bitrunner"
 //Service
 #define JOB_BARTENDER "Bartender"

--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -70,7 +70,6 @@
 #define JOB_QUARTERMASTER "Quartermaster"
 #define JOB_CARGO_TECHNICIAN "Cargo Technician"
 #define JOB_SHAFT_MINER "Shaft Miner"
-#define JOB_EXPLORER "Explorer"
 #define JOB_BITRUNNER "Bitrunner"
 //Service
 #define JOB_BARTENDER "Bartender"

--- a/code/__DEFINES/~monkestation/jobs.dm
+++ b/code/__DEFINES/~monkestation/jobs.dm
@@ -4,9 +4,9 @@
 
 #define JOB_NANOTRASEN_REPRESENTATIVE "Nanotrasen Representative"
 
-#define JOB_LATEJOIN_BARBER "Barber"
+#define JOB_EXPLORER "Explorer"
 
-#define JOB_LATEJOIN_EXPLORER "Explorer"
+#define JOB_LATEJOIN_BARBER "Barber"
 
 /// Whether this job is enabled/disabled by the spooktober config
 #define JOB_SPOOKTOBER (1<<16)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -21,6 +21,7 @@
 		JOB_PRISONER,
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
+		JOB_EXPLORER,
 	)
 	restricted_roles = list(
 		JOB_AI,
@@ -114,6 +115,7 @@
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
 		JOB_SECURITY_ASSISTANT,
+		JOB_EXPLORER,
 	)
 	restricted_roles = list(
 		JOB_AI,
@@ -172,6 +174,7 @@
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
 		JOB_SECURITY_ASSISTANT,
+		JOB_EXPLORER,
 	)
 	restricted_roles = list(
 		JOB_AI,
@@ -358,6 +361,7 @@
 		JOB_PRISONER,
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
+		JOB_EXPLORER,
 	)
 	required_candidates = 2
 	weight = 3
@@ -535,6 +539,7 @@
 		JOB_RESEARCH_DIRECTOR,
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
+		JOB_EXPLORER,
 	)
 	required_candidates = 3
 	weight = 1

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -129,7 +129,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		JOB_QUARTERMASTER = 50,
 		JOB_SHAFT_MINER = 51,
 		JOB_CARGO_TECHNICIAN = 52,
-		JOB_LATEJOIN_EXPLORER = 53, //monkestation edit: explorer
+		JOB_EXPLORER = 53, //monkestation edit: explorer
 		// 60+: Civilian/other
 		JOB_HEAD_OF_PERSONNEL = 60,
 		JOB_BARTENDER = 61,

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_ruleset.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_ruleset.dm
@@ -15,6 +15,8 @@
 		JOB_WARDEN, JOB_SECURITY_OFFICER, JOB_DETECTIVE, JOB_SECURITY_ASSISTANT,
 		// Curator
 		JOB_CURATOR,
+		//People who tend to fuck off
+		JOB_EXPLORER,
 	)
 	restricted_roles = list(JOB_AI, JOB_CYBORG)
 	required_candidates = 1

--- a/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
+++ b/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
@@ -195,6 +195,12 @@
 
 /datum/job/engineering_guard //see orderly
 
+/datum/job/explorer
+	alt_titles = list(
+		"Explorer",
+		"Space Salvager",
+		"Insurance Agent",
+	)
 /datum/job/geneticist
 	alt_titles = list(
 		"Geneticist",

--- a/monkestation/code/modules/jobs/job_types/explorer.dm
+++ b/monkestation/code/modules/jobs/job_types/explorer.dm
@@ -1,11 +1,11 @@
 /datum/job/explorer
-	title = JOB_LATEJOIN_EXPLORER
+	title = JOB_EXPLORER
 	description = "Explore space. Salvage supplies. \
 		Visit strange places. Die in space."
 	department_head = list(JOB_HEAD_OF_PERSONNEL)
 	faction = FACTION_STATION
-	total_positions = 6
-	spawn_positions = 6
+	total_positions = 3
+	spawn_positions = 3
 	supervisors = SUPERVISOR_QM
 	exp_granted_type = EXP_TYPE_CREW
 	config_tag = "EXPLORER"
@@ -21,7 +21,7 @@
 	display_order = JOB_DISPLAY_ORDER_EXPLORER
 	bounty_types = CIV_JOB_MINE
 	departments_list = list(
-		/datum/job_department/late,
+		/datum/job_department/cargo,
 		)
 
 	family_heirlooms = list(


### PR DESCRIPTION
## About The Pull Request
Moves Explorer to roundstart.
Explorer Roles reduced from 6-3
Explorer can NO longer be the following roundstart antags: Traitor, Changeling, Blood Cultist, Bloodsucker.
## Why It's Good For The Game
I love explorer. It's an excellent idea with a bit of love and could use some patches to bring it to roundstart.
Now for my changes.

Explorer is mostly an OFFSTATION role, and therefore shouldn't be able to be the 4 most common crew antags we have. if you find more, give me a heads up.

Explorer doesn't need 6 slots as a roundstart in a side-dept like Supply. That would give the QM a total of 14 Max people in their tiny sub-dept, when it should be closer to 10. This brings it into parity with shaft miner
## Changelog
:cl:
add: Explorer moved to roundstart.
balance: Explorer can no longer be a multitude of roundstart antagonists.
balance: Explorer slots have been halved to match Shaft Miner
/:cl:
