### PR TITLE
Blob zombie fixes

### DIFF
--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -207,7 +207,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 			if(live_guy.stat != DEAD)
 				live_guy.investigate_log("has died from blob takeover.", INVESTIGATE_DEATHS)
 			live_guy.death()
-			create_spore(guy_turf)
+			create_spore(guy_turf, spore_type = /mob/living/basic/blob_minion/spore)
 		else
 			live_guy.fully_heal()
 

--- a/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
@@ -85,7 +85,7 @@
 
 /mob/living/basic/blob_minion/zombie/controlled/consume_corpse(mob/living/carbon/human/new_corpse)
 	. = ..()
-	if (!isnull(client))
+	if (!isnull(client) || SSticker.current_state == GAME_STATE_FINISHED)
 		return
 	AddComponent(\
 		/datum/component/ghost_direct_control,\

--- a/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
+++ b/code/modules/mob/living/basic/blob_minions/blob_zombie.dm
@@ -51,13 +51,13 @@
 	. = ..()
 	death()
 
-/mob/living/basic/blob_minion/zombie/update_overlays()
-	. = ..()
+//Sets up our appearance
+/mob/living/basic/blob_minion/zombie/proc/set_up_zombie_appearance()
 	copy_overlays(corpse, TRUE)
 	var/mutable_appearance/blob_head_overlay = mutable_appearance('icons/mob/nonhuman-player/blob.dmi', "blob_head")
 	blob_head_overlay.color = LAZYACCESS(atom_colours, FIXED_COLOUR_PRIORITY) || COLOR_WHITE
 	color = initial(color) // reversing what our component did lol, but we needed the value for the overlay
-	. += blob_head_overlay
+	overlays += blob_head_overlay
 
 /// Create an explosion of spores on death
 /mob/living/basic/blob_minion/zombie/proc/death_burst()
@@ -71,6 +71,7 @@
 	new_corpse.forceMove(src)
 	corpse = new_corpse
 	update_appearance(UPDATE_ICON)
+	set_up_zombie_appearance()
 	RegisterSignal(corpse, COMSIG_LIVING_REVIVE, PROC_REF(on_corpse_revived))
 
 /// Dynamic changeling reentry


### PR DESCRIPTION

## About The Pull Request

Ports the following PRs from tg:
- https://github.com/tgstation/tgstation/pull/81485
- https://github.com/tgstation/tgstation/pull/82542
- https://github.com/tgstation/tgstation/pull/85078

Fixes https://github.com/Monkestation/Monkestation2.0/issues/2297

## Why It's Good For The Game

yay bugfixes

## Changelog
:cl:
fix: (IndieanaJones) Blob Zombies now render their blob heads correctly again.
fix: (Rhials) The tide of post-round blob zombies when a blob wins will no longer break the speakers in your headset.
fix: (SmArtKar) Blob victory no longer spams spore zombie notifications to ghosts.
/:cl:
