### PR TITLE
Charlie Station's equipment access ID can now open the on-station secure engineering crate

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -4264,10 +4264,6 @@
 "pz" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/card/id/advanced/old{
-	trim = /datum/id_trim/job/away/old/apc;
-	name = "Engineering Equipment Access"
-	},
 /obj/item/crowbar,
 /obj/item/stock_parts/cell/high,
 /obj/machinery/door/window/right/directional/east{
@@ -4276,6 +4272,7 @@
 	},
 /obj/item/paper/fluff/ruins/oldstation/apc_note,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/item/card/id/away/old/equipment,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/engie)
 "pK" = (
@@ -6672,11 +6669,10 @@
 "Hr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
-/obj/item/card/id/advanced/old{
-	trim = /datum/id_trim/job/away/old/robo;
-	registered_name = "Ash Holm";
+/obj/item/card/id/away/old/robo{
+	assignment = "Charlie Station Roboticist";
 	name = "Ash Holm";
-	assignment = "Charlie Station Roboticist"
+	registered_name = "Ash Holm"
 	},
 /turf/open/floor/plating{
 	initial_gas_mix = "co2=6;o2=16;n2=82;TEMP=293.15"

--- a/code/datums/id_trim/ruins.dm
+++ b/code/datums/id_trim/ruins.dm
@@ -70,12 +70,13 @@
 	assignment = "Charlie Station Engineer"
 
 /// Trim for the oldstation ruin/Charlie station to access APCs and other equipment
-/datum/id_trim/job/away/old/apc
+/datum/id_trim/job/away/old/equipment
 	minimal_access = list(
+		ACCESS_AWAY_ENGINEERING,
 		ACCESS_ENGINEERING,
 		ACCESS_ENGINE_EQUIP
 	)
-	assignment = "Engineering Equipment Access"
+	assignment = "Engine Equipment Access"
 
 /// Trim for the oldstation ruin/Charlie station to access robots, and downloading of paper publishing software for experiments
 /datum/id_trim/job/away/old/robo

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -864,10 +864,10 @@
 	desc = "A faded Charlie Station ID card. You can make out the rank \"Station Engineer\"."
 	trim = /datum/id_trim/job/away/old/eng /// MONKESTATION EDIT - Turns all Charlie Station trims into /datum/id_trim/job trims
 
-/obj/item/card/id/away/old/apc
-	name = "APC Access ID"
-	desc = "A special ID card that allows access to APC terminals."
-	trim = /datum/id_trim/job/away/old/apc /// MONKESTATION EDIT - Turns all Charlie Station trims into /datum/id_trim/job trims
+/obj/item/card/id/away/old/equipment
+	name = "Engineering Equipment Access"
+	desc = "A special ID card that allows access to engineering equipment."
+	trim = /datum/id_trim/job/away/old/equipment /// MONKESTATION EDIT - Turns all Charlie Station trims into /datum/id_trim/job trims
 
 /obj/item/card/id/away/old/robo
 	name = "Delta Station Roboticist's ID card"

--- a/monkestation/code/datums/id_trim/ruins.dm
+++ b/monkestation/code/datums/id_trim/ruins.dm
@@ -134,7 +134,7 @@
 		ACCESS_ENGINE_EQUIP
 	)
 
-/datum/id_trim/job/away/old/apc
+/datum/id_trim/job/away/old/equipment
 	sechud_icon_state = SECHUD_APC_AWAY
 
 /datum/id_trim/pirate/lustrous


### PR DESCRIPTION
## About The Pull Request
Fixes #5683 - it turns out the crate requires `ACCESS_AWAY_ENGINEERING`, but the card never had it.

This also includes a tiny part of https://github.com/tgstation/tgstation/pull/75259. Specifically, I brought over the typepath and ID name changes to the equipment ID, as the card is now more of a general equipment access, rather than something specific to APCs. I opted not to bring over the change that brings over `ACCESS_AWAY_GENERAL`, as I feel that makes this card a replacement for the proper engineering IDs (something which it's not meant to be).

Additionally, I replaced the two ID cards items on Charlie Station, with more appropriate ID card items. This shouldn't result in any functional change (aside from the changes above), as the two share the same ID trim.

## Why It's Good For The Game
Bugfixes, and less getting in the way of a fun experience.

## Changelog

:cl: MichiRecRoom
fix: Charlie Station's equipment access ID now has access to open the secure engineering crate that's contained in the Beta Station Engine area.
/:cl: