### PR TITLE
[PORTS] HUD Screen stuff

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -558,7 +558,7 @@
 	M.Scale(px/sx, py/sy)
 	transform = M
 
-/atom/movable/screen/click_catcher/Initialize(mapload)
+/atom/movable/screen/click_catcher/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	RegisterSignal(SSmapping, COMSIG_PLANE_OFFSET_INCREASE, PROC_REF(offset_increased))
 	offset_increased(SSmapping, 0, SSmapping.max_plane_offset)

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -276,12 +276,12 @@
 
 /atom/movable/screen/button_palette/Destroy()
 	if(our_hud)
-		our_hud.mymob?.client?.screen -= src
+		our_hud.mymob?.canon_client?.screen -= src
 		our_hud.toggle_palette = null
 		our_hud = null
 	return ..()
 
-/atom/movable/screen/button_palette/Initialize(mapload)
+/atom/movable/screen/button_palette/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	update_appearance()
 
@@ -441,7 +441,7 @@ GLOBAL_LIST_INIT(palette_removed_matrix, list(1.4,0,0,0, 0.7,0.4,0,0, 0.4,0,0.6,
 
 /atom/movable/screen/palette_scroll/down/Destroy()
 	if(our_hud)
-		our_hud.mymob?.client?.screen -= src
+		our_hud.mymob?.canon_client?.screen -= src
 		our_hud.palette_down = null
 		our_hud = null
 	return ..()
@@ -454,7 +454,7 @@ GLOBAL_LIST_INIT(palette_removed_matrix, list(1.4,0,0,0, 0.7,0.4,0,0, 0.4,0,0.6,
 
 /atom/movable/screen/palette_scroll/up/Destroy()
 	if(our_hud)
-		our_hud.mymob?.client?.screen -= src
+		our_hud.mymob?.canon_client?.screen -= src
 		our_hud.palette_up = null
 		our_hud = null
 	return ..()
@@ -472,7 +472,7 @@ GLOBAL_LIST_INIT(palette_removed_matrix, list(1.4,0,0,0, 0.7,0.4,0,0, 0.4,0,0.6,
 /atom/movable/screen/action_landing/Destroy()
 	if(owner)
 		owner.landing = null
-		owner?.owner?.mymob?.client?.screen -= src
+		owner?.owner?.mymob?.canon_client?.screen -= src
 		owner.refresh_actions()
 		owner = null
 	return ..()

--- a/code/_onclick/hud/ai.dm
+++ b/code/_onclick/hud/ai.dm
@@ -183,106 +183,89 @@
 	var/mob/living/silicon/ai/myai = mymob
 
 // Language menu
-	using = new /atom/movable/screen/language_menu
+	using = new /atom/movable/screen/language_menu(null, src)
 	using.screen_loc = ui_ai_language_menu
-	using.hud = src
 	static_inventory += using
 
 //AI core
-	using = new /atom/movable/screen/ai/aicore()
+	using = new /atom/movable/screen/ai/aicore(null, src)
 	using.screen_loc = ui_ai_core
-	using.hud = src
 	static_inventory += using
 
 //Camera list
-	using = new /atom/movable/screen/ai/camera_list()
+	using = new /atom/movable/screen/ai/camera_list(null, src)
 	using.screen_loc = ui_ai_camera_list
-	using.hud = src
 	static_inventory += using
 
 //Track
-	using = new /atom/movable/screen/ai/camera_track()
+	using = new /atom/movable/screen/ai/camera_track(null, src)
 	using.screen_loc = ui_ai_track_with_camera
-	using.hud = src
 	static_inventory += using
 
 //Camera light
-	using = new /atom/movable/screen/ai/camera_light()
+	using = new /atom/movable/screen/ai/camera_light(null, src)
 	using.screen_loc = ui_ai_camera_light
-	using.hud = src
 	static_inventory += using
 
 //Crew Monitoring
-	using = new /atom/movable/screen/ai/crew_monitor()
+	using = new /atom/movable/screen/ai/crew_monitor(null, src)
 	using.screen_loc = ui_ai_crew_monitor
-	using.hud = src
 	static_inventory += using
 
 //Crew Manifest
-	using = new /atom/movable/screen/ai/crew_manifest()
+	using = new /atom/movable/screen/ai/crew_manifest(null, src)
 	using.screen_loc = ui_ai_crew_manifest
-	using.hud = src
 	static_inventory += using
 
 //Alerts
-	using = new /atom/movable/screen/ai/alerts()
+	using = new /atom/movable/screen/ai/alerts(null, src)
 	using.screen_loc = ui_ai_alerts
-	using.hud = src
 	static_inventory += using
 
 //Announcement
-	using = new /atom/movable/screen/ai/announcement()
+	using = new /atom/movable/screen/ai/announcement(null, src)
 	using.screen_loc = ui_ai_announcement
-	using.hud = src
 	static_inventory += using
 
 //Shuttle
-	using = new /atom/movable/screen/ai/call_shuttle()
+	using = new /atom/movable/screen/ai/call_shuttle(null, src)
 	using.screen_loc = ui_ai_shuttle
-	using.hud = src
 	static_inventory += using
 
 //Laws
-	using = new /atom/movable/screen/ai/state_laws()
+	using = new /atom/movable/screen/ai/state_laws(null, src)
 	using.screen_loc = ui_ai_state_laws
-	using.hud = src
 	static_inventory += using
 
 // Modular Interface
-	using = new /atom/movable/screen/ai/modpc()
+	using = new /atom/movable/screen/ai/modpc(null, src)
 	using.screen_loc = ui_ai_mod_int
-	using.hud = src
 	static_inventory += using
 	myai.interfaceButton = using
 	var/atom/movable/screen/ai/modpc/tabletbutton = using
 	tabletbutton.robot = myai
 
 //Take image
-	using = new /atom/movable/screen/ai/image_take()
+	using = new /atom/movable/screen/ai/image_take(null, src)
 	using.screen_loc = ui_ai_take_picture
-	using.hud = src
 	static_inventory += using
 
 //View images
-	using = new /atom/movable/screen/ai/image_view()
+	using = new /atom/movable/screen/ai/image_view(null, src)
 	using.screen_loc = ui_ai_view_images
-	using.hud = src
 	static_inventory += using
 
 //Medical/Security sensors
-	using = new /atom/movable/screen/ai/sensors()
+	using = new /atom/movable/screen/ai/sensors(null, src)
 	using.screen_loc = ui_ai_sensor
-	using.hud = src
 	static_inventory += using
 
 //Multicamera mode
-	using = new /atom/movable/screen/ai/multicam()
+	using = new /atom/movable/screen/ai/multicam(null, src)
 	using.screen_loc = ui_ai_multicam
-	using.hud = src
 	static_inventory += using
 
 //Add multicamera camera
-	using = new /atom/movable/screen/ai/add_multicam()
+	using = new /atom/movable/screen/ai/add_multicam(null, src)
 	using.screen_loc = ui_ai_add_multicam
-	using.hud = src
 	static_inventory += using

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -639,7 +639,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	var/angle = 0
 	var/mob/living/basic/construct/Cviewer
 
-/atom/movable/screen/alert/bloodsense/Initialize(mapload)
+/atom/movable/screen/alert/bloodsense/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	narnar = new('icons/hud/screen_alert.dmi', "mini_nar")
 	START_PROCESSING(SSprocessing, src)
@@ -766,7 +766,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	desc = "Unit's power cell has no charge remaining. No modules available until power cell is recharged."
 	icon_state = "empty_cell"
 
-/atom/movable/screen/alert/emptycell/Initialize(mapload)
+/atom/movable/screen/alert/emptycell/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	update_appearance(updates=UPDATE_DESC)
 
@@ -781,7 +781,7 @@ or shoot a gun to move around via Newton's 3rd Law of Motion."
 	desc = "Unit's power cell is running low."
 	icon_state = "low_cell"
 
-/atom/movable/screen/alert/lowcell/Initialize(mapload)
+/atom/movable/screen/alert/lowcell/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	update_appearance(updates=UPDATE_DESC)
 

--- a/code/_onclick/hud/alien.dm
+++ b/code/_onclick/hud/alien.dm
@@ -37,18 +37,16 @@
 
 //begin buttons
 
-	using = new /atom/movable/screen/swap_hand()
+	using = new /atom/movable/screen/swap_hand(null, src)
 	using.icon = ui_style
 	using.icon_state = "swap_1"
 	using.screen_loc = ui_swaphand_position(owner,1)
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/swap_hand()
+	using = new /atom/movable/screen/swap_hand(null, src)
 	using.icon = ui_style
 	using.icon_state = "swap_2"
 	using.screen_loc = ui_swaphand_position(owner,2)
-	using.hud = src
 	static_inventory += using
 
 	if(isalienhunter(mymob))
@@ -57,64 +55,53 @@
 		H.leap_icon.screen_loc = ui_alien_storage_r
 		static_inventory += H.leap_icon
 
-	using = new/atom/movable/screen/language_menu
+	using = new/atom/movable/screen/language_menu(null, src)
 	using.screen_loc = ui_alien_language_menu
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/navigate
+	using = new /atom/movable/screen/navigate(null, src)
 	using.screen_loc = ui_alien_navigate_menu
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/drop()
+	using = new /atom/movable/screen/drop(null, src)
 	using.icon = ui_style
 	using.screen_loc = ui_drop_throw
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/resist()
+	using = new /atom/movable/screen/resist(null, src)
 	using.icon = ui_style
 	using.screen_loc = ui_above_movement
-	using.hud = src
 	hotkeybuttons += using
 
-	throw_icon = new /atom/movable/screen/throw_catch()
+	throw_icon = new /atom/movable/screen/throw_catch(null, src)
 	throw_icon.icon = ui_style
 	throw_icon.screen_loc = ui_drop_throw
-	throw_icon.hud = src
 	hotkeybuttons += throw_icon
 
-	pull_icon = new /atom/movable/screen/pull()
+	pull_icon = new /atom/movable/screen/pull(null, src)
 	pull_icon.icon = ui_style
 	pull_icon.update_appearance()
 	pull_icon.screen_loc = ui_above_movement
-	pull_icon.hud = src
 	static_inventory += pull_icon
 
 //begin indicators
 
-	healths = new /atom/movable/screen/healths/alien()
-	healths.hud = src
+	healths = new /atom/movable/screen/healths/alien(null, src)
 	infodisplay += healths
 
-	alien_plasma_display = new /atom/movable/screen/alien/plasma_display()
-	alien_plasma_display.hud = src
+	alien_plasma_display = new /atom/movable/screen/alien/plasma_display(null, src)
 	infodisplay += alien_plasma_display
 
 	if(!isalienqueen(mymob))
-		alien_queen_finder = new /atom/movable/screen/alien/alien_queen_finder
-		alien_queen_finder.hud = src
+		alien_queen_finder = new /atom/movable/screen/alien/alien_queen_finder(null, src)
 		infodisplay += alien_queen_finder
 
-	zone_select = new /atom/movable/screen/zone_sel/alien()
-	zone_select.hud = src
+	zone_select = new /atom/movable/screen/zone_sel/alien(null, src)
 	zone_select.update_appearance()
 	static_inventory += zone_select
 
 	for(var/atom/movable/screen/inventory/inv in (static_inventory + toggleable_inventory))
 		if(inv.slot_id)
-			inv.hud = src
 			inv_slots[TOBITSHIFT(inv.slot_id) + 1] = inv
 			inv.update_appearance()
 

--- a/code/_onclick/hud/alien_larva.dm
+++ b/code/_onclick/hud/alien_larva.dm
@@ -6,32 +6,26 @@
 	..()
 	var/atom/movable/screen/using
 
-	healths = new /atom/movable/screen/healths/alien()
-	healths.hud = src
+	healths = new /atom/movable/screen/healths/alien(null, src)
 	infodisplay += healths
 
-	alien_queen_finder = new /atom/movable/screen/alien/alien_queen_finder()
-	alien_queen_finder.hud = src
+	alien_queen_finder = new /atom/movable/screen/alien/alien_queen_finder(null, src)
 	infodisplay += alien_queen_finder
 
-	pull_icon = new /atom/movable/screen/pull()
+	pull_icon = new /atom/movable/screen/pull(null, src)
 	pull_icon.icon = 'icons/hud/screen_alien.dmi'
 	pull_icon.update_appearance()
 	pull_icon.screen_loc = ui_above_movement
-	pull_icon.hud = src
 	hotkeybuttons += pull_icon
 
-	using = new/atom/movable/screen/language_menu
+	using = new/atom/movable/screen/language_menu(null, src)
 	using.screen_loc = ui_alien_language_menu
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/navigate
+	using = new /atom/movable/screen/navigate(null, src)
 	using.screen_loc = ui_alien_navigate_menu
-	using.hud = src
 	static_inventory += using
 
-	zone_select = new /atom/movable/screen/zone_sel/alien()
-	zone_select.hud = src
+	zone_select = new /atom/movable/screen/zone_sel/alien(null, src)
 	zone_select.update_appearance()
 	static_inventory += zone_select

--- a/code/_onclick/hud/blob_overmind.dm
+++ b/code/_onclick/hud/blob_overmind.dm
@@ -51,7 +51,7 @@
 	name = "Produce Blobbernaut (ERROR)"
 	desc = "Produces a strong, smart blobbernaut from a factory blob for (ERROR) resources.<br>The factory blob used will become fragile and unable to produce spores."
 
-/atom/movable/screen/blob/blobbernaut/Initialize(mapload)
+/atom/movable/screen/blob/blobbernaut/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	name = "Produce Blobbernaut ([BLOBMOB_BLOBBERNAUT_RESOURCE_COST])"
 	desc = "Produces a strong, smart blobbernaut from a factory blob for [BLOBMOB_BLOBBERNAUT_RESOURCE_COST] resources.<br>The factory blob used will become fragile and unable to produce spores."
@@ -68,7 +68,7 @@
 	name = "Produce Resource Blob (ERROR)"
 	desc = "Produces a resource blob for ERROR resources.<br>Resource blobs will give you resources every few seconds."
 
-/atom/movable/screen/blob/resource_blob/Initialize(mapload)
+/atom/movable/screen/blob/resource_blob/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	name = "Produce Resource Blob ([BLOB_STRUCTURE_RESOURCE_COST])"
 	desc = "Produces a resource blob for [BLOB_STRUCTURE_RESOURCE_COST] resources.<br>Resource blobs will give you resources every few seconds."
@@ -85,7 +85,7 @@
 	name = "Produce Node Blob (ERROR)"
 	desc = "Produces a node blob for ERROR resources.<br>Node blobs will expand and activate nearby resource and factory blobs."
 
-/atom/movable/screen/blob/node_blob/Initialize(mapload)
+/atom/movable/screen/blob/node_blob/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	name = "Produce Node Blob ([BLOB_STRUCTURE_NODE_COST])"
 	desc = "Produces a node blob for [BLOB_STRUCTURE_NODE_COST] resources.<br>Node blobs will expand and activate nearby resource and factory blobs."
@@ -102,7 +102,7 @@
 	name = "Produce Factory Blob (ERROR)"
 	desc = "Produces a factory blob for ERROR resources.<br>Factory blobs will produce spores every few seconds."
 
-/atom/movable/screen/blob/factory_blob/Initialize(mapload)
+/atom/movable/screen/blob/factory_blob/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	name = "Produce Factory Blob ([BLOB_STRUCTURE_FACTORY_COST])"
 	desc = "Produces a factory blob for [BLOB_STRUCTURE_FACTORY_COST] resources.<br>Factory blobs will produce spores every few seconds."
@@ -141,7 +141,7 @@
 	name = "Relocate Core (ERROR)"
 	desc = "Swaps a node and your core for ERROR resources."
 
-/atom/movable/screen/blob/relocate_core/Initialize(mapload)
+/atom/movable/screen/blob/relocate_core/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	name = "Relocate Core ([BLOB_POWER_RELOCATE_COST])"
 	desc = "Swaps a node and your core for [BLOB_POWER_RELOCATE_COST] resources."
@@ -155,55 +155,45 @@
 	..()
 	var/atom/movable/screen/using
 
-	blobpwrdisplay = new /atom/movable/screen()
+	blobpwrdisplay = new /atom/movable/screen(null, src)
 	blobpwrdisplay.name = "blob power"
 	blobpwrdisplay.icon_state = "block"
 	blobpwrdisplay.screen_loc = ui_health
 	blobpwrdisplay.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	SET_PLANE_EXPLICIT(blobpwrdisplay, ABOVE_HUD_PLANE, owner)
-	blobpwrdisplay.hud = src
 	infodisplay += blobpwrdisplay
 
-	healths = new /atom/movable/screen/healths/blob()
-	healths.hud = src
+	healths = new /atom/movable/screen/healths/blob(null, src)
 	infodisplay += healths
 
-	using = new /atom/movable/screen/blob/jump_to_node()
+	using = new /atom/movable/screen/blob/jump_to_node(null, src)
 	using.screen_loc = ui_inventory
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/blob/jump_to_core()
+	using = new /atom/movable/screen/blob/jump_to_core(null, src)
 	using.screen_loc = ui_zonesel
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/blob/blobbernaut()
+	using = new /atom/movable/screen/blob/blobbernaut(null, src)
 	using.screen_loc = ui_belt
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/blob/resource_blob()
+	using = new /atom/movable/screen/blob/resource_blob(null, src)
 	using.screen_loc = ui_back
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/blob/node_blob()
+	using = new /atom/movable/screen/blob/node_blob(null, src)
 	using.screen_loc = ui_hand_position(2)
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/blob/factory_blob()
+	using = new /atom/movable/screen/blob/factory_blob(null, src)
 	using.screen_loc = ui_hand_position(1)
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/blob/readapt_strain()
+	using = new /atom/movable/screen/blob/readapt_strain(null, src)
 	using.screen_loc = ui_storage1
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/blob/relocate_core()
+	using = new /atom/movable/screen/blob/relocate_core(null, src)
 	using.screen_loc = ui_storage2
-	using.hud = src
 	static_inventory += using

--- a/code/_onclick/hud/blobbernaut.dm
+++ b/code/_onclick/hud/blobbernaut.dm
@@ -1,6 +1,5 @@
 /datum/hud/living/blobbernaut/New(mob/living/owner)
 	. = ..()
 
-	blobpwrdisplay = new /atom/movable/screen/healths/blob/overmind()
-	blobpwrdisplay.hud = src
+	blobpwrdisplay = new /atom/movable/screen/healths/blob/overmind(null, src)
 	infodisplay += blobpwrdisplay

--- a/code/_onclick/hud/drones.dm
+++ b/code/_onclick/hud/drones.dm
@@ -2,29 +2,26 @@
 	..()
 	var/atom/movable/screen/inventory/inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "internal storage"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "suit_storage"
 // inv_box.icon_full = "template"
 	inv_box.screen_loc = ui_drone_storage
 	inv_box.slot_id = ITEM_SLOT_DEX_STORAGE
-	inv_box.hud = src
 	static_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "head/mask"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "mask"
 // inv_box.icon_full = "template"
 	inv_box.screen_loc = ui_drone_head
 	inv_box.slot_id = ITEM_SLOT_HEAD
-	inv_box.hud = src
 	static_inventory += inv_box
 
 	for(var/atom/movable/screen/inventory/inv in (static_inventory + toggleable_inventory))
 		if(inv.slot_id)
-			inv.hud = src
 			inv_slots[TOBITSHIFT(inv.slot_id) + 1] = inv
 			inv.update_appearance()
 

--- a/code/_onclick/hud/ghost.dm
+++ b/code/_onclick/hud/ghost.dm
@@ -58,40 +58,33 @@
 	..()
 	var/atom/movable/screen/using
 
-	using = new /atom/movable/screen/ghost/spawners_menu()
+	using = new /atom/movable/screen/ghost/spawners_menu(null, src)
 	using.screen_loc = ui_ghost_spawners_menu
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/ghost/orbit()
+	using = new /atom/movable/screen/ghost/orbit(null, src)
 	using.screen_loc = ui_ghost_orbit
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/ghost/reenter_corpse()
+	using = new /atom/movable/screen/ghost/reenter_corpse(null, src)
 	using.screen_loc = ui_ghost_reenter_corpse
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/ghost/teleport()
+	using = new /atom/movable/screen/ghost/teleport(null, src)
 	using.screen_loc = ui_ghost_teleport
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/ghost/pai()
+	using = new /atom/movable/screen/ghost/pai(null, src)
 	using.screen_loc = ui_ghost_pai
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/ghost/minigames_menu()
+	using = new /atom/movable/screen/ghost/minigames_menu(null, src)
 	using.screen_loc = ui_ghost_minigames
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/language_menu
+	using = new /atom/movable/screen/language_menu(null, src)
 	using.screen_loc = ui_ghost_language_menu
 	using.icon = ui_style
-	using.hud = src
 	static_inventory += using
 
 /datum/hud/ghost/show_hud(version = 0, mob/viewmob)

--- a/code/_onclick/hud/guardian.dm
+++ b/code/_onclick/hud/guardian.dm
@@ -5,40 +5,33 @@
 	..()
 	var/atom/movable/screen/using
 
-	pull_icon = new /atom/movable/screen/pull()
+	pull_icon = new /atom/movable/screen/pull(null, src)
 	pull_icon.icon = ui_style
 	pull_icon.update_appearance()
 	pull_icon.screen_loc = ui_living_pull
-	pull_icon.hud = src
 	static_inventory += pull_icon
 
-	healths = new /atom/movable/screen/healths/guardian()
-	healths.hud = src
+	healths = new /atom/movable/screen/healths/guardian(null, src)
 	infodisplay += healths
 
-	using = new /atom/movable/screen/guardian/manifest()
+	using = new /atom/movable/screen/guardian/manifest(null, src)
 	using.screen_loc = ui_hand_position(2)
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/guardian/recall()
+	using = new /atom/movable/screen/guardian/recall(null, src)
 	using.screen_loc = ui_hand_position(1)
-	using.hud = src
 	static_inventory += using
 
-	using = new owner.toggle_button_type()
+	using = new owner.toggle_button_type(null, src)
 	using.screen_loc = ui_storage1
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/guardian/toggle_light()
+	using = new /atom/movable/screen/guardian/toggle_light(null, src)
 	using.screen_loc = ui_inventory
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/guardian/communicate()
+	using = new /atom/movable/screen/guardian/communicate(null, src)
 	using.screen_loc = ui_back
-	using.hud = src
 	static_inventory += using
 
 /datum/hud/dextrous/guardian/New(mob/living/basic/guardian/owner) //for a dextrous guardian
@@ -47,56 +40,47 @@
 	if(istype(owner, /mob/living/basic/guardian/dextrous))
 		var/atom/movable/screen/inventory/inv_box
 
-		inv_box = new /atom/movable/screen/inventory()
+		inv_box = new /atom/movable/screen/inventory(null, src)
 		inv_box.name = "internal storage"
 		inv_box.icon = ui_style
 		inv_box.icon_state = "suit_storage"
 		inv_box.screen_loc = ui_id
 		inv_box.slot_id = ITEM_SLOT_DEX_STORAGE
-		inv_box.hud = src
 		static_inventory += inv_box
 
-		using = new /atom/movable/screen/guardian/communicate()
+		using = new /atom/movable/screen/guardian/communicate(null, src)
 		using.screen_loc = ui_sstore1
-		using.hud = src
 		static_inventory += using
 
 	else
 
-		using = new /atom/movable/screen/guardian/communicate()
+		using = new /atom/movable/screen/guardian/communicate(null, src)
 		using.screen_loc = ui_id
-		using.hud = src
 		static_inventory += using
 
-	pull_icon = new /atom/movable/screen/pull()
+	pull_icon = new /atom/movable/screen/pull(null, src)
 	pull_icon.icon = ui_style
 	pull_icon.update_appearance()
 	pull_icon.screen_loc = ui_living_pull
-	pull_icon.hud = src
 	static_inventory += pull_icon
 
-	healths = new /atom/movable/screen/healths/guardian()
-	healths.hud = src
+	healths = new /atom/movable/screen/healths/guardian(null, src)
 	infodisplay += healths
 
-	using = new /atom/movable/screen/guardian/manifest()
+	using = new /atom/movable/screen/guardian/manifest(null, src)
 	using.screen_loc = ui_belt
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/guardian/recall()
+	using = new /atom/movable/screen/guardian/recall(null, src)
 	using.screen_loc = ui_back
-	using.hud = src
 	static_inventory += using
 
-	using = new owner.toggle_button_type()
+	using = new owner.toggle_button_type(null, src)
 	using.screen_loc = ui_storage2
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/guardian/toggle_light()
+	using = new /atom/movable/screen/guardian/toggle_light(null, src)
 	using.screen_loc = ui_inventory
-	using.hud = src
 	static_inventory += using
 
 /datum/hud/dextrous/guardian/persistent_inventory_update()

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -146,7 +146,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 
 /datum/hud/proc/client_refresh(datum/source)
 	SIGNAL_HANDLER
-	var/client/client = mymob.client
+	var/client/client = mymob.canon_client
 	if(client.rebuild_plane_masters)
 		var/new_relay_loc = (client.byond_version > 515) ? "1,1" : "CENTER"
 		for(var/group_key as anything in master_groups)
@@ -472,14 +472,13 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	hand_slots = list()
 	var/atom/movable/screen/inventory/hand/hand_box
 	for(var/i in 1 to mymob.held_items.len)
-		hand_box = new /atom/movable/screen/inventory/hand()
+		hand_box = new /atom/movable/screen/inventory/hand(null, src)
 		hand_box.name = mymob.get_held_index_name(i)
 		hand_box.icon = ui_style
 		hand_box.icon_state = "hand_[mymob.held_index_to_dir(i)]"
 		hand_box.screen_loc = ui_hand_position(i)
 		hand_box.held_index = i
 		hand_slots["[i]"] = hand_box
-		hand_box.hud = src
 		static_inventory += hand_box
 		hand_box.update_appearance()
 
@@ -533,7 +532,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 			palette_actions.insert_action(button, palette_actions.index_of(relative_to))
 		if(SCRN_OBJ_FLOATING) // If we don't have it as a define, this is a screen_loc, and we should be floating
 			floating_actions += button
-			var/client/our_client = mymob.client
+			var/client/our_client = mymob.canon_client
 			if(!our_client)
 				position_action(button, button.linked_action.default_button_position)
 				return
@@ -574,7 +573,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 
 /// Ensures all of our buttons are properly within the bounds of our client's view, moves them if they're not
 /datum/hud/proc/view_audit_buttons()
-	var/our_view = mymob?.client?.view
+	var/our_view = mymob?.canon_client?.view
 	if(!our_view)
 		return
 	listed_actions.check_against_view()
@@ -692,7 +691,7 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 	return "WEST[coord_col]:[coord_col_offset],NORTH[coord_row]:-[pixel_north_offset]"
 
 /datum/action_group/proc/check_against_view()
-	var/owner_view = owner?.mymob?.client?.view
+	var/owner_view = owner?.mymob?.canon_client?.view
 	if(!owner_view)
 		return
 	// Unlikey as it is, we may have been changed. Want to start from our target position and fail down

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -64,266 +64,232 @@
 	var/atom/movable/screen/using
 	var/atom/movable/screen/inventory/inv_box
 
-	using = new/atom/movable/screen/language_menu
+	using = new /atom/movable/screen/language_menu(null, src)
 	using.icon = ui_style
-	using.hud = src
 	static_inventory += using
 
-	using = new/atom/movable/screen/navigate
+	using = new /atom/movable/screen/navigate(null, src)
 	using.icon = ui_style
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/area_creator
+	using = new /atom/movable/screen/area_creator(null, src)
 	using.icon = ui_style
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/mov_intent
+	using = new /atom/movable/screen/mov_intent(null, src)
 	using.icon = ui_style
 	using.icon_state = (mymob.m_intent == MOVE_INTENT_WALK ? "walking" : "running")
 	using.screen_loc = ui_movi
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/drop()
+	using = new /atom/movable/screen/drop(null, src)
 	using.icon = ui_style
 	using.screen_loc = ui_drop_throw
-	using.hud = src
 	static_inventory += using
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "uniform"
 	inv_box.icon = ui_style
 	inv_box.slot_id = ITEM_SLOT_ICLOTHING
 	inv_box.icon_state = "uniform"
 	inv_box.icon_full = "template"
 	inv_box.screen_loc = ui_iclothing
-	inv_box.hud = src
 	toggleable_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "suit"
 	inv_box.icon = ui_style
 	inv_box.slot_id = ITEM_SLOT_OCLOTHING
 	inv_box.icon_state = "suit"
 	inv_box.icon_full = "template"
 	inv_box.screen_loc = ui_oclothing
-	inv_box.hud = src
 	toggleable_inventory += inv_box
 
 	build_hand_slots()
 
-	using = new /atom/movable/screen/swap_hand()
+	using = new /atom/movable/screen/swap_hand(null, src)
 	using.icon = ui_style
 	using.icon_state = "swap_1"
 	using.screen_loc = ui_swaphand_position(owner,1)
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/swap_hand()
+	using = new /atom/movable/screen/swap_hand(null, src)
 	using.icon = ui_style
 	using.icon_state = "swap_2"
 	using.screen_loc = ui_swaphand_position(owner,2)
-	using.hud = src
 	static_inventory += using
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "id"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "id"
 	inv_box.icon_full = "template_small"
 	inv_box.screen_loc = ui_id
 	inv_box.slot_id = ITEM_SLOT_ID
-	inv_box.hud = src
 	static_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "mask"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "mask"
 	inv_box.icon_full = "template"
 	inv_box.screen_loc = ui_mask
 	inv_box.slot_id = ITEM_SLOT_MASK
-	inv_box.hud = src
 	toggleable_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "neck"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "neck"
 	inv_box.icon_full = "template"
 	inv_box.screen_loc = ui_neck
 	inv_box.slot_id = ITEM_SLOT_NECK
-	inv_box.hud = src
 	toggleable_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "back"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "back"
 	inv_box.icon_full = "template_small"
 	inv_box.screen_loc = ui_back
 	inv_box.slot_id = ITEM_SLOT_BACK
-	inv_box.hud = src
 	static_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "left pocket"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "pocket"
 	inv_box.icon_full = "template_small"
 	inv_box.screen_loc = ui_storage1
 	inv_box.slot_id = ITEM_SLOT_LPOCKET
-	inv_box.hud = src
 	static_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "right pocket"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "pocket"
 	inv_box.icon_full = "template_small"
 	inv_box.screen_loc = ui_storage2
 	inv_box.slot_id = ITEM_SLOT_RPOCKET
-	inv_box.hud = src
 	static_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "suit storage"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "suit_storage"
 	inv_box.icon_full = "template"
 	inv_box.screen_loc = ui_sstore1
 	inv_box.slot_id = ITEM_SLOT_SUITSTORE
-	inv_box.hud = src
 	static_inventory += inv_box
 
-	using = new /atom/movable/screen/resist()
+	using = new /atom/movable/screen/resist(null, src)
 	using.icon = ui_style
 	using.screen_loc = ui_above_intent
-	using.hud = src
 	hotkeybuttons += using
 
-	using = new /atom/movable/screen/human/toggle()
+	using = new /atom/movable/screen/human/toggle(null, src)
 	using.icon = ui_style
 	using.screen_loc = ui_inventory
-	using.hud = src
 	static_inventory += using
 
 	using = new /atom/movable/screen/human/equip()
 	using.icon = ui_style
 	using.screen_loc = ui_equip_position(mymob)
-	using.hud = src
 	static_inventory += using
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "gloves"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "gloves"
 	inv_box.icon_full = "template"
 	inv_box.screen_loc = ui_gloves
 	inv_box.slot_id = ITEM_SLOT_GLOVES
-	inv_box.hud = src
 	toggleable_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "eyes"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "glasses"
 	inv_box.icon_full = "template"
 	inv_box.screen_loc = ui_glasses
 	inv_box.slot_id = ITEM_SLOT_EYES
-	inv_box.hud = src
 	toggleable_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "ears"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "ears"
 	inv_box.icon_full = "template"
 	inv_box.screen_loc = ui_ears
 	inv_box.slot_id = ITEM_SLOT_EARS
-	inv_box.hud = src
 	toggleable_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "head"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "head"
 	inv_box.icon_full = "template"
 	inv_box.screen_loc = ui_head
 	inv_box.slot_id = ITEM_SLOT_HEAD
-	inv_box.hud = src
 	toggleable_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "shoes"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "shoes"
 	inv_box.icon_full = "template"
 	inv_box.screen_loc = ui_shoes
 	inv_box.slot_id = ITEM_SLOT_FEET
-	inv_box.hud = src
 	toggleable_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "belt"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "belt"
 	inv_box.icon_full = "template_small"
 	inv_box.screen_loc = ui_belt
 	inv_box.slot_id = ITEM_SLOT_BELT
-	inv_box.hud = src
 	static_inventory += inv_box
 
-	throw_icon = new /atom/movable/screen/throw_catch()
+	throw_icon = new /atom/movable/screen/throw_catch(null, src)
 	throw_icon.icon = ui_style
 	throw_icon.screen_loc = ui_drop_throw
-	throw_icon.hud = src
 	hotkeybuttons += throw_icon
 
-	rest_icon = new /atom/movable/screen/rest()
+	rest_icon = new /atom/movable/screen/rest(null, src)
 	rest_icon.icon = ui_style
 	rest_icon.screen_loc = ui_above_movement
-	rest_icon.hud = src
 	rest_icon.update_appearance()
 	static_inventory += rest_icon
 
-	spacesuit = new /atom/movable/screen/spacesuit
-	spacesuit.hud = src
+	spacesuit = new /atom/movable/screen/spacesuit(null, src)
 	infodisplay += spacesuit
 
-	healths = new /atom/movable/screen/healths()
-	healths.hud = src
+	healths = new /atom/movable/screen/healths(null, src)
 	infodisplay += healths
 
-	healthdoll = new /atom/movable/screen/healthdoll()
-	healthdoll.hud = src
+	healthdoll = new /atom/movable/screen/healthdoll(null, src)
 	infodisplay += healthdoll
 
-	stamina = new /atom/movable/screen/stamina()
-	stamina.hud = src
+	stamina = new /atom/movable/screen/stamina(null, src)
 	infodisplay += stamina
 
-	pull_icon = new /atom/movable/screen/pull()
+	pull_icon = new /atom/movable/screen/pull(null, src)
 	pull_icon.icon = ui_style
 	pull_icon.screen_loc = ui_above_intent
-	pull_icon.hud = src
 	pull_icon.update_appearance()
 	static_inventory += pull_icon
 
-	zone_select = new /atom/movable/screen/zone_sel()
+	zone_select = new /atom/movable/screen/zone_sel(null, src)
 	zone_select.icon = ui_style
-	zone_select.hud = src
 	zone_select.update_appearance()
 	static_inventory += zone_select
 
-	combo_display = new /atom/movable/screen/combo()
+	combo_display = new /atom/movable/screen/combo(null, src)
 	infodisplay += combo_display
 
 	for(var/atom/movable/screen/inventory/inv in (static_inventory + toggleable_inventory))
 		if(inv.slot_id)
-			inv.hud = src
 			inv_slots[TOBITSHIFT(inv.slot_id) + 1] = inv
 			inv.update_appearance()
 

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -192,7 +192,7 @@
 	using.screen_loc = ui_inventory
 	static_inventory += using
 
-	using = new /atom/movable/screen/human/equip()
+	using = new /atom/movable/screen/human/equip(null, src)
 	using.icon = ui_style
 	using.screen_loc = ui_equip_position(mymob)
 	static_inventory += using

--- a/code/_onclick/hud/living.dm
+++ b/code/_onclick/hud/living.dm
@@ -4,17 +4,15 @@
 /datum/hud/living/New(mob/living/owner)
 	..()
 
-	pull_icon = new /atom/movable/screen/pull()
+	pull_icon = new /atom/movable/screen/pull(null, src)
 	pull_icon.icon = ui_style
 	pull_icon.update_appearance()
 	pull_icon.screen_loc = ui_living_pull
-	pull_icon.hud = src
 	static_inventory += pull_icon
 
-	combo_display = new /atom/movable/screen/combo()
+	combo_display = new /atom/movable/screen/combo(null, src)
 	infodisplay += combo_display
 
 	//mob health doll! assumes whatever sprite the mob is
-	healthdoll = new /atom/movable/screen/healthdoll/living()
-	healthdoll.hud = src
+	healthdoll = new /atom/movable/screen/healthdoll/living(null, src)
 	infodisplay += healthdoll

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -121,7 +121,7 @@
 	if(!.)
 		return
 
-	var/datum/preferences/preferences = hud.mymob.client.prefs
+	var/datum/preferences/preferences = hud.mymob.canon_client.prefs
 	preferences.current_window = PREFERENCE_TAB_CHARACTER_PREFERENCES
 	preferences.update_static_data(usr)
 	preferences.ui_interact(usr)
@@ -134,7 +134,7 @@
 	base_icon_state = "not_ready"
 	var/ready = FALSE
 
-/atom/movable/screen/lobby/button/ready/Initialize(mapload)
+/atom/movable/screen/lobby/button/ready/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	switch(SSticker.current_state)
 		if(GAME_STATE_PREGAME, GAME_STATE_STARTUP)
@@ -188,7 +188,7 @@
 	icon_state = "" //Default to not visible
 	base_icon_state = "join_game"
 
-/atom/movable/screen/lobby/button/join/Initialize(mapload)
+/atom/movable/screen/lobby/button/join/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	set_button_status(FALSE)
 	switch(SSticker.current_state)
@@ -267,7 +267,7 @@
 	base_icon_state = "observe"
 	enabled = FALSE
 
-/atom/movable/screen/lobby/button/observe/Initialize(mapload)
+/atom/movable/screen/lobby/button/observe/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	if(SSticker.current_state > GAME_STATE_STARTUP)
 		set_button_status(TRUE)
@@ -351,7 +351,7 @@
 	if(!.)
 		return
 
-	var/datum/preferences/preferences = hud.mymob.client.prefs
+	var/datum/preferences/preferences = hud.mymob.canon_client.prefs
 	preferences.current_window = PREFERENCE_TAB_GAME_PREFERENCES
 	preferences.update_static_data(usr)
 	preferences.ui_interact(usr)

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -54,7 +54,7 @@
 	var/owner
 	var/area/misc/start/lobbyarea
 
-/atom/movable/screen/lobby/button/Initialize(mapload)
+/atom/movable/screen/lobby/button/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	lobbyarea = GLOB.areas_by_type[/area/misc/start]
 
@@ -590,7 +590,7 @@
 	var/static/disabled = FALSE
 	var/static/mutable_appearance/job_overlay
 
-/atom/movable/screen/lobby/overflow_alert/Initialize(mapload)
+/atom/movable/screen/lobby/overflow_alert/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	if(SSticker.current_state == GAME_STATE_STARTUP)
 		RegisterSignal(SSticker, COMSIG_TICKER_ENTER_PREGAME, PROC_REF(initial_setup))

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -471,11 +471,9 @@
 	icon_state = "you_are_here"
 	screen_loc = "TOP,CENTER:-61"
 
-INITIALIZE_IMMEDIATE(/atom/movable/screen/lobby/youarehere)
-
 //Explanation: It gets the port then sets the "here" var in /movable/screen/lobby to the port number
 // and if the port number matches it makes clicking the button do nothing so you dont spam reconnect to the server your in
-/atom/movable/screen/lobby/youarehere/Initialize(mapload)
+/atom/movable/screen/lobby/youarehere/SlowInit(mapload)
 	. = ..()
 	var/port = world.port
 	switch(port)
@@ -499,9 +497,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/lobby/youarehere)
 	/// The port of this server.
 	var/server_port
 
-INITIALIZE_IMMEDIATE(/atom/movable/screen/lobby/button/server)
-
-/atom/movable/screen/lobby/button/server/Initialize(mapload)
+/atom/movable/screen/lobby/button/server/SlowInit(mapload)
 	. = ..()
 	set_button_status(is_available())
 	update_appearance(UPDATE_ICON_STATE)

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -13,9 +13,8 @@
 	for(var/atom/movable/screen/lobby/button_type as anything in buttons)
 		if(button_type::abstract_type == button_type)
 			continue
-		var/atom/movable/screen/lobby/lobbyscreen = new button_type
+		var/atom/movable/screen/lobby/lobbyscreen = new button_type(our_hud = src)
 		lobbyscreen.SlowInit()
-		lobbyscreen.hud = src
 		static_inventory += lobbyscreen
 		if(istype(lobbyscreen, /atom/movable/screen/lobby/button))
 			var/atom/movable/screen/lobby/button/lobby_button = lobbyscreen
@@ -29,6 +28,10 @@
 	var/abstract_type = /atom/movable/screen/lobby
 	var/here
 
+///Set the HUD in New, as lobby screens are made before Atoms are Initialized.
+/atom/movable/screen/lobby/New(loc, datum/hud/our_hud, ...)
+	set_new_hud(our_hud)
+	return ..()
 
 /// Run sleeping actions after initialize
 /atom/movable/screen/lobby/proc/SlowInit()

--- a/code/_onclick/hud/ooze.dm
+++ b/code/_onclick/hud/ooze.dm
@@ -2,14 +2,12 @@
 /datum/hud/ooze/New(mob/living/owner)
 	. = ..()
 
-	zone_select = new /atom/movable/screen/zone_sel()
+	zone_select = new /atom/movable/screen/zone_sel(null, src)
 	zone_select.icon = ui_style
-	zone_select.hud = src
 	zone_select.update_appearance()
 	static_inventory += zone_select
 
-	alien_plasma_display = new /atom/movable/screen/ooze_nutrition_display //Just going to use the alien plasma display because making new vars for each object is braindead.
-	alien_plasma_display.hud = src
+	alien_plasma_display = new /atom/movable/screen/ooze_nutrition_display(null, src) //Just going to use the alien plasma display because making new vars for each object is braindead.
 	infodisplay += alien_plasma_display
 
 /atom/movable/screen/ooze_nutrition_display

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -282,7 +282,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_layer)
 	. = ..()
 	// Parallax layers are independant of hud, they care about client
 	// Not doing this will just create a bunch of hard deletes
-	hud = null
+	set_new_hud(hud_owner = null)
 
 	var/client/boss = hud_owner?.mymob?.canon_client
 	if(!boss) // If this typepath all starts to harddel your culprit is likely this

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -325,7 +325,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_layer)
 	speed = 0.5
 	layer = 1
 
-/atom/movable/screen/parallax_layer/layer_1/Initialize(mapload, mob/owner)
+/atom/movable/screen/parallax_layer/layer_1/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	src.add_atom_colour(GLOB.starlight_color, ADMIN_COLOUR_PRIORITY)
 

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -280,6 +280,10 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_layer)
 
 /atom/movable/screen/parallax_layer/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
+	// Parallax layers are independant of hud, they care about client
+	// Not doing this will just create a bunch of hard deletes
+	hud = null
+
 	var/client/boss = hud_owner?.mymob?.canon_client
 	if(!boss) // If this typepath all starts to harddel your culprit is likely this
 		return INITIALIZE_HINT_QDEL

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -14,15 +14,15 @@
 
 	if(!length(C.parallax_layers_cached))
 		C.parallax_layers_cached = list()
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_1(null, screenmob)
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/stars(null, screenmob) //monkestation edit
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_1(null, src)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/stars(null, src) //monkestation edit
 		/* monkestation removal
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_2(null, screenmob)
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/planet(null, screenmob)
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/nebula(null, screenmob)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_2(null, src)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/planet(null, src)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/nebula(null, src)
 		if(SSparallax.random_layer)
-			C.parallax_layers_cached += new SSparallax.random_layer(null, screenmob)
-		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_3(null, screenmob)
+			C.parallax_layers_cached += new SSparallax.random_layer(null, src)
+		C.parallax_layers_cached += new /atom/movable/screen/parallax_layer/layer_3(null, src)
 		*/ //monkestation removal end
 
 	C.parallax_layers = C.parallax_layers_cached.Copy()
@@ -278,9 +278,9 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_layer)
 	screen_loc = "CENTER-7,CENTER-7"
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
-/atom/movable/screen/parallax_layer/Initialize(mapload, mob/owner)
+/atom/movable/screen/parallax_layer/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
-	var/client/boss = owner?.client
+	var/client/boss = hud_owner?.mymob?.canon_client
 	if(!boss) // If this typepath all starts to harddel your culprit is likely this
 		return INITIALIZE_HINT_QDEL
 
@@ -354,9 +354,9 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_layer)
 /atom/movable/screen/parallax_layer/random/space_gas
 	icon_state = "space_gas"
 
-/atom/movable/screen/parallax_layer/random/space_gas/Initialize(mapload, mob/owner)
+/atom/movable/screen/parallax_layer/random/space_gas/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
-	src.add_atom_colour(SSparallax.random_parallax_color, ADMIN_COLOUR_PRIORITY)
+	add_atom_colour(SSparallax.random_parallax_color, ADMIN_COLOUR_PRIORITY)
 
 /atom/movable/screen/parallax_layer/random/asteroids
 	icon_state = "asteroids"
@@ -368,16 +368,17 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/parallax_layer)
 	speed = 3
 	layer = 30
 
-/atom/movable/screen/parallax_layer/planet/Initialize(mapload, mob/owner)
+/atom/movable/screen/parallax_layer/planet/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
-	if(!owner?.client)
+	var/client/boss = hud_owner?.mymob?.canon_client
+	if(!boss)
 		return
 	var/static/list/connections = list(
 		COMSIG_MOVABLE_Z_CHANGED = PROC_REF(on_z_change),
 		COMSIG_MOB_LOGOUT = PROC_REF(on_mob_logout),
 	)
-	AddComponent(/datum/component/connect_mob_behalf, owner.client, connections)
-	on_z_change(owner)
+	AddComponent(/datum/component/connect_mob_behalf, boss, connections)
+	on_z_change(hud_owner?.mymob)
 
 /atom/movable/screen/parallax_layer/planet/proc/on_mob_logout(mob/source)
 	SIGNAL_HANDLER

--- a/code/_onclick/hud/picture_in_picture.dm
+++ b/code/_onclick/hud/picture_in_picture.dm
@@ -13,7 +13,7 @@
 
 	var/mutable_appearance/standard_background
 
-/atom/movable/screen/movable/pic_in_pic/Initialize(mapload)
+/atom/movable/screen/movable/pic_in_pic/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	make_backgrounds()
 	RegisterSignal(SSmapping, COMSIG_PLANE_OFFSET_INCREASE, PROC_REF(multiz_offset_increase))

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -244,7 +244,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	multiz_scaled = FALSE
 	critical = PLANE_CRITICAL_DISPLAY
 
-/atom/movable/screen/plane_master/clickcatcher/Initialize(mapload, datum/plane_master_group/home, offset)
+/atom/movable/screen/plane_master/clickcatcher/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
 	RegisterSignal(SSmapping, COMSIG_PLANE_OFFSET_INCREASE, PROC_REF(offset_increased))
 	offset_increased(SSmapping, 0, SSmapping.max_plane_offset)
@@ -265,7 +265,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	render_relay_planes = list(RENDER_PLANE_GAME, LIGHT_MASK_PLANE)
 	critical = PLANE_CRITICAL_FUCKO_PARALLAX // goes funny when touched. no idea why I don't trust byond
 
-/atom/movable/screen/plane_master/parallax_white/Initialize(mapload, datum/plane_master_group/home, offset)
+/atom/movable/screen/plane_master/parallax_white/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
 	add_relay_to(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset), relay_layer = EMISSIVE_SPACE_LAYER)
 
@@ -282,7 +282,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	multiz_scaled = FALSE
 
-/atom/movable/screen/plane_master/parallax/Initialize(mapload, datum/plane_master_group/home, offset)
+/atom/movable/screen/plane_master/parallax/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
 	if(offset != 0)
 		// You aren't the source? don't change yourself
@@ -360,7 +360,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	// Needs to be critical or it uh, it'll look white
 	critical = PLANE_CRITICAL_DISPLAY|PLANE_CRITICAL_NO_RELAY
 
-/atom/movable/screen/plane_master/floor/Initialize(mapload, datum/plane_master_group/home, offset)
+/atom/movable/screen/plane_master/floor/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
 	add_relay_to(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset), relay_layer = EMISSIVE_FLOOR_LAYER, relay_color = GLOB.em_block_color)
 
@@ -370,7 +370,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	plane = WALL_PLANE
 	render_relay_planes = list(RENDER_PLANE_GAME_WORLD, LIGHT_MASK_PLANE)
 
-/atom/movable/screen/plane_master/wall/Initialize(mapload, datum/plane_master_group/home, offset)
+/atom/movable/screen/plane_master/wall/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
 	add_relay_to(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset), relay_layer = EMISSIVE_WALL_LAYER, relay_color = GLOB.em_block_color)
 
@@ -406,7 +406,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	// This is safe because we will ALWAYS be on the top z layer, so it DON'T MATTER
 	multiz_scaled = FALSE
 
-/atom/movable/screen/plane_master/field_of_vision_blocker/Initialize(mapload, datum/plane_master_group/home, offset)
+/atom/movable/screen/plane_master/field_of_vision_blocker/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
 	mirror_parent_hidden()
 
@@ -423,7 +423,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	plane = WALL_PLANE_UPPER
 	render_relay_planes = list(RENDER_PLANE_GAME_WORLD, LIGHT_MASK_PLANE)
 
-/atom/movable/screen/plane_master/wall_upper/Initialize(mapload, datum/plane_master_group/home, offset)
+/atom/movable/screen/plane_master/wall_upper/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
 	add_relay_to(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset), relay_layer = EMISSIVE_WALL_LAYER, relay_color = GLOB.em_block_color)
 

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -64,7 +64,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	/// If this plane master is outside of our visual bounds right now
 	var/is_outside_bounds = FALSE
 
-/atom/movable/screen/plane_master/Initialize(mapload, datum/plane_master_group/home, offset = 0)
+/atom/movable/screen/plane_master/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset = 0)
 	. = ..()
 	src.offset = offset
 	true_alpha = alpha
@@ -132,7 +132,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	if(force_hidden)
 		return FALSE
 
-	var/client/our_client = mymob?.client
+	var/client/our_client = mymob?.canon_client
 	// Alright, let's get this out of the way
 	// Mobs can move z levels without their client. If this happens, we need to ensure critical display settings are respected
 	// This is done here. Mild to severe pain but it's nessesary
@@ -386,7 +386,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	plane = GAME_PLANE_FOV_HIDDEN
 	render_relay_planes = list(RENDER_PLANE_GAME_WORLD)
 
-/atom/movable/screen/plane_master/game_world_fov_hidden/Initialize(mapload)
+/atom/movable/screen/plane_master/game_world_fov_hidden/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	add_filter("vision_cone", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(FIELD_OF_VISION_BLOCKER_RENDER_TARGET, offset), flags = MASK_INVERSE))
 
@@ -433,7 +433,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	plane = GAME_PLANE_UPPER_FOV_HIDDEN
 	render_relay_planes = list(RENDER_PLANE_GAME_WORLD)
 
-/atom/movable/screen/plane_master/game_world_upper_fov_hidden/Initialize(mapload)
+/atom/movable/screen/plane_master/game_world_upper_fov_hidden/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	// Dupe of the other hidden plane
 	add_filter("vision_cone", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(FIELD_OF_VISION_BLOCKER_RENDER_TARGET, offset), flags = MASK_INVERSE))
@@ -568,7 +568,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	plane = PIPECRAWL_IMAGES_PLANE
 	start_hidden = TRUE
 
-/atom/movable/screen/plane_master/pipecrawl/Initialize(mapload)
+/atom/movable/screen/plane_master/pipecrawl/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	// Makes everything on this plane slightly brighter
 	// Has a nice effect, makes thing stand out
@@ -595,7 +595,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	// This can call on a cycle cause we don't clear in hide_from
 	// Yes this is the best way of hooking into the hud, I hate myself too
 	RegisterSignal(our_hud, COMSIG_HUD_EYE_CHANGED, PROC_REF(eye_changed), override = TRUE)
-	eye_changed(our_hud, null, our_hud.mymob?.client?.eye)
+	eye_changed(our_hud, null, our_hud.mymob?.canon_client?.eye)
 
 /atom/movable/screen/plane_master/camera_static/proc/eye_changed(datum/hud/source, atom/old_eye, atom/new_eye)
 	SIGNAL_HANDLER
@@ -643,7 +643,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 	if(!.)
 		return
 	remove_filter("AO")
-	if(istype(mymob) && mymob.client?.prefs?.read_preference(/datum/preference/toggle/ambient_occlusion))
+	if(istype(mymob) && mymob.canon_client?.prefs?.read_preference(/datum/preference/toggle/ambient_occlusion))
 		add_filter("AO", 1, drop_shadow_filter(x = 0, y = -2, size = 4, color = "#04080FAA"))
 
 /atom/movable/screen/plane_master/balloon_chat

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -109,7 +109,7 @@
 		for(var/plane_offset in starting_offset to ending_offset)
 			if(plane_offset != 0 && !initial(mytype.allows_offsetting))
 				continue
-			var/atom/movable/screen/plane_master/instance = new mytype(null, src, plane_offset)
+			var/atom/movable/screen/plane_master/instance = new mytype(null, null, src, plane_offset)
 			plane_masters["[instance.plane]"] = instance
 			prep_plane_instance(instance)
 

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -76,7 +76,7 @@
 	plane = RENDER_PLANE_GAME
 	render_relay_planes = list(RENDER_PLANE_MASTER)
 
-/atom/movable/screen/plane_master/rendering_plate/game_plate/Initialize(mapload)
+/atom/movable/screen/plane_master/rendering_plate/game_plate/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	add_filter("displacer", 1, displacement_map_filter(render_source = OFFSET_RENDER_TARGET(GRAVITY_PULSE_RENDER_TARGET, offset), size = 10))
 
@@ -91,7 +91,7 @@
 	plane = RENDER_PLANE_TRANSPARENT
 	appearance_flags = PLANE_MASTER
 
-/atom/movable/screen/plane_master/rendering_plate/transparent/Initialize(mapload, datum/plane_master_group/home, offset)
+/atom/movable/screen/plane_master/rendering_plate/transparent/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
 	// Don't display us if we're below everything else yeah?
 	AddComponent(/datum/component/plane_hide_highest_offset)
@@ -110,7 +110,7 @@
 	if(!.)
 		return
 	remove_filter("AO")
-	if(istype(mymob) && mymob.client?.prefs?.read_preference(/datum/preference/toggle/ambient_occlusion))
+	if(istype(mymob) && mymob.canon_client?.prefs?.read_preference(/datum/preference/toggle/ambient_occlusion))
 		add_filter("AO", 1, drop_shadow_filter(x = 0, y = -2, size = 4, color = "#04080FAA"))
 
 ///Contains all lighting objects
@@ -140,7 +140,7 @@
  * A color matrix filter is applied to the emissive plane to mask out anything that isn't whatever the emissive color is.
  * This is then used to alpha mask the lighting plane.
  */
-/atom/movable/screen/plane_master/rendering_plate/lighting/Initialize(mapload)
+/atom/movable/screen/plane_master/rendering_plate/lighting/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	add_filter("emissives", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(EMISSIVE_RENDER_TARGET, offset), flags = MASK_INVERSE))
 	add_filter("object_lighting", 2, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(O_LIGHTING_VISUAL_RENDER_TARGET, offset), flags = MASK_INVERSE))
@@ -232,7 +232,7 @@
 	render_relay_planes = list()
 	critical = PLANE_CRITICAL_DISPLAY
 
-/atom/movable/screen/plane_master/rendering_plate/emissive_slate/Initialize(mapload, datum/plane_master_group/home, offset)
+/atom/movable/screen/plane_master/rendering_plate/emissive_slate/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
 	add_filter("em_block_masking", 2, color_matrix_filter(GLOB.em_mask_matrix))
 	if(offset != 0)
@@ -333,7 +333,7 @@
 	if(get_relay_to(target_plane))
 		return
 	render_relay_planes += target_plane
-	var/client/display_lad = home?.our_hud?.mymob?.client
+	var/client/display_lad = home?.our_hud?.mymob?.canon_client
 	var/atom/movable/render_plane_relay/relay = generate_relay_to(target_plane, show_to = display_lad, blend_override = blend_override, relay_layer = relay_layer)
 	relay.color = relay_color
 
@@ -383,7 +383,7 @@
 	relays -= existing_relay
 	if(!length(relays) && !initial(render_target))
 		render_target = null
-	var/client/lad = home?.our_hud?.mymob?.client
+	var/client/lad = home?.our_hud?.mymob?.canon_client
 	if(lad)
 		lad.screen -= existing_relay
 

--- a/code/_onclick/hud/revenanthud.dm
+++ b/code/_onclick/hud/revenanthud.dm
@@ -4,13 +4,11 @@
 /datum/hud/revenant/New(mob/owner)
 	..()
 
-	pull_icon = new /atom/movable/screen/pull()
+	pull_icon = new /atom/movable/screen/pull(null, src)
 	pull_icon.icon = ui_style
 	pull_icon.update_appearance()
 	pull_icon.screen_loc = ui_living_pull
-	pull_icon.hud = src
 	static_inventory += pull_icon
 
-	healths = new /atom/movable/screen/healths/revenant()
-	healths.hud = src
+	healths = new /atom/movable/screen/healths/revenant(null, src)
 	infodisplay += healths

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -79,62 +79,52 @@
 	var/mob/living/silicon/robot/robit = mymob
 	var/atom/movable/screen/using
 
-	using = new/atom/movable/screen/language_menu
+	using = new/atom/movable/screen/language_menu(null, src)
 	using.screen_loc = ui_borg_language_menu
 	static_inventory += using
 
 // Navigation
-	using = new /atom/movable/screen/navigate
+	using = new /atom/movable/screen/navigate(null, src)
 	using.screen_loc = ui_borg_navigate_menu
 	static_inventory += using
 
 //Radio
-	using = new /atom/movable/screen/robot/radio()
+	using = new /atom/movable/screen/robot/radio(null, src)
 	using.screen_loc = ui_borg_radio
-	using.hud = src
 	static_inventory += using
 
 //Module select
 	if(!robit.inv1)
-		robit.inv1 = new /atom/movable/screen/robot/module1()
-
+		robit.inv1 = new /atom/movable/screen/robot/module1(null, src)
 	robit.inv1.screen_loc = ui_inv1
-	robit.inv1.hud = src
 	static_inventory += robit.inv1
 
 	if(!robit.inv2)
-		robit.inv2 = new /atom/movable/screen/robot/module2()
-
+		robit.inv2 = new /atom/movable/screen/robot/module2(null, src)
 	robit.inv2.screen_loc = ui_inv2
-	robit.inv2.hud = src
 	static_inventory += robit.inv2
 
 	if(!robit.inv3)
-		robit.inv3 = new /atom/movable/screen/robot/module3()
-
+		robit.inv3 = new /atom/movable/screen/robot/module3(null, src)
 	robit.inv3.screen_loc = ui_inv3
-	robit.inv3.hud = src
 	static_inventory += robit.inv3
 
 //End of module select
-	using = new /atom/movable/screen/robot/lamp()
+	using = new /atom/movable/screen/robot/lamp(null, src)
 	using.screen_loc = ui_borg_lamp
-	using.hud = src
 	static_inventory += using
 	robit.lampButton = using
 	var/atom/movable/screen/robot/lamp/lampscreen = using
 	lampscreen.robot = robit
 
 //Photography stuff
-	using = new /atom/movable/screen/ai/image_take()
+	using = new /atom/movable/screen/ai/image_take(null, src)
 	using.screen_loc = ui_borg_camera
-	using.hud = src
 	static_inventory += using
 
 //Borg Integrated Tablet
-	using = new /atom/movable/screen/robot/modpc()
+	using = new /atom/movable/screen/robot/modpc(null, src)
 	using.screen_loc = ui_borg_tablet
-	using.hud = src
 	static_inventory += using
 	robit.interfaceButton = using
 	if(robit.modularInterface)
@@ -145,37 +135,31 @@
 	tabletbutton.robot = robit
 
 //Alerts
-	using = new /atom/movable/screen/robot/alerts()
+	using = new /atom/movable/screen/robot/alerts(null, src)
 	using.screen_loc = ui_borg_alerts
-	using.hud = src
 	static_inventory += using
 
 //Health
-	healths = new /atom/movable/screen/healths/robot()
-	healths.hud = src
+	healths = new /atom/movable/screen/healths/robot(null, src)
 	infodisplay += healths
 
 //Installed Module
-	robit.hands = new /atom/movable/screen/robot/module()
+	robit.hands = new /atom/movable/screen/robot/module(null, src)
 	robit.hands.screen_loc = ui_borg_module
-	robit.hands.hud = src
 	static_inventory += robit.hands
 
 //Store
-	module_store_icon = new /atom/movable/screen/robot/store()
+	module_store_icon = new /atom/movable/screen/robot/store(null, src)
 	module_store_icon.screen_loc = ui_borg_store
-	module_store_icon.hud = src
 
-	pull_icon = new /atom/movable/screen/pull()
+	pull_icon = new /atom/movable/screen/pull(null, src)
 	pull_icon.icon = 'icons/hud/screen_cyborg.dmi'
 	pull_icon.screen_loc = ui_borg_pull
-	pull_icon.hud = src
 	pull_icon.update_appearance()
 	hotkeybuttons += pull_icon
 
 
-	zone_select = new /atom/movable/screen/zone_sel/robot()
-	zone_select.hud = src
+	zone_select = new /atom/movable/screen/zone_sel/robot(null, src)
 	zone_select.update_appearance()
 	static_inventory += zone_select
 

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -44,8 +44,9 @@
 
 /atom/movable/screen/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
-	if(hud_owner && istype(hud_owner))
-		hud = hud_owner
+	if(isnull(hud_owner)) //some screens set their hud owners on /new, this prevents overriding them with null post atoms init
+		return
+	set_new_hud(hud_owner)
 
 /atom/movable/screen/Destroy()
 	master = null
@@ -66,6 +67,25 @@
 
 /atom/movable/screen/proc/component_click(atom/movable/screen/component_button/component, params)
 	return
+
+///setter used to set our new hud
+/atom/movable/screen/proc/set_new_hud(datum/hud/hud_owner)
+	if(hud)
+		UnregisterSignal(hud, COMSIG_QDELETING)
+	if(isnull(hud_owner))
+		hud = null
+		return
+	hud = hud_owner
+	RegisterSignal(hud, COMSIG_QDELETING, PROC_REF(on_hud_delete))
+
+/// Returns the mob this is being displayed to, if any
+/atom/movable/screen/proc/get_mob()
+	return hud?.mymob
+
+/atom/movable/screen/proc/on_hud_delete(datum/source)
+	SIGNAL_HANDLER
+
+	set_new_hud(hud_owner = null)
 
 /atom/movable/screen/text
 	icon = null

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -18,7 +18,14 @@
 	/// A reference to the object in the slot. Grabs or items, generally.
 	var/obj/master = null
 	/// A reference to the owner HUD, if any.
+	// MONKESTATION EDIT START: There are a couple uses of this variable in
+	// `code\datums\interactions\interaction_mode.dm` that I'm unsure how to remove - so this can't
+	// be private at the moment.
+	/* //MONKESTATION EDIT ORIGINAL
 	VAR_PRIVATE/datum/hud/hud = null
+	*/
+	var/datum/hud/hud = null
+	//MONKESTATION EDIT END
 	/**
 	 * Map name assigned to this object.
 	 * Automatically set by /client/proc/add_obj_to_map.
@@ -314,8 +321,9 @@
 	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/datum/interaction_mode/combat_mode/combat_mode
 
-/atom/movable/screen/combattoggle/Initialize(mapload, datum/hud/hud_owner)
+/atom/movable/screen/combattoggle/Initialize(mapload, datum/hud/hud_owner, datum/interaction_mode/combat_mode/combat_mode_owner)
 	. = ..()
+	combat_mode = combat_mode_owner
 	update_appearance()
 
 /atom/movable/screen/combattoggle/Destroy()

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -18,7 +18,7 @@
 	/// A reference to the object in the slot. Grabs or items, generally.
 	var/obj/master = null
 	/// A reference to the owner HUD, if any.
-	var/datum/hud/hud = null
+	VAR_PRIVATE/datum/hud/hud = null
 	/**
 	 * Map name assigned to this object.
 	 * Automatically set by /client/proc/add_obj_to_map.
@@ -41,6 +41,11 @@
 	/// Generally we don't want default Click stuff, which results in bugs like using Telekinesis on a screen element
 	/// or trying to point your gun at your screen.
 	var/default_click = FALSE
+
+/atom/movable/screen/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	if(hud_owner && istype(hud_owner))
+		hud = hud_owner
 
 /atom/movable/screen/Destroy()
 	master = null
@@ -261,7 +266,7 @@
 	icon_state = "backpack_close"
 	mouse_over_pointer = MOUSE_HAND_POINTER
 
-/atom/movable/screen/close/Initialize(mapload, new_master)
+/atom/movable/screen/close/Initialize(mapload, datum/hud/hud_owner, new_master)
 	. = ..()
 	master = new_master
 
@@ -289,7 +294,7 @@
 	mouse_over_pointer = MOUSE_HAND_POINTER
 	var/datum/interaction_mode/combat_mode/combat_mode
 
-/atom/movable/screen/combattoggle/Initialize(mapload)
+/atom/movable/screen/combattoggle/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	update_appearance()
 
@@ -441,7 +446,7 @@
 	screen_loc = "7,7 to 10,8"
 	plane = HUD_PLANE
 
-/atom/movable/screen/storage/Initialize(mapload, new_master)
+/atom/movable/screen/storage/Initialize(mapload, datum/hud/hud_owner, new_master)
 	. = ..()
 	master = new_master
 
@@ -683,7 +688,7 @@
 
 INITIALIZE_IMMEDIATE(/atom/movable/screen/splash)
 
-/atom/movable/screen/splash/Initialize(mapload, client/C, visible, use_previous_title)
+/atom/movable/screen/splash/Initialize(mapload, datum/hud/hud_owner, client/C, visible, use_previous_title)
 	. = ..()
 	if(!istype(C))
 		return

--- a/code/_onclick/hud/screentip.dm
+++ b/code/_onclick/hud/screentip.dm
@@ -8,15 +8,14 @@
 	maptext = ""
 	layer = SCREENTIP_LAYER //Added to make screentips appear above action buttons (and other /atom/movable/screen objects)
 
-/atom/movable/screen/screentip/Initialize(mapload, _hud)
+/atom/movable/screen/screentip/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
-	hud = _hud
 	update_view()
 
 /atom/movable/screen/screentip/proc/update_view(datum/source)
 	SIGNAL_HANDLER
 	if(!hud || !hud.mymob.canon_client?.view_size) //Might not have been initialized by now
 		return
-	maptext_width = view_to_pixels(hud.mymob.client.view_size.getView())[1]
+	maptext_width = view_to_pixels(hud.mymob.canon_client.view_size.getView())[1]
 
 

--- a/code/datums/components/admin_popup.dm
+++ b/code/datums/components/admin_popup.dm
@@ -83,7 +83,7 @@
 	/// The `world.time` when the last color update occurred.
 	var/last_update_time = 0
 
-/atom/movable/screen/admin_popup/Initialize(mapload, ...)
+/atom/movable/screen/admin_popup/Initialize(mapload, datum/hud/hud_owner, ...)
 	. = ..()
 
 	START_PROCESSING(SSobj, src)

--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -173,7 +173,7 @@
 	layer = ECHO_LAYER
 	show_when_dead = TRUE
 
-/atom/movable/screen/fullscreen/echo/Initialize(mapload)
+/atom/movable/screen/fullscreen/echo/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	particles = new /particles/echo()
 

--- a/code/datums/interactions/combat_mode.dm
+++ b/code/datums/interactions/combat_mode.dm
@@ -18,10 +18,8 @@
 /datum/interaction_mode/combat_mode/procure_hud(mob/M, datum/hud/H)
 	if (!M.hud_used?.has_interaction_ui)
 		return
-	var/atom/movable/screen/combattoggle/flashy/CT = new
-	CT.hud = H
+	var/atom/movable/screen/combattoggle/flashy/CT = new(null, H, src)
 	CT.icon = H.ui_style
-	CT.combat_mode = src
 	UI = CT
 	return CT
 

--- a/code/datums/interactions/cyborg_combat_mode.dm
+++ b/code/datums/interactions/cyborg_combat_mode.dm
@@ -4,10 +4,8 @@
 /datum/interaction_mode/combat_mode/cyborg/procure_hud(mob/M, datum/hud/H)
 	if (!M.hud_used?.has_interaction_ui)
 		return
-	var/atom/movable/screen/combattoggle/robot/CT = new
-	CT.hud = H
+	var/atom/movable/screen/combattoggle/robot/CT = new(null, H, src)
 	CT.icon = H.ui_style
-	CT.combat_mode = src
 	UI = CT
 	return CT
 

--- a/code/datums/interactions/intents.dm
+++ b/code/datums/interactions/intents.dm
@@ -29,8 +29,7 @@
 /datum/interaction_mode/intents3/procure_hud(mob/M, datum/hud/H)
 	if (!M.hud_used?.has_interaction_ui)
 		return
-	var/atom/movable/screen/act_intent3/AI = new
-	AI.hud = H
+	var/atom/movable/screen/act_intent3/AI = new(null, H)
 	AI.intents = src
 	UI = AI
 	return AI

--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -89,8 +89,8 @@
 	var/display_contents = TRUE
 
 /datum/storage/New(atom/parent, max_slots, max_specific_storage, max_total_storage, numerical_stacking, allow_quick_gather, allow_quick_empty, collection_mode, attack_hand_interact)
-	boxes = new(null, src)
-	closer = new(null, src)
+	boxes = new(null, null, src)
+	closer = new(null, null, src)
 
 	src.parent = WEAKREF(parent)
 	src.real_location = src.parent

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -119,7 +119,7 @@
 	color = EM_BLOCK_COLOR
 	appearance_flags = EMISSIVE_APPEARANCE_FLAGS
 
-/atom/movable/Initialize(mapload)
+/atom/movable/Initialize(mapload, ...)
 	. = ..()
 #ifdef UNIT_TESTS
 	if(explosion_block && !HAS_TRAIT(src, TRAIT_BLOCKING_EXPLOSIVES))

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -147,12 +147,10 @@
 	if(living_mob.hud_used)
 		var/datum/hud/hud_used = living_mob.hud_used
 
-		lingchemdisplay = new /atom/movable/screen/ling/chems()
-		lingchemdisplay.hud = hud_used
+		lingchemdisplay = new /atom/movable/screen/ling/chems(null, hud_used)
 		hud_used.infodisplay += lingchemdisplay
 
-		lingstingdisplay = new /atom/movable/screen/ling/sting()
-		lingstingdisplay.hud = hud_used
+		lingstingdisplay = new /atom/movable/screen/ling/sting(null, hud_used)
 		hud_used.infodisplay += lingstingdisplay
 
 		hud_used.show_hud(hud_used.hud_version)
@@ -187,12 +185,10 @@
 
 	var/datum/hud/ling_hud = owner.current.hud_used
 
-	lingchemdisplay = new
-	lingchemdisplay.hud = ling_hud
+	lingchemdisplay = new(null, ling_hud)
 	ling_hud.infodisplay += lingchemdisplay
 
-	lingstingdisplay = new
-	lingstingdisplay.hud = ling_hud
+	lingstingdisplay = new(null, ling_hud)
 	ling_hud.infodisplay += lingstingdisplay
 
 	ling_hud.show_hud(ling_hud.hud_version)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -18,7 +18,7 @@
 
 /datum/action/innate/cult/blood_magic/proc/Positioning()
 	for(var/datum/hud/hud as anything in viewers)
-		var/our_view = hud.mymob?.client?.view || "15x15"
+		var/our_view = hud.mymob?.canon_client?.view || "15x15"
 		var/atom/movable/screen/movable/action_button/button = viewers[hud]
 		var/position = screen_loc_to_offset(button.screen_loc)
 		var/list/position_list = list()

--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -381,7 +381,7 @@ GLOBAL_LIST_EMPTY(gateway_destinations)
 	/// Handles the background of the portal, ensures the effect well, works properly
 	var/atom/movable/screen/background/cam_background
 
-/atom/movable/screen/map_view/gateway_port/Initialize(mapload)
+/atom/movable/screen/map_view/gateway_port/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	cam_background = new
 	cam_background.del_on_map_removal = FALSE

--- a/code/modules/escape_menu/details.dm
+++ b/code/modules/escape_menu/details.dm
@@ -13,7 +13,7 @@ GLOBAL_DATUM(escape_menu_details, /atom/movable/screen/escape_menu/details)
 	maptext_height = 100
 	maptext_width = 200
 
-/atom/movable/screen/escape_menu/details/Initialize(mapload)
+/atom/movable/screen/escape_menu/details/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 
 	update_text()

--- a/code/modules/escape_menu/home_page.dm
+++ b/code/modules/escape_menu/home_page.dm
@@ -2,6 +2,7 @@
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/home_button(
 			null,
+			/* hud_owner = */ src,
 			src,
 			"Resume",
 			/* offset = */ 0,
@@ -12,6 +13,7 @@
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/home_button(
 			null,
+			/* hud_owner = */ null,
 			src,
 			"Settings",
 			/* offset = */ 1,
@@ -50,6 +52,7 @@
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/home_button/admin_help(
 			null,
+			/* hud_owner = */ src,
 			src,
 			"Admin Help",
 			/* offset = */ 5,
@@ -59,6 +62,7 @@
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/home_button/leave_body(
 			null,
+			/* hud_owner = */ src,
 			src,
 			"Leave Body",
 			/* offset = */ 6,
@@ -95,6 +99,7 @@
 
 /atom/movable/screen/escape_menu/home_button/Initialize(
 	mapload,
+	datum/hud/hud_owner,
 	datum/escape_menu/escape_menu,
 	button_text,
 	offset,
@@ -107,6 +112,7 @@
 
 	home_button_text = new /atom/movable/screen/escape_menu/home_button_text(
 		src,
+		/* hud_owner = */ src,
 		button_text,
 	)
 
@@ -149,7 +155,7 @@
 		button_text
 		hovered = FALSE
 
-/atom/movable/screen/escape_menu/home_button_text/Initialize(mapload, button_text)
+/atom/movable/screen/escape_menu/home_button_text/Initialize(mapload, datum/hud/hud_owner, button_text)
 	. = ..()
 
 	src.button_text = button_text

--- a/code/modules/escape_menu/home_page.dm
+++ b/code/modules/escape_menu/home_page.dm
@@ -2,7 +2,7 @@
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/home_button(
 			null,
-			/* hud_owner = */ src,
+			/* hud_owner = */ null,
 			src,
 			"Resume",
 			/* offset = */ 0,
@@ -55,7 +55,7 @@
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/home_button/admin_help(
 			null,
-			/* hud_owner = */ src,
+			/* hud_owner = */ null,
 			src,
 			"Admin Help",
 			/* offset = */ 5,
@@ -65,7 +65,7 @@
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/home_button/leave_body(
 			null,
-			/* hud_owner = */ src,
+			/* hud_owner = */ null,
 			src,
 			"Leave Body",
 			/* offset = */ 6,
@@ -190,6 +190,7 @@
 
 /atom/movable/screen/escape_menu/home_button/admin_help/Initialize(
 	mapload,
+	datum/hud/hud_owner,
 	datum/escape_menu/escape_menu,
 	button_text,
 	offset,
@@ -313,6 +314,7 @@
 
 /atom/movable/screen/escape_menu/home_button/leave_body/Initialize(
 	mapload,
+	datum/hud/hud_owner,
 	datum/escape_menu/escape_menu,
 	button_text,
 	offset,

--- a/code/modules/escape_menu/home_page.dm
+++ b/code/modules/escape_menu/home_page.dm
@@ -24,6 +24,7 @@
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/home_button(
 			null,
+			/* hud_owner = */ null,
 			src,
 			"Redeem Code",
 			/* offset = */ 2,
@@ -33,6 +34,7 @@
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/home_button(
 			null,
+			/* hud_owner = */ null,
 			src,
 			"Open Lootbox",
 			/* offset = */ 3,
@@ -43,6 +45,7 @@
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/home_button(
 			null,
+			/* hud_owner = */ null,
 			src,
 			"Open Map",
 			/* offset = */ 4,

--- a/code/modules/escape_menu/leave_body.dm
+++ b/code/modules/escape_menu/leave_body.dm
@@ -9,7 +9,8 @@
 			stack_trace("The leave body menu was opened before the atoms SS. This shouldn't be possible, as the leave body menu should only be accessible when you have a body.")
 
 	page_holder.give_screen_object(new /atom/movable/screen/escape_menu/leave_body_button(
-		src,
+		null,
+		/* hud_owner = */ null,
 		"Suicide",
 		"Perform a dramatic suicide in game",
 		/* pixel_offset = */ -105,
@@ -19,7 +20,8 @@
 
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/leave_body_button(
-			src,
+			null,
+			/* hud_owner = */ null,
 			"Ghost",
 			"Exit quietly, leaving your body",
 			/* pixel_offset = */ 0,
@@ -30,7 +32,8 @@
 
 	page_holder.give_screen_object(
 		new /atom/movable/screen/escape_menu/leave_body_button(
-			src,
+			null,
+			/* hud_owner = */ null,
 			"Back",
 			/* tooltip_text = */ null,
 			/* pixel_offset = */ 105,
@@ -85,6 +88,7 @@
 
 /atom/movable/screen/escape_menu/leave_body_button/Initialize(
 	mapload,
+	datum/hud/hud_owner,
 	button_text,
 	tooltip_text,
 	pixel_offset,

--- a/code/modules/escape_menu/title.dm
+++ b/code/modules/escape_menu/title.dm
@@ -13,7 +13,7 @@ GLOBAL_DATUM(escape_menu_title, /atom/movable/screen/escape_menu/title)
 	maptext_height = 100
 	maptext_width = 500
 
-/atom/movable/screen/escape_menu/title/Initialize(mapload)
+/atom/movable/screen/escape_menu/title/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 
 	update_text()

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -75,7 +75,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 	var/client/C = client
 	to_chat(C, span_notice("Sending you to [pick]."))
-	new /atom/movable/screen/splash(null, C)
+	new /atom/movable/screen/splash(null, null, C)
 
 	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, SERVER_HOPPER_TRAIT)
 	sleep(2.9 SECONDS) //let the animation play

--- a/code/modules/mob/living/silicon/ai/multicam.dm
+++ b/code/modules/mob/living/silicon/ai/multicam.dm
@@ -6,7 +6,7 @@
 	var/highlighted = FALSE
 	var/mob/camera/ai_eye/pic_in_pic/aiEye
 
-/atom/movable/screen/movable/pic_in_pic/ai/Initialize(mapload)
+/atom/movable/screen/movable/pic_in_pic/ai/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	aiEye = new /mob/camera/ai_eye/pic_in_pic()
 	aiEye.screen = src

--- a/code/modules/pai/hud.dm
+++ b/code/modules/pai/hud.dm
@@ -182,62 +182,62 @@
 	var/mob/living/silicon/pai/mypai = mymob
 
 // Software menu
-	using = new /atom/movable/screen/pai/software
+	using = new /atom/movable/screen/pai/software(null, src)
 	using.screen_loc = ui_pai_software
 	static_inventory += using
 
 // Holoform
-	using = new /atom/movable/screen/pai/shell
+	using = new /atom/movable/screen/pai/shell(null, src)
 	using.screen_loc = ui_pai_shell
 	static_inventory += using
 
 // Chassis Select Menu
-	using = new /atom/movable/screen/pai/chassis
+	using = new /atom/movable/screen/pai/chassis(null, src)
 	using.screen_loc = ui_pai_chassis
 	static_inventory += using
 
 // Rest
-	using = new /atom/movable/screen/pai/rest
+	using = new /atom/movable/screen/pai/rest(null, src)
 	using.screen_loc = ui_pai_rest
 	static_inventory += using
 
 // Integrated Light
-	using = new /atom/movable/screen/pai/light
+	using = new /atom/movable/screen/pai/light(null, src)
 	using.screen_loc = ui_pai_light
 	static_inventory += using
 
 // Newscaster
-	using = new /atom/movable/screen/pai/newscaster
+	using = new /atom/movable/screen/pai/newscaster(null, src)
 	using.screen_loc = ui_pai_newscaster
 	static_inventory += using
 
 // Language menu
-	using = new /atom/movable/screen/language_menu
+	using = new /atom/movable/screen/language_menu(null, src)
 	using.screen_loc = ui_pai_language_menu
 	static_inventory += using
 
 // Navigation
-	using = new /atom/movable/screen/navigate
+	using = new /atom/movable/screen/navigate(null, src)
 	using.screen_loc = ui_pai_navigate_menu
 	static_inventory += using
 
 // Host Monitor
-	using = new /atom/movable/screen/pai/host_monitor()
+	using = new /atom/movable/screen/pai/host_monitor(null, src)
 	using.screen_loc = ui_pai_host_monitor
 	static_inventory += using
 
 // Crew Manifest
-	using = new /atom/movable/screen/pai/crew_manifest()
+	using = new /atom/movable/screen/pai/crew_manifest(null, src)
 	using.screen_loc = ui_pai_crew_manifest
 	static_inventory += using
 
 // Laws
-	using = new /atom/movable/screen/pai/state_laws()
+	using = new /atom/movable/screen/pai/state_laws(null, src)
 	using.screen_loc = ui_pai_state_laws
 	static_inventory += using
 
 // Modular Interface
-	using = new /atom/movable/screen/pai/modpc()
+	using = new /atom/movable/screen/pai/modpc(null, src)
 	using.screen_loc = ui_pai_mod_int
 	static_inventory += using
 	mypai.pda_button = using
@@ -245,22 +245,22 @@
 	tablet_button.pAI = mypai
 
 // Internal GPS
-	using = new /atom/movable/screen/pai/internal_gps()
+	using = new /atom/movable/screen/pai/internal_gps(null, src)
 	using.screen_loc = ui_pai_internal_gps
 	static_inventory += using
 
 // Take image
-	using = new /atom/movable/screen/pai/image_take()
+	using = new /atom/movable/screen/pai/image_take(null, src)
 	using.screen_loc = ui_pai_take_picture
 	static_inventory += using
 
 // View images
-	using = new /atom/movable/screen/pai/image_view()
+	using = new /atom/movable/screen/pai/image_view(null, src)
 	using.screen_loc = ui_pai_view_images
 	static_inventory += using
 
 // Radio
-	using = new /atom/movable/screen/pai/radio()
+	using = new /atom/movable/screen/pai/radio(null, src)
 	using.screen_loc = ui_pai_radio
 	static_inventory += using
 

--- a/code/modules/tutorials/_tutorial.dm
+++ b/code/modules/tutorials/_tutorial.dm
@@ -106,7 +106,7 @@
 		RegisterSignal(skip_button, COMSIG_SCREEN_ELEMENT_CLICK, PROC_REF(dismiss))
 
 	if (isnull(instruction_screen))
-		instruction_screen = new(null, message, user.client)
+		instruction_screen = new(null, null, message, user.client)
 		user.client?.screen += instruction_screen
 	else
 		instruction_screen.change_message(message)

--- a/code/modules/tutorials/tutorial_instruction.dm
+++ b/code/modules/tutorials/tutorial_instruction.dm
@@ -9,14 +9,14 @@
 
 	var/atom/movable/screen/tutorial_instruction_text/instruction_text
 
-/atom/movable/screen/tutorial_instruction/Initialize(mapload, message, client/client)
+/atom/movable/screen/tutorial_instruction/Initialize(mapload, datum/hud/hud_owner, message, client/client)
 	. = ..()
 
 	transform = transform.Scale(36, 2.5)
 
 	animate(src, alpha = 245, time = 0.8 SECONDS, easing = SINE_EASING)
 
-	instruction_text = new(src, message, client)
+	instruction_text = new(src, null, message, client)
 	vis_contents += instruction_text
 
 /atom/movable/screen/tutorial_instruction/Destroy()
@@ -33,7 +33,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	layer = TUTORIAL_INSTRUCTIONS_LAYER
 
-/atom/movable/screen/tutorial_instruction_text/Initialize(mapload, message, client/client)
+/atom/movable/screen/tutorial_instruction_text/Initialize(mapload, datum/hud/hud_owner, message, client/client)
 	. = ..()
 
 	var/view = client?.view_size.getView()

--- a/monkestation/code/_onclick/hud/alert.dm
+++ b/monkestation/code/_onclick/hud/alert.dm
@@ -6,7 +6,7 @@
 	icon_state = "clockinfo"
 //	alerttooltipstyle = "clockwork" //clockwork tooltips are currently broken, this is a known issue on TG
 
-/atom/movable/screen/alert/clockwork/clocksense/Initialize(mapload)
+/atom/movable/screen/alert/clockwork/clocksense/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	START_PROCESSING(SSprocessing, src)
 

--- a/monkestation/code/datums/status_effects/changeling.dm
+++ b/monkestation/code/datums/status_effects/changeling.dm
@@ -1,7 +1,7 @@
 /atom/movable/screen/alert/status_effect/changeling
 	icon = 'icons/mob/actions/actions_changeling.dmi'
 
-/atom/movable/screen/alert/status_effect/changeling/Initialize(mapload)
+/atom/movable/screen/alert/status_effect/changeling/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	underlays += mutable_appearance('icons/mob/actions/backgrounds.dmi', "bg_changeling")
 	add_overlay(mutable_appearance('icons/mob/actions/backgrounds.dmi', "bg_changeling_border"))

--- a/monkestation/code/modules/and_roll_credits/_credits.dm
+++ b/monkestation/code/modules/and_roll_credits/_credits.dm
@@ -26,7 +26,7 @@
 		if(count && !istype(credit, /atom/movable/screen/map_view/char_preview))
 			sleep(CREDIT_SPAWN_SPEED)
 
-		new /atom/movable/screen/credit(null, credit)
+		new /atom/movable/screen/credit(null, null, credit)
 
 		if(istype(credit, /atom/movable/screen/map_view/char_preview))
 			count++
@@ -63,7 +63,7 @@
 
 	var/matrix/target
 
-/atom/movable/screen/credit/Initialize(mapload, credited)
+/atom/movable/screen/credit/Initialize(mapload, datum/hud/hud_owner, credited)
 	. = ..()
 	icon = CREDITS_PATH
 

--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/components/team_monitor.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/components/team_monitor.dm
@@ -179,13 +179,12 @@ GLOBAL_LIST_EMPTY(tracker_beacons)
 		return
 	if(!screen)
 		//Create the screen
-		screen = new
+		screen = new(null, updating.hud_used)
 		screen.alpha = 240
 		if(multiz && !share_z && screen.color != beacon.z_diff_colour)
 			screen.color = beacon.z_diff_colour
 		else if(screen.color != beacon.colour)
 			screen.color = beacon.colour
-		screen.hud = updating.hud_used
 		updating.hud_used.team_finder_arrows += screen
 		tracking[beacon] = screen
 		//Update their hud
@@ -219,7 +218,7 @@ GLOBAL_LIST_EMPTY(tracker_beacons)
 	for(var/datum/component/tracking_beacon/key in tracking)
 		if(!key.visible) // calling show_hud should not show hidden beacons
 			continue
-		var/atom/movable/screen/arrow/arrow = new
+		var/atom/movable/screen/arrow/arrow = new(null, target.hud_used)
 		arrow.alpha = 240
 		var/turf/target_turf = get_turf(key.parent)
 		var/turf/parent_turf = get_turf(parent)
@@ -227,7 +226,6 @@ GLOBAL_LIST_EMPTY(tracker_beacons)
 			arrow.color = key.z_diff_colour
 		else if(arrow.color != key.colour)
 			arrow.color = key.colour
-		arrow.hud = target.hud_used
 		target.hud_used.team_finder_arrows += arrow
 		tracking[key] = arrow
 	//Update their hud
@@ -313,7 +311,7 @@ GLOBAL_LIST_EMPTY(tracker_beacons)
 /datum/component/team_monitor/proc/add_to_tracking_network(datum/component/tracking_beacon/beacon)
 	if(beacon != attached_beacon)
 		if(updating?.hud_used)
-			var/atom/movable/screen/arrow/arrow = new
+			var/atom/movable/screen/arrow/arrow = new(null, updating.hud_used)
 			arrow.alpha = 240
 			var/turf/target_turf = get_turf(beacon.parent)
 			var/turf/parent_turf = get_turf(parent)
@@ -321,7 +319,6 @@ GLOBAL_LIST_EMPTY(tracker_beacons)
 				arrow.color = beacon.z_diff_colour
 			else if(arrow.color != beacon.colour)
 				arrow.color = beacon.colour
-			arrow.hud = updating.hud_used
 			updating.hud_used.team_finder_arrows += arrow
 			tracking[beacon] = arrow
 			//Update arrow direction

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
@@ -169,16 +169,13 @@
 	SIGNAL_HANDLER
 	var/datum/hud/bloodsucker_hud = owner.current.hud_used
 
-	blood_display = new /atom/movable/screen/bloodsucker/blood_counter()
-	blood_display.hud = bloodsucker_hud
+	blood_display = new /atom/movable/screen/bloodsucker/blood_counter(null, bloodsucker_hud)
 	bloodsucker_hud.infodisplay += blood_display
 
-	vamprank_display = new /atom/movable/screen/bloodsucker/rank_counter()
-	vamprank_display.hud = bloodsucker_hud
+	vamprank_display = new /atom/movable/screen/bloodsucker/rank_counter(null, bloodsucker_hud)
 	bloodsucker_hud.infodisplay += vamprank_display
 
-	sunlight_display = new /atom/movable/screen/bloodsucker/sunlight_counter()
-	sunlight_display.hud = bloodsucker_hud
+	sunlight_display = new /atom/movable/screen/bloodsucker/sunlight_counter(null, bloodsucker_hud)
 	bloodsucker_hud.infodisplay += sunlight_display
 
 	bloodsucker_hud.show_hud(bloodsucker_hud.hud_version)

--- a/monkestation/code/modules/botany/species/apid/species.dm
+++ b/monkestation/code/modules/botany/species/apid/species.dm
@@ -86,8 +86,7 @@
 	if(human_who_gained_species.hud_used)
 		var/datum/hud/hud_used = human_who_gained_species.hud_used
 
-		honeydisplay = new /atom/movable/screen/apid/honey()
-		honeydisplay.hud = hud_used
+		honeydisplay = new /atom/movable/screen/apid/honey(null, hud_used)
 		hud_used.infodisplay += honeydisplay
 		adjust_honeycount(0)
 		hud_used.show_hud(hud_used.hud_version)
@@ -120,8 +119,7 @@
 	if(H.hud_used)
 		var/datum/hud/hud_used = H.hud_used
 
-		honeydisplay = new /atom/movable/screen/apid/honey()
-		honeydisplay.hud = hud_used
+		honeydisplay = new /atom/movable/screen/apid/honey(null, hud_used)
 		hud_used.infodisplay += honeydisplay
 		adjust_honeycount(0)
 		hud_used.show_hud(hud_used.hud_version)

--- a/monkestation/code/modules/cybernetics/augments/arm_augments/unsorted.dm
+++ b/monkestation/code/modules/cybernetics/augments/arm_augments/unsorted.dm
@@ -143,17 +143,15 @@
 			return
 		H.cybernetics_ammo[zone] = null
 
-		counter_ref.hud = null
 		H.infodisplay -= counter_ref
 		H.mymob.client.screen -= counter_ref
 		QDEL_NULL(counter_ref)
 		return
 
 	if(!H.cybernetics_ammo[zone])
-		counter_ref = new()
+		counter_ref = new(null, H)
 		counter_ref.screen_loc =  zone == BODY_ZONE_L_ARM ? ui_hand_position(1,1,9) : ui_hand_position(2,1,9)
 		H.cybernetics_ammo[zone] = counter_ref
-		counter_ref.hud = H
 		H.infodisplay += counter_ref
 		H.mymob.client.screen += counter_ref
 

--- a/monkestation/code/modules/outdoors/code/_onclick/hud/fullscreen.dm
+++ b/monkestation/code/modules/outdoors/code/_onclick/hud/fullscreen.dm
@@ -13,7 +13,7 @@
 	needs_offsetting = FALSE
 
 
-/atom/movable/screen/fullscreen/lighting_backdrop/sunlight/Initialize()
+/atom/movable/screen/fullscreen/lighting_backdrop/sunlight/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	if(!SSoutdoor_effects.enabled)
 		return

--- a/monkestation/code/modules/outdoors/code/_onclick/hud/rendering/plane_master.dm
+++ b/monkestation/code/modules/outdoors/code/_onclick/hud/rendering/plane_master.dm
@@ -28,7 +28,7 @@
 	critical = PLANE_CRITICAL_DISPLAY
 	var/z_type = "Default"
 
-/atom/movable/screen/plane_master/weather_effect/Initialize()
+/atom/movable/screen/plane_master/weather_effect/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	//filters += filter(type="alpha", render_source=WEATHER_RENDER_TARGET)
 	if(SSoutdoor_effects.enabled)

--- a/monkestation/code/modules/possession/possessed_hud.dm
+++ b/monkestation/code/modules/possession/possessed_hud.dm
@@ -29,123 +29,105 @@
 	var/atom/movable/screen/using
 	var/atom/movable/screen/inventory/inv_box
 
-	using = new/atom/movable/screen/language_menu
+	using = new/atom/movable/screen/language_menu(null, src)
 	using.icon = ui_style
-	using.hud = src
 	static_inventory += using
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "id"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "id"
 	inv_box.icon_full = "template_small"
 	inv_box.screen_loc = ui_id
 	inv_box.slot_id = ITEM_SLOT_ID
-	inv_box.hud = src
 	static_inventory += inv_box
 
-	inv_box = new /atom/movable/screen/inventory()
+	inv_box = new /atom/movable/screen/inventory(null, src)
 	inv_box.name = "head"
 	inv_box.icon = ui_style
 	inv_box.icon_state = "head"
 	inv_box.icon_full = "template"
 	inv_box.screen_loc = ui_head
 	inv_box.slot_id = ITEM_SLOT_HEAD
-	inv_box.hud = src
 	toggleable_inventory += inv_box
 
-	using = new/atom/movable/screen/navigate
+	using = new/atom/movable/screen/navigate(null, src)
 	using.icon = ui_style
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/area_creator
+	using = new /atom/movable/screen/area_creator(null, src)
 	using.icon = ui_style
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/mov_intent
+	using = new /atom/movable/screen/mov_intent(null, src)
 	using.icon = ui_style
 	using.icon_state = (mymob.m_intent == MOVE_INTENT_WALK ? "walking" : "running")
 	using.screen_loc = ui_movi
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/drop()
+	using = new /atom/movable/screen/drop(null, src)
 	using.icon = ui_style
 	using.screen_loc = ui_drop_throw
-	using.hud = src
 	static_inventory += using
 
 	build_hand_slots()
 
-	using = new /atom/movable/screen/swap_hand()
+	using = new /atom/movable/screen/swap_hand(null, src)
 	using.icon = ui_style
 	using.icon_state = "swap_1"
 	using.screen_loc = ui_swaphand_position(owner,1)
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/swap_hand()
+	using = new /atom/movable/screen/swap_hand(null, src)
 	using.icon = ui_style
 	using.icon_state = "swap_2"
 	using.screen_loc = ui_swaphand_position(owner,2)
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/resist()
+	using = new /atom/movable/screen/resist(null, src)
 	using.icon = ui_style
 	using.screen_loc = ui_above_intent
-	using.hud = src
 	hotkeybuttons += using
 
-	using = new /atom/movable/screen/possessed/toggle()
+	using = new /atom/movable/screen/possessed/toggle(null, src)
 	using.icon = ui_style
 	using.screen_loc = ui_inventory
-	using.hud = src
 	static_inventory += using
 
-	using = new /atom/movable/screen/human/equip()
+	using = new /atom/movable/screen/human/equip(null, src)
 	using.icon = ui_style
 	using.screen_loc = ui_equip_position(mymob)
-	using.hud = src
 	static_inventory += using
 
-	throw_icon = new /atom/movable/screen/throw_catch()
+	throw_icon = new /atom/movable/screen/throw_catch(null, src)
 	throw_icon.icon = ui_style
 	throw_icon.screen_loc = ui_drop_throw
-	throw_icon.hud = src
 	hotkeybuttons += throw_icon
 
-	rest_icon = new /atom/movable/screen/rest()
+	rest_icon = new /atom/movable/screen/rest(null, src)
 	rest_icon.icon = ui_style
 	rest_icon.screen_loc = ui_above_movement
-	rest_icon.hud = src
 	rest_icon.update_appearance()
 	static_inventory += rest_icon
 
-	healthdoll = new /atom/movable/screen/healthdoll()
-	healthdoll.hud = src
+	healthdoll = new /atom/movable/screen/healthdoll(null, src)
 	infodisplay += healthdoll
 
-	stamina = new /atom/movable/screen/stamina()
-	stamina.hud = src
+	stamina = new /atom/movable/screen/stamina(null, src)
 	infodisplay += stamina
 
-	pull_icon = new /atom/movable/screen/pull()
+	pull_icon = new /atom/movable/screen/pull(null, src)
 	pull_icon.icon = ui_style
 	pull_icon.screen_loc = ui_above_intent
-	pull_icon.hud = src
 	pull_icon.update_appearance()
 	static_inventory += pull_icon
 
-	zone_select = new /atom/movable/screen/zone_sel()
+	zone_select = new /atom/movable/screen/zone_sel(null, src)
 	zone_select.icon = ui_style
-	zone_select.hud = src
 	zone_select.update_appearance()
 	static_inventory += zone_select
 
-	combo_display = new /atom/movable/screen/combo()
+	combo_display = new /atom/movable/screen/combo(null, src)
 	infodisplay += combo_display
 
 /datum/hud/possessed/persistent_inventory_update()

--- a/monkestation/code/modules/ranching/name_tags/name_tag.dm
+++ b/monkestation/code/modules/ranching/name_tags/name_tag.dm
@@ -136,7 +136,7 @@
 	render_relay_planes = list(RENDER_PLANE_GAME_WORLD)
 	alpha = 0
 
-/atom/movable/screen/plane_master/name_tags/Initialize(mapload)
+/atom/movable/screen/plane_master/name_tags/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	add_filter("vision_cone", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(NAME_TAG_RENDER_TARGET, offset), flags = MASK_INVERSE))
 


### PR DESCRIPTION
## About The Pull Request
This PR ports the following PRs from tgstation:
* tgstation/tgstation#76772
* tgstation/tgstation#88307 - Caused by 76772
* tgstation/tgstation#78066 - Caused by 76772
* tgstation/tgstation#83987
* tgstation/tgstation#76443 (Partial - just the code to support the other PRs)

These changes are intended to fix various issues regarding HUDs.

NOTE: While testing, I encountered certain HUD-related issues. The following is a list of issues I know NOT to be the result of this PR:
* The Character setup screen would show your characters as super-tiny. (This is a bug caused by 516; reverting to 515 fixes the issue.)
* The asterisk next to runechat emotes, as well as the mouse icons shown below the name of certain hovered objects, being much bigger. (This is a bug caused by 516; reverting to 515 fixes the issue.)
* Taking possession of a `/mob/living/basic/possession_holder` will give you a black screen. (This is a bug caused by 516; reverting to 515 fixes the issue.)

## Why It's Good For The Game
Bugfixes and better code.

## Changelog
:cl:MichiRecRoom
refactor: The code behind many HUD systems has been refactored slightly. Due to the massive amount of HUD types we have, I only tested monkestation-specific HUDs - so please let me know if you see any broken HUDs!
refactor: (JohnFulpWillard) Huds now have their hud owner set in Initialize
/:cl: