### PR TITLE
Window sill fixes + qol

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -938,7 +938,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/window/reinforced/tinted/frosted/spaw
 	icon = 'icons/obj/smooth_structures/clockwork_window.dmi'
 	icon_state = "clockwork_window_single"
 	glass_type = /obj/item/stack/sheet/bronze
-	uses_color // monkestation edit
+	//uses_color // monkestation edit
 
 /obj/structure/window/bronze/unanchored
 	anchored = FALSE

--- a/monkestation/code/modules/aesthetics/objects/window_sill.dm
+++ b/monkestation/code/modules/aesthetics/objects/window_sill.dm
@@ -1,3 +1,13 @@
+GLOBAL_LIST_INIT(sheets_to_window_types, zebra_typecacheof(list(
+	/obj/item/stack/sheet/glass = /obj/structure/window/fulltile,
+	/obj/item/stack/sheet/rglass = /obj/structure/window/reinforced/fulltile,
+	/obj/item/stack/sheet/plasmaglass = /obj/structure/window/plasma/fulltile,
+	/obj/item/stack/sheet/plasmarglass = /obj/structure/window/reinforced/plasma/fulltile,
+	/obj/item/stack/sheet/plastitaniumglass = /obj/structure/window/reinforced/plasma/plastitanium,
+	/obj/item/stack/sheet/bronze = /obj/structure/window/bronze/fulltile,
+	/obj/item/stack/rods = /obj/structure/grille/window_sill,
+)))
+
 /obj/structure/window_sill
 	icon = 'monkestation/icons/obj/structures/window/window_sill.dmi'
 	base_icon_state = "window_sill"
@@ -14,6 +24,7 @@
 /obj/structure/window_sill/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/climbable)
+	AddElement(/datum/element/elevation, pixel_shift = 12)
 
 /obj/structure/window_sill/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()
@@ -52,52 +63,58 @@
 	return existing_grille.rcd_act(user, the_rcd, passed_mode)
 
 /obj/structure/window_sill/attackby(obj/item/attacking_item, mob/user, params)
-	. = ..()
-	if(!isstack(attacking_item))
-		return FALSE
-	var/obj/item/stack/stack_item = attacking_item
-	if(istype(attacking_item, /obj/item/stack/sheet/glass))
-		if(stack_item.amount < 2)
-			return FALSE
-		if(do_after(user, 2 SECONDS, src))
-			new /obj/structure/window/fulltile(get_turf(src))
-			stack_item.amount -= 2
-			return TRUE
-
-	if(istype(attacking_item, /obj/item/stack/sheet/rglass))
-		if(stack_item.amount < 2)
-			return FALSE
-		if(do_after(user, 2 SECONDS, src))
-			new /obj/structure/window/reinforced/fulltile(get_turf(src))
-			stack_item.amount -= 2
-			return TRUE
-
-	if(istype(attacking_item, /obj/item/stack/sheet/plasmarglass))
-		if(stack_item.amount < 2)
-			return FALSE
-		if(do_after(user, 2 SECONDS, src))
-			new /obj/structure/window/reinforced/plasma/fulltile(get_turf(src))
-			stack_item.amount -= 2
-			return TRUE
-
-	if(istype(attacking_item, /obj/item/stack/sheet/plasmaglass))
-		if(stack_item.amount < 2)
-			return FALSE
-		if(do_after(user, 2 SECONDS, src))
-			new /obj/structure/window/fulltile(get_turf(src))
-			stack_item.amount -= 2
-			return TRUE
-
-	if(istype(attacking_item, /obj/item/stack/rods))
-		if(stack_item.amount < 2)
-			return FALSE
-		if(do_after(user, 2 SECONDS, src))
-			new /obj/structure/grille/window_sill(get_turf(src))
-			stack_item.amount -= 2
-			return TRUE
+	var/obj/item/stack/stack = attacking_item
+	if((user.istate & ISTATE_HARM) || !isstack(stack))
+		return ..()
+	var/obj/structure/window_type = GLOB.sheets_to_window_types[stack.type]
+	if(!window_type)
+		return ..()
+	var/turf/our_turf = get_turf(src)
+	if(our_turf.is_blocked_turf(
+		exclude_mobs = TRUE,
+		source_atom = src,
+		ignore_atoms = ispath(window_type, /obj/structure/grille) ? null : typesof(/obj/structure/grille),
+		type_list = TRUE,
+	))
+		balloon_alert(user, "blocked!")
+		return
+	if(stack.amount < 2)
+		balloon_alert(user, "need at least 2 of \the [stack]!")
+		return
+	balloon_alert_to_viewers(user, "building [window_type::name]...")
+	if(!do_after(user, 2 SECONDS, src, extra_checks = CALLBACK(src, PROC_REF(window_build_check), stack, 2)))
+		return
+	if(!stack.use(2))
+		balloon_alert(user, "need at least 2 of \the [stack]!")
+		return
+	balloon_alert_to_viewers(user, "built [window_type::name]")
+	new window_type(our_turf)
 
 //merges adjacent full-tile windows into one
 /obj/structure/window_sill/update_overlays(updates=ALL)
 	. = ..()
 	if((updates & UPDATE_SMOOTHING) && (smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK)))
 		QUEUE_SMOOTH(src)
+
+/obj/structure/window_sill/CanAllowThrough(atom/movable/mover, border_dir)
+	. = ..()
+	if(.)
+		return
+	if(mover.throwing)
+		return TRUE
+	if(mover.movement_type & (FLYING | FLOATING))
+		return TRUE
+	if(locate(/obj/structure/window_sill) in get_turf(mover))
+		return TRUE
+
+/obj/structure/window_sill/CanAStarPass(to_dir, datum/can_pass_info/pass_info)
+	if(!density)
+		return TRUE
+	if(pass_info.movement_type & (FLYING | FLOATING))
+		return TRUE
+	if(pass_info.pass_flags & PASSTABLE)
+		return TRUE
+	return FALSE
+
+/obj/structure/window_sill/proc/window_build_check(obj/item/stack/stack, min_amt)
+	return !QDELETED(src) && !QDELETED(stack) && stack.amount >= min_amt

--- a/monkestation/code/modules/aesthetics/objects/windows.dm
+++ b/monkestation/code/modules/aesthetics/objects/windows.dm
@@ -57,7 +57,7 @@
 
 /obj/structure/grille/window_sill/atom_break()
 	. = ..()
-	Destroy()
+	qdel(src)
 
 /obj/structure/grille/update_overlays(updates=ALL)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

this is just much-needed touchups for window sills - both code and functionality wise. see changelog.

## Why It's Good For The Game

bugfix is qol for these is nice.

## Changelog
:cl:
fix: You no longer whack window sills with glass sheets when building windows on them.
fix: Window sills will no longer create nonexistent/negative stacks of glass.
fix: You can now create plastitanium glass windows on window sills.
qol: You can now walk to another window sill while already standing a window sill.
qol: Flying/floating mobs can now pass window sills.
add: Window sills now elevate you while standing on them.
/:cl:
