### PR TITLE
Allow bloodsuckers to vassalize xenos

### DIFF
--- a/monkestation/code/modules/bloodsuckers/powers/fortitude.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/fortitude.dm
@@ -67,18 +67,15 @@
 		user.buckled.unbuckle_mob(src, force=TRUE)
 
 /datum/action/cooldown/bloodsucker/fortitude/DeactivatePower()
-	if(!ishuman(owner))
-		return
-	var/mob/living/carbon/human/bloodsucker_user = owner
-	if(IS_BLOODSUCKER(owner) || IS_VASSAL(owner))
+	if(ishuman(owner) && (IS_BLOODSUCKER(owner) || IS_VASSAL(owner)))
+		var/mob/living/carbon/human/bloodsucker_user = owner
 		bloodsucker_user.physiology.brute_mod /= fortitude_resist
-		if(!HAS_TRAIT_FROM(bloodsucker_user, TRAIT_STUNIMMUNE, FORTITUDE_TRAIT))
-			bloodsucker_user.physiology.stamina_mod /= fortitude_resist
+		bloodsucker_user.physiology.stamina_mod /= fortitude_resist
 	// Remove Traits & Effects
 	owner.remove_traits(base_traits + upgraded_traits, FORTITUDE_TRAIT)
 
-	if(was_running && bloodsucker_user.m_intent == MOVE_INTENT_WALK)
-		bloodsucker_user.set_move_intent(MOVE_INTENT_RUN)
+	if(was_running && owner.m_intent == MOVE_INTENT_WALK)
+		owner.set_move_intent(MOVE_INTENT_RUN)
 	owner.balloon_alert(owner, "fortitude turned off.")
 
 	return ..()

--- a/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
+++ b/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
@@ -314,7 +314,7 @@
 			balloon_alert(user, "someone else's vassal!")
 			return FALSE
 
-	if(!ishuman(target))
+	if(!iscarbon(target))
 		balloon_alert(user, "you can't torture an animal or basic mob!")
 		return FALSE
 	if(disloyalty_offered)


### PR DESCRIPTION

## About The Pull Request

This changes an `ishuman` check to `iscarbon` for the persuasion rack, allowing non-human carbons (xenos) to also be buckled to them.

Also fixed a couple of potential bugs in fortitude

## Why It's Good For The Game

1. if you can actually _pull off_ vassalizing a xeno, you kinda deserve it tbh
2. it will be INCREDIBLY funny

## Changelog
:cl:
balance: Bloodsuckers can now vassalize xenos. Have fun trying to do that.
/:cl:
