### PR TITLE
Make the Recolorable Turtleneck available to all (though donators still get the item for free)

### DIFF
--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -71,6 +71,7 @@
 				/obj/item/clothing/under/dress/wlpinafore = 2, //MONKESTATION EDIT ADDITION
 				/obj/item/clothing/under/dress/ribbondress = 2, //MONKESTATION EDIT ADDITION
 				/obj/item/clothing/under/dress/skirt/plaid = 4,
+				/obj/item/clothing/under/costume/donatorgrayscaleturtleneck/nondonator = 4, //MONKESTATION ADDITION
 				/obj/item/clothing/under/dress/skirt/turtleskirt = 4,
 				/obj/item/clothing/under/misc/overalls = 2,
 				/obj/item/clothing/under/pants/camo = 2,

--- a/monkestation/code/modules/donator/code/datum/loadout.dm
+++ b/monkestation/code/modules/donator/code/datum/loadout.dm
@@ -720,7 +720,7 @@
 
 //TheSpecialSnowflake
 /datum/loadout_item/under/miscellaneous/turtleneck
-	name = "Colorable Turtleneck"
+	name = "Recolorable Turtleneck (Donator)"
 	item_path = /obj/item/clothing/under/costume/donatorgrayscaleturtleneck
 	donator_only = TRUE
 	requires_purchase = FALSE

--- a/monkestation/code/modules/donator/code/item/clothing.dm
+++ b/monkestation/code/modules/donator/code/item/clothing.dm
@@ -639,6 +639,7 @@
 	icon_file = 'monkestation/code/modules/donator/icons/mob/clothing.dmi'
 	json_config = 'monkestation/code/modules/donator/code/greyscale/turtleneck.json'
 	expected_colors = 2
+/obj/item/clothing/under/costume/donatorgrayscaleturtleneck/nondonator
 
 /obj/item/clothing/neck/donatorwhitefurshawl
 	name = "white fur shawl"

--- a/monkestation/code/modules/loadouts/items/under/under.dm
+++ b/monkestation/code/modules/loadouts/items/under/under.dm
@@ -147,6 +147,31 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	name = "Recolorable Plaid Skirt"
 	item_path = /obj/item/clothing/under/dress/skirt/plaid
 
+// So, story time - which should hopefully explain the weird name and why this isn't just called
+// `/datum/loadout_item/under/miscellaneous/turtleneck` like the original.
+//
+// The recolorable turtleneck item used to be a donator exclusive loadout item, granted to
+// TheSpecialSnowflake. However, with TheSpecialSnowflake's permission, this was changed, and the
+// recolorable turtleneck was made available to all.
+//
+// Unfortunately, due to how our loadout system works, there is no way to add an previously donator-
+// -exclusive item to the store, without some donators losing the item in the process.
+//
+// Per CannibalHunter, the choice was made to simply make the nondonator turtleneck a separate
+// loadout item datum, which should hopefully resolve any conflicts.
+/datum/loadout_item/under/miscellaneous/nondonatorturtleneck
+	name = "Recolorable Turtleneck"
+	// This item path is deliberately slightly different from the original. This is because, when
+	// the list of loadout item datums is generated, it uses `item_path` as the key - which means
+	// using the same key as the original would cause a conflict.
+	//
+	// Such a conflict could cause, among other things, the inability for a user to use a
+	// non-donator item (if one of the loadout item datums marks it as donator-only).
+	//
+	// By adding a subtype, the same exact item can have two different loadout item datums, and the
+	// issue is resolved.
+	item_path = /obj/item/clothing/under/costume/donatorgrayscaleturtleneck/nondonator
+
 /datum/loadout_item/under/miscellaneous/skirt_turtleneck
 	name = "Recolorable Turtleneck Skirt"
 	item_path = /obj/item/clothing/under/dress/skirt/turtleskirt

--- a/monkestation/code/modules/store/store_items/under.dm
+++ b/monkestation/code/modules/store/store_items/under.dm
@@ -126,6 +126,10 @@ GLOBAL_LIST_INIT(store_miscunders, generate_store_items(/datum/store_item/under/
 	name = "Recolorable Plaid Skirt"
 	item_path = /obj/item/clothing/under/dress/skirt/plaid
 
+/datum/store_item/under/miscellaneous/turtleneck
+	name = "Recolorable Turtleneck"
+	item_path = /obj/item/clothing/under/costume/donatorgrayscaleturtleneck/nondonator
+
 /datum/store_item/under/miscellaneous/skirt_turtleneck
 	name = "Recolorable Turtleneck Skirt"
 	item_path = /obj/item/clothing/under/dress/skirt/turtleskirt


### PR DESCRIPTION
## About The Pull Request
This PR adds the Recolorable Turtleneck loadout item to the store, allowing all to enjoy its benefits.

This was previously restricted to donators, as it was a donator item intended for TheSpecialSnowflake - however, TheSpecialSnowflake gave permission to make this available to all. <https://discord.com/channels/748354466335686736/808983978459004968/1350629297790128209>

To avoid donators losing the item (since they've already had the item), donators still get the item for free. The way I handled this ends up allowing donators to have TWO recolorable turtlenecks in their inventory (and as such, I've marked one as "Donator" so people aren't confused). However, this shouldn't be an issue - it'll just look a little goofy.

## Why It's Good For The Game
More colorable clothes for all!

## Changelog

:cl:MichiRecRoom
add: The Recolorable Turtleneck loadout item is now available to all! You can find it in the "Misc. Under" section of the store for 3000 Monkecoin. Donators are unaffected by this change and still receive a Recolorable Turtleneck for free (though you can purchase the item anyways if you want two Recolorable Turtlenecks in your inventory).
/:cl: