### PR TITLE
TRAIT_NOHUNGER and TRAIT_FAT refactor stuff

### DIFF
--- a/code/modules/surgery/organs/stomach/_stomach.dm
+++ b/code/modules/surgery/organs/stomach/_stomach.dm
@@ -125,21 +125,12 @@
 	if(HAS_TRAIT(human, TRAIT_NOHUNGER))
 		return //hunger is for BABIES
 
-	//The fucking TRAIT_FAT mutation is the dumbest shit ever. It makes the code so difficult to work with
-	if(HAS_TRAIT_FROM(human, TRAIT_FAT, OBESITY))//I share your pain, past coder.
-		if(human.overeatduration < (200 SECONDS))
-			to_chat(human, span_notice("You feel fit again!"))
-			REMOVE_TRAIT(human, TRAIT_FAT, OBESITY)
-			human.remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
-			human.update_worn_undersuit()
-			human.update_worn_oversuit()
-	else
-		if(human.overeatduration >= (200 SECONDS))
-			to_chat(human, span_danger("You suddenly feel blubbery!"))
-			ADD_TRAIT(human, TRAIT_FAT, OBESITY)
-			human.add_movespeed_modifier(/datum/movespeed_modifier/obesity)
-			human.update_worn_undersuit()
-			human.update_worn_oversuit()
+	// MONKESTATION REFACTOR START: Move all this bullshit into trait signals.
+	if(HAS_TRAIT_FROM(human, TRAIT_FAT, OBESITY) && human.overeatduration < (200 SECONDS))
+		REMOVE_TRAIT(human, TRAIT_FAT, OBESITY) // If you're obese and haven't overeaten in a while, become fit.
+	else if(human.overeatduration >= (200 SECONDS))
+		ADD_TRAIT(human, TRAIT_FAT, OBESITY) // If you're fit and you've overeaten a bunch, become obese.
+	// MONKESTATION REFACTOR END
 
 	// nutrition decrease and satiety
 	if (human.nutrition > 0 && human.stat != DEAD)

--- a/monkestation/code/modules/mob/living/carbon/human/init_signals.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/init_signals.dm
@@ -2,6 +2,23 @@
 	. = ..()
 	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_NOBLOOD), PROC_REF(on_lose_noblood_trait))
 
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_FAT), PROC_REF(on_trait_fat_gain))
+	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_FAT), PROC_REF(on_trait_fat_loss))
+
 /mob/living/carbon/human/proc/on_lose_noblood_trait(datum/source)
 	SIGNAL_HANDLER
 	blood_volume = clamp(blood_volume, BLOOD_VOLUME_NORMAL, BLOOD_VOLUME_MAXIMUM - 1)
+
+/mob/living/carbon/human/proc/on_trait_fat_gain(datum/source)
+	SIGNAL_HANDLER
+	to_chat(src, span_danger("You suddenly feel blubbery!"))
+	add_movespeed_modifier(/datum/movespeed_modifier/obesity)
+	update_worn_undersuit()
+	update_worn_oversuit()
+
+/mob/living/carbon/human/proc/on_trait_fat_loss(datum/source)
+	SIGNAL_HANDLER
+	to_chat(src, span_notice("You feel fit again!"))
+	remove_movespeed_modifier(/datum/movespeed_modifier/obesity)
+	update_worn_undersuit()
+	update_worn_oversuit()

--- a/monkestation/code/modules/mob/living/init_signals.dm
+++ b/monkestation/code/modules/mob/living/init_signals.dm
@@ -9,6 +9,9 @@
 	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_CLOWN_DISBELIEVER), PROC_REF(on_clown_disbeliever_trait_gain))
 	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_CLOWN_DISBELIEVER), PROC_REF(on_clown_disbeliever_trait_loss))
 
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_NOHUNGER), PROC_REF(on_nohunger_trait_gain))
+	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_NOHUNGER), PROC_REF(on_nohunger_trait_loss))
+
 /mob/living/proc/on_ignoredamageslowdown_trait_gain(datum/source)
 	SIGNAL_HANDLER
 	add_movespeed_mod_immunities(TRAIT_IGNOREDAMAGESLOWDOWN, /datum/movespeed_modifier/damage_slowdown)
@@ -35,3 +38,11 @@
 	SIGNAL_HANDLER
 	for(var/datum/atom_hud/alternate_appearance/basic/clown_disbelief/clown_to_hide in GLOB.active_alternate_appearances)
 		clown_to_hide.hide_from(src)
+
+/mob/living/proc/on_nohunger_trait_gain(datum/source)
+	SIGNAL_HANDLER
+	reset_hunger()
+
+/mob/living/proc/on_nohunger_trait_loss(datum/source)
+	SIGNAL_HANDLER
+	reset_hunger()

--- a/monkestation/code/modules/mob/living/living.dm
+++ b/monkestation/code/modules/mob/living/living.dm
@@ -1,3 +1,16 @@
 // This adds extra overhead to getting `lying_angle` directly but doing so upsets SpacemanDMM as it's set to protected
 /mob/living/proc/get_lying_angle()
 	return lying_angle
+
+/// Comprehensively resets every single hunger thing the mob could possibly have from alerts to obesity. At least ideally it does.
+/mob/living/proc/reset_hunger()
+	// Reset all the funny variables.
+	set_nutrition(NUTRITION_LEVEL_FED)
+	metabolism_efficiency = 1
+	overeatduration = 0
+	satiety = 0
+
+	// And then undo a couple effects.
+	remove_movespeed_modifier(/datum/movespeed_modifier/hunger)
+	REMOVE_TRAIT(src, TRAIT_FAT, OBESITY)
+	clear_alert(ALERT_NUTRITION)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

TRAIT_NOHUNGER now resets your hunger status when added/removed so the alert and such don't stick around.
TRAIT_FAT now handles all the associated code on add/remove instead of it being snowflaked separately.

I checked and TRAIT_FAT is added/removed nowhere other than where I touched it.
This PR has also been tested in-game, things seem to work as expected so far.
Pretty sure the overlays not updating properly is unrelated to this PR.

In fact it seems the overlays just don't have ANY associated code. At all. Anywhere.
Very weird, I think I just stumbled upon another bug. Gonna leave the update code in though.
Why leave it in? Just in case someone else comes in and fixes this shit. No reason not to leave it in.

There's also some fat mutation oldcode BS going on in there. Said mutation doesn't exist.
And yet our code is accounting for it via sources and such, ugh... not my problem.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes the code less painful to read and makes "you can't be hungry" actually stand true.
Also I just wanted to do this for the vamp rework cause it uses the trait.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
refactor: Refactored the trait that makes people not get hungry and made obesity code less dumb. Report any problems please.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
