### PR TITLE
Fix donator ticket 250. Tall Pukeko granter uses the propper mob now.

### DIFF
--- a/monkestation/code/modules/donator/code/item/effects.dm
+++ b/monkestation/code/modules/donator/code/item/effects.dm
@@ -145,4 +145,4 @@
 	name = "tall baby pukeko"
 	icon = 'monkestation/code/modules/donator/icons/mob/pets_160x160.dmi'
 	icon_state = "tallbabypukeko"
-	animal_transformation = /mob/living/basic/pet/babypukeko
+	animal_transformation = /mob/living/basic/pet/babypukeko/tall


### PR DESCRIPTION

## About The Pull Request
I made the tall granter the small one, it's the tall one now.

I my eyes must've glazed over when I was looking at this last night when I double checked my stuff.
![image](https://github.com/user-attachments/assets/c69736a6-a525-48b6-ba71-cfac19c63bfe)

## Changelog
:cl:
fix: Tall Baby Pukeko effect granter is fixed to give the propper tall one.
/:cl:
