### PR TITLE
Prevents normal players from messing with event controls.

### DIFF
--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -165,6 +165,10 @@
 
 /datum/round_event_control/Topic(href, href_list)
 	..()
+
+	if(!check_rights(R_ADMIN))
+		return
+
 	if(href_list["cancel"])
 		if(!triggering)
 			to_chat(usr, span_admin("You are too late to cancel that event"))
@@ -344,6 +348,10 @@ Runs the event
 	. = ..()
 	if(QDELETED(src))
 		return
+
+	if(!check_rights(R_ADMIN))
+		return
+
 	switch(href_list["action"])
 		if("schedule")
 			message_admins("[key_name_admin(usr)] scheduled event [src.name].")


### PR DESCRIPTION

## About The Pull Request

Refs are, in fact, guessable.

Not sure if `R_ADMIN` is the correct choice.

## Why It's Good For The Game

Just because :>

## Changelog
:cl:
admin: Controlling events now requires basic admin permissions.
/:cl:
