### PR TITLE
Duct-tape some more bloodsucker jank by preventing them from being mindswapped

### DIFF
--- a/code/modules/spells/spell_types/pointed/mind_transfer.dm
+++ b/code/modules/spells/spell_types/pointed/mind_transfer.dm
@@ -42,6 +42,12 @@
 		return FALSE
 	if(!isliving(owner))
 		return FALSE
+	// monkestation start: prevent mindswap if you have TRAIT_NO_MINDSWAP
+	if(HAS_TRAIT(owner, TRAIT_NO_MINDSWAP))
+		if(feedback)
+			to_chat(owner, span_warning("Your mind can't be swapped!"))
+		return FALSE
+	// monkestation end
 	if(HAS_TRAIT(owner, TRAIT_SUICIDED))
 		if(feedback)
 			to_chat(owner, span_warning("You're killing yourself! You can't concentrate enough to do this!"))

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
@@ -82,6 +82,10 @@
 		/datum/antagonist/changeling,
 		/datum/antagonist/cult,
 	)
+	/// Traits that don't get removed by Masquerade
+	var/static/list/always_traits = list(
+		TRAIT_NO_MINDSWAP, // mindswapping bloodsuckers is buggy af and I'm too lazy to properly fix it. ~Absolucy
+	)
 	///Default Bloodsucker traits
 	var/static/list/bloodsucker_traits = list(
 		TRAIT_NOBREATH,
@@ -282,8 +286,8 @@
 		new_right_arm.unarmed_damage_high = old_right_arm_unarmed_damage_high
 
 	//Give Bloodsucker Traits
-	old_body?.remove_traits(bloodsucker_traits, BLOODSUCKER_TRAIT)
-	new_body.add_traits(bloodsucker_traits, BLOODSUCKER_TRAIT)
+	old_body?.remove_traits(bloodsucker_traits + always_traits, BLOODSUCKER_TRAIT)
+	new_body.add_traits(bloodsucker_traits + always_traits, BLOODSUCKER_TRAIT)
 
 /datum/antagonist/bloodsucker/greet()
 	. = ..()
@@ -437,7 +441,7 @@
 		user_right_arm.unarmed_damage_low += 1 //lowest possible punch damage - 0
 		user_right_arm.unarmed_damage_high += 1 //highest possible punch damage - 9
 	//Give Bloodsucker Traits
-	owner.current.add_traits(bloodsucker_traits, BLOODSUCKER_TRAIT)
+	owner.current.add_traits(bloodsucker_traits + always_traits, BLOODSUCKER_TRAIT)
 	//Clear Addictions
 	for(var/addiction_type in subtypesof(/datum/addiction))
 		owner.current.mind.remove_addiction_points(addiction_type, MAX_ADDICTION_POINTS)
@@ -474,7 +478,7 @@
 		var/datum/species/user_species = user.dna.species
 		user_species.inherent_traits -= TRAIT_DRINKS_BLOOD
 	// Remove all bloodsucker traits
-	owner.current.remove_traits(bloodsucker_traits, BLOODSUCKER_TRAIT)
+	owner.current.remove_traits(bloodsucker_traits + always_traits, BLOODSUCKER_TRAIT)
 	// Update Health
 	owner.current.setMaxHealth(initial(owner.current.maxHealth))
 	// Language

--- a/monkestation/code/modules/spells/spell_types/aoe_spell/mind_swap.dm
+++ b/monkestation/code/modules/spells/spell_types/aoe_spell/mind_swap.dm
@@ -44,6 +44,12 @@
 		return FALSE
 	if(!isliving(owner))
 		return FALSE
+	// monkestation start: prevent mindswap if you have TRAIT_NO_MINDSWAP
+	if(HAS_TRAIT(owner, TRAIT_NO_MINDSWAP))
+		if(feedback)
+			to_chat(owner, span_warning("Your mind can't be swapped!"))
+		return FALSE
+	// monkestation end
 	if(HAS_TRAIT(owner, TRAIT_SUICIDED))
 		if(feedback)
 			to_chat(owner, span_warning("You're killing yourself! You can't concentrate enough to do this!"))


### PR DESCRIPTION
## About The Pull Request

so turns out, mindswapping with bloodsuckers is a bugfest

(from @ThePooba)
> holy fuck a vampire mindswapped a blood brother
> and the mindswapped is perma dead in a dead vampire
> thar cant revive
> oh my god he was a bloodsucker without the datum

and I do not want to refactor this shitcode right now. so here's a duct-tape fix. no more mindswapping bloodsuckers

## Why It's Good For The Game

im not sure it is

## Changelog
:cl:
fix: "Fixed" some further bloodsucker jank caused by mindswapping.
/:cl:
