### PR TITLE
Crusher can FINALLY used to crush rocks

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -19,6 +19,7 @@
 	attack_verb_continuous = list("smashes", "crushes", "cleaves", "chops", "pulps")
 	attack_verb_simple = list("smash", "crush", "cleave", "chop", "pulp")
 	sharpness = SHARP_EDGED
+	tool_behaviour = TOOL_MINING
 	actions_types = list(/datum/action/item_action/toggle_light)
 	obj_flags = UNIQUE_RENAME
 	light_system = OVERLAY_LIGHT


### PR DESCRIPTION


## About The Pull Request

gives crushers the tool behavior mining. allowing them to be used to dig up sand and actually mine walls

## Why It's Good For The Game

its a giant pickaxe that shoots energy why cant it smash rocks normally?

## Changelog
:cl:
qol: Prokinetic Crushers can be used as pickaxes now
/:cl:
