### PR TITLE
[Port] Roundstart crew hint message fixes / improvements

### DIFF
--- a/code/datums/mind/_mind.dm
+++ b/code/datums/mind/_mind.dm
@@ -561,16 +561,18 @@
 /// Sets us to the passed job datum, then greets them to their new job.
 /// Use this one for when you're assigning this mind to a new job for the first time,
 /// or for when someone's recieving a job they'd really want to be greeted to.
-/datum/mind/proc/set_assigned_role_with_greeting(datum/job/new_role, client/incoming_client)
+/// monkestation edit: added "chosen_title" argument
+/datum/mind/proc/set_assigned_role_with_greeting(datum/job/new_role, client/incoming_client, chosen_title)
 	. = set_assigned_role(new_role)
 	if(assigned_role != new_role)
 		return
 
-	to_chat(incoming_client || src, span_infoplain("<b>You are the [new_role.title].</b>"))
-
-	var/related_policy = get_policy(new_role.title)
-	if(related_policy)
-		to_chat(incoming_client || src, related_policy)
+	// monkestation edit start
+	// var/intro_message = new_role.get_spawn_message() original
+	var/intro_message = new_role.get_spawn_message(chosen_title)
+	// monkestation edit end
+	if(incoming_client && intro_message)
+		to_chat(incoming_client, intro_message)
 
 /mob/proc/sync_mind()
 	mind_initialize() //updates the mind (or creates and initializes one if one doesn't exist)

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -198,6 +198,8 @@
 		spawned.infect_disease(disease, TRUE, "Random Dormant Disease [key_name(src)]")
 		disease.Refresh_Acute()
 
+/// Announce that this job as joined the round to all crew members.
+/// Note the joining mob has no client at this point.
 /datum/job/proc/announce_job(mob/living/joining_mob, job_title)
 	if(head_announce)
 		announce_head(joining_mob, head_announce, job_title)
@@ -211,13 +213,27 @@
 /mob/living/proc/on_job_equipping(datum/job/equipping)
 	return
 
+
+#define VERY_LATE_ARRIVAL_TOAST_PROB 20
+
 /mob/living/carbon/human/on_job_equipping(datum/job/equipping, datum/preferences/used_pref)
 	var/datum/bank_account/bank_account = new(real_name, equipping, dna.species.payday_modifier)
 	bank_account.payday(STARTING_PAYCHECKS, TRUE)
 	account_id = bank_account.account_id
 	bank_account.replaceable = FALSE
-	dress_up_as_job(equipping, FALSE, used_pref)
+	add_mob_memory(/datum/memory/key/account, remembered_id = account_id)
 
+	// monkestation edit start
+	/* original
+	dress_up_as_job(equipping)
+	*/
+	dress_up_as_job(equipping, FALSE, used_pref)
+	// monkestation edit end
+
+	if(EMERGENCY_PAST_POINT_OF_NO_RETURN && prob(VERY_LATE_ARRIVAL_TOAST_PROB))
+		equip_to_slot_or_del(new /obj/item/food/griddle_toast(src), ITEM_SLOT_MASK)
+
+#undef VERY_LATE_ARRIVAL_TOAST_PROB
 
 /mob/living/proc/dress_up_as_job(datum/job/equipping, visual_only = FALSE)
 	return
@@ -291,8 +307,49 @@
 
 	return TRUE
 
-/datum/job/proc/radio_help_message(mob/M)
-	to_chat(M, "<b>Prefix your message with :h to speak on your department's radio. To see other prefixes, look closely at your headset.</b>")
+/// Gets the message that shows up when spawning as this job
+/// monkestation edit: added "chosen_title" argument
+/datum/job/proc/get_spawn_message(chosen_title)
+	SHOULD_NOT_OVERRIDE(TRUE)
+	// monkestation edit start
+	// return boxed_message(span_infoplain(jointext(get_spawn_message_information(), "\n&bull; "))) original
+	return boxed_message(span_infoplain(jointext(get_spawn_message_information(chosen_title), "\n&bull; ")))
+	// monkestation edit end
+
+/// Returns a list of strings that correspond to chat messages sent to this mob when they join the round.
+/// monkestation edit: added "chosen_title" argument
+/datum/job/proc/get_spawn_message_information(chosen_title)
+	SHOULD_CALL_PARENT(TRUE)
+	var/list/info = list()
+	info += "<b>You are the [title].</b>\n"
+	var/related_policy = get_policy(title)
+	var/radio_info = get_radio_information()
+	if(related_policy)
+		info += related_policy
+	if(supervisors)
+		info += "As the [title] you answer directly to [supervisors]. Special circumstances may change this."
+	if(radio_info)
+		info += radio_info
+	if(req_admin_notify)
+		info += "<b>You are playing a job that is important for Game Progression. \
+			If you have to disconnect, please notify the admins via adminhelp.</b>"
+	if(CONFIG_GET(number/minimal_access_threshold))
+		info += span_boldnotice("As this station was initially staffed with a \
+			[CONFIG_GET(flag/jobs_have_minimal_access) ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] \
+			have been added to your ID card.")
+
+	// monkestation edit start
+	if(chosen_title != title)
+		info += "Remember that alternate titles are purely for flavor and roleplay. " \
+			+ span_warning("Do not use your \"[chosen_title]\" alt \ title as an excuse to forego your duties as a [title].")
+	// monkestation edit end
+
+	return info
+
+/// Returns information pertaining to this job's radio.
+/datum/job/proc/get_radio_information()
+	if(job_flags & JOB_CREW_MEMBER)
+		return "<b>Prefix your message with :h to speak on your department's radio. To see other prefixes, look closely at your headset.</b>"
 
 /datum/outfit/job
 	name = "Standard Gear"

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -93,5 +93,5 @@
 /datum/job/ai/config_check()
 	return CONFIG_GET(flag/allow_ai)
 
-/datum/job/ai/radio_help_message(mob/M)
-	to_chat(M, "<b>Prefix your message with :b to speak with cyborgs and other AIs.</b>")
+/datum/job/ai/get_radio_information()
+	return "<b>Prefix your message with :b to speak with cyborgs and other AIs.</b>"

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -51,6 +51,8 @@
 /datum/job/captain/get_captaincy_announcement(mob/living/captain)
 	return "Captain [captain.real_name] on deck!"
 
+/datum/job/captain/get_radio_information()
+	. = list(..(), "You have access to all radio channels, but they are not automatically tuned. Check your radio for more information.")
 
 /datum/outfit/job/captain
 	name = "Captain"

--- a/code/modules/jobs/job_types/cyborg.dm
+++ b/code/modules/jobs/job_types/cyborg.dm
@@ -57,5 +57,5 @@
 		robot_spawn.log_current_laws()
 	return TRUE
 
-/datum/job/cyborg/radio_help_message(mob/M)
-	to_chat(M, "<b>Prefix your message with :b to speak with other cyborgs and AI.</b>")
+/datum/job/cyborg/get_radio_information()
+	return "<b>Prefix your message with :b to speak with other cyborgs and AI.</b>"

--- a/monkestation/code/controllers/subsystem/job.dm
+++ b/monkestation/code/controllers/subsystem/job.dm
@@ -213,3 +213,13 @@
 
 	SSgamemode.current_roundstart_event = pick_weight(valid_rolesets)
 	log_storyteller("p_d_r pass, Selected Roleset: [SSgamemode.current_roundstart_event]")
+
+///trys to free up a job slot via the rank
+/datum/controller/subsystem/job/proc/FreeRole(rank)
+	if(!rank)
+		return
+	JobDebug("Freeing role: [rank]")
+	var/datum/job/job = GetJob(rank)
+	if(!job)
+		return FALSE
+	job.current_positions = max(0, job.current_positions - 1)


### PR DESCRIPTION
## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/78647

- Fixes roundstart jobs not getting information from `radio_help_message`

- Adds extra information for the Captain

- Examine blocks out roundstart / latejoin job information

![image](https://github.com/user-attachments/assets/2a4ce2cb-ad66-4b33-9d3a-e712744ddb2b)
## Why It's Good For The Game
1. Roundstart mobs weren't getting radio information due to them not being cliented yet, this has been fixed.
2. The roundstart block was pretty cumbersome to read and easy to have your eyes glaze over, this should make it easier.

## Changelog
:cl:
qol: Boxed roundstart / latejoin job information. 
qol: Captain gets a little bit more information about how their radio works roundstart.
fix: Fixed roundstart players not getting radio information.
/:cl:
