### PR TITLE
Adds lesser strange seeds

### DIFF
--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -610,13 +610,20 @@
 	var/amount_random_reagents = rand(lower, upper)
 	for(var/i in 1 to amount_random_reagents)
 		var/random_amount = rand(4, 15) * 0.01 // this must be multiplied by 0.01, otherwise, it will not properly associate
-		var/datum/plant_gene/reagent/R = new(get_random_reagent_id(), random_amount)
+		var/datum/plant_gene/reagent/R = new(pick_reagent(), random_amount) // monkestation edit: pick_reagent proc
 		if(R.can_add(src))
 			if(!R.try_upgrade_gene(src))
 				genes += R
 		else
 			qdel(R)
 	reagents_from_genes()
+
+// monkestation start: pick_reagent proc
+/// Returns a random reagent ID.
+/// Just a wrapper around [get_random_reagent_id] by default, this exists so subtypes can override it.
+/obj/item/seeds/proc/pick_reagent()
+	return get_random_reagent_id()
+// monkestation end
 
 /obj/item/seeds/proc/add_random_traits(lower = 0, upper = 2)
 	var/amount_random_traits = rand(lower, upper)

--- a/monkestation/code/modules/hydroponics/grown/random.dm
+++ b/monkestation/code/modules/hydroponics/grown/random.dm
@@ -1,0 +1,37 @@
+/obj/item/seeds/random/lesser
+	name = "pack of lesser strange seeds"
+	desc = "Mysterious seeds as strange as their name implies, albeit with less potential than their \"normal\" counterparts."
+	/// Typecache of reagents forbidden from appearing.
+	/// This is not an exhaustive list, as any reagent without REAGENT_CAN_BE_SYNTHESIZED is also blacklisted.
+	var/static/list/reagent_blacklist = typecacheof(list(
+		/datum/reagent/aslimetoxin,
+		/datum/reagent/drug/blastoff,
+		/datum/reagent/drug/demoneye,
+		/datum/reagent/drug/twitch,
+		/datum/reagent/magillitis,
+		/datum/reagent/medicine/antipathogenic/changeling,
+		/datum/reagent/medicine/changelinghaste,
+		/datum/reagent/medicine/coagulant,
+		/datum/reagent/medicine/regen_jelly,
+		/datum/reagent/medicine/stimulants,
+		/datum/reagent/medicine/syndicate_nanites,
+		/datum/reagent/metalgen,
+		/datum/reagent/mulligan,
+		/datum/reagent/mutationtoxin,
+		/datum/reagent/prefactor_a,
+		/datum/reagent/prefactor_b,
+		/datum/reagent/reaction_agent,
+		/datum/reagent/spider_extract,
+	))
+
+/obj/item/seeds/random/lesser/pick_reagent()
+	var/static/list/valid_reagent_list
+	if(isnull(valid_reagent_list))
+		LAZYINITLIST(valid_reagent_list)
+		for(var/datum/reagent/reagent_path as anything in subtypesof(/datum/reagent))
+			if(!(reagent_path::chemical_flags & REAGENT_CAN_BE_SYNTHESIZED))
+				continue
+			if(is_type_in_typecache(reagent_path, reagent_blacklist))
+				continue
+			valid_reagent_list += reagent_path
+	return pick(valid_reagent_list)

--- a/monkestation/code/modules/research/designs/biogenerator_designs.dm
+++ b/monkestation/code/modules/research/designs/biogenerator_designs.dm
@@ -1,3 +1,7 @@
+/datum/design/strange_seeds
+	name = "Lesser Strange Seeds"
+	build_path = /obj/item/seeds/random/lesser
+
 /datum/design/rat_cube // Monkestation, useful for chaplain and pathologist.
 	name = "Mouse Cube"
 	id = "rcube" // R for Rat

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7438,6 +7438,7 @@
 #include "monkestation\code\modules\hydroponics\seeds.dm"
 #include "monkestation\code\modules\hydroponics\grown\coconut.dm"
 #include "monkestation\code\modules\hydroponics\grown\honeydew.dm"
+#include "monkestation\code\modules\hydroponics\grown\random.dm"
 #include "monkestation\code\modules\hydroponics\machines\composter.dm"
 #include "monkestation\code\modules\hydroponics\machines\splicer.dm"
 #include "monkestation\code\modules\hydroponics\mutations\_mutations.dm"


### PR DESCRIPTION

## About The Pull Request

this adds "Lesser Strange Seeds", which biogenerators can print. these have a more extensive reagent blacklist (in addition to the usual list of stuff that strange seeds can't make)

## Why It's Good For The Game

Feels like a good middle-ground between nuking strange seeds and leaving them un-nerfed

## Changelog
:cl:
add: Added "Lesser Strange Seeds", variants of strange seeds with a wider limitation on reagents.
balance: Biogenerators can now only print lesser strange seeds. Other sources of strange seeds remain unchanged.
/:cl:
