### PR TITLE
Blacklists money from interaction component

### DIFF
--- a/monkestation/code/modules/mech_comp/objects/interactor.dm
+++ b/monkestation/code/modules/mech_comp/objects/interactor.dm
@@ -18,15 +18,11 @@
 	var/stored_dir = NORTH
 	///the interaction range defaults to ontop of itself
 	var/range = FALSE
-	///blacklisted types
-	var/list/blacklist = list(
+	/// Typecache of items forbidden from being held and used by the component.
+	var/static/list/item_blacklist = typecacheof(list(
 		/obj/item/stack/spacecash,
 		/obj/item/stack/monkecoin,
-	)
-
-
-
-
+	))
 
 /obj/item/mcobject/interactor/Initialize(mapload)
 	. = ..()

--- a/monkestation/code/modules/mech_comp/objects/interactor.dm
+++ b/monkestation/code/modules/mech_comp/objects/interactor.dm
@@ -22,6 +22,7 @@
 	var/static/list/item_blacklist = typecacheof(list(
 		/obj/item/stack/spacecash,
 		/obj/item/stack/monkecoin,
+		/obj/item/holochip,
 	))
 
 /obj/item/mcobject/interactor/Initialize(mapload)

--- a/monkestation/code/modules/mech_comp/objects/interactor.dm
+++ b/monkestation/code/modules/mech_comp/objects/interactor.dm
@@ -18,6 +18,15 @@
 	var/stored_dir = NORTH
 	///the interaction range defaults to ontop of itself
 	var/range = FALSE
+	///blacklisted types
+	var/list/blacklist = list(
+		/obj/item/stack/spacecash,
+		/obj/item/stack/monkecoin,
+	)
+
+
+
+
 
 /obj/item/mcobject/interactor/Initialize(mapload)
 	. = ..()
@@ -166,6 +175,9 @@
 		else
 			held_item.forceMove(drop_location())
 		held_item = null
+	if(is_type_in_list(weapon, blacklist))
+		say("[weapon] is incompatible with the interaction component!")
+		return
 	held_item = weapon
 	dummy_human.put_in_l_hand(weapon)
 	update_appearance()

--- a/monkestation/code/modules/mech_comp/objects/interactor.dm
+++ b/monkestation/code/modules/mech_comp/objects/interactor.dm
@@ -171,7 +171,7 @@
 		else
 			held_item.forceMove(drop_location())
 		held_item = null
-	if(is_type_in_list(weapon, blacklist))
+	if(is_type_in_typecache(weapon, item_blacklist))
 		say("[weapon] is incompatible with the interaction component!")
 		return
 	held_item = weapon


### PR DESCRIPTION

## About The Pull Request

Fixes #5245, #5262.

Disables money from being placed within an interaction component, fixing a money dupe.


## Changelog
:cl:
fix: Fixes a money dupe by blacklisting spacecash and monkecoin from interaction components.
/:cl:
