### PR TITLE
Gives back NT rep and Blueshield their CC comms + Blueshield Outfit Changes

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -31,6 +31,8 @@ GLOBAL_LIST_EMPTY(alarmdisplay)
 GLOBAL_LIST_EMPTY_TYPED(singularities, /datum/component/singularity)
 /// list of all /obj/machinery/mechpad
 GLOBAL_LIST_EMPTY(mechpad_list)
+/// list of all crewside CentCom headsets on station
+GLOBAL_LIST_EMPTY(crew_cc_keys)
 
 /// list of all /datum/chemical_reaction datums indexed by their typepath. Use this for general lookup stuff
 GLOBAL_LIST(chemical_reactions_list)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -194,6 +194,38 @@
 	greyscale_config = /datum/greyscale_config/encryptionkey_centcom
 	greyscale_colors = "#24a157#dca01b"
 
+//MONKESTATION EDIT
+/obj/item/encryptionkey/headset_cent/crew
+	desc = "An encryption key for a radio headset. It looks like there is a bluespace chip attached to it."
+
+/obj/item/encryptionkey/headset_cent/crew/Initialize()
+	. = ..()
+	GLOB.crew_cc_keys += src
+
+/obj/item/encryptionkey/headset_cent/crew/proc/toggle_off()
+	independent = FALSE
+	channels = null
+	playsound(src, 'sound/weapons/flash.ogg', 25, TRUE)
+	do_sparks(2, FALSE, src)
+	if(istype(src.loc, /obj/item/radio))
+		var/obj/item/radio/our_radio  = src.loc
+		our_radio.recalculateChannels()
+
+/obj/item/encryptionkey/headset_cent/crew/proc/toggle_on()
+	independent = TRUE
+	channels = list(RADIO_CHANNEL_CENTCOM = 1)
+	playsound(src, 'sound/weapons/flash.ogg', 25, TRUE)
+	do_sparks(2, FALSE, src)
+	if(istype(src.loc, /obj/item/radio))
+		var/obj/item/radio/our_radio = src.loc
+		our_radio.recalculateChannels()
+
+/obj/item/encryptionkey/headset_cent/crew/Destroy()
+	if(src in GLOB.crew_cc_keys)
+		GLOB.crew_cc_keys -= src
+	return ..()
+//MONKESTATION EDIT STOP
+
 /obj/item/encryptionkey/ai //ported from NT, this goes 'inside' the AI.
 	channels = list(
 		RADIO_CHANNEL_COMMAND = 1,

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -198,7 +198,7 @@
 /obj/item/encryptionkey/headset_cent/crew
 	desc = "An encryption key for a radio headset. It looks like there is a bluespace chip attached to it."
 
-/obj/item/encryptionkey/headset_cent/crew/Initialize()
+/obj/item/encryptionkey/headset_cent/crew/Initialize(mapload)
 	. = ..()
 	GLOB.crew_cc_keys += src
 

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -374,6 +374,11 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	desc = "A headset used by the lower ranking members of Central Command."
 	keyslot = /obj/item/encryptionkey/headset_com
 	keyslot2 = null
+
+/obj/item/radio/headset/headset_cent/representative/Initialize(mapload)
+	. = ..()
+	keyslot2 = new /obj/item/encryptionkey/headset_cent/crew(src)
+	src.recalculateChannels()
 //monkestation addition end
 
 /obj/item/radio/headset/headset_cent/alt/Initialize(mapload)

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -285,7 +285,10 @@
 		return
 	if(!talking_movable.try_speak(message))
 		return
-
+	//MONKESTATION EDIT START
+	if(istype(get_area(src), /area/centcom/heretic_sacrifice))
+		return
+	//MONKESTATION EDIT STOP
 	if(channel == FREQ_RADIO && !radio_host)
 		return
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -166,6 +166,7 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/summon_twitch_event, //monkestation addition
 	/client/proc/toggle_nuke,
 	/client/proc/toggle_random_events,
+	/client/proc/toggle_crew_cc_comms, //monkestation addition
 	))
 GLOBAL_PROTECT(admin_verbs_fun)
 GLOBAL_LIST_INIT(admin_verbs_spawn, list(/datum/admins/proc/spawn_atom, /datum/admins/proc/podspawn_atom, /datum/admins/proc/spawn_cargo, /datum/admins/proc/spawn_objasmob, /client/proc/respawn_character, /datum/admins/proc/beaker_panel, /client/proc/spawn_mixtape,)) //Monkestation Addition: mixtape spawner

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -478,3 +478,22 @@
 	else
 		SScommunications.block_command_report++
 		message_admins("[usr] has delayed the roundstart command report.")
+
+//MONKESTATION EDIT START
+/client/proc/toggle_crew_cc_comms()
+	set category = "Admin.Events"
+	set name = "Toggle Crew CC Comms"
+	set popup_menu = FALSE
+	if(!check_rights(R_DEBUG))
+		return
+	var/toggle = tgui_alert(src, "Toggle Crew CC Comms", "Toggle", list("On", "Off"))
+	for(var/obj/item/encryptionkey/headset_cent/crew/key in GLOB.crew_cc_keys)
+		if(toggle == "On")
+			key.toggle_on()
+		if(toggle == "Off")
+			key.toggle_off()
+		log_admin("[key_name(usr)] toggled crew CC comms [toggle].")
+		message_admins("[ADMIN_LOOKUPFLW(usr)] toggled crew CC comms [toggle].")
+		SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Crew CC Comms", "[toggle]]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+//MONKESTATION EDIT STOP
+

--- a/code/modules/admin/verbs/adminevents.dm
+++ b/code/modules/admin/verbs/adminevents.dm
@@ -492,8 +492,8 @@
 			key.toggle_on()
 		if(toggle == "Off")
 			key.toggle_off()
-		log_admin("[key_name(usr)] toggled crew CC comms [toggle].")
-		message_admins("[ADMIN_LOOKUPFLW(usr)] toggled crew CC comms [toggle].")
-		SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Crew CC Comms", "[toggle]]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	log_admin("[key_name(usr)] toggled crew CC comms [toggle].")
+	message_admins("[ADMIN_LOOKUPFLW(usr)] toggled crew CC comms [toggle].")
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Crew CC Comms", "[toggle]]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 //MONKESTATION EDIT STOP
 

--- a/code/modules/bitrunning/server/obj_generation.dm
+++ b/code/modules/bitrunning/server/obj_generation.dm
@@ -12,6 +12,7 @@
 	to_wear.r_pocket = null
 	to_wear.suit = null
 	to_wear.suit_store = null
+	to_wear.ears = null //monkestation addition
 
 	avatar.equipOutfit(to_wear, visualsOnly = TRUE)
 

--- a/monkestation/code/game/objects/structures/crates_lockers/closets/secure/blueshield.dm
+++ b/monkestation/code/game/objects/structures/crates_lockers/closets/secure/blueshield.dm
@@ -11,6 +11,4 @@
 	new /obj/item/storage/medkit/frontier/stocked(src)
 	new /obj/item/storage/bag/garment/blueshield(src)
 	new /obj/item/sensor_device/blueshield(src)
-	new /obj/item/radio/headset/headset_bs(src)
-	new /obj/item/radio/headset/headset_bs/alt(src)
 	new /obj/item/storage/photo_album/blueshield(src)

--- a/monkestation/code/modules/blueshield/clothing.dm
+++ b/monkestation/code/modules/blueshield/clothing.dm
@@ -209,7 +209,12 @@
 	icon_state = "bshield_headset"
 	worn_icon_state = "bshield_headset"
 	keyslot = /obj/item/encryptionkey/heads/blueshield
-	keyslot2 = null
+	keyslot2 = /obj/item/encryptionkey/headset_cent/crew
+
+/obj/item/radio/headset/headset_bs/Initialize(mapload)
+	. = ..()
+	keyslot2 = new /obj/item/encryptionkey/headset_cent/crew(src)
+	src.recalculateChannels()
 
 /obj/item/radio/headset/headset_bs/alt
 	name = "\proper the blueshield's bowman headset"
@@ -221,11 +226,12 @@
 	. = ..()
 	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_EARS))
 
-/obj/item/storage/belt/security/blueshield
-	name = "\improper the blueshields's security belt"
-	desc = "A modified security toolbelt designed to help hold more in exchange for it's baton holster."
 
-/obj/item/storage/belt/security/blueshield/Initialize(mapload)
-	. = ..()
-	atom_storage.max_slots = 7
-	atom_storage.set_holdable(list(), list(/obj/item/melee/baton))
+/obj/item/storage/belt/military/assault/blueshield/PopulateContents()
+	generate_items_inside(list(
+		/obj/item/grenade/flashbang = 2,
+		/obj/item/reagent_containers/spray/pepper = 1,
+		/obj/item/restraints/handcuffs = 1,
+		/obj/item/assembly/flash/handheld = 1,
+		/obj/item/melee/baton/telescopic = 1,
+	), src)

--- a/monkestation/code/modules/jobs/job_types/blueshield.dm
+++ b/monkestation/code/modules/jobs/job_types/blueshield.dm
@@ -62,11 +62,11 @@
 	id = /obj/item/card/id/advanced/centcom
 	shoes = /obj/item/clothing/shoes/jackboots
 	ears = /obj/item/radio/headset/headset_bs/alt
-	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
+	glasses = /obj/item/clothing/glasses/hud/health/sunglasses
+
 	implants = list(/obj/item/implant/mindshield)
 	backpack_contents = list(
 		/obj/item/choice_beacon/blueshield = 1,
-		/obj/item/melee/baton/telescopic = 1,
 	)
 	backpack = /obj/item/storage/backpack/blueshield
 	satchel = /obj/item/storage/backpack/satchel/blueshield
@@ -74,7 +74,7 @@
 
 	head = /obj/item/clothing/head/beret/blueshield
 	box = /obj/item/storage/box/survival/security
-	belt = /obj/item/storage/belt/security/blueshield
+	belt = /obj/item/storage/belt/military/assault/blueshield
 	l_pocket = /obj/item/sensor_device/blueshield
 	r_pocket = /obj/item/modular_computer/pda/blueshield
 	pda_slot = ITEM_SLOT_RPOCKET


### PR DESCRIPTION
## About The Pull Request
Gives back NT rep and Blueshield their CC comms via a special CentCom radio key that admins can control with a new admin verb appropriately called "Toggle Crew CC Comms." So if an admin want's crew CC comms disabled for any reason they just use that verb to toggle all CentCom radio keys given to the crew on or off. Also removed Blueshield's extra headsets from their locker as players were abusing them to give other command members access to the CC frequency.

Replaced the Blueshield security belt with a pre-equipped assault belt. Serves practically the same function of holding ammo and can also hold their telescopic baton. Blueshields get a pair of medhud sunglasses instead of sechud sunglasses roundstart. Their locker still has a pair sechud sunglasses so they can switch to those if needed.

Removed radios from bitrunning avatars so they can't use CC comms by selecting Blueshield or NT rep as their outfit. 

Mansus now blocks radio transmission.

## Why It's Good For The Game
NT rep's and Blueshield's CC comms were removed because it was interfering with admin events along with the fact the CC frequency works regardless of telecomms...  Against the second reasoning, there's now only 3 points of crew access to CC comms. The meeting room intercom, NT rep's headset, and the Blueshield's headset where the latter two no longer get spare headsets to give out to others. Admins can now also disable crew access to CC comms for events.

As for the Blueshield outfit changes, their job is to protect command so a medhud makes sense as you can tell how injured people are at a glance. Giving them medhud sunglasses roundstart just gives them a choice between a medhud or sechud as their is a pair of sechud sunglasses in their locker. The assault belt just seems like a nicer version of the Blueshield security belt while still serving the same function.

## Changelog

:cl:
add: gave back NT rep and Blueshield their CC comms via a special CentCom radio key.
add: Blueshields get a pair of medhud sunglasses instead of sechud sunglasses roundstart. 
del: removed the Blueshield security belt and replaced it with a pre-equipped assault belt.
del: removed Blueshield's extra headsets from their locker.
del: removed radios from bitrunning avatars.
add: the mansus blocks radio transmission.
admin: new admin verb for disabling crew CC comms called "Toggle Crew CC Comms."
/:cl:

