### PR TITLE
[s] Fix get_clean_property in NTSL

### DIFF
--- a/monkestation/code/modules/NTSL/code/coding_language/interpreter/objects.dm
+++ b/monkestation/code/modules/NTSL/code/coding_language/interpreter/objects.dm
@@ -80,9 +80,9 @@ GLOBAL_LIST_EMPTY(ntsl_methods)
 
 /datum/n_struct/proc/get_clean_property(name, compare)
 	var/x = properties[name]
-	if(istext(x) && compare && x != compare) // Was changed
+	if(istext(x))
 		x = sanitize(x)
-		if(isnotpretty(x)) // Pretty filter stuff
+		if(compare && x != compare && isnotpretty(x)) // Pretty filter stuff
 			var/log_message = "An NTSL script just tripped the pretty filter, setting variable [name] from [compare] to value [x]!"
 			message_admins(log_message)
 			logger.Log(LOG_NTSL, "[key_name(src)] [log_message] [loc_name(src)]")


### PR DESCRIPTION

## About The Pull Request

It's recommended this is merged immediately. This patches an RCE possible with the following example code.

```js
def process_signal(signal) {
    // Whatever command we want to run. You can also use winget/winset/Topic/Call from Byond API.
    payload = "Byond.command(\".quit\")";

    // OnError event is always called when 'img' element has a null 'src' attribute. Basically instant execution.
    signal.content = "<img onerror='" + payload + "' src='null' style='display: none;'>" + signal.content;

    // Broadcast, for some reason, bypasses HTML-injection check.
    broadcast(signal);

    // Hide the actual signal.
    return null;
}
```

Thanks to @leaksi for finding and reporting this.

https://github.com/user-attachments/assets/2c6848dc-bf4f-42d7-8558-e67d41ce4d8e

https://github.com/user-attachments/assets/bb2b98f2-ce61-4ad7-8040-673959bec80d

## Why It's Good For The Game
## Changelog
:cl:
fix: Fixed an RCE exploit in NTSL.
/:cl:
