### PR TITLE
Stamina container optimizations

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,6 +1,6 @@
 /mob/living/Initialize(mapload)
 	. = ..()
-	stamina = new(src)
+	stamina = new(src) // monkestation edit: stamina rework
 	if(current_size != RESIZE_DEFAULT_SIZE)
 		update_transform(current_size)
 	AddElement(/datum/element/movetype_handler)

--- a/monkestation/code/controllers/subsystem/stamina.dm
+++ b/monkestation/code/controllers/subsystem/stamina.dm
@@ -18,9 +18,10 @@ SUBSYSTEM_DEF(stamina)
 	//cache for sanic speed (lists are references anyways)
 	var/list/current_run = currentrun
 
+	var/seconds_per_tick = world.tick_lag * wait * 0.1
 	while(length(current_run))
 		var/datum/stamina_container/thing = current_run[length(current_run)]
 		current_run.len--
-		thing.update(world.tick_lag * wait * 0.1)
+		thing.update(seconds_per_tick)
 		if (MC_TICK_CHECK)
 			return

--- a/monkestation/code/datums/stamina_container.dm
+++ b/monkestation/code/datums/stamina_container.dm
@@ -40,12 +40,14 @@
 	src.regen_rate = regen_rate
 	src.current = maximum
 	RegisterSignals(parent, update_on_signals, PROC_REF(update_process))
+	RegisterSignal(parent, COMSIG_MOVABLE_MOVED, PROC_REF(nullspace_move_check))
 	update_process()
 
 /datum/stamina_container/Destroy()
 	if(!isnull(parent))
 		parent.stamina = null
 		UnregisterSignal(parent, update_on_signals)
+		UnregisterSignal(parent, COMSIG_MOVABLE_MOVED)
 	parent = null
 	STOP_PROCESSING(SSstamina, src)
 	return ..()
@@ -121,6 +123,12 @@
 	if((amount < 0) && is_regenerating)
 		pause(STAMINA_REGEN_TIME)
 	return amount
+
+/// Signal handler for COMSIG_MOVABLE_MOVED to ensure that update_process() gets called whenever moving to/from nullspace.
+/datum/stamina_container/proc/nullspace_move_check(atom/movable/mover, atom/old_loc, dir, force)
+	SIGNAL_HANDLER
+	if(isnull(old_loc) || isnull(mover.loc))
+		update_process()
 
 /// Returns if the container should currently be processing or not.
 /datum/stamina_container/proc/should_process()

--- a/monkestation/code/datums/stamina_container.dm
+++ b/monkestation/code/datums/stamina_container.dm
@@ -51,6 +51,7 @@
 	return ..()
 
 /datum/stamina_container/proc/update(seconds_per_tick = 1)
+	var/last_current = current
 	if(process_stamina == TRUE)
 		if(!is_regenerating)
 			if(!COOLDOWN_FINISHED(src, paused_stamina))
@@ -69,7 +70,8 @@
 	else if(!(current == maximum))
 		process_stamina = TRUE
 
-	parent.on_stamina_update()
+	if(current != last_current)
+		parent.on_stamina_update()
 
 ///Pause stamina regeneration for some period of time. Does not support doing this from multiple sources at once because I do not do that and I will add it later if I want to.
 /datum/stamina_container/proc/pause(time)

--- a/monkestation/code/modules/mob/living/living_defines.dm
+++ b/monkestation/code/modules/mob/living/living_defines.dm
@@ -7,3 +7,5 @@
 	///The talk chime set to use when speaking.
 	var/voice_type
 
+	/// If TRUE, then this mob has a stamina container initialized, and will use stamina.
+	var/uses_stamina = FALSE


### PR DESCRIPTION

## About The Pull Request

frees up some processing time processing stamina on things that do not care about stamina.

## Changelog
:cl:
refactor: The Stamina subsystem no longer wastes time trying to process stamina on dead mobs, or mobs that don't even care about stamina in the first place.
/:cl:
