### PR TITLE
Revert "Allows admins to adjust monkecoins to negative"

### DIFF
--- a/monkestation/code/modules/store/admin/admin_coin_modification.dm
+++ b/monkestation/code/modules/store/admin/admin_coin_modification.dm
@@ -13,6 +13,9 @@
 	if(!adjustment_amount)
 		return
 
+	if(adjustment_amount + chosen_client.prefs.metacoins < 0)
+		adjustment_amount = -chosen_client.prefs.metacoins
+
 	chosen_client.prefs.adjust_metacoins(chosen_client.ckey, adjustment_amount, "Admin [ckey] adjusted coins", FALSE, FALSE)
 
 /client/proc/mass_add_metacoins()


### PR DESCRIPTION
Reverts Monkestation/Monkestation2.0#5880

That if statement is important, have a hypothetical series of events as to why:

Admin catches some shitter afk farming monkey coins, they are up to quite a few coin
![image](https://github.com/user-attachments/assets/351fe20e-0354-402b-ae2a-40e3f6eac3b9)
and they need oblitterated, so admin goes fuck em, take it all and then some
![image](https://github.com/user-attachments/assets/bc8d1d9d-b4ed-4c07-832f-be56df2fe86b)
and if they check their balance
![image](https://github.com/user-attachments/assets/5de7c9d8-3301-4980-a1a2-e355bd7ec6af)
perfect, but what is this?
![image](https://github.com/user-attachments/assets/4f4dd4e5-f3d2-4dea-9dd6-ca03ede9619a)
if we check back next round
![image](https://github.com/user-attachments/assets/1f7baed1-1abd-4f2c-84b8-a14da09193e7)

This isn't just if an admin is intentionally trying to set them as negative, if someone has a balance of 54573, and an admin tries to take 54574, the player gets to keep all their monkecoin.

The if statement is important.