### PR TITLE
Adds Whitelist to Botany Strange Seed Chemicals and Adds Gatfruit & Money Tree to Seed Mesh Blacklist

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -609,11 +609,38 @@
 /obj/item/seeds/proc/add_random_reagents(lower = 0, upper = 2)
 	// Defines list of allowed plant reagents
 	var/list/allowed_reagents = list(
-		/datum/reagent/water,
-		/datum/reagent/consumable/nutriment,
-		/datum/reagent/potassium,
-		/datum/reagent/consumable/banana,
-		/datum/reagent/consumable/nutriment/vitamin
+		/datum/reagent/water, /datum/reagent/consumable/nutriment, /datum/reagent/medicine/c2/multiver,
+		/datum/reagent/potassium, /datum/reagent/toxin/acid, /datum/reagent/toxin/acid/fluacid,
+		/datum/reagent/consumable/banana, /datum/reagent/medicine/silibinin, /datum/reagent/toxin/formaldehyde
+		/datum/reagent/consumable/nutriment/vitamin, /datum/reagent/fluorine, /datum/reagent/medicine/c2/aiuri,
+		/datum/reagent/medicine/c2/libital, /datum/reagent/drug/space_drugs, /datum/reagent/toxin,
+		/datum/reagent/medicine/omnizine, /datum/reagent/medicine/synaptizine, /datum/reagent/medicine/earthsblood,
+		/datum/reagent/gold, /datum/reagent/consumable/nothing, /datum/reagent/toxin/mutetoxin,
+		/datum/reagent/bluespace, /datum/reagent/liquid_dark_matter, /datum/reagent/consumable/cooking_oil,
+		/datum/reagent/toxin/carpotoxin, /datum/reagent/ants, /datum/reagent/toxin/cyanide,
+		/datum/reagent/toxin/staminatoxin, /datum/reagent/toxin/coniine, /datum/reagent/uranium,
+		/datum/reagent/iodine, /datum/reagent/consumable/sugar, /datum/reagent/toxin/itching_powder,
+		/datum/reagent/sulfur, /datum/reagent/consumable/liquidelectricity, /datum/reagent/drug/cannabis,
+		/datum/reagent/colorful_reagent, /datum/reagent/medicine/psicodine, /datum/reagent/drug/happiness,
+		/datum/reagent/toxin/mindbreaker, /datum/reagent/toxin/lipolicide, /datum/reagent/mercury,
+		/datum/reagent/lithium, /datum/reagent/medicine/atropine, /datum/reagent/drug/methamphetamine,
+		/datum/reagent/drug/bath_salts, /datum/reagent/drug/krokodil, /datum/reagent/drug/nicotine,
+		/datum/reagent/oxygen, /datum/reagent/gunpowder, /datum/reagent/consumable/capsaicin,
+		/datum/reagent/consumable/frostoil, /datum/reagent/consumable/condensedcapsaicin, /datum/reagent/fuel,
+		/datum/reagent/medicine/haloperidol, /datum/reagent/consumable/coco, /datum/reagent/consumable/vanilla,
+		/datum/reagent/consumable/enzyme, /datum/reagent/toxin/bungotoxin, /datum/reagent/consumable/cornoil,
+		/datum/reagent/fuel/oil, /datum/reagent/consumable/ethanol/moonshine, /datum/reagent/medicine/granibitaluri,
+		/datum/reagent/plastic_polymers, /datum/reagent/consumable/garlic, /datum/reagent/carbon,
+		/datum/reagent/nitrogen, /datum/reagent/hydrogen, /datum/reagent/consumable/korta_nectar,
+		/datum/reagent/water/holywater, /datum/reagent/consumable/ethanol/ale, /datum/reagent/medicine/painkiller/morphine,
+		/datum/reagent/growthserum, /datum/reagent/toxin/amatoxin, /datum/reagent/drug/mushroomhallucinogen,
+		/datum/reagent/toxin/amanitin, /datum/reagent/uranium/radium, /datum/reagent/phosphorus,
+		/datum/reagent/teslium, /datum/reagent/toxin/spore, /datum/reagent/consumable/tearjuice,
+		/datum/reagent/consumable/laughter, /datum/reagent/pax, /datum/reagent/impurity/rosenol,
+		/datum/reagent/lead, /datum/reagent/ammonia, /datum/reagent/chlorine,
+		/datum/reagent/medicine/oculine, /datum/reagent/aluminium, /datum/reagent/toxin/teapowder,
+		/datum/reagent/toxin/coffeepowder, /datum/reagent/medicine/ephedrine, /datum/reagent/medicine/salbutamol,
+		/datum/reagent/blood, /datum/reagent/lube, /datum/reagent/cellulose, /datum/reagent/iron
 	)
 
 	var/amount_random_reagents = rand(lower, upper)

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -607,6 +607,7 @@
 	maturation = rand(6, 12)
 
 /obj/item/seeds/proc/add_random_reagents(lower = 0, upper = 2)
+	// MONKESTATION EDIT START
 	// Defines list of allowed plant reagents
 	var/list/allowed_reagents = list(
 		/datum/reagent/water, /datum/reagent/consumable/nutriment, /datum/reagent/medicine/c2/multiver,
@@ -642,12 +643,16 @@
 		/datum/reagent/toxin/coffeepowder, /datum/reagent/medicine/ephedrine, /datum/reagent/medicine/salbutamol,
 		/datum/reagent/blood, /datum/reagent/lube, /datum/reagent/cellulose, /datum/reagent/iron
 	)
+	// MONKESTATION EDIT END
 
 	var/amount_random_reagents = rand(lower, upper)
 	for(var/i in 1 to amount_random_reagents)
 		var/random_amount = rand(4, 15) * 0.01 // this must be multiplied by 0.01, otherwise, it will not properly associate
+		// MONKESTATION EDIT START
+		// var/datum/plant_gene/reagent/R = new(get_random_reagent_id(), random_amount) - MONKESTATION EDIT ORIGINAL
 		var/selected_reagent = pick(allowed_reagents)// Selects a random reagent from the allowed list
 		var/datum/plant_gene/reagent/R = new(selected_reagent, random_amount)
+		// MONKESTATION EDIT END
 		if(R.can_add(src))
 			if(!R.try_upgrade_gene(src))
 				genes += R

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -611,7 +611,7 @@
 	var/list/allowed_reagents = list(
 		/datum/reagent/water, /datum/reagent/consumable/nutriment, /datum/reagent/medicine/c2/multiver,
 		/datum/reagent/potassium, /datum/reagent/toxin/acid, /datum/reagent/toxin/acid/fluacid,
-		/datum/reagent/consumable/banana, /datum/reagent/medicine/silibinin, /datum/reagent/toxin/formaldehyde
+		/datum/reagent/consumable/banana, /datum/reagent/medicine/silibinin, /datum/reagent/toxin/formaldehyde,
 		/datum/reagent/consumable/nutriment/vitamin, /datum/reagent/fluorine, /datum/reagent/medicine/c2/aiuri,
 		/datum/reagent/medicine/c2/libital, /datum/reagent/drug/space_drugs, /datum/reagent/toxin,
 		/datum/reagent/medicine/omnizine, /datum/reagent/medicine/synaptizine, /datum/reagent/medicine/earthsblood,

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -607,10 +607,20 @@
 	maturation = rand(6, 12)
 
 /obj/item/seeds/proc/add_random_reagents(lower = 0, upper = 2)
+	// Defines list of allowed plant reagents
+	var/list/allowed_reagents = list(
+		/datum/reagent/water,
+		/datum/reagent/consumable/nutriment,
+		/datum/reagent/potassium,
+		/datum/reagent/consumable/banana,
+		/datum/reagent/consumable/nutriment/vitamin
+	)
+
 	var/amount_random_reagents = rand(lower, upper)
 	for(var/i in 1 to amount_random_reagents)
 		var/random_amount = rand(4, 15) * 0.01 // this must be multiplied by 0.01, otherwise, it will not properly associate
-		var/datum/plant_gene/reagent/R = new(get_random_reagent_id(), random_amount)
+		var/selected_reagent = pick(allowed_reagents)// Selects a random reagent from the allowed list
+		var/datum/plant_gene/reagent/R = new(selected_reagent, random_amount)
 		if(R.can_add(src))
 			if(!R.try_upgrade_gene(src))
 				genes += R

--- a/monkestation/code/modules/blueshift/items/ash_walker.dm
+++ b/monkestation/code/modules/blueshift/items/ash_walker.dm
@@ -61,6 +61,8 @@
 	icon_state = "mesh"
 	var/list/static/seeds_blacklist = list(
 		/obj/item/seeds/lavaland,
+		/obj/item/seeds/gatfruit,
+		/obj/item/seeds/tree/money,
 	)
 
 /obj/item/seed_mesh/attackby(obj/item/attacking_item, mob/user, params)


### PR DESCRIPTION
## About The Pull Request

This PR makes two balance changes to botany:

### Strange Seed Chemical Whitelist

1. Strange seeds generated from the biogenerator will now only produce reagents that can already be obtained through other botany plants.
2. Botanists will no longer be able to obtain overpowered, restricted, or admin-only reagents such as Metalgen, Gluttony's Blessing, and Admindrozine.
3. This still allows botanists to get powerful chemicals like Bath Salts (Omega Weed) and Omnizine (Ambrosia), but prevents botany from easily bypassing chemistry or acquiring traitor-level reagents.

### Seed Mesh Blacklist Additions

1. Gatfruit and the Money Tree have been added to the Seed Mesh blacklist.
2. Gatfruit essentially gives infinite guns, and the Money Tree provides infinite money, both of which are highly exploitable.

## Why It's Good For The Game

I play as botanist alot and have been able to obtain game-breaking chemicals and also see other botanists do the same. Botany should not be able to get immortality and stun immunity 30 minutes into a round, nor should people be able to create infinite weapons or money with minimal effort. As the seed mesh is easy to make with watcher's sinew, cloth and glass.

![image](https://github.com/user-attachments/assets/1c729852-97bd-411f-8718-fc55c9ad99aa)
(Above photo is the chemical scan of a botany player who does this often and uses Android Mutation Toxin to bypass the negative effects of the chemicals)

Also the whitelist change can actually promote botanists to start taking the job for its intended purpose of making plants for the crew and chef and keep power-gamers away that choose the job in order to get the best chemical such as restorative nanites, mutation toxin, and TWitch.

This PR keeps some of botany’s fun and potential while making sure that certain reagents and plants remain appropriately gated behind their intended mechanics.

## Changelog

:cl:
balance: Strange seeds now only generate chemicals that can already be obtained from other botany plants.
balance: Gatfruit and Money Tree are now blacklisted from the Seed Mesh
/:cl:
