### PR TITLE
Seedlings and Craig now use JPS pathfinding instead of basic avoidance

### DIFF
--- a/code/modules/mob/living/basic/jungle/seedling/seedling_ai.dm
+++ b/code/modules/mob/living/basic/jungle/seedling/seedling_ai.dm
@@ -6,7 +6,7 @@
 		BB_WATERLEVEL_THRESHOLD = 90,
 	)
 
-	ai_movement = /datum/ai_movement/basic_avoidance
+	ai_movement = /datum/ai_movement/jps // monkestation edit: use jps instead of basic avoidance
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 	planning_subtrees = list(
 		/datum/ai_planning_subtree/pet_planning,

--- a/monkestation/code/modules/botany/potty.dm
+++ b/monkestation/code/modules/botany/potty.dm
@@ -147,7 +147,7 @@
 		BB_WATERLEVEL_THRESHOLD = 90,
 	)
 
-	ai_movement = /datum/ai_movement/basic_avoidance
+	ai_movement = /datum/ai_movement/jps
 	idle_behavior = /datum/idle_behavior/idle_random_walk
 	planning_subtrees = list(
 		/datum/ai_planning_subtree/pet_planning,


### PR DESCRIPTION

## About The Pull Request

this changes the seedling and craig movement controllers from basic avoidance to JPS, so it'll use actual pathfinding instead of naively walking towards the target

## Why It's Good For The Game

leading goobers anywhere is a sisyphean task. and having 50 of them bunched up in botany is incredibly annoying. 

and craig having better pathfinding is also helpful

## Changelog
:cl:
qol: Seedlings and Craig now use JPS pathfinding instead of basic avoidance, so they're less likely to get stuck on stupid obstacles.
/:cl:
