### PR TITLE
Fixed accidentally doubling metacoin

### DIFF
--- a/monkestation/code/modules/store/admin/admin_coin_modification.dm
+++ b/monkestation/code/modules/store/admin/admin_coin_modification.dm
@@ -14,7 +14,7 @@
 		return
 
 	if(adjustment_amount + chosen_client.prefs.metacoins < 0)
-		adjustment_amount = chosen_client.prefs.metacoins
+		adjustment_amount = -chosen_client.prefs.metacoins
 
 	chosen_client.prefs.adjust_metacoins(chosen_client.ckey, adjustment_amount, null, TRUE, FALSE)
 


### PR DESCRIPTION

## About The Pull Request
Sign error caused the adjust meta coin verb to add an amount of coin equal to the amount the players had if the admin tried to remove more than they had.
## Why It's Good For The Game
Giving coin to someone coin is being removed from is bad
## Changelog
:cl:
fix: fixed monkecoin being given when it should be removed
/:cl:
