### PR TITLE
Reduces the range of flashbang guaranteed stun to <1

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -45,7 +45,7 @@
 		living_mob.Knockdown(200)
 		living_mob.soundbang_act(1, 200, 10, 15)
 	else
-		if(distance <= 1) // Adds more stun as to not prime n' pull (#45381)
+		if(distance < 1) // MONKESTATION EDIT - No more adjacent guaranteed stun
 			living_mob.Paralyze(5)
 			living_mob.Knockdown(30)
 		living_mob.soundbang_act(1, max(200 / max(1, distance), 60), rand(0, 5))


### PR DESCRIPTION

## About The Pull Request

Simply makes flashbangs only get a stun on protected individuals if they are on the SAME tile as the flashbang. No more good cop / suicide cop dynamic duos (one guy runs in and stands next to bad guy with grenade in hand and the other follows with batong).


## Why It's Good For The Game

Who thought giving security a guaranteed AOE hard stun was a good idea?

## Changelog


:cl:

balance: Flashbangs only get a guaranteed stun on the same tile, not adjacent tiles.
/:cl:

