### PR TITLE
Charlie Station now has a unique ID console program and ID painter.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -4265,7 +4265,7 @@
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/card/id/advanced/old{
-	trim = /datum/id_trim/away/old/apc;
+	trim = /datum/id_trim/job/away/old/apc;
 	name = "Engineering Equipment Access"
 	},
 /obj/item/crowbar,
@@ -6227,7 +6227,7 @@
 "Ed" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/modular_computer/preset/id,
+/obj/machinery/modular_computer/preset/id/old,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/bridge)
 "Eg" = (
@@ -6673,7 +6673,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /obj/item/card/id/advanced/old{
-	trim = /datum/id_trim/away/old/robo;
+	trim = /datum/id_trim/job/away/old/robo;
 	registered_name = "Ash Holm";
 	name = "Ash Holm";
 	assignment = "Charlie Station Roboticist"
@@ -8754,7 +8754,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/fluff/ruins/oldstation/report,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/modular_computer/preset/command,
+/obj/machinery/modular_computer/preset/command/old,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/bridge)
 "UV" = (
@@ -8882,6 +8882,12 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/engine,
 /area/ruin/space/ancientstation/delta/biolab)
+"VX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/oldpdapainter,
+/turf/open/floor/iron,
+/area/ruin/space/ancientstation/charlie/bridge)
 "VZ" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -13314,7 +13320,7 @@ aI
 ei
 aI
 aI
-bm
+VX
 zr
 zy
 OT

--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -547,6 +547,31 @@
 /// Used to seed the accesses_by_region list in SSid_access. A list of all CENTCOM_ACCESS regional accesses.
 #define REGION_ACCESS_CENTCOM CENTCOM_ACCESS
 
+/// MONKESTATION ADDITION - Adds Charlie Station region, for the Charlie Station ID console.
+/// Name for the Charlie Station region.
+#define REGION_CHARLIE_STATION "Charlie Station"
+/// Used to seed the accesses_by_region list in SSid_access. A list of all ACCESS_AWAY regional accesses.
+#define REGION_ACCESS_CHARLIE_STATION list( \
+	ACCESS_AWAY_GENERAL, \
+	ACCESS_ROBOTICS, \
+	ACCESS_ORDNANCE, \
+	ACCESS_RESEARCH, \
+	ACCESS_AWAY_SCIENCE, \
+	ACCESS_AWAY_MAINTENANCE, \
+	ACCESS_AWAY_SUPPLY, \
+	ACCESS_AWAY_GENERIC1, \
+	ACCESS_AWAY_GENERIC2, \
+	ACCESS_AWAY_GENERIC3, \
+	ACCESS_AWAY_GENERIC4, \
+	ACCESS_AWAY_COMMAND, \
+	ACCESS_AWAY_MEDICAL, \
+	ACCESS_AWAY_SEC, \
+	ACCESS_AWAY_ENGINEERING, \
+	ACCESS_ENGINEERING, \
+	ACCESS_ENGINE_EQUIP, \
+)
+/// END OF ADDITION
+
 /**
  * A list of PDA paths that can be painted as well as the regional heads which should be able to paint them.
  * If a PDA is not in this list, it cannot be painted using the PDA & ID Painter.

--- a/code/controllers/subsystem/id_access.dm
+++ b/code/controllers/subsystem/id_access.dm
@@ -121,6 +121,7 @@ SUBSYSTEM_DEF(id_access)
 	accesses_by_region[REGION_SUPPLY] = REGION_ACCESS_SUPPLY
 	accesses_by_region[REGION_COMMAND] = REGION_ACCESS_COMMAND
 	accesses_by_region[REGION_CENTCOM] = REGION_ACCESS_CENTCOM
+	accesses_by_region[REGION_CHARLIE_STATION] = REGION_ACCESS_CHARLIE_STATION //MONKESTATION ADDITION - Used for Charlie Station ID console.
 
 	station_regions = REGION_AREA_STATION
 
@@ -324,6 +325,20 @@ SUBSYSTEM_DEF(id_access)
 	desc_by_access["[ACCESS_CENT_BAR]"] = "Code Scotch"
 	desc_by_access["[ACCESS_BIT_DEN]"] = "Bitrunner Den"
 	desc_by_access["[ACCESS_PERMABRIG]"] = "Permabrig" // monkestation edit: add permabrig-only access
+	//MONKESTATION EDITION - Adds descriptions to Charlie Station access levels. Used for Charlie Station ID Console.
+	desc_by_access["[ACCESS_AWAY_GENERAL]"] = "Charlie Station General"
+	desc_by_access["[ACCESS_AWAY_SCIENCE]"] = "Charlie Station Science"
+	desc_by_access["[ACCESS_AWAY_MAINTENANCE]"] = "Charlie Station Maintenance"
+	desc_by_access["[ACCESS_AWAY_SUPPLY]"] = "Charlie Station Supply"
+	desc_by_access["[ACCESS_AWAY_GENERIC1]"] = "Charlie Station Generic 1"
+	desc_by_access["[ACCESS_AWAY_GENERIC2]"] = "Charlie Station Generic 2"
+	desc_by_access["[ACCESS_AWAY_GENERIC3]"] = "Charlie Station Generic 3"
+	desc_by_access["[ACCESS_AWAY_GENERIC4]"] = "Charlie Station Generic 4"
+	desc_by_access["[ACCESS_AWAY_COMMAND]"] = "Charlie Station Command"
+	desc_by_access["[ACCESS_AWAY_MEDICAL]"] = "Charlie Station Medical"
+	desc_by_access["[ACCESS_AWAY_SEC]"] = "Charlie Station Security"
+	desc_by_access["[ACCESS_AWAY_ENGINEERING]"] = "Charlie Station Engineering"
+	//END OF ADDITION
 
 /**
  * Returns the access bitflags associated with any given access level.

--- a/code/controllers/subsystem/id_access.dm
+++ b/code/controllers/subsystem/id_access.dm
@@ -325,7 +325,7 @@ SUBSYSTEM_DEF(id_access)
 	desc_by_access["[ACCESS_CENT_BAR]"] = "Code Scotch"
 	desc_by_access["[ACCESS_BIT_DEN]"] = "Bitrunner Den"
 	desc_by_access["[ACCESS_PERMABRIG]"] = "Permabrig" // monkestation edit: add permabrig-only access
-	//MONKESTATION EDITION - Adds descriptions to Charlie Station access levels. Used for Charlie Station ID Console.
+	//MONKESTATION ADDITION - Adds descriptions to Charlie Station access levels. Used for Charlie Station ID Console.
 	desc_by_access["[ACCESS_AWAY_GENERAL]"] = "Charlie Station General"
 	desc_by_access["[ACCESS_AWAY_SCIENCE]"] = "Charlie Station Science"
 	desc_by_access["[ACCESS_AWAY_MAINTENANCE]"] = "Charlie Station Maintenance"

--- a/code/datums/id_trim/ruins.dm
+++ b/code/datums/id_trim/ruins.dm
@@ -10,29 +10,81 @@
 /datum/id_trim/away/hotel/security
 	access = list(ACCESS_AWAY_GENERAL, ACCESS_AWAY_MAINTENANCE, ACCESS_AWAY_SEC)
 
+/// MONKESTATION EDIT - Turns all Charlie Station trims into /datum/id_trim/job trims and adds extra_access (except where not needed).
 /// Trim for the oldstation ruin/Charlie station
-/datum/id_trim/away/old/sec
-	access = list(ACCESS_AWAY_GENERAL, ACCESS_AWAY_SEC)
+/datum/id_trim/job/away/old/sec
+	minimal_access = list(
+		ACCESS_AWAY_GENERAL,
+		ACCESS_AWAY_SEC
+	)
+	extra_access = list(
+		ACCESS_ROBOTICS,
+		ACCESS_ORDNANCE,
+		ACCESS_RESEARCH,
+		ACCESS_AWAY_SCIENCE,
+		ACCESS_AWAY_MAINTENANCE,
+		ACCESS_AWAY_SUPPLY,
+		ACCESS_AWAY_GENERIC1,
+		ACCESS_AWAY_GENERIC2,
+		ACCESS_AWAY_GENERIC3,
+		ACCESS_AWAY_GENERIC4,
+		ACCESS_AWAY_COMMAND,
+		ACCESS_AWAY_MEDICAL,
+		ACCESS_AWAY_ENGINEERING,
+		ACCESS_ENGINEERING,
+		ACCESS_ENGINE_EQUIP
+	)
 	assignment = "Charlie Station Security Officer"
 
 /// Trim for the oldstation ruin/Charlie station
-/datum/id_trim/away/old/sci
-	access = list(ACCESS_AWAY_GENERAL, ACCESS_AWAY_SCIENCE)
+/datum/id_trim/job/away/old/sci
+	minimal_access = list(
+		ACCESS_AWAY_GENERAL,
+		ACCESS_AWAY_SCIENCE
+	)
 	assignment = "Charlie Station Scientist"
 
 /// Trim for the oldstation ruin/Charlie station
-/datum/id_trim/away/old/eng
-	access = list(ACCESS_AWAY_GENERAL, ACCESS_AWAY_ENGINEERING)
+/datum/id_trim/job/away/old/eng
+	minimal_access = list(
+		ACCESS_AWAY_GENERAL,
+		ACCESS_AWAY_ENGINEERING
+	)
+	extra_access = list(
+		ACCESS_ROBOTICS,
+		ACCESS_ORDNANCE,
+		ACCESS_RESEARCH,
+		ACCESS_AWAY_SCIENCE,
+		ACCESS_AWAY_MAINTENANCE,
+		ACCESS_AWAY_SUPPLY,
+		ACCESS_AWAY_GENERIC1,
+		ACCESS_AWAY_GENERIC2,
+		ACCESS_AWAY_GENERIC3,
+		ACCESS_AWAY_GENERIC4,
+		ACCESS_AWAY_COMMAND,
+		ACCESS_AWAY_MEDICAL,
+		ACCESS_AWAY_SEC,
+		ACCESS_ENGINEERING,
+		ACCESS_ENGINE_EQUIP
+	)
 	assignment = "Charlie Station Engineer"
 
 /// Trim for the oldstation ruin/Charlie station to access APCs and other equipment
-/datum/id_trim/away/old/apc
-	access = list(ACCESS_ENGINEERING, ACCESS_ENGINE_EQUIP)
+/datum/id_trim/job/away/old/apc
+	minimal_access = list(
+		ACCESS_ENGINEERING,
+		ACCESS_ENGINE_EQUIP
+	)
 	assignment = "Engineering Equipment Access"
 
 /// Trim for the oldstation ruin/Charlie station to access robots, and downloading of paper publishing software for experiments
-/datum/id_trim/away/old/robo
-	access = list(ACCESS_AWAY_GENERAL, ACCESS_ROBOTICS, ACCESS_ORDNANCE)
+/datum/id_trim/job/away/old/robo
+	minimal_access = list(
+		ACCESS_AWAY_GENERAL,
+		ACCESS_ROBOTICS,
+		ACCESS_ORDNANCE
+	)
+///END OF EDIT
 
 /// Trim for the cat surgeon ruin.
 /datum/id_trim/away/cat_surgeon

--- a/code/game/objects/items/cards/card_ids.dm
+++ b/code/game/objects/items/cards/card_ids.dm
@@ -1,14 +1,14 @@
 /obj/item/card/id/away/old/cmo
 	name = "Charlie Station Chief Medical Officer's ID card"
 	desc = "A faded Charlie Station ID card. You can make out the rank \"Chief Medical Officer\"."
-	trim = /datum/id_trim/away/old/cmo
+	trim = /datum/id_trim/job/away/old/cmo
 
 /obj/item/card/id/away/old/chef
 	name = "Charlie Station Chef's ID card"
 	desc = "A faded Charlie Station ID card. You can make out the rank \"Chef\"."
-	trim = /datum/id_trim/away/old/chef
+	trim = /datum/id_trim/job/away/old/chef
 
 /obj/item/card/id/away/old/explorer
 	name = "Charlie Station Explorer's ID card"
 	desc = "A faded Charlie Station ID card. You can make out the rank \"Explorer\"."
-	trim = /datum/id_trim/away/old/explorer
+	trim = /datum/id_trim/job/away/old/explorer

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -852,27 +852,27 @@
 /obj/item/card/id/away/old/sec
 	name = "Charlie Station Security Officer's ID card"
 	desc = "A faded Charlie Station ID card. You can make out the rank \"Security Officer\"."
-	trim = /datum/id_trim/away/old/sec
+	trim = /datum/id_trim/job/away/old/sec /// MONKESTATION EDIT - Turns all Charlie Station trims into /datum/id_trim/job trims
 
 /obj/item/card/id/away/old/sci
 	name = "Charlie Station Scientist's ID card"
 	desc = "A faded Charlie Station ID card. You can make out the rank \"Scientist\"."
-	trim = /datum/id_trim/away/old/sci
+	trim = /datum/id_trim/job/away/old/sci /// MONKESTATION EDIT - Turns all Charlie Station trims into /datum/id_trim/job trims
 
 /obj/item/card/id/away/old/eng
 	name = "Charlie Station Engineer's ID card"
 	desc = "A faded Charlie Station ID card. You can make out the rank \"Station Engineer\"."
-	trim = /datum/id_trim/away/old/eng
+	trim = /datum/id_trim/job/away/old/eng /// MONKESTATION EDIT - Turns all Charlie Station trims into /datum/id_trim/job trims
 
 /obj/item/card/id/away/old/apc
 	name = "APC Access ID"
 	desc = "A special ID card that allows access to APC terminals."
-	trim = /datum/id_trim/away/old/apc
+	trim = /datum/id_trim/job/away/old/apc /// MONKESTATION EDIT - Turns all Charlie Station trims into /datum/id_trim/job trims
 
 /obj/item/card/id/away/old/robo
 	name = "Delta Station Roboticist's ID card"
 	desc = "An ID card that allows access to bots maintenance protocols."
-	trim = /datum/id_trim/away/old/robo
+	trim = /datum/id_trim/job/away/old/robo /// MONKESTATION EDIT - Turns all Charlie Station trims into /datum/id_trim/job trims
 
 /obj/item/card/id/away/deep_storage //deepstorage.dmm space ruin
 	name = "bunker access ID"

--- a/code/modules/research/designs/autolathe/engineering_designs.dm
+++ b/code/modules/research/designs/autolathe/engineering_designs.dm
@@ -243,7 +243,7 @@
 /datum/design/airlock_board
 	name = "Airlock Electronics"
 	id = "airlock_board"
-	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
+	build_type = AUTOLATHE | PROTOLATHE //MONKESTATION EDIT - Removes 'AWAY_LATHE' from build_type, since we have a subtype of airlock electronics for offstation lathes
 	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*0.5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*0.5)
 	build_path = /obj/item/electronics/airlock
 	category = list(

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -636,6 +636,7 @@
 		"high_micro_laser",
 		"mesons",
 		"nano_mani",
+		"airlock_board_offstation", //MONKESTATION ADDITION - old airlock board for charlie station
 		"oxygen_tank",
 		"pacman",
 		"plasma_tank",

--- a/monkestation/code/datums/id_trim/ruins.dm
+++ b/monkestation/code/datums/id_trim/ruins.dm
@@ -5,36 +5,136 @@
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 
-/datum/id_trim/away/old/cmo
-	access = list(ACCESS_AWAY_GENERAL, ACCESS_AWAY_COMMAND, ACCESS_AWAY_MEDICAL, ACCESS_AWAY_MAINTENANCE)
+/datum/id_trim/job/away/old/cmo
+	minimal_access = list(
+		ACCESS_AWAY_GENERAL,
+		ACCESS_AWAY_COMMAND,
+		ACCESS_AWAY_MEDICAL,
+		ACCESS_AWAY_MAINTENANCE
+	)
+	extra_access = list(
+		ACCESS_ROBOTICS,
+		ACCESS_ORDNANCE,
+		ACCESS_RESEARCH,
+		ACCESS_AWAY_SCIENCE,
+		ACCESS_AWAY_SUPPLY,
+		ACCESS_AWAY_GENERIC1,
+		ACCESS_AWAY_GENERIC2,
+		ACCESS_AWAY_GENERIC3,
+		ACCESS_AWAY_GENERIC4,
+		ACCESS_AWAY_SEC,
+		ACCESS_AWAY_ENGINEERING,
+		ACCESS_ENGINEERING,
+		ACCESS_ENGINE_EQUIP
+	)
 	assignment = "Charlie Station Chief Medical Officer"
 	sechud_icon_state = SECHUD_CHIEF_MEDICAL_OFFICER_AWAY
 
-/datum/id_trim/away/old/chef
-	access = list(ACCESS_AWAY_GENERAL, ACCESS_AWAY_MAINTENANCE)
+/datum/id_trim/job/away/old/chef
+	minimal_access = list(
+		ACCESS_AWAY_GENERAL,
+		ACCESS_AWAY_MAINTENANCE
+	)
+	extra_access = list(
+		ACCESS_ROBOTICS,
+		ACCESS_ORDNANCE,
+		ACCESS_RESEARCH,
+		ACCESS_AWAY_SCIENCE,
+		ACCESS_AWAY_SUPPLY,
+		ACCESS_AWAY_GENERIC1,
+		ACCESS_AWAY_GENERIC2,
+		ACCESS_AWAY_GENERIC3,
+		ACCESS_AWAY_GENERIC4,
+		ACCESS_AWAY_COMMAND,
+		ACCESS_AWAY_MEDICAL,
+		ACCESS_AWAY_SEC,
+		ACCESS_AWAY_ENGINEERING,
+		ACCESS_ENGINEERING,
+		ACCESS_ENGINE_EQUIP
+	)
 	assignment = "Charlie Station Chef"
 	sechud_icon_state = SECHUD_CHEF_AWAY
 
-/datum/id_trim/away/old/explorer
-	access = list(ACCESS_AWAY_GENERAL, ACCESS_AWAY_SCIENCE, ACCESS_AWAY_MAINTENANCE, ACCESS_AWAY_SUPPLY, ACCESS_AWAY_GENERIC1, ACCESS_AWAY_GENERIC2, ACCESS_AWAY_GENERIC3, ACCESS_AWAY_GENERIC4) //purposefully has the most msc. access giving them a advantage for having less equipment than a normal explorer upon start.
+/datum/id_trim/job/away/old/explorer
+	minimal_access = list(
+		ACCESS_AWAY_GENERAL,
+		ACCESS_AWAY_SCIENCE,
+		ACCESS_AWAY_MAINTENANCE,
+		ACCESS_AWAY_SUPPLY,
+		ACCESS_AWAY_GENERIC1,
+		ACCESS_AWAY_GENERIC2,
+		ACCESS_AWAY_GENERIC3,
+		ACCESS_AWAY_GENERIC4
+	) //purposefully has the most msc. access giving them a advantage for having less equipment than a normal explorer upon start.
+	extra_access = list(
+		ACCESS_ROBOTICS,
+		ACCESS_ORDNANCE,
+		ACCESS_RESEARCH,
+		ACCESS_AWAY_COMMAND,
+		ACCESS_AWAY_MEDICAL,
+		ACCESS_AWAY_SEC,
+		ACCESS_AWAY_ENGINEERING,
+		ACCESS_ENGINEERING,
+		ACCESS_ENGINE_EQUIP
+	)
 	assignment = "Charlie Station Explorer"
 	sechud_icon_state = SECHUD_EXPLORER_AWAY
 
-/datum/id_trim/away/old/sci
+/datum/id_trim/job/away/old/sci
 	sechud_icon_state = SECHUD_SCIENTIST_AWAY
-	access = list(ACCESS_AWAY_GENERAL, ACCESS_AWAY_SCIENCE, ACCESS_RESEARCH)
+	minimal_access = list(
+		ACCESS_AWAY_GENERAL,
+		ACCESS_AWAY_SCIENCE,
+		ACCESS_RESEARCH
+	)
+	extra_access = list(
+		ACCESS_ROBOTICS,
+		ACCESS_ORDNANCE,
+		ACCESS_AWAY_MAINTENANCE,
+		ACCESS_AWAY_SUPPLY,
+		ACCESS_AWAY_GENERIC1,
+		ACCESS_AWAY_GENERIC2,
+		ACCESS_AWAY_GENERIC3,
+		ACCESS_AWAY_GENERIC4,
+		ACCESS_AWAY_COMMAND,
+		ACCESS_AWAY_MEDICAL,
+		ACCESS_AWAY_SEC,
+		ACCESS_AWAY_ENGINEERING,
+		ACCESS_ENGINEERING,
+		ACCESS_ENGINE_EQUIP
+	)
 
-/datum/id_trim/away/old/sec
+/datum/id_trim/job/away/old/sec
 	sechud_icon_state = SECHUD_SECURITY_OFFICER_AWAY
 
-/datum/id_trim/away/old/eng
+/datum/id_trim/job/away/old/eng
 	sechud_icon_state = SECHUD_STATION_ENGINEER_AWAY
 
-/datum/id_trim/away/old/robo
+/datum/id_trim/job/away/old/robo
 	sechud_icon_state = SECHUD_ROBOTICIST_AWAY
-	access = list(ACCESS_AWAY_GENERAL, ACCESS_ROBOTICS, ACCESS_ORDNANCE, ACCESS_RESEARCH, ACCESS_AWAY_SCIENCE)
+	minimal_access = list(
+		ACCESS_AWAY_GENERAL,
+		ACCESS_ROBOTICS,
+		ACCESS_ORDNANCE,
+		ACCESS_RESEARCH,
+		ACCESS_AWAY_SCIENCE
+	)
+	extra_access = list(
+		ACCESS_AWAY_MAINTENANCE,
+		ACCESS_AWAY_SUPPLY,
+		ACCESS_AWAY_GENERIC1,
+		ACCESS_AWAY_GENERIC2,
+		ACCESS_AWAY_GENERIC3,
+		ACCESS_AWAY_GENERIC4,
+		ACCESS_AWAY_COMMAND,
+		ACCESS_AWAY_MEDICAL,
+		ACCESS_AWAY_SEC,
+		ACCESS_AWAY_ENGINEERING,
+		ACCESS_ENGINEERING,
+		ACCESS_ENGINE_EQUIP
+	)
 
-/datum/id_trim/away/old/apc
+/datum/id_trim/job/away/old/apc
 	sechud_icon_state = SECHUD_APC_AWAY
 
 /datum/id_trim/pirate/lustrous

--- a/monkestation/code/modules/blueshift/structures/fluff.dm
+++ b/monkestation/code/modules/blueshift/structures/fluff.dm
@@ -5,7 +5,7 @@
 /obj/item/card/id/away/old/salvagepod	//Used for salvagepost ruin access	-- NOT WORKING YET REE
 	name = "Cutter's Pod access card"
 	desc = "An ancient access card with the words \"Cutter's Pod\" printed on in big bold letters. It'll be a miracle if this still works."
-	trim = /datum/id_trim/away/old/eng
+	trim = /datum/id_trim/job/away/old/eng
 
 /* ----------------- Lore ----------------- */
 //Tape subtype for adding ruin lore -- the variables below are the ones you need to change

--- a/monkestation/code/modules/mob_spawn/ghost_roles/space_roles/oldchef.dm
+++ b/monkestation/code/modules/mob_spawn/ghost_roles/space_roles/oldchef.dm
@@ -22,7 +22,7 @@
 /datum/outfit/oldchef
 	name = "Ancient Chef"
 	id = /obj/item/card/id/advanced/old
-	id_trim = /datum/id_trim/away/old/chef
+	id_trim = /datum/id_trim/job/away/old/chef
 	uniform = /obj/item/clothing/under/rank/civilian/chef
 	suit = /obj/item/clothing/suit/toggle/chef
 	ears = /obj/item/radio/headset/headset_old

--- a/monkestation/code/modules/mob_spawn/ghost_roles/space_roles/oldcmo.dm
+++ b/monkestation/code/modules/mob_spawn/ghost_roles/space_roles/oldcmo.dm
@@ -22,7 +22,7 @@
 /datum/outfit/oldcmo
 	name = "Ancient Chief Medical Officer"
 	id = /obj/item/card/id/advanced/old
-	id_trim = /datum/id_trim/away/old/cmo
+	id_trim = /datum/id_trim/job/away/old/cmo
 	uniform = /obj/item/clothing/under/rank/medical/chief_medical_officer/turtleneck
 	shoes = /obj/item/clothing/shoes/jackboots
 	l_pocket = /obj/item/flashlight/pen/paramedic

--- a/monkestation/code/modules/mob_spawn/ghost_roles/space_roles/oldeng.dm
+++ b/monkestation/code/modules/mob_spawn/ghost_roles/space_roles/oldeng.dm
@@ -2,7 +2,7 @@
 	ears = /obj/item/radio/headset/headset_old
 	skillchips = /obj/item/skillchip/job/engineer
 	id = /obj/item/card/id/advanced/old
-	id_trim = /datum/id_trim/away/old/eng
+	id_trim = /datum/id_trim/job/away/old/eng
 	belt = /obj/item/storage/belt/utility/full/engi
 
 /datum/outfit/oldeng/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/monkestation/code/modules/mob_spawn/ghost_roles/space_roles/oldexplorer.dm
+++ b/monkestation/code/modules/mob_spawn/ghost_roles/space_roles/oldexplorer.dm
@@ -22,7 +22,7 @@
 /datum/outfit/oldexplorer
 	name = "Ancient Explorer"
 	id = /obj/item/card/id/advanced/old
-	id_trim = /datum/id_trim/away/old/explorer
+	id_trim = /datum/id_trim/job/away/old/explorer
 	uniform = /obj/item/clothing/under/rank/cargo/miner
 	shoes = /obj/item/clothing/shoes/workboots/mining
 	gloves = /obj/item/clothing/gloves/color/black

--- a/monkestation/code/modules/mob_spawn/ghost_roles/space_roles/oldsci.dm
+++ b/monkestation/code/modules/mob_spawn/ghost_roles/space_roles/oldsci.dm
@@ -1,7 +1,7 @@
 /datum/outfit/oldsci
 	ears = /obj/item/radio/headset/headset_old
 	id = /obj/item/card/id/advanced/old
-	id_trim = /datum/id_trim/away/old/sci
+	id_trim = /datum/id_trim/job/away/old/sci
 
 /datum/outfit/oldsci/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)

--- a/monkestation/code/modules/mob_spawn/ghost_roles/space_roles/oldsec.dm
+++ b/monkestation/code/modules/mob_spawn/ghost_roles/space_roles/oldsec.dm
@@ -2,7 +2,7 @@
 	ears = /obj/item/radio/headset/headset_old/alt
 	implants = list(/obj/item/implant/mindshield)
 	id = /obj/item/card/id/advanced/old
-	id_trim = /datum/id_trim/away/old/sec
+	id_trim = /datum/id_trim/job/away/old/sec
 	belt = /obj/item/gun/energy/laser/retro/old
 
 /datum/outfit/oldsec/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_airlock_board.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_airlock_board.dm
@@ -1,0 +1,28 @@
+/obj/item/electronics/airlock/old //subtype of airlock electronics for charlie station, useful if you want to make locked doors or lockers
+	name = "ancient airlock electronics"
+	desc = "Looks like a circuit. Probably is. Looks odd." //that isnt a misspell of old
+
+/obj/item/electronics/airlock/old/ui_static_data(mob/user)
+	var/list/data = list()
+
+	var/list/regions = list()
+	var/list/tgui_region_data = SSid_access.all_region_access_tgui
+	for(var/region in SSid_access.station_regions)
+		regions += tgui_region_data[region]
+
+	regions += tgui_region_data[REGION_CHARLIE_STATION] //im not removing other regions because i dont want this to be a downgrade
+
+	data["regions"] = regions
+	return data
+
+/datum/design/airlock_board_offstation
+	name = "Ancient Airlock Electronics"
+	id = "airlock_board_offstation"
+	build_type = AWAY_LATHE
+	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*0.5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*0.5)
+	build_path = /obj/item/electronics/airlock/old
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_ELECTRONICS,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -12,14 +12,12 @@
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.02
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.05
 	//dont turn these ids into charlie station ids please, this might be redundant
-	var/list/blacklisted_types = list()
-
-/obj/machinery/oldpdapainter/Initialize()
-	blacklisted_types += typesof(/obj/item/card/id/away)
-	blacklisted_types += typesof(/obj/item/card/id/advanced/silver)
-	blacklisted_types += typesof(/obj/item/card/id/advanced/gold)
-	blacklisted_types += typesof(/obj/item/card/id/advanced/chameleon)
-	. = ..()
+	var/static/list/blacklisted_typecache = typecacheof(list(
+		/obj/item/card/id/away,
+		/obj/item/card/id/advanced/silver,
+		/obj/item/card/id/advanced/gold,
+		/obj/item/card/id/advanced/chameleon,
+	))
 
 /obj/machinery/oldpdapainter/attackby(obj/item/item, mob/living/user, params)
 	if(!is_operational)

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -1,0 +1,146 @@
+//i'd rather type suicide in the command bar than put everything in separate files
+
+//charlie station uses it's own machine for this since all it does is turn the id into an old id
+/obj/machinery/oldpdapainter
+	name = "Charlie Station ID Painter"
+	desc = "A painting machine that can be used to paint IDs. To use, simply insert the ID. It looks old and dusty.."
+	icon = 'icons/obj/pda.dmi'
+	icon_state = "pdapainter"
+	density = TRUE
+	max_integrity = 200
+	use_power = IDLE_POWER_USE
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.02
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.05
+	//dont turn these ids into charlie station ids please
+	var/list/blacklisted_types = list()
+
+/obj/machinery/oldpdapainter/Initialize()
+	blacklisted_types += typesof(/obj/item/card/id/away)
+	blacklisted_types += typesof(/obj/item/card/id/advanced/silver)
+	blacklisted_types += typesof(/obj/item/card/id/advanced/gold)
+	. = ..()
+
+/obj/machinery/oldpdapainter/attackby(obj/item/I, mob/living/user, params)
+	if(!is_operational)
+		to_chat(user, span_warning("[src] has to be on to do this!"))
+		return FALSE
+
+	if(istype(I, /obj/item/card/id) && !(I.type in blacklisted_types))
+		to_chat(user, span_notice("You start painting \the [I]..."))
+
+		if(!do_after(user, 40, target = src))
+			return FALSE
+
+		use_power(active_power_usage)
+
+		var/old_name = I.name
+		QDEL_NULL(I)
+
+		var/obj/item/card/id/away/old/custom/new_id = new(get_turf(src))
+		SSid_access.apply_trim_to_card(new_id, /datum/id_trim/job/away/old/custom, copy_access = FALSE)
+
+		to_chat(user, span_notice("You paint \the [old_name]!"))
+	else
+		return ..()
+
+/datum/computer_file/program/card_mod/old
+	filename = "charliestationidwriter"
+	filedesc = "Charlie Station Access Management"
+
+	//every access i could find on charlie station ids
+	valid_access = list(
+		ACCESS_AWAY_GENERAL,
+		ACCESS_ROBOTICS,
+		ACCESS_ORDNANCE,
+		ACCESS_RESEARCH,
+		ACCESS_AWAY_SCIENCE,
+		ACCESS_AWAY_MAINTENANCE,
+		ACCESS_AWAY_SUPPLY,
+		ACCESS_AWAY_GENERIC1,
+		ACCESS_AWAY_GENERIC2,
+		ACCESS_AWAY_GENERIC3,
+		ACCESS_AWAY_GENERIC4,
+		ACCESS_AWAY_COMMAND,
+		ACCESS_AWAY_MEDICAL,
+		ACCESS_AWAY_SEC,
+		ACCESS_AWAY_ENGINEERING,
+		ACCESS_ENGINEERING,
+		ACCESS_ENGINE_EQUIP
+	)
+
+/datum/computer_file/program/card_mod/old/authenticate(mob/user, obj/item/card/id/auth_card)
+	if(!auth_card)
+		return
+
+	if((ACCESS_AWAY_COMMAND in auth_card.access))
+		authenticated_card = "[auth_card.name]"
+		authenticated_user = auth_card.registered_name ? auth_card.registered_name : "Unknown"
+		update_static_data(user)
+		return TRUE
+
+	return FALSE
+
+/datum/computer_file/program/card_mod/old/ui_static_data(mob/user)
+	var/list/data = list()
+	data["station_name"] = "Charlie Station" //we arent ss13, don't show as such (despite the fact this isn't shown anywhere??)
+	data["centcom_access"] = is_centcom
+	data["minor"] = target_dept || minor ? TRUE : FALSE
+
+	var/list/regions = list()
+	var/list/tgui_region_data = SSid_access.all_region_access_tgui
+
+	regions += tgui_region_data[REGION_CHARLIE_STATION] //we only give charlie access, sorry buddy
+
+	data["regions"] = regions
+
+
+	data["accessFlags"] = SSid_access.flags_by_access
+	data["wildcardFlags"] = SSid_access.wildcard_flags_by_wildcard
+	data["accessFlagNames"] = SSid_access.access_flag_string_by_flag
+	data["showBasic"] = TRUE
+	data["templates"] = job_templates
+
+	return data
+
+/obj/machinery/modular_computer/preset/id/old
+	starting_programs = list(
+		/datum/computer_file/program/chatclient,
+		/datum/computer_file/program/card_mod/old,
+		/datum/computer_file/program/job_management,
+		/datum/computer_file/program/crew_manifest,
+	)
+
+/obj/machinery/modular_computer/preset/command/old
+	starting_programs = list(
+		/datum/computer_file/program/chatclient,
+		/datum/computer_file/program/card_mod/old,
+	)
+
+/datum/id_trim/job/away/old
+	trim_state = null
+
+/datum/id_trim/job/away/old/custom
+	assignment = "Charlie Station Crew"
+	minimal_access = list(
+		ACCESS_AWAY_GENERAL,
+		ACCESS_ROBOTICS,
+		ACCESS_ORDNANCE,
+		ACCESS_RESEARCH,
+		ACCESS_AWAY_SCIENCE,
+		ACCESS_AWAY_MAINTENANCE,
+		ACCESS_AWAY_SUPPLY,
+		ACCESS_AWAY_GENERIC1,
+		ACCESS_AWAY_GENERIC2,
+		ACCESS_AWAY_GENERIC3,
+		ACCESS_AWAY_GENERIC4,
+		ACCESS_AWAY_COMMAND,
+		ACCESS_AWAY_MEDICAL,
+		ACCESS_AWAY_SEC,
+		ACCESS_AWAY_ENGINEERING,
+		ACCESS_ENGINEERING,
+		ACCESS_ENGINE_EQUIP
+	)
+
+/obj/item/card/id/away/old/custom
+	name = "Charlie Station ID card"
+	desc = "A card used to provide ID and determine access across Charlie Station."

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -81,7 +81,6 @@
 	if((ACCESS_AWAY_COMMAND in auth_card.access))
 		authenticated_card = "[auth_card.name]"
 		authenticated_user = auth_card.registered_name ? auth_card.registered_name : "Unknown"
-		update_static_data(user)
 		return TRUE
 
 	return FALSE

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -151,32 +151,3 @@
 /obj/item/card/id/away/old/custom
 	name = "Charlie Station ID card"
 	desc = "A card used to provide ID and determine access across Charlie Station."
-
-/obj/item/electronics/airlock/old //subtype of airlock electronics for charlie station, useful if you want to make locked doors or lockers
-	name = "ancient airlock electronics"
-	desc = "Looks like a circuit. Probably is. Looks odd." //that isnt a misspell of old
-
-/obj/item/electronics/airlock/old/ui_static_data(mob/user)
-	var/list/data = list()
-
-	var/list/regions = list()
-	var/list/tgui_region_data = SSid_access.all_region_access_tgui
-	for(var/region in SSid_access.station_regions)
-		regions += tgui_region_data[region]
-
-	regions += tgui_region_data[REGION_CHARLIE_STATION] //im not removing other regions because i dont want this to be a downgrade
-
-	data["regions"] = regions
-	return data
-
-/datum/design/airlock_board_offstation
-	name = "Ancient Airlock Electronics"
-	id = "airlock_board_offstation"
-	build_type = AWAY_LATHE
-	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*0.5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*0.5)
-	build_path = /obj/item/electronics/airlock/old
-	category = list(
-		RND_CATEGORY_INITIAL,
-		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_ELECTRONICS,
-	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -151,3 +151,32 @@
 /obj/item/card/id/away/old/custom
 	name = "Charlie Station ID card"
 	desc = "A card used to provide ID and determine access across Charlie Station."
+
+/obj/item/electronics/airlock/old //subtype of airlock electronics for charlie station, useful if you want to make locked doors or lockers
+	name = "ancient airlock electronics"
+	desc = "Looks like a circuit. Probably is. Looks odd." //that isnt a misspell of old
+
+/obj/item/electronics/airlock/old/ui_static_data(mob/user)
+	var/list/data = list()
+
+	var/list/regions = list()
+	var/list/tgui_region_data = SSid_access.all_region_access_tgui
+	for(var/region in SSid_access.station_regions)
+		regions += tgui_region_data[region]
+
+	regions += tgui_region_data[REGION_CHARLIE_STATION] //im not removing other regions because i dont want this to be a downgrade
+
+	data["regions"] = regions
+	return data
+
+/datum/design/airlock_board_offstation
+	name = "Ancient Airlock Electronics"
+	id = "airlock_board_offstation"
+	build_type = AWAY_LATHE
+	materials = list(/datum/material/iron =SMALL_MATERIAL_AMOUNT*0.5, /datum/material/glass =SMALL_MATERIAL_AMOUNT*0.5)
+	build_path = /obj/item/electronics/airlock/old
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_CONSTRUCTION + RND_SUBCATEGORY_CONSTRUCTION_ELECTRONICS,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -35,7 +35,7 @@
 
 		to_chat(user, span_notice("You start painting \the [card]..."))
 
-		if(!do_after(user, 40, target = src))
+		if(!do_after(user, 4 SECONDS, target = src))
 			return FALSE
 
 		use_power(active_power_usage)

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -21,7 +21,7 @@
 	blacklisted_types += typesof(/obj/item/card/id/advanced/chameleon)
 	. = ..()
 
-/obj/machinery/oldpdapainter/attackby(obj/item/I, mob/living/user, params)
+/obj/machinery/oldpdapainter/attackby(obj/item/item, mob/living/user, params)
 	if(!is_operational)
 		to_chat(user, span_warning("[src] has to be on to do this!"))
 		return FALSE

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -43,7 +43,7 @@
 		var/old_name = card.name
 		QDEL_NULL(card)
 
-		var/obj/item/card/id/away/old/custom/new_id = new(get_turf(src))
+		var/obj/item/card/id/away/old/custom/new_id = new(drop_location())
 		SSid_access.apply_trim_to_card(new_id, /datum/id_trim/job/away/old/custom, copy_access = FALSE)
 
 		to_chat(user, span_notice("You paint \the [old_name]!"))

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -24,8 +24,8 @@
 		to_chat(user, span_warning("[src] has to be on to do this!"))
 		return FALSE
 
-	if(istype(I, /obj/item/card/id))
-		var/obj/item/card/id/card = I
+	if(istype(item, /obj/item/card/id))
+		var/obj/item/card/id/card = item
 
 		if(is_type_in_typecache(card, blacklisted_typecache) || card.trim)
 			to_chat(user, span_warning("You can't paint this card!"))

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -29,7 +29,7 @@
 	if(istype(I, /obj/item/card/id))
 		var/obj/item/card/id/card = I
 
-		if(I.type in blacklisted_types || card.trim)
+		if((I.type in blacklisted_types) || card.trim)
 			to_chat(user, span_warning("You can't paint this card!"))
 			return FALSE
 

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -11,13 +11,14 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.02
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.05
-	//dont turn these ids into charlie station ids please
+	//dont turn these ids into charlie station ids please, this might be redundant
 	var/list/blacklisted_types = list()
 
 /obj/machinery/oldpdapainter/Initialize()
 	blacklisted_types += typesof(/obj/item/card/id/away)
 	blacklisted_types += typesof(/obj/item/card/id/advanced/silver)
 	blacklisted_types += typesof(/obj/item/card/id/advanced/gold)
+	blacklisted_types += typesof(/obj/item/card/id/advanced/chameleon)
 	. = ..()
 
 /obj/machinery/oldpdapainter/attackby(obj/item/I, mob/living/user, params)
@@ -25,16 +26,22 @@
 		to_chat(user, span_warning("[src] has to be on to do this!"))
 		return FALSE
 
-	if(istype(I, /obj/item/card/id) && !(I.type in blacklisted_types))
-		to_chat(user, span_notice("You start painting \the [I]..."))
+	if(istype(I, /obj/item/card/id))
+		var/obj/item/card/id/card = I
+
+		if(I.type in blacklisted_types || card.trim)
+			to_chat(user, span_warning("You can't paint this card!"))
+			return FALSE
+
+		to_chat(user, span_notice("You start painting \the [card]..."))
 
 		if(!do_after(user, 40, target = src))
 			return FALSE
 
 		use_power(active_power_usage)
 
-		var/old_name = I.name
-		QDEL_NULL(I)
+		var/old_name = card.name
+		QDEL_NULL(card)
 
 		var/obj/item/card/id/away/old/custom/new_id = new(get_turf(src))
 		SSid_access.apply_trim_to_card(new_id, /datum/id_trim/job/away/old/custom, copy_access = FALSE)

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -27,7 +27,7 @@
 	if(istype(I, /obj/item/card/id))
 		var/obj/item/card/id/card = I
 
-		if((I.type in blacklisted_types) || card.trim)
+		if(is_type_in_typecache(card, blacklisted_typecache) || card.trim)
 			to_chat(user, span_warning("You can't paint this card!"))
 			return FALSE
 

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -53,6 +53,7 @@
 /datum/computer_file/program/card_mod/old
 	filename = "charliestationidwriter"
 	filedesc = "Charlie Station Access Management"
+	available_on_ntnet = FALSE //charlie station only fools
 
 	//every access i could find on charlie station ids
 	valid_access = list(

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7853,6 +7853,7 @@
 #include "monkestation\code\modules\ocean_content\mobs\ai\behaviours\attempt_group_find.dm"
 #include "monkestation\code\modules\ocean_content\mobs\ai\behaviours\group_move_towards.dm"
 #include "monkestation\code\modules\ocean_content\mobs\ai\subtrees\simple_try_attach_group.dm"
+#include "monkestation\code\modules\oldstation_idconsole\oldstation_idconsole.dm"
 #include "monkestation\code\modules\outdoors\code\admin_commands.dm"
 #include "monkestation\code\modules\outdoors\code\misc_procs.dm"
 #include "monkestation\code\modules\outdoors\code\new_vars.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7853,6 +7853,7 @@
 #include "monkestation\code\modules\ocean_content\mobs\ai\behaviours\attempt_group_find.dm"
 #include "monkestation\code\modules\ocean_content\mobs\ai\behaviours\group_move_towards.dm"
 #include "monkestation\code\modules\ocean_content\mobs\ai\subtrees\simple_try_attach_group.dm"
+#include "monkestation\code\modules\oldstation_idconsole\oldstation_airlock_board.dm"
 #include "monkestation\code\modules\oldstation_idconsole\oldstation_idconsole.dm"
 #include "monkestation\code\modules\outdoors\code\admin_commands.dm"
 #include "monkestation\code\modules\outdoors\code\misc_procs.dm"


### PR DESCRIPTION
## About The Pull Request

Charlie Station now has a unique ID console program which gives Charlie Station access, along with a unique ID painter (which is not actually an ID painter.) I also changed Charlie Station ID trims to job ID trims so they can use extra_access. This COULD be used to get free engie / sci access but who the fuck would do that just ask the HoP dude
They also have unique airlock electronics if they want to lock doors or closets.

## Why It's Good For The Game

i have wanted for the longest time to rename my id from charlie station chief medical officer to charlie station captain
also a few rounds ago someone did a thing about reestablishing the chain of command and made me the first officer, which was cool i liked that. also if you have experimental clones / station crew seeking refuge you can make them ids to not have to open doors for them every 5 seconds. oh you could also like lose your id by getting dusted by the sm then cloned but thats unlikely idfk its like 12 AM i need to sleep
## Changelog
:cl:
add: Added unique ID console program to Charlie Station.
add: Added unique "ID painter" to Charlie Station.
add: Added subtype of airlock electronics for Charlie Station.
qol: Charlie Station IDs now have extra access on lowpop.
/:cl:
