### PR TITLE
Converts IPC Compact Posibrain to Full Posibrain

### DIFF
--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -39,6 +39,8 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	var/searching = FALSE
 	///List of all ckeys who has already entered this posibrain once before.
 	var/list/ckeys_entered = list()
+	///Does this posibrain ping ghosts on creation? MONKESTATION EDIT
+	var/autoping = TRUE
 
 ///Notify ghosts that the posibrain is up for grabs
 /obj/item/mmi/posibrain/proc/ping_ghosts(msg, newlymade)
@@ -218,3 +220,11 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 
 /obj/item/mmi/posibrain/add_mmi_overlay()
 	return
+
+// MONKE STATION ADDITION START
+
+/obj/item/mmi/posibrain/ipc/Initialize
+	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. It has an IPC serial number engraved on the top."
+	autoping = FALSE
+
+// MONKE STATION ADDITION END

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
@@ -45,7 +45,7 @@
 
 	species_language_holder = /datum/language_holder/synthetic
 
-	mutantbrain = /obj/item/organ/internal/brain/synth
+	mutantbrain = /obj/item/organ/internal/brain/mmi_holder/posibrain
 	mutantstomach = /obj/item/organ/internal/stomach/synth
 	mutantears = /obj/item/organ/internal/ears/synth
 	mutanttongue = /obj/item/organ/internal/tongue/synth

--- a/monkestation/code/modules/surgery/organs/internal/brain_item.dm
+++ b/monkestation/code/modules/surgery/organs/internal/brain_item.dm
@@ -1,0 +1,93 @@
+
+// IPC brain fuckery. This is for using normal Posibrain objects as an IPC Posibrain.
+
+/obj/item/organ/internal/brain/mmi_holder
+	name = "implanted MMI brain"
+	slot = ORGAN_SLOT_BRAIN
+	zone = BODY_ZONE_CHEST
+	status = ORGAN_ROBOTIC
+	var/remove_on_qdel = FALSE
+	var/obj/item/mmi/stored_mmi
+	var/mmi_type = /obj/item/mmi/
+
+/obj/item/organ/internal/brain/mmi_holder/posibrain
+	name = "positronic brain"
+	mmi_type = /obj/item/mmi/posibrain/ipc
+
+/obj/item/organ/internal/brain/mmi_holder/Destroy()
+	QDEL_NULL(stored_mmi)
+	return ..()
+
+/obj/item/organ/internal/brain/mmi_holder/Insert(mob/living/carbon/receiver, special = FALSE, no_id_transfer = FALSE)
+	receiver.organs |= src
+	receiver.organs_slot[slot] = src
+	owner = receiver
+	loc = null
+	//the above bits are copypaste from organ/proc/Insert, because I couldn't go through the parent here.
+
+	if(stored_mmi.brainmob)
+		if(receiver.key)
+			receiver.ghostize()
+		var/mob/living/brain/B = stored_mmi.brainmob
+		if(stored_mmi.brainmob.mind)
+			B.mind.transfer_to(receiver)
+		else
+			receiver.key = B.key
+
+	if(ishuman(receiver))
+		var/mob/living/carbon/human/H = receiver
+		if(HAS_TRAIT(H, TRAIT_REVIVES_BY_HEALING) && H > SYNTH_BRAIN_WAKE_THRESHOLD)
+			if(!HAS_TRAIT(H, TRAIT_DEFIB_BLACKLISTED))
+				H.revive(FALSE)
+
+	update_from_mmi()
+
+/obj/item/organ/internal/brain/mmi_holder/Remove(var/mob/living/user, special = 0)
+	if(!special)
+		if(stored_mmi)
+			. = stored_mmi
+			if(owner.mind)
+				owner.mind.transfer_to(stored_mmi.brainmob)
+			stored_mmi.loc = owner.loc
+			if(stored_mmi.brainmob)
+				var/mob/living/brain/B = stored_mmi.brainmob
+				spawn(0)
+					if(B)
+						B.stat = 0
+			stored_mmi = null
+
+	..()
+	spawn(0)//so it can properly keep surgery going
+		qdel(src)
+
+/obj/item/organ/internal/brain/mmi_holder/proc/update_from_mmi()
+	if(!stored_mmi)
+		return
+	name = stored_mmi.name
+	desc = stored_mmi.desc
+	icon = stored_mmi.icon
+	icon_state = stored_mmi.icon_state
+
+/obj/item/organ/internal/brain/mmi_holder/posibrain/New(var/obj/item/mmi/MMI)
+	. = ..()
+	if(MMI)
+		stored_mmi = MMI
+		MMI.forceMove(src)
+	else
+		stored_mmi = new /obj/item/mmi/posibrain/ipc(src)
+	spawn(5)
+		if(owner && stored_mmi)
+			stored_mmi.name = "positronic brain ([owner.real_name])"
+			stored_mmi.brainmob.real_name = owner.real_name
+			stored_mmi.brainmob.name = stored_mmi.brainmob.real_name
+			stored_mmi.icon_state = "posibrain-occupied"
+			update_from_mmi()
+
+/obj/item/organ/internal/brain/mmi_holder/emp_act(severity)
+	switch(severity)
+		if(1)
+			owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 55)
+			to_chat(owner, "<span class='warning'>Alert: Posibrain heavily damaged.</span>")
+		if(2)
+			owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, 15)
+			to_chat(owner, "<span class='warning'>Alert: Posibrain damaged.</span>")

--- a/monkestation/code/modules/surgery/organs/internal/brain_item.dm
+++ b/monkestation/code/modules/surgery/organs/internal/brain_item.dm
@@ -1,12 +1,10 @@
-
-// IPC brain fuckery. This is for using normal Posibrain objects as an IPC Posibrain.
-
+// IPC brain stuff. This is for using normal Posibrain objects as an IPC Posibrain.
 /obj/item/organ/internal/brain/mmi_holder
-	name = "implanted MMI brain"
+	name = "implanted MMI brain" // ignore the fact that, for the moment, this base type is not used. maybe some day.
 	slot = ORGAN_SLOT_BRAIN
 	zone = BODY_ZONE_CHEST
 	status = ORGAN_ROBOTIC
-	var/remove_on_qdel = FALSE
+	var/remove_on_qdel = FALSE // The actual "organ" deletes itself on removal, because it's just a holder.
 	var/obj/item/mmi/stored_mmi
 	var/mmi_type = /obj/item/mmi/
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8348,6 +8348,7 @@
 #include "monkestation\code\modules\surgery\organs\external\tail\clockworktail.dm"
 #include "monkestation\code\modules\surgery\organs\external\wings\functional_wings.dm"
 #include "monkestation\code\modules\surgery\organs\internal\brain.dm"
+#include "monkestation\code\modules\surgery\organs\internal\brain_item.dm"
 #include "monkestation\code\modules\surgery\organs\internal\butts.dm"
 #include "monkestation\code\modules\surgery\organs\internal\ears.dm"
 #include "monkestation\code\modules\surgery\organs\internal\eyes.dm"


### PR DESCRIPTION
## About The Pull Request

**What do you mean it's just been a normal brain with a posibrain sprite on it since the rebase. Why am I just learning this now.**

At a high level, I aim to convert the posibrain object into a posibrain organ while retaining the functionality of the object on the organ. This may necessitate removal of MMIs and allowing brains to be directly installed into borgs and AIs.

- [ ] Compiles
- [ ] Runtimes resolved
- [ ] Posibrain able to be removed (surgical, dismemberment) and the ghost remains in it
- [ ] Posibrain able to be re-inserted into IPC and ghost has control of the body
- [ ] IPC traumas, skillchips, brain damage stay retained to the posibrain but are not utilized in cyborg/AI usecases
- [ ] Posibrain damage can be resolved by applying liquid solder to the posibrain object directly
- [ ] Posibrain brain surgery properly repairs brain damage even inside of MMI holder
- [ ] Ghosts are not offered the posibrain belonging to a living IPC when it spawns (previous bug)
- [ ] Posibrains belonging to spawned IPCs should not be offered to other players if removed from chassis (previous bug)

## Why It's Good For The Game

Adds a ton of uniqueness to the IPCs in that they have interchangeable posibrains with silicons. As was always intended.

## Changelog

:cl:
add: IPC posibrains are now fully fledged posibrains. Consequently, printed posibrains can now be inserted into IPC bodies.
/:cl:
