### PR TITLE
TRAIT_NOBLOOD now resets your blood volume

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -251,6 +251,10 @@
 	var/apparent_blood_volume = blood_volume
 	if(HAS_TRAIT(src, TRAIT_USES_SKINTONES) && (skin_tone == "albino"))
 		apparent_blood_volume -= 150 // enough to knock you down one tier
+	// MONKESTATION EDIT START
+	if(HAS_TRAIT(src, TRAIT_NOBLOOD))
+		apparent_blood_volume = BLOOD_VOLUME_NORMAL // Duh.
+	// MONKESTATION EDIT END
 	if(isethereal(src))//Monkestation Changes Start:
 		if(appears_dead)
 			if(blood_volume < ETHEREAL_BLOOD_CHARGE_LOWEST_PASSIVE)

--- a/monkestation/code/modules/mob/living/carbon/human/init_signals.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/init_signals.dm
@@ -1,5 +1,6 @@
 /mob/living/carbon/human/register_init_signals()
 	. = ..()
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_NOBLOOD), PROC_REF(on_gain_noblood_trait))
 	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_NOBLOOD), PROC_REF(on_lose_noblood_trait))
 
 	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_FAT), PROC_REF(on_trait_fat_gain))

--- a/monkestation/code/modules/mob/living/carbon/human/init_signals.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/init_signals.dm
@@ -5,9 +5,13 @@
 	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_FAT), PROC_REF(on_trait_fat_gain))
 	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_FAT), PROC_REF(on_trait_fat_loss))
 
+/mob/living/carbon/human/proc/on_gain_noblood_trait(datum/source)
+	SIGNAL_HANDLER
+	blood_volume = BLOOD_VOLUME_NORMAL
+
 /mob/living/carbon/human/proc/on_lose_noblood_trait(datum/source)
 	SIGNAL_HANDLER
-	blood_volume = clamp(blood_volume, BLOOD_VOLUME_NORMAL, BLOOD_VOLUME_MAXIMUM - 1)
+	blood_volume = BLOOD_VOLUME_NORMAL
 
 /mob/living/carbon/human/proc/on_trait_fat_gain(datum/source)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request

Previously, it did some wack snowflake math when the trait was removed to reset your blood volume.
Now it resets it to normal on both add and remove.

Also adds a final check to the examine proc itself that makes sure you never look pale or anything if you have the trait.
## Why It's Good For The Game

Bloodless people shouldn't look like crushed juice pouches when examined. (found while testing enthrallment on vamp rework)
## Changelog
:cl:
fix: People who have the "no blood" trait don't show up as crushed juice pouches on examine if they were physically drained of blood before getting the trait.
/:cl:
