### PR TITLE
Proper bomb check, genturf description change

### DIFF
--- a/code/datums/mapgen/JungleGenerator.dm
+++ b/code/datums/mapgen/JungleGenerator.dm
@@ -89,7 +89,7 @@
 /// This turf doesn't actually do anything beyond provide contrast for mappers and be very visible when stuff breaks in game. The actual areas are what drive cave generation.
 /turf/open/genturf
 	name = "green ungenerated turf"
-	desc = "If you see this, and you're not a ghost, yell at coders"
+	desc = "If you see this, and you're not a ghost, make a bug report with where and what" //MONKESTATION EDIT everything after comment pls don't yell at me org: "yell at coders"
 	icon = 'icons/turf/debug.dmi'
 	icon_state = "genturf_green"
 

--- a/monkestation/code/game/machinery/bomb_actualizer.dm
+++ b/monkestation/code/game/machinery/bomb_actualizer.dm
@@ -131,8 +131,8 @@
 			TIMER_COOLDOWN_START(src, COOLDOWN_BOMB_BUTTON, 3 SECONDS)
 			return
 
-		else if(istype(get_area(src), /area/space))
-			say("ERROR: Does not work in space!")
+		else if(!istype(get_area(src), /area/station))
+			say("ERROR: Does not work off station!")
 			TIMER_COOLDOWN_START(src, COOLDOWN_BOMB_BUTTON, 3 SECONDS)
 			return
 


### PR DESCRIPTION

## About The Pull Request
Genturf description is now 
If you see this, and you're not a ghost, make a bug report with where and what
instead of 
If you see this, and you're not a ghost, yell at coders


Bomb actuallizer now checks if station area, and not if you aren't in space area

## Why It's Good For The Game
People took "yell at coders" a bit to literally, and just resulted in constant 0 info bug reports besides "saw genturf, said yell at coders", hopefully better now.

Bomb actuallizer check should've been this in first place, wasn't because I goofed and couldn't think of area to check for, so did space as place holder. correcting old mistake

## Changelog

:cl:
add: Updated genturf description
fix: bomb actuallizer checks proper area
/:cl:

