### PR TITLE
nerfs Moffer (hides centcom fax machines so they can't be used to break in)

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -19500,12 +19500,10 @@
 /area/centcom/central_command_areas/admin)
 "brG" = (
 /obj/structure/table/reinforced/plasmarglass,
-/obj/structure/fluff{
-	icon = 'icons/obj/fax.dmi';
-	icon_state = "fax";
-	name = "fax machine";
-	desc = "A CentCom-owned fax machine. It's been disconnected from the network.";
-	density = 1
+/obj/machinery/fax{
+	fax_name = "Raziel's Desk";
+	name = "Cassiel's Fax Machine";
+	visible_to_network = 0
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/centcom/central_command_areas/adminroom)
@@ -20195,12 +20193,9 @@
 	layer = 2.8
 	},
 /obj/structure/table/wood,
-/obj/structure/fluff{
-	icon = 'icons/obj/fax.dmi';
-	icon_state = "fax";
-	name = "fax machine";
-	desc = "A CentCom-owned fax machine. It's been disconnected from the network.";
-	density = 1
+/obj/machinery/fax/messageadmins{
+	fax_name = "Wolf's Office";
+	visible_to_network = 0
 	},
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/adminroom)
@@ -25129,12 +25124,9 @@
 /area/centcom/central_command_areas/retirement_yard)
 "pcz" = (
 /obj/structure/table/reinforced,
-/obj/structure/fluff{
-	icon = 'icons/obj/fax.dmi';
-	icon_state = "fax";
-	name = "fax machine";
-	desc = "A CentCom-owned fax machine. It's been disconnected from the network.";
-	density = 1
+/obj/machinery/fax{
+	name = "Beverly's Fax Machine";
+	visible_to_network = 0
 	},
 /turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/admin)

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -20551,12 +20551,10 @@
 /area/centcom/central_command_areas/admin)
 "dNQ" = (
 /obj/structure/table/greyscale,
-/obj/structure/fluff{
-	icon = 'icons/obj/fax.dmi';
-	icon_state = "fax";
-	name = "fax machine";
-	desc = "A CentCom-owned fax machine. It's been disconnected from the network.";
-	density = 1
+/obj/machinery/fax/messageadmins{
+	fax_name = "Central Command Intern Office";
+	pixel_y = 4;
+	visible_to_network = 0
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/admin)

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -19500,9 +19500,12 @@
 /area/centcom/central_command_areas/admin)
 "brG" = (
 /obj/structure/table/reinforced/plasmarglass,
-/obj/machinery/fax{
-	fax_name = "Raziel's Desk";
-	name = "Cassiel's Fax Machine"
+/obj/structure/fluff{
+	icon = 'icons/obj/fax.dmi';
+	icon_state = "fax";
+	name = "fax machine";
+	desc = "A CentCom-owned fax machine. It's been disconnected from the network.";
+	density = 1
 	},
 /turf/open/floor/mineral/titanium/purple,
 /area/centcom/central_command_areas/adminroom)
@@ -20192,8 +20195,12 @@
 	layer = 2.8
 	},
 /obj/structure/table/wood,
-/obj/machinery/fax/messageadmins{
-	fax_name = "Wolf's Office"
+/obj/structure/fluff{
+	icon = 'icons/obj/fax.dmi';
+	icon_state = "fax";
+	name = "fax machine";
+	desc = "A CentCom-owned fax machine. It's been disconnected from the network.";
+	density = 1
 	},
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/adminroom)
@@ -20544,9 +20551,12 @@
 /area/centcom/central_command_areas/admin)
 "dNQ" = (
 /obj/structure/table/greyscale,
-/obj/machinery/fax/messageadmins{
-	fax_name = "Central Command Intern Office";
-	pixel_y = 4
+/obj/structure/fluff{
+	icon = 'icons/obj/fax.dmi';
+	icon_state = "fax";
+	name = "fax machine";
+	desc = "A CentCom-owned fax machine. It's been disconnected from the network.";
+	density = 1
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/admin)
@@ -25121,8 +25131,12 @@
 /area/centcom/central_command_areas/retirement_yard)
 "pcz" = (
 /obj/structure/table/reinforced,
-/obj/machinery/fax{
-	name = "Beverly's Fax Machine"
+/obj/structure/fluff{
+	icon = 'icons/obj/fax.dmi';
+	icon_state = "fax";
+	name = "fax machine";
+	desc = "A CentCom-owned fax machine. It's been disconnected from the network.";
+	density = 1
 	},
 /turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/admin)


### PR DESCRIPTION
## About The Pull Request

Hides all centcom fax machines from the network to prevent breakins.

Admins can make them visible to the network by changing visible_to_network to 1 in VV

## Why It's Good For The Game

god fucking damnit moffer
(centcom breakin bad)

## Changelog
:cl:
fix: Johnson and Co Architecture has sent in a crack team to forcibly reprogram every fax machine at Central Command to prevent break-ins.
/:cl:
