### PR TITLE
Bowie, combat, and sabre damage change

### DIFF
--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -120,7 +120,7 @@
 	icon_state = "buckknife"
 	desc = "A military combat utility survival knife."
 	embedding = list("pain_mult" = 4, "embed_chance" = 65, "fall_chance" = 10, "ignore_throwspeed_threshold" = TRUE)
-	force = 20
+	force = 17 // MONKESTATION EDIT ORG: 20
 	throwforce = 20
 	attack_verb_continuous = list("slashes", "stabs", "slices", "tears", "lacerates", "rips", "cuts")
 	attack_verb_simple = list("slash", "stab", "slice", "tear", "lacerate", "rip", "cut")

--- a/monkestation/code/modules/blueshift/items/knives.dm
+++ b/monkestation/code/modules/blueshift/items/knives.dm
@@ -10,7 +10,7 @@
 	lefthand_file = 'monkestation/code/modules/blueshift/icons/bowie_lefthand.dmi'
 	righthand_file = 'monkestation/code/modules/blueshift/icons/bowie_righthand.dmi'
 	worn_icon_state = "knife"
-	force = 20 // Zoowee Momma!
+	force = 17
 	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 15
 	wound_bonus = 10 //scalpel tier

--- a/monkestation/code/modules/blueshift/items/melee.dm
+++ b/monkestation/code/modules/blueshift/items/melee.dm
@@ -14,7 +14,7 @@
 	name = "authentic shamshir sabre"
 	desc = "An expertly crafted historical human sword once used by the Persians which has recently gained traction due to Venusian historal recreation sports. One small flaw, the Taj-based company who produces these has mistaken them for British cavalry sabres akin to those used by high ranking Nanotrasen officials. Atleast it cuts the same way!"
 	icon = 'monkestation/code/modules/blueshift/icons/obj/melee.dmi'
-	force = 15
+	force = 18
 	block_chance = 20
 	armour_penetration = 10
 	wound_bonus = 0


### PR DESCRIPTION

## About The Pull Request
Ups cargo sabre damage from 15 to 18
lowers bowie and combat damage from 20 to 17 

## Why It's Good For The Game
While these changes seem minor, they do make quite a bit of difference in the long run making people take 1 more hit to drop.
In the case of the cargo sabre when I originally changed its stats I kinda screwed it up by dropping all its stats a bit. This keeps its other stats down a bit but gives it a bit more damage to be worthy of being a actual sword.

As for the bowie and combat knife, 20 force with great wounding is a lot for easily and wildly accessible crew melee weapons that can be hidden in bag. A large chunk of our antags are melee based, while crew should be able to fight em these knifes really execeeded some antag weapons, the bowie knife stats being 1:1 a heretic blade, besides AP, and while a heretic has magic, crew can have many of these knifes. They allowed most our melee antags to really be fought on nearly equal terms quick with high wounding.

This change is to make them still worth using over a common weapon like a circular saw, but also not quite as good as they were before being able to drop some higher armor targets pretty easily with good wounds and damage.

## Changelog

:cl:
balance: cargo sabre damage is now 18 from 15
balance: bowie and combat knives damage are now 17 from 20
/:cl:

