### PR TITLE
Fix smite ignoring antimagic, also tell the caster what the smite was

### DIFF
--- a/monkestation/code/modules/spells/spell_types/pointed/smite.dm
+++ b/monkestation/code/modules/spells/spell_types/pointed/smite.dm
@@ -11,6 +11,7 @@
 	cooldown_time = 40 SECONDS
 	cooldown_reduction_per_rank = 5 SECONDS
 	cast_range = 2
+	antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY // the gods have mercy upon the holy
 
 	invocation = "EI NATH!!"
 
@@ -34,8 +35,13 @@
 		return FALSE
 	return TRUE
 
-/datum/action/cooldown/spell/pointed/smite/cast(atom/cast_on)
+/datum/action/cooldown/spell/pointed/smite/cast(mob/living/carbon/cast_on)
 	. = ..()
+	if(cast_on.can_block_magic(antimagic_flags))
+		to_chat(cast_on, span_notice("You feel as if the gods have granted you mercy."))
+		to_chat(owner, span_warning("The spell had no effect!"))
+		return FALSE
+
 	smite_type = forced_smite_type
 	if(!smite_type)
 		if(prob(70))
@@ -68,11 +74,12 @@
 		else
 			picked_smite = new picked_smite
 			do_smite(picked_smite, cast_on)
+	to_chat(owner, span_notice("You call down a strike from the heavens upon [cast_on], resulting in [picked_smite::name]!"))
 
 /datum/action/cooldown/spell/pointed/smite/after_cast(atom/cast_on)
 	. = ..()
 	if(smite_type == LIGHT_SMITE) //these should give a lower cooldown as they dont do as much
-		next_use_time -= cooldown_time/2
+		next_use_time -= cooldown_time / 2
 	smite_type = null
 
 /datum/action/cooldown/spell/pointed/smite/proc/do_smite(datum/smite/real_smite, mob/living/carbon/target)

--- a/monkestation/code/modules/spells/spell_types/pointed/smite.dm
+++ b/monkestation/code/modules/spells/spell_types/pointed/smite.dm
@@ -74,7 +74,7 @@
 		else
 			picked_smite = new picked_smite
 			do_smite(picked_smite, cast_on)
-	to_chat(owner, span_notice("You call down a strike from the heavens upon [cast_on], resulting in [picked_smite::name]!"))
+	to_chat(owner, span_notice("You call down a strike from the heavens upon [cast_on], resulting in [picked_smite.name]!"))
 
 /datum/action/cooldown/spell/pointed/smite/after_cast(atom/cast_on)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/5360

this makes it so smite will fail if the target has antimagic (either normal antimagic, or holy antimagic)

also makes it so the caster which smite was used.

## Why It's Good For The Game

bugfix, and just a minor qol so it doesn't seem like nothing happened with certain smites.

## Changelog
:cl:
fix: Smite (the spell) is now properly blocked by antimagic.
qol: Smite now tells the caster which smite was inflicted.
/:cl:
