### PR TITLE
Don't start an extra database for no reason in CI

### DIFF
--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -27,14 +27,6 @@ jobs:
     name: Run Tests (${{ inputs.major && format('{0}.{1}; ', inputs.major, inputs.minor) || '' }}${{ inputs.map }}; ${{ inputs.max_required_byond_client }})
     runs-on: ubuntu-latest
     timeout-minutes: 30 # Monkestation edit: Our CI takes nearly twice as long, so the timeout is twice as long
-    services:
-      mysql:
-        image: mysql:latest
-        env:
-          MYSQL_ROOT_PASSWORD: root
-        ports:
-          - 3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
       - uses: actions/checkout@v4
       - name: Setup database


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/DaedalusDock/daedalusdock/pull/1220

So, turns out, `run_integration_tests` sets up a random mysql container... and then ignores it and uses the pre-installed database on the `ubuntu-latest` image.

Yeahhh. That's a huge waste of time.