### PR TITLE
Fixes basic mobs targeting ventcrawling/jaunting mobs

### DIFF
--- a/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
+++ b/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
@@ -55,7 +55,9 @@
 	if(living_mob.see_invisible < the_target.invisibility) //Target's invisible to us, forget it
 		return FALSE
 
-	if(isturf(living_mob.loc) && isturf(the_target.loc) && living_mob.z != the_target.z) // z check will always fail if target is in a mech or pawn is shapeshifted or jaunting
+	if(!isturf(living_mob.loc))
+		return FALSE
+	if(isturf(the_target.loc) && living_mob.z != the_target.z) // z check will always fail if target is in a mech or pawn is shapeshifted or jaunting
 		return FALSE
 
 	if(isliving(the_target)) //Targeting vs living mobs

--- a/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
+++ b/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
@@ -36,6 +36,9 @@
 	var/atom/target_loc = the_target.loc
 	var/atom/mob_loc = living_mob.loc
 
+	if(QDELETED(target_loc) || QDELETED(mob_loc))
+		return FALSE // I don't know how you'd end up in this situation, but let's just... not.
+
 	if(HAS_TRAIT(target_loc, TRAIT_SECLUDED_LOCATION))
 		return FALSE // don't attack people in an out-of-bounds location (aka if they're using a desynchronizer)
 

--- a/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
+++ b/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
@@ -36,6 +36,9 @@
 	var/atom/target_loc = the_target.loc
 	var/atom/mob_loc = living_mob.loc
 
+	if(HAS_TRAIT(target_loc, TRAIT_SECLUDED_LOCATION))
+		return FALSE // don't attack people in an out-of-bounds location (aka if they're using a desynchronizer)
+
 	if(isobj(target_loc))
 		var/obj/container = target_loc
 		if(container.resistance_flags & INDESTRUCTIBLE)

--- a/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
+++ b/code/datums/ai/basic_mobs/targeting_strategies/basic_targeting_strategy.dm
@@ -9,8 +9,9 @@
 ///Returns something the target might be hiding inside of
 /datum/targeting_strategy/proc/find_hidden_mobs(mob/living/living_mob, atom/target)
 	var/atom/target_hiding_location
-	if(istype(target.loc, /obj/structure/closet) || istype(target.loc, /obj/machinery/disposal) || istype(target.loc, /obj/machinery/sleeper))
-		target_hiding_location = target.loc
+	var/atom/target_loc = target.loc
+	if(istype(target_loc, /obj/structure/closet) || istype(target_loc, /obj/machinery/disposal) || istype(target_loc, /obj/machinery/sleeper))
+		target_hiding_location = target_loc
 	return target_hiding_location
 
 /datum/targeting_strategy/basic
@@ -32,22 +33,25 @@
 	if(isturf(the_target) || isnull(the_target)) // bail out on invalids
 		return FALSE
 
-	if(isobj(the_target.loc))
-		var/obj/container = the_target.loc
+	var/atom/target_loc = the_target.loc
+	var/atom/mob_loc = living_mob.loc
+
+	if(isobj(target_loc))
+		var/obj/container = target_loc
 		if(container.resistance_flags & INDESTRUCTIBLE)
 			return FALSE
+		if(isstructure(the_target))
+			return HAS_TRAIT(the_target, TRAIT_MOB_DESTROYABLE)
 
-	if(isstructure(the_target))
-		if(!HAS_TRAIT(the_target, TRAIT_MOB_DESTROYABLE))
-			return FALSE
-		return TRUE
-
-	if(ismob(the_target)) //Target is in godmode, ignore it.
-		if(living_mob.loc == the_target)
+	if(ismob(the_target))
+		if(mob_loc == the_target)
 			return FALSE // We've either been eaten or are shapeshifted, let's assume the latter because we're still alive
-		var/mob/M = the_target
-		if(HAS_TRAIT(M, TRAIT_GODMODE))
-			return FALSE
+		if(HAS_TRAIT(the_target, TRAIT_MOVE_VENTCRAWLING))
+			return FALSE // you can't bite people inside of vents
+		if(HAS_TRAIT(the_target, TRAIT_MAGICALLY_PHASED))
+			return FALSE // you can't bite anything that's incorporeal
+		if(HAS_TRAIT(the_target, TRAIT_GODMODE))
+			return FALSE // target is in godmode, ignore it
 
 	if(!ignore_sight && !can_see(living_mob, the_target, vision_range)) //Target has moved behind cover and we have lost line of sight to it
 		return FALSE
@@ -55,9 +59,10 @@
 	if(living_mob.see_invisible < the_target.invisibility) //Target's invisible to us, forget it
 		return FALSE
 
-	if(!isturf(living_mob.loc))
+	if(!isturf(mob_loc))
 		return FALSE
-	if(isturf(the_target.loc) && living_mob.z != the_target.z) // z check will always fail if target is in a mech or pawn is shapeshifted or jaunting
+
+	if(isturf(target_loc) && living_mob.z != the_target.z) // z check will always fail if target is in a mech or pawn is shapeshifted or jaunting
 		return FALSE
 
 	if(isliving(the_target)) //Targeting vs living mobs


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/4873

This makes it so basic `/datum/targeting_strategy/basic` won't consider any targets with `TRAIT_MOVE_VENTCRAWLING` or `TRAIT_MAGICALLY_PHASED` to be valid targets - and thus, won't attack them.

I also did some slight code cleanup.

The code is not modularized bc I will port this upstream if it works (I don't see any reason why it wouldn't either)

Also ports https://github.com/tgstation/tgstation/pull/81804.

## Why It's Good For The Game

bugfix good

## Changelog
:cl:
fix: AI-controlled basic mobs will no longer somehow attack people who are ventcrawling or jaunting.
fix: (Hatterhat) Basic mobs no longer have the (unintended) ability to shoot out of containers, like bluespace body bags.
/:cl:
