### PR TITLE
Fixes (hopefully) Blueshield's alt titles not showing up

### DIFF
--- a/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
+++ b/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
@@ -373,13 +373,3 @@
 		"Brig Governor",
 		"Jailer",
 	)
-
-/datum/job/blueshield
-	alt_titles = list(
-		"Blueshield",
-		"Corporate Henchman",
-		"Bodyguard",
-		"Revolutionary Repellent",
-		"Heavily Armed Butler",
-		"Honor Guard",
-	)

--- a/monkestation/code/modules/jobs/job_types/blueshield.dm
+++ b/monkestation/code/modules/jobs/job_types/blueshield.dm
@@ -44,7 +44,14 @@
 	rpg_title = "Guard"
 	job_flags = STATION_JOB_FLAGS | JOB_BOLD_SELECT_TEXT | JOB_CANNOT_OPEN_SLOTS
 
-	alt_titles = list()
+	alt_titles = list(
+		"Blueshield",
+		"Corporate Henchman",
+		"Bodyguard",
+		"Revolutionary Repellent",
+		"Heavily Armed Butler",
+		"Honor Guard",
+	)
 
 /datum/outfit/job/blueshield
 	name = "Blueshield"


### PR DESCRIPTION
## About The Pull Request
Apparently Blueshield's alt job titles weren't showing up. I tracked this down to the alt_titles list being defined twice - once with an empty list, and once with a full list of names.

## Why It's Good For The Game
We should honestly just delete SS13 and start over with a better game.

## Changelog

:cl:MichiRecRoom
fix: Blueshield's alt job titles should work now.
/:cl: