### PR TITLE
Tones down ethereal blood a bit

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -899,7 +899,7 @@
 		M.blood_volume += 1 * seconds_per_tick
 	else if(SPT_PROB(10, seconds_per_tick)) //lmao at the newbs who eat energy bars
 		M.electrocute_act(rand(5,10), "Liquid Electricity in their body", 1, SHOCK_NOGLOVES | SHOCK_NOSTUN) //the shock is coming from inside the house //MONKESTATION ADDITION NO STUN
-		M.Immobilize(10) //MONKESTATION ADDITION
+		M.Immobilize(1 SECOND) //MONKESTATION ADDITION
 		playsound(M, SFX_SPARKS, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	return ..()
 

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -898,7 +898,8 @@
 	if(isethereal(M))
 		M.blood_volume += 1 * seconds_per_tick
 	else if(SPT_PROB(10, seconds_per_tick)) //lmao at the newbs who eat energy bars
-		M.electrocute_act(rand(5,10), "Liquid Electricity in their body", 1, SHOCK_NOGLOVES) //the shock is coming from inside the house
+		M.electrocute_act(rand(5,10), "Liquid Electricity in their body", 1, SHOCK_NOGLOVES | SHOCK_NOSTUN) //the shock is coming from inside the house //MONKESTATION ADDITION NO STUN
+		M.Immobilize(10) //MONKESTATION ADDITION
 		playsound(M, SFX_SPARKS, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	return ..()
 


### PR DESCRIPTION

## About The Pull Request
Makes shocking from ethereal blood not full stun (knockdown + stun)
Immobilizes for one second

## Why It's Good For The Game
Weaponizing blood as a ethereal is a amazingly cool concept, but it is a bit over the top currently being able to easily take your own blood and hit anyone with it, and stun lock them to death. Pretty often, this tones it down a bit while leaving it weaponizinable but still fightable and not a total you loss/won thing.

## Changelog

:cl:
balance: ethereal blood immobilizes instead of knockdown stuns
/:cl:

