### PR TITLE
[PORT] *Properly* rebuild plane masters after client login if switching between 515 and 516

### DIFF
--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -105,6 +105,10 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 
 	var/list/team_finder_arrows = list()
 
+	/// The BYOND version of the client that was last logged into this mob.
+	/// Currently used to rebuild all plane master groups when going between 515<->516.
+	var/last_byond_version
+
 /datum/hud/New(mob/owner)
 	mymob = owner
 
@@ -147,13 +151,17 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 /datum/hud/proc/client_refresh(datum/source)
 	SIGNAL_HANDLER
 	var/client/client = mymob.canon_client
-	if(client.rebuild_plane_masters)
-		var/new_relay_loc = (client.byond_version > 515) ? "1,1" : "CENTER"
+	var/new_byond_version = client.byond_version
+#if MIN_COMPILER_VERSION > 515
+	#warn Fully change default relay_loc to "1,1", rather than changing it based on client version
+#endif
+	if(!isnull(last_byond_version) && new_byond_version != last_byond_version)
+		var/new_relay_loc = (new_byond_version > 515) ? "1,1" : "CENTER"
 		for(var/group_key as anything in master_groups)
 			var/datum/plane_master_group/group = master_groups[group_key]
 			group.relay_loc = new_relay_loc
 			group.rebuild_hud()
-		client.rebuild_plane_masters = FALSE
+	last_byond_version = new_byond_version
 	RegisterSignal(client, COMSIG_CLIENT_SET_EYE, PROC_REF(on_eye_change))
 	on_eye_change(null, null, client.eye)
 

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -271,7 +271,3 @@
 
 	/// Does this client have typing indicators enabled?
 	var/typing_indicators = FALSE
-
-	/// Does this client's mob need to rebuild its plane masters after login?
-	/// This is currently only used so a client can switch between 515 and 516 without breaking their rendering.
-	var/rebuild_plane_masters = FALSE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -339,16 +339,8 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 	if(GLOB.player_details[ckey])
 		reconnecting = TRUE
 		player_details = GLOB.player_details[ckey]
-		var/old_version = player_details.byond_version
 		player_details.byond_version = byond_version
 		player_details.byond_build = byond_build
-
-#if MIN_COMPILER_VERSION > 516
-	#warn Fully change default relay_loc to "1,1", rather than changing it based on client version
-#endif
-		if(old_version != byond_version)
-			rebuild_plane_masters = TRUE
-
 	else
 		player_details = new(ckey)
 		player_details.byond_version = byond_version


### PR DESCRIPTION
## About The Pull Request
* Ports tgstation/tgstation#88829

Fixes an issue discovered in recent days, where a 516 client taking over a mob previously owned by a 515 client would have hud issues until they ghosted.

## Why It's Good For The Game
per absolucy:
> whoopsie breaking graphics is bad

## Changelog

:cl:MichiRecRoom
fix: (Ported from tgstation - Absolucy) Fixed graphics getting screwed up when reconnecting with BYOND 515 after playing on BYOND 516.
/:cl: