### PR TITLE
Paco Balancing

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1649,7 +1649,6 @@
 	design_ids = list(
 		"pin_testing",
 		"tele_shield",
-		"lethal_c35", //monkestation edit: paco sec
 		"mag_autorifle_rub", //monkestation edit: autorifles
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
@@ -1662,6 +1661,7 @@
 	prereq_ids = list("adv_engi", "weaponry")
 	design_ids = list(
 		"pin_loyalty",
+		"lethal_c35", //monkestation edit: paco sec
 		"mag_autorifle", //monkestation edit: autorifles
 		"mag_autorifle_salt", //monkestation edit: autorifles
 	)

--- a/monkestation/code/game/objects/items/guns/wt_ammo.dm
+++ b/monkestation/code/game/objects/items/guns/wt_ammo.dm
@@ -17,7 +17,7 @@
 /obj/projectile/bullet/c46x30mm/rub
 	name = "4.6x30mm rubber bullet"
 	damage = 4
-	stamina = 35
+	stamina = 50
 	embedding = null
 	sharpness = NONE
 
@@ -40,7 +40,7 @@
 /obj/projectile/bullet/c46x30mm/salt
 	name = "4.6x30mm saltshot bullet"
 	damage = 0
-	stamina = 30
+	stamina = 40
 	embedding = null
 	sharpness = NONE
 

--- a/monkestation/code/modules/cargo/crates/security.dm
+++ b/monkestation/code/modules/cargo/crates/security.dm
@@ -17,34 +17,34 @@
 
 /datum/supply_pack/security/paco
 	name = "FS HG .35 Auto \"Paco\" weapon crate"
-	desc = "Did security slip and lose their handguns? in that case, this crate contains two \"Paco\" handguns with two magazines of rubber."
+	desc = "Did security slip and lose their handguns? in that case, this crate contains three \"Paco\" handguns with three magazines of rubber."
 	cost = CARGO_CRATE_VALUE * 5
 	access_view = ACCESS_SECURITY
 	contains = list(
-		/obj/item/gun/ballistic/automatic/pistol/paco/no_mag = 2,
-		/obj/item/ammo_box/magazine/m35/rubber = 2,
+		/obj/item/gun/ballistic/automatic/pistol/paco/no_mag = 3,
+		/obj/item/ammo_box/magazine/m35/rubber = 3,
 		)
 	crate_name = "\improper \"Paco\" handgun crate"
 
 /datum/supply_pack/security/pacoammo
 	name = "FS HG .35 Auto \"Paco\" non-lethal ammo crate"
-	desc = "Short on ammo? No worries, this crate contains two .35 Auto rubber magazines, and the respective ammunition packet."
+	desc = "Short on ammo? No worries, this crate contains three .35 Auto rubber magazines, and two of the respective ammunition packet."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(
-		/obj/item/ammo_box/magazine/m35/rubber = 2,
-		/obj/item/ammo_box/c35/rubber = 1,
+		/obj/item/ammo_box/magazine/m35/rubber = 3,
+		/obj/item/ammo_box/c35/rubber = 2,
 		)
 	crate_name = ".35 Auto Non-Lethal Ammo crate"
 
 /datum/supply_pack/security/armory/pacoammo
 	name = "FS HG .35 Auto \"Paco\" lethal ammo crate"
-	desc = "Short on ammo? No worries, this crate contains two lethally loaded .35 Auto magazines, and the respective ammunition packet."
-	cost = CARGO_CRATE_VALUE * 2
+	desc = "Short on ammo? No worries, this crate contains three lethally loaded .35 Auto magazines, and two of the respective ammunition packet."
+	cost = CARGO_CRATE_VALUE * 4
 	access_view = ACCESS_SECURITY
 	contains = list(
-		/obj/item/ammo_box/magazine/m35 = 2,
-		/obj/item/ammo_box/c35 = 1,
+		/obj/item/ammo_box/magazine/m35 = 3,
+		/obj/item/ammo_box/c35 = 2,
 		)
 	crate_name = ".35 Auto Lethal Ammo crate"
 

--- a/monkestation/code/modules/cargo/crates/security.dm
+++ b/monkestation/code/modules/cargo/crates/security.dm
@@ -28,23 +28,23 @@
 
 /datum/supply_pack/security/pacoammo
 	name = "FS HG .35 Auto \"Paco\" non-lethal ammo crate"
-	desc = "Short on ammo? No worries, this crate contains three .35 Auto rubber magazines, and two of the respective ammunition packet."
+	desc = "Short on ammo? No worries, this crate contains three .35 Auto rubber magazines, and the respective ammunition packet."
 	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(
 		/obj/item/ammo_box/magazine/m35/rubber = 3,
-		/obj/item/ammo_box/c35/rubber = 2,
+		/obj/item/ammo_box/c35/rubber = 1,
 		)
 	crate_name = ".35 Auto Non-Lethal Ammo crate"
 
 /datum/supply_pack/security/armory/pacoammo
 	name = "FS HG .35 Auto \"Paco\" lethal ammo crate"
-	desc = "Short on ammo? No worries, this crate contains three lethally loaded .35 Auto magazines, and two of the respective ammunition packet."
+	desc = "Short on ammo? No worries, this crate contains three lethally loaded .35 Auto magazines, and the respective ammunition packet."
 	cost = CARGO_CRATE_VALUE * 4
 	access_view = ACCESS_SECURITY
 	contains = list(
 		/obj/item/ammo_box/magazine/m35 = 3,
-		/obj/item/ammo_box/c35 = 2,
+		/obj/item/ammo_box/c35 = 1,
 		)
 	crate_name = ".35 Auto Lethal Ammo crate"
 

--- a/monkestation/code/modules/cargo/crates/security.dm
+++ b/monkestation/code/modules/cargo/crates/security.dm
@@ -27,17 +27,26 @@
 	crate_name = "\improper \"Paco\" handgun crate"
 
 /datum/supply_pack/security/pacoammo
-	name = "FS HG .35 Auto \"Paco\" ammo crate"
-	desc = "Short on ammo? No worries, this crate contains two .35 Auto rubber magazines, two lethally loaded magazines and respective ammunition packets."
-	cost = CARGO_CRATE_VALUE * 4
+	name = "FS HG .35 Auto \"Paco\" non-lethal ammo crate"
+	desc = "Short on ammo? No worries, this crate contains two .35 Auto rubber magazines, and the respective ammunition packet."
+	cost = CARGO_CRATE_VALUE * 2
+	access_view = ACCESS_SECURITY
+	contains = list(
+		/obj/item/ammo_box/magazine/m35/rubber = 2,
+		/obj/item/ammo_box/c35/rubber = 1,
+		)
+	crate_name = ".35 Auto Non-Lethal Ammo crate"
+
+/datum/supply_pack/security/armory/pacoammo
+	name = "FS HG .35 Auto \"Paco\" lethal ammo crate"
+	desc = "Short on ammo? No worries, this crate contains two lethally loaded .35 Auto magazines, and the respective ammunition packet."
+	cost = CARGO_CRATE_VALUE * 2
 	access_view = ACCESS_SECURITY
 	contains = list(
 		/obj/item/ammo_box/magazine/m35 = 2,
-		/obj/item/ammo_box/magazine/m35/rubber = 2,
 		/obj/item/ammo_box/c35 = 1,
-		/obj/item/ammo_box/c35/rubber = 1,
 		)
-	crate_name = ".35 Auto Ammo crate"
+	crate_name = ".35 Auto Lethal Ammo crate"
 
 /datum/supply_pack/security/blueshirt
 	name = "Blue Shirt Uniform Crate"

--- a/monkestation/code/modules/security/code/weapons/paco.dm
+++ b/monkestation/code/modules/security/code/weapons/paco.dm
@@ -78,7 +78,7 @@
 	max_ammo = 16
 	multiple_sprites = AMMO_BOX_PER_BULLET
 	multiple_sprite_use_base = TRUE
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ammo_box/magazine/m35/update_icon_state()
 	. = ..()
@@ -106,7 +106,7 @@
 	icon_state = "35r"
 	base_icon_state = "35r"
 	ammo_type = /obj/item/ammo_casing/c35/rubber
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 
 /obj/item/ammo_casing/c35/rubber
 	name = ".35 Auto rubber bullet casing"
@@ -119,7 +119,7 @@
 	icon = 'monkestation/code/modules/security/icons/paco_ammo.dmi'
 	icon_state = "rubber_bullet"
 	damage = 4
-	stamina = 35 // Turns out 35 stamina damage is not good enough.
+	stamina = 50 // Turns out 35 stamina damage is not good enough.
 	sharpness = NONE
 	embedding = null
 


### PR DESCRIPTION
## About The Pull Request
### Reverts: https://github.com/Monkestation/Monkestation2.0/pull/4663

made paco mags small again, in exchange i made paco lethals harder to get by locking lethal paco ammo behind a higher tier of sec research and behind the armoury in cargo. increased paco and wt rubbershot stamina damage from 35 to 50. wt saltshot got buffed from 35 to 40. Added another Paco to the Paco weapon crate to match the ammo crate changes

## Why It's Good For The Game
if the issue the reverted PR was trying to fix was sec being overloaded with paco lethals why not just make said lethals harder to get. my reasoning for the stamina damage increases so paco's are more of a sidegrade to disablers. wt ammo stamina buffs are so they are on par with disabler beams. 

quick comparison: 

Disabler
- 20 shots total
- no recoil
- 5 shots to stam crit
- can shoot through windows
- rechargeable 
- applies debilitated stacks  which causes the target to drain more stamina whenever they take additional stamina damage

Paco with  Rubbershot
- 16 shots total
- recoil
- 5 shots to stam crit
- can't shoot through windows
- non-rechargeable/cannot be EMPed
- might get sued by lawyers for bruises caused by using rubbershot

im pretty sure no other magazine is normal sized either.

## Changelog

:cl:
balance: Paco mags are small again.
balance: locked lethal Paco ammo behind the "Advanced Weaponry" tech node.
balance: split Paco ammo between non-lethal ammo as a security order and lethal ammo as an armoury locked order. added another Paco to the Paco weapon crate.
/:cl:

