### PR TITLE
[PORT] Improves text readability in some parts of the PDA retro theme

### DIFF
--- a/tgui/packages/tgui/styles/themes/ntOS95.scss
+++ b/tgui/packages/tgui/styles/themes/ntOS95.scss
@@ -32,7 +32,7 @@ $scrollbar-color-multiplier: 1;
     '../components/Button.scss',
     $with: (
       'color-default': #e8e4c9,
-      'color-disabled': #363636,
+      'color-disabled': #707070,
       'color-selected': #007c11,
       'color-caution': #be6209,
       'color-danger': #9d0808
@@ -71,12 +71,24 @@ $scrollbar-color-multiplier: 1;
   }
 
   .Section {
+    &__titleText {
+      color: black;
+    }
     color: black;
     background-color: #c0c0c0;
     outline: base.em(2px) outset #c3c3c3;
   }
 
   .Input {
+    background-color: white;
+    outline: base.em(2px) inset #c3c3c3;
+    color: black;
+    &__input:-ms-input-placeholder {
+      color: black;
+    }
+  }
+
+  .TextArea {
     background-color: white;
     outline: base.em(2px) inset #c3c3c3;
   }


### PR DESCRIPTION
## About The Pull Request
Ports the following PR from tgstation:
* https://github.com/tgstation/tgstation/pull/77111

now input boxes on the retro theme aren't impossible to read:

![image](https://github.com/user-attachments/assets/85ecad44-8060-4894-975e-18a35773f128)

## Changelog
:cl: distributivgesetz
qol: Made reading text with the PDA retro theme a bit more accessible.
/:cl:
