### PR TITLE
Coloring greyscale loadout items now updates the character preview

### DIFF
--- a/monkestation/code/modules/loadouts/loadout_middleware.dm
+++ b/monkestation/code/modules/loadouts/loadout_middleware.dm
@@ -311,6 +311,7 @@
 	var/list/colors = open_menu.split_colors
 	if(colors)
 		preferences.loadout_list[path][INFO_GREYSCALE] = colors.Join("")
+		preferences.character_preview_view?.update_body()
 
 /datum/preference_middleware/loadout/proc/clear_all_items()
 	LAZYNULL(preferences.loadout_list)


### PR DESCRIPTION
## About The Pull Request
Previously, when users colored a greyscale loadout item, we did not update the character preview. Unfortunately, because selecting/deselecting an item removes the greyscale config, there was no way for a user to get past this oversight without closing and reopening the character setup menu.

This PR fixes this, by updating the character preview whenever a player changes the color of a greyscale loadout item.

## Why It's Good For The Game
Players can now live-preview how their items look on them, without needing to close and re-open the character setup menu.

## Changelog

:cl:MichiRecRoom
fix: Clicking "Apply" when coloring a loadout item will now update your character preview to use the new colors. This enables you to live(-ish) preview what a certain set of colors will look like on your character.
/:cl:
