### PR TITLE
Disable tgui music playback on 516 for now

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -108,7 +108,14 @@ SUBSYSTEM_DEF(statpanels)
 			return
 
 /datum/controller/subsystem/statpanels/proc/set_status_tab(client/target)
-	var/static/list/beta_notice = list("", "You are on the BYOND 516 beta, various UIs and such may be broken!", "Please report issues, and switch back to BYOND 515 if things are causing too many issues for you.")
+	// monkestation start: add notice regarding music player
+	var/static/list/beta_notice = list(
+		"",
+		"You are on the BYOND 516 beta, various UIs and such may be broken!",
+		"Please report issues, and switch back to BYOND 515 if things are causing too many issues for you.",
+		"Music playback currently does NOT work on BYOND 516."
+	)
+	// monkestation end
 	if(!global_data)//statbrowser hasnt fired yet and we were called from immediate_send_stat_data()
 		return
 

--- a/code/modules/tgui_panel/audio.dm
+++ b/code/modules/tgui_panel/audio.dm
@@ -20,6 +20,10 @@
  * optional extra_data list Optional settings.
  */
 /datum/tgui_panel/proc/play_music(url, extra_data)
+	// monkestation start: prevent chat crashes until music player is fixed
+	if(client?.byond_version > 515)
+		return
+	// monkestation end
 	if(!is_ready())
 		return
 	if(!findtext(url, GLOB.is_http_protocol))
@@ -37,6 +41,10 @@
  * Stops playing music through the browser.
  */
 /datum/tgui_panel/proc/stop_music()
+	// monkestation start: prevent chat crashes until music player is fixed
+	if(client?.byond_version > 515)
+		return
+	// monkestation end
 	if(!is_ready())
 		return
 	window.send_message("audio/stopMusic")


### PR DESCRIPTION

## About The Pull Request

As a stopgap until https://github.com/tgstation/tgstation/issues/88968 is properly fixed, this just completely disabled tgui-based music playback (curator/admin music) on 516 clients.

I've also added a line of text explaining that it's disabled to the stat panel on 516.

## Why It's Good For The Game

makes 516 more playable in the meantime

## Changelog
:cl:
fix: Disabled music playback on BYOND 516 for the time being, to prevent random chat crashes, until the issue is properly fixed.
/:cl:
