### PR TITLE
Weapons implant for assault operatives

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -44,6 +44,9 @@
 	ammo_x_offset = 2
 
 //MONKESTATION EDIT START
+/obj/item/gun/energy/e_gun/advtaser/evil
+	pin = /obj/item/firing_pin/implant/pindicate
+	
 /obj/item/gun/energy/e_gun/advtaser/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	if(select == 1)
 		playsound(src, 'monkestation/sound/effects/taser_charge.ogg', 45, TRUE, 1)

--- a/monkestation/code/game/objects/items/implants/implant_misc.dm
+++ b/monkestation/code/game/objects/items/implants/implant_misc.dm
@@ -1,0 +1,9 @@
+/obj/item/implanter/weapons_auth
+	name = "implanter (Weapons Authorization)"
+	imp_type = /obj/item/implant/weapons_auth
+
+/obj/item/storage/box/syndie_kit/weapons_auth
+	name = "Weapons Authorization kit"
+
+/obj/item/storage/box/syndie_kit/emp/PopulateContents()
+	new /obj/item/implanter/weapons_auth(src)

--- a/monkestation/code/modules/assault_ops/code/armaments/_base.dm
+++ b/monkestation/code/modules/assault_ops/code/armaments/_base.dm
@@ -181,7 +181,7 @@
 	subcategory = OPS_SUBCATEGORY_NONLETHAL_SIDE
 
 /datum/armament_entry/assault_operatives/secondary/nonlethal/taze_me_bro
-	item_type = /obj/item/gun/energy/e_gun/advtaser
+	item_type = /obj/item/gun/energy/e_gun/advtaser/evil
 
 /datum/armament_entry/assault_operatives/secondary/nonlethal/baton
 	item_type = /obj/item/melee/baton/telescopic/contractor_baton

--- a/monkestation/code/modules/assault_ops/code/outfits.dm
+++ b/monkestation/code/modules/assault_ops/code/outfits.dm
@@ -14,6 +14,7 @@
 
 	id = /obj/item/card/id/advanced/chameleon
 	id_trim = /datum/id_trim/chameleon/operative
+	implants = list(/obj/item/implant/weapons_auth)
 
 /datum/outfit/assaultops/post_equip(mob/living/carbon/human/equipping_human)
 	var/obj/item/radio/radio = equipping_human.ears

--- a/monkestation/code/modules/blueshift/items/company_guns.dm
+++ b/monkestation/code/modules/blueshift/items/company_guns.dm
@@ -164,6 +164,7 @@
 	projectile_wound_bonus = 5
 	projectile_damage_multiplier = 1.25
 	fire_delay = 0.3 SECONDS
+	pin = /obj/item/firing_pin/implant/pindicate
 
 /obj/item/gun/ballistic/automatic/sol_rifle/evil/no_mag
 	spawnwithmagazine = FALSE
@@ -235,6 +236,7 @@
 	worn_icon_state = "renoster_evil"
 	inhand_icon_state = "renoster_evil"
 	projectile_wound_bonus = 15
+	pin = /obj/item/firing_pin/implant/pindicate
 
 // Low caliber grenade launcher (fun & games)
 
@@ -331,6 +333,7 @@
 	inhand_icon_state = "kiboko_evil"
 	projectile_wound_bonus = 5
 	fire_delay = 0.30 SECONDS
+	pin = /obj/item/firing_pin/implant/pindicate
 
 	spawn_magazine_type = /obj/item/ammo_box/magazine/c980_grenade/drum/thunderdome_shrapnel
 
@@ -474,6 +477,9 @@
 	w_class = WEIGHT_CLASS_SMALL
 	can_suppress = TRUE
 
+/obj/item/gun/ballistic/revolver/sol/evil
+	pin = /obj/item/firing_pin/implant/pindicate
+
 /obj/item/gun/ballistic/revolver/sol/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_TRAPPISTE)
 
@@ -597,6 +603,7 @@
 	desc = "The standard issue service pistol of SolFed's various military branches. Comes with attached light. This one is painted tacticool black."
 
 	icon_state = "wespe_evil"
+	pin = /obj/item/firing_pin/implant/pindicate
 
 /obj/item/gun/ballistic/automatic/pistol/sol/evil/no_mag
 	spawnwithmagazine = FALSE
@@ -1054,6 +1061,7 @@
 	inhand_icon_state = "sindano_evil"
 	spread = 5
 	projectile_wound_bonus = 5
+	pin = /obj/item/firing_pin/implant/pindicate
 
 /obj/item/gun/ballistic/automatic/sol_smg/evil/no_mag
 	spawnwithmagazine = FALSE

--- a/monkestation/code/modules/blueshift/opfor/equipment/guns.dm
+++ b/monkestation/code/modules/blueshift/opfor/equipment/guns.dm
@@ -10,6 +10,7 @@
 	new /obj/item/gun/ballistic/shotgun/riot/sol/evil(src)
 	new /obj/item/ammo_box/advanced/s12gauge/buckshot(src)
 	new /obj/item/ammo_box/advanced/s12gauge/buckshot(src)
+	new /obj/item/storage/box/syndie_kit/weapons_auth(src)
 
 /datum/opposing_force_equipment/ranged/infanteria
 	name = "Carwo-Cawil Battle Rifle"
@@ -20,6 +21,7 @@
 	new /obj/item/gun/ballistic/automatic/sol_rifle/evil(src)
 	new /obj/item/ammo_box/magazine/c40sol_rifle/standard(src)
 	new /obj/item/ammo_box/magazine/c40sol_rifle/standard(src)
+	new /obj/item/storage/box/syndie_kit/weapons_auth(src)
 
 /datum/opposing_force_equipment/ranged/miecz
 	name = "'Miecz' Submachinegun"
@@ -40,6 +42,7 @@
 	new /obj/item/gun/ballistic/automatic/sol_grenade_launcher/evil(src)
 	new /obj/item/ammo_box/magazine/c980_grenade/drum/thunderdome_shrapnel(src)
 	new /obj/item/ammo_box/magazine/c980_grenade/drum/thunderdome_shrapnel(src)
+	new /obj/item/storage/box/syndie_kit/weapons_auth(src)
 
 /datum/opposing_force_equipment/ranged/amr
 	name = "'Wyłom' AMR"
@@ -158,6 +161,7 @@
 	new /obj/item/gun/ballistic/automatic/sol_smg/evil(src)
 	new /obj/item/ammo_box/magazine/c35sol_pistol/stendo(src)
 	new /obj/item/ammo_box/magazine/c35sol_pistol/stendo(src)
+	new /obj/item/storage/box/syndie_kit/weapons_auth(src)
 
 /datum/opposing_force_equipment/ranged_stealth/wespe
 	name = "Wespe Pistol"
@@ -168,6 +172,7 @@
 	new /obj/item/gun/ballistic/automatic/pistol/sol/evil(src)
 	new /obj/item/ammo_box/magazine/c35sol_pistol(src)
 	new /obj/item/ammo_box/magazine/c35sol_pistol(src)
+	new /obj/item/storage/box/syndie_kit/weapons_auth(src)
 
 /datum/opposing_force_equipment/ranged_stealth/makarov
 	name = "Makarov Pistol"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6178,6 +6178,7 @@
 #include "monkestation\code\game\objects\items\guns\SRN.dm"
 #include "monkestation\code\game\objects\items\guns\wt_ammo.dm"
 #include "monkestation\code\game\objects\items\implants\hardlight.dm"
+#include "monkestation\code\game\objects\items\implants\implant_misc.dm"
 #include "monkestation\code\game\objects\items\rayne_corp\rayne_lantern.dm"
 #include "monkestation\code\game\objects\items\rayne_corp\rayne_mender.dm"
 #include "monkestation\code\game\objects\items\robot\items\hypo.dm"


### PR DESCRIPTION

## About The Pull Request
**_Alright, most recent mission report. Operative Random Randy was... slipped in maintence by a banana peel... To which an assistant stole their gun, and shot them with it. Any of Ideas of how to adjust lads?_**

Gives assault operatives weapon authorization firing pins.
## Why It's Good For The Game
Assault operatives guns can currently be used by anyone. This keeps their assets from falling into enemy hands easier by restricting it to weapon auth implants. Akin to how nukies, lone ops, and syndicate aligned ghost roles already have.
## Changelog
:cl:
add: Assault operative weapons now have weapon authentication implants and their guns the corresponding firing pins.
/:cl:
