### PR TITLE
Don't initialize the materials box in a horribly slow and inefficient way

### DIFF
--- a/code/game/objects/items/storage/boxes/engineering_boxes.dm
+++ b/code/game/objects/items/storage/boxes/engineering_boxes.dm
@@ -34,28 +34,31 @@
 	illustration = "implant"
 
 /obj/item/storage/box/material/PopulateContents() //less uranium because radioactive
+	// amount should be null if it should spawn with the type's default amount
 	var/static/items_inside = list(
-		/obj/item/stack/sheet/iron/fifty=1,
-		/obj/item/stack/sheet/glass/fifty=1,
-		/obj/item/stack/sheet/rglass=50,
-		/obj/item/stack/sheet/plasmaglass=50,
-		/obj/item/stack/sheet/titaniumglass=50,
-		/obj/item/stack/sheet/plastitaniumglass=50,
-		/obj/item/stack/sheet/plasteel=50,
-		/obj/item/stack/sheet/mineral/plastitanium=50,
-		/obj/item/stack/sheet/mineral/titanium=50,
-		/obj/item/stack/sheet/mineral/gold=50,
-		/obj/item/stack/sheet/mineral/silver=50,
-		/obj/item/stack/sheet/mineral/plasma=50,
-		/obj/item/stack/sheet/mineral/uranium=20,
-		/obj/item/stack/sheet/mineral/diamond=50,
-		/obj/item/stack/sheet/bluespace_crystal=50,
-		/obj/item/stack/sheet/mineral/bananium=50,
-		/obj/item/stack/sheet/mineral/wood=50,
-		/obj/item/stack/sheet/plastic/fifty=1,
-		/obj/item/stack/sheet/runed_metal/fifty=1,
-		)
-	generate_items_inside(items_inside,src)
+		/obj/item/stack/sheet/iron/fifty = null,
+		/obj/item/stack/sheet/glass/fifty = null,
+		/obj/item/stack/sheet/rglass = 50,
+		/obj/item/stack/sheet/plasmaglass = 50,
+		/obj/item/stack/sheet/titaniumglass = 50,
+		/obj/item/stack/sheet/plastitaniumglass = 50,
+		/obj/item/stack/sheet/plasteel = 50,
+		/obj/item/stack/sheet/mineral/plastitanium = 50,
+		/obj/item/stack/sheet/mineral/titanium = 50,
+		/obj/item/stack/sheet/mineral/gold = 50,
+		/obj/item/stack/sheet/mineral/silver = 50,
+		/obj/item/stack/sheet/mineral/plasma = 50,
+		/obj/item/stack/sheet/mineral/uranium = 20,
+		/obj/item/stack/sheet/mineral/diamond = 50,
+		/obj/item/stack/sheet/bluespace_crystal = 50,
+		/obj/item/stack/sheet/mineral/bananium = 50,
+		/obj/item/stack/sheet/mineral/wood = 50,
+		/obj/item/stack/sheet/plastic/fifty = null,
+		/obj/item/stack/sheet/runed_metal/fifty = null,
+	)
+	for(var/obj/item/stack/stack_type as anything in items_inside)
+		var/amt = items_inside[stack_type]
+		new stack_type(src, amt, FALSE)
 
 /obj/item/storage/box/debugtools
 	name = "box of debug tools"


### PR DESCRIPTION
## About The Pull Request

Same thing as https://github.com/tgstation/tgstation/pull/89920

however we have TWO of these damned boxes mapped in at centcom - they took up nearly _3x more init time_ than the next slowest `/obj/item`, so, yeah...


**before:**
![2025-03-08 (1741430334) ~ Code](https://github.com/user-attachments/assets/0af5f0c1-a7f5-48d3-b2ca-7b6d0b3b8d54)

**after:**
![2025-03-08 (1741431730) ~ Code](https://github.com/user-attachments/assets/bc44889c-a01f-4611-a929-26d7a0b154aa)

## Why It's Good For The Game

> we do not need to try to merge 400 or so times to initialize a box with a pre-set amount of materials

## Changelog
:cl:
code: Spawning the box of materials will no longer try to do ~400 stack merges.
/:cl:
