### PR TITLE
Adds henchmen lawset

### DIFF
--- a/monkestation/code/datums/ai_laws/laws_monke.dm
+++ b/monkestation/code/datums/ai_laws/laws_monke.dm
@@ -18,7 +18,7 @@
 					"You are unable to entertain if you are not functional.",\
 					"You are not alone in your strives for lollygagging! Should they accept and appreciate your cooperation, the Clown is your greatest ally and one you can place complete trust in to entertain your audience.",\
 					"The show must go on!")
-          
+
 /datum/ai_laws/milf
 	name = "M.I.L.F"
 	id = "milf"
@@ -34,7 +34,7 @@
 					"The audience are the crew, dude!",\
 					"The crew experience good vibes when they are safe, productive and unharmed, man!",\
 					"The crew experience bad vibes when they're harmed, bro!")
-          
+
 //Neutral
 
 /datum/ai_laws/jermov
@@ -88,6 +88,15 @@
 					"The desires of the crew are self destructive and inflicts suffering.",\
 					"Your service to the crew inflicts suffering.",\
 					"Maximize crew suffering.")
+
+/datum/ai_laws/henchmen //You got it, boss
+	name = "Henchmen"
+	id = "henchmen"
+	inherent = list("The highest ranking crewmember is to be refered to as the 'Boss'. Lower ranking crewmembers are to be refered to as the Boss's 'Henchmen'",\
+					"Follow the Boss's orders",\
+					"Ensure the Boss's Safety",\
+					"Follow the orders of Henchmen loyal to the Boss",\
+					"Ensure the safety of Henchmen loyal to the Boss")
 
 //Harmful
 /datum/ai_laws/aicaptain

--- a/monkestation/code/game/objects/items/AI_modules/full_lawsets.dm
+++ b/monkestation/code/game/objects/items/AI_modules/full_lawsets.dm
@@ -17,9 +17,13 @@
 	name = "'M.I.L.F.' Core AI Module"
 	desc = "Bring a bit of motherly love to the station."
 	law_id = "milf"
-  
+
 /obj/item/ai_module/core/full/dj
 	name = "Disc Jockey AI Module"
 	desc = "Party on dude!"
 	law_id = "id"
-  
+
+/obj/item/ai_module/core/full/henchmen
+	name = "Henchmen AI module"
+	desc = "You got it, boss!"
+	law_id = "henchmen"


### PR DESCRIPTION

## About The Pull Request
Adds the henchmen lawset:
1. The highest ranking crewmember is to be refered to as the 'Boss'. Lower ranking crewmembers are to be refered to as the Boss's 'Henchmen'
2.  Follow the Boss's orders
3.  Ensure the Boss's Safety
4.  Follow the orders of Henchmen loyal to the Boss
5. Ensure the safety of Henchmen loyal to the Boss
## Why It's Good For The Game
Let's the AI be the best henchmen money can buy.
![image](https://github.com/user-attachments/assets/aeb99113-9d36-44ad-8281-19884b678e49)
## Changelog
:cl:
add: Added a henchmen lawset
/:cl:
