### PR TITLE
fix admin logging with antag tokens

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1790,9 +1790,9 @@
 		var/datum/meta_token_holder/token_holder = user_client?.client_token_holder
 		if(!token_holder?.in_queue)
 			return
-		token_holder.approve_antag_token()
 		message_admins("[key_name_admin(owner)] approved a [token_holder.in_queue] token from [ADMIN_LOOKUPFLW(user_client)]")
 		log_admin("[user_client]'s [token_holder.in_queue] token has been approved by [owner].")
+		token_holder.approve_antag_token()
 
 	else if(href_list["reject_antag_token"])
 		if(!check_rights(R_ADMIN))
@@ -1804,9 +1804,9 @@
 		var/datum/meta_token_holder/token_holder = user_client?.client_token_holder
 		if(!token_holder?.in_queue)
 			return
-		token_holder.reject_antag_token()
 		message_admins("[key_name_admin(owner)] rejected a [token_holder.in_queue] token from [ADMIN_LOOKUPFLW(user_client)]")
 		log_admin("[user_client]'s [token_holder.in_queue] token has been rejected by [owner].")
+		token_holder.reject_antag_token()
 
 	else if(href_list["open_music_review"])
 		if(!check_rights(R_ADMIN))


### PR DESCRIPTION
## Changelog
:cl:
admin: Fixed admin logging for antag token approval/rejection not properly showing the name of the antag.
/:cl:
