### PR TITLE
Lone Op Cap Fix

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -38,9 +38,10 @@
 /obj/item/disk/nuclear/proc/secured_process(last_move)
 	var/turf/new_turf = get_turf(src)
 	var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
+	var/datum/round_event_control/operative/loneopmode = locate(/datum/round_event_control/operative) in SSgamemode.control
 	if(istype(loneop) && loneop.occurrences < loneop.max_occurrences && prob(loneop.weight))
 		loneop.weight = max(loneop.weight - 1, 1) //monkestation edit: increased minimum to 1
-		loneop.checks_antag_cap = (loneop.weight < 3)
+		loneopmode.checks_antag_cap = (loneop.weight < 3)
 		if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
 			message_admins("[src] is secured (currently in [ADMIN_VERBOSEJMP(new_turf)]). The weight of Lone Operative is now [loneop.weight].")
 		log_game("[src] being secured has reduced the weight of the Lone Operative event to [loneop.weight].")
@@ -57,8 +58,9 @@
 
 	if(last_move < world.time - 300 SECONDS && prob((world.time - 300 SECONDS - last_move)*0.0001)) //monkestation edit: weight will start increasing at 5 minutes unsecure, rather than 8.3
 		var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
+		var/datum/round_event_control/operative/loneopmode = locate(/datum/round_event_control/operative) in SSgamemode.control
 		if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
-			loneop.checks_antag_cap = (loneop.weight < 3)
+			loneopmode.checks_antag_cap = (loneop.weight < 3)
 			loneop.weight += 1
 			if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
 				if(disk_comfort_level >= 2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This fix properly sets the checks_antag_cap in the proper reference so it will do what it says. Not check antag cap when the weight of the event grows past 3. Due to how the event system and game_mode system work there is two different references to the same event. So while the event will use the weight(Not even sure if this is true) to call a lone op into game_mode the game_mode subsystem will use its own reference of lone ops and will not see the change applied from events and its reference. Confusing I know sorry. Either way the proper reference has the flag now properly adjusted so lone ops can now ignore antag caps.

## Why It's Good For The Game

I honestly don't know. I guess to really punish Captains who ignore the disk. Was told it was a bug that many were sore about so I fixed it. Fixes to bugs are always good for the game. 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:Siro
fix: Lone ops will now ignore the antag cap if the weight grows beyond 3.
code: Reference to loneops in ssgame_mode now has its checks_antag_cap adjusted due to weight.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
