### PR TITLE
Adds cascade trait support and ports a trait macro runtime fix from upstream

### DIFF
--- a/code/__DEFINES/traits/_traits.dm
+++ b/code/__DEFINES/traits/_traits.dm
@@ -74,7 +74,9 @@
 		var/list/_S = sources; \
 		if (_L) { \
 			for (var/_T in _L) { \
-				_L[_T] &= _S;\
+				if (_L[_T]) { \
+					_L[_T] &= _S; \
+				}; \
 				if (!length(_L[_T])) { \
 					_L -= _T; \
 					SEND_SIGNAL(target, SIGNAL_REMOVETRAIT(_T), _T); \
@@ -97,7 +99,9 @@
 		}; \
 		if (_L) { \
 			for (var/_T in _L) { \
-				_L[_T] -= _S;\
+				if (_L[_T]) { \
+					_L[_T] -= _S; \
+				}; \
 				if (!length(_L[_T])) { \
 					_L -= _T; \
 					SEND_SIGNAL(target, SIGNAL_REMOVETRAIT(_T)); \

--- a/code/__HELPERS/~monkestation-helpers/traits.dm
+++ b/code/__HELPERS/~monkestation-helpers/traits.dm
@@ -1,0 +1,15 @@
+/datum
+	/// Lazylist of trait cascade targets. Don't modify this directly, refer to 'cascade_trait()' instead.
+	var/list/_cascade_targets
+
+/// Links 'trait' to 'target_trait', such that when 'trait' is added/removed 'target_trait' is too. Uses 'trait' as the source.
+/datum/proc/cascade_trait(trait, target_trait)
+	RegisterSignal(src, SIGNAL_ADDTRAIT(trait), PROC_REF(_cascade_trait_gain))
+	RegisterSignal(src, SIGNAL_REMOVETRAIT(trait), PROC_REF(_cascade_trait_loss))
+	LAZYSET(_cascade_targets, trait, target_trait)
+
+/datum/proc/_cascade_trait_gain(datum/source, trait)
+	ADD_TRAIT(src, _cascade_targets[trait], trait)
+
+/datum/proc/_cascade_trait_loss(datum/source, trait)
+	REMOVE_TRAIT(src, _cascade_targets[trait], trait)

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -10,7 +10,7 @@
 	if(HAS_TRAIT(src, TRAIT_NOBLOOD) || HAS_TRAIT(src, TRAIT_FAKEDEATH))
 		return
 
-	if(bodytemperature < BLOOD_STOP_TEMP || HAS_TRAIT(src, TRAIT_HUSK)) //cold or husked people do not pump the blood.
+	if(bodytemperature < BLOOD_STOP_TEMP) // MONKESTATION EDIT: Made TRAIT_HUSK cascade into TRAIT_NOBLOOD, making snowflake checks unnecessary.
 		return
 
 	var/sigreturn = SEND_SIGNAL(src, COMSIG_HUMAN_ON_HANDLE_BLOOD, seconds_per_tick, times_fired)
@@ -289,12 +289,12 @@
 	return GLOB.blood_types[/datum/blood_type/oil]
 
 /mob/living/carbon/alien/get_blood_type()
-	if(HAS_TRAIT(src, TRAIT_HUSK) || HAS_TRAIT(src, TRAIT_NOBLOOD))
+	if(HAS_TRAIT(src, TRAIT_NOBLOOD)) // MONKESTATION EDIT: Made TRAIT_HUSK cascade into TRAIT_NOBLOOD, making snowflake checks unnecessary.
 		return null
 	return GLOB.blood_types[/datum/blood_type/xenomorph]
 
 /mob/living/carbon/human/get_blood_type()
-	if(HAS_TRAIT(src, TRAIT_HUSK) || isnull(dna) || HAS_TRAIT(src, TRAIT_NOBLOOD))
+	if(!has_dna() || HAS_TRAIT(src, TRAIT_NOBLOOD)) // MONKESTATION EDIT: Made TRAIT_HUSK cascade into TRAIT_NOBLOOD, making snowflake checks unnecessary.
 		return null
 	if(check_holidays(APRIL_FOOLS) && is_clown_job(mind?.assigned_role))
 		return GLOB.blood_types[/datum/blood_type/clown]

--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -10,7 +10,7 @@
 	)
 
 /datum/surgery/blood_filter/can_start(mob/user, mob/living/carbon/target)
-	if(HAS_TRAIT(target, TRAIT_HUSK)) //You can filter the blood of a dead person just not husked
+	if(HAS_TRAIT(target, TRAIT_NOBLOOD)) // MONKESTATION EDIT: You can't filter the blood of people without blood. Duh.
 		return FALSE
 	return ..()
 

--- a/monkestation/code/modules/mob/living/init_signals.dm
+++ b/monkestation/code/modules/mob/living/init_signals.dm
@@ -1,5 +1,8 @@
 /mob/living/register_init_signals()
 	. = ..()
+
+	cascade_trait(TRAIT_HUSK, TRAIT_NOBLOOD)
+
 	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_IGNOREDAMAGESLOWDOWN), PROC_REF(on_ignoredamageslowdown_trait_gain))
 	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_IGNOREDAMAGESLOWDOWN), PROC_REF(on_ignoredamageslowdown_trait_loss))
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -611,6 +611,7 @@
 #include "code\__HELPERS\~monkestation-helpers\records.dm"
 #include "code\__HELPERS\~monkestation-helpers\roundend.dm"
 #include "code\__HELPERS\~monkestation-helpers\time.dm"
+#include "code\__HELPERS\~monkestation-helpers\traits.dm"
 #include "code\__HELPERS\~monkestation-helpers\uwuify.dm"
 #include "code\__HELPERS\~monkestation-helpers\virology.dm"
 #include "code\__HELPERS\~monkestation-helpers\logging\attack.dm"


### PR DESCRIPTION
## About The Pull Request

Ports [#89344](https://github.com/tgstation/tgstation/pull/89344)

Adds cascade trait support. Cascade traits are traits which add other traits. This is already done manually on some things like TRAIT_HUSK adding TRAIT_DISFIGURED and TRAIT_KNOCKEDOUT adding TRAIT_HANDS_BLOCKED and whatnot.

This streamlines that. I'm not going to refactor the existing stuff too much out of fear of breaking it, especially TRAIT_DISFIGURED as it seems to be tied to update_body() in the husk procs. I also just don't want to spend time on that.

Either way, this adds a framework for doing this in the future and refactors out TRAIT_HUSK being synonymous to TRAIT_NOBLOOD to an extent. Basically it was snowflake checked in several places. Now it isn't.

As a result, husks no longer have blood. Proper. They kinda didn't before. Now they absolutely just don't have any.
## Why It's Good For The Game

Better code quality, also helps me with the vampire rework.
## Changelog
:cl:
refactor: Husks no longer "kind of do kind of don't" have blood, rather they just don't have any, proper. Report issues.
/:cl:
