### PR TITLE
Renames plasmaflood license to murderbone

### DIFF
--- a/monkestation/code/game/objects/items/plasma_license.dm
+++ b/monkestation/code/game/objects/items/plasma_license.dm
@@ -1,6 +1,6 @@
 /obj/item/card/plasma_license
-	name = "License to Plasmaflood"
-	desc = "A charred contract letting the holder plasmaflood the halls. Not offically recognized by Nanotrasen."
+	name = "License to Murderbone"
+	desc = "A charred contract letting the holder kill everyone they want. Not offically recognized by Nanotrasen."
 	icon = 'monkestation/icons/obj/items/plasmalicense.dmi'
 	icon_state = "plasmalicense"
 	resistance_flags = FIRE_PROOF
@@ -14,7 +14,7 @@
 
 /obj/item/card/plasma_license/Initialize(mapload)
 	. = ..()
-	message_admins("A plasmaflood license has been created.")
+	message_admins("A murderbone license has been created.")
 
 /obj/item/card/plasma_license/examine(mob/user)
 	. = ..()
@@ -29,8 +29,8 @@
 			return
 		to_chat(user, span_notice("You sign your name at the bottom of the [src]."))
 		owner = user.mind
-		message_admins("A License to Plasmaflood has been signed by [owner].")
-		investigate_log("A License to Plasmaflood by [key_name(user)]", INVESTIGATE_ATMOS)
+		message_admins("A License to Murderbone has been signed by [owner].")
+		investigate_log("A License to Murderbone by [key_name(user)]", INVESTIGATE_ATMOS)
 		return
 
 	if(user.mind != owner)

--- a/monkestation/code/game/objects/items/plasma_license.dm
+++ b/monkestation/code/game/objects/items/plasma_license.dm
@@ -1,6 +1,6 @@
 /obj/item/card/plasma_license
 	name = "License to Murderbone"
-	desc = "A charred contract letting the holder kill everyone they want. Not offically recognized by Nanotrasen."
+	desc = "A charred contract letting the holder kill everyone they meet. Not offically recognized by Nanotrasen."
 	icon = 'monkestation/icons/obj/items/plasmalicense.dmi'
 	icon_state = "plasmalicense"
 	resistance_flags = FIRE_PROOF

--- a/monkestation/code/modules/uplink/uplink_items/misc.dm
+++ b/monkestation/code/modules/uplink/uplink_items/misc.dm
@@ -31,7 +31,7 @@
 /datum/uplink_item/device_tools/plasma_license
 	name = "License to Murderbone"
 	desc = "A contract abusing a loophole found by plasmamen to invade halls with harmful gases \
-			without repricution or warning, garnering no attention from any higher powers. \
+			without repercussion or warning, garnering no attention from any higher powers. \
 			Has to be signed by purchaser to be considered valid."
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	item = /obj/item/card/plasma_license

--- a/monkestation/code/modules/uplink/uplink_items/misc.dm
+++ b/monkestation/code/modules/uplink/uplink_items/misc.dm
@@ -29,10 +29,10 @@
 	cost = 2
 
 /datum/uplink_item/device_tools/plasma_license
-	name = "License to Plasmaflood"
+	name = "License to Murderbone"
 	desc = "A contract abusing a loophole founud by plasmamen to invade halls with harmful gases \
 			without repricution or warning, garnering no attention from any higher powers. \
-			Has to be signed by purchaser to be consider valid."
+			Has to be signed by purchaser to be considered valid."
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	item = /obj/item/card/plasma_license
 	cost = 20

--- a/monkestation/code/modules/uplink/uplink_items/misc.dm
+++ b/monkestation/code/modules/uplink/uplink_items/misc.dm
@@ -30,7 +30,7 @@
 
 /datum/uplink_item/device_tools/plasma_license
 	name = "License to Murderbone"
-	desc = "A contract abusing a loophole founud by plasmamen to invade halls with harmful gases \
+	desc = "A contract abusing a loophole found by plasmamen to invade halls with harmful gases \
 			without repricution or warning, garnering no attention from any higher powers. \
 			Has to be signed by purchaser to be considered valid."
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)


### PR DESCRIPTION

## About The Pull Request
Renames License to Plasmaflood to License to Murderbone.
## Why It's Good For The Game
![Screenshot 2_9_2025 12_34_22 PM](https://github.com/user-attachments/assets/70e017a6-8b3d-4cd4-b796-b8a89fb2963c)
## Changelog
:cl:
balance: License to Plasmaflood has been rebranded to License to Murderbone
/:cl:
