### PR TITLE
[PORT] Fixes borgs not being able to navigate through access restricted doors

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -475,3 +475,6 @@
 		stack_trace("Silicon [src] ( [type] ) was somehow missing their integrated tablet. Please make a bug report.")
 		create_modularInterface()
 	modularInterface.imprint_id(name = newname)
+
+/mob/living/silicon/get_access()
+	return REGION_ACCESS_ALL_STATION

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -435,3 +435,6 @@
 	if (new_distance < HOLOFORM_MIN_RANGE || new_distance > HOLOFORM_MAX_RANGE)
 		return
 	leash.set_distance(new_distance)
+
+/mob/living/silicon/pai/get_access()
+	return list()


### PR DESCRIPTION
Ports tgstation/tgstation#89773
## About The Pull Request
Currently if a borg attempts to use nav to access a waypoint in a restricted area of the station (brig for example) it will fail with "no valid path with current access" because get_access on a borg return nothing because they don't have an ID. get_access for silicons will now return all station accesses.
## Why It's Good For The Game

Borgs need to find things, and not being able to nav into any restricted areas is annoying.
## Changelog
:cl:
add: Added the ability for borgs to pathfind into and through restricted areas.
/:cl:
