### PR TITLE
Fix some hard deletes probably related to replays

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -70,8 +70,8 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 /// Yes I know this is a stupid flag, no you can't take him from me
 #define DECAL_INIT_UPDATE_EXPERIENCED_1 (1<<20)
 
-/// Used for items that cannot be used directly to harm people with, ex. loafs
-#define CANNOT_ATTACK_WITH (1<<21)
+/// This atom should never be marked in demos/replays. (monkestation addition)
+#define DEMO_IGNORE_1 (1<<21)
 
 // Update flags for [/atom/proc/update_appearance]
 /// Update the atom's name

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -203,7 +203,10 @@
 		if(SSatoms.InitAtom(src, FALSE, args))
 			//we were deleted
 			return
-		SSdemo.mark_new(src) //Monkestation edit: Replays
+		// monkestation start: replays
+		if(!(flags_1 & DEMO_IGNORE_1))
+			SSdemo.mark_new(src)
+		// monkestation end
 
 /**
  * The primary method that objects are setup in SS13 with

--- a/monkestation/code/modules/replays/hooks/generic_hooks.dm
+++ b/monkestation/code/modules/replays/hooks/generic_hooks.dm
@@ -27,3 +27,30 @@
 /atom/movable/setDir()
 	. = ..()
 	SSdemo.mark_dirty(src)
+
+/mob/dview
+	flags_1 = parent_type::flags_1 | DEMO_IGNORE_1
+
+/mob/oranges_ear
+	flags_1 = parent_type::flags_1 | DEMO_IGNORE_1
+
+/mob/living/carbon/human/dummy
+	flags_1 = parent_type::flags_1 | DEMO_IGNORE_1
+
+/obj/effect/spawner
+	flags_1 = parent_type::flags_1 | DEMO_IGNORE_1
+
+/obj/effect/turf_decal
+	flags_1 = parent_type::flags_1 | DEMO_IGNORE_1
+
+/obj/effect/abstract/name_tag
+	flags_1 = parent_type::flags_1 | DEMO_IGNORE_1
+
+/obj/effect/abstract/marker
+	flags_1 = parent_type::flags_1 | DEMO_IGNORE_1
+
+/obj/effect/abstract/info
+	flags_1 = parent_type::flags_1 | DEMO_IGNORE_1
+
+/obj/effect/abstract/chasm_storage
+	flags_1 = parent_type::flags_1 | DEMO_IGNORE_1

--- a/monkestation/code/modules/replays/hooks/generic_hooks.dm
+++ b/monkestation/code/modules/replays/hooks/generic_hooks.dm
@@ -43,6 +43,9 @@
 /obj/effect/turf_decal
 	flags_1 = parent_type::flags_1 | DEMO_IGNORE_1
 
+/obj/effect/mapping_helpers
+	flags_1 = parent_type::flags_1 | DEMO_IGNORE_1
+
 /obj/effect/abstract/name_tag
 	flags_1 = parent_type::flags_1 | DEMO_IGNORE_1
 

--- a/monkestation/code/modules/replays/subsystem/replay.dm
+++ b/monkestation/code/modules/replays/subsystem/replay.dm
@@ -484,16 +484,16 @@ SUBSYSTEM_DEF(demo)
 			continue
 		marked_turfs[turf] = TRUE
 
-/datum/controller/subsystem/demo/proc/mark_new(atom/movable/M)
+/datum/controller/subsystem/demo/proc/mark_new(atom/movable/atom)
 	if(disabled)
 		return
-	if(!isobj(M) && !ismob(M))
+	if(!isobj(atom) && !ismob(atom))
 		return
-	if(QDELING(M))
+	if(QDELING(atom))
 		return
-	marked_new[M] = TRUE
-	if(marked_dirty[M])
-		marked_dirty -= M
+	marked_new[atom] = TRUE
+	if(marked_dirty[atom])
+		marked_dirty -= atom
 
 /datum/controller/subsystem/demo/proc/mark_multiple_new(list/atom/atom_list)
 	if(disabled)
@@ -501,22 +501,22 @@ SUBSYSTEM_DEF(demo)
 	for(var/atom/atom as anything in atom_list)
 		if(!isobj(atom) && !ismob(atom))
 			continue
-		if(QDELING(atom))
+		if(QDELING(atom) || (atom.flags_1 & DEMO_IGNORE_1))
 			continue
 		marked_new[atom] = TRUE
 		if(marked_dirty[atom])
 			marked_dirty -= atom
 
 // I can't wait for when TG ports this and they make this a #define macro.
-/datum/controller/subsystem/demo/proc/mark_dirty(atom/movable/M)
+/datum/controller/subsystem/demo/proc/mark_dirty(atom/movable/dirty)
 	if(disabled)
 		return
-	if(!isobj(M) && !ismob(M))
+	if(!isobj(dirty) && !ismob(dirty))
 		return
-	if(QDELING(M))
+	if(QDELING(dirty) || (dirty.flags_1 & DEMO_IGNORE_1))
 		return
-	if(!marked_new[M])
-		marked_dirty[M] = TRUE
+	if(!marked_new[dirty])
+		marked_dirty[dirty] = TRUE
 
 /datum/controller/subsystem/demo/proc/mark_multiple_dirty(list/atom/movable/dirty_list)
 	if(disabled)
@@ -524,19 +524,21 @@ SUBSYSTEM_DEF(demo)
 	for(var/atom/movable/dirty as anything in dirty_list)
 		if(!isobj(dirty) && !ismob(dirty))
 			continue
-		if(QDELING(dirty))
+		if(QDELING(dirty) || (dirty.flags_1 & DEMO_IGNORE_1))
 			continue
 		if(!marked_new[dirty])
 			marked_dirty[dirty] = TRUE
 
-/datum/controller/subsystem/demo/proc/mark_destroyed(atom/movable/M)
+/datum/controller/subsystem/demo/proc/mark_destroyed(atom/movable/destroyed)
 	if(disabled)
 		return
-	if(!isobj(M) && !ismob(M))
+	if(!isobj(destroyed) && !ismob(destroyed))
 		return
-	if(marked_new[M])
-		marked_new -= M
-	if(marked_dirty[M])
-		marked_dirty -= M
+	if(destroyed.flags_1 & DEMO_IGNORE_1)
+		return
+	if(marked_new[destroyed])
+		marked_new -= destroyed
+	if(marked_dirty[destroyed])
+		marked_dirty -= destroyed
 	if(initialized)
-		del_list[ref(M)] = TRUE
+		del_list[ref(destroyed)] = TRUE

--- a/monkestation/code/modules/virology/disease/symptom_cracker/symptom_component.dm
+++ b/monkestation/code/modules/virology/disease/symptom_cracker/symptom_component.dm
@@ -118,7 +118,7 @@
 	current_extrapolator = null
 	SStgui.close_uis(puzzle)
 	UnregisterSignal(src, list(COMSIG_CRACKER_PUZZLE_FAILURE, COMSIG_CRACKER_PUZZLE_SUCCESS))
-	qdel(puzzle)
+	QDEL_NULL(puzzle)
 
 /datum/component/symptom_genes/proc/on_puzzle_success()
 	playsound(current_user, 'sound/machines/defib_success.ogg', 50, FALSE)


### PR DESCRIPTION
I added a new flag to `/atom/flags_1`: `DEMO_IGNORE_1`, which makes something entirely ignored by `SSdemo`.

I added it to spawners, turf decal spawners (the decals themselves are an element), dummy mobs, and several abstract effects.