### PR TITLE
Fix the Debug Cassette Tape appearing (at least for random tapes); plus, emit stack traces when failing to load cassette data

### DIFF
--- a/monkestation/code/modules/cassettes/cassette.dm
+++ b/monkestation/code/modules/cassettes/cassette.dm
@@ -40,18 +40,13 @@
 			id = pick(GLOB.approved_ids)
 
 	var/loaded_successfully = load_current_id()
-
-	// randomized cassettes get three chances to load different IDs. non-randomized cassettes only
-	// get one chance
-	if(!loaded_successfully && random)
-		// replace it with another random cassette - hopefully this one won't fail
-		id = pick(GLOB.approved_ids)
-		loaded_successfully = load_current_id()
-
-	if(!loaded_successfully && random)
-		// again?
-		id = pick(GLOB.approved_ids)
-		loaded_successfully = load_current_id()
+	if(random && !loaded_successfully)
+		var/list/approved_ids = GLOB.approved_ids.Copy()
+		var/attempts_left = 2
+		while(!loaded_successfully && length(approved_ids) && attempts_left > 0)
+			id = pick_n_take(approved_ids)
+			loaded_successfully = load_current_id()
+			attempts_left--
 
 	if(!loaded_successfully)
 		// this isn't working

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -9,8 +9,10 @@ if [[ $# -eq 2 ]] ; then
   cd $2
 fi
 
+# `$1/data/cassette_storage`` is a monkestation addition
 mkdir -p \
     $1/_maps \
+    $1/data/cassette_storage \
     $1/icons/effects \
     $1/icons/mob/clothing \
     $1/icons/mob/inhands \
@@ -29,6 +31,7 @@ fi
 
 cp tgstation.dmb tgstation.rsc $1/
 cp -r _maps/* $1/_maps/
+cp -r data/cassette_storage/* $1/data/cassette_storage/ # Monkestation addition
 cp -r icons/effects/* $1/icons/effects/
 cp -r icons/mob/clothing/* $1/icons/mob/clothing/
 cp -r icons/mob/inhands/* $1/icons/mob/inhands/


### PR DESCRIPTION
Randomized cassettes (cassettes with `random = TRUE`) will attempt to load random IDs three times - non-randomized cassettes will only try once
## About The Pull Request
In rare circumstances, cassettes can fail to load. This may be due to a missing JSON file, or perhaps the JSON itself is invalid.

This PR fixes this by implementing several things:
* When loading an ID from the cassette storage, more proper stack traces will be output in the following cases:
  * When the cassette storage doesn't contain the relevant ID
  * When the JSON we attempt to load from cassette storage is somehow invalid (usually only possible through tampering with the files, but computers are weird)
* When a cassette is random (as the ones from the the cassette pouch and cargo supply packs are), three attempts will be made to load a valid cassette. Non-random cassettes will only be given the one chance to load (as we assume they are manually spawned in)
* When a cassette fails to load (after three times for random cassettes, or one for non-random cassettes), admins will be sent a chat message, containing the coordinates of the tape, and a recommendation to check the runtime logs for more information.

## Why It's Good For The Game
Reduces the number of times you'll see a weird (and harmless) Debug Cassette Tape.

Fixes #5649.

## Changelog

:cl:MichiRecRoom
fix: The Debug Cassette Tape shouldn't appear as much anymore, as we now make three attempts to load a random cassette ID (for random cassettes).
admin: You will be notified if a cassette fails to load (after three attempts for a random cassette, or one for a specific cassette).
/:cl:
