### PR TITLE
Nerf delightful effect syndrome's moodlet

### DIFF
--- a/monkestation/code/modules/datums/mood_events/generic_positive_events.dm
+++ b/monkestation/code/modules/datums/mood_events/generic_positive_events.dm
@@ -21,4 +21,4 @@
 
 /datum/mood_event/delightful_symptom
 	description = "Everything feels so nice and wonderful!"
-	mood_change = 50
+	mood_change = 30


### PR DESCRIPTION

## About The Pull Request
Nerfs delightful syndrome Moodlet (50 -> 30)
## Why It's Good For The Game
Delightful syndrome has had a bug fix, as a byproduct you no longer need mind restoration for it to work without harming the user. As such we now have a effect that practically guarantees you are always at an estactic moodlet.

You could stare into the mansus (Pierced reality) and not seen your obsession for the max period of time. And you will still remain a happy moodlet. (Total of -45 moodlet.)

This change makes it so some of the more severe negative effects will have a overall impact of your mood.
## Changelog
:cl:
balance: Delightful syndrome moodlet: 50+->30+
/:cl:
