### PR TITLE
Remove a period from the regex used to determine valid youtube IDs

### DIFF
--- a/monkestation/code/modules/cassettes/machines/stationary_mixer.dm
+++ b/monkestation/code/modules/cassettes/machines/stationary_mixer.dm
@@ -99,7 +99,7 @@
 			var/url = stripped_input(usr, "Insert the ID of the video in question (characters after the =):", no_trim = TRUE)
 			var/list/data
 			///the REGEX used for determining if its a valid ID or not
-			var/static/regex/link_check = regex(@"^[a-zA-Z0-9_.-]{11}$")
+			var/static/regex/link_check = regex(@"^[a-zA-Z0-9_-]{11}$")
 			if(!link_check.Find(url))
 				to_chat(usr, "Error: Bad ID!")
 				return


### PR DESCRIPTION
## About The Pull Request
Does what it says on the tin.

In the context of its location in this regex, this period matches a literal period - `.` - which means periods are allowed to be in youtube IDs. However periods can never appear in youtube IDs - or at least, I've never seen them. So there's no reason for this regex to allow them through.

## Why It's Good For The Game
Tiny optimization, I guess?

## Changelog
No player-facing changes - not unless they were submitting invalid youtube IDs?