### PR TITLE
Small credits refactor

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -230,12 +230,12 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 	popcount = gather_roundend_feedback()
 
 	for(var/client/C in GLOB.clients)
-		if(!C?.credits)
-			C?.RollCredits()
 		C?.playtitlemusic(40)
 		if(speed_round && was_forced != ADMIN_FORCE_END_ROUND)
 			C?.give_award(/datum/award/achievement/misc/speed_round, C?.mob)
 		HandleRandomHardcoreScore(C)
+
+	RollCredits()
 
 	display_report(popcount)
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -270,7 +270,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	if(succumbed)
 		succumb(TRUE)
 		to_chat(src, compose_message(src, language, message, , spans, message_mods))
-	talkcount++
+
 	return TRUE
 
 /mob/living/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods = list(), message_range=0)

--- a/monkestation/code/modules/and_roll_credits/_credits.dm
+++ b/monkestation/code/modules/and_roll_credits/_credits.dm
@@ -16,10 +16,9 @@
 	for(var/client/client in GLOB.clients)
 		add_verb(client, /client/proc/ClearCredits)
 
-	var/credit_order = SScredits.credit_order
 	var/count = 0
 
-	for(var/credit in credit_order)
+	for(var/credit in SScredits.credit_order)
 		if(istype(credit, /obj/effect/title_card_object)) //huge image sleep
 			sleep(CREDIT_SPAWN_SPEED * 3.3)
 			count = 0

--- a/monkestation/code/modules/and_roll_credits/_credits.dm
+++ b/monkestation/code/modules/and_roll_credits/_credits.dm
@@ -1,152 +1,108 @@
-#define CREDIT_ROLL_SPEED 9 SECONDS
+#define CREDIT_ROLL_SPEED 18 SECONDS
 #define CREDIT_SPAWN_SPEED 1 SECONDS
-#define CREDIT_ANIMATE_HEIGHT (16 * world.icon_size)
+#define CREDIT_ANIMATE_HEIGHT (32 * world.icon_size)
 #define CREDIT_EASE_DURATION 2.2 SECONDS
 #define CREDITS_PATH "[global.config.directory]/contributors.dmi"
 
-/client/proc/RollCredits()
+/proc/RollCredits()
 	set waitfor = FALSE
-	if(!fexists(CREDITS_PATH) || !prefs?.read_preference(/datum/preference/toggle/show_roundend_credits))
+
+	if(!fexists(CREDITS_PATH))
 		return
-	LAZYINITLIST(credits)
-	var/list/_credits = credits
-	add_verb(src, /client/proc/ClearCredits)
-	var/static/list/credit_order_for_this_round
-	if(isnull(credit_order_for_this_round))
-		SScredits.draft()
-		SScredits.finalize()
-		credit_order_for_this_round = list()
-		credit_order_for_this_round += SScredits.episode_string
-		credit_order_for_this_round += SScredits.producers_string
-		credit_order_for_this_round += SScredits.disclaimers_string
-		credit_order_for_this_round += SScredits.cast_string
-		credit_order_for_this_round += "<center>The Admin Bus</center>"
-		var/list/admins = shuffle(SScredits.admin_pref_images)
 
-		var/y_offset = 0
-		var/admin_length = length(admins)
-		for(var/i in 1 to admin_length)
-			var/x_offset = -40
-			for(var/b in 1 to 8)
-				var/atom/movable/screen/map_view/char_preview/picked = pick_n_take(admins)
-				if(!picked)
-					break
-				picked.pixel_x = x_offset
-				picked.pixel_y = y_offset
-				x_offset += 70
-				credit_order_for_this_round += picked
+	if(!SScredits.credit_order)
+		SScredits.generate_credits()
 
-		credit_order_for_this_round += "<center>Our Lovely Contributors</center>"
-		var/list/contributors = shuffle(SScredits.contributer_pref_images)
+	for(var/client/client in GLOB.clients)
+		add_verb(client, /client/proc/ClearCredits)
 
-		var/contributors_length = length(contributors)
-		for(var/i in 1 to contributors_length)
-			var/x_offset = -40
-			for(var/b in 1 to 8)
-				if(b == 1)
-					y_offset = 0
-				var/atom/movable/screen/map_view/char_preview/picked = pick_n_take(contributors)
-				if(!picked)
-					break
-				picked.pixel_x = x_offset
-				picked.pixel_y = y_offset
-				x_offset += 70
-				credit_order_for_this_round += picked
-
-		for(var/i in SScredits.major_event_icons)
-			credit_order_for_this_round += i
-			var/list/returned_images = SScredits.resolve_clients(SScredits.major_event_icons[i], i)
-			for(var/y in 1 to length(returned_images))
-				var/x_offset = -40
-				for(var/b in 1 to 8)
-					var/atom/movable/screen/map_view/char_preview/client_image = pick_n_take(returned_images)
-					if(!client_image)
-						break
-					client_image.pixel_x = x_offset
-					client_image.pixel_y = y_offset
-					x_offset += 70
-					credit_order_for_this_round += client_image
-
+	var/credit_order = SScredits.credit_order
 	var/count = 0
-	for(var/I in credit_order_for_this_round)
-		if(!credits)
-			return
-		if(istype(I, /obj/effect/title_card_object)) //huge image sleep
+
+	for(var/credit in credit_order)
+		if(istype(credit, /obj/effect/title_card_object)) //huge image sleep
 			sleep(CREDIT_SPAWN_SPEED * 3.3)
 			count = 0
-		if(count && !istype(I, /atom/movable/screen/map_view/char_preview))
+
+		if(count && !istype(credit, /atom/movable/screen/map_view/char_preview))
 			sleep(CREDIT_SPAWN_SPEED)
 
-		_credits += new /atom/movable/screen/credit(null, I, src)
-		if(istype(I, /atom/movable/screen/map_view/char_preview))
+		new /atom/movable/screen/credit(null, credit)
+
+		if(istype(credit, /atom/movable/screen/map_view/char_preview))
 			count++
 			if(count >= 8)
 				count = 0
 				sleep(CREDIT_SPAWN_SPEED)
-		if(!istype(I, /atom/movable/screen/map_view/char_preview))
+
+		if(!istype(credit, /atom/movable/screen/map_view/char_preview))
 			sleep(CREDIT_SPAWN_SPEED)
 			count = 0
+
 	sleep(CREDIT_ROLL_SPEED - CREDIT_SPAWN_SPEED)
-	remove_verb(src, /client/proc/ClearCredits)
+
+	for(var/client/client in GLOB.clients)
+		remove_verb(client, /client/proc/ClearCredits)
+
+	LAZYNULL(SScredits.ignored_clients)
 
 /client/proc/ClearCredits()
 	set name = "Hide Credits"
 	set category = "OOC"
 	remove_verb(src, /client/proc/ClearCredits)
-	QDEL_LAZYLIST(credits)
+
+	LAZYADDASSOC(SScredits.ignored_clients, src, TRUE)
+
+	for(var/atom/movable/screen/credit/credit in src.screen)
+		src.screen -= credit
 
 /atom/movable/screen/credit
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	alpha = 0
 	plane = SPLASHSCREEN_PLANE
-	screen_loc = "3,1"
-	var/client/parent
+	screen_loc = "CENTER-6:16,BOTTOM"
+
 	var/matrix/target
 
-/atom/movable/screen/credit/Initialize(mapload, credited, client/P)
+/atom/movable/screen/credit/Initialize(mapload, credited)
 	. = ..()
 	icon = CREDITS_PATH
-	parent = P
-	var/view = P?.view
-	var/list/offsets = screen_loc_to_offset("3,1", view)
 
 	if(istype(credited, /atom/movable/screen/map_view/char_preview))
 		var/atom/movable/screen/map_view/char_preview/choice = credited
 		choice.plane = plane
-		choice.screen_loc = screen_loc
 		choice.alpha = alpha
 		maptext_width = choice.maptext_width
 		maptext = choice.maptext
+		screen_loc = choice.screen_loc
 		appearance = choice.appearance
-		screen_loc = offset_to_screen_loc(offsets[1] + choice.pixel_x, offsets[2] + choice.pixel_y)
+		choice.screen_loc = null
 		add_overlay(choice)
 
 	if(istype(credited, /mutable_appearance))
 		var/mutable_appearance/choice = credited
 		choice.plane = plane
-		choice.screen_loc = screen_loc
 		choice.alpha = alpha
 		maptext_width = choice.maptext_width
 		maptext = choice.maptext
+		screen_loc = choice.screen_loc
 		appearance = choice.appearance
-		screen_loc = offset_to_screen_loc(offsets[1] + choice.pixel_x, offsets[2] + choice.pixel_y)
+		choice.screen_loc = null
 		add_overlay(choice)
 
 	if(istype(credited, /obj/effect/title_card_object))
 		var/obj/effect/title_card_object/choice = credited
 		choice.plane = plane
-		choice.screen_loc = screen_loc
 		choice.alpha = alpha
 		maptext_width = choice.maptext_width
 		maptext = choice.maptext
+		screen_loc = choice.screen_loc
 		appearance = choice.appearance
-		screen_loc = offset_to_screen_loc(offsets[1] + choice.pixel_x, offsets[2] + choice.pixel_y)
+		choice.screen_loc = null
 		add_overlay(choice)
 
 	if(istext(credited))
 		maptext = MAPTEXT_PIXELLARI(credited)
-		maptext_x = world.icon_size + 8
-		maptext_y = (world.icon_size / 2) - 4
 		maptext_width = world.icon_size * 12
 		maptext_height = world.icon_size * 2
 
@@ -155,20 +111,23 @@
 	animate(src, transform = M, time = CREDIT_ROLL_SPEED)
 	target = M
 	animate(src, alpha = 255, time = CREDIT_EASE_DURATION, flags = ANIMATION_PARALLEL)
-	addtimer(CALLBACK(src, PROC_REF(FadeOut)), CREDIT_ROLL_SPEED - CREDIT_EASE_DURATION)
+	addtimer(CALLBACK(src, PROC_REF(fadeout)), CREDIT_ROLL_SPEED - CREDIT_EASE_DURATION)
+	INVOKE_ASYNC(src, PROC_REF(show_to_players))
 	QDEL_IN(src, CREDIT_ROLL_SPEED)
-	parent?.screen += src
 
 /atom/movable/screen/credit/Destroy()
-	icon = null
-	if(parent)
-		parent.screen -= src
-		LAZYREMOVE(parent.credits, src)
-		parent = null
+	screen_loc = null
+	target = null
 	return ..()
 
-/atom/movable/screen/credit/proc/FadeOut()
+/atom/movable/screen/credit/proc/fadeout()
 	animate(src, alpha = 0, transform = target, time = CREDIT_EASE_DURATION)
+
+/atom/movable/screen/credit/proc/show_to_players()
+	for(var/client/client in GLOB.clients)
+		if(LAZYACCESS(SScredits.ignored_clients, client) || !client?.prefs?.read_preference(/datum/preference/toggle/show_roundend_credits))
+			continue
+		client.screen += src
 
 #undef CREDIT_ANIMATE_HEIGHT
 #undef CREDIT_EASE_DURATION

--- a/monkestation/code/modules/and_roll_credits/credits_subsystem.dm
+++ b/monkestation/code/modules/and_roll_credits/credits_subsystem.dm
@@ -30,10 +30,59 @@ SUBSYSTEM_DEF(credits)
 	var/list/major_event_icons = list()
 	var/list/contributors = list()
 
+	var/list/credit_order
+	var/list/ignored_clients
+
 /datum/controller/subsystem/credits/Initialize()
 	load_contributors()
 	generate_pref_images()
 	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/credits/proc/generate_credits()
+	credit_order = list()
+
+	draft()
+	finalize()
+
+	credit_order += episode_string
+	credit_order += producers_string
+	credit_order += disclaimers_string
+	credit_order += cast_string
+
+	credit_order += "<center>The Admin Bus</center>"
+	var/list/admins = shuffle(admin_pref_images)
+	var/admin_length = length(admins)
+
+	for(var/i in 1 to admin_length)
+		for(var/b in 1 to 8)
+			var/atom/movable/screen/map_view/char_preview/client_image = pick_n_take(admins)
+			if(!client_image)
+				break
+			client_image.screen_loc = "LEFT+[(b - 1) * 13]%:24,BOTTOM"
+			credit_order += client_image
+
+	credit_order += "<center>Our Lovely Contributors</center>"
+	var/list/contributors = shuffle(contributer_pref_images)
+
+	var/contributors_length = length(contributors)
+	for(var/i in 1 to contributors_length)
+		for(var/b in 1 to 8)
+			var/atom/movable/screen/map_view/char_preview/client_image = pick_n_take(contributors)
+			if(!client_image)
+				break
+			client_image.screen_loc = "LEFT+[(b - 1) * 13]%:24,BOTTOM"
+			credit_order += client_image
+
+	for(var/i in major_event_icons)
+		credit_order += i
+		var/list/returned_images = resolve_clients(major_event_icons[i], i)
+		for(var/y in 1 to length(returned_images))
+			for(var/b in 1 to 8)
+				var/atom/movable/screen/map_view/char_preview/client_image = pick_n_take(returned_images)
+				if(!client_image)
+					break
+				client_image.screen_loc = "LEFT+[(b - 1) * 13]%:24,BOTTOM"
+				credit_order += client_image
 
 /datum/controller/subsystem/credits/proc/load_contributors()
 	contributors = list()
@@ -56,7 +105,6 @@ SUBSYSTEM_DEF(credits)
 	finalize_disclaimerstring()
 
 /datum/controller/subsystem/credits/proc/generate_pref_images()
-
 	for(var/ckey in contributors)
 		var/datum/client_interface/interface = new(ckey)
 		var/datum/preferences/mocked = new(interface)
@@ -64,8 +112,8 @@ SUBSYSTEM_DEF(credits)
 		var/atom/movable/screen/map_view/char_preview/appearance = new(null, mocked)
 		appearance.update_body()
 		appearance.maptext_width = 120
-		appearance.maptext_y = -8
 		appearance.maptext_x = -42
+		appearance.maptext_y = -12
 		appearance.maptext = "<center>[ckey]</center>"
 		contributer_pref_images += appearance
 
@@ -77,7 +125,7 @@ SUBSYSTEM_DEF(credits)
 		appearance.update_body()
 		appearance.maptext_width = 120
 		appearance.maptext_x = -42
-		appearance.maptext_y = -8
+		appearance.maptext_y = -12
 		appearance.maptext = "<center>[ckey]</center>"
 		admin_pref_images += appearance
 
@@ -89,7 +137,6 @@ SUBSYSTEM_DEF(credits)
 		if(!most_talked || H.talkcount > most_talked.talkcount)
 			most_talked = H
 	star = thebigstar(most_talked)
-
 
 /datum/controller/subsystem/credits/proc/finalize_name()
 	if(customized_name)
@@ -117,6 +164,7 @@ SUBSYSTEM_DEF(credits)
 	disclaimers_string =  list()
 	for(var/disclaimer in disclaimers)
 		disclaimers_string += "<center>[disclaimer]</center>"
+
 /datum/controller/subsystem/credits/proc/draft_disclaimers()
 	disclaimers += "Filmed on Location at [station_name()].<br>"
 	disclaimers += "Filmed with BYOND&#169; cameras and lenses. Outer space footage provided by NASA.<br>"
@@ -149,7 +197,7 @@ SUBSYSTEM_DEF(credits)
 		cast_num++
 
 	if(!cast_num)
-		cast_string += "<center><td class='actorsegue'> Nobody! </td></center>"
+		cast_string += "<center><td class='actorsegue'>Nobody!</td></center>"
 
 	var/list/corpses = list()
 	for(var/mob/living/carbon/human/H in GLOB.dead_mob_list)
@@ -160,8 +208,7 @@ SUBSYSTEM_DEF(credits)
 	if(corpses.len)
 		var/true_story_bro = "<center><br>[pick("BASED ON","INSPIRED BY","A RE-ENACTMENT OF")] [pick("A TRUE STORY","REAL EVENTS","THE EVENTS ABOARD [uppertext(station_name())]")]</center>"
 		cast_string += "<center><h3>[true_story_bro]</h3><br>In memory of those that did not make it.<br>[english_list(corpses)].<br></center>"
-	cast_string += "</div><br>"
-
+	cast_string += "<br>"
 
 /datum/controller/subsystem/credits/proc/thebigstar(star)
 	if(istext(star))
@@ -178,10 +225,10 @@ SUBSYSTEM_DEF(credits)
 		if(effect.icon_state == passed_icon_state)
 			MA = effect
 			break
+
 	if(!MA)
 		MA = new
 		MA.icon_state = passed_icon_state
-		MA.pixel_x = 80
 		major_event_icons += MA
 		major_event_icons[MA] = list()
 
@@ -191,40 +238,42 @@ SUBSYSTEM_DEF(credits)
 	var/list/created_appearances = list()
 
 	//hell
-	if(icon_state == "cult")
-		var/datum/team/cult/cult = locate(/datum/team/cult) in GLOB.antagonist_teams
-		if(cult)
-			for(var/mob/living/cultist in cult.true_cultists)
-				if(!cultist.client)
-					continue
-				clients |= WEAKREF(cultist.client)
-	if(icon_state == "revolution")
-		var/datum/team/revolution/cult = locate(/datum/team/revolution) in GLOB.antagonist_teams
-		if(cult)
-			for(var/datum/mind/cultist in (cult.ex_revs + cult.ex_headrevs + cult.members))
-				if(!cultist?.current?.client)
-					continue
-				clients |= WEAKREF(cultist.current.client)
-	if(icon_state == "clockcult")
-		var/datum/team/clock_cult/cult = locate(/datum/team/clock_cult) in GLOB.antagonist_teams
-		if(cult)
-			for(var/mob/living/carbon/human/cultist in (cult.human_servants))
-				if(!cultist.client)
-					continue
-				clients |= WEAKREF(cultist.client)
+	switch(icon_state)
+		if("cult")
+			var/datum/team/cult/cult = locate(/datum/team/cult) in GLOB.antagonist_teams
+			if(cult)
+				for(var/mob/living/cultist in cult.true_cultists)
+					if(!cultist.client)
+						continue
+					clients |= WEAKREF(cultist.client)
+		if("revolution")
+			var/datum/team/revolution/revolution = locate(/datum/team/revolution) in GLOB.antagonist_teams
+			if(revolution)
+				for(var/datum/mind/revolutionist in (revolution.ex_revs + revolution.ex_headrevs + revolution.members))
+					if(!revolutionist?.current?.client)
+						continue
+					clients |= WEAKREF(revolutionist.current.client)
+		if("clockcult")
+			var/datum/team/clock_cult/clock_cult = locate(/datum/team/clock_cult) in GLOB.antagonist_teams
+			if(clock_cult)
+				for(var/mob/living/carbon/human/cultist in (clock_cult.human_servants))
+					if(!cultist.client)
+						continue
+					clients |= WEAKREF(cultist.client)
 
 	for(var/datum/weakref/weak as anything in clients)
 		var/client/client = weak.resolve()
 		if(!client)
 			continue
-		var/atom/movable/screen/map_view/char_preview/appereance = new(null, client.prefs)
+		var/atom/movable/screen/map_view/char_preview/appearance = new(null, client.prefs)
 		var/mutable_appearance/preview = new(getFlatIcon(client.mob?.appearance))
-		appereance.appearance = preview.appearance
-		appereance.maptext_width = 120
-		appereance.maptext_y = -8
-		appereance.maptext_x = -42
-		appereance.maptext = "<center>[client.mob.real_name]</center>"
-		created_appearances += appereance
+		appearance.appearance = preview.appearance
+		appearance.maptext_width = 120
+		appearance.maptext_x = -42
+		appearance.maptext_y = -12
+		appearance.maptext = "<center>[client.mob.real_name]</center>"
+		created_appearances += appearance
+
 	return created_appearances
 
 /mob/living/var/talkcount = 0
@@ -232,3 +281,4 @@ SUBSYSTEM_DEF(credits)
 /obj/effect/title_card_object
 	plane = SPLASHSCREEN_PLANE
 	icon = 'monkestation/code/modules/and_roll_credits/icons/title_cards.dmi'
+	screen_loc = "CENTER-4,BOTTOM"

--- a/monkestation/code/modules/and_roll_credits/credits_subsystem.dm
+++ b/monkestation/code/modules/and_roll_credits/credits_subsystem.dm
@@ -4,8 +4,6 @@ SUBSYSTEM_DEF(credits)
 	init_order = INIT_ORDER_CREDITS
 
 	var/director = "Some monkey we found on the street"
-	var/star = ""
-	var/ss = ""
 	var/list/disclaimers = list()
 	var/list/datum/episode_name/episode_names = list()
 
@@ -18,12 +16,8 @@ SUBSYSTEM_DEF(credits)
 
 	//If any of the following five are modified, the episode is considered "not a rerun".
 	var/customized_name = ""
-	var/customized_star = ""
-	var/customized_ss = ""
 	var/rare_episode_name = FALSE
 	var/theme = "NT"
-
-	var/js_args = list()
 
 	var/list/contributer_pref_images = list()
 	var/list/admin_pref_images = list()
@@ -129,15 +123,6 @@ SUBSYSTEM_DEF(credits)
 		appearance.maptext = "<center>[ckey]</center>"
 		admin_pref_images += appearance
 
-/datum/controller/subsystem/credits/proc/draft_star()
-	var/mob/living/carbon/human/most_talked
-	for(var/mob/living/carbon/human/H in GLOB.player_list)
-		if(!H.ckey || H.stat == DEAD)
-			continue
-		if(!most_talked || H.talkcount > most_talked.talkcount)
-			most_talked = H
-	star = thebigstar(most_talked)
-
 /datum/controller/subsystem/credits/proc/finalize_name()
 	if(customized_name)
 		episode_name = customized_name
@@ -210,13 +195,6 @@ SUBSYSTEM_DEF(credits)
 		cast_string += "<center><h3>[true_story_bro]</h3><br>In memory of those that did not make it.<br>[english_list(corpses)].<br></center>"
 	cast_string += "<br>"
 
-/datum/controller/subsystem/credits/proc/thebigstar(star)
-	if(istext(star))
-		return star
-	if(ismob(star))
-		var/mob/M = star
-		return "[uppertext(M.mind.key)] as [M.real_name]"
-
 /datum/controller/subsystem/credits/proc/generate_major_icon(list/mobs, passed_icon_state)
 	if(!passed_icon_state)
 		return
@@ -275,8 +253,6 @@ SUBSYSTEM_DEF(credits)
 		created_appearances += appearance
 
 	return created_appearances
-
-/mob/living/var/talkcount = 0
 
 /obj/effect/title_card_object
 	plane = SPLASHSCREEN_PLANE


### PR DESCRIPTION
## About The Pull Request

Right now, every `/atom/movable/screen/credit` is duplicated for every client that doesn't have credits disabled.
This results in *a lot* of objects being created and deleted every second while credits are rolling.
I think it was coded this way to support different viewport sizes, but it doesn't actually work(?).

This PR massively reduces the total amount of created objects, while maintaining the same look.
Also, credits now properly adjust their position when player's viewport size changes.

<details>
<summary>Example</summary>

https://github.com/user-attachments/assets/ac63921e-2d15-453e-9aab-2afa0b18bd09

</details>

## Why It's Good For The Game
Less lag during round-end.

## Changelog
:cl:
refactor: Credits have been slightly refactored. This should result in increased perfomance during the end of the round.
/:cl:
