### PR TITLE
Removes pain on being damaged

### DIFF
--- a/monkestation/code/modules/can_spessmen_feel_pain/pain/_base.dm
+++ b/monkestation/code/modules/can_spessmen_feel_pain/pain/_base.dm
@@ -86,7 +86,7 @@
 	RegisterSignal(parent, COMSIG_CARBON_REMOVE_LIMB, PROC_REF(remove_bodypart))
 	RegisterSignal(parent, COMSIG_LIVING_HEALTHSCAN, PROC_REF(on_analyzed))
 	RegisterSignal(parent, COMSIG_LIVING_POST_FULLY_HEAL, PROC_REF(on_fully_healed))
-	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(add_damage_pain))
+//	RegisterSignal(parent, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(add_damage_pain))
 	RegisterSignal(parent, COMSIG_MOB_STATCHANGE, PROC_REF(on_parent_statchance))
 	RegisterSignals(parent, list(SIGNAL_ADDTRAIT(TRAIT_NO_PAIN_EFFECTS), SIGNAL_REMOVETRAIT(TRAIT_NO_PAIN_EFFECTS)), PROC_REF(refresh_pain_attributes))
 	RegisterSignal(parent, COMSIG_LIVING_TREAT_MESSAGE, PROC_REF(handle_message))
@@ -363,7 +363,7 @@
  * damage - the amount of damage sustained
  * damagetype - the type of damage sustained
  * def_zone - the limb being targeted with damage (either a bodypart zone or an obj/item/bodypart)
- */
+
 /datum/pain/proc/add_damage_pain(
 	mob/living/carbon/source,
 	damage,
@@ -483,7 +483,7 @@
 #endif
 
 	adjust_bodypart_pain(def_zone, pain, damagetype)
-
+*/
 /**
  * Add pain in from a received wound based on severity.
  *


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Comments out proc "add_damage_pain"

Being damage no longer directly causes pain. Otherwise untouched, things like broken legs, regen extracts, and other things that directly do pain still do.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Pain is a mechanic most people don't mind or hate while also enjoyed by a few.
![image](https://github.com/user-attachments/assets/3cb23ae9-5062-44c2-bc76-3be1b736c243)
This will leave pain as a mechanic that can be played around or through, along with giving a greater amount of control over it for coders and people being hurt by it, and using it to hurt. As well as making it slightly more minor.

Pain is great in concept, it allows for another thing to be played around, its a great way to balance out some items such as regen extracts, another mechanic for doctors when it comes up, its also great in combat for wounding and disabling to a greater degree, however it being tied to damage is where stuff starts getting messy. 

People who take a prolonged amount of damage or are able to take more, are greatly affected by pain although they shouldn't be in most cases(cultist, his grace, most antags in general). While most these are fixed by PRs overtime, more pop up pretty often, and its only after someone has ran into that issue on these not so common antags ruining a rare roll. Beyond this it also screws with weapon balance quite a bit, being a aspect hard to account for, a few weapons were buffed GREATLY by pain being able to send people into pain stuns in 2 or 3 hits, effectively being 2-3 hits to kill considering they can't move and are basically dead at this point.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Taking damage no longer causes pain, things like wounds still do.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
