### PR TITLE
fix: don't dementor admins when deadmining

### DIFF
--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -110,8 +110,9 @@ GLOBAL_PROTECT(href_token)
 	GLOB.admin_datums -= target
 	QDEL_NULL(plane_debug)
 
-	if(owner)
-		dementor(owner)
+	// MONKESTATION REMOVAL
+	//if(owner)
+	//	dementor(owner)
 	deadmined = TRUE
 
 	var/client/client = owner || GLOB.directory[target]


### PR DESCRIPTION

## About The Pull Request

This removes two lines from the admin holder so that when the admin deadmins, it doesn't remove their mentor status. They can always deactivate it in the mentor tab if they don't want to mentor, but this just makes it so that they **always** have a mentor datum.
## Why It's Good For The Game

yes

## Changelog
:cl:
fix: don't dementor admins when deadmining
/:cl:
