### PR TITLE
Reduce some memory usage

### DIFF
--- a/code/__DEFINES/~monkestation/dcs/signals/signals_atom.dm
+++ b/code/__DEFINES/~monkestation/dcs/signals/signals_atom.dm
@@ -16,9 +16,14 @@
 #define COMSIG_CELL_CHANGE_POWER "cell_change_power"
 
 
+// This isn't even used at the moment.
+// Refactor this to a component if it's ever brought back.
+// ~Absolucy
+/*
 /// Mob is trying to open the hacking menu of a target [/atom], from /datum/hacking/interactable(): (mob/user)
 #define COMSIG_TRY_HACKING_INTERACT "try_hacking_interact"
 	#define COMPONENT_CANT_INTERACT_HACKING (1<<0)
+*/
 
 /// generic turf checker signal
 #define COMSIG_CHECK_TURF_GENERIC "check_turf_generic"

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -268,8 +268,10 @@
 	// Station blueprints do that too, but only if the wires are not randomized.
 	if(user.is_holding_item_of_type(/obj/item/areaeditor/blueprints) && !randomize)
 		return TRUE
+/*
 	if(revealed_wires)
 		return TRUE
+*/
 	return FALSE
 
 /**

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1006,9 +1006,10 @@
 		if(panel_open)
 			attempt_wire_interaction(user)
 			return
-		else
+/*		else
 			attempt_hacking_interaction(user)
 			return
+*/
 
 	else if(panel_open && security_level == AIRLOCK_SECURITY_NONE && istype(C, /obj/item/stack/sheet))
 		if(istype(C, /obj/item/stack/sheet/iron))

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -9,7 +9,6 @@ GLOBAL_VAR_INIT(starlight_color, pick(COLOR_TEAL, COLOR_GREEN, COLOR_CYAN, COLOR
 	temperature = TCMB
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = 700000
-	var/starlight_source_count = 0
 
 	var/destination_z
 	var/destination_x

--- a/code/modules/forensics/forensics_helpers.dm
+++ b/code/modules/forensics/forensics_helpers.dm
@@ -73,7 +73,7 @@
 		forensics.inherit_new(blood_DNA = blood_DNA_to_add)
 	else
 		forensics = new(src, blood_DNA = blood_DNA_to_add)
-	cached_blood_dna_color = null
+	forensics?.cached_blood_dna_color = null
 	update_appearance()
 	return TRUE
 
@@ -112,7 +112,7 @@
 			forensics = new(src)
 		forensics.inherit_new(blood_DNA = blood_DNA_to_add)
 		blood_in_hands = rand(2, 4)
-	cached_blood_dna_color = null
+	forensics?.cached_blood_dna_color = null
 	update_worn_gloves()
 	return TRUE
 

--- a/code/modules/forensics/forensics_helpers.dm
+++ b/code/modules/forensics/forensics_helpers.dm
@@ -73,8 +73,10 @@
 		forensics.inherit_new(blood_DNA = blood_DNA_to_add)
 	else
 		forensics = new(src, blood_DNA = blood_DNA_to_add)
+	//MONKESTATION ADDITION START: Keep track of the blood dna color
 	forensics?.cached_blood_dna_color = null
 	update_appearance()
+	//MONKESTATION ADDITION END
 	return TRUE
 
 /obj/item/add_blood_DNA(list/blood_DNA_to_add)

--- a/code/modules/forensics/forensics_helpers.dm
+++ b/code/modules/forensics/forensics_helpers.dm
@@ -112,7 +112,7 @@
 			forensics = new(src)
 		forensics.inherit_new(blood_DNA = blood_DNA_to_add)
 		blood_in_hands = rand(2, 4)
-	forensics?.cached_blood_dna_color = null
+	forensics?.cached_blood_dna_color = null //MONKESTATION ADDITION: Keep track of the blood dna color
 	update_worn_gloves()
 	return TRUE
 

--- a/monkestation/code/modules/blood_datum/forensics_helpers.dm
+++ b/monkestation/code/modules/blood_datum/forensics_helpers.dm
@@ -1,10 +1,10 @@
-/atom
+/datum/forensics
 	/// Cached mixed color of all blood DNA on us
-	VAR_PROTECTED/cached_blood_dna_color
+	var/cached_blood_dna_color
 
 /atom/proc/get_blood_dna_color()
-	if(cached_blood_dna_color)
-		return cached_blood_dna_color
+	if(forensics?.cached_blood_dna_color)
+		return forensics.cached_blood_dna_color
 
 	var/list/colors = list()
 	var/list/all_dna = GET_ATOM_BLOOD_DNA(src)
@@ -16,7 +16,7 @@
 		final_color = pop(colors)
 		for(var/color in colors)
 			final_color = BlendRGB(final_color, color, 0.5)
-	cached_blood_dna_color = final_color
+	forensics?.cached_blood_dna_color = final_color
 	return final_color
 
 /obj/effect/decal/cleanable/blood/get_blood_dna_color()

--- a/monkestation/code/modules/cybernetics/minigame/airlock_hacking_datum.dm
+++ b/monkestation/code/modules/cybernetics/minigame/airlock_hacking_datum.dm
@@ -1,3 +1,7 @@
+// This isn't even used at the moment.
+// Refactor this to a component if it's ever brought back.
+// ~Absolucy
+/*
 /datum/wires
 	var/revealed_wires = FALSE
 
@@ -45,3 +49,4 @@
  */
 /obj/machinery/door/airlock/proc/set_hacking()
 	//return new /datum/hacking/airlock(src)
+*/

--- a/monkestation/code/modules/cybernetics/minigame/general_hacking.dm
+++ b/monkestation/code/modules/cybernetics/minigame/general_hacking.dm
@@ -1,3 +1,7 @@
+// This isn't even used at the moment.
+// Refactor this to a component if it's ever brought back.
+// ~Absolucy
+/*
 PROCESSING_SUBSYSTEM_DEF(hacking)
 	name = "Hacking"
 	wait = 1 SECONDS
@@ -358,3 +362,4 @@ PROCESSING_SUBSYSTEM_DEF(hacking)
 	var/botnets = rand(1, 100)
 	. += span_info("[src] reports...")
 	. += span_big(span_alert("[botnets] BOTNET[botnets == 1 ? "" : "S"] ONLINE"))
+*/

--- a/monkestation/code/modules/outdoors/code/datum/particle_weathers/weather_types/snow.dm
+++ b/monkestation/code/modules/outdoors/code/datum/particle_weathers/weather_types/snow.dm
@@ -1,8 +1,12 @@
 #define SNOW_STORM_TEMP		CELCIUS_TO_KELVIN(-40 CELCIUS)
 #define SNOW_GENTLE_TEMP	CELCIUS_TO_KELVIN(-12 CELCIUS)
 
+// this var isn't even SET anywhere
+// uncomment this is it ever is used. or even better. find a way that doesn't require a var on base /turf ~Absolucy
+/*
 /turf
 	var/weather_affectable = TRUE
+*/
 
 /datum/particle_weather/snow_gentle
 	name = "Snow"

--- a/monkestation/code/modules/outdoors/code/sunlight/sunlight_object.dm
+++ b/monkestation/code/modules/outdoors/code/sunlight/sunlight_object.dm
@@ -254,7 +254,7 @@ Sunlight System
 
 /turf/proc/apply_weather_effect(datum/source, datum/weather_effect/effect)
 	SIGNAL_HANDLER
-	if(!weather_affectable || !prob(effect.probability))
+	if(/* !weather_affectable || */ !prob(effect.probability)) // weather_affectable isn't set anywhere. uncomment that if it's ever actually used. ~Absolucy
 		return
 
 	effect.effect_affect(src)


### PR DESCRIPTION
## About The Pull Request

This does a few things to reduce memory usage, mostly removing some vars off of base types:
- Gets rid of the code for the airlock hacking minigame, since it's impossible to access said minigame anyways, and it had a var on `/atom`. If anyone wants this back, they can refactor it to a component.
- The `cached_blood_dna_color` var on `/atom` was moved to `/datum/forensics` 
- Removes the `weather_affectable` var on `/turf` - nothing anywhere ever actually changes it from the default `TRUE`

## Why It's Good For The Game

I want to make these numbers smaller
![2025-03-03 (1740993176) ~ dreamseeker](https://github.com/user-attachments/assets/049aec9a-1b5b-4241-a765-8336c4f79534)

## Changelog
:cl:
refactor: Removed some unused code and rearranged some other code to hopefully reduce server-side memory usage.
/:cl:
