### PR TITLE
Re-disables asset caching in the default config

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -529,7 +529,7 @@ MOTD motd.txt
 ## The cache is assumed to be cleared by TGS recompiling, which deletes `tmp`.
 ## This should be disabled (through `CACHE_ASSETS 0`) on development,
 ## but enabled on production (the default).
-CACHE_ASSETS 1
+CACHE_ASSETS 0
 
 ## If this remains commented out, we will allow players to download their own preferences as a JSON file to do whatever they wish.
 ## This does require the game code to read (and only read) the /data folder where these files are stored, and then use the BYOND FTP Function to send the file to the client.


### PR DESCRIPTION

## About The Pull Request

this makes `CACHE_ASSETS 0` the default, so people stop getting confused about why spritesheets and such don't seem to work when coding new features.

## Changelog

No player-facing changes at all, the actual server's config is unaffected by repo config changes.