### PR TITLE
Removes unused mobs from credits

### DIFF
--- a/monkestation/code/modules/and_roll_credits/credits_subsystem.dm
+++ b/monkestation/code/modules/and_roll_credits/credits_subsystem.dm
@@ -61,31 +61,25 @@ SUBSYSTEM_DEF(credits)
 		var/datum/client_interface/interface = new(ckey)
 		var/datum/preferences/mocked = new(interface)
 
-		var/mob/living/carbon/human/dummy/extra_tall/dummy = new
-		dummy.appearance_flags &= ~TILE_BOUND
-
-		var/atom/movable/screen/map_view/char_preview/appereance = new(null, mocked)
-		appereance.update_body()
-		appereance.maptext_width = 120
-		appereance.maptext_y = -8
-		appereance.maptext_x = -42
-		appereance.maptext = "<center>[ckey]</center>"
-		contributer_pref_images += appereance
+		var/atom/movable/screen/map_view/char_preview/appearance = new(null, mocked)
+		appearance.update_body()
+		appearance.maptext_width = 120
+		appearance.maptext_y = -8
+		appearance.maptext_x = -42
+		appearance.maptext = "<center>[ckey]</center>"
+		contributer_pref_images += appearance
 
 	for(var/ckey in GLOB.admin_datums)
 		var/datum/client_interface/interface = new(ckey(ckey))
 		var/datum/preferences/mocked = new(interface)
 
-		var/mob/living/carbon/human/dummy/extra_tall/dummy = new
-		dummy.appearance_flags &= ~TILE_BOUND
-
-		var/atom/movable/screen/map_view/char_preview/appereance = new(null, mocked)
-		appereance.update_body()
-		appereance.maptext_width = 120
-		appereance.maptext_x = -42
-		appereance.maptext_y = -8
-		appereance.maptext = "<center>[ckey]</center>"
-		admin_pref_images += appereance
+		var/atom/movable/screen/map_view/char_preview/appearance = new(null, mocked)
+		appearance.update_body()
+		appearance.maptext_width = 120
+		appearance.maptext_x = -42
+		appearance.maptext_y = -8
+		appearance.maptext = "<center>[ckey]</center>"
+		admin_pref_images += appearance
 
 /datum/controller/subsystem/credits/proc/draft_star()
 	var/mob/living/carbon/human/most_talked


### PR DESCRIPTION
## About The Pull Request

`/atom/movable/screen/map_view/char_preview` already creates necessary mobs.
So those dummies were just stuck in the void, doing nothing.

## Why It's Good For The Game

Lowers initialization time for `Credits Screen Storage` subsystem by ~25%.

## Changelog

No player-facing changes.