### PR TITLE
Unopened goody cases can no longer be sent back on the cargo shuttle

### DIFF
--- a/code/game/objects/items/storage/lockbox.dm
+++ b/code/game/objects/items/storage/lockbox.dm
@@ -247,7 +247,7 @@
 /obj/item/storage/lockbox/order/Initialize(mapload, datum/bank_account/_buyer_account)
 	. = ..()
 	buyer_account = _buyer_account
-	ADD_TRAIT(src, TRAIT_NO_MISSING_ITEM_ERROR, TRAIT_GENERIC)
+	add_traits(list(TRAIT_NO_MISSING_ITEM_ERROR, TRAIT_BANNED_FROM_CARGO_SHUTTLE), TRAIT_GENERIC) // monkestation edit: prevent locked goody cases from being sent back
 
 /obj/item/storage/lockbox/order/attackby(obj/item/W, mob/user, params)
 	var/obj/item/card/id/id_card = W.GetID()
@@ -261,6 +261,7 @@
 	if(privacy_lock)
 		atom_storage.locked = STORAGE_NOT_LOCKED
 		icon_state = icon_locked
+		REMOVE_TRAIT(src, TRAIT_BANNED_FROM_CARGO_SHUTTLE, TRAIT_GENERIC) // monkestation edit: prevent locked goody cases from being sent back
 	else
 		atom_storage.locked = STORAGE_FULLY_LOCKED
 		icon_state = icon_closed


### PR DESCRIPTION

## About The Pull Request

this makes it so locked goody cases can't be sent back on the cargo shuttle.

they can be sent after being unlocked - this is just so cargo techies won't accidentally send them back, and they don't even refund the buyer.

## Why It's Good For The Game

i am so tired of cargo techies accidentally sending my cases back

## Changelog
:cl:
qol: Unopened goody cases can no longer be sent back on the cargo shuttle.
/:cl:
