### PR TITLE
BSAs can no longer target oozeling cores

### DIFF
--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -331,7 +331,7 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 		return
 	var/list/gps_locators = list()
 	for(var/datum/component/gps/G in GLOB.GPS_list) //nulls on the list somehow
-		if(G.tracking)
+		if(G.tracking && G.bsa_targetable) // monkestation edit: bsa_targetable
 			gps_locators[G.gpstag] = G
 
 	var/list/options = gps_locators
@@ -360,6 +360,10 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 		return pick(get_area_turfs(target))
 	else if(istype(target, /datum/component/gps))
 		var/datum/component/gps/G = target
+		// monkestation start: bsa_targetable sanity check
+		if(!G.bsa_targetable)
+			CRASH("BSA tried to fire at [G.gpstag] ([G.parent]), despite bsa_targetable being set to false")
+		// monkestation end
 		return get_turf(G.parent)
 
 /obj/machinery/computer/bsa_control/proc/fire(mob/user)

--- a/monkestation/code/datums/components/gps.dm
+++ b/monkestation/code/datums/components/gps.dm
@@ -1,3 +1,10 @@
+/datum/component/gps
+	/// Can this GPS be targeted by a BSA?
+	var/bsa_targetable = TRUE
+
+/datum/component/gps/no_bsa
+	bsa_targetable = FALSE
+
 /datum/component/gps/item
 	/// If TRUE, then this GPS needs to be calibrated to point to specific z-levels.
 	var/requires_z_calibration = TRUE

--- a/monkestation/code/modules/surgery/organs/internal/brain.dm
+++ b/monkestation/code/modules/surgery/organs/internal/brain.dm
@@ -125,7 +125,7 @@
 		span_notice("You find the densest point, crushing it in your palm. The blinking light in the core slowly dissapates and items start to come out."),
 		span_notice("You hear a wet crunching sound."))
 		gps_active =  FALSE
-		qdel(GetComponent(/datum/component/gps))//Actually remove the gps signal
+		qdel(GetComponent(/datum/component/gps/no_bsa))//Actually remove the gps signal
 
 	else
 		user.visible_message(span_warning("[user] crunches something deep in the slime core! It gradually stops glowing."),
@@ -202,7 +202,7 @@
 	playsound(victim, 'sound/effects/blobattack.ogg', 80, TRUE)
 
 	if(gps_active) // adding the gps signal if they have activated the ability
-		AddComponent(/datum/component/gps, "[victim]'s Core")
+		AddComponent(/datum/component/gps/no_bsa, "[victim]'s Core")
 
 	if(brainmob)
 		membrane_mur.Grant(brainmob)


### PR DESCRIPTION

## About The Pull Request

this makes it so BSAs can't target oozeling cores

a new var, `bsa_targetable` has been added to `/datum/component/gps`, with a simple subtype, `/datum/component/gps/no_bsa` having it set to false.

## Why It's Good For The Game

leave the poor oozelings alone :(

## Changelog
:cl:
balance: Bluespace artillery cannons can no longer target oozeling cores.
/:cl:
