### PR TITLE
blacklist die of fate from being tossed out while searching a trash pile

### DIFF
--- a/monkestation/code/game/objects/structures/trash_pile.dm
+++ b/monkestation/code/game/objects/structures/trash_pile.dm
@@ -189,7 +189,11 @@
 	if(COOLDOWN_FINISHED(src, trash_cooldown))
 		COOLDOWN_START(src, trash_cooldown, trash_delay * 0.5 + rand() * trash_delay) // x0.5 to x1.5
 		remaining_trash_throws[ckey]--
-		var/item_to_spawn = prob(0.1) ? pick(GLOB.oddity_loot) : pick_weight_recursive(GLOB.trash_pile_loot)
+		var/item_to_spawn
+		if(prob(0.1))
+			item_to_spawn = pick(GLOB.oddity_loot - typesof(/obj/item/dice/d20/fate)) // die of fate are blacklisted bc it will be automatically rolled due to the throw, likely insta-RRing the user without any counter
+		else
+			item_to_spawn = pick_weight_recursive(GLOB.trash_pile_loot)
 		var/obj/item/spawned_item = new item_to_spawn(drop_location())
 		var/turf/throw_at = get_ranged_target_turf_direct(src, user, 7, rand(-60, 60))
 		// this can totally be changed to use /datum/component/movable_physics to make it way more fun and expressive, but i can't be bothered to figure out good velocity/friction values right now


### PR DESCRIPTION
## About The Pull Request

this blacklists die of fate (both the normal single-use one and the cursed one) from being tossed out behind you while searching through a trash pile.

however, they are still in the oddity loot table - meaning you can still find one _in_ the trash pile, it's your choice whether you roll the d20 you found or not.

## Why It's Good For The Game

instant unpredictable round removal kinda sucks ngl

## Changelog
:cl:
qol: You no longer have an completely random and unpredictable chance of being automatically dusted while searching through a trash pile. If you dig out a random d20 and decide to roll it yourself, though, that's your gamble to make.
/:cl:
