### PR TITLE
Remove double text from ghost role description

### DIFF
--- a/monkestation/code/modules/syndicate_ghostroles/listeningpost.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/listeningpost.dm
@@ -12,7 +12,7 @@
 
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/comms/space
 	you_are_text = "You are a syndicate agent, assigned to a small listening post station situated near your hated enemy's top secret research facility: Space Station 13."
-	flavour_text = "Monitor enemy activity as best you can, and try to keep a low profile. Monitor enemy activity as best you can, and try to keep a low profile. Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!"
+	flavour_text = "Monitor enemy activity as best you can, and try to keep a low profile. Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!"
 	important_text = "DO NOT leave the base. You are not a field agent, and are not permitted to do their job for them."
 	spawner_job_path = /datum/job/lavaland_syndicate/space
 


### PR DESCRIPTION
## About The Pull Request
Removes doubled text from the syndicate comms
## Why It's Good For The Game
Doubled text looks bad
## Changelog
:cl:
del: Removed doubled text from syndicate listening post job description
/:cl:
