### PR TITLE
Doomsday Device no longer affects non-organic life

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -360,7 +360,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 	SSticker.force_ending = FORCE_END_ROUND
 
 /proc/bring_doomsday(mob/living/victim, atom/source)
-	if(issilicon(victim))
+	if(issilicon(victim) || !(victim.mob_biotypes & MOB_ORGANIC)) // monkestation edit: ignore non-organic mobs, as the description suggests it would
 		return FALSE
 
 	to_chat(victim, span_userdanger("The blast wave from [source] tears you atom from atom!"))


### PR DESCRIPTION

## About The Pull Request

The doomsday device has this description:

> A weapon which disintegrates all **organic life** in a large area.

and

> Activate a weapon that will disintegrate all **organic life** on the station after a 450 second delay

So it's kinda silly that it'd also wipe out non-organic life. This makes it only affect mobs with the `MOB_ORGANIC` biotype.

## Why It's Good For The Game

consistency is good. 

## Changelog
:cl:
balance: Doomsday Device no longer affects non-organic life, consistent with its description.
/:cl:
