### PR TITLE
Actually give pAIs maints access, for real this time

### DIFF
--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -15,7 +15,11 @@
 		return FALSE
 	if(issilicon(accessor))
 		if(ispAI(accessor))
-			return FALSE
+			//MONKESTATION EDIT START: pAI has inherent maintenance access
+			// return FALSE //MONKESTATION EDIT ORIGINAL
+			var/mob/living/silicon/pai/pai = accessor
+			return check_access_list(pai.get_access())
+			//MONKESTATION EDIT END
 		if(!(ROLE_SYNDICATE in accessor.faction))
 			if((ACCESS_SYNDICATE in req_access) || (ACCESS_SYNDICATE_LEADER in req_access) || (ACCESS_SYNDICATE in req_one_access) || (ACCESS_SYNDICATE_LEADER in req_one_access))
 				return FALSE


### PR DESCRIPTION
## About The Pull Request
Turns out #5870 didn't work, as pAIs were just flatly refused by doors unless they were public doors. Now they get their actual access from `get_access()` (which is still just maintenance doors).

## Why It's Good For The Game
Actually give pAIs maints access, for real this time

## Changelog

:cl:MichiRecRoom
fix: pAIs now ACTUALLY have maints access, as compared to before where the doors just said "no" no matter what.
/:cl:
