### PR TITLE
[PORT] Fix player panel encoding

### DIFF
--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -2,7 +2,7 @@
 	if(!check_rights())
 		return
 	log_admin("[key_name(usr)] checked the player panel.")
-	var/dat = "<html><head><meta http-equiv='X-UA-Compatible' content='IE=edge; charset=UTF-8'/><title>Player Panel</title></head>"
+	var/dat = "<html><head><meta http-equiv='X-UA-Compatible' content='IE=edge' charset='UTF-8'/><title>Player Panel</title></head>"
 
 	//javascript, the part that does most of the work~
 	dat += {"


### PR DESCRIPTION
This PR ports tgstation/tgstation#75584, which fixes an issue in the player panel where utf-8 support wasn't being set properly. This change shouldn't actually affect us, but I felt it was worthwhile to port it anyways.

Original PR comments follows:

----

## About The Pull Request
Fixes ?typo? in player panel html. Now non English text looks fine.

## Why It's Good For The Game
Forks that allow non English names now can see them in player panel properly.

----

Before:
![239761336-9ebfdf27-b73b-4cb2-b9a4-54ce397195aa](https://github.com/user-attachments/assets/51651187-0f25-4aed-b666-bce6fcebdb07)

After:
![239760462-179bd8dc-9105-4fb0-89d4-6ab321ca493a](https://github.com/user-attachments/assets/1ea8d59a-1e22-4335-bba2-33be6e388b14)
