### PR TITLE
Some various entertainment channel/monitor QoL

### DIFF
--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -11,6 +11,7 @@
 #define MESSAGE_TYPE_SYSTEM "system"
 #define MESSAGE_TYPE_LOCALCHAT "localchat"
 #define MESSAGE_TYPE_RADIO "radio"
+#define MESSAGE_TYPE_ENTERTAINMENT = "entertainment"
 #define MESSAGE_TYPE_INFO "info"
 #define MESSAGE_TYPE_WARNING "warning"
 #define MESSAGE_TYPE_DEADCHAT "deadchat"

--- a/code/__DEFINES/chat.dm
+++ b/code/__DEFINES/chat.dm
@@ -11,7 +11,7 @@
 #define MESSAGE_TYPE_SYSTEM "system"
 #define MESSAGE_TYPE_LOCALCHAT "localchat"
 #define MESSAGE_TYPE_RADIO "radio"
-#define MESSAGE_TYPE_ENTERTAINMENT = "entertainment"
+#define MESSAGE_TYPE_ENTERTAINMENT "entertainment"
 #define MESSAGE_TYPE_INFO "info"
 #define MESSAGE_TYPE_WARNING "warning"
 #define MESSAGE_TYPE_DEADCHAT "deadchat"

--- a/code/game/machinery/computer/telescreen.dm
+++ b/code/game/machinery/computer/telescreen.dm
@@ -43,10 +43,19 @@
 	circuit = null
 	interaction_flags_atom = INTERACT_ATOM_UI_INTERACT | INTERACT_ATOM_NO_FINGERPRINT_INTERACT | INTERACT_ATOM_NO_FINGERPRINT_ATTACK_HAND | INTERACT_MACHINE_REQUIRES_SIGHT
 	frame_type = /obj/item/wallframe/telescreen/entertainment
-	var/icon_state_off = "entertainment_blank"
-	var/icon_state_on = "entertainment"
 	/// Virtual radio inside of the entertainment monitor to broadcast audio
 	var/obj/item/radio/entertainment/speakers/speakers
+	var/icon_state_off = "entertainment_blank"
+	var/icon_state_on = "entertainment"
+
+/obj/machinery/computer/security/telescreen/entertainment/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+	context[SCREENTIP_CONTEXT_CTRL_LMB] = "Toggle mute button"
+	return CONTEXTUAL_SCREENTIP_SET
+
+/obj/machinery/computer/security/telescreen/entertainment/CtrlClick(mob/user)
+	. = ..()
+	balloon_alert(user, speakers.should_be_listening ? "muted" : "unmuted")
+	speakers.toggle_mute()
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertainment, 32)
 
@@ -58,26 +67,78 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 
 /obj/machinery/computer/security/telescreen/entertainment/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, COMSIG_CLICK, PROC_REF(BigClick))
-	RegisterSignal(SSdcs, COMSIG_GLOB_NETWORK_BROADCAST_UPDATED, PROC_REF(on_network_broadcast_updated)) // monkestation edit: convert to signal handler
+	find_and_hang_on_wall()
+	register_context()
+	RegisterSignal(SSdcs, COMSIG_GLOB_NETWORK_BROADCAST_UPDATED, PROC_REF(on_network_broadcast_updated))
 	speakers = new(src)
 
 /obj/machinery/computer/security/telescreen/entertainment/Destroy()
-	UnregisterSignal(SSdcs, COMSIG_GLOB_NETWORK_BROADCAST_UPDATED) // monkestation edit: convert to signal handler
+	UnregisterSignal(SSdcs, COMSIG_GLOB_NETWORK_BROADCAST_UPDATED)
 	QDEL_NULL(speakers)
 	return ..()
 
-// Bypass clickchain to allow humans to use the telescreen from a distance
-/obj/machinery/computer/security/telescreen/entertainment/proc/BigClick()
-	SIGNAL_HANDLER
+/obj/machinery/computer/security/telescreen/entertainment/examine(mob/user)
+	. = ..()
+	. += length(network) ? span_notice("The TV is broadcasting something!") : span_notice("<i>There's nothing on TV.</i>")
+	. += span_notice("The volume is currently [speakers.should_be_listening ? "on" : "off"]")
 
-	if(!length(network))
-		balloon_alert(usr, "nothing on TV!")
+/obj/machinery/computer/security/telescreen/entertainment/ui_state(mob/user)
+	return GLOB.always_state
+
+// Snowflake ui status to allow mobs to watch TV from across the room,
+// but only allow adjacent mobs / tk users / silicon to change the channel
+/obj/machinery/computer/security/telescreen/entertainment/ui_status(mob/living/user, datum/ui_state/state)
+	if(!can_watch_tv(user))
+		return UI_CLOSE
+	if(!isliving(user))
+		return isAdminGhostAI(user) ? UI_INTERACTIVE : UI_UPDATE
+	if(user.stat >= SOFT_CRIT)
+		return UI_UPDATE
+
+	var/can_range = FALSE
+	if(iscarbon(user))
+		var/mob/living/carbon/carbon_user = user
+		if(carbon_user.dna?.check_mutation(/datum/mutation/human/telekinesis) && tkMaxRangeCheck(user, src))
+			can_range = TRUE
+	if(user.has_unlimited_silicon_privilege || (user.interaction_range && user.interaction_range >= get_dist(user, src)))
+		can_range = TRUE
+
+	if((can_range || user.CanReach(src)) && ISADVANCEDTOOLUSER(user))
+		if(user.incapacitated())
+			return UI_UPDATE
+		if(!can_range && user.can_hold_items() && (user.usable_hands <= 0 || HAS_TRAIT(user, TRAIT_HANDS_BLOCKED)))
+			return UI_UPDATE
+		return UI_INTERACTIVE
+	return UI_UPDATE
+
+/obj/machinery/computer/security/telescreen/entertainment/Click(location, control, params)
+	if(world.time <= usr.next_click + 1)
+		return // just so someone can't turn an auto clicker on and spam tvs
+
+	. = ..()
+	if(!can_watch_tv(usr))
 		return
-
+	if((!length(network) && !Adjacent(usr)) || LAZYACCESS(params2list(params), SHIFT_CLICK)) // let people examine
+		return
+	// Lets us see the tv regardless of click results
 	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom, interact), usr)
 
-///Sets the monitor's icon to the selected state, and says an announcement
+/obj/machinery/computer/security/telescreen/entertainment/proc/can_watch_tv(mob/living/watcher)
+	if(!is_operational)
+		return FALSE
+	if((watcher.sight & SEE_OBJS) || watcher.has_unlimited_silicon_privilege)
+		if(get_dist(watcher, src) > 7)
+			return FALSE
+	else
+		if(!can_see(watcher, src, 7))
+			return FALSE
+	if(watcher.is_blind())
+		return FALSE
+	if(!isobserver(watcher) && watcher.stat >= UNCONSCIOUS)
+		return FALSE
+	return TRUE
+
+/// Sets the monitor's icon to the selected state, and says an announcement
 /obj/machinery/computer/security/telescreen/entertainment/proc/notify(on, announcement)
 	if(on && icon_state == icon_state_off)
 		icon_state = icon_state_on
@@ -87,7 +148,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 		say(announcement)
 
 /// Adds a camera network ID to the entertainment monitor, and turns off the monitor if network list is empty
-/obj/machinery/computer/security/telescreen/entertainment/proc/on_network_broadcast_updated(datum/source, tv_show_id, is_show_active, announcement) // monkestation edit: convert to signal handler
+/obj/machinery/computer/security/telescreen/entertainment/proc/on_network_broadcast_updated(datum/source, tv_show_id, is_show_active, announcement)
 	SIGNAL_HANDLER
 	if(!network)
 		return
@@ -97,7 +158,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
 	else
 		network -= tv_show_id
 
-	INVOKE_ASYNC(src, TYPE_PROC_REF(/datum, update_static_data_for_all_viewers)) // monkestation edit: ensure static data is always updated
+	INVOKE_ASYNC(src, TYPE_PROC_REF(/datum, update_static_data_for_all_viewers))
 	notify(length(network), announcement)
 
 /**
@@ -108,14 +169,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/computer/security/telescreen/entertai
  */
 /proc/start_broadcasting_network(camera_net, announcement)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NETWORK_BROADCAST_UPDATED, camera_net, TRUE, announcement)
-/* monkestation edit: convert to global signal
-	for(var/obj/machinery/computer/security/telescreen/entertainment/tv as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/computer/security/telescreen/entertainment))
-		tv.update_shows(
-			is_show_active = TRUE,
-			tv_show_id = camera_net,
-			announcement = announcement,
-		)
-monkestation end */
 
 /**
  * Removes a camera network from all entertainment monitors.
@@ -125,14 +178,6 @@ monkestation end */
  */
 /proc/stop_broadcasting_network(camera_net, announcement)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NETWORK_BROADCAST_UPDATED, camera_net, FALSE, announcement)
-/* monkestation edit: convert to global signal
-	for(var/obj/machinery/computer/security/telescreen/entertainment/tv as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/computer/security/telescreen/entertainment))
-		tv.update_shows(
-			is_show_active = FALSE,
-			tv_show_id = camera_net,
-			announcement = announcement,
-		)
-monkestation end */
 
 /**
  * Sets the camera network status on all entertainment monitors.
@@ -147,14 +192,6 @@ monkestation end */
  */
 /proc/set_network_broadcast_status(camera_net, is_show_active, announcement)
 	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_NETWORK_BROADCAST_UPDATED, camera_net, is_show_active, announcement)
-/* monkestation edit: convert to global signal
-	for(var/obj/machinery/computer/security/telescreen/entertainment/tv as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/computer/security/telescreen/entertainment))
-		tv.update_shows(
-			is_show_active = is_show_active,
-			tv_show_id = camera_net,
-			announcement = announcement,
-		)
-monkestation end */
 
 /obj/machinery/computer/security/telescreen/rd
 	name = "\improper Research Director's telescreen"

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -631,6 +631,9 @@
 	should_be_listening = TRUE
 	should_be_broadcasting = FALSE
 
+/obj/item/radio/entertainment/speakers/proc/toggle_mute()
+	should_be_listening = !should_be_listening
+
 /obj/item/radio/entertainment/speakers/Initialize(mapload)
 	. = ..()
 	set_broadcasting(FALSE)

--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -24,6 +24,7 @@ export const MESSAGE_TYPE_INTERNAL = 'internal';
 export const MESSAGE_TYPE_SYSTEM = 'system';
 export const MESSAGE_TYPE_LOCALCHAT = 'localchat';
 export const MESSAGE_TYPE_RADIO = 'radio';
+export const MESSAGE_TYPE_ENTERTAINMENT = 'entertainment';
 export const MESSAGE_TYPE_INFO = 'info';
 export const MESSAGE_TYPE_WARNING = 'warning';
 export const MESSAGE_TYPE_DEADCHAT = 'deadchat';
@@ -62,7 +63,13 @@ export const MESSAGE_TYPES = [
     description: 'All departments of radio messages',
     selector:
       //      '.alert, .minorannounce, .syndradio, .centcomradio, .aiprivradio, .enteradio, .comradio, .secradio, .gangradio, .engradio, .medradio, .sciradio, .suppradio, .servradio, .radio, .deptradio, .binarysay, .newscaster, .resonate, .abductor, .alien, .changeling', MONKESTATION EDIT CHANGE OLD
-      '.alert, .minorannounce, .syndradio, .centcomradio, .aiprivradio, .enteradio, .comradio, .secradio, .gangradio, .engradio, .medradio, .sciradio, .suppradio, .servradio, .radio, .deptradio, .binarysay, .newscaster, .resonate, .abductor, .alien, .changeling, .radioradio .uncommonradio', // MONKESTATION EDIT CHANGE NEW
+      '.alert, .minorannounce, .syndradio, .centcomradio, .aiprivradio, .comradio, .secradio, .gangradio, .engradio, .medradio, .sciradio, .suppradio, .servradio, .radio, .deptradio, .binarysay, .resonate, .abductor, .alien, .changeling, .radioradio .uncommonradio', // MONKESTATION EDIT CHANGE NEW
+  },
+  {
+    type: MESSAGE_TYPE_ENTERTAINMENT,
+    name: 'Entertainment',
+    description: 'Entertainment and newscaster broadcasts',
+    selector: '.enteradio, .newscaster',
   },
   {
     type: MESSAGE_TYPE_INFO,

--- a/tgui/packages/tgui-panel/chat/constants.js
+++ b/tgui/packages/tgui-panel/chat/constants.js
@@ -63,7 +63,7 @@ export const MESSAGE_TYPES = [
     description: 'All departments of radio messages',
     selector:
       //      '.alert, .minorannounce, .syndradio, .centcomradio, .aiprivradio, .enteradio, .comradio, .secradio, .gangradio, .engradio, .medradio, .sciradio, .suppradio, .servradio, .radio, .deptradio, .binarysay, .newscaster, .resonate, .abductor, .alien, .changeling', MONKESTATION EDIT CHANGE OLD
-      '.alert, .minorannounce, .syndradio, .centcomradio, .aiprivradio, .comradio, .secradio, .gangradio, .engradio, .medradio, .sciradio, .suppradio, .servradio, .radio, .deptradio, .binarysay, .resonate, .abductor, .alien, .changeling, .radioradio .uncommonradio', // MONKESTATION EDIT CHANGE NEW
+      '.alert, .minorannounce, .syndradio, .centcomradio, .aiprivradio, .comradio, .secradio, .gangradio, .engradio, .medradio, .sciradio, .suppradio, .servradio, .radio, .deptradio, .binarysay, .resonate, .abductor, .alien, .changeling, .radioradio, .uncommonradio', // MONKESTATION EDIT CHANGE NEW
   },
   {
     type: MESSAGE_TYPE_ENTERTAINMENT,


### PR DESCRIPTION
## About The Pull Request

Ports the following PRs from tg:
- https://github.com/tgstation/tgstation/pull/88712
- https://github.com/tgstation/tgstation/pull/86543
- https://github.com/tgstation/tgstation/pull/87445
- https://github.com/tgstation/tgstation/pull/88036

Also includes a fix of my own where the radio and uncommon channels wouldn't properly filter into the Radio chat tab, and removed some modularization comments with entertainment monitors, bc the changes were upstreamed to tg.

## Why It's Good For The Game

fixes some minor gripes people had with this

## Changelog
:cl:
fix: The Radio and Uncommon channels will now properly appear under "Radio" chat tabs.
qol: (LT3) Entertainment and newscaster broadcasts can be toggled in chat tabs.
qol: (Melbert) You can watch entertainment monitors from up to seven tiles away, though you still need to be adjacent (or telekinetic, or a silicon) if you want to change the channel.
qol: (grungussuss) you can now turn off the volume on an entertainment monitor
/:cl:
