### PR TITLE
Add character savedata migration to sanitize previous alt job titles

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -162,7 +162,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			return FALSE
 
 	var/needs_update = save_data_needs_update(savefile.get_entry())
-	if(load_and_save && (needs_update == -2)) //fatal, can't load any data
+	var/needs_update_monkestation = save_data_needs_update_monkestation(savefile.get_entry()) //MONKESTATION ADDITION - Modular updates
+	if(load_and_save && (needs_update == -2 || needs_update_monkestation == -2)) //fatal, can't load any data //MONKESTATION EDIT - Modular updates
 		var/bacpath = "[path].updatebac" //todo: if the savefile version is higher then the server, check the backup, and give the player a prompt to load the backup
 		if (fexists(bacpath))
 			fdel(bacpath) //only keep 1 version of backup
@@ -197,18 +198,23 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	load_metacoins(parent_ckey)
 	load_inventory(parent_ckey)
 
-	load_preferences_monkestation()
+	load_preferences_monkestation() //MONKESTATION ADDITION - Monkestation-specific data
 
 	// Custom hotkeys
 	key_bindings = savefile.get_entry("key_bindings", key_bindings)
 
 	//try to fix any outdated data if necessary
-	if(needs_update >= 0)
+	if(needs_update >= 0 || needs_update_monkestation >= 0) //MONKESTATION EDIT - Modular updates
 		var/bacpath = "[path].updatebac" //todo: if the savefile version is higher then the server, check the backup, and give the player a prompt to load the backup
 		if (fexists(bacpath))
 			fdel(bacpath) //only keep 1 version of backup
 		fcopy(savefile.path, bacpath) //byond helpfully lets you use a savefile for the first arg.
-		update_preferences(needs_update, savefile) //needs_update = savefile_version if we need an update (positive integer)
+		//MONKESTATION EDIT START - Modular updates
+		if(needs_update >= 0)
+			update_preferences(needs_update, savefile) //needs_update = savefile_version if we need an update (positive integer)
+		if(needs_update_monkestation >= 0)
+			update_preferences_monkestation(needs_update_monkestation, savefile)
+		//MONKESTATION EDIT END
 
 	check_keybindings() // this apparently fails every time and overwrites any unloaded prefs with the default values, so don't load anything after this line or it won't actually save
 	key_bindings_by_key = get_key_bindings_by_key(key_bindings)
@@ -221,7 +227,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	key_bindings = sanitize_keybindings(key_bindings)
 	favorite_outfits = SANITIZE_LIST(favorite_outfits)
 
-	if(needs_update >= 0) //save the updated version
+	if(needs_update >= 0 || needs_update_monkestation >= 0) //save the updated version //MONKESTATION EDIT - Modular updates
 		var/old_default_slot = default_slot
 		var/old_max_save_slots = max_save_slots
 
@@ -284,7 +290,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	var/tree_key = "character[slot]"
 	var/list/save_data = savefile.get_entry(tree_key)
 	var/needs_update = save_data_needs_update(save_data)
-	if(needs_update == -2) //fatal, can't load any data
+	var/needs_update_monkestation = save_data_needs_update_monkestation(save_data) //MONKESTATION ADDITION - Modular updates
+	if(needs_update == -2 || needs_update_monkestation == -2) //fatal, can't load any data //MONKESTATION EDIT - Modular updates
 		return FALSE
 
 	// Read everything into cache
@@ -305,12 +312,16 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//Quirks
 	all_quirks = save_data?["all_quirks"]
 
-	load_character_monkestation(save_data)
-
 	//try to fix any outdated data if necessary
 	//preference updating will handle saving the updated data for us.
 	if(needs_update >= 0)
 		update_character(needs_update, save_data) //needs_update == savefile_version if we need an update (positive integer)
+	//MONKESTATION ADDITION START - Modular updates
+	if(needs_update_monkestation >= 0)
+		update_character_monkestation(needs_update_monkestation, save_data)
+	//MONKESTATION ADDITION END
+
+	load_character_monkestation(save_data) //MONKESTATION ADDITION - Monkestation-specific data
 
 	//Sanitize
 	randomise = SANITIZE_LIST(randomise)

--- a/monkestation/code/modules/client/preference_savefile.dm
+++ b/monkestation/code/modules/client/preference_savefile.dm
@@ -3,11 +3,9 @@
  * You can't really use the non-modular version, least you eventually want asinine merge
  * conflicts and/or potentially disastrous issues to arise, so here's your own.
  */
-#define MODULAR_SAVEFILE_VERSION_MAX 3
+#define MODULAR_SAVEFILE_VERSION_MAX 4
 
 #define MODULAR_SAVEFILE_UP_TO_DATE -1
-
-
 
 /datum/preferences/proc/load_character_monkestation(list/save_data)
 	if(!save_data)
@@ -42,14 +40,32 @@
 	loadout_list = sanitize_loadout_list(save_loadout)
 	special_loadout_list = texted_special_save_loadouts
 
-	if(needs_update >= 0)
-		update_character_monkestation(needs_update, save_data) // needs_update == savefile_version if we need an update (positive integer)
+/datum/preferences/proc/save_data_needs_update_monkestation(list/save_data)
+	// This proc copied wholesale from `/datum/preferences/proc/save_data_needs_update`
+	if(!save_data) // empty list, either savefile isnt loaded or its a new char
+		return MODULAR_SAVEFILE_UP_TO_DATE
 
+	/* // We don't really have a minimum save file version.
+	if(save_data["modular_version"] < SAVEFILE_VERSION_MIN)
+		return -2
+	*/
+
+	// There was a version where `modular_version` only existed in characters - not in the
+	// preferences overall.
+	if(!save_data.Find("modular_version"))
+		return 3 // 3 is the version we were at before `modular_version` was added to preferences overall.
+
+	if(save_data["modular_version"] < MODULAR_SAVEFILE_VERSION_MAX)
+		return save_data["modular_version"]
+
+	return MODULAR_SAVEFILE_UP_TO_DATE
 
 /// Brings a savefile up to date with modular preferences. Called if savefile_needs_update_monkestation() returned a value higher than 0
 /datum/preferences/proc/update_character_monkestation(current_version, list/save_data)
 	return
 
+/datum/preferences/proc/update_preferences_monkestation(current_modular_version, datum/json_savefile/save_data)
+	return
 
 /// Saves the modular customizations of a character on the savefile
 /datum/preferences/proc/save_character_monkestation(list/save_data)
@@ -65,6 +81,7 @@
 	savefile.set_entry("extra_stat_inventory", extra_stat_inventory)
 	savefile.set_entry("lootboxes_owned", lootboxes_owned)
 	savefile.set_entry("antag_rep", antag_rep)
+	savefile.set_entry("modular_version", MODULAR_SAVEFILE_VERSION_MAX)
 
 /datum/preferences/proc/load_preferences_monkestation()
 	load_jobxp_preferences()

--- a/monkestation/code/modules/client/preference_savefile.dm
+++ b/monkestation/code/modules/client/preference_savefile.dm
@@ -61,8 +61,9 @@
 	return MODULAR_SAVEFILE_UP_TO_DATE
 
 /// Brings a savefile up to date with modular preferences. Called if savefile_needs_update_monkestation() returned a value higher than 0
-/datum/preferences/proc/update_character_monkestation(current_version, list/save_data)
-	return
+/datum/preferences/proc/update_character_monkestation(current_modular_version, list/save_data)
+	if(current_modular_version < 4)
+		monkestation_sanitize_alt_job_titles(save_data)
 
 /datum/preferences/proc/update_preferences_monkestation(current_modular_version, datum/json_savefile/save_data)
 	return

--- a/monkestation/code/modules/client/preferences/migrations/sanitize_alt_job_titles.dm
+++ b/monkestation/code/modules/client/preferences/migrations/sanitize_alt_job_titles.dm
@@ -1,0 +1,19 @@
+// Ensures that any existing characters are only using valid job titles.
+//
+// As a note, this will apply to ANY invalid job titles, even if they were once valid in the past.
+/datum/preferences/proc/monkestation_sanitize_alt_job_titles(list/save_data)
+	var/list/old_alt_job_titles = save_data["alt_job_titles"]
+	var/list/new_alt_job_titles = list()
+	for(var/job_name in old_alt_job_titles)
+		var/alt_title = old_alt_job_titles[job_name]
+		var/datum/job/job = SSjob.GetJob(job_name)
+
+		if(isnull(job))
+			continue
+
+		if(!(alt_title in job.alt_titles))
+			continue
+
+		// Allows the job title into the new list.
+		new_alt_job_titles[job_name] = alt_title
+	save_data["alt_job_titles"] = new_alt_job_titles

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7164,6 +7164,7 @@
 #include "monkestation\code\modules\client\preferences\tunnel_vision.dm"
 #include "monkestation\code\modules\client\preferences\alt_jobs\_job.dm"
 #include "monkestation\code\modules\client\preferences\alt_jobs\titles.dm"
+#include "monkestation\code\modules\client\preferences\migrations\sanitize_alt_job_titles.dm"
 #include "monkestation\code\modules\client\preferences\species_features\arachnid.dm"
 #include "monkestation\code\modules\client\preferences\species_features\ethereal.dm"
 #include "monkestation\code\modules\client\preferences\species_features\floran.dm"


### PR DESCRIPTION
## About The Pull Request
This change should've been included in https://github.com/Monkestation/Monkestation2.0/pull/5430, but I forgot.

This adds a migration to save data, to sanitize previous alt job titles solely to those that are allowed. This check will only happen once per character, when they are next loaded, and then never again.

This has the unfortunate side effect of cleaning out any alt job titles that were renamed/removed (which we can consider otherwise valid job titles), but it ensures we only have allowed job titles.

Save file migrations will trigger a local backup of the save data - so if I bugged up something in this code (which I quadruple-checked to ensure I didn't, but still!), the old un-updated save data will be available to be restored.

## Changelog

:cl:MichiRecRoom
code: Alt job titles will be sanitized the next time your character data is loaded. Most people will be unaffected - but if you used an alt job title that was previously removed or renamed, you may find that said job title is no longer applied. Sorry!
/:cl:
