### PR TITLE
[PORT] Allows Signers to send COMSIG_MOB_SAY

### DIFF
--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -205,11 +205,10 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	last_say_args_ref = REF(args)
 	#endif
 
-	if(!HAS_TRAIT(src, TRAIT_SIGN_LANG)) // if using sign language skip sending the say signal
-		// Make sure the arglist is passed exactly - don't pass a copy of it. Say signal handlers will modify some of the parameters.
-		var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args)
-		if(sigreturn & COMPONENT_UPPERCASE_SPEECH)
-			message = uppertext(message)
+	// Make sure the arglist is passed exactly - don't pass a copy of it. Say signal handlers will modify some of the parameters.
+	var/sigreturn = SEND_SIGNAL(src, COMSIG_MOB_SAY, args)
+	if(sigreturn & COMPONENT_UPPERCASE_SPEECH)
+		message = uppertext(message)
 
 	if(!message)
 		if(succumbed)


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/79677

> By removing a conditional statement which prevented signers from sending a `COMSIG_MOB_SAY` signal (for some reason), this PR fixes a few things in one go:
> 
> - Sign language once again prints a notice that the signer raises or lowers their eyebrows for exclamations and questions respectively.
> - Tonal indicators (sign/typing icons that depict eyebrows raising or lowering) are also working again.
> - RuneChat is now punctuated the same as the chat box for Signers.

## Why It's Good For The Game

> Repairs intended functionality that broke a while ago. Adds a little flavor and spice to sign conversation again. Makes RuneChat properly register Signer punctuation.

## Changelog
:cl: Absolucy, Danny Boy
fix: Fixed Signer eyebrow raising/lowering indicators and emotes
fix: Fixed Signer RuneChat punctuation
/:cl:
