### PR TITLE
Fix opening the Lua editor being broken

### DIFF
--- a/code/modules/admin/verbs/lua/lua_editor.dm
+++ b/code/modules/admin/verbs/lua/lua_editor.dm
@@ -286,7 +286,7 @@
 	set name = "Open Lua Editor"
 	set desc = "Its codin' time."
 	set category = "Debug"
-	if(!check_rights(src, R_DEBUG))
+	if(!check_rights(R_DEBUG))
 		return
 #ifndef DISABLE_DREAMLUAU
 	var/datum/lua_editor/editor = new


### PR DESCRIPTION
## Changelog
:cl:
fix: Admins can once again use the Lua editor.
/:cl:
