### PR TITLE
Fixes ghost critters not applying client's screentip preferences

### DIFF
--- a/monkestation/code/modules/ghost_critters/client_addons.dm
+++ b/monkestation/code/modules/ghost_critters/client_addons.dm
@@ -47,17 +47,16 @@
 	var/cooldown_time = get_critter_cooldown()
 	ghost_critter_cooldown = cooldown_time
 
+	if(!mob.mind)
+		mob.mind = new /datum/mind(key)
+
+	created_mob.key = key
+
 	if(player_details.patreon.has_access(ACCESS_NUKIE_RANK) || is_admin(src))
 		created_mob.AddComponent(/datum/component/basic_inhands, y_offset = -6)
 		created_mob.AddComponent(/datum/component/max_held_weight, WEIGHT_CLASS_SMALL)
 		created_mob.AddElement(/datum/element/dextrous)
 	created_mob.add_traits(list(TRAIT_MUTE, TRAIT_GHOST_CRITTER), INNATE_TRAIT)
-
-	if(!mob.mind)
-		mob.mind = new /datum/mind(key)
-
-	var/mob/dead/observer/observe = mob
-	created_mob.key = observe.key
 
 	init_verbs()
 


### PR DESCRIPTION
## About The Pull Request

`AddElement(/datum/element/dextrous)` generates a hud, which uses a bunch of things from client's preferences.
Client should no longer be null.

## Why It's Good For The Game
mewo

## Changelog
:cl:
fix: Screentip for ghost critters (with hands) is no longer stuck in top left.
/:cl:
