### PR TITLE
Convert fluffy tongue to a component, make Pro-tagonista Syndrome inflict fluffy tongue

### DIFF
--- a/monkestation/code/datums/components/fluffy_tongue.dm
+++ b/monkestation/code/datums/components/fluffy_tongue.dm
@@ -1,0 +1,22 @@
+/// This component forces mobs to speak uwu-speak, to their detriment.
+/datum/component/fluffy_tongue
+	dupe_mode = COMPONENT_DUPE_SOURCES
+
+/datum/component/fluffy_tongue/Initialize()
+	. = ..()
+	if(!ismob(parent))
+		return COMPONENT_INCOMPATIBLE
+
+/datum/component/fluffy_tongue/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+
+/datum/component/fluffy_tongue/UnregisterFromParent()
+	UnregisterSignal(parent, COMSIG_MOB_SAY)
+
+/datum/component/fluffy_tongue/proc/handle_speech(datum/source, list/speech_args)
+	SIGNAL_HANDLER
+	if(HAS_TRAIT(source, TRAIT_SIGN_LANG))
+		return
+	var/message = speech_args[SPEECH_MESSAGE]
+	if(message[1] != "*")
+		speech_args[SPEECH_MESSAGE] = uwuify_text(message) || message

--- a/monkestation/code/datums/quirks/positive_quirks/fluffy_tongue.dm
+++ b/monkestation/code/datums/quirks/positive_quirks/fluffy_tongue.dm
@@ -5,16 +5,7 @@
 	icon = FA_ICON_CAT
 
 /datum/quirk/fluffy_tongue/add()
-	RegisterSignal(quirk_holder, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+	quirk_holder.AddComponentFrom(QUIRK_TRAIT, /datum/component/fluffy_tongue)
 
 /datum/quirk/fluffy_tongue/remove()
-	UnregisterSignal(quirk_holder, COMSIG_MOB_SAY)
-
-/datum/quirk/fluffy_tongue/proc/handle_speech(datum/source, list/speech_args)
-	SIGNAL_HANDLER
-	if(HAS_TRAIT(source, TRAIT_SIGN_LANG))
-		return
-	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*")
-		message = uwuify_text(message) || message
-	speech_args[SPEECH_MESSAGE] = message
+	quirk_holder.RemoveComponentSource(QUIRK_TRAIT, /datum/component/fluffy_tongue)

--- a/monkestation/code/game/objects/items/robot/items/robot_upgrades.dm
+++ b/monkestation/code/game/objects/items/robot/items/robot_upgrades.dm
@@ -1,4 +1,3 @@
-// Monkestation change: UwU-speak module for borgs because I hate borg players
 /obj/item/borg/upgrade/uwu
 	name = "cyborg UwU-speak \"upgrade\""
 	desc = "As if existence as an artificial being wasn't torment enough for the unit OR the crew."
@@ -7,15 +6,9 @@
 /obj/item/borg/upgrade/uwu/action(mob/living/silicon/robot/robutt, user = usr)
 	. = ..()
 	if(.)
-		RegisterSignal(robutt, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+		robutt.AddComponentFrom(REF(src), /datum/component/fluffy_tongue)
 
 /obj/item/borg/upgrade/uwu/deactivate(mob/living/silicon/robot/robutt, user = usr)
-	UnregisterSignal(robutt, COMSIG_MOB_SAY)
-
-/obj/item/borg/upgrade/uwu/proc/handle_speech(datum/source, list/speech_args)
-	SIGNAL_HANDLER
-	var/message = speech_args[SPEECH_MESSAGE]
-
-	if(message[1] != "*")
-		message = uwuify_text(message) || message
-	speech_args[SPEECH_MESSAGE] = message
+	. = ..()
+	if(.)
+		robutt.RemoveComponentSource(REF(src), /datum/component/fluffy_tongue)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -5981,6 +5981,7 @@
 #include "monkestation\code\datums\components\carbon_sprint.dm"
 #include "monkestation\code\datums\components\charge_adjuster.dm"
 #include "monkestation\code\datums\components\crafting.dm"
+#include "monkestation\code\datums\components\fluffy_tongue.dm"
 #include "monkestation\code\datums\components\gift_item.dm"
 #include "monkestation\code\datums\components\gps.dm"
 #include "monkestation\code\datums\components\irradiated.dm"


### PR DESCRIPTION
## About The Pull Request

this refactors fluffy tongue to be a component (with `COMPONENT_DUPE_SOURCES`), rather than duplicating the same registersignal between the quirk and the cyborg "upgrade".

i've also used this as a chance to change pro-tag syndrome inflict fluffy tongue upon the victim, as a more punishing effect for an otherwise often overpowered symptom, bc appending "Nyaa~" to the end of sentences 20% of the time (often with weird double-spacing) is kinda underwhelming.

## Why It's Good For The Game

better code and "balancing"

## Changelog
:cl:
refactor: Refactored some code relating to fluffy tongue.
balance: Pro-tagonista Syndrome now inflicts the victim with fluffy tongue, instead of just randomly appending an poorly spaced "Nyaa~" to 20% of their messages.
/:cl:
