### PR TITLE
Re-adds gender and gendered laughs to IPCs

### DIFF
--- a/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
@@ -9,7 +9,7 @@
 	name = "\improper Integrated Positronic Chassis"
 	id = SPECIES_IPC
 	inherent_biotypes = MOB_ROBOTIC | MOB_HUMANOID
-	sexes = FALSE
+	sexes = TRUE
 	inherent_traits = list(
 		TRAIT_ROBOT_CAN_BLEED,
 		TRAIT_CAN_STRIP,

--- a/monkestation/code/modules/surgery/organs/internal/tongue.dm
+++ b/monkestation/code/modules/surgery/organs/internal/tongue.dm
@@ -65,11 +65,27 @@
 	return 'monkestation/sound/voice/screams/silicon/scream_silicon.ogg'
 
 /obj/item/organ/internal/tongue/synth/get_laugh_sound()
-	return pick(
-		'monkestation/sound/voice/laugh/silicon/laugh_siliconE1M0.ogg',
-		'monkestation/sound/voice/laugh/silicon/laugh_siliconE1M1.ogg',
-		'monkestation/sound/voice/laugh/silicon/laugh_siliconM2.ogg',
-	)
+	if(owner.gender == FEMALE)
+		return pick(
+			'monkestation/sound/voice/laugh/silicon/laugh_siliconF0.ogg', 
+			'monkestation/sound/voice/laugh/silicon/laugh_siliconF1.ogg', 
+			'monkestation/sound/voice/laugh/silicon/laugh_siliconF2.ogg',
+		)		
+	if(owner.gender == MALE)
+		return pick(
+			'monkestation/sound/voice/laugh/silicon/laugh_siliconE1M0.ogg', 
+			'monkestation/sound/voice/laugh/silicon/laugh_siliconE1M1.ogg', 
+			'monkestation/sound/voice/laugh/silicon/laugh_siliconM2.ogg',
+		)
+	else
+		return pick(
+			'monkestation/sound/voice/laugh/silicon/laugh_siliconE1M0.ogg', 
+			'monkestation/sound/voice/laugh/silicon/laugh_siliconE1M1.ogg', 
+			'monkestation/sound/voice/laugh/silicon/laugh_siliconM2.ogg', 
+			'monkestation/sound/voice/laugh/silicon/laugh_siliconF0.ogg', 
+			'monkestation/sound/voice/laugh/silicon/laugh_siliconF1.ogg', 
+			'monkestation/sound/voice/laugh/silicon/laugh_siliconF2.ogg',
+		)
 
 /obj/item/organ/internal/tongue/synth/can_speak_language(language)
 	return TRUE


### PR DESCRIPTION

## About The Pull Request

This looks like something that got lost in the rebase - the sound files were already there, but IPCs did not utilize them.

## Why It's Good For The Game

Adds a bit more missing flavor to IPCs.

## Changelog
:cl:
add: IPCs now have gender identity.
add: IPCs now have gendered laughs if applicable
/:cl:
