### PR TITLE
finally make heart worms not a royal pain in the ass to deal with

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -479,7 +479,7 @@
 	return TRUE
 
 /mob/living/carbon/proc/set_heartattack(status)
-	if(!can_heartattack())
+	if(status && !can_heartattack())
 		return FALSE
 
 	var/obj/item/organ/internal/heart/heart = get_organ_slot(ORGAN_SLOT_HEART)

--- a/monkestation/code/modules/virology/disease/premades/heart_attack.dm
+++ b/monkestation/code/modules/virology/disease/premades/heart_attack.dm
@@ -14,3 +14,16 @@
 	infectionchance_base = 0
 	stage_variance = 0
 	severity = DISEASE_SEVERITY_DANGEROUS
+
+/datum/disease/acute/premade/heart_failure/activate(mob/living/mob, starved, seconds_per_tick)
+	if(iscarbon(mob))
+		var/mob/living/carbon/carbon_mob = mob
+		if(!carbon_mob.can_heartattack())
+			cure(target = mob)
+			return
+	return ..()
+
+/datum/disease/acute/premade/heart_failure/cure(add_resistance, mob/living/carbon/target)
+	if(iscarbon(target))
+		target.set_heartattack(FALSE)
+	return ..()


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/82738

Fixes https://github.com/Monkestation/Monkestation2.0/issues/5450

this also makes heart worms self-cure whenever the victim no longer needs a heart

## Why It's Good For The Game

this stupid thing is a pain in everyone's ass

## Changelog
:cl:
fix: (TheRyeGuyWhoWillNowDie) Being revived with a cyber-heart now properly restarts the cyber heart.
fix: Heart worms will now self-cure if the victim no longer needs a heart.
/:cl:
