### PR TITLE
pAIs now have inherent maintenance access

### DIFF
--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -437,4 +437,4 @@
 	leash.set_distance(new_distance)
 
 /mob/living/silicon/pai/get_access()
-	return list()
+	return list(ACCESS_MAINT_TUNNELS) //MONKESTATION EDIT: Add inherent maints access to pAIs


### PR DESCRIPTION
## About The Pull Request
This PR gives pAIs inherent maintenance access, allowing them to enter and exit into maintenance as they desire.

## Why It's Good For The Game
This makes it a little less annoying to explore as pAI (especially a free pAI). Previously, you were locked to the public halls (you were equivalent to someone without an ID) unless you downloaded doorjack (which takes up a whole 35% of memory) and had someone to open a door for you (defeating the purpose of exploring on your own - plus, annoying if nobody is paying attention).

Now, while you still don't have access to the whole station (and rightfully so, since you don't answer to anybody but your owner), you can at least access maintenance without the need for doorjacking or getting someone to open a door for you.

This actually enhances the utility of pAIs a bit. For example, currently, a Security member can task their pAI with scouting remote locations - but the lack of access prevents this from being useful. With inherent maintenance access, a pAI can be much more effective in scouting remote locations without the need of an accompanying crew member.

## Changelog

:cl:MichiRecRoom
qol: pAIs now have inherent maintenance access
/:cl:
