### PR TITLE
Lone Op weight changes

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -39,7 +39,7 @@
 	var/turf/new_turf = get_turf(src)
 	var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 	if(istype(loneop) && loneop.occurrences < loneop.max_occurrences && prob(loneop.weight))
-		loneop.weight = max(loneop.weight - 1, 0)
+		loneop.weight = max(loneop.weight - 1, 1) //monkestation edit: increased minimum to 1
 		loneop.checks_antag_cap = (loneop.weight < 3)
 		if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
 			message_admins("[src] is secured (currently in [ADMIN_VERBOSEJMP(new_turf)]). The weight of Lone Operative is now [loneop.weight].")
@@ -55,7 +55,7 @@
 		if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
 			disk_comfort_level++
 
-	if(last_move < world.time - 500 SECONDS && prob((world.time - 500 SECONDS - last_move)*0.0001))
+	if(last_move < world.time - 300 SECONDS && prob((world.time - 300 SECONDS - last_move)*0.0001)) //monkestation edit: weight will start increasing at 5 minutes unsecure, rather than 8.3
 		var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
 		if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
 			loneop.checks_antag_cap = (loneop.weight < 3)

--- a/code/modules/events/ghost_role/operative.dm
+++ b/code/modules/events/ghost_role/operative.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/operative
 	name = "Lone Operative"
 	typepath = /datum/round_event/ghost_role/operative
-	weight = 0 //its weight is relative to how much stationary and neglected the nuke disk is. See nuclearbomb.dm. Shouldn't be dynamic hijackable.
+	weight = 1 //its weight is relative to how much stationary and neglected the nuke disk is. See nuclearbomb.dm. Shouldn't be dynamic hijackable. //monkestation edit: changed to 1 to allow it to always have a slim chance to roll
 	max_occurrences = 1
 	category = EVENT_CATEGORY_INVASION
 	description = "A single nuclear operative assaults the station."


### PR DESCRIPTION

## About The Pull Request
Changes it so lone operatives have a minimum weight of 1, so that there is always a slim chance for them to spawn if the antag cap hasn't been reached (for reference, this is the same chance as a slaughter demon spawning). Changes it so that weight will start to attempt to increase after 5 minutes of the disk being unsecure, down from 8.3.
## Why It's Good For The Game
Right now, lone ops rarely, if ever, spawn in. This is partly due to the fact that it takes about 20 minutes of the disk remaining unsecure for lone ops to bypass the antag cap, and partly due to it taking almost 12 minutes in order for lone ops to even have a chance to spawn at all. This will hopefully make it so leaving the disk unsecure will actually result in a lone op spawning, and give lone ops a slim chance to spawn even if the disk is secure.
## Changelog
:cl:
balance: Reduced the time it takes for an unsecure disk to start increasing lone op weight (5 minutes, down from 8.3)
balance: Lone ops now have a minimum weight of 1
/:cl:
