### PR TITLE
Florans will no longer place their hats atop an invisible gigapompadour

### DIFF
--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -67,13 +67,13 @@
 		. += mutable_appearance('icons/effects/item_damage.dmi', "damagedhelmet")
 
 	if(!(flags_inv & HIDEHAIR))
-		if(ismob(loc))
-			if(ishuman(loc))
-				var/mob/living/carbon/human/user = loc
+		if(ismob(loc) && ishuman(loc))
+			var/mob/living/carbon/human/user = loc
+			var/obj/item/bodypart/head/head = user.get_bodypart(BODY_ZONE_HEAD)
+			if(head.head_flags & HEAD_HAIR)
 				var/datum/sprite_accessory/hair/hair_style = GLOB.hairstyles_list[user.hairstyle]
-				if(hair_style)
-					if(hair_style.vertical_offset)
-						standing.pixel_y = hair_style.vertical_offset
+				if(hair_style?.vertical_offset)
+					standing.pixel_y = hair_style.vertical_offset
 
 	if(contents)
 		var/current_hat = 1


### PR DESCRIPTION
## About The Pull Request
Previously, the vertical offset of regular hairstyles was being applied to Florans. However, Florans don't use regular hairstyles - they use special pod hairstyles. This PR fixes it such that hats are now worn at the appropriate height by Florans.

The steps used to replicate the original issue, and to test that this is fixed:
1. Create a character
2. Set their hairstyle to Gigapompadour, or another hairstyle that vertically offsets hats.
3. Add a hat in the loadout menu (or test this slowly in-game, I ain't judging)
4. Switch the character's species to Floran.

Before this fix, the above steps would result in the hat being vertically offset, despite no visible hair. After this fix, the hat is no longer vertically offset.

## Why It's Good For The Game
Makes Floran sprites look a little less messier under the rare circumstance of a Floran having an invisible gigapompadour.

## Changelog

:cl: MichiRecRoom
fix: Floran characters should no longer float hats above their head, if you set their hairstyle to one that vertically offsets hats before switching to Floran.
/:cl: