### PR TITLE
Allows admins to adjust monkecoins to negative

### DIFF
--- a/monkestation/code/modules/store/admin/admin_coin_modification.dm
+++ b/monkestation/code/modules/store/admin/admin_coin_modification.dm
@@ -13,9 +13,6 @@
 	if(!adjustment_amount)
 		return
 
-	if(adjustment_amount + chosen_client.prefs.metacoins < 0)
-		adjustment_amount = -chosen_client.prefs.metacoins
-
 	chosen_client.prefs.adjust_metacoins(chosen_client.ckey, adjustment_amount, "Admin [ckey] adjusted coins", FALSE, FALSE)
 
 /client/proc/mass_add_metacoins()


### PR DESCRIPTION
## "Fuck you" *sets you to negative 1 morbillion monkecoins
## Allows admins to adjust players monkecoins amount to a negative, also should fix an issue where taking away more thana player had would instead add the negative amount as a positive number (for some reason)
## Changelog
:cl:
admin: (del) Removes negative value check for adjusting monkecoins
/:cl:
