### PR TITLE
Fix replays bloating init times even when they're disabled

### DIFF
--- a/monkestation/code/modules/replays/subsystem/replay.dm
+++ b/monkestation/code/modules/replays/subsystem/replay.dm
@@ -29,14 +29,18 @@ SUBSYSTEM_DEF(demo)
 	//var/last_queued = 0
 	//var/last_completed = 0
 
-/datum/controller/subsystem/demo/Initialize()
+/datum/controller/subsystem/demo/OnConfigLoad()
+	. = ..()
 #if defined(UNIT_TESTS) || defined(AUTOWIKI) // lazy way of doing this but idc
-	CONFIG_SET(flag/demos_enabled, FALSE)
-#endif
+	disable()
+#else
 	if(!CONFIG_GET(flag/demos_enabled))
 		disable()
-		return SS_INIT_NO_NEED
+#endif
 
+/datum/controller/subsystem/demo/Initialize()
+	if(disabled)
+		return SS_INIT_NO_NEED
 	rustg_file_write("[GLOB.round_id]", "[GLOB.demo_directory]/round_number_[world.port].txt")
 
 	WRITE_LOG_NO_FORMAT(GLOB.demo_log, "demo version 1\n") // increment this if you change the format
@@ -251,7 +255,7 @@ SUBSYSTEM_DEF(demo)
 	return ..()
 
 /datum/controller/subsystem/demo/proc/disable()
-	flags |= SS_NO_FIRE
+	flags |= SS_NO_INIT|SS_NO_FIRE
 	can_fire = FALSE
 	disabled = TRUE
 	pre_init_lines = null


### PR DESCRIPTION

## About The Pull Request

so it turns out, yeah, `SSdemo.disabled` doesn't get set until `SSdemo` initializes - which it very late into init - so it wastes a lot of during `SSatoms` and such marking atoms that are just gonna get cleared as soon as it gets disabled during init.

this makes it so it will check and disabled it during `OnConfigLoad` instead

## Why It's Good For The Game

faster inits are nice

## Changelog

No server-side changes, as this only affects when `DEMOS_ENABLED` is false - but they're enabled on the server