### PR TITLE
plane debugger now checks for +DEBUG

### DIFF
--- a/code/modules/admin/verbs/plane_debugger.dm
+++ b/code/modules/admin/verbs/plane_debugger.dm
@@ -77,7 +77,7 @@
 	set_target(get_target())
 
 /datum/plane_master_debug/ui_state(mob/user)
-	return GLOB.admin_state
+	return GLOB.debug_state // monkestation edit: a debug UI should check for +DEBUG
 
 /datum/plane_master_debug/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION

## About The Pull Request

the plane debugger UI (Debug -> Edit/Debug Planes) now uses `GLOB.debug_state` instead of `GLOB.admin_state`

## Why It's Good For The Game

> _debug_ UI
> verb is given to users with +DEBUG
> doesn't actually work with just +DEBUG

## Changelog

no player facing changes, and i'm prolly like the only person on monke who's ever going to use the plane debugger anyways