### PR TITLE
Wizard "invincibility" event (+ adminordrazine) no longer spams skillchip messages

### DIFF
--- a/code/modules/library/skill_learning/skillchip.dm
+++ b/code/modules/library/skill_learning/skillchip.dm
@@ -359,13 +359,14 @@
  * Does not set any owner or brain status. Handle that externally.
  * Arguments:
  * metadata - Ideally the output of another chip's get_metadata proc. Assoc list of metadata.
+ * silent - Whether or not an activation message should be shown to the user.
  */
-/obj/item/skillchip/proc/set_metadata(list/metadata)
+/obj/item/skillchip/proc/set_metadata(list/metadata, silent = FALSE) // monkestation edit: add silent arg
 	var/active_msg
 	// Start by trying to activate.
 	active = metadata["active"]
 	if(active)
-		active_msg = try_activate_skillchip(FALSE, TRUE)
+		active_msg = try_activate_skillchip(silent = silent, force = TRUE) // monkestation edit: add silent arg
 
 	// Whether it worked or not, set the rest of the metadata and then return any activate message.
 	chip_cooldown = metadata["chip_cooldown"]

--- a/monkestation/code/modules/mob/living/carbon/human/_species.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/_species.dm
@@ -10,4 +10,4 @@
 		if(organ_holder.implant_skillchip(skillchip, force = TRUE))
 			qdel(skillchip)
 			continue
-		skillchip.set_metadata(chip)
+		skillchip.set_metadata(chip, silent = TRUE)


### PR DESCRIPTION
## About The Pull Request

_Actually_ fixes https://github.com/Monkestation/Monkestation2.0/issues/4129
Fixes https://github.com/Monkestation/Monkestation2.0/issues/4871
Fixes https://github.com/Monkestation/Monkestation2.0/issues/5209

this makes it so `/datum/species/regenerate_organs` carrying your skillchips over is now fully silent, meaning no chat message spam.

## Changelog
:cl:
fix: Adminordrazine (usually from the wizard "Invincibility" event) no longer spams your chat with skillchip messages.
/:cl:
