### PR TITLE
Revert "Slipping and Smashing."

### DIFF
--- a/code/controllers/subsystem/movement/movement_types.dm
+++ b/code/controllers/subsystem/movement/movement_types.dm
@@ -129,10 +129,6 @@
 
 	SEND_SIGNAL(src, COMSIG_MOVELOOP_POSTPROCESS, result, delay * visual_delay)
 
-	if(result == MOVELOOP_FAILURE && ishuman(src.moving) && istype(src, /datum/move_loop/has_target/move_towards)) // Tell the mob we slipped and what happened
-		var/datum/move_loop/has_target/move_towards/collide_move = src
-		SEND_SIGNAL(src.moving, COMSIG_MOVELOOP_POSTPROCESS, result, delay * visual_delay, collide_move.moving_towards, src)
-
 	if(QDELETED(src) || result != MOVELOOP_SUCCESS) //Can happen
 		return
 

--- a/code/datums/components/force_move.dm
+++ b/code/datums/components/force_move.dm
@@ -12,7 +12,6 @@
 	var/datum/move_loop/loop = SSmove_manager.move_towards(mob_parent, target, delay = 1, timeout = dist)
 	RegisterSignal(mob_parent, COMSIG_MOB_CLIENT_PRE_LIVING_MOVE, PROC_REF(stop_move))
 	RegisterSignal(mob_parent, COMSIG_ATOM_PRE_PRESSURE_PUSH, PROC_REF(stop_pressure))
-	RegisterSignal(mob_parent, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(slip_crash))
 	if(spin)
 		RegisterSignal(loop, COMSIG_MOVELOOP_POSTPROCESS, PROC_REF(slip_spin))
 	RegisterSignal(loop, COMSIG_QDELETING, PROC_REF(loop_ended))
@@ -29,23 +28,6 @@
 	SIGNAL_HANDLER
 	var/mob/mob_parent = parent
 	mob_parent.spin(1, 1)
-
-/datum/component/force_move/proc/slip_crash(datum/source, result, delay, turf/target_turf, datum/blocked)
-	SIGNAL_HANDLER
-	if(!result && ishuman(parent) && istype(blocked, /datum/move_loop/has_target/move_towards)) // Something prevented us from moving into the space.
-		var/obj/machinery/heavy_weight = (locate(/obj/machinery/vending) in target_turf)
-		var/datum/move_loop/has_target/move_towards/blocked_move = blocked
-		if(istype(heavy_weight, /obj/machinery/vending)) // When a stoppable force hits immovable capitalism.
-			blocked_move.lifetime = -1
-			INVOKE_ASYNC(heavy_weight, /obj/machinery/vending/proc/tilt, parent) // We hit the machine so let them hit back.
-
-		else
-			// We hit a structure and we need to keep going.
-			var/mob/living/mob_parent = parent
-			mob_parent.Immobilize(0.8 SECONDS) // Prevent them from throw bending around objects.
-			// We don't exactly know what stopped us. So throw us at the turf and let physics handle it.
-			blocked_move.lifetime = -1
-			INVOKE_ASYNC(mob_parent, /atom/movable/proc/throw_at, target_turf, 1, 1)
 
 /datum/component/force_move/proc/loop_ended(datum/source)
 	SIGNAL_HANDLER

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -408,9 +408,6 @@
 		else
 			visible_message(span_notice("[AM] bounces off of [src]'s rim!"))
 			return ..()
-	if(ishuman(AM) && AM.CanEnterDisposals())
-		AM.forceMove(src)
-		flush() // Might need to use do_flush if this causes problems.
 	else
 		return ..()
 


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Reverts Monkestation/Monkestation2.0#4776
There is a lot of bugs with this code. Especially when it comes to banana tiles and ice tiles. A fix was in the works for it as well as more lube slipping interactions but I have since lost all motivation to continue. The bugs caused by this PR is causing a lot of rr's in the clown ruins as well as the bit runners den. Probably any puzzles involving slip mechanics probably do not work right anymore. Until these are properly fixed this should be removed.

## Why It's Good For The Game
As funny as this is I want to add things that don't break more stuff. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removes slipping causing extra interactions
fix: Stops constant throwing caused by certain slipping tiles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->