### PR TITLE
Goodie boxes ordered with departmental budget will now open with head of staff ID

### DIFF
--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -254,7 +254,7 @@
 	if(!id_card)
 		return ..()
 
-	if(id_card.registered_account != buyer_account)
+	if(id_card.registered_account != buyer_account && (department_purchase && (id_card.registered_account?.account_job?.paycheck_department) == (department_account.department_id)))
 		balloon_alert(user, "incorrect bank account!")
 		return FALSE
 

--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -247,6 +247,9 @@
 /obj/item/storage/lockbox/order/Initialize(mapload, datum/bank_account/_buyer_account)
 	. = ..()
 	buyer_account = _buyer_account
+	if(istype(buyer_account, /datum/bank_account/department))
+		department_purchase = TRUE
+		department_account = buyer_account
 	ADD_TRAIT(src, TRAIT_NO_MISSING_ITEM_ERROR, TRAIT_GENERIC)
 
 /obj/item/storage/lockbox/order/attackby(obj/item/W, mob/user, params)
@@ -254,7 +257,7 @@
 	if(!id_card)
 		return ..()
 
-	if(id_card.registered_account != buyer_account && (department_purchase && (id_card.registered_account?.account_job?.paycheck_department) == (department_account.department_id)))
+	if(id_card.registered_account != buyer_account && (id_card.registered_account?.account_job?.paycheck_department) != (department_account.department_id))
 		balloon_alert(user, "incorrect bank account!")
 		return FALSE
 


### PR DESCRIPTION
Fixes #2610 
Fixes #5268 

## Why It's Good For The Game

No more begging Warden/HoS/Blueshield to blast open goodie boxes.

## Changelog

:cl: QuarianCommando
fix: Small goodie boxes now check if they were ordered using departmental funds
fix: Small goodie boxes ordered with departmental funds open with head IDs
/:cl: