### PR TITLE
ERT Code Yellow

### DIFF
--- a/_maps/shuttles/ert_dropship-engineering.dmm
+++ b/_maps/shuttles/ert_dropship-engineering.dmm
@@ -1,0 +1,484 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"b" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/grenade/chem_grenade/metalfoam,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/grenade/chem_grenade/metalfoam{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/grenade/chem_grenade/metalfoam{
+	pixel_x = -8;
+	pixel_y = 0
+	},
+/obj/item/grenade/chem_grenade/metalfoam{
+	pixel_x = -7;
+	pixel_y = 0
+	},
+/obj/item/grenade/chem_grenade/metalfoam{
+	pixel_x = -7;
+	pixel_y = 0
+	},
+/obj/item/rcd_ammo/large{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/item/rcd_ammo/large{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/item/rcd_ammo/large{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/item/rcd_ammo/large{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/obj/item/rcd_ammo/large{
+	pixel_x = 6;
+	pixel_y = 0
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/ert/powered)
+"c" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/ert/powered)
+"d" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/reagent_dispensers/foamtank,
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/ert/powered)
+"e" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/ert{
+	x_offset = 0;
+	y_offset = 10
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/shuttle/ert/powered)
+"f" = (
+/obj/structure/table/reinforced,
+/obj/machinery/button/door{
+	id = "ert_dropship_bridge";
+	req_access = list("cent_general")
+	},
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/ert/powered)
+"g" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light/directional/west,
+/obj/structure/closet/crate,
+/mob/living/simple_animal/bot/floorbot,
+/mob/living/simple_animal/bot/floorbot,
+/mob/living/simple_animal/bot/floorbot,
+/obj/item/storage/part_replacer/bluespace/tier3,
+/obj/item/storage/part_replacer/bluespace/tier3,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/ert/powered)
+"h" = (
+/obj/machinery/power/shuttle_engine/heater,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/plating/airless,
+/area/shuttle/ert/powered)
+"i" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/ert/powered)
+"j" = (
+/obj/effect/turf_decal/stripes/blue{
+	dir = 8
+	},
+/obj/effect/landmark/ert_shuttle_spawn,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"l" = (
+/obj/machinery/computer/shuttle/ert,
+/obj/effect/turf_decal/stripes,
+/obj/effect/turf_decal/stripes{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/shuttle/ert/powered)
+"m" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"n" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/ert/powered)
+"p" = (
+/obj/effect/turf_decal/stripes/blue{
+	dir = 6
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"q" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/ert/powered)
+"r" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/vehicle/sealed/mecha/working/ripley/mk2/engineering,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/ert/powered)
+"s" = (
+/obj/effect/turf_decal/stripes/blue{
+	dir = 10
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"t" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"u" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/landmark/ert_shuttle_brief_spawn,
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/ert/powered)
+"v" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/ert/powered)
+"w" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/ert/powered)
+"x" = (
+/obj/effect/turf_decal/stripes/blue,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"y" = (
+/turf/open/space/basic,
+/area/template_noop)
+"z" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/ert/powered)
+"A" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/preopen{
+	dir = 4;
+	id = "ert_dropship_bridge"
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/ert/powered)
+"C" = (
+/obj/structure/table/reinforced,
+/obj/machinery/cell_charger,
+/obj/machinery/light/directional/east,
+/obj/item/gun/ballistic/SRN_rocketlauncher{
+	pixel_x = 0;
+	pixel_y = 7
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/ert/powered)
+"D" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/ert/powered)
+"E" = (
+/obj/effect/turf_decal/caution/stand_clear/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/blue{
+	dir = 8
+	},
+/obj/effect/landmark/ert_shuttle_spawn,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"F" = (
+/obj/effect/spawner/structure/window/reinforced/shuttle,
+/obj/machinery/door/poddoor/preopen{
+	id = "ert_dropship_bridge"
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/ert/powered)
+"G" = (
+/obj/machinery/holopad,
+/obj/effect/turf_decal/box,
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/ert/powered)
+"H" = (
+/obj/effect/turf_decal/stripes/blue{
+	dir = 4
+	},
+/obj/effect/landmark/ert_shuttle_spawn,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"J" = (
+/obj/effect/turf_decal/stripes/blue{
+	dir = 9
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"K" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger{
+	pixel_x = -7;
+	pixel_y = 0
+	},
+/obj/machinery/recharger{
+	pixel_x = 2;
+	pixel_y = 0
+	},
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 1;
+	pixel_y = 15
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/ert/powered)
+"L" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/ert/powered)
+"M" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/machinery/door/airlock/shuttle/glass,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/ert/powered)
+"N" = (
+/obj/machinery/computer/security,
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/tiled/blue,
+/area/shuttle/ert/powered)
+"O" = (
+/obj/machinery/button/door/directional/south{
+	id = "ert_dropship_doors";
+	req_access = list("cent_general")
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/stripes/blue{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"P" = (
+/obj/effect/turf_decal/stripes/blue{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"Q" = (
+/obj/machinery/vending/wallmed/directional/north,
+/obj/structure/rack,
+/obj/item/storage/medkit{
+	pixel_x = 0;
+	pixel_y = 3
+	},
+/obj/effect/turf_decal/stripes/blue,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"R" = (
+/obj/effect/turf_decal/caution/stand_clear/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/blue{
+	dir = 4
+	},
+/obj/effect/landmark/ert_shuttle_spawn,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"S" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/ert/powered)
+"T" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/stripes/blue/box,
+/obj/machinery/door/poddoor{
+	dir = 8;
+	id = "ert_dropship_doors"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"U" = (
+/obj/machinery/power/shuttle_engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/ert/powered)
+"V" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/mineral/titanium/tiled,
+/area/shuttle/ert/powered)
+"W" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/ert/powered)
+"X" = (
+/obj/effect/turf_decal/stripes/blue{
+	dir = 5
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/ert/powered)
+"Y" = (
+/obj/machinery/power/shuttle_engine/propulsion,
+/obj/docking_port/mobile/ert{
+	dir = 2
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/ert/powered)
+
+(1,1,1) = {"
+y
+y
+w
+S
+T
+T
+T
+T
+T
+T
+w
+w
+w
+w
+y
+"}
+(2,1,1) = {"
+A
+A
+w
+n
+p
+E
+j
+j
+E
+X
+r
+g
+b
+h
+U
+"}
+(3,1,1) = {"
+F
+N
+V
+w
+P
+t
+t
+t
+t
+x
+L
+v
+D
+h
+U
+"}
+(4,1,1) = {"
+F
+l
+z
+M
+O
+w
+m
+m
+w
+Q
+u
+G
+c
+h
+Y
+"}
+(5,1,1) = {"
+F
+e
+f
+w
+P
+a
+a
+a
+a
+x
+i
+q
+d
+h
+U
+"}
+(6,1,1) = {"
+A
+A
+w
+n
+s
+R
+H
+H
+R
+J
+W
+C
+K
+h
+U
+"}
+(7,1,1) = {"
+y
+y
+w
+S
+T
+T
+T
+T
+T
+T
+w
+w
+w
+w
+y
+"}

--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -240,6 +240,17 @@
 	poll_icon = /obj/item/clothing/head/helmet/space/ert/janitor
 	polldesc = "a Nanotrasen Janitorial Response Team"
 
+/datum/ert/code/yellow
+	leader_role = /datum/antagonist/ert/generic/engineer/blue
+	roles = list(
+		/datum/antagonist/ert/generic/engineer,
+	)
+	opendoors = FALSE
+	ert_template = /datum/map_template/shuttle/ert/dropship/engineer
+	mission = "Fix everything."
+	poll_icon = /obj/item/clothing/head/helmet/space/ert/engineer
+	polldesc = "a Nanotrasen Engineering Response Team"
+
 /datum/ert/code/lambda
 	leader_role = /datum/antagonist/ert/generic/chaplain/red
 	roles = list(

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -138,6 +138,8 @@
 	)
 
 /obj/vehicle/sealed/mecha/working/ripley/deathripley/real
+	operation_req_access = list(ACCESS_CENT_SPECOPS)
+	internals_req_access = list(ACCESS_CENT_SPECOPS)
 	desc = "OH SHIT IT'S THE DEATHSQUAD WE'RE ALL GONNA DIE. FOR REAL"
 	equip_by_category = list(
 		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill,

--- a/monkestation/code/modules/ERT/ERT_shuttle.dm
+++ b/monkestation/code/modules/ERT/ERT_shuttle.dm
@@ -82,6 +82,10 @@
 	suffix = "dropship-janitor"
 	name = "ERT Dropship"
 
+/datum/map_template/shuttle/ert/dropship/engineer
+	suffix = "dropship-engineer"
+	name = "ERT Dropship"
+	
 /datum/map_template/shuttle/ert/deathsquad
 	suffix = "deathsquad"
 	name = "Deathsquad Shuttle"

--- a/monkestation/code/modules/ERT/ERT_shuttle.dm
+++ b/monkestation/code/modules/ERT/ERT_shuttle.dm
@@ -83,9 +83,9 @@
 	name = "ERT Dropship"
 
 /datum/map_template/shuttle/ert/dropship/engineer
-	suffix = "dropship-engineer"
+	suffix = "dropship-engineering"
 	name = "ERT Dropship"
-	
+
 /datum/map_template/shuttle/ert/deathsquad
 	suffix = "deathsquad"
 	name = "Deathsquad Shuttle"

--- a/monkestation/code/modules/vehicles/mecha/working/ripley.dm
+++ b/monkestation/code/modules/vehicles/mecha/working/ripley.dm
@@ -1,0 +1,29 @@
+/obj/vehicle/sealed/mecha/working/ripley/mk2/engineering
+	equip_by_category = list(
+		MECHA_R_ARM = /obj/item/mecha_parts/mecha_equipment/rcd,
+		MECHA_L_ARM = /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
+		MECHA_POWER = list(/obj/item/mecha_parts/mecha_equipment/generator),
+		MECHA_UTILITY = list(/obj/item/mecha_parts/mecha_equipment/thrusters, /obj/item/mecha_parts/mecha_equipment/ejector, /obj/item/mecha_parts/mecha_equipment/extinguisher),
+	)
+	max_equip_by_category = list(
+		MECHA_UTILITY = 3,
+		MECHA_POWER = 1,
+		MECHA_ARMOR = 1,
+	)
+	armor_type = /datum/armor/working_ripley/engineering
+	movedelay = 1.5 //Move speed, lower is faster.
+	lights_power = 7
+	fast_pressure_step_in = 1.75
+	slow_pressure_step_in = 3
+	step_energy_drain = 6
+	operation_req_access = list(ACCESS_MECH_ENGINE)
+	internals_req_access = list(ACCESS_CENT_GENERAL)
+
+/datum/armor/working_ripley/engineering
+	melee = 40
+	bullet = 20
+	laser = 20
+	energy = 20
+	bomb = 60
+	fire = 100
+	acid = 100

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8436,6 +8436,7 @@
 #include "monkestation\code\modules\vehicles\wheelchair.dm"
 #include "monkestation\code\modules\vehicles\mecha\mecha_actions.dm"
 #include "monkestation\code\modules\vehicles\mecha\equipment\tools\other_tools.dm"
+#include "monkestation\code\modules\vehicles\mecha\working\ripley.dm"
 #include "monkestation\code\modules\vending\megaseed.dm"
 #include "monkestation\code\modules\vending\megaseed_wall.dm"
 #include "monkestation\code\modules\vending\nutrimax_wall.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -15,6 +15,7 @@
 // BEGIN_INCLUDE
 #include "__odlint.dm"
 #include "_maps\_basemap.dm"
+#include "_maps\shuttles\ert_dropship-engineering.dmm"
 #include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"
 #include "code\_experiments.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -15,7 +15,6 @@
 // BEGIN_INCLUDE
 #include "__odlint.dm"
 #include "_maps\_basemap.dm"
-#include "_maps\shuttles\ert_dropship-engineering.dmm"
 #include "code\__byond_version_compat.dm"
 #include "code\_compile_options.dm"
 #include "code\_experiments.dm"


### PR DESCRIPTION

## About The Pull Request
Adds a yellow alert ERT into the game.

Also access locks Real Death Ripley's to Specops access
## Why It's Good For The Game
People have believed a engineering ERT exists when it does not, now it does.

Akin to Code Purple the leader is a blue ERT while the rest are generic ERT, all of the engineering variety.

They come equipped with their own dropship, with a custom made Ripley with a clamp and RCD. Being the almost the best of both worlds of the Ripley MK1 and MK2. A spacial nullifier, some floorbots, and enough materials to secure a decent portion of the station on their own
## Changelog
:cl:
add: ERT Code: Yellow has been initialized
fix: Real Death Ripleys will have SPECOPS access. As normal civilians should not pilot nor know what the existence of anything I said is.
/:cl:
