### PR TITLE
Changes junior operatives max occurences and event track

### DIFF
--- a/monkestation/code/modules/antagonists/nukeop/nukeop.dm
+++ b/monkestation/code/modules/antagonists/nukeop/nukeop.dm
@@ -8,6 +8,8 @@
 	category = EVENT_CATEGORY_INVASION
 	description = "A junior nuclear operative infiltrates the station."
 	weight = 1
+	max_occurrences = 5
+	track = EVENT_TRACK_MAJOR
 
 /datum/round_event/ghost_role/junior_operative
 	minimum_required = 1


### PR DESCRIPTION

## About The Pull Request
Lowers junior operatives max occurences down to 5 (from 20), and changes the event to major (from moderate)
## Why It's Good For The Game
20 max occurrences is absurd, especially considering if the other events in that category runs out, then it'll start spamming junior operatives. Also junior operatives are not on the same level as florida men and slashers (also moderate antag events), and are more in line with major events like dragon and lone operatives.
## Changelog
:cl:
balance: Junior operative max occurrences lowered from 20 to 5
balance: Junior operative event category changed from moderate to major
/:cl:
