### PR TITLE
PENLITE  buff and Immunity scanners storage

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -267,6 +267,7 @@
 		/obj/item/surgicaldrill,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/wrench/medical,
+		/obj/item/device/antibody_scanner //monkestation addition
 	))
 
 /obj/item/storage/belt/medical/paramedic

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -71,6 +71,7 @@
 		/obj/item/pinpointer/crew,
 		/obj/item/holosign_creator/medical,
 		/obj/item/stack/sticky_tape,
+		/obj/item/device/antibody_scanner //monkestation addition
 	)
 
 /obj/item/storage/medkit/Initialize(mapload)

--- a/monkestation/code/game/objects/items/holosign_creator.dm
+++ b/monkestation/code/game/objects/items/holosign_creator.dm
@@ -3,3 +3,6 @@
 	for(var/obj/structure/holosign/sign as anything in signs)
 		if(prob(90 / severity))
 			qdel(sign)
+
+/obj/item/holosign_creator/medical
+	max_signs = 6


### PR DESCRIPTION
## About The Pull Request
PENLITE  holobarriers now can produce 6, rather than 3 holobarriers

Immunity scanners can now be stored in surgical medkits and medical belts
## Why It's Good For The Game
PENLITE holobarriers are are primarily informational tools. Rather than the utiltiy control that atmospheric or security provides. With changes they are now both able to be disabled and even destroyed. Losing the control they previously had I'd like it see go to versatility, being a tool where you can set up mini checkpoints all around the station for information.

Immunity scanners are medical tools and its a QOL for them to be able ot be stored elsewhere from loosley in your backpack/pocket.
## Changelog
:cl:
qol: Immunity scanners can be stored in medical toolbelts and surgical medkits
balance: PENLITE can create 6, instead of 3 barriers.
/:cl:
