### PR TITLE
Fixes shatter element dropping stuff on blocked turfs

### DIFF
--- a/code/modules/food_and_drinks/plate.dm
+++ b/code/modules/food_and_drinks/plate.dm
@@ -78,8 +78,10 @@
 	. = ..()
 	if(.)
 		return
+	var/turf/scatter_turf = get_turf(hit_atom)
+	if(!hit_atom.CanPass(src, get_dir(src, hit_atom))) //Object is too dense to fall apart on
+		scatter_turf = get_turf(src)
 	var/generator/scatter_gen = generator(GEN_CIRCLE, 0, 48, NORMAL_RAND)
-	var/scatter_turf = get_turf(hit_atom)
 
 	for(var/obj/item/scattered_item as anything in contents)
 		ItemRemovedFromPlate(scattered_item)


### PR DESCRIPTION
## About The Pull Request
ports https://github.com/tgstation/tgstation/pull/88739
Makes plates unable to break into blocked turfs
fixes https://github.com/Monkestation/Monkestation2.0/issues/5628

## Why It's Good For The Game
Fixes bug which allows clipping through walls you shouldn't

## Changelog

:cl:
fix: plates breaking inside of walls
/:cl:

