### PR TITLE
[PORT] Fixes species/tongue-based speech modification altering sign language

### DIFF
--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -77,8 +77,11 @@
 
 /obj/item/organ/internal/tongue/proc/handle_speech(datum/source, list/speech_args)
 	SIGNAL_HANDLER
-	if(speech_args[SPEECH_LANGUAGE] in languages_native)
-		return FALSE //no changes
+
+	if(speech_args[SPEECH_LANGUAGE] in languages_native) // Speaking a native language?
+		return FALSE // Don't modify speech
+	if(HAS_TRAIT(source, TRAIT_SIGN_LANG)) // No modifiers for signers - I hate this but I simply cannot get these to combine into one statement
+		return FALSE // Don't modify speech
 	modify_speech(source, speech_args)
 
 /obj/item/organ/internal/tongue/proc/modify_speech(datum/source, list/speech_args)


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/79685

> This PR seeks to correct Signers from having a species/tongue-based speech modification while signing, i.e. no 'Sss'.
> 
> Being drunk still affects Signer speech - this is fine for me,

## Why It's Good For The Game

> Makes sign language more consistent and returns it to its full functionality before it broke.

## Changelog
:cl: Absolucy, Danny Boy
fix: Signers no longer sign with their species' tongue
/:cl:
