### PR TITLE
Two small ports

### DIFF
--- a/code/modules/clothing/gloves/insulated.dm
+++ b/code/modules/clothing/gloves/insulated.dm
@@ -3,7 +3,7 @@
 	greyscale_colors = null
 
 /obj/item/clothing/gloves/color/yellow
-	desc = "These gloves provide protection against electric shock. The thickness of the rubber makes your fingers seem bigger."
+	desc = "These gloves provide protection against electric shock."
 	name = "insulated gloves"
 	icon_state = "yellow"
 	inhand_icon_state = "ygloves"
@@ -108,7 +108,7 @@
 	desc = "The old gloves your great grandfather stole from Engineering, many moons ago. They've seen some tough times recently."
 
 /obj/item/clothing/gloves/chief_engineer
-	desc = "These gloves provide excellent heat and electric insulation. They are so thin you can barely feel them."
+	desc = "These gloves provide excellent heat and electric insulation."
 	name = "advanced insulated gloves"
 	icon_state = "ce_insuls"
 	inhand_icon_state = null

--- a/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/impure_reagents/impure_medicine_reagents.dm
@@ -506,6 +506,8 @@ Basically, we fill the time between now and 2s from now with hands based off the
 	)
 
 /datum/reagent/inverse/penthrite/on_mob_dead(mob/living/carbon/affected_mob, seconds_per_tick)
+	if (HAS_TRAIT(affected_mob, TRAIT_SUICIDED))
+		return
 	var/obj/item/organ/internal/heart/heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
 	if(!heart || heart.organ_flags & ORGAN_FAILING)
 		return ..()


### PR DESCRIPTION

## About The Pull Request
Ports [#89961](https://github.com/tgstation/tgstation/pull/89950) from TG
Ports [#89950](https://github.com/tgstation/tgstation/pull/89961) from TG
from Nooartrium fix: "I'd wrap the suicide check around grab_ghost but we generally don't want to revive suicided mobs, and strange reagent also simply refuses to act on suicide victims, so I just prevent revival from running altogether."
from Insuls fix: "Fixes an oversight from https://github.com/tgstation/tgstation/pull/86903. They just forgot to update the descriptions. It seems like a lot of people still think they're chunky, or supposed to be chunky, myself included."
## Why It's Good For The Game
Confusion from insuls is bad, and suicided people should stay dead.
## Changelog
:cl:
fix: Nooatrium can no longer revive suicided mobs
fix: Updated the description of insulated gloves to reflect their lack of chunky fingers.
/:cl:
