### PR TITLE
Flusher component fixes + make ticker component obtainable

### DIFF
--- a/monkestation/code/modules/cargo/packs/vending_restock.dm
+++ b/monkestation/code/modules/cargo/packs/vending_restock.dm
@@ -1,0 +1,6 @@
+/datum/supply_pack/vending/mechcomp
+	name = "ThinkTronic MechComp Dispenser Supply Crate"
+	desc = "Bring on the doohickeys."
+	cost = CARGO_CRATE_VALUE * 3
+	contains = list(/obj/item/vending_refill/mechcomp)
+	crate_name = "mechcomp supply crate"

--- a/monkestation/code/modules/mech_comp/objects/flush.dm
+++ b/monkestation/code/modules/mech_comp/objects/flush.dm
@@ -9,10 +9,18 @@
 	var/obj/structure/disposalpipe/trunk/trunk = null
 	///the max amount of items we can flush at once
 	var/max_capacity = 100
-
+	/// Typecache of things that the flusher will ignore.
+	var/static/list/flush_blacklist
 
 /obj/item/mcobject/flusher/Initialize(mapload)
 	. = ..()
+	if(isnull(flush_blacklist))
+		// keeping this as minimal as possible because it's kinda funny - only non-living mobs (i.e ghosts or camera eyes) and abstract effects are ignored.
+		flush_blacklist = zebra_typecacheof(list(
+			/mob = TRUE,
+			/mob/living = FALSE,
+			/obj/effect/abstract = TRUE,
+		))
 	MC_ADD_INPUT("flush", flush)
 
 /obj/item/mcobject/flusher/Destroy(force)
@@ -28,46 +36,43 @@
 			trunk = null
 
 /obj/item/mcobject/flusher/proc/flush(datum/mcmessage/input)
-	trunk_check()
-	if(!trunk || !COOLDOWN_FINISHED(src, flush_cd) || !input?.cmd)
-		return
-
-	if(QDELETED(trunk))
-		trunk = null
+	if(!trunk_check() || !COOLDOWN_FINISHED(src, flush_cd) || !input?.cmd)
 		return
 
 	var/count = 0
-	for(var/atom/movable/listed_movable in src.loc)
-		if(listed_movable.anchored)
+	for(var/atom/movable/thing in loc)
+		if(thing.anchored || is_type_in_typecache(thing, flush_blacklist))
 			continue
 		if(count == max_capacity)
 			break
 		count++
-		listed_movable.forceMove(src)
+		thing.forceMove(src)
 
-	var/obj/structure/disposalholder/holder = new(src)
 	flick("comp_flush1", src)
-	sleep(0.5 SECONDS)
+	COOLDOWN_START(src, flush_cd, 5 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(finish_flush)), 0.5 SECONDS)
+
+/obj/item/mcobject/flusher/proc/finish_flush()
+	var/obj/structure/disposalholder/holder = new(src)
 	holder.init(src)
 	holder.forceMove(trunk)
 	holder.active = TRUE
 	holder.setDir(DOWN)
 	holder.start_moving()
 
-
-	COOLDOWN_START(src, flush_cd, 5 SECONDS)
-
-/obj/item/mcobject/flusher/proc/expel(obj/structure/disposalholder/H)
+/obj/item/mcobject/flusher/proc/expel(obj/structure/disposalholder/holder)
 	playsound(src, 'sound/machines/hiss.ogg', 50, FALSE, FALSE)
 	flick("comp_flush1", src)
-	pipe_eject(H)
+	pipe_eject(holder)
 
-	H.vent_gas(loc)
-	qdel(H)
+	holder.vent_gas(loc)
+	qdel(holder)
 
 /obj/item/mcobject/flusher/proc/trunk_check()
-	trunk = locate() in src.loc
-	if(trunk)
-		trunk.linked = src
-	else
+	trunk = locate() in loc
+	if(QDELETED(trunk))
 		trunk = null
+		return FALSE
+	else
+		trunk.linked = src
+		return TRUE

--- a/monkestation/code/modules/mech_comp/objects/messages/ticker.dm
+++ b/monkestation/code/modules/mech_comp/objects/messages/ticker.dm
@@ -8,30 +8,60 @@
 	var/total_loops = -1
 	var/loops = -1
 	var/on = FALSE
+	/// Cooldown for when the next loop fires.
+	COOLDOWN_DECLARE(next_loop)
 
 /obj/item/mcobject/messaging/ticker/Initialize(mapload)
 	. = ..()
 	MC_ADD_CONFIG("Set Interval", set_interval)
 	MC_ADD_CONFIG("Set Loop Counter", set_loops)
-	MC_ADD_INPUT("begin loop", start_loop)
+	MC_ADD_INPUT("Start Ticker", start_ticker)
+	MC_ADD_INPUT("Stop Ticker", stop_ticker)
+	MC_ADD_INPUT("Toggle Ticker", toggle_ticker)
+
+/obj/item/mcobject/messaging/ticker/Destroy(force)
+	STOP_PROCESSING(SSfastprocess, src)
+	return ..()
 
 /obj/item/mcobject/messaging/ticker/examine(mob/user)
 	. = ..()
 	. += span_notice("It is currently [on ? "on" : "off"].")
-	. += span_notice("Interval time: [interval] second(s).")
+	. += span_notice("Interval time: [DisplayTimeText(interval)].")
 	. += span_notice("Total loops: [total_loops == -1 ? "infinite" : total_loops].")
 
+/obj/item/mcobject/messaging/ticker/process()
+	if(QDELETED(src) || !on || (total_loops != -1 && loops <= 0) || !COOLDOWN_FINISHED(src, next_loop))
+		return PROCESS_KILL
+	fire(stored_message)
+	loops--
+	COOLDOWN_START(src, next_loop, interval)
+
 /obj/item/mcobject/messaging/ticker/proc/set_interval(mob/user, obj/item/tool)
-	var/num = input(user, "Set interval in seconds (0.5 - 60)", "Configure Component", interval) as null|num
+	var/num = tgui_input_number(
+		user,
+		message = "Set interval in seconds (0.5 - 60)",
+		title = "Configure Component",
+		default = interval * 0.1,
+		max_value = 60,
+		min_value = 0.5,
+		round_value = FALSE
+	)
 	if(!num)
 		return
 
-	interval = clamp(num, 0.5, 60)
-	to_chat(user, "You set [src]'s interval to [interval] seconds.")
+	interval = round(clamp(num, 0.5, 60) SECONDS, world.tick_lag)
+	to_chat(user, "You set [src]'s interval to [DisplayTimeText(interval)].")
 	return TRUE
 
 /obj/item/mcobject/messaging/ticker/proc/set_loops(mob/user, obj/item/tool)
-	var/num = input(user, "Set number of loops (-1 for infinite)", "Configure Component", total_loops) as null|num
+	var/num = tgui_input_number(
+		user,
+		message = "Set number of loops (-1 for infinite)",
+		title = "Configure Component",
+		default = total_loops,
+		max_value = 100,
+		min_value = -1
+	)
 	if(isnull(num))
 		return
 
@@ -39,14 +69,24 @@
 	to_chat(user, "You set [src]'s loop count to [total_loops == -1 ? "infinite" : "[total_loops]"].")
 	return TRUE
 
-/obj/item/mcobject/messaging/ticker/proc/start_loop(datum/mcmessage/input)
-	set waitfor = FALSE
+/obj/item/mcobject/messaging/ticker/proc/start_ticker(datum/mcmessage/input)
 	if(on)
 		return
 	on = TRUE
 	loops = total_loops
-	while(!QDELETED(src) && ((loops > 0) || total_loops == -1))
-		loops--
-		fire(stored_message)
-		sleep(interval * 10) //Convert interval to deciseconds
+	START_PROCESSING(SSfastprocess, src)
+	balloon_alert_to_viewers("started ticking")
+
+/obj/item/mcobject/messaging/ticker/proc/stop_ticker(datum/mcmessage/input)
+	if(!on)
+		return
+	STOP_PROCESSING(SSfastprocess, src)
 	on = FALSE
+	loops = 0
+	balloon_alert_to_viewers("stopped ticking")
+
+/obj/item/mcobject/messaging/ticker/proc/toggle_ticker(datum/mcmessage/input)
+	if(on)
+		stop_ticker(input)
+	else
+		start_ticker(input)

--- a/monkestation/code/modules/mech_comp/vending_machine.dm
+++ b/monkestation/code/modules/mech_comp/vending_machine.dm
@@ -40,7 +40,8 @@
 		/obj/item/mcobject/messaging/storage = STANDARD_COMPONENT_SUPPLY,
 		/obj/item/mcobject/messaging/type_sensor = STANDARD_COMPONENT_SUPPLY,
 		/obj/item/mcobject/messaging/clock = STANDARD_COMPONENT_SUPPLY,
-		/obj/item/mcobject/messaging/repeater = LOW_COMPONENT_SUPPLY
+		/obj/item/mcobject/messaging/repeater = LOW_COMPONENT_SUPPLY,
+		/obj/item/mcobject/messaging/ticker = LOW_COMPONENT_SUPPLY,
 	)
 
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7118,6 +7118,7 @@
 #include "monkestation\code\modules\cargo\packs\hardsuit_crates.dm"
 #include "monkestation\code\modules\cargo\packs\medical.dm"
 #include "monkestation\code\modules\cargo\packs\service.dm"
+#include "monkestation\code\modules\cargo\packs\vending_restock.dm"
 #include "monkestation\code\modules\cargoborg\code\cargo_module.dm"
 #include "monkestation\code\modules\cargoborg\code\cargo_teleporter.dm"
 #include "monkestation\code\modules\cargoborg\code\cargoborg_items.dm"


### PR DESCRIPTION

## About The Pull Request

i rewrote the ticker component to use `process()`, made it possible to turn it off, and added it to the mechcomp vendor.

i added a (very very loose) blacklist to the flusher component, and got rid of a sleep in its code, making it use a timer instead.

i also made the mechcomp vendor resupply canister orderable from cargo.

## Why It's Good For The Game

mechcomp is fun. this adds more possibilities while fixing some issues.

## Changelog
:cl:
add: The ticker component is now obtainable from the mechcomp vendor.
refactor: Rewrote the ticker component to be less janky and use a proper processor.
fix: The flusher component can no longer flush ghosts or camera eyes.
add: Added the ThinkTronic MechComp Dispenser Supply Crate to cargo.
/:cl:
