### PR TITLE
Fixes RDS quirk not working on non-IPCs

### DIFF
--- a/monkestation/code/datums/quirks/negative_quirks/insanity.dm
+++ b/monkestation/code/datums/quirks/negative_quirks/insanity.dm
@@ -1,18 +1,19 @@
 //IPC PUNISHMENT SYSTEM//
 /datum/quirk/insanity/add()
+	. = ..()
 	if(!isipc(quirk_holder)) // this checks ishuman too
-		return
-	var/mob/living/carbon/human/ipc_holder = quirk_holder
-	ipc_holder.physiology?.brute_mod *= 1.3
-	ipc_holder.physiology?.burn_mod *= 1.3
+		var/mob/living/carbon/human/ipc_holder = quirk_holder
+		ipc_holder.physiology?.brute_mod *= 1.3
+		ipc_holder.physiology?.burn_mod *= 1.3
 
 /datum/quirk/insanity/remove()
+	. = ..()
 	if(!isipc(quirk_holder)) // this checks ishuman too
-		return
-	var/mob/living/carbon/human/ipc_holder = quirk_holder
-	ipc_holder.physiology?.brute_mod /= 1.3
-	ipc_holder.physiology?.burn_mod /= 1.3
+		var/mob/living/carbon/human/ipc_holder = quirk_holder
+		ipc_holder.physiology?.brute_mod /= 1.3
+		ipc_holder.physiology?.burn_mod /= 1.3
 
 /datum/quirk/insanity/post_add()
+	. = ..()
 	if(isipc(quirk_holder))
 		to_chat(quirk_holder, span_boldnotice("Your chassis feels frail."))


### PR DESCRIPTION
## About The Pull Request

RDS was broken by #4992 due to trying to replacing the add() proc of insanity quirk instead of adding lines to it... Ideally IPCs wouldn't have to go through the entire RDS quirk adding process but for now this will do.
## Why It's Good For The Game

Fixes #5311
Reality Dissociation Syndrome was broken for a while and was a free 8 quirk points, this fixes it.

## Changelog
:cl:
fix: Reality Dissociation Syndrome properly works now.
/:cl:
