### PR TITLE
Fix the Delightful Effect symptom

### DIFF
--- a/monkestation/code/modules/datums/mood_events/generic_positive_events.dm
+++ b/monkestation/code/modules/datums/mood_events/generic_positive_events.dm
@@ -18,3 +18,7 @@
 	description = "Oooh, jazzy!"
 	mood_change = 2
 	timeout = 1 MINUTE
+
+/datum/mood_event/delightful_symptom
+	description = "Everything feels so nice and wonderful!"
+	mood_change = 50

--- a/monkestation/code/modules/virology/disease/symtoms/helpful/delightful.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/helpful/delightful.dm
@@ -6,6 +6,9 @@
 	severity = 0
 
 /datum/symptom/delightful/activate(mob/living/carbon/mob)
-	to_chat(mob, "<span class = 'notice'>You feel delightful!</span>")
-	if (mob.reagents?.get_reagent_amount(/datum/reagent/drug/happiness) < 5)
-		mob.reagents.add_reagent(/datum/reagent/drug/happiness, 10)
+	if(!mob.mob_mood?.has_mood_of_category(REF(src)))
+		to_chat(mob, span_hypnophrase("You feel delightful!"))
+	mob.add_mood_event(REF(src), /datum/mood_event/delightful_symptom)
+
+/datum/symptom/delightful/deactivate(mob/living/carbon/mob, datum/disease/acute/disease)
+	mob?.clear_mood_event(REF(src))


### PR DESCRIPTION
## About The Pull Request

this fixes of a runtime in the Delightful Effect symptom, and just makes it directly add a moodlet instead of injecting happiness.

happiness causes brain damage - and borbop confirmed that causing brain damage was an oversight rather than an intentional side-effect.

## Why It's Good For The Game

bugfix good

## Changelog
:cl:
fix: The "Delightful Effect" symptom no longer causes brain damage, and should also no longer potentially spam chat.
/:cl:
