### PR TITLE
Syndicate Depot Revision 3: Black-Box Data Storage

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -111,11 +111,9 @@
 	},
 /area/ruin/syndicate_lava_base/arrivals)
 "bx" = (
-/obj/machinery/syndicatebomb/self_destruct{
-	anchored = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4,
 /obj/structure/cable,
+/obj/machinery/syndicatebomb/self_destruct/announce,
 /turf/open/floor/circuit/red,
 /area/ruin/syndicate_lava_base/main)
 "bC" = (

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -84,9 +84,7 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "au" = (
-/obj/machinery/syndicatebomb/self_destruct{
-	anchored = 1
-	},
+/obj/machinery/syndicatebomb/self_destruct/announce,
 /turf/open/floor/circuit/red,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "aw" = (

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -628,9 +628,7 @@
 	name = "Emergency Self Destruct Access"
 	},
 /obj/structure/sign/warning/explosives/alt/directional/north,
-/obj/machinery/syndicatebomb/self_destruct{
-	anchored = 1
-	},
+/obj/machinery/syndicatebomb/self_destruct/announce,
 /turf/open/floor/circuit/red/anim,
 /area/ruin/space/has_grav/listeningstation/support)
 "rx" = (

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -128,14 +128,6 @@
 	pixel_y = 3
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/button/door/directional/south{
-	id = "syndicate_depot_eva";
-	name = "EVA Storage Shutters";
-	req_access = list("syndicate_leader")
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/eva_storage)
@@ -259,6 +251,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"dn" = (
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/space/has_grav/syndicate_depot/hallway)
 "dp" = (
 /obj/machinery/camera/directional/east{
 	network = list("syndicate_depot");
@@ -339,13 +334,8 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "dZ" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Exterior: Vault Auxiliary Turret";
-	network = list("syndicate_depot")
-	},
-/turf/open/misc/asteroid/airless,
-/area/ruin/space/has_grav/syndicate_depot)
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/space/has_grav/syndicate_depot/crew_quarters)
 "ea" = (
 /obj/structure/closet/toolcloset,
 /obj/item/pipe_dispenser,
@@ -420,6 +410,9 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/misc/dirt/station,
 /area/ruin/space/has_grav/syndicate_depot/hydroponics)
+"eZ" = (
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/space/has_grav/syndicate_depot/manufacturing)
 "fc" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -617,14 +610,17 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "gR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/mapping_helpers/apc/syndicate_access,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/mapping_helpers/apc/cut_AI_wire,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/syndicate_depot/eva_storage)
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "syndicate_depot_lockdown"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/door/firedoor,
+/obj/structure/sign/warning/explosives/alt/directional/west,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/hallway)
 "gS" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -692,15 +688,13 @@
 /turf/open/floor/iron/kitchen/small,
 /area/ruin/space/has_grav/syndicate_depot/crew_quarters)
 "hB" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas/syndicate,
-/obj/effect/turf_decal/stripes/corner,
-/obj/item/pickaxe/drill,
-/obj/item/t_scanner/adv_mining_scanner/lesser,
-/obj/item/storage/bag/ore,
-/obj/item/mod/control/pre_equipped/nuclear,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/syndicate_depot/eva_storage)
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/blackbox_recorder/syndicate,
+/turf/open/floor/pod/dark,
+/area/ruin/space/has_grav/syndicate_depot/vault)
 "hJ" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/structure/closet/crate,
@@ -959,6 +953,25 @@
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/syndicate_depot)
+"kA" = (
+/obj/structure/cable,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
+/obj/machinery/button/door/directional/north{
+	req_access = list("syndicate_leader");
+	id = "syndicate_depot_eva";
+	name = "EVA Storage Shutters"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "kH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -1206,17 +1219,12 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "nH" = (
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/west,
+/obj/machinery/atmospherics/pipe/layer_manifold/general/hidden{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/apc/syndicate_access,
-/obj/effect/mapping_helpers/apc/cell_10k,
-/obj/structure/safe,
-/obj/item/stack/telecrystal/five,
-/obj/item/stack/telecrystal/twenty,
-/obj/effect/mapping_helpers/apc/cut_AI_wire,
-/turf/open/floor/circuit/red/anim,
-/area/ruin/space/has_grav/syndicate_depot/vault)
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "nJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -1359,11 +1367,25 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/syndicate_depot/control_room)
 "pc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/pen{
+	pixel_x = -7;
+	pixel_y = 6
+	},
+/obj/item/paper_bin{
+	pixel_x = -7;
+	pixel_y = 4
+	},
+/obj/item/stamp/denied{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/item/stamp/granted{
+	pixel_x = 11;
+	pixel_y = -1
 	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
@@ -1477,16 +1499,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "rl" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "syndicate_depot_eva"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
+/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/syndicate_depot/eva_storage)
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "rq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1563,16 +1579,32 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/hydroponics)
 "si" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/machinery/fax{
-	syndicate_network = 1;
-	name = "Depot Fax Machine";
-	fax_name = "Syndicate Depot Cargo Bay"
-	},
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
+/obj/structure/filingcabinet,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/button/door/directional/south{
+	id = "syndicate_depot_eva";
+	name = "EVA Storage Shutters";
+	req_access = list("syndicate_leader")
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
+"sj" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/effect/mapping_helpers/apc/cell_10k,
+/obj/structure/safe,
+/obj/item/stack/telecrystal/five,
+/obj/item/stack/telecrystal/twenty,
+/obj/effect/mapping_helpers/apc/cut_AI_wire,
+/obj/item/card/id/advanced/chameleon,
+/obj/item/card/id/advanced/chameleon,
+/turf/open/floor/circuit/red/anim,
+/area/ruin/space/has_grav/syndicate_depot/vault)
 "sn" = (
 /obj/machinery/button/door/directional/south{
 	normaldoorcontrol = 1;
@@ -1765,16 +1797,51 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/security)
 "tN" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/syndicate_depot/eva_storage)
+/obj/machinery/button/door/directional/south{
+	req_access = list("syndicate_leader");
+	name = "Emergency Base Lockdown";
+	id = "syndicate_depot_lockdown"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/closet/crate/engineering,
+/obj/item/stack/sheet/plastic/fifty,
+/obj/item/stack/sheet/mineral/uranium/five,
+/obj/item/stack/sheet/mineral/uranium/five,
+/obj/item/stack/sheet/mineral/silver/twenty,
+/obj/item/stack/sheet/mineral/gold/five,
+/obj/item/stack/sheet/mineral/gold/five,
+/obj/item/stack/sheet/mineral/diamond/five,
+/obj/item/stack/sheet/mineral/diamond/five,
+/obj/item/stack/sheet/mineral/titanium/fifty,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/mineral/plastitanium{
+	amount = 50
+	},
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/mineral/plasma/thirty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/circuit/red/anim,
+/area/ruin/space/has_grav/syndicate_depot/vault)
 "tO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/syndicate_depot/eva_storage)
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -4;
+	pixel_y = -7
+	},
+/obj/item/multitool{
+	pixel_x = 14;
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/turf/open/floor/circuit/red/anim,
+/area/ruin/space/has_grav/syndicate_depot/vault)
 "tQ" = (
 /obj/machinery/conveyor/inverted{
 	dir = 10;
@@ -2111,9 +2178,10 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "xM" = (
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/syndicate_depot/hallway)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "xU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -2402,17 +2470,10 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "AJ" = (
-/obj/machinery/button/door/directional/south{
-	req_access = list("syndicate_leader");
-	name = "Emergency Base Lockdown";
-	id = "syndicate_depot_lockdown"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/circuit/red/anim,
-/area/ruin/space/has_grav/syndicate_depot/vault)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "AS" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -2485,13 +2546,12 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "BW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/syndicate_depot/eva_storage)
+/turf/closed/wall/mineral/plastitanium/explosive,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "BZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/light/small/directional/south,
+/obj/machinery/atmospherics/components/binary/pump/off/general/visible/layer4{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
@@ -2527,14 +2587,12 @@
 /turf/open/floor/iron/white/small,
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
 "CE" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/photocopier/gratis,
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 1
 	},
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
+/obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "CG" = (
@@ -2696,10 +2754,11 @@
 /turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Ft" = (
-/obj/structure/table/reinforced/plastitaniumglass,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 8
 	},
+/obj/machinery/photocopier/gratis,
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Fy" = (
@@ -2884,13 +2943,12 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "HW" = (
-/obj/item/storage/toolbox/electrical,
-/obj/item/multitool,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/machinery/airalarm/directional/north,
-/obj/effect/mapping_helpers/airalarm/syndicate_access,
-/turf/open/floor/circuit/red/anim,
-/area/ruin/space/has_grav/syndicate_depot/vault)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "HX" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
 /obj/machinery/door/poddoor/shutters{
@@ -3346,32 +3404,18 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Nb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/rack,
+/obj/item/clothing/mask/gas/syndicate,
+/obj/item/pickaxe/drill,
+/obj/item/t_scanner/adv_mining_scanner/lesser,
+/obj/item/storage/bag/ore,
+/obj/item/mod/control/pre_equipped/nuclear,
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/obj/structure/closet/crate/engineering,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/mineral/plasma/thirty,
-/obj/item/stack/sheet/mineral/plastitanium{
-	amount = 50
-	},
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/item/stack/sheet/mineral/titanium/fifty,
-/obj/item/stack/sheet/mineral/diamond/five,
-/obj/item/stack/sheet/mineral/diamond/five,
-/obj/item/stack/sheet/mineral/gold/five,
-/obj/item/stack/sheet/mineral/gold/five,
-/obj/item/stack/sheet/mineral/silver/twenty,
-/obj/item/stack/sheet/mineral/uranium/five,
-/obj/item/stack/sheet/mineral/uranium/five,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/stack/sheet/plastic/fifty,
-/turf/open/floor/pod/dark,
-/area/ruin/space/has_grav/syndicate_depot/vault)
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "Nk" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "depot_shipbreak";
@@ -3473,9 +3517,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 "OD" = (
-/obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/iron/dark,
-/area/ruin/space/has_grav/syndicate_depot/eva_storage)
+/obj/machinery/atmospherics/components/tank/air{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "OQ" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -3581,15 +3628,17 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/syndicate_depot)
 "PQ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/filingcabinet,
 /obj/machinery/light/directional/north,
 /obj/machinery/light_switch/directional/east,
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/fax{
+	syndicate_network = 1;
+	name = "Depot Fax Machine";
+	fax_name = "Syndicate Depot Cargo Bay"
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "PR" = (
@@ -3969,24 +4018,8 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "TY" = (
-/obj/structure/table/reinforced/plastitaniumglass,
-/obj/item/paper_bin{
-	pixel_x = -7;
-	pixel_y = 4
-	},
-/obj/item/pen{
-	pixel_x = -7;
-	pixel_y = 6
-	},
-/obj/item/stamp/denied{
-	pixel_x = 4;
-	pixel_y = -1
-	},
-/obj/item/stamp/granted{
-	pixel_x = 11;
-	pixel_y = -1
-	},
 /obj/effect/turf_decal/tile/brown/half/contrasted,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Ue" = (
@@ -4111,6 +4144,11 @@
 /obj/item/wrench/medical,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/infirmary)
+"VF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "VI" = (
 /turf/open/floor/engine/plasma,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
@@ -4201,9 +4239,16 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/hydroponics)
 "WE" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/dark,
+/obj/machinery/door/poddoor/shutters{
+	id = "syndicate_depot_eva";
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "WJ" = (
 /obj/effect/turf_decal/sand/plating,
@@ -4418,16 +4463,12 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "YP" = (
-/obj/effect/turf_decal/sand/plating,
-/obj/machinery/porta_turret/syndicate/depot{
-	dir = 10;
-	desc = "A ballistic machine-gun auto-turret. This one has had one of its barrels replaced with a taser. You can see a little drawing of a face engraved into it, with the turret's cameras for eyes; silently mocking you."
+/obj/structure/tank_dispenser/oxygen,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/asteroid/line{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/ruin/space/has_grav/syndicate_depot)
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "YQ" = (
 /obj/machinery/door/poddoor{
 	id = "syndicate_depot_airlock_out"
@@ -6702,7 +6743,7 @@ Fc
 Fc
 tF
 jG
-aK
+eZ
 Sg
 aK
 tF
@@ -7031,7 +7072,7 @@ nt
 Fc
 hq
 hq
-et
+hq
 et
 et
 BF
@@ -7109,8 +7150,8 @@ Nu
 zU
 dx
 Fc
-hq
-hq
+Fc
+Fc
 hq
 hq
 et
@@ -7185,12 +7226,12 @@ wZ
 KL
 NO
 wN
-Nu
+BW
 Me
 PU
+Nu
+OD
 Fc
-et
-et
 hq
 hq
 et
@@ -7268,9 +7309,9 @@ AB
 Nu
 Hn
 Nu
+Nu
+nH
 Fc
-Fc
-et
 hq
 hq
 et
@@ -7334,7 +7375,7 @@ Xk
 vZ
 jw
 eC
-iD
+dn
 MZ
 HU
 dU
@@ -7349,8 +7390,8 @@ xD
 fR
 fR
 fR
+BZ
 Fc
-et
 hq
 hq
 et
@@ -7413,24 +7454,24 @@ Se
 rE
 hc
 IG
-BR
-BR
-BR
-BR
-BR
-Nu
+mz
+mz
+mz
+mz
+mz
+BW
 RH
 Jn
 Nu
-mz
-mz
-mz
-mz
-mz
+BR
+BR
+BR
+BR
+BR
 BE
-BZ
+fR
+rl
 Fc
-et
 hq
 hq
 et
@@ -7493,24 +7534,24 @@ Se
 jx
 FY
 jx
-BR
-OD
-xc
+mz
+on
+sj
 hB
-BR
+mz
 CE
 kg
 rQ
 Ft
-mz
-on
-nH
+BR
+YP
+xc
 Nb
-mz
+BR
 hV
 sK
+Me
 Fc
-dZ
 hq
 hq
 Vj
@@ -7573,24 +7614,24 @@ sR
 cs
 br
 fm
-BR
+mz
 tO
-BW
+Au
 tN
-rl
+mz
 pc
 le
 le
 TY
-mz
+WE
 HW
-Au
+xM
 AJ
-mz
+BR
 LS
 oy
+Me
 Fc
-YP
 hq
 hq
 hq
@@ -7653,20 +7694,20 @@ PC
 kc
 vZ
 Xk
-QR
-gR
-WE
-bD
-BR
-PQ
-Qx
-kH
-si
 mz
 xd
 aW
 kK
 mz
+PQ
+Qx
+kH
+si
+BR
+kA
+VF
+bD
+BR
 Oe
 Oe
 Oe
@@ -7733,20 +7774,20 @@ PC
 kc
 vZ
 jw
-BR
-BR
-BR
-BR
-BR
-Nu
-IE
-XO
-Nu
 mz
 mz
 Mi
 mz
 mz
+Nu
+IE
+XO
+Nu
+BR
+BR
+QR
+BR
+BR
 dt
 lU
 eo
@@ -7813,17 +7854,17 @@ sR
 Yo
 vZ
 Ay
-Ay
 Am
-ln
+gR
 aR
+nM
 yS
 qt
 UO
 xg
 Yy
 Ay
-nM
+Ay
 wb
 pk
 vB
@@ -7893,10 +7934,10 @@ ZW
 Xk
 vZ
 vZ
-vZ
 Up
 yI
 iq
+vZ
 vZ
 vZ
 vZ
@@ -7973,10 +8014,10 @@ Nz
 LH
 Uf
 Eq
-xM
 Am
 ln
 kc
+Ay
 Ay
 vZ
 Ay
@@ -8053,7 +8094,7 @@ fS
 iD
 RL
 SX
-SX
+dZ
 SX
 SX
 Zk

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -31,12 +31,13 @@
 /turf/open/floor/carpet/red,
 /area/ruin/space/has_grav/syndicate_depot/control_room)
 "aR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = 6
 	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/syndicate_depot/hallway)
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "aS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1091,6 +1092,7 @@
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "lQ" = (
 /obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/cell_charger,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "lU" = (
@@ -1501,6 +1503,7 @@
 "rl" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "rq" = (
@@ -2490,6 +2493,11 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"Bk" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Bn" = (
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/components/unary/portables_connector/layer4,
@@ -3363,6 +3371,13 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/misc/asteroid/airless,
 /area/ruin/space/has_grav/syndicate_depot)
+"Mx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/syndicate_depot/hallway)
 "Mz" = (
 /obj/machinery/biogenerator,
 /obj/item/reagent_containers/cup/beaker/large,
@@ -7551,7 +7566,7 @@ Nb
 BR
 hV
 sK
-Me
+aR
 Fc
 hq
 hq
@@ -7631,7 +7646,7 @@ AJ
 BR
 LS
 oy
-Me
+Bk
 Fc
 hq
 hq
@@ -8017,7 +8032,7 @@ Uf
 Eq
 Am
 ln
-aR
+Mx
 Ay
 Ay
 vZ

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -692,7 +692,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/blackbox_recorder/syndicate,
+/obj/machinery/syndicate_blackbox_recorder,
 /turf/open/floor/pod/dark,
 /area/ruin/space/has_grav/syndicate_depot/vault)
 "hJ" = (
@@ -3240,6 +3240,7 @@
 /obj/item/circuitboard/machine/quantumpad,
 /obj/item/circuitboard/machine/quantumpad,
 /obj/item/storage/toolbox/electrical,
+/obj/item/circuitboard/machine/spaceship_navigation_beacon,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "KP" = (

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -34,7 +34,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/light/directional/west,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/hallway)
 "aS" = (
@@ -7857,7 +7857,7 @@ vZ
 Ay
 Am
 gR
-aR
+kc
 nM
 yS
 qt
@@ -8017,7 +8017,7 @@ Uf
 Eq
 Am
 ln
-kc
+aR
 Ay
 Ay
 vZ

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -2637,6 +2637,15 @@
 /obj/structure/railing,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
+"CN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/syndicate_depot/hallway)
 "CX" = (
 /obj/machinery/computer/security{
 	network = list("syndicate_depot");
@@ -4163,6 +4172,7 @@
 "VF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/syndicate_depot/eva_storage)
 "VI" = (
@@ -7709,7 +7719,7 @@ tM
 PC
 kc
 vZ
-Xk
+Ay
 mz
 xd
 aW
@@ -7872,7 +7882,7 @@ vZ
 Ay
 Am
 gR
-kc
+CN
 nM
 yS
 qt

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -2446,11 +2446,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "Au" = (
-/obj/machinery/syndicatebomb/self_destruct,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/syndicatebomb/self_destruct/announce,
 /turf/open/floor/circuit/red/anim,
 /area/ruin/space/has_grav/syndicate_depot/vault)
 "Ay" = (

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -262,6 +262,9 @@ GLOBAL_LIST_INIT(cat_typecache, typecacheof(list(
 
 #define is_reagent_container(O) (istype(O, /obj/item/reagent_containers))
 
+//MONKESTATION EDIT: used to block cargo teleporters from escaping with syndicate blackbox
+#define issyndicateblackbox(O) (istype(O, /obj/item/syndicate_blackbox))
+
 //Assemblies
 #define isassembly(O) (istype(O, /obj/item/assembly))
 

--- a/code/modules/cargo/exports/spaceloot.dm
+++ b/code/modules/cargo/exports/spaceloot.dm
@@ -8,7 +8,7 @@
 	unit_name = "syndicate salvage"
 
 /datum/export/space_salvage/syndicate/blackbox
-	cost = CARGO_CRATE_VALUE * 10 //good luck getting it though lmao
+	cost = CARGO_CRATE_VALUE * 25 //good luck getting it though lmao
 	unit_name = "syndicate data recorder"
 	export_types = list(/obj/item/syndicate_blackbox)
 
@@ -16,3 +16,8 @@
 	cost = CARGO_CRATE_VALUE * 3 //you can get them from traitors, but explorers can get them from deep storage and depot (even if nobody spawns) and the other syndicate roles. sell that shit, dont give it to sec. trust me bro.
 	unit_name = "syndicate encryption device"
 	export_types = list(/obj/item/encryptionkey/syndicate)
+
+/datum/export/space_salvage/syndicate/id_card
+	cost = CARGO_CRATE_VALUE * 2 //appears anywhere there are syndicate corpses, so worth less than the key but still valuable
+	unit_name = "syndicate identification card"
+	export_types = list(/obj/item/card/id/advanced/chameleon)

--- a/code/modules/cargo/exports/spaceloot.dm
+++ b/code/modules/cargo/exports/spaceloot.dm
@@ -9,10 +9,10 @@
 
 /datum/export/space_salvage/syndicate/blackbox
 	cost = CARGO_CRATE_VALUE * 10 //good luck getting it though lmao
-	unit_name = "vital syndicate intelligence"
+	unit_name = "syndicate data recorder"
 	export_types = list(/obj/item/syndicate_blackbox)
 
 /datum/export/space_salvage/syndicate/key
 	cost = CARGO_CRATE_VALUE * 3 //you can get them from traitors, but explorers can get them from deep storage and depot (even if nobody spawns) and the other syndicate roles. sell that shit, dont give it to sec. trust me bro.
-	unit_name = "syndicate encryption equipment"
+	unit_name = "syndicate encryption device"
 	export_types = list(/obj/item/encryptionkey/syndicate)

--- a/code/modules/cargo/exports/spaceloot.dm
+++ b/code/modules/cargo/exports/spaceloot.dm
@@ -1,0 +1,18 @@
+//ALL OF THIS IS MONKESTATION EDIT
+
+/datum/export/space_salvage
+	cost = CARGO_CRATE_VALUE * 2
+	unit_name = "space salvage"
+
+/datum/export/space_salvage/syndicate
+	unit_name = "syndicate salvage"
+
+/datum/export/space_salvage/syndicate/blackbox
+	cost = CARGO_CRATE_VALUE * 10 //good luck getting it though lmao
+	unit_name = "vital syndicate intelligence"
+	export_types = list(/obj/item/syndicate_blackbox)
+
+/datum/export/space_salvage/syndicate/key
+	cost = CARGO_CRATE_VALUE * 3 //you can get them from traitors, but explorers can get them from deep storage and depot (even if nobody spawns) and the other syndicate roles. sell that shit, dont give it to sec. trust me bro.
+	unit_name = "syndicate encryption equipment"
+	export_types = list(/obj/item/encryptionkey/syndicate)

--- a/monkestation/code/modules/cargoborg/code/cargo_teleporter.dm
+++ b/monkestation/code/modules/cargoborg/code/cargo_teleporter.dm
@@ -57,6 +57,8 @@ GLOBAL_LIST_EMPTY(cargo_marks)
 			continue
 		if(!ismovable(check_content))
 			continue
+		if(issyndicateblackbox(check_content))
+			continue
 		var/atom/movable/movable_content = check_content
 		if(isliving(movable_content))
 			continue

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -183,7 +183,7 @@
 
 /obj/machinery/syndicate_blackbox_recorder
 	name = "syndicate blackbox recorder"
-	desc = "A modified blackbox recorder used by Syndicate outposts, usually documenting general happenings of outposts, but also more strategically exotic information such as supply manifests and strike team dispatches. A sticker on it says 'WARNING: REMOVAL OF BLACKBOX WILL SEND A DISTRESS SIGNAL'. Huh."
+	desc = "A modified blackbox recorder used by Syndicate outposts, usually documenting general happenings of outposts, but also more strategically exotic information such as supply manifests and strike team dispatches. While the black-box is inside, it can't be destroyed. A sticker on it says 'WARNING: REMOVAL OF BLACKBOX WILL SEND A DISTRESS SIGNAL'. Huh."
 	density = TRUE
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "blackbox"

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -249,7 +249,8 @@
 			if(Adjacent(user))
 				user.put_in_hands(stored)
 			stored = null
-			to_chat(user, span_notice("You remove the blackbox from [src]. The tapes stop spinning, and you hear a quiet alarm from inside the recorder."))
+			to_chat(user, span_notice("You remove the blackbox from [src]. The tapes stop spinning, and you hear an alarm from inside the recorder."))
+			playsound(src, 'sound/effects/alert.ogg', 50, TRUE)
 			notify_ghosts("A Syndicate black-box has been stolen!",
 			source = src,
 			header = "Explorers afoot!",

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -270,9 +270,6 @@
 		source = src,
 		header = "That's gotta hurt!",
 		)
-		var/area/A = get_area(loc)
-		var/message = "DANGER: Recorder integrity compromised at [initial(A.name)]!! All units respond immediately!!!"
-		radio.talk_into(src, message, radio_channel)
 		QDEL_NULL(radio)
 		stored.forceMove(loc)
 		new /obj/effect/decal/cleanable/oil(loc)

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -273,6 +273,7 @@
 		var/area/A = get_area(loc)
 		var/message = "DANGER: Recorder integrity compromised at [initial(A.name)]!! All units respond immediately!!!"
 		radio.talk_into(src, message, radio_channel)
+		QDEL_NULL(radio)
 		stored.forceMove(loc)
 		new /obj/effect/decal/cleanable/oil(loc)
 	return ..()

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -192,9 +192,7 @@
 	var/obj/item/radio/radio //i hate this fucking code
 	var/radio_channel = RADIO_CHANNEL_SYNDICATE
 	var/obj/item/stored
-	var/next_warning = 0
-	///The amount of time we have between warnings
-	var/minimum_time_between_warnings = 40 SECONDS
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //meant to be breakable when box not inserted, but it might shit itself if i change resistance flags mid-operation
 
 /obj/machinery/syndicate_blackbox_recorder/Initialize(mapload)
 	. = ..()
@@ -228,6 +226,7 @@
 			return
 		user.visible_message(span_notice("[user] clicks [I] into [src]!"), \
 		span_notice("You press the device into [src], and it clicks into place. The tapes begin spinning again."))
+		resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
 		var/area/A = get_area(loc)
 		var/message = "Storage device re-connected in [initial(A.name)]."
@@ -258,6 +257,7 @@
 			var/area/A = get_area(loc)
 			var/message = "ALERT: Confidential storage device removed in [initial(A.name)]! Immediate response required!"
 			radio.talk_into(src, message, radio_channel)
+			resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 			update_appearance()
 		return
 	else

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -250,7 +250,7 @@
 				user.put_in_hands(stored)
 			stored = null
 			to_chat(user, span_notice("You remove the blackbox from [src]. The tapes stop spinning, and you realize the Syndicate are on to you now."))
-			notify_ghosts("A Syndicate black-box has been stolen or tampered with!",
+			notify_ghosts("A Syndicate black-box has been stolen!",
 			source = src,
 			header = "Explorers afoot!",
 			)

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -249,7 +249,7 @@
 			if(Adjacent(user))
 				user.put_in_hands(stored)
 			stored = null
-			to_chat(user, span_notice("You remove the blackbox from [src]. The tapes stop spinning, and you realise the Syndicate are on to you now."))
+			to_chat(user, span_notice("You remove the blackbox from [src]. The tapes stop spinning, and you realize the Syndicate are on to you now."))
 			notify_ghosts("A Syndicate black-box has been stolen or tampered with!",
 			source = src,
 			header = "Explorers afoot!",

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -185,20 +185,32 @@
 	name = "syndicate blackbox recorder"
 	desc = "A modified blackbox recorder used by Syndicate outposts, usually documenting general happenings of outposts, but also more strategically exotic information such as supply manifests and strike team dispatches. A sticker on it says 'WARNING: REMOVAL OF BLACKBOX WILL SEND A DISTRESS SIGNAL'. Huh."
 	density = TRUE
-	///The machine's internal radio, used to broadcast alerts.
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "blackbox"
 	armor_type = /datum/armor/machinery_blackbox_recorder
+	///The machine's internal radio, used to broadcast alerts.
+	var/obj/item/radio/radio //i hate this fucking code
+	var/radio_channel = RADIO_CHANNEL_SYNDICATE
 	var/obj/item/stored
+	var/next_warning = 0
+	///The amount of time we have between warnings
+	var/minimum_time_between_warnings = 40 SECONDS
 
-
-/obj/machinery/blackbox_recorder/syndicate/Initialize(mapload)
+/obj/machinery/syndicate_blackbox_recorder/Initialize(mapload)
 	. = ..()
 	stored = new /obj/item/syndicate_blackbox(src)
+	radio = new(src)
+	radio.make_syndie()
+	radio.subspace_transmission = TRUE
+	radio.canhear_range = 0
+	radio.set_listening(FALSE)
+	radio.recalculateChannels()
+	radio.command = TRUE
+	radio.use_command = TRUE
 
 /obj/item/syndicate_blackbox
 	name = "\proper syndicate black box"
-	desc = "A large, heavily armoured black box bearing the insignia of the Syndicate coalition, containing extremely valuable intelligence data. The weight of its armour makes it tricky to move around while carrying it. It can be sold on the cargo shuttle to Central Command; getting it there, however..."
+	desc = "A large, heavily armoured black box bearing the insignia of the Syndicate coalition, containing extremely valuable intelligence data. It can be sold on the cargo shuttle to Central Command; getting it there, however..."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "blackcube"
 	inhand_icon_state = "blackcube"
@@ -206,7 +218,6 @@
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	w_class = WEIGHT_CLASS_BULKY
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
-	slowdown = 1
 
 
 
@@ -219,7 +230,7 @@
 		span_notice("You press the device into [src], and it clicks into place. The tapes begin spinning again."))
 		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
 		var/area/A = get_area(loc)
-		var/message = "Storage device re-connected in [initial(A.name)]. All units return to code 4."
+		var/message = "Storage device re-connected in [initial(A.name)]."
 		radio.talk_into(src, message, radio_channel)
 		stored = I
 		update_appearance()
@@ -233,19 +244,21 @@
 /obj/machinery/syndicate_blackbox_recorder/attack_hand(mob/living/user, list/modifiers)
 	. = ..()
 	if(stored)
-		stored.forceMove(drop_location())
-		if(Adjacent(user))
-			user.put_in_hands(stored)
-		stored = null
-		to_chat(user, span_notice("You remove the blackbox from [src]. The tapes stop spinning, and you realise the Syndicate are on to you now."))
-		notify_ghosts("A Syndicate black-box has been stolen or tampered with!",
-		source = src,
-		header = "Explorers afoot!",
-		)
-		var/area/A = get_area(loc)
-		var/message = "ALERT: Confidential storage device removed in [initial(A.name)]! Immediate response required!"
-		radio.talk_into(src, message, radio_channel)
-		update_appearance()
+		balloon_alert(user, "removing blackbox...")
+		if(do_after(user, 60, target = src))
+			stored.forceMove(drop_location())
+			if(Adjacent(user))
+				user.put_in_hands(stored)
+			stored = null
+			to_chat(user, span_notice("You remove the blackbox from [src]. The tapes stop spinning, and you realise the Syndicate are on to you now."))
+			notify_ghosts("A Syndicate black-box has been stolen or tampered with!",
+			source = src,
+			header = "Explorers afoot!",
+			)
+			var/area/A = get_area(loc)
+			var/message = "ALERT: Confidential storage device removed in [initial(A.name)]! Immediate response required!"
+			radio.talk_into(src, message, radio_channel)
+			update_appearance()
 		return
 	else
 		to_chat(user, span_warning("It seems that the blackbox is missing..."))
@@ -267,10 +280,3 @@
 /obj/machinery/syndicate_blackbox_recorder/update_icon_state()
 	icon_state = "blackbox[stored ? null : "_b"]"
 	return ..()
-
-/obj/machinery/sydnicate_black_box/get_communication_players()
-	var/list/targets = list()
-	for(var/mob/target in GLOB.player_list)
-		if(target.stat == DEAD || target.z == z)
-			targets += target
-	return targets

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -249,7 +249,7 @@
 			if(Adjacent(user))
 				user.put_in_hands(stored)
 			stored = null
-			to_chat(user, span_notice("You remove the blackbox from [src]. The tapes stop spinning, and you realize the Syndicate are on to you now."))
+			to_chat(user, span_notice("You remove the blackbox from [src]. The tapes stop spinning, and you hear a quiet alarm from inside the recorder."))
 			notify_ghosts("A Syndicate black-box has been stolen!",
 			source = src,
 			header = "Explorers afoot!",

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -266,10 +266,6 @@
 
 /obj/machinery/syndicate_blackbox_recorder/Destroy()
 	if(stored)
-		notify_ghosts("A Syndicate black-box recorder has been destroyed!",
-		source = src,
-		header = "That's gotta hurt!",
-		)
 		QDEL_NULL(radio)
 		stored.forceMove(loc)
 		new /obj/effect/decal/cleanable/oil(loc)
@@ -284,6 +280,7 @@
 	desc = "Do not taunt. Warranty invalid if exposed to high temperature. Not suitable for agents under 3 years of age. Alerts Syndicate personnel once armed."
 	var/obj/item/radio/radio //i hate this fucking code
 	var/radio_channel = RADIO_CHANNEL_SYNDICATE
+	anchored = TRUE
 
 /obj/machinery/syndicatebomb/self_destruct/announce/Initialize(mapload)
 	. = ..()

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -208,7 +208,7 @@
 
 /obj/item/syndicate_blackbox
 	name = "\proper syndicate black box"
-	desc = "A large, heavily armoured black box bearing the insignia of the Syndicate coalition, containing extremely valuable intelligence data. It can be sold on the cargo shuttle to Central Command; getting it there, however..."
+	desc = "A large, heavily armoured black box bearing the insignia of the Syndicate coalition, containing extremely valuable intelligence data. It cannot be teleported with a cargo teleporter. It can be sold on the cargo shuttle to Central Command; getting it there, however..."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "blackcube"
 	inhand_icon_state = "blackcube"
@@ -278,3 +278,33 @@
 /obj/machinery/syndicate_blackbox_recorder/update_icon_state()
 	icon_state = "blackbox[stored ? null : "_b"]"
 	return ..()
+
+/obj/machinery/syndicatebomb/self_destruct/announce
+
+	desc = "Do not taunt. Warranty invalid if exposed to high temperature. Not suitable for agents under 3 years of age. Alerts Syndicate personnel once armed."
+	var/obj/item/radio/radio //i hate this fucking code
+	var/radio_channel = RADIO_CHANNEL_SYNDICATE
+
+/obj/machinery/syndicatebomb/self_destruct/announce/Initialize(mapload)
+	. = ..()
+	radio = new(src)
+	radio.make_syndie()
+	radio.subspace_transmission = TRUE
+	radio.canhear_range = 0
+	radio.set_listening(FALSE)
+	radio.recalculateChannels()
+	radio.command = TRUE
+	radio.use_command = TRUE
+
+
+/obj/machinery/syndicatebomb/self_destruct/announce/activate()
+	active = TRUE
+	begin_processing()
+	countdown.start()
+	next_beep = world.time + 10
+	detonation_timer = world.time + (timer_set * 10)
+	var/area/A = get_area(loc)
+	var/message = "ALERT: Self-destruct charge activated in [initial(A.name)]! Detonation in [timer_set] seconds! Evacuate the area immediately!"
+	radio.talk_into(src, message, radio_channel)
+	playsound(loc, 'sound/machines/click.ogg', 30, TRUE)
+	update_appearance()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3456,6 +3456,7 @@
 #include "code\modules\cargo\exports\parts.dm"
 #include "code\modules\cargo\exports\seeds.dm"
 #include "code\modules\cargo\exports\sheets.dm"
+#include "code\modules\cargo\exports\spaceloot.dm"
 #include "code\modules\cargo\exports\stamped_paperwork.dm"
 #include "code\modules\cargo\exports\tools.dm"
 #include "code\modules\cargo\exports\weapons.dm"


### PR DESCRIPTION
## About The Pull Request

- Swaps the Depot's vault and EVA storage rooms to reduce risk of cheese (someone accidentally fucking cheesed the vault. what the fuck.)
- Adds agent IDs to the depot safe
- Adds the new Syndicate Black Box, which explorers can steal and sell on the cargo shuttle for a notable sum (cargo_crate_value * 25), but which will also alert ALL syndicate agents of its theft, as well as notifying ghosts so it's harder to cheese just by showing up while they're asleep
- You can also now sell encryption keys to centcom for analysis I guess
- Syndicate outpost self-destructs now make a radio announcement that they've been armed



## Why It's Good For The Game

Gives explorers a challenge while also letting the depot vault have a stronger boom. The black-box is designed so it can be implemented on any Syndicate ruin, but I'll rip your fucking hair out if you put it on one that doesn't have a ghost-role spawner.

Also good idea to keep people from arming self-destructs without alerting everyone in the Syndicate to their exact position.

## Changelog
:cl:
add: Syndicate depots have begun tracking internal and external activities automatically with a modified Nanotrasen black-box, that can be stolen by explorers and sold for a notable sum.
add: Syndicate depots have had some refits to assist this.
add: Syndicate encryption keys and agent cards found in space may be sold to CentCom for analysis.
add: Syndicate outpost self-destruct devices have been refitted with a warning system to alert the base's crew if they're armed.
/:cl:
