### PR TITLE
Slasher machette fixes

### DIFF
--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/abilities/recall_machette.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/abilities/recall_machette.dm
@@ -50,6 +50,35 @@
 	sharpness = SHARP_EDGED
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 
+	/// Used to keep track of the force we had before throws. After the throw, `throwforce` is
+	/// restored to this.
+	var/pre_throw_force
+
+/obj/item/slasher_machette/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_MOVABLE_PRE_THROW, PROC_REF(pre_throw))
+	RegisterSignal(src, COMSIG_MOVABLE_POST_THROW, PROC_REF(post_throw))
+
+/obj/item/slasher_machette/Destroy(force)
+	UnregisterSignal(src, list(COMSIG_MOVABLE_PRE_THROW, COMSIG_MOVABLE_POST_THROW))
+	return ..()
+
+/obj/item/slasher_machette/proc/pre_throw(obj/item/source, list/arguments)
+	SIGNAL_HANDLER
+	var/mob/living/thrower = arguments[4]
+	if(!istype(thrower) || !thrower.mind.has_antag_datum(/datum/antagonist/slasher))
+		// Just in case our thrower isn't actually a slasher (somehow). This shouldn't ever come up,
+		// but if it does, then we just prevent the throw.
+		return COMPONENT_CANCEL_THROW
+
+	var/turf/below_turf = get_turf(arguments[4]) // the turf below the person throwing
+	var/turf_light_level = below_turf.get_lumcount()
+	var/area/ismaints = get_area(below_turf)
+	pre_throw_force = throwforce
+	if(istype(ismaints, /area/station/maintenance))
+		throwforce = 1.1 * throwforce
+	else
+		throwforce = throwforce * (max(clamp((1 - turf_light_level), 0, 1)))
 
 /obj/item/slasher_machette/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
@@ -58,16 +87,11 @@
 	if(isliving(hit_atom))
 		var/mob/living/hit_living = hit_atom
 		hit_living.Knockdown(2 SECONDS)
-/obj/item/slasher_machette/on_thrown(mob/living/carbon/user, atom/target)
-	var/turf/below_turf = get_turf(user)
-	var/turf_light_level = below_turf.get_lumcount()
-	var/area/ismaints = get_area(below_turf)
-	if(istype(ismaints, /area/station/maintenance))
-		throwforce = 1.1 * throwforce
-	else
-		throwforce = throwforce * (max(clamp((1 - turf_light_level), 0, 1)))
-	// Who knows, the slasher might have TRAIT_PACIFIST. (Or more likely, the machette is no-drop.)
-	return ..()
+
+/obj/item/slasher_machette/proc/post_throw(obj/item/source, datum/thrownthing, spin)
+	SIGNAL_HANDLER
+	// Restore the force we had before the throw.
+	throwforce = pre_throw_force
 
 /obj/item/slasher_machette/attack_hand(mob/user, list/modifiers)
 	if(isliving(user))

--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/abilities/recall_machette.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/abilities/recall_machette.dm
@@ -66,6 +66,8 @@
 		throwforce = 1.1 * throwforce
 	else
 		throwforce = throwforce * (max(clamp((1 - turf_light_level), 0, 1)))
+	// Who knows, the slasher might have TRAIT_PACIFIST. (Or more likely, the machette is no-drop.)
+	return ..()
 
 /obj/item/slasher_machette/attack_hand(mob/user, list/modifiers)
 	if(isliving(user))

--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/slasher_datum.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/slasher_datum.dm
@@ -125,6 +125,7 @@
 
 
 /datum/antagonist/slasher/proc/LifeTick(mob/living/source, seconds_per_tick, times_fired)
+	SIGNAL_HANDLER
 
 	var/list/currently_beating = list()
 	var/list/current_statics = list()
@@ -308,6 +309,7 @@
 	stalked_human = null
 
 /datum/antagonist/slasher/proc/check_attack(mob/living/attacking_person, mob/living/attacked_mob)
+	SIGNAL_HANDLER
 	var/obj/item/held_item = attacking_person.get_active_held_item()
 
 	var/held_force = 3
@@ -320,9 +322,11 @@
 		attacked_mob.blood_particles(2, max_deviation = rand(-120, 120), min_pixel_z = rand(-4, 12), max_pixel_z = rand(-4, 12))
 
 /datum/antagonist/slasher/proc/item_pickup(datum/input_source, obj/item/source)
+	SIGNAL_HANDLER
 	RegisterSignal(source, COMSIG_ITEM_DAMAGE_MULTIPLIER, PROC_REF(damage_multiplier))
 
 /datum/antagonist/slasher/proc/item_unequipped(datum/input_source, obj/item/source)
+	SIGNAL_HANDLER
 	UnregisterSignal(source, COMSIG_ITEM_DAMAGE_MULTIPLIER)
 
 /obj/item/var/last_multi = 1

--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/slasher_datum.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/slasher_datum.dm
@@ -83,7 +83,7 @@
 
 	RegisterSignal(current_mob, COMSIG_LIVING_LIFE, PROC_REF(LifeTick))
 	RegisterSignal(current_mob, COMSIG_LIVING_PICKED_UP_ITEM, PROC_REF(item_pickup))
-	RegisterSignal(current_mob, COMSIG_MOB_DROPPING_ITEM, PROC_REF(item_drop))
+	RegisterSignal(current_mob, COMSIG_MOB_UNEQUIPPED_ITEM, PROC_REF(item_unequipped))
 	RegisterSignal(current_mob, COMSIG_MOB_ITEM_ATTACK, PROC_REF(check_attack))
 	RegisterSignal(current_mob, COMSIG_LIVING_DEATH, PROC_REF(on_death))
 	for(var/datum/quirk/quirk as anything in current_mob.quirks)
@@ -322,7 +322,7 @@
 /datum/antagonist/slasher/proc/item_pickup(datum/input_source, obj/item/source)
 	RegisterSignal(source, COMSIG_ITEM_DAMAGE_MULTIPLIER, PROC_REF(damage_multiplier))
 
-/datum/antagonist/slasher/proc/item_drop(datum/input_source, obj/item/source)
+/datum/antagonist/slasher/proc/item_unequipped(datum/input_source, obj/item/source)
 	UnregisterSignal(source, COMSIG_ITEM_DAMAGE_MULTIPLIER)
 
 /obj/item/var/last_multi = 1


### PR DESCRIPTION
## About The Pull Request
`on_thrown` expects you to return the object that you want to throw. Unfortunately, the slasher machette previously overrode the proc without actually returning anything.

## Why It's Good For The Game
Ki ki ki ma ma ma.

## Changelog

:cl:MichiRecRoom
fix: The slasher's machette can be thrown once more. Go wild, discount horror movie antagonists.
/:cl: