### PR TITLE
Removes pH buffers from maints loot

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -136,7 +136,9 @@ GLOBAL_LIST_INIT(common_loot, list( //common: basic items
 		/obj/item/grenade/chem_grenade/cleaner = 1,
 		/obj/item/lead_pipe = 1,
 		/obj/item/reagent_containers/cup/beaker = 1,
+/* monkestation removal: we don't use ph or purity
 		/obj/item/reagent_containers/cup/bottle/random_buffer = 2,
+monkestation end */
 		/obj/item/reagent_containers/cup/rag = 1,
 		/obj/item/reagent_containers/hypospray/medipen/pumpup = 2,
 		/obj/item/reagent_containers/syringe = 1,


### PR DESCRIPTION

## About The Pull Request

this removes the pH buffer bottles from maints loot. simple as that

## Why It's Good For The Game

i'm too lazy to remove _all_ traces of pH and purity from the codebase, so let's just stop polluting the maints pool stuff with this useless shit for now.

## Changelog
:cl:
del: Removes pH buffers from maints loot (we have pH and purity disabled anyways)
/:cl:
