### PR TITLE
Better rechargers for goldeneye and fixes surgery disk

### DIFF
--- a/_maps/shuttles/nova/goldeneye_cruiser.dmm
+++ b/_maps/shuttles/nova/goldeneye_cruiser.dmm
@@ -19,8 +19,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/hallway)
 "ah" = (
-/obj/machinery/recharge_station,
 /obj/effect/turf_decal/bot_white,
+/obj/machinery/recharge_station/fullupgrade,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/hallway)
 "bf" = (
@@ -141,6 +141,7 @@
 /obj/machinery/computer/operating{
 	dir = 4
 	},
+/obj/item/disk/surgery/irs,
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/medical)
 "dT" = (

--- a/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
+++ b/code/modules/antagonists/pirate/pirate_shuttle_equipment.dm
@@ -127,9 +127,8 @@
 		/datum/surgery/advanced/lobotomy,
 		/datum/surgery/advanced/bioware/vein_threading,
 		/datum/surgery/advanced/bioware/nerve_splicing,
-		/datum/surgery_step/heal/combo/upgraded,
-		/datum/surgery_step/pacify,
-		/datum/surgery_step/revive,
+		/datum/surgery/healing/combo/upgraded, // monkestation edit: Fixed surgeries
+		/datum/surgery/advanced/pacify, // monkestation edit: Fixed surgeries
 	)
 
 /obj/machinery/loot_locator/interact(mob/user)

--- a/monkestation/code/game/machinery/rechargestation.dm
+++ b/monkestation/code/game/machinery/rechargestation.dm
@@ -1,0 +1,2 @@
+/obj/machinery/recharge_station/fullupgrade
+	circuit = /obj/item/circuitboard/machine/cyborgrecharger/fullupgrade

--- a/monkestation/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/monkestation/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -109,3 +109,13 @@
 	req_components = list(
 		/datum/stock_part/manipulator = 1,
 	)
+
+/obj/item/circuitboard/machine/cyborgrecharger/fullupgrade
+	name = "Cyborg Recharger"
+	greyscale_colors = CIRCUIT_COLOR_SCIENCE
+	build_path = /obj/machinery/recharge_station/fullupgrade
+	req_components = list(
+		/datum/stock_part/capacitor/tier4 = 2,
+		/obj/item/stock_parts/cell = 1,
+		/datum/stock_part/manipulator/tier4 = 1)
+	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/bluespace)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6068,6 +6068,7 @@
 #include "monkestation\code\game\machinery\launch_pad.dm"
 #include "monkestation\code\game\machinery\player_hologram.dm"
 #include "monkestation\code\game\machinery\prize_vendor.dm"
+#include "monkestation\code\game\machinery\rechargestation.dm"
 #include "monkestation\code\game\machinery\suit_storage_unit.dm"
 #include "monkestation\code\game\machinery\computer\camera.dm"
 #include "monkestation\code\game\machinery\computer\cloning.dm"


### PR DESCRIPTION

## About The Pull Request

- Gives the goldeneye cruiser a upgraded cyborg recharger
- Gives goldeneye cruiser a advanced surgery techdisk.
- Fixes advanced surgery giving surgery steps rather than surgeries.
## Why It's Good For The Game

- Technically an issue since they were initially added, but goldeneye cruisers has had basic unupgraded cyborg rechargers.  Meaning if they exist on station for long periods of time their one safe place to recharge is unbelievably slow while having decently to large-sized power cells
Issue was only compounded with the addition of saboteur cyborgs who rely on this power to operate. This should help keep them a more active threat rather than sitting in rechargers so they are able to return to the station.
- Goldeneye cruiser is reliant on the station to do surgery research limiting their recovery abilities. They have been given a Advanced surgery disk to help combat this.

- Fixes the advanced surgery disk. The advanced surgery disk would give multiple surgery steps to download, rather than the surgery itself, this has been rectified.
## Changelog
:cl:
add: Added upgraded rechargers to the Goldeneye cruiser.
add: Added an advanced surgery disk to the Goldeneye cruiser.
fix: fixed the advanced surgery disk not giving correct surgeries
/:cl:
