### PR TITLE
Satyr balancing and fixing rerevert

### DIFF
--- a/monkestation/code/modules/mob/living/carbon/human/species_type/satyr.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/satyr.dm
@@ -18,7 +18,7 @@
 	mutanttongue = /obj/item/organ/internal/tongue/satyr
 	mutantliver = /obj/item/organ/internal/liver/satyr
 	maxhealthmod = 1
-	stunmod = 1.1
+	stunmod = 1.2
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/satyr,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/satyr,
@@ -99,14 +99,14 @@
 	var/datum/component/living_drunk/drunk = organ_owner.GetComponent(/datum/component/living_drunk)
 	qdel(drunk)
 
-/datum/species/floran/handle_chemical(datum/reagent/chem, mob/living/carbon/human/H, seconds_per_tick, times_fired)
+/datum/species/satyr/handle_chemical(datum/reagent/chem, mob/living/carbon/human/H, seconds_per_tick, times_fired)
 	if(chem.type == (/datum/reagent/silver)) //
 		H.adjustToxLoss(3 * REM * seconds_per_tick)
 		H.reagents.remove_reagent(chem.type, REAGENTS_METABOLISM * seconds_per_tick)
 		return TRUE
 	if(chem.type == /datum/reagent/medicine/antihol) //Cures alchol, which they need, to live.
 		to_chat(H, span_danger("You feel your viens constrict as your heads spin"))
-		H.adjustOxyLoss(3 * REM * seconds_per_tick)
+		H.adjustOxyLoss(4 * REM * seconds_per_tick)
 		H.reagents.remove_reagent(chem.type, REAGENTS_METABOLISM * seconds_per_tick)
 		return TRUE
 	return ..()

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/satyr.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/satyr.dm
@@ -91,3 +91,15 @@
 	. = ..()
 	var/datum/component/living_drunk/drunk = organ_owner.GetComponent(/datum/component/living_drunk)
 	qdel(drunk)
+
+/datum/species/floran/handle_chemical(datum/reagent/chem, mob/living/carbon/human/H, seconds_per_tick, times_fired)
+	if(chem.type == (/datum/reagent/silver)) //
+		H.adjustToxLoss(3 * REM * seconds_per_tick)
+		H.reagents.remove_reagent(chem.type, REAGENTS_METABOLISM * seconds_per_tick)
+		return TRUE
+	if(chem.type == /datum/reagent/medicine/antihol) //Cures alchol, which they need, to live.
+		to_chat(H, span_danger("You feel your viens constrict as your heads spin"))
+		H.adjustOxyLoss(3 * REM * seconds_per_tick)
+		H.reagents.remove_reagent(chem.type, REAGENTS_METABOLISM * seconds_per_tick)
+		return TRUE
+	return ..()

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/satyr.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/satyr.dm
@@ -17,7 +17,7 @@
 	meat = /obj/item/food/meat/steak
 	mutanttongue = /obj/item/organ/internal/tongue/satyr
 	mutantliver = /obj/item/organ/internal/liver/satyr
-	maxhealthmod = 0.8
+	maxhealthmod = 1
 	stunmod = 1.2
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/satyr,
@@ -61,7 +61,14 @@
 			SPECIES_PERK_DESC = "Satyr's require a constant supply of booze to not become drunk.",
 		)
 	)
-
+	to_add += list(
+		list(
+			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
+			SPECIES_PERK_ICON = "fa-book-dead",
+			SPECIES_PERK_NAME = "Fey Ancenstry",
+			SPECIES_PERK_DESC = "Satyr's possess a acute allergy to silver.",
+		)
+	)
 	return to_add
 
 /obj/item/organ/internal/tongue/satyr

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/satyr.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/satyr.dm
@@ -66,7 +66,7 @@
 			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
 			SPECIES_PERK_ICON = "fa-book-dead",
 			SPECIES_PERK_NAME = "Fey Ancenstry",
-			SPECIES_PERK_DESC = "Satyr's possess a acute allergy to silver.",
+			SPECIES_PERK_DESC = "Satyr's possess a acute allergy to iron.",
 		)
 	)
 	return to_add
@@ -100,7 +100,7 @@
 	qdel(drunk)
 
 /datum/species/satyr/handle_chemical(datum/reagent/chem, mob/living/carbon/human/H, seconds_per_tick, times_fired)
-	if(chem.type == (/datum/reagent/silver)) //
+	if(chem.type == (/datum/reagent/iron))
 		H.adjustToxLoss(3 * REM * seconds_per_tick)
 		H.reagents.remove_reagent(chem.type, REAGENTS_METABOLISM * seconds_per_tick)
 		return TRUE

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/satyr.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/satyr.dm
@@ -18,7 +18,7 @@
 	mutanttongue = /obj/item/organ/internal/tongue/satyr
 	mutantliver = /obj/item/organ/internal/liver/satyr
 	maxhealthmod = 1
-	stunmod = 1.2
+	stunmod = 1.1
 	bodypart_overrides = list(
 		BODY_ZONE_HEAD = /obj/item/bodypart/head/satyr,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/satyr,

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/satyr.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/satyr.dm
@@ -66,7 +66,7 @@
 			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
 			SPECIES_PERK_ICON = "fa-book-dead",
 			SPECIES_PERK_NAME = "Fey Ancenstry",
-			SPECIES_PERK_DESC = "Satyr's possess a acute allergy to iron.",
+			SPECIES_PERK_DESC = "Satyr's possess a acute allergy to cold iron.",
 		)
 	)
 	return to_add

--- a/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
+++ b/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
@@ -55,10 +55,10 @@
 /datum/component/living_drunk/proc/drunkness_change_effects()
 	var/mob/living/living = parent
 	if((current_drunkness <= 10) && drunk_state != 2)
-		living.apply_status_effect(/datum/status_effect/inebriated/drunk, 80)
+		living.apply_status_effect(/datum/status_effect/inebriated/drunk, 71)
 		drunk_state = 2
 		return
-	if((current_drunkness <= 30) && (drunk_state != 1 || drunk_state != 2))
+	if((current_drunkness <= 30) && (drunk_state != 1 && drunk_state != 2))
 		living.apply_status_effect(/datum/status_effect/inebriated/tipsy, 5)
 		drunk_state = 1
 		return

--- a/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
+++ b/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
@@ -48,7 +48,7 @@
 	if(!COOLDOWN_FINISHED(src, drank_grace))
 		return
 
-	current_drunkness = max(min_drunkness, (current_drunkness -= 0.2))
+	current_drunkness = max(min_drunkness, (current_drunkness -= 0.1.5))
 	drunkness_change_effects()
 
 /datum/component/living_drunk/proc/drunkness_change_effects()

--- a/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
+++ b/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
@@ -48,7 +48,7 @@
 	if(!COOLDOWN_FINISHED(src, drank_grace))
 		return
 
-	current_drunkness = max(min_drunkness, (current_drunkness -= 1.5))
+	current_drunkness = max(min_drunkness, (current_drunkness -= 0.15))
 	drunkness_change_effects()
 
 /datum/component/living_drunk/proc/drunkness_change_effects()

--- a/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
+++ b/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
@@ -5,11 +5,12 @@
 
 	COOLDOWN_DECLARE(drank_grace)
 	var/grace_period = 5 MINUTES
-	var/booze_per_drunkness = 100
+	var/booze_per_drunkness = 1
+	var/min_drunkness = 0
 
 	var/drunk_state = 0
 
-/datum/component/living_drunk/Initialize(grace_period = 5 MINUTES, booze_per_drunkness = 100)
+/datum/component/living_drunk/Initialize(grace_period = 5 MINUTES, booze_per_drunkness = 1)
 	. = ..()
 	src.grace_period = grace_period
 	src.booze_per_drunkness = booze_per_drunkness
@@ -46,7 +47,9 @@
 /datum/component/living_drunk/process(seconds_per_tick)
 	if(!COOLDOWN_FINISHED(src, drank_grace))
 		return
-	current_drunkness -= 0.1
+
+	if(current_drunkness > 0)
+		current_drunkness -= 0.1
 	drunkness_change_effects()
 
 /datum/component/living_drunk/proc/drunkness_change_effects()

--- a/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
+++ b/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
@@ -48,8 +48,7 @@
 	if(!COOLDOWN_FINISHED(src, drank_grace))
 		return
 
-	if(current_drunkness > 0)
-		current_drunkness -= 0.1
+	current_drunkness = max(min_drunkness, (current_drunkness -= 0.2))
 	drunkness_change_effects()
 
 /datum/component/living_drunk/proc/drunkness_change_effects()

--- a/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
+++ b/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
@@ -48,7 +48,7 @@
 	if(!COOLDOWN_FINISHED(src, drank_grace))
 		return
 
-	current_drunkness = max(min_drunkness, (current_drunkness -= 0.1.5))
+	current_drunkness = max(min_drunkness, (current_drunkness -= 1.5))
 	drunkness_change_effects()
 
 /datum/component/living_drunk/proc/drunkness_change_effects()


### PR DESCRIPTION
## About The Pull Request
Reimplements most changes from #4712 with a bug fix to the code


### Other changes

- Satyr health modifer 0.8 -> 1
- Satyr will be lethally poisoned by antihol and iron
## Why It's Good For The Game
#4712 It was a good PR I initially called for the reversion of because of one critical bug. That being all satry's would be forever drunk. 
After investigation today I found that issue. It used min rather than max meaning the max was 0 drunkness rather than min of 0. This has been swapped meaning the rest of the code is healthy.

What are the boons and bains of being a satyr beforehand?

- Boon: Hooves: Inbuilt shoes so you wont step on glass and die.  Same benefits as wearing shoes or taking the hardened soles quirk for 2 points.
- Boon: Alcohol tolerance you can't be poisoned via alcohol.
- Boon: You can the ability to head butt. You can headbutt anyone who is *exactly three tiles away*. Otherwise you will overshoot. Landing a headbutt will knockdown yourself and anyone you hit, dealing 55 stamina and 15 brute. With how specific the range is to land, it is a honest skillshot unlike most abilities, its most consistent use is as a dash. (Not listed as a upside)
- Bane: You now have a secondary mechanic that has to be managed or suffer all the consequences of drunkenness without the ones that kill you. Including confusion, stuns, vomitting, and mood debuffs.
- Bane: You have 20% less overall health. (Not listed as a downside)
- Bane: You incur 20% more stun duration. (Not listed as a downside)

My proposed changes are:

- Satyrs have unique poisons. Mostly a flavour thing but drinking antihol, which makes someone sober, will kill them as they need to drink to live. And Iron, as feys are weak to iron. A fun nod to the mythology and serves a purpose in some medicines like applying iron for bloodloss..
- Removal of the health decrease. Their main positive ability is their headbutt, which does not set them on par with goblins ability to just constantly be faster than everyone. Speed means alot, and the goat people shouldn't be weaker than a simian in terms of HP. (0.85)
## Changelog
:cl:
balance: Satyr's now are poisoned by Ironand antihol
balance: Satyr's no longer have a 80% Maximum Health
balance: Satyrs get sober faster now, again
balance: Satyrs don't take a few centuries to get drunk again, again
fix: Satyrs don't flicker between being drunk and not anymore, again
fix: Satyrs drunkenness can no longer go negative, again
/:cl:
/:cl:
