### PR TITLE
Fix chem smoke runtiming when it tries to cancel its spread

### DIFF
--- a/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
@@ -91,7 +91,7 @@
 		spread_smoke.lifetime = lifetime
 
 		// the smoke spreads rapidly, but not instantly
-		SSfoam.queue_spread(spread_smoke)
+		SSsmoke.queue_spread(spread_smoke)
 
 
 /obj/effect/particle_effect/fluid/smoke/process(seconds_per_tick)


### PR DESCRIPTION
This PR is mirrored on tgstation's repo, at tgstation/tgstation#89750.

## About The Pull Request
Chem smoke asks the smoke subsystem to cancel its spread, if it's qdel'd or otherwise reaches the end of its lifetime before it finishes spreading.

However, an error in how chem smoke was coded causes it to queue spreading with the *foam* subsystem, rather than the *smoke* subsystem. This causes a runtime in SSsmoke, as it attempts to index into the spread carousel at a bucket index that was returned from SSfoam.

This runtime actually happens spuriously during CI over on Monkestation. However, I only started noticing it because it kept appearing in failed runs on my fork - where I have the "Rerun flaky tests" workflow disabled.

I was able to replicate the runtime locally, whilst debugging it on the Monkestation fork:
1. Tag any turf as the place to spawn the smoke at (I chose one right next to a door)
2. Use Debug -> Advanced ProcCall to spawn in chem smoke with a high range (`/proc/do_chem_smoke`, `range` = 10, `location` = the tagged turf) (Technically speaking, the high range isn't needed, but it makes it easier to trigger the runtime.)
3. Wait some time (I found that around 12 seconds worked on my machine, when using `range = 10`)
4. Do something to make the chem smoke start spreading (opening a door works)
5. Wait - if the chem smoke is still spreading when its lifetime is up, it will cancel its spread - and in turn, trigger the runtime.

Following these same steps after the change in this PR seems to show that this fixes the runtime.

## Why It's Good For The Game
Less runtimes = More gooder

## Changelog
No player-facing changes.