### PR TITLE
Rebalances the malf intercom honk a bit

### DIFF
--- a/code/__HELPERS/~monkestation-helpers/mapping.dm
+++ b/code/__HELPERS/~monkestation-helpers/mapping.dm
@@ -1,6 +1,8 @@
 /proc/are_zs_connected(atom/a, atom/b)
 	a = get_turf(a)
 	b = get_turf(b)
+	if(isnull(a) || isnull(b))
+		return FALSE
 	if(a.z == b.z)
 		return TRUE
 	return (b.z in SSmapping.get_connected_levels(a))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see changelog

## Why It's Good For The Game

kinda sucks to be permanently deafened if ur standing in an unlucky spot, or if its spammed, and there's no indicator that it's permanent outside of self-examine or a health analyzer.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The malf AI intercom honk (Percussive Intercomm Interference) no longer stacks with multiple intercoms on a single person, which could instantly deafen people in an unlucky spot.
balance: The intercom honk also won't affect people who can't hear anyways.
balance: The intercom honk now doesn't affect people in spaced areas unless they're right next to the intercom, like how sound usually works.
balance: The intercom honk now only affects Z-levels connected to the AI's z-level (i.e an on-station AI will only affect station intercoms)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
