### PR TITLE
Vim Internal Life Support

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -624,8 +624,7 @@
 				if(!user.temporarilyRemoveItemFromInventory(part))
 					return
 				balloon_alert(user, "assembly finished!")
-				var/obj/item/tank/internals/emergency_oxygen/assembly_tank
-				assembly_tank = part
+				var/obj/item/tank/internals/emergency_oxygen/assembly_tank = part
 				var/obj/vehicle/sealed/car/vim/new_vim = new(drop_location())
 				new_vim.name = created_name
 				new_vim.tank = assembly_tank

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -590,6 +590,7 @@
 				qdel(part)
 				build_step++
 
+		//MONKESTATION EDIT START
 		if(ASSEMBLY_THIRD_STEP)
 			if(part.tool_behaviour == TOOL_SCREWDRIVER)
 				balloon_alert(user, "securing flashlight...")
@@ -597,15 +598,37 @@
 					return
 				balloon_alert(user, "flashlight secured")
 				icon_state = "vim_3"
-				desc = "Some kind of incomplete mechanism. It seems nearly completed, and just needs a voice assembly."
+				desc = "Some kind of incomplete mechanism. It seems nearly completed, and just needs an oxygen tank and voice assembly."
 				build_step++
 
 		if(ASSEMBLY_FOURTH_STEP)
 			if(istype(part, /obj/item/assembly/voice))
 				if(!can_finish_build(part, user))
 					return
-				balloon_alert(user, "assembly finished")
+				balloon_alert(user, "voice assembly added")
+				qdel(part)
+				desc = "Some kind of incomplete mechanism. The voice assembly is added, but not secured."
+				build_step++
+
+		if(ASSEMBLY_FIFTH_STEP)
+			if(part.tool_behaviour == TOOL_SCREWDRIVER)
+				balloon_alert(user, "securing voice assembly...")
+				if(!part.use_tool(src, user, 4 SECONDS, volume=100))
+					return
+				balloon_alert(user, "voice assembly secured")
+				desc = "Some kind of incomplete mechanism. It seems nearly completed, and just needs an oxygen tank."
+				build_step++
+
+		if(ASSEMBLY_SIXTH_STEP)
+			if(istype(part, /obj/item/tank/internals/emergency_oxygen))
+				if(!user.temporarilyRemoveItemFromInventory(part))
+					return
+				balloon_alert(user, "assembly finished!")
+				var/obj/item/tank/internals/emergency_oxygen/assembly_tank
+				assembly_tank = part
 				var/obj/vehicle/sealed/car/vim/new_vim = new(drop_location())
 				new_vim.name = created_name
-				qdel(part)
+				new_vim.tank = assembly_tank
+				assembly_tank.forceMove(new_vim)
 				qdel(src)
+		//MONKESTATION EDIT STOP

--- a/code/modules/vehicles/cars/car.dm
+++ b/code/modules/vehicles/cars/car.dm
@@ -13,6 +13,8 @@
 	var/vehicle_move_delay = 1
 	/// How long it takes to rev (vrrm vrrm!)
 	COOLDOWN_DECLARE(enginesound_cooldown)
+	//monkestation addition: does it explode on destruction
+	var/explode_on_destruction = TRUE
 
 /obj/vehicle/sealed/car/generate_actions()
 	. = ..()
@@ -75,8 +77,9 @@
 	add_occupant(kidnapped, VEHICLE_CONTROL_KIDNAPPED)
 
 /obj/vehicle/sealed/car/atom_destruction(damage_flag)
-	explosion(src, heavy_impact_range = 1, light_impact_range = 2, flash_range = 3, adminlog = FALSE)
-	log_message("[src] exploded due to destruction", LOG_ATTACK)
+	if(explode_on_destruction) //monkestation edit
+		explosion(src, heavy_impact_range = 1, light_impact_range = 2, flash_range = 3, adminlog = FALSE)
+		log_message("[src] exploded due to destruction", LOG_ATTACK)
 	return ..()
 
 /obj/vehicle/sealed/car/relaymove(mob/living/user, direction)

--- a/code/modules/vehicles/cars/vim.dm
+++ b/code/modules/vehicles/cars/vim.dm
@@ -21,6 +21,9 @@
 	///Maximum size of a mob trying to enter the mech
 	var/maximum_mob_size = MOB_SIZE_SMALL
 	COOLDOWN_DECLARE(sound_cooldown)
+	//monkestation additions
+	var/obj/item/tank/internals/emergency_oxygen/tank
+	explode_on_destruction = FALSE
 
 /datum/armor/car_vim
 	melee = 70
@@ -46,6 +49,13 @@
 	new /obj/effect/decal/cleanable/oil(get_turf(src))
 	do_sparks(5, TRUE, src)
 	visible_message(span_boldannounce("[src] blows apart!"))
+	//MONKESTATION EDIT START
+	new /obj/effect/decal/cleanable/robot_debris/limb(get_turf(src))
+	var/turf/T = get_turf(src)
+	if(tank)
+		tank.forceMove(T)
+		tank = null
+	//MONKESTATION EDIT STOP
 	return ..()
 
 /obj/vehicle/sealed/car/vim/mob_try_enter(mob/entering)
@@ -114,6 +124,20 @@
 		. += piloted_overlay
 	if(headlights_toggle)
 		. += headlights_overlay
+
+//MONKESTATION EDIT START
+/obj/vehicle/sealed/car/vim/return_air()
+	if(tank)
+		return tank.return_air()
+	else
+		return loc.return_air()
+
+/obj/vehicle/sealed/car/vim/return_analyzable_air()
+	if(tank)
+		return tank.return_analyzable_air()
+	else
+		return null
+//MONKESTATION EDIT STOP
 
 /obj/item/circuit_component/vim
 	display_name = "Vim"

--- a/code/modules/vehicles/cars/vim.dm
+++ b/code/modules/vehicles/cars/vim.dm
@@ -133,10 +133,7 @@
 		return loc.return_air()
 
 /obj/vehicle/sealed/car/vim/return_analyzable_air()
-	if(tank)
-		return tank.return_analyzable_air()
-	else
-		return null
+	return tank?.return_analyzable_air()
 //MONKESTATION EDIT STOP
 
 /obj/item/circuit_component/vim


### PR DESCRIPTION

## About The Pull Request
Vim's crafted by slap crafting require an emergency oxygen tank to provide life support for the pilot.

## Why It's Good For The Game
RIP McGruff.
Vim's protect critters a bit more by giving them atmosphere in spaced areas.

## Changelog

:cl:
qol: Assembly crafting Vims now requires an emergency oxygen tank that will be used as life support for the pilot.
/:cl:

