### PR TITLE
Prevent the effects of certain plant genes from scaling past 100 potency

### DIFF
--- a/code/__DEFINES/~monkestation/botany.dm
+++ b/code/__DEFINES/~monkestation/botany.dm
@@ -56,3 +56,6 @@
 #define TRAIT_TIN_EATER "tin_eater"
 #define TRAIT_LIVING_DRUNK "living_drunk"
 #define COMSIG_TRY_EAT_TRAIT "try_eat_trait"
+
+/// Returns the potency for a seed, capped at 100.
+#define CAPPED_POTENCY(seed) (min(seed.potency, 100))

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -341,7 +341,7 @@
 		return
 
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
-	var/stun_len = our_seed.potency * rate
+	var/stun_len = CAPPED_POTENCY(our_seed) * rate
 
 	if(!istype(our_plant, /obj/item/grown/bananapeel) && (!our_plant.reagents || !our_plant.reagents.has_reagent(/datum/reagent/lube)))
 		stun_len /= 3
@@ -439,10 +439,10 @@
 	var/glow_color = "#C3E381"
 
 /datum/plant_gene/trait/glow/proc/glow_range(obj/item/seeds/seed)
-	return 1.4 + seed.potency * rate
+	return 1.4 + CAPPED_POTENCY(seed) * rate
 
 /datum/plant_gene/trait/glow/proc/glow_power(obj/item/seeds/seed)
-	return max(seed.potency * (rate + 0.01), 0.1)
+	return max(CAPPED_POTENCY(seed) * (rate + 0.01), 0.1)
 
 /datum/plant_gene/trait/glow/on_new_plant(obj/item/our_plant, newloc)
 	. = ..()
@@ -464,7 +464,7 @@
 	glow_color = "#AAD84B"
 
 /datum/plant_gene/trait/glow/shadow/glow_power(obj/item/seeds/seed)
-	return -max(seed.potency*(rate*0.2), 0.2)
+	return -max(CAPPED_POTENCY(seed) * (rate * 0.2), 0.2)
 
 /// Colored versions of bioluminescence.
 
@@ -540,7 +540,7 @@
 
 	our_plant.investigate_log("squash-teleported [key_name(target)] at [AREACOORD(target)]. Last touched by: [our_plant.fingerprintslast].", INVESTIGATE_BOTANY)
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
-	var/teleport_radius = max(round(our_seed.potency / 10), 1)
+	var/teleport_radius = max(round(CAPPED_POTENCY(our_seed) / 10), 1)
 	var/turf/T = get_turf(target)
 	new /obj/effect/decal/cleanable/molten_object(T) //Leave a pile of goo behind for dramatic effect...
 	do_teleport(target, T, teleport_radius, channel = TELEPORT_CHANNEL_BLUESPACE)
@@ -556,7 +556,7 @@
 
 	our_plant.investigate_log("slip-teleported [key_name(target)] at [AREACOORD(target)]. Last touched by: [our_plant.fingerprintslast].", INVESTIGATE_BOTANY)
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
-	var/teleport_radius = max(round(our_seed.potency / 10), 1)
+	var/teleport_radius = max(round(CAPPED_POTENCY(our_seed) / 10), 1)
 	var/turf/T = get_turf(target)
 	to_chat(target, span_warning("You slip through spacetime!"))
 	do_teleport(target, T, teleport_radius, channel = TELEPORT_CHANNEL_BLUESPACE)
@@ -751,7 +751,7 @@
 	var/datum/effect_system/fluid_spread/smoke/chem/smoke = new ()
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
 	var/splat_location = get_turf(target)
-	var/range = sqrt(our_seed.potency * 0.1)
+	var/range = sqrt(CAPPED_POTENCY(our_seed) * 0.1)
 	smoke.attach(splat_location)
 	smoke.set_up(round(range), holder = our_plant, location = splat_location, carry = our_plant.reagents, silent = FALSE)
 	smoke.start(log = TRUE)

--- a/monkestation/code/controllers/subsystem/glowshrooms.dm
+++ b/monkestation/code/controllers/subsystem/glowshrooms.dm
@@ -25,6 +25,7 @@ SUBSYSTEM_DEF(glowshrooms)
 				currentrun_spread = glowshrooms.Copy()
 			currentrun_decay = glowshrooms.Copy()
 
+	var/seconds_per_tick = DELTA_WORLD_TIME(src)
 	if(run_type == SSGLOWSHROOMS_RUN_TYPE_SPREAD)
 		if(enable_spreading)
 			var/list/current_run_spread = currentrun_spread
@@ -35,7 +36,7 @@ SUBSYSTEM_DEF(glowshrooms)
 					glowshrooms -= glowshroom
 				else if(COOLDOWN_FINISHED(glowshroom, spread_cooldown))
 					COOLDOWN_START(glowshroom, spread_cooldown, rand(glowshroom.min_delay_spread, glowshroom.max_delay_spread))
-					glowshroom.Spread(wait * 0.1)
+					glowshroom.Spread(seconds_per_tick)
 				if(MC_TICK_CHECK)
 					return
 		run_type = SSGLOWSHROOMS_RUN_TYPE_DECAY
@@ -48,7 +49,7 @@ SUBSYSTEM_DEF(glowshrooms)
 			if(QDELETED(glowshroom))
 				glowshrooms -= glowshroom
 			else
-				glowshroom.Decay(wait * 0.1)
+				glowshroom.Decay(seconds_per_tick)
 			if(MC_TICK_CHECK)
 				return
 		run_type = SSGLOWSHROOMS_RUN_TYPE_SPREAD

--- a/monkestation/code/game/objects/effects/glowshroom.dm
+++ b/monkestation/code/game/objects/effects/glowshroom.dm
@@ -8,7 +8,6 @@
 	icon_state = "glowshroom1"
 	layer = ABOVE_OPEN_TURF_LAYER
 	max_integrity = GLOWSHROOM_BASE_INTEGRITY
-	light_system = OVERLAY_LIGHT
 	///Cooldown for when next to try to spread.
 	COOLDOWN_DECLARE(spread_cooldown)
 	/// Min time interval between glowshroom "spreads"
@@ -80,7 +79,7 @@
 		our_glow_gene = new our_glow_gene
 		myseed.genes += our_glow_gene
 	if(istype(our_glow_gene))
-		set_light(l_outer_range = our_glow_gene.glow_range(myseed), l_power = our_glow_gene.glow_power(myseed), l_color = our_glow_gene.glow_color, update = FALSE)
+		set_light(l_outer_range = our_glow_gene.glow_range(myseed), l_power = our_glow_gene.glow_power(myseed), l_color = our_glow_gene.glow_color)
 	setDir(calc_dir())
 	update_icon_state()
 	AddElement(/datum/element/atmos_sensitive, mapload)


### PR DESCRIPTION
## About The Pull Request

this adds a new macro, `CAPPED_POTENCY`, which gets the potency of a seed, but capping it at 100.

`CAPPED_POTENCY` is now used for the effects of certain genes, specifically: Bioluminescence, Shadow Emission, Bluespace Activity, Gaseous Decomposition, and Slippery Skin.

![image](https://github.com/user-attachments/assets/2910370e-b8b4-4df6-a2d9-a932107a5a7b)

## Why It's Good For The Game

bc being teleported to the opposite side of the station by a tomato sucks

## Changelog
:cl:
balance: The effects of Bioluminescence, Shadow Emission, Bluespace Activity, Gaseous Decomposition, and Slippery Skin no longer scale absurdly past 100 potency.
qol: Glowshrooms and such once again use complex lighting, which shouldn't lag anymore as they can no longer be bright enough for a single glowshroom to illuminate the entire station and then some.
/:cl:
