### PR TITLE
[PORT] Changes entertainment radio to be darker

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -378,7 +378,7 @@ em {
 }
 
 .enteradio {
-  color: #00ff99;
+  color: #79c5a8;
 }
 
 .redteamradio {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -396,7 +396,7 @@ em {
 }
 
 .enteradio {
-  color: #00d680;
+  color: #5c8a87;
 }
 
 .redteamradio {

--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -19,7 +19,7 @@ $_channel_map: (
   'Me': #5975da,
   'Med': #57b8f0,
   'OOC': #cca300,
-  'Ent': #00ff99,
+  'Ent': #5c8a87,
   'LOOC': #fafa3b,
   'Mentor': #ff00ff,
   'Radio': #1ecc43,


### PR DESCRIPTION
This PR is a port of the following PR from tgstation:
* https://github.com/tgstation/tgstation/pull/87459

Before I show the original PR description, here's an example of what our entertainment radio messages currently look like:
![image](https://github.com/user-attachments/assets/72e43064-c426-42ec-affd-6efc7e3a52c5)
![image](https://github.com/user-attachments/assets/11adc4ee-d477-4333-8aaa-14e85f858933)

Original PR description follows:

## About The Pull Request

I made the entertainment radio text a little less eye-searing.

![380234524-d95c10aa-cfa1-4365-922b-b3a5c03e3bfd](https://github.com/user-attachments/assets/a82110f4-232a-47a8-a5f1-6296a9ec2200)
![380234533-aed97d39-2938-4fdb-8ccc-930a65deb592](https://github.com/user-attachments/assets/d2421b7c-4718-4ce6-9eda-81ebc363c4b6)
![380326969-436632c1-59eb-4fb4-a632-0c3b2448e45a](https://github.com/user-attachments/assets/7b843ae8-75e2-407f-a304-9b680d086b88)

## Why It's Good For The Game

I'm sure it looked kind of okay on dark mode, but for us light mode heathens, entertainment chat could be kind of hard to read sometimes. This shade looks better and, while not as bright, I think fits the role better - I went for something similar to the kind of blue/grey of a reporter's suit.
## Changelog

:cl:MichiRecRoom, Vekter
fix: Changed the color of entertainment radio to be darker
/:cl:

