### PR TITLE
Prevent using more than one seed mesh at a time

### DIFF
--- a/code/__DEFINES/do_afters.dm
+++ b/code/__DEFINES/do_afters.dm
@@ -7,3 +7,4 @@
 #define DOAFTER_SOURCE_HEAL_TOUCH "doafter_heal_touch"
 #define DOAFTER_SOURCE_PLANTING_DEVICE "doafter_planting_device"
 #define DOAFTER_SOURCE_CHARGE_GUNCRANK "doafter_charge_guncrank"
+#define DOAFTER_SOURCE_SEED_MESH "doafter_seed_mesh"

--- a/monkestation/code/modules/blueshift/items/ash_walker.dm
+++ b/monkestation/code/modules/blueshift/items/ash_walker.dm
@@ -64,6 +64,9 @@
 	)
 
 /obj/item/seed_mesh/attackby(obj/item/attacking_item, mob/user, params)
+	if(DOING_INTERACTION(user, DOAFTER_SOURCE_SEED_MESH))
+		balloon_alert(user, "already filtering seeds!")
+		return
 	if(istype(attacking_item, /obj/item/stack/ore/glass))
 		var/obj/item/stack/ore/ore_item = attacking_item
 		if(ore_item.points == 0)
@@ -73,7 +76,7 @@
 		var/ore_usage = 5
 		while(ore_item.amount >= ore_usage)
 			var/skill_modifier = user.mind.get_skill_modifier(/datum/skill/primitive, SKILL_SPEED_MODIFIER)
-			if(!do_after(user, 5 SECONDS * skill_modifier, src))
+			if(!do_after(user, 5 SECONDS * skill_modifier, src, interaction_key = DOAFTER_SOURCE_SEED_MESH))
 				user.balloon_alert(user, "have to stand still!")
 				return
 


### PR DESCRIPTION

## About The Pull Request

this just makes it so you can simultaneously interact with as many seed meshes as you can reach.

## Changelog
:cl:
balance: You can no longer simultaneously filter sand through as many seed meshes as you can reach.
/:cl:
