### PR TITLE
Adds a BCI manipulator to Void Raptor's circuit lab

### DIFF
--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -46280,6 +46280,7 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
+/obj/machinery/bci_implanter,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 8
 	},


### PR DESCRIPTION

## About The Pull Request

Title, it was missing even though it should be present on all maps.
## Why It's Good For The Game

It's an annoying thing to build and its components serve no upgrade purposes anyway.
It's also standardized on all other maps by me myself and I, so here's another.
## Changelog
:cl:
add: There's a BCI manipulator in Void Raptor's circuit lab now.
/:cl:
