### PR TITLE
[PORT] Uses icon_exists in getflaticon instead of iconstates

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -767,9 +767,8 @@ world
 	var/render_icon = curicon
 
 	if (render_icon)
-		var/curstates = icon_states(curicon)
-		if(!(curstate in curstates))
-			if ("" in curstates)
+		if(!icon_exists(curicon, curstate))
+			if(icon_exists(curicon, ""))
 				curstate = ""
 			else
 				render_icon = FALSE

--- a/code/modules/asset_cache/assets/research_designs.dm
+++ b/code/modules/asset_cache/assets/research_designs.dm
@@ -58,10 +58,9 @@
 				var/obj/machinery/computer/C = item
 				var/screen = initial(C.icon_screen)
 				var/keyboard = initial(C.icon_keyboard)
-				var/all_states = icon_states(icon_file)
-				if (screen && (screen in all_states))
+				if (screen && icon_exists(icon_file, screen))
 					I.Blend(icon(icon_file, screen, SOUTH), ICON_OVERLAY)
-				if (keyboard && (keyboard in all_states))
+				if (keyboard && icon_exists(icon_file, keyboard))
 					I.Blend(icon(icon_file, keyboard, SOUTH), ICON_OVERLAY)
 
 		Insert(initial(path.id), I)

--- a/monkestation/code/modules/mob/living/carbon/human/custom_bodytype.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/custom_bodytype.dm
@@ -71,10 +71,9 @@ GLOBAL_LIST_EMPTY(species_clothing_fallback_cache)
 		return null
 
 	var/icon/species_worn_icon = custom_worn_icons[item_slot]
-	var/list/species_icon_states = icon_states(species_worn_icon)
 
 	// Check if there is a custom icon state.
-	if(!((item.worn_icon_state || item.icon_state) in species_icon_states))
+	if(!icon_exists(species_worn_icon, item.worn_icon_state || item.icon_state))
 		return null
 
 	// Remember and use icon.


### PR DESCRIPTION

## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/89547

> This was missed in the new pr prolly cus it didnt use "in iconstates"

## Changelog
:cl: Absolucy, TiviPlus
code: Optimized some icon code.
/:cl:
