### PR TITLE
Changes coritical borer threats to medical and medical adjacent staff.

### DIFF
--- a/monkestation/code/modules/antagonists/borers/code/antagonist_stuff/midround_event.dm
+++ b/monkestation/code/modules/antagonists/borers/code/antagonist_stuff/midround_event.dm
@@ -8,10 +8,10 @@
 	antag_flag = ROLE_CORTICAL_BORER
 	track = EVENT_TRACK_MAJOR
 	enemy_roles = list(
-		JOB_CAPTAIN,
-		JOB_DETECTIVE,
-		JOB_HEAD_OF_SECURITY,
-		JOB_SECURITY_OFFICER,
+		JOB_CHIEF_MEDICAL_OFFICER,
+		JOB_MEDICAL_DOCTOR,
+		JOB_CHEMIST,
+		JOB_BRIG_PHYSICIAN,
 	)
 	required_enemies = 2
 	weight = 5 // as rare as a natural blob

--- a/monkestation/code/modules/cargo/crates/medical.dm
+++ b/monkestation/code/modules/cargo/crates/medical.dm
@@ -69,7 +69,7 @@
 /datum/supply_pack/medical/borer_cage
 	name = "Borer cage"
 	desc = "A troublesome brain worm dumping one to many unprescribed drugs into your patients? Well this crate if for you!"
-	cost = CARGO_CRATE_VALUE * 10
+	cost = CARGO_CRATE_VALUE * 5
 	contraband = TRUE
 	contains = list(/obj/item/cortical_cage)
 	crate_name = "anti-borer crate"

--- a/monkestation/code/modules/cargo/crates/medical.dm
+++ b/monkestation/code/modules/cargo/crates/medical.dm
@@ -67,9 +67,9 @@
 	crate_name = "experimental medicine crate"
 
 /datum/supply_pack/medical/borer_cage
-	name = "Borer cage"
-	desc = "A troublesome brain worm dumping one to many unprescribed drugs into your patients? Well this crate if for you!"
+	name = "Cortical Borer Cages"
+	desc = "Troublesome brain worms dumping one to many unprescribed drugs into your patients? Well this crate is for you!"
 	cost = CARGO_CRATE_VALUE * 10
 	contraband = TRUE
-	contains = list(/obj/item/cortical_cage)
-	crate_name = "anti-borer crate"
+	contains = list(/obj/item/cortical_cage = 3)
+	crate_name = "Anti-Borer crate"

--- a/monkestation/code/modules/cargo/crates/medical.dm
+++ b/monkestation/code/modules/cargo/crates/medical.dm
@@ -69,7 +69,7 @@
 /datum/supply_pack/medical/borer_cage
 	name = "Borer cage"
 	desc = "A troublesome brain worm dumping one to many unprescribed drugs into your patients? Well this crate if for you!"
-	cost = CARGO_CRATE_VALUE * 5
+	cost = CARGO_CRATE_VALUE * 10
 	contraband = TRUE
 	contains = list(/obj/item/cortical_cage)
 	crate_name = "anti-borer crate"

--- a/monkestation/code/modules/cargo/crates/security.dm
+++ b/monkestation/code/modules/cargo/crates/security.dm
@@ -51,14 +51,6 @@
 	)
 	crate_name = "\improper Blue Shirt uniform crate"
 
-/datum/supply_pack/security/borer_cage
-	name = "Borer cage"
-	desc = "Ever needed capture those pesky illegal borers to put them on a trial? Well this crate if for you!"
-	cost = CARGO_CRATE_VALUE * 10
-	contraband = TRUE
-	contains = list(/obj/item/cortical_cage)
-	crate_name = "anti-borer crate"
-
 /datum/supply_pack/security/taser
 	name = "Taser Crate"
 	desc = "Contains three tasers, ready to tase criminals."


### PR DESCRIPTION
## About The Pull Request
Coritical borers will now check for the following jobs as enemies

- Chief Medical officer
- Medical Doctor
- Chemists
- Brig physican

In addition the express order crate for Medical Cortical Borer Cages now comes with three cages.
Security is no longer able to order borer cages from their express console. closes: #5056
Open
## Why It's Good For The Game
Borers are not a security threat/enemy. They have the tools/resources to remove/capture borer cages. But rarley are the priotity to security in a round. When Cortical Borers go evil and people have to deal with them its often the medical staff who do kill them.

As for the crates, borers reproduce very quickly. And often to kill the borer inside you'll have to end up destroying your cage in the process. As there's no way force one out of a cage yourself. This makes deconstucting a borer  (My personal go-to method) less expensive.

## Changelog
:cl:
del: Security can no longer order Borer cages
balance: Medical Borer Crates now comes with three cages. 
code: Chief Medical Officer, Medical Doctors, Chemists, and Brig Physicians are now classified as the new enemies for Cortical Borers to spawn
/:cl:
