### PR TITLE
Fixes IPC chassis coloring / Adds mutcolor secondary antenna

### DIFF
--- a/monkestation/code/modules/mob/dead/new_player/sprite_accessories/ipc_antenna.dm
+++ b/monkestation/code/modules/mob/dead/new_player/sprite_accessories/ipc_antenna.dm
@@ -1,7 +1,7 @@
 /datum/sprite_accessory/ipc_antennas
 	icon = 'monkestation/icons/mob/species/ipc/ipc_antennas.dmi'
 	palette = /datum/color_palette/generic_colors
-	palette_key = MUTANT_COLOR
+	palette_key = MUTANT_COLOR_SECONDARY
 
 /datum/sprite_accessory/ipc_antennas/none
 	name = "None"

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
@@ -22,6 +22,8 @@
 		TRAIT_REVIVES_BY_HEALING,
 		TRAIT_NO_DNA_COPY,
 		TRAIT_NO_TRANSFORMATION_STING,
+		TRAIT_MUTANT_COLORS,
+		TRAIT_MUTANT_COLORS_SECONDARY,
 		TRAIT_NO_HUSK,
 
 	)
@@ -222,7 +224,7 @@
 		BP.limb_id = chassis_of_choice.icon_state
 		BP.name = "\improper[chassis_of_choice.name] [parse_zone(BP.body_zone)]"
 		BP.update_limb()
-		if(chassis_of_choice.color_src == MUTANT_COLOR)
+		if(chassis_of_choice.palette_key == MUTANT_COLOR)
 			BP.should_draw_greyscale = TRUE
 
 /datum/species/ipc/proc/on_emag_act(mob/living/carbon/human/owner, mob/user)

--- a/monkestation/code/modules/surgery/bodyparts/ipc_bodyparts.dm
+++ b/monkestation/code/modules/surgery/bodyparts/ipc_bodyparts.dm
@@ -6,6 +6,8 @@
 	icon_state = "synth_head"
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
+	palette = /datum/color_palette/generic_colors
+	palette_key = MUTANT_COLOR
 	biological_state = BIO_ROBOTIC | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 	head_flags = HEAD_HAIR |  HEAD_LIPS | HEAD_EYECOLOR | HEAD_LIPS
@@ -30,6 +32,8 @@
 	icon_state = "synth_chest"
 	is_dimorphic = FALSE
 	should_draw_greyscale = FALSE
+	palette = /datum/color_palette/generic_colors
+	palette_key = MUTANT_COLOR
 	biological_state = BIO_ROBOTIC | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 	bodypart_traits = list(TRAIT_LIMBATTACHMENT)
@@ -54,6 +58,8 @@
 	icon_state = "synth_l_arm"
 	flags_1 = CONDUCT_1
 	should_draw_greyscale = FALSE
+	palette = /datum/color_palette/generic_colors
+	palette_key = MUTANT_COLOR
 	biological_state = BIO_ROBOTIC | BIO_JOINTED | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 	brute_modifier = 1.2 // Monkestation Edit
@@ -78,6 +84,8 @@
 	icon_state = "synth_r_arm"
 	flags_1 = CONDUCT_1
 	should_draw_greyscale = FALSE
+	palette = /datum/color_palette/generic_colors
+	palette_key = MUTANT_COLOR
 	biological_state = BIO_ROBOTIC | BIO_JOINTED | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 	brute_modifier = 1.2 // Monkestation Edit
@@ -102,6 +110,8 @@
 	icon_state = "synth_l_leg"
 	flags_1 = CONDUCT_1
 	should_draw_greyscale = FALSE
+	palette = /datum/color_palette/generic_colors
+	palette_key = MUTANT_COLOR
 	biological_state = BIO_ROBOTIC | BIO_JOINTED | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 	brute_modifier = 1.2 // Monkestation Edit
@@ -124,6 +134,8 @@
 	icon_state = "synth_r_leg"
 	flags_1 = CONDUCT_1
 	should_draw_greyscale = FALSE
+	palette = /datum/color_palette/generic_colors
+	palette_key = MUTANT_COLOR
 	biological_state = BIO_ROBOTIC | BIO_JOINTED | BIO_BLOODED
 	bodytype = BODYTYPE_HUMANOID | BODYTYPE_ROBOTIC
 	brute_modifier = 1.2 // Monkestation Edit

--- a/monkestation/code/modules/surgery/organs/external/ipc.dm
+++ b/monkestation/code/modules/surgery/organs/external/ipc.dm
@@ -16,6 +16,9 @@
 /datum/bodypart_overlay/mutant/antennae/ipc
 	layers = EXTERNAL_FRONT | EXTERNAL_BEHIND
 	feature_key = "ipc_antenna"
+	palette = /datum/color_palette/generic_colors
+	palette_key = MUTANT_COLOR_SECONDARY
+	color_source = ORGAN_COLOR_MUTSECONDARY
 
 /datum/bodypart_overlay/mutant/antennae/ipc/get_global_feature_list()
 	return GLOB.ipc_antennas_list


### PR DESCRIPTION
## About The Pull Request

I logged in to monke for the first time to discover that IPCs Cyberkinetics chassis were not colorable, despite being greyscale and designed to do so, oh no! This corrects that specific chassis to allow MUTANT_COLOR, and fixes the antenna options to allow MUTANT_COLOR_SECONDARY
## Why It's Good For The Game

![dreamseeker_EZO7qETpKo](https://github.com/user-attachments/assets/1318af0c-dd5a-463c-b5a8-2ccaba193c84)


Character customization options are nice! I compared them against other species offerings, and I think this is in line with the choices/design options available to others.
## Changelog
:cl:
fix: IPC Cyberkinetics Chassis (Greyscale) now accepts Mutant colors
add: IPC Antenna options now accept Secondary Mutant colors
/:cl:
