### PR TITLE
[PORT] Makes the Syndicate Tome's uplink desc actually tell people what it does

### DIFF
--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -36,8 +36,10 @@
 	name = "Syndicate Tome"
 	desc = "Using rare artifacts acquired at great cost, the Syndicate has reverse engineered \
 			the seemingly magical books of a certain cult. Though lacking the esoteric abilities \
-			of the originals, these inferior copies are still quite useful, being able to provide \
-			both weal and woe on the battlefield, even if they do occasionally bite off a finger."
+			of the originals, these inferior copies are still quite useful. \
+			Often used by agents to protect themselves against foes who rely on magic while it's held. \
+			Though, it can be used to heal and harm other people with decent effectiveness much like a regular bible. \
+			Can also be used in-hand to 'claim' it, granting you priest-like abilities -- no training required!"
 	item = /obj/item/book/bible/syndicate
 	cost = 5
 


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/89438

fun fact: I merged that PR to tg from an iMac G3! (a computer from 1998) 

> Much like what i did with the Syndie Lipstick, this item was real vague on what it does, and because of that, not only does nobody know what this item even does, nobody wants to buy it (even in situations of which they should).
> 
> Did you know holding a syndicate tome grants anti-magic like the null-rod? me neither!

## Why It's Good For The Game

> Being able to tell what an item does before you buy it is a good thing. Nor should you have to look into the code like i did to figure out what this thing does.

## Changelog

:cl: Absolucy, hyperjll
qol: The Syndicate Tome's uplink description has been changed to mention it's functionality.
/:cl: