### PR TITLE
`/mob/living/infect_disease()` now compares the uniqueID and subID directly

### DIFF
--- a/monkestation/code/modules/virology/living/spread_disease.dm
+++ b/monkestation/code/modules/virology/living/spread_disease.dm
@@ -29,8 +29,8 @@
 	if(!disease.spread_flags && !(disease.disease_flags & DISEASE_DORMANT))
 		return FALSE
 
-	for(var/datum/disease/acute/D as anything in diseases)
-		if("[disease.uniqueID]-[disease.subID]" == "[D.uniqueID]-[D.subID]") // child ids are for pathogenic mutations and aren't accounted for as thats fucked.
+	for(var/datum/disease/acute/old_disease as anything in diseases)
+		if(disease.uniqueID == old_disease.uniqueID && disease.subID == old_disease.subID) // child ids are for pathogenic mutations and aren't accounted for as thats fucked.
 			return FALSE
 
 	if(immune_system && !immune_system.CanInfect(disease))


### PR DESCRIPTION
## About The Pull Request
Previously, this line concatenated the unique ID and sub ID into a string, and compared that.

However, the use of a string here was completely unnecessary, and we could just compare the values directly, which is infinitely faster.

## Why It's Good For The Game
performance number go up weeee

## Changelog
N/A no player-facing changes