### PR TITLE
Fix the Experimental Destructive Scanner's UI

### DIFF
--- a/tgui/packages/tgui/interfaces/ExperimentConfigure.jsx
+++ b/tgui/packages/tgui/interfaces/ExperimentConfigure.jsx
@@ -121,6 +121,10 @@ export const ExperimentConfigure = (props) => {
     }
   });
 
+  // MONKESTATION NOTE(react): (?) The experiments section was broken on 516 - specifically,
+  // something prevented the scrollbar in the experiment section from appearing, until the
+  // `scrollable` and `fill` attributes were added. When porting to react, see if the UI still works
+  // when removing them.
   return (
     <Window resizable width={600} height={735}>
       <Window.Content>
@@ -143,6 +147,8 @@ export const ExperimentConfigure = (props) => {
               <Section
                 title="Experiments"
                 className="ExperimentConfigure__ExperimentsContainer"
+                scrollable // MONKESTATION ADDITION: See note(react) above
+                fill // MONKESTATION ADDITION: See note(react) above
               >
                 <Flex.Item mb={1}>
                   {(experiments.length &&


### PR DESCRIPTION
## About The Pull Request
Somehow, the Experimental Destructive Scanner's UI is broken over here on Monke. Specifically, the scrollbar in the Experiments section doesn't appear to show on 516.

Notably, the same tgui code (or seemingly the same code) doesn't appear to break over on tgstation, indicating a possible discrepancy between React and Inferno and how they handle WebView2.

As such, I have marked it as something to investigate when we eventually get to porting to React.

#### Before
![experimental destructive scanner-before2](https://github.com/user-attachments/assets/32147629-dd42-4f7d-bdfe-8ae97a3382a3)
#### After
![experimental destructive scanner-after2](https://github.com/user-attachments/assets/5f937b64-df13-4ce1-97a6-bcd2a1a9c96e)

## Why It's Good For The Game
Fixes #5875

## Changelog

:cl:MichiRecRoom
fix: The experimental destructive scanner's UI should now show a scrollbar on 516. (Please let me know if any other UIs that show a list of experiments are broken.)
/:cl: