### PR TITLE
Removes stolen CC clothes from reps closet

### DIFF
--- a/monkestation/code/game/objects/structures/crates_lockers/closets/secure/nanotrasen_rep.dm
+++ b/monkestation/code/game/objects/structures/crates_lockers/closets/secure/nanotrasen_rep.dm
@@ -6,7 +6,6 @@
 
 /obj/structure/closet/secure_closet/nanotrasen_representative/PopulateContents()
 	..()
-	new /obj/item/storage/bag/garment/stolen(src)
 	new /obj/item/storage/backpack/satchel/leather(src)
 	new /obj/item/storage/photo_album/personal(src)
 	new /obj/item/assembly/flash(src)

--- a/monkestation/code/modules/NTrep/clothing/NTrep_clothing.dm
+++ b/monkestation/code/modules/NTrep/clothing/NTrep_clothing.dm
@@ -76,17 +76,3 @@
 	new /obj/item/clothing/suit/armor/vest/nanotrasen_representative(src)
 	new /obj/item/clothing/gloves/color/black(src)
 	new /obj/item/clothing/shoes/laceup(src)
-
-/obj/item/storage/bag/garment/stolen
-	name = "stolen garment bag"
-	desc = "Somewhere a CentCom commander is livid about their drycleaning going missing."
-
-/obj/item/storage/bag/garment/stolen/PopulateContents()
-	new /obj/item/clothing/head/hats/centhat(src)
-	new /obj/item/clothing/under/rank/centcom/commander(src)
-	new /obj/item/clothing/suit/armor/centcom_formal(src)
-	new /obj/item/clothing/gloves/tackler/combat(src)
-	new /obj/item/clothing/shoes/laceup(src)
-
-
-

--- a/monkestation/code/modules/blueshift/structures/locker.dm
+++ b/monkestation/code/modules/blueshift/structures/locker.dm
@@ -24,7 +24,6 @@
 
 /obj/structure/closet/secure_closet/nanotrasen_consultant/PopulateContents()
 	..()
-	new /obj/item/storage/bag/garment/stolen(src)
 	new /obj/item/storage/backpack/satchel/leather(src)
 	new /obj/item/storage/photo_album/personal(src)
 	new /obj/item/assembly/flash(src)


### PR DESCRIPTION

## About The Pull Request
Title, also gets ride of the item from the code. Partial atomization of #5052 
## Why It's Good For The Game
No one but the rep would know that the gear is supposed to be stolen, and them wearing it makes it look like they have more authority then they actually do. This helps let people know they don't have the same authority as a CC commander by preventing them from wearing the same armor as one.
## Changelog
:cl:
del: Removed the stolen CC clothes from the nanotrasen reps closet.
/:cl:
