### PR TITLE
[BOUNTY] Implements atom integrity for walls, (which is needed to do) Upgraded Emitters can now tear down walls! Take Two!

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -398,6 +398,10 @@
 /obj/machinery/door/poddoor,
 /turf/open/floor/engine,
 /area/station/cargo/miningoffice)
+"bP" = (
+/obj/item/storage/part_replacer/bluespace/tier3,
+/turf/open/floor/plating,
+/area/station/construction)
 "bQ" = (
 /obj/machinery/chem_master,
 /turf/open/floor/iron/dark,
@@ -1485,6 +1489,7 @@
 	pixel_x = 32;
 	pixel_y = -7
 	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "fN" = (
@@ -1597,6 +1602,11 @@
 /obj/effect/mapping_helpers/airalarm/unlocked,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"gj" = (
+/obj/structure/cable,
+/obj/machinery/power/rtg/debug,
+/turf/open/floor/plating,
+/area/station/construction)
 "gk" = (
 /obj/structure/sign/departments/evac,
 /turf/closed/wall/r_wall,
@@ -1964,6 +1974,10 @@
 "qQ" = (
 /turf/open/floor/engine,
 /area/station/cargo/miningoffice)
+"rj" = (
+/obj/item/storage/part_replacer/bluespace/tier2,
+/turf/open/floor/plating,
+/area/station/construction)
 "rn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -2010,6 +2024,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
+"ti" = (
+/obj/item/storage/part_replacer/bluespace/tier1,
+/turf/open/floor/plating,
+/area/station/construction)
 "tB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/south,
@@ -2253,6 +2271,11 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/medical/medbay)
+"Ej" = (
+/obj/machinery/power/emitter/welded,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/construction)
 "Em" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/unlocked,
@@ -2316,6 +2339,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/storage/primary)
+"Ia" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/station/construction)
 "If" = (
 /obj/machinery/rnd/production/techfab/department,
 /turf/open/floor/iron,
@@ -2341,6 +2368,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"Jg" = (
+/obj/item/storage/part_replacer/bluespace/tier4,
+/turf/open/floor/plating,
+/area/station/construction)
 "Jn" = (
 /obj/machinery/camera/directional/east,
 /turf/open/floor/iron/dark,
@@ -2410,6 +2441,9 @@
 /obj/machinery/chem_recipe_debug,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
+"Np" = (
+/turf/closed/wall,
+/area/station/construction)
 "Ns" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable,
@@ -2671,6 +2705,12 @@
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"ZJ" = (
+/obj/machinery/light/floor/has_bulb,
+/obj/structure/cable,
+/obj/item/card/emag,
+/turf/open/floor/plating,
+/area/station/construction)
 "ZP" = (
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
@@ -6295,13 +6335,13 @@ bE
 ef
 EA
 dn
+gj
+ti
+dn
+Ej
 dn
 dn
-dn
-dn
-dn
-dn
-dn
+Np
 dn
 dn
 dL
@@ -6387,10 +6427,10 @@ bE
 cN
 BW
 dn
+gj
+rj
 dn
-dn
-dn
-dn
+Ia
 dn
 dn
 dn
@@ -6479,10 +6519,10 @@ bE
 cN
 EA
 dn
-dn
-XE
-dn
-dn
+Ia
+ZJ
+Ia
+Ia
 dn
 dn
 XE
@@ -6571,10 +6611,10 @@ bE
 cN
 cY
 dn
+gj
+bP
 dn
-dn
-dn
-dn
+Ia
 dn
 dn
 dn
@@ -6663,13 +6703,13 @@ bE
 cN
 cY
 dn
+gj
+Jg
+dn
+Ej
 dn
 dn
-dn
-dn
-dn
-dn
-dn
+cN
 dn
 dn
 dL

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -398,10 +398,6 @@
 /obj/machinery/door/poddoor,
 /turf/open/floor/engine,
 /area/station/cargo/miningoffice)
-"bP" = (
-/obj/item/storage/part_replacer/bluespace/tier3,
-/turf/open/floor/plating,
-/area/station/construction)
 "bQ" = (
 /obj/machinery/chem_master,
 /turf/open/floor/iron/dark,
@@ -1489,7 +1485,6 @@
 	pixel_x = 32;
 	pixel_y = -7
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "fN" = (
@@ -1602,11 +1597,6 @@
 /obj/effect/mapping_helpers/airalarm/unlocked,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"gj" = (
-/obj/structure/cable,
-/obj/machinery/power/rtg/debug,
-/turf/open/floor/plating,
-/area/station/construction)
 "gk" = (
 /obj/structure/sign/departments/evac,
 /turf/closed/wall/r_wall,
@@ -1946,7 +1936,6 @@
 	},
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/light/directional/west,
-/obj/structure/test_boulder_spawner,
 /turf/open/floor/iron,
 /area/station/construction)
 "pI" = (
@@ -1974,10 +1963,6 @@
 "qQ" = (
 /turf/open/floor/engine,
 /area/station/cargo/miningoffice)
-"rj" = (
-/obj/item/storage/part_replacer/bluespace/tier2,
-/turf/open/floor/plating,
-/area/station/construction)
 "rn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
@@ -2024,10 +2009,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
-"ti" = (
-/obj/item/storage/part_replacer/bluespace/tier1,
-/turf/open/floor/plating,
-/area/station/construction)
 "tB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/directional/south,
@@ -2271,11 +2252,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/medical/medbay)
-"Ej" = (
-/obj/machinery/power/emitter/welded,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/construction)
 "Em" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/unlocked,
@@ -2321,6 +2297,8 @@
 /obj/item/screwdriver{
 	pixel_y = 10
 	},
+/obj/item/storage/box/beakers/variety,
+/obj/item/storage/box/beakers,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
 "GS" = (
@@ -2339,10 +2317,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/storage/primary)
-"Ia" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/construction)
 "If" = (
 /obj/machinery/rnd/production/techfab/department,
 /turf/open/floor/iron,
@@ -2368,10 +2342,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"Jg" = (
-/obj/item/storage/part_replacer/bluespace/tier4,
-/turf/open/floor/plating,
-/area/station/construction)
 "Jn" = (
 /obj/machinery/camera/directional/east,
 /turf/open/floor/iron/dark,
@@ -2441,9 +2411,6 @@
 /obj/machinery/chem_recipe_debug,
 /turf/open/floor/iron,
 /area/station/medical/chemistry)
-"Np" = (
-/turf/closed/wall,
-/area/station/construction)
 "Ns" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/structure/cable,
@@ -2705,12 +2672,6 @@
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"ZJ" = (
-/obj/machinery/light/floor/has_bulb,
-/obj/structure/cable,
-/obj/item/card/emag,
-/turf/open/floor/plating,
-/area/station/construction)
 "ZP" = (
 /turf/open/floor/iron/dark,
 /area/station/science/explab)
@@ -6335,13 +6296,13 @@ bE
 ef
 EA
 dn
-gj
-ti
-dn
-Ej
 dn
 dn
-Np
+dn
+dn
+dn
+dn
+dn
 dn
 dn
 dL
@@ -6427,10 +6388,10 @@ bE
 cN
 BW
 dn
-gj
-rj
 dn
-Ia
+dn
+dn
+dn
 dn
 dn
 dn
@@ -6519,10 +6480,10 @@ bE
 cN
 EA
 dn
-Ia
-ZJ
-Ia
-Ia
+dn
+XE
+dn
+dn
 dn
 dn
 XE
@@ -6611,10 +6572,10 @@ bE
 cN
 cY
 dn
-gj
-bP
 dn
-Ia
+dn
+dn
+dn
 dn
 dn
 dn
@@ -6703,13 +6664,13 @@ bE
 cN
 cY
 dn
-gj
-Jg
-dn
-Ej
 dn
 dn
-cN
+dn
+dn
+dn
+dn
+dn
 dn
 dn
 dL

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -9,6 +9,18 @@
 	rad_insulation = RAD_MEDIUM_INSULATION
 	pass_flags_self = PASSCLOSEDTURF
 
+/turf/closed/examine(mob/user)
+	. = ..()
+	if(uses_integrity && atom_integrity < max_integrity)
+		var/healthpercent = (atom_integrity/max_integrity) * 100
+		switch(healthpercent)
+			if(50 to 99)
+				. +=  "It looks slightly damaged."
+			if(25 to 50)
+				. +=  "It appears heavily damaged."
+			if(0 to 25)
+				. += span_warning("It's falling apart!")
+
 /turf/closed/AfterChange()
 	. = ..()
 	SSair.high_pressure_delta -= src

--- a/code/game/turfs/closed/_closed.dm
+++ b/code/game/turfs/closed/_closed.dm
@@ -9,6 +9,7 @@
 	rad_insulation = RAD_MEDIUM_INSULATION
 	pass_flags_self = PASSCLOSEDTURF
 
+//Monkestation edit start
 /turf/closed/examine(mob/user)
 	. = ..()
 	if(uses_integrity && atom_integrity < max_integrity)
@@ -20,6 +21,7 @@
 				. +=  "It appears heavily damaged."
 			if(0 to 25)
 				. += span_warning("It's falling apart!")
+//Monkestation edit end
 
 /turf/closed/AfterChange()
 	. = ..()

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -13,6 +13,8 @@
 	sheet_amount = 1
 	girder_type = /obj/structure/girder/reinforced
 	explosive_resistance = 2
+	max_integrity = 400
+	damage_deflection = 75 // can't be damaged with most conventional weapons or tools
 	rad_insulation = RAD_HEAVY_INSULATION
 	heat_capacity = 312500 //a little over 5 cm thick , 312500 for 1 m by 2.5 m by 0.25 m plasteel wall. also indicates the temperature at wich the wall will melt (currently only able to melt with H/E pipes)
 	///Dismantled state, related to deconstruction.
@@ -205,7 +207,7 @@
 		icon_state = "[base_icon_state]-[smoothing_junction]"
 	return ..()
 
-/turf/closed/wall/r_wall/wall_singularity_pull(current_size)
+/turf/closed/wall/r_wall/singularity_pull(current_size)
 	if(current_size >= STAGE_FIVE)
 		if(prob(30))
 			dismantle_wall()

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -8,6 +8,7 @@
 	density = TRUE
 	turf_flags = IS_SOLID
 	smoothing_flags = SMOOTH_BITMASK
+	hardness = 10
 	sheet_type = /obj/item/stack/sheet/plasteel
 	sheet_amount = 1
 	girder_type = /obj/structure/girder/reinforced

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -12,8 +12,8 @@
 	sheet_amount = 1
 	girder_type = /obj/structure/girder/reinforced
 	explosive_resistance = 2
-	max_integrity = 600
-	damage_deflection = 75 // can't be damaged with most conventional weapons or tools
+	max_integrity = 600 //Monkestation edit
+	damage_deflection = 75 // can't be damaged with most conventional weapons or tools Monkestation edit
 	rad_insulation = RAD_HEAVY_INSULATION
 	heat_capacity = 312500 //a little over 5 cm thick , 312500 for 1 m by 2.5 m by 0.25 m plasteel wall. also indicates the temperature at wich the wall will melt (currently only able to melt with H/E pipes)
 	///Dismantled state, related to deconstruction.
@@ -206,7 +206,7 @@
 		icon_state = "[base_icon_state]-[smoothing_junction]"
 	return ..()
 
-/turf/closed/wall/r_wall/singularity_pull(current_size)
+/turf/closed/wall/r_wall/singularity_pull(current_size) //Monkestation edit
 	if(current_size >= STAGE_FIVE)
 		if(prob(30))
 			dismantle_wall()

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -8,12 +8,11 @@
 	density = TRUE
 	turf_flags = IS_SOLID
 	smoothing_flags = SMOOTH_BITMASK
-	hardness = 10
 	sheet_type = /obj/item/stack/sheet/plasteel
 	sheet_amount = 1
 	girder_type = /obj/structure/girder/reinforced
 	explosive_resistance = 2
-	max_integrity = 400
+	max_integrity = 600
 	damage_deflection = 75 // can't be damaged with most conventional weapons or tools
 	rad_insulation = RAD_HEAVY_INSULATION
 	heat_capacity = 312500 //a little over 5 cm thick , 312500 for 1 m by 2.5 m by 0.25 m plasteel wall. also indicates the temperature at wich the wall will melt (currently only able to melt with H/E pipes)

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -349,6 +349,17 @@
 		take_damage(150, armour_penetration=100)
 	//monkestation edit end
 
+/* //MONKESTATION REMOVAL: Deprecated, obselete old code proc
+/turf/closed/wall/proc/wall_singularity_pull(current_size)
+	if(current_size >= STAGE_FIVE)
+		if(prob(50))
+			dismantle_wall()
+		return
+	if(current_size == STAGE_FOUR)
+		if(prob(30))
+			dismantle_wall()
+*/
+
 /turf/closed/wall/narsie_act(force, ignore_mobs, probability = 20)
 	. = ..()
 	if(.)

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -144,7 +144,7 @@
 
 /turf/closed/wall/attacked_by(obj/item/attacking_item, mob/living/user)
 	if(!uses_integrity)
-		CRASH("attacked_by() was called on an object that doesnt use integrity!")
+		CRASH("attacked_by() was called on an wall that doesn't use integrity!")
 
 	if(!attacking_item.force)
 		return

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -36,7 +36,7 @@
 	var/list/dent_decals
 
 	max_integrity = 300
-	damage_deflection = 25 // big chunk of solid metal
+	damage_deflection = 22 // big chunk of solid metal
 	uses_integrity = TRUE
 	armor_type = /datum/armor/wall
 

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -35,6 +35,7 @@
 
 	var/list/dent_decals
 
+	//Monkestation edit start
 	max_integrity = 300
 	damage_deflection = 22 // big chunk of solid metal
 	uses_integrity = TRUE
@@ -49,11 +50,7 @@
 	bio = 0
 	acid = 50
 	wound = 0
-
-///type paths of projectiles explicitely whitelisted to damage walls
-	var/list/projectile_whitelist = list(
-		/obj/projectile/beam/emitter/hitscan
-	)
+//Monkestation edit end
 
 
 /turf/closed/wall/MouseDrop_T(mob/living/carbon/carbon_mob, mob/user)
@@ -139,6 +136,7 @@
 	. += ..()
 	. += deconstruction_hints(user)
 
+//monkestation edit start
 /turf/closed/wall/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)
 	. = ..()
 	if(.) // add a dent if it took damage
@@ -154,6 +152,7 @@
 	if(damage_flag == MELEE)
 		playsound(src, 'sound/effects/meteorimpact.ogg', 50, TRUE) //Otherwise there's no sound for hitting the wall, since it's just dismantled
 	dismantle_wall(TRUE, TRUE)
+//monkestation edit end
 
 /turf/closed/wall/proc/deconstruction_hints(mob/user)
 	return span_notice("The outer plating is <b>welded</b> firmly in place.")
@@ -200,7 +199,7 @@
 
 /turf/closed/wall/ex_act(severity, target)
 	if(target == src)
-		dismantle_wall(TRUE, TRUE)
+		dismantle_wall(TRUE, TRUE) //monkestation edit
 		return
 
 	switch(severity)
@@ -212,14 +211,16 @@
 		if(EXPLODE_HEAVY)
 			dismantle_wall(prob(50), TRUE)
 		if(EXPLODE_LIGHT)
-			take_damage(150, BRUTE, BOMB) // less kaboom
+			take_damage(150, BRUTE, BOMB) // less kaboom monkestation edit
 	if(!density)
 		..()
 
 
 /turf/closed/wall/blob_act(obj/structure/blob/B)
+	//monkestation edit start
 	take_damage(400, BRUTE, MELEE, FALSE)
 	playsound(src, 'sound/effects/meteorimpact.ogg', 100, 1)
+	//monkestation edit end
 
 /turf/closed/wall/attack_paw(mob/living/user, list/modifiers)
 	user.changeNext_move(CLICK_CD_MELEE)
@@ -232,12 +233,14 @@
 		return
 	if(arm.bodypart_disabled)
 		return
+	//monkestation edit start
 	user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
 	take_damage(400, BRUTE, MELEE, FALSE)
 	playsound(src, 'sound/effects/bang.ogg', 50, 1)
 	to_chat(user, span_notice("You punch the wall."))
 	hulk_recoil(arm, user)
 	return TRUE
+	//monkestation edit end
 
 /**
  *Deals damage back to the hulk's arm.
@@ -266,7 +269,7 @@
 	playsound(src, 'sound/weapons/genhit.ogg', 25, TRUE)
 	add_fingerprint(user)
 
-/turf/closed/wall/attackby(obj/item/attacking_item, mob/user, params)
+/turf/closed/wall/attackby(obj/item/attacking_item, mob/user, params) //monkestation edit
 	user.changeNext_move(CLICK_CD_MELEE)
 	if (!ISADVANCEDTOOLUSER(user))
 		to_chat(user, span_warning("You don't have the dexterity to do this!"))
@@ -279,7 +282,7 @@
 	add_fingerprint(user)
 
 	//the istype cascade has been spread among various procs for easy overriding
-	if(try_clean(attacking_item, user) || try_wallmount(attacking_item, user) || try_decon(attacking_item, user))
+	if(try_clean(attacking_item, user) || try_wallmount(attacking_item, user) || try_decon(attacking_item, user)) //monkestation edit
 		return
 
 	return ..() || (attacking_item.attack_atom(src, user))
@@ -288,6 +291,7 @@
 	if(((user.istate & ISTATE_HARM)))
 		return FALSE
 
+	//monkestation edit start
 	if(W.tool_behaviour == TOOL_WELDER)
 		if(atom_integrity >= max_integrity)
 			to_chat(user, span_warning("[src] is intact!"))
@@ -305,7 +309,7 @@
 			dent_decals.Cut()
 			return TRUE
 		return TRUE
-
+	//monkestation edit end
 	return FALSE
 
 /turf/closed/wall/proc/try_wallmount(obj/item/W, mob/user)
@@ -338,10 +342,12 @@
 
 /turf/closed/wall/singularity_pull(S, current_size)
 	. = ..()
+	//monkestation edit start
 	if(current_size >= STAGE_FIVE)
 		take_damage(300, armour_penetration=100) // LORD SINGULOTH CARES NOT FOR YOUR "ARMOR"
 	else if(current_size == STAGE_FOUR)
 		take_damage(150, armour_penetration=100)
+	//monkestation edit end
 
 /turf/closed/wall/narsie_act(force, ignore_mobs, probability = 20)
 	. = ..()
@@ -381,10 +387,12 @@
 			return TRUE
 	return FALSE
 
-/turf/proc/add_dent(denttype, x=rand(-8, 8), y=rand(-8, 8)) // this only exists because turf code is terrible
+//monkestation edit start
+/turf/proc/add_dent(denttype, x=rand(-8, 8), y=rand(-8, 8)) // this only exists because turf code is terrible, monkestation
 	return
 
 /turf/closed/wall/add_dent(denttype, x=rand(-8, 8), y=rand(-8, 8))
+//monkestation edit end
 	if(LAZYLEN(dent_decals) >= MAX_DENT_DECALS)
 		return
 

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -288,7 +288,7 @@
 	return ..() || (attacking_item.attack_atom(src, user))
 
 /turf/closed/wall/proc/try_clean(obj/item/W, mob/living/user, turf/T)
-	if(((user.istate & ISTATE_HARM)))
+	if(!(user.istate & ISTATE_HARM)) //monkestation edit
 		return FALSE
 
 	//monkestation edit start

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -142,6 +142,19 @@
 	if(.) // add a dent if it took damage
 		add_dent(WALL_DENT_HIT)
 
+/turf/closed/wall/attacked_by(obj/item/attacking_item, mob/living/user)
+	if(!uses_integrity)
+		CRASH("attacked_by() was called on an object that doesnt use integrity!")
+
+	if(!attacking_item.force)
+		return
+
+	var/damage = take_damage(attacking_item.force * attacking_item.demolition_mod, attacking_item.damtype, MELEE, 1)
+	//only witnesses close by and the victim see a hit message.
+	user.visible_message(span_danger("[user] hits [src] with [attacking_item][damage ? "." : ", without leaving a mark!"]"), \
+		span_danger("You hit [src] with [attacking_item][damage ? "." : ", without leaving a mark!"]"), null, COMBAT_MESSAGE_RANGE)
+	log_combat(user, src, "attacked", attacking_item)
+
 /turf/closed/wall/run_atom_armor(damage_amount, damage_type, damage_flag, attack_dir, armour_penetration)
 	if(damage_amount < damage_deflection && (damage_type in list(MELEE, BULLET, LASER, ENERGY)))
 		return 0 // absolutely no bypassing damage deflection by using projectiles

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -36,7 +36,7 @@
 	var/list/dent_decals
 
 	max_integrity = 300
-	damage_deflection = 20 // big chunk of solid metal
+	damage_deflection = 25 // big chunk of solid metal
 	uses_integrity = TRUE
 	armor_type = /datum/armor/wall
 

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -35,6 +35,21 @@
 
 	var/list/dent_decals
 
+	max_integrity = 300
+	damage_deflection = 20 // big chunk of solid metal
+	uses_integrity = TRUE
+	armor_type = /datum/armor/wall
+
+/datum/armor/wall
+	melee = 60
+	bullet = 60
+	laser = 60
+	energy = 0
+	bomb = 0
+	bio = 0
+	acid = 50
+	wound = 0
+
 /turf/closed/wall/MouseDrop_T(mob/living/carbon/carbon_mob, mob/user)
 	..()
 	if(carbon_mob != user)
@@ -108,10 +123,6 @@
 	if(SSstation_coloring.wall_trims)
 		trim_color = SSstation_coloring.get_default_color()
 
-/turf/closed/wall/atom_destruction(damage_flag)
-	. = ..()
-	dismantle_wall(TRUE, FALSE)
-
 /turf/closed/wall/Destroy()
 	if(is_station_level(z))
 		GLOB.station_turfs -= src
@@ -121,6 +132,22 @@
 /turf/closed/wall/examine(mob/user)
 	. += ..()
 	. += deconstruction_hints(user)
+
+/turf/closed/wall/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armour_penetration)
+	. = ..()
+	if(.) // add a dent if it took damage
+		add_dent(WALL_DENT_HIT)
+
+/turf/closed/wall/run_atom_armor(damage_amount, damage_type, damage_flag, attack_dir, armour_penetration)
+	if(damage_amount < damage_deflection && (damage_type in list(MELEE, BULLET, LASER, ENERGY)))
+		return 0 // absolutely no bypassing damage deflection by using projectiles
+	return ..()
+
+/turf/closed/wall/atom_destruction(damage_flag)
+	. = ..()
+	if(damage_flag == MELEE)
+		playsound(src, 'sound/effects/meteorimpact.ogg', 50, TRUE) //Otherwise there's no sound for hitting the wall, since it's just dismantled
+	dismantle_wall(TRUE, TRUE)
 
 /turf/closed/wall/proc/deconstruction_hints(mob/user)
 	return span_notice("The outer plating is <b>welded</b> firmly in place.")
@@ -167,7 +194,7 @@
 
 /turf/closed/wall/ex_act(severity, target)
 	if(target == src)
-		dismantle_wall(1,1)
+		dismantle_wall(TRUE, TRUE)
 		return
 
 	switch(severity)
@@ -179,17 +206,14 @@
 		if(EXPLODE_HEAVY)
 			dismantle_wall(prob(50), TRUE)
 		if(EXPLODE_LIGHT)
-			if (prob(hardness))
-				dismantle_wall(0,1)
+			take_damage(150, BRUTE, BOMB) // less kaboom
 	if(!density)
 		..()
 
 
 /turf/closed/wall/blob_act(obj/structure/blob/B)
-	if(prob(50))
-		dismantle_wall()
-	else
-		add_dent(WALL_DENT_HIT)
+	take_damage(400, BRUTE, MELEE, FALSE)
+	playsound(src, 'sound/effects/meteorimpact.ogg', 100, 1)
 
 /turf/closed/wall/attack_paw(mob/living/user, list/modifiers)
 	user.changeNext_move(CLICK_CD_MELEE)
@@ -202,18 +226,11 @@
 		return
 	if(arm.bodypart_disabled)
 		return
-	if(prob(hardness))
-		playsound(src, 'sound/effects/meteorimpact.ogg', 100, TRUE)
-		user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
-		hulk_recoil(arm, user)
-		dismantle_wall(1)
-
-	else
-		playsound(src, 'sound/effects/bang.ogg', 50, TRUE)
-		add_dent(WALL_DENT_HIT)
-		user.visible_message(span_danger("[user] smashes \the [src]!"), \
-					span_danger("You smash \the [src]!"), \
-					span_hear("You hear a booming smash!"))
+	user.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
+	take_damage(400, BRUTE, MELEE, FALSE)
+	playsound(src, 'sound/effects/bang.ogg', 50, 1)
+	to_chat(user, span_notice("You punch the wall."))
+	hulk_recoil(arm, user)
 	return TRUE
 
 /**
@@ -243,7 +260,7 @@
 	playsound(src, 'sound/weapons/genhit.ogg', 25, TRUE)
 	add_fingerprint(user)
 
-/turf/closed/wall/attackby(obj/item/W, mob/user, params)
+/turf/closed/wall/attackby(obj/item/attacking_item, mob/user, params)
 	user.changeNext_move(CLICK_CD_MELEE)
 	if (!ISADVANCEDTOOLUSER(user))
 		to_chat(user, span_warning("You don't have the dexterity to do this!"))
@@ -256,26 +273,32 @@
 	add_fingerprint(user)
 
 	//the istype cascade has been spread among various procs for easy overriding
-	if(try_clean(W, user) || try_wallmount(W, user) || try_decon(W, user))
+	if(try_clean(attacking_item, user) || try_wallmount(attacking_item, user) || try_decon(attacking_item, user))
 		return
 
-	return ..()
+	return ..() || (attacking_item.attack_atom(src, user))
 
 /turf/closed/wall/proc/try_clean(obj/item/W, mob/living/user, turf/T)
-	if(((user.istate & ISTATE_HARM)) || !LAZYLEN(dent_decals))
+	if(((user.istate & ISTATE_HARM)))
 		return FALSE
 
 	if(W.tool_behaviour == TOOL_WELDER)
-		if(!W.tool_start_check(user, amount=0))
-			return FALSE
-
-		to_chat(user, span_notice("You begin fixing dents on the wall..."))
-		if(W.use_tool(src, user, 0, volume=100))
-			if(iswallturf(src) && LAZYLEN(dent_decals))
-				to_chat(user, span_notice("You fix some dents on the wall."))
-				cut_overlay(dent_decals)
-				dent_decals.Cut()
+		if(atom_integrity >= max_integrity)
+			to_chat(user, span_warning("[src] is intact!"))
 			return TRUE
+
+		if(!W.tool_start_check(user, amount=0))
+			to_chat(user, span_warning("You need more fuel to repair [src]!"))
+			return TRUE
+
+		to_chat(user, span_notice("You begin repairing [src]..."))
+		if(W.use_tool(src, user, 3 SECONDS, volume=100))
+			update_integrity(max_integrity)
+			to_chat(user, span_notice("You repair [src]."))
+			cut_overlay(dent_decals)
+			dent_decals.Cut()
+			return TRUE
+		return TRUE
 
 	return FALSE
 
@@ -308,17 +331,11 @@
 	return FALSE
 
 /turf/closed/wall/singularity_pull(S, current_size)
-	..()
-	wall_singularity_pull(current_size)
-
-/turf/closed/wall/proc/wall_singularity_pull(current_size)
+	. = ..()
 	if(current_size >= STAGE_FIVE)
-		if(prob(50))
-			dismantle_wall()
-		return
-	if(current_size == STAGE_FOUR)
-		if(prob(30))
-			dismantle_wall()
+		take_damage(300, armour_penetration=100) // LORD SINGULOTH CARES NOT FOR YOUR "ARMOR"
+	else if(current_size == STAGE_FOUR)
+		take_damage(150, armour_penetration=100)
 
 /turf/closed/wall/narsie_act(force, ignore_mobs, probability = 20)
 	. = ..()
@@ -358,7 +375,10 @@
 			return TRUE
 	return FALSE
 
-/turf/closed/wall/proc/add_dent(denttype, x=rand(-8, 8), y=rand(-8, 8))
+/turf/proc/add_dent(denttype, x=rand(-8, 8), y=rand(-8, 8)) // this only exists because turf code is terrible
+	return
+
+/turf/closed/wall/add_dent(denttype, x=rand(-8, 8), y=rand(-8, 8))
 	if(LAZYLEN(dent_decals) >= MAX_DENT_DECALS)
 		return
 

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -50,6 +50,12 @@
 	acid = 50
 	wound = 0
 
+///type paths of projectiles explicitely whitelisted to damage walls
+	var/list/projectile_whitelist = list(
+		/obj/projectile/beam/emitter/hitscan
+	)
+
+
 /turf/closed/wall/MouseDrop_T(mob/living/carbon/carbon_mob, mob/user)
 	..()
 	if(carbon_mob != user)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -50,6 +50,11 @@
 	/// We are flagged PHASING temporarily to not stop moving when we Bump something but want to keep going anyways.
 	var/temporary_unstoppable_movement = FALSE
 
+	/// Do we damage walls?
+	var/damage_walls = FALSE
+	/// demolition mod on walls
+	var/wall_dem_mod = 1
+
 	/** PROJECTILE PIERCING
 	  * WARNING:
 	  * Projectile piercing MUST be done using these variables.
@@ -297,6 +302,8 @@
 		if(damage > 0 && (damage_type == BRUTE || damage_type == BURN) && iswallturf(target_turf) && prob(75))
 			var/turf/closed/wall/target_wall = target_turf
 			target_wall.add_dent(WALL_DENT_SHOT, hitx, hity)
+			if(damage_walls)
+				target_wall.take_damage(damage * wall_dem_mod, damage_type, armor_flag)
 
 		return BULLET_ACT_HIT
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -50,10 +50,12 @@
 	/// We are flagged PHASING temporarily to not stop moving when we Bump something but want to keep going anyways.
 	var/temporary_unstoppable_movement = FALSE
 
+	//monkestation edit start
 	/// Do we damage walls?
 	var/damage_walls = FALSE
 	/// demolition mod on walls
 	var/wall_dem_mod = 1
+	//monkestation edit end
 
 	/** PROJECTILE PIERCING
 	  * WARNING:
@@ -302,8 +304,10 @@
 		if(damage > 0 && (damage_type == BRUTE || damage_type == BURN) && iswallturf(target_turf) && prob(75))
 			var/turf/closed/wall/target_wall = target_turf
 			target_wall.add_dent(WALL_DENT_SHOT, hitx, hity)
+			//monkestation edit start
 			if(damage_walls)
 				target_wall.take_damage(damage * wall_dem_mod, damage_type, armor_flag)
+			//monkestation edit end
 
 		return BULLET_ACT_HIT
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -306,7 +306,7 @@
 			target_wall.add_dent(WALL_DENT_SHOT, hitx, hity)
 			//monkestation edit start
 			if(damage_walls)
-				target_wall.take_damage(damage * wall_dem_mod, damage_type, armor_flag)
+				target_wall.take_damage(damage * wall_dem_mod, damage_type, armor_flag, armour_penetration = 100)
 			//monkestation edit end
 
 		return BULLET_ACT_HIT

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -199,6 +199,7 @@
 	impact_light_intensity = 7
 	impact_light_outer_range = 2.5
 	impact_light_color_override = COLOR_LIME
+	range = 255 //come on, have some fun now! monkestation edit
 
 /obj/projectile/beam/lasertag
 	name = "laser tag beam"


### PR DESCRIPTION
## About The Pull Request
Ports yogstation13/Yogstation#21336
Retake of #5706
This PR is a double bounty, makes it so that walls behaves the same way as any other structures or machineries, being able to be damaged and destroyed by normal weapons instead of very specific ways/deconstruction

Normal walls have 300 damage + armor, with a damage minimum for it to take effect of 25
Normal walls have 600 damage + armor, with a damage minimum for it to take effect of 75

Emitters with upgraded lasers can now be able to tear down walls, stock parts emitters still functions the same. Below are the damage table needed to tear a wall down

T1 laser: cannot damage walls, operates normally.
T2: 20 hits to break normal walls, r wall or stronger cannot be damaged.
T3: 10 hits to kill normal walls, r wall or stronger cannot be damaged.
T4: 5 hits to kill normal walls, r walls or strong take 10 hits to be killed.
T5: 3 hits to kill normal, 7 to kill r walls or higher
Emagging the emitters increases the parts tier above by one (which is how you'd get T5) at the cost of 5% damage to the emitters. This functionality only applies if the projectile emitted by the emitters is the default hitscan emitters shots.

Pooba said that for my first PR to go through, we'd need to implement atom integrity, which they'd gracefully posted a bounty for.
## Why It's Good For The Game
Here is it in action:
https://github.com/user-attachments/assets/34b999b0-a7f6-4fa7-ac26-5e804e3ba5ad

Walls being able to use the integrity system means destroying them in a way that isn't instantaneous  and no longer needs to rely on tons of snowflake code for each instance/case of something breaking a wall. It also means they aren't totally invincible to damage, which I think could allow for some fun interactions.

Anyhow, as for the emitter PR. i'll just copy this verbatim: You know how the emitters looks like a heavy, industrial laser cannon that you'd be able to see be used as an impromptu blaster? How come can it not damage walls? Anyways, this adds a new way of breaching walls besides thermite, tools or c-4/x-4, Albeit a pretty slow and loud one at that. More tools for engineer's arsenal is good!
## Changelog
:cl:
add: Walls now have atom integrity, being able to be attacked and destroyed like other machineries and structures. they're a tough nut to crack though
 add: Emitters can now tear down walls! (once upgraded)
/:cl:
