### PR TITLE
Fixes ghost critter cooldowns not working (plus, refactors them to use the cooldown macros)

### DIFF
--- a/monkestation/code/modules/ghost_critters/client_addons.dm
+++ b/monkestation/code/modules/ghost_critters/client_addons.dm
@@ -1,5 +1,5 @@
 /client
-	var/ghost_critter_cooldown = 0
+	COOLDOWN_DECLARE(ghost_critter_cooldown)
 
 
 /client/proc/get_critter_spawn(obj/structure/ghost_critter_spawn/spawner)
@@ -45,7 +45,7 @@
 	var/mob/living/basic/created_mob = new spawned_mob(turf)
 
 	var/cooldown_time = get_critter_cooldown()
-	ghost_critter_cooldown = cooldown_time
+	COOLDOWN_START(src, ghost_critter_cooldown, cooldown_time)
 
 	if(player_details.patreon.has_access(ACCESS_NUKIE_RANK) || is_admin(src))
 		created_mob.AddComponent(/datum/component/basic_inhands, y_offset = -6)

--- a/monkestation/code/modules/ghost_critters/ghost_critter_spawnpoint.dm
+++ b/monkestation/code/modules/ghost_critters/ghost_critter_spawnpoint.dm
@@ -3,15 +3,13 @@
 /datum/hover_data/ghost_critter/setup_data(atom/source, mob/enterer)
 	if(!enterer.client)
 		return
-	var/time_left = enterer.client.ghost_critter_cooldown
-	if(world.time > time_left)
+	if(COOLDOWN_FINISHED(enterer.client, ghost_critter_cooldown))
 		return
 
-	time_left -= world.time
 	var/obj/effect/overlay/hover/data = new(null)
 	data.icon = 'icons/effects/effects.dmi'
 	data.icon_state = "empty"
-	data.maptext = "<span class='pixel c ol'><span style='font-size: 6px; text-align: center;'>You have [DisplayTimeText(time_left)] left until you can spawn as a ghost critter again.</span></span>"
+	data.maptext = "<span class='pixel c ol'><span style='font-size: 6px; text-align: center;'>You have [DisplayTimeText(COOLDOWN_TIMELEFT(enterer.client, ghost_critter_cooldown))] left until you can spawn as a ghost critter again.</span></span>"
 	data.maptext_width = 256
 	data.maptext_height = 128
 	data.maptext_y = 28
@@ -51,7 +49,7 @@
 	if(!ghost.client)
 		return
 
-	if(ghost.client.ghost_critter_cooldown > world.time)
+	if(!COOLDOWN_FINISHED(ghost.client, ghost_critter_cooldown))
 		return
 
 	var/confirm_critter = tgui_alert(usr, "Would you like to spawn as a ghost critter? This will make you unrevivable.", "Ghost critter confirmation", list("Yes", "No"))


### PR DESCRIPTION
## About The Pull Request
For a while, cooldowns on ghost critter spawnpoints weren't a thing. I thought they might have simply been removed, but nope - they were broken. I only realized this while looking into the spawnpoints code recently.

Combine that with lower cooldowns being part of patreon ranks, and this turns into an even bigger bug.

I also took the time to rewrite the ghost critter cooldown handling, to use the `COOLDOWN_*` macros. :D

## Changelog

:cl: MichiRecRoom
fix: Ghost critter spawnpoint cooldowns are working once more. Sorry if you liked the lack of cooldown - I know I sure did.
/:cl: