### PR TITLE
[PORT] Fix some runtimes in mutation code

### DIFF
--- a/code/datums/mutations/_mutations.dm
+++ b/code/datums/mutations/_mutations.dm
@@ -174,7 +174,7 @@
  * returns an instance of a power if modification was complete
  */
 /datum/mutation/human/proc/modify()
-	if(modified || !power_path || !owner)
+	if(modified || !power_path || QDELETED(owner))
 		return
 	var/datum/action/cooldown/modified_power = locate(power_path) in owner.actions
 	if(!modified_power)

--- a/code/datums/mutations/radioactive.dm
+++ b/code/datums/mutations/radioactive.dm
@@ -24,7 +24,8 @@
 
 /datum/mutation/human/radioactive/modify()
 	. = ..()
-	make_radioactive(owner)
+	if(!QDELETED(owner))
+		make_radioactive(owner)
 
 /**
  * Makes the passed mob radioactive, or if they're already radioactive,


### PR DESCRIPTION
## About The Pull Request
This PR ports the following PRs from tgstation:
* tgstation/tgstation#79829
* tgstation/tgstation#89805

which fix some runtimes with mutations. One of these runtimes was actually encountered on our fork - see #5768 - which is what spurred me to fix them.

## Why It's Good For The Game
Fixes runtimes. Fixes #5768.

## Changelog

:cl:MichiRecRoom, vinylspiders
fix: (vinylspiders) fixed a race condition with mutations
fix: (MichiRecRoom) Fixes a runtime with the radioactivity mutation when it spawns in a random data disk.
/:cl: