### PR TITLE
distribute rewards immediately at roundend

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -221,6 +221,11 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 
 	INVOKE_ASYNC(world, TYPE_PROC_REF(/world, flush_byond_tracy)) // monkestation edit: byond-tracy
 
+	// monkestation edit: distribute monkecoin rewards
+	distribute_rewards()
+	CHECK_TICK
+	// monkestation end
+
 	for(var/datum/callback/roundend_callbacks as anything in round_end_events)
 		roundend_callbacks.InvokeAsync()
 	LAZYCLEARLIST(round_end_events)
@@ -302,7 +307,6 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 	// monkestation start: token backups, monkecoin rewards, challenges, and roundend webhook
 	save_tokens()
 	refund_cassette()
-	distribute_rewards()
 	sleep(5 SECONDS)
 	ready_for_reboot = TRUE
 	var/datum/discord_embed/embed = format_roundend_embed("<@&999008528595419278>")


### PR DESCRIPTION

## About The Pull Request

this moves `distribute_rewards()` to the very start of roundend code, before anything else possibly intensive occurs, so that everyone gets their rewards immediately, rather than a bit *after* the round ends.

## Why It's Good For The Game

reduces/eliminates the chance of eorg ruining challenge rewards

## Changelog
:cl:
fix: Challenge and job rewards will now be checked and distributed as soon as the round ends, rather than a bit afterwards.
/:cl:
