### PR TITLE
Whips respect blocking, sentient monkeys use MONKEY_ATTACK_DISARM_PROB

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -250,7 +250,8 @@
 		user.client.give_award(/datum/award/achievement/misc/selfouch, user)
 
 	user.do_attack_animation(target_mob, used_item = src) // MONKESTATION EDIT: Okay so why the FUCK was an attack proc on *item* not passing the fucking *item* to this? WHY?!
-	target_mob.attacked_by(src, user)
+	if(!target_mob.attacked_by(src, user))
+		return TRUE
 
 	log_combat(user, target_mob, "attacked", src.name, "(ISTATE: [user.log_istate()]) (DAMTYPE: [uppertext(damtype)])")
 	add_fingerprint(user)

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -311,9 +311,11 @@
 	attack_verb_simple = list("flog", "whip", "lash", "discipline")
 	hitsound = 'sound/weapons/whip.ogg'
 
-/obj/item/melee/curator_whip/afterattack(target, mob/user, proximity_flag)
+/obj/item/melee/curator_whip/attack(mob/living/target, mob/living/user, params)
 	. = ..()
-	if(ishuman(target) && proximity_flag)
+	if(.)
+		return
+	if(ishuman(target))
 		var/mob/living/carbon/human/human_target = target
 		human_target.drop_all_held_items()
 		human_target.visible_message(span_danger("[user] disarms [human_target]!"), span_userdanger("[user] disarmed you!"))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -232,11 +232,12 @@
 
 	if((user.istate & ISTATE_SECONDARY)) //Always drop item in hand, if no item, get stunned instead.
 		var/obj/item/I = get_active_held_item()
-		if(I && !(I.item_flags & ABSTRACT) && dropItemToGround(I))
-			playsound(loc, 'sound/weapons/slash.ogg', 25, TRUE, -1)
-			visible_message(span_danger("[user] disarmed [src]!"), \
-							span_userdanger("[user] disarmed you!"), span_hear("You hear aggressive shuffling!"), null, user)
-			to_chat(user, span_danger("You disarm [src]!"))
+		if(!user.client || prob(MONKEY_ATTACK_DISARM_PROB)) // MONKESTATION ADDITION, not even natural monkeys get a 100% disarm
+			if(I && !(I.item_flags & ABSTRACT) && dropItemToGround(I))
+				playsound(loc, 'sound/weapons/slash.ogg', 25, TRUE, -1)
+				visible_message(span_danger("[user] disarmed [src]!"), \
+								span_userdanger("[user] disarmed you!"), span_hear("You hear aggressive shuffling!"), null, user)
+				to_chat(user, span_danger("You disarm [src]!"))
 		else if(!user.client || prob(5)) // only natural monkeys get to stun reliably, (they only do it occasionaly)
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, TRUE, -1)
 			if (src.IsKnockdown() && !src.IsParalyzed())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
ports https://github.com/tgstation/tgstation/pull/83543

Makes sentient monkeys use MONKEY_ATTACK_DISARM_PROB (20%) instead of disarming 100% of the time
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Basically the same for both. 100% disarm are insanely OP and powerful, regardless of what gear you have, weapon, block chance both of these can yoink the weapon you have instantly.

In curator whips case it pretends to use block but totally goes through it so this is a fix in a sense but also pretty balancey with how long its been around.

As for monkies I do want to make theirs respect block too but no brain power for that rn and I think this is better than nothing.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Curator whip respects blocking
balance: sentient monkeys only have a 20% disarm rate instead of 100%
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
