### PR TITLE
Fix a runtime when a player-controlled slime tries to latch onto a non-mob

### DIFF
--- a/monkestation/code/modules/slimecore/mobs/_base_slime.dm
+++ b/monkestation/code/modules/slimecore/mobs/_base_slime.dm
@@ -189,7 +189,7 @@
 	if(GetComponent(/datum/component/latch_feeding))
 		buckled?.unbuckle_mob(src, force = TRUE)
 		return
-	else if(CanReach(target) && !HAS_TRAIT(target, TRAIT_LATCH_FEEDERED))
+	else if(isliving(target) && CanReach(target) && !HAS_TRAIT(target, TRAIT_LATCH_FEEDERED))
 		AddComponent(/datum/component/latch_feeding, target, TRUE, TOX, 2, 4, FALSE, CALLBACK(src, TYPE_PROC_REF(/mob/living/basic/slime, latch_callback), target))
 		return
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Apparently we weren't checking if the thing that was right-clicked was actually a living mob. Woops!

## Why It's Good For The Game
Less runtimes!

## Changelog
No player-facing changes - the runtime caused the latch attempt to fail anyways.