### PR TITLE
[BOUNTY] Upgraded Emitters can now tear down walls!

### DIFF
--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -18,6 +18,10 @@
 	///Dismantled state, related to deconstruction.
 	var/d_state = INTACT
 
+	//monkestation edit start
+	wall_integrity =  3000
+	minimum_damage = 180
+	//monkestation edit end
 
 /turf/closed/wall/r_wall/deconstruction_hints(mob/user)
 	switch(d_state)

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -132,8 +132,6 @@
 
 /turf/closed/wall/examine(mob/user)
 	. += ..()
-	. += deconstruction_hints(user)
-
 	//monkestation edit start
 	var/healthpercent = round((current_integrity/wall_integrity) * 100, 1)
 	switch(healthpercent)
@@ -144,6 +142,7 @@
 		if(0 to 25)
 			. += span_warning("It's falling apart!")
 	//monkestation edit end
+	. += deconstruction_hints(user)
 
 /turf/closed/wall/proc/deconstruction_hints(mob/user)
 	return span_notice("The outer plating is <b>welded</b> firmly in place.")

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -35,6 +35,17 @@
 
 	var/list/dent_decals
 
+	//monkestation edit start
+	//How much integrity the wall has, Currently only emitter shots is able to damage walls.
+	/// The damage taken by the wall is multiplied by this number, lower better.
+	/// Wall integrity
+	var/wall_integrity = 900
+	/// Current integrity
+	var/current_integrity
+	/// Minimum damage to actually deal damage to the wall
+	var/minimum_damage = 35
+	//monkestation edit stop
+
 /turf/closed/wall/MouseDrop_T(mob/living/carbon/carbon_mob, mob/user)
 	..()
 	if(carbon_mob != user)
@@ -107,6 +118,7 @@
 	//monkestation edit start
 	if(SSstation_coloring.wall_trims)
 		trim_color = SSstation_coloring.get_default_color()
+	current_integrity = wall_integrity
 
 /turf/closed/wall/atom_destruction(damage_flag)
 	. = ..()
@@ -121,6 +133,17 @@
 /turf/closed/wall/examine(mob/user)
 	. += ..()
 	. += deconstruction_hints(user)
+
+	//monkestation edit start
+	var/healthpercent = round((current_integrity/wall_integrity) * 100, 1)
+	switch(healthpercent)
+		if(50 to 99)
+			. += span_info("It looks slightly damaged.")
+		if(25 to 50)
+			. += span_info("It appears heavily damaged.")
+		if(0 to 25)
+			. += span_warning("It's falling apart!")
+	//monkestation edit end
 
 /turf/closed/wall/proc/deconstruction_hints(mob/user)
 	return span_notice("The outer plating is <b>welded</b> firmly in place.")
@@ -146,6 +169,15 @@
 	else
 		ScrapeAway()
 	QUEUE_SMOOTH_NEIGHBORS(src)
+
+//monkestation edit start
+/turf/closed/wall/proc/damage_wall(damage)
+	if(minimum_damage > damage)
+		return
+	current_integrity -= damage
+	if(current_integrity <= 0)
+		dismantle_wall()
+//monkestation edit end
 
 /turf/closed/wall/proc/break_wall()
 	var/area/shipbreak/A = get_area(src)

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -302,10 +302,16 @@
 
 		to_chat(user, span_notice("You begin fixing dents on the wall..."))
 		if(W.use_tool(src, user, 0, volume=100))
-			if(iswallturf(src) && LAZYLEN(dent_decals))
-				to_chat(user, span_notice("You fix some dents on the wall."))
-				cut_overlay(dent_decals)
-				dent_decals.Cut()
+			//monkestation edit start
+			if(iswallturf(src))
+				if(LAZYLEN(dent_decals))
+					to_chat(user, span_notice("You fix some dents on the wall."))
+					cut_overlay(dent_decals)
+					dent_decals.Cut()
+				if(max_integrity > current_integrity)
+					to_chat(user, span_notice("You fix some damage on the wall."))
+					current_integrity += clamp(round(max_integrity/100 * 20), 0, max_integrity)
+			//monkestation edit end
 			return TRUE
 
 	return FALSE

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -37,8 +37,7 @@
 
 	//monkestation edit start
 	//How much integrity the wall has, Currently only emitter shots is able to damage walls.
-	/// The damage taken by the wall is multiplied by this number, lower better.
-	/// Wall integrity
+	/// Wall integrity (how much health it has at initialization)
 	var/wall_integrity = 900
 	/// Current integrity
 	var/current_integrity
@@ -293,24 +292,26 @@
 	return ..()
 
 /turf/closed/wall/proc/try_clean(obj/item/W, mob/living/user, turf/T)
-	if(((user.istate & ISTATE_HARM)) || !LAZYLEN(dent_decals))
+	if(((user.istate & ISTATE_HARM)))//monkestation edit
 		return FALSE
 
 	if(W.tool_behaviour == TOOL_WELDER)
 		if(!W.tool_start_check(user, amount=0))
 			return FALSE
 
-		to_chat(user, span_notice("You begin fixing dents on the wall..."))
 		if(W.use_tool(src, user, 0, volume=100))
 			//monkestation edit start
 			if(iswallturf(src))
+				var/did_something = FALSE
 				if(LAZYLEN(dent_decals))
-					to_chat(user, span_notice("You fix some dents on the wall."))
 					cut_overlay(dent_decals)
 					dent_decals.Cut()
-				if(max_integrity > current_integrity)
-					to_chat(user, span_notice("You fix some damage on the wall."))
+					did_something = TRUE
+				if(wall_integrity > current_integrity)
 					current_integrity += clamp(round(max_integrity/100 * 20), 0, max_integrity)
+					did_something = TRUE
+				if(did_something)
+					to_chat(user, span_notice("You fix some dents on the wall."))
 			//monkestation edit end
 			return TRUE
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -57,6 +57,14 @@
 	///stores the direction and orientation of the last projectile
 	var/last_projectile_params
 
+	//monkestation edit start
+	//Basic Emitters projectile characteristics
+	///damage modifier on walls
+	var/wall_dem_mod = 1
+	///can projectile hit walls
+	var/is_proj_hit_walls = FALSE
+	//monkestation edit end
+
 /obj/machinery/power/emitter/Initialize(mapload)
 	. = ..()
 	RefreshParts()
@@ -87,10 +95,19 @@
 	var/fire_shoot_delay = 12 SECONDS
 	var/min_fire_delay = 2.4 SECONDS
 	var/power_usage = 350
+	//monkestation edit start
+	var/list/wall_mod_table = list(1, 1.5, 3, 6, 10) //infinite, 20, 10, 5, 3 hits respectively to destroy a normal wall, last two tiers, 20~, 10 shots for r-walls
 	for(var/datum/stock_part/micro_laser/laser in component_parts)
 		max_fire_delay -= 2 SECONDS * laser.tier
 		min_fire_delay -= 0.4 SECONDS * laser.tier
-		fire_shoot_delay -= 2 SECONDS * laser.tier
+		var/parts_tier = laser.tier
+		if(obj_flags & EMAGGED)
+			parts_tier += 1
+		if(parts_tier >= 2)
+			is_proj_hit_walls = TRUE
+		wall_dem_mod = wall_mod_table[clamp(parts_tier, 0, LAZYLEN(wall_mod_table))]
+	//monkestation edit end
+
 	maximum_fire_delay = max_fire_delay
 	minimum_fire_delay = min_fire_delay
 	fire_delay = fire_shoot_delay
@@ -220,6 +237,12 @@
 /obj/machinery/power/emitter/proc/fire_beam(mob/user)
 	var/obj/projectile/projectile = new projectile_type(get_turf(src))
 	playsound(src, projectile_sound, 50, TRUE)
+	//monkestation edit start
+	if(istype(projectile, /obj/projectile/beam/emitter/hitscan)) //TODO: LESS SNOWFLAKE CHECK
+		projectile.wall_mod = wall_dem_mod
+		projectile.can_hit_walls = is_proj_hit_walls
+
+	//monkestation edit end
 	if(prob(35))
 		sparks.start()
 	projectile.firer = user ? user : src
@@ -374,6 +397,7 @@
 	locked = FALSE
 	obj_flags |= EMAGGED
 	balloon_alert(user, "id lock shorted out")
+	RefreshParts() //monkestation edit
 	return TRUE
 
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -241,6 +241,9 @@
 	if(istype(projectile, /obj/projectile/beam/emitter/hitscan)) //TODO: LESS SNOWFLAKE CHECK
 		projectile.wall_mod = wall_dem_mod
 		projectile.can_hit_walls = is_proj_hit_walls
+		if(obj_flags & EMAGGED)
+			take_damage((round(max_integrity/100 * 5)))
+			visible_message(span_warning("The [src] visibly buckles under overloaded pressure!"))
 
 	//monkestation edit end
 	if(prob(35))
@@ -396,7 +399,7 @@
 		return FALSE
 	locked = FALSE
 	obj_flags |= EMAGGED
-	balloon_alert(user, "id lock shorted out")
+	balloon_alert(user, "id lock shorted out and lasers overloaded") //monkestation edit
 	RefreshParts() //monkestation edit
 	return TRUE
 

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -100,6 +100,7 @@
 	for(var/datum/stock_part/micro_laser/laser in component_parts)
 		max_fire_delay -= 2 SECONDS * laser.tier
 		min_fire_delay -= 0.4 SECONDS * laser.tier
+		fire_shoot_delay -= 2 SECONDS * laser.tier
 		var/parts_tier = laser.tier
 		if(obj_flags & EMAGGED)
 			parts_tier += 1

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -215,6 +215,10 @@
 	var/debilitating = FALSE
 	/// How many stacks the projectile applies per hit. Default is 1, each stack adds 0.05, it stacks up to 2x stamina damage
 	var/debilitate_mult = 1
+	/// If true, can damage walls
+	var/can_hit_walls = FALSE //monkestation edit
+	/// damage modifier on wall hits
+	var/wall_mod = 1 //monkestation edit
 
 /obj/projectile/Initialize(mapload)
 	. = ..()
@@ -294,11 +298,19 @@
 	if(!isliving(target))
 		if(impact_effect_type && !hitscan)
 			new impact_effect_type(target_turf, hitx, hity)
-		if(damage > 0 && (damage_type == BRUTE || damage_type == BURN) && iswallturf(target_turf) && prob(75))
+
+		//monkestation edit start
+		if(iswallturf(target_turf))
 			var/turf/closed/wall/target_wall = target_turf
-			target_wall.add_dent(WALL_DENT_SHOT, hitx, hity)
+			if(can_hit_walls == TRUE)
+				target_wall.add_dent(WALL_DENT_SHOT, hitx, hity)
+				target_wall.damage_wall(damage * wall_mod)
+				return BULLET_ACT_HIT
+			if(damage > 0 && (damage_type == BRUTE || damage_type == BURN) && prob(75))
+				target_wall.add_dent(WALL_DENT_SHOT, hitx, hity)
 
 		return BULLET_ACT_HIT
+		//monkestation edit end
 
 	var/mob/living/living_target = target
 


### PR DESCRIPTION

## About The Pull Request
This PR makes it so that emitters with upgraded lasers can now be able to tear down walls, stock parts emitters still functions the same. Below are the damage table needed to tear a wall down (this number does not include girders)

T1 laser: cannot damage walls, operates normally.
T2: 20 hits to break normal walls, r wall or stronger cannot be damaged.
T3: 10 hits to kill normal walls, r wall or stronger cannot be damaged.
T4: 5 hits to kill normal walls, r walls or strong take 18 hits to be killed.
T5: 3 hits to kill normal, 10 to kill r walls or higher

Emagging the emitters increases the parts tier above by one (which is how you'd get T5) at the cost of 5% damage to the emitters. This functionality only applies if the projectile emitted by the emitters is the default hitscan emitters shots.
## Why It's Good For The Game
You know how the emitters looks like a heavy, industrial laser cannon that you'd be able to see be used as an impromptu blaster? How come can it not damage walls? Anyways, this adds a new way of breaching walls besides thermite, tools or c-4/x-4, Albeit a pretty slow and loud one at that. More tools for engineer's arsenal is good!
## Changelog
:cl:
add: Emitters can now tear down walls! (once upgraded)
/:cl:
