### PR TITLE
Fix the component printer not showing item icons in its UI

### DIFF
--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -71,7 +71,8 @@
 
 /obj/machinery/component_printer/ui_assets(mob/user)
 	return list(
-		get_asset_datum(/datum/asset/spritesheet/sheetmaterials)
+		get_asset_datum(/datum/asset/spritesheet/sheetmaterials),
+		get_asset_datum(/datum/asset/spritesheet/research_designs)
 	)
 
 /obj/machinery/component_printer/proc/calculate_efficiency()


### PR DESCRIPTION
This PR is mirrored over at https://github.com/tgstation/tgstation/pull/89762.

## About The Pull Request
Whilst testing another PR, I found out the component printer wasn't showing icons for the items in its UI. This PR fixes that.

In fairness, the icons don't really do much here - most of the component printer designs are the same icon:

![image](https://github.com/user-attachments/assets/e4ebe5ab-860f-4294-8137-08b41f83860a)

But they're already in the asset datum, and it makes this UI look a little nicer, so why not use them?

## Why It's Good For The Game
Makes this UI more consistent with other UIs that look like it (i.e. the protolathe).

## Changelog

:cl:MichiRecRoom
fix: The component printer now shows icons for the items in its UI.
/:cl: