### PR TITLE
[PORT] Nuke Detonation now handles off-station detonation correctly. Now nukes the syndie base if detonated on the syndiebase.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -399,10 +399,6 @@ SUBSYSTEM_DEF(ticker)
 	else
 		LAZYADD(round_end_events, cb)
 
-/datum/controller/subsystem/ticker/proc/station_explosion_detonation(atom/bomb)
-	if(bomb) //BOOM
-		qdel(bomb)
-
 /datum/controller/subsystem/ticker/proc/create_characters()
 	for(var/player in GLOB.new_player_list)
 		create_character(player)

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -587,7 +587,7 @@ GLOBAL_VAR(station_nuke_source)
 /obj/machinery/nuclearbomb/proc/really_actually_explode(detonation_status)
 	var/cinematic = get_cinematic_type(detonation_status)
 	if(!isnull(cinematic))
-		play_cinematic(cinematic, world, CALLBACK(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, station_explosion_detonation), src))
+		play_cinematic(cinematic, world)
 
 	var/drop_level = TRUE
 	switch(detonation_status)
@@ -618,6 +618,7 @@ GLOBAL_VAR(station_nuke_source)
 
 	if(drop_level)
 		SSsecurity_level.set_level(SEC_LEVEL_RED)
+	qdel(src)
 	return TRUE
 
 /// Cause nuke effects to the passed z-levels.

--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/_nuclear_bomb.dm
@@ -585,20 +585,39 @@ GLOBAL_VAR(station_nuke_source)
 	return detonation_status
 
 /obj/machinery/nuclearbomb/proc/really_actually_explode(detonation_status)
-	play_cinematic(get_cinematic_type(detonation_status), world, CALLBACK(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, station_explosion_detonation), src))
+	var/cinematic = get_cinematic_type(detonation_status)
+	if(!isnull(cinematic))
+		play_cinematic(cinematic, world, CALLBACK(SSticker, TYPE_PROC_REF(/datum/controller/subsystem/ticker, station_explosion_detonation), src))
 
-	var/turf/bomb_location = get_turf(src)
-	var/list/z_levels_to_blow = list()
-	if(detonation_status == DETONATION_HIT_STATION)
-		z_levels_to_blow |= SSmapping.levels_by_trait(ZTRAIT_STATION) - SSmapping.levels_by_trait(ZTRAIT_FORCED_SAFETY) // monkesation edit: allow escaping nuke by going to safe z-levels
+	var/drop_level = TRUE
+	switch(detonation_status)
+		if(DETONATION_HIT_STATION)
+			nuke_effects(SSmapping.levels_by_trait(ZTRAIT_STATION) - SSmapping.levels_by_trait(ZTRAIT_FORCED_SAFETY)) // monkesation edit: allow escaping nuke by going to safe z-levels
+			drop_level = FALSE
 
-	// Don't kill people in the station if the nuke missed, even if we are technically on the same z-level
-	else if(detonation_status != DETONATION_NEAR_MISSED_STATION)
-		z_levels_to_blow |= bomb_location.z
+		if(DETONATION_HIT_SYNDIE_BASE)
+			priority_announce(
+				"Long Range Scanners indicate that the nuclear device has detonated on a previously unknown base, we assume \
+				the base to be of Syndicate Origin. Good work crew.",
+				"Nuclear Operations Command",
+			)
 
-	if(length(z_levels_to_blow))
-		nuke_effects(z_levels_to_blow)
+			var/datum/turf_reservation/syndicate_base = SSmapping.lazy_load_template(LAZY_TEMPLATE_KEY_NUKIEBASE)
+			ASYNC
+				for(var/turf/turf as anything in syndicate_base.reserved_turfs)
+					for(var/mob/living/about_to_explode in turf)
+						nuke_gib(about_to_explode, src)
+					CHECK_TICK
 
+		else
+			priority_announce(
+				"Long Range Scanners indicate that the nuclear device has detonated; however seismic activity on the station \
+				is minimal. We anticipate that the device has not detonated on the station itself.",
+				"Nuclear Operations Command",
+			)
+
+	if(drop_level)
+		SSsecurity_level.set_level(SEC_LEVEL_RED)
 	return TRUE
 
 /// Cause nuke effects to the passed z-levels.


### PR DESCRIPTION
## About The Pull Request
This PR ports the following PR from tgstation:
* tgstation/tgstation#75967

As well as a supporting PR that fixes a potential hard-del in the same code, as well as ensures the nuke will ALWAYS be deleted upon exploding:
* tgstation/tgstation#89752

Besides refactoring the nuke explosion code and fixing some potential runtimes, this also adds priority announcements should the nuke not actually hit the station. It also drops the Security level to red in those same cases.

## Why It's Good For The Game
Fixes a potential runtime. Also, funny messages if it doesn't blow up on-station!

## Changelog

:cl:MichiRecRoom, ZephyrTFA
add: (ZephyrTFA) Nuclear Detonation now drops security level if it missed the station.
add: (ZephyrTFA) Nuclear Detonation now nukes the syndie base if its on the syndie base.
fix: (ZephyrTFA) Nuclear Detonation now handles not playing a cinematic correctly.
refactor: (ZephyrTFA) Changed z level iteration for Nuclear Detonation
fix: (MichiRecRoom) Nukes will now always be deleted upon exploding, no matter if they have a valid cutscene to play.
/:cl: