### PR TITLE
[Bounty] Head of __

### DIFF
--- a/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
+++ b/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
@@ -88,6 +88,7 @@
 		"Site Manager",
 		"Criminally Underpaid Babysitter",
 		"Princess",
+		"Head of Command",
 	)
 
 /datum/job/cargo_technician
@@ -296,6 +297,7 @@
 		"Research Supervisor",
 		"Chief Science Officer",
 		"Chief Artificer",
+		"Head of Science",
 	)
 
 /datum/job/roboticist

--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -116,6 +116,7 @@ const ALTTITLES = {
   'Commanding Officer': BASEICONS['Captain'],
   'Site Manager': BASEICONS['Captain'],
   'Criminally Underpaid Babysitter': BASEICONS['Captain'],
+  'Head of Command': BASEICONS['Captain'], //Monkestation Addition: Head of _
   Princess: BASEICONS['Captain'],
   // Cargo Technician - box
   'Warehouse Technician': BASEICONS['Cargo Technician'],
@@ -242,6 +243,7 @@ const ALTTITLES = {
   'Research Supervisor': BASEICONS['Research Director'],
   'Chief Science Officer': BASEICONS['Research Director'],
   'Chief Artificer': BASEICONS['Research Director'],
+  'Head of Science': BASEICONS['Research Director'], // Monkestation Addition: Head of _
   // Roboticist - battery-half
   'Biomechanical Engineer': BASEICONS['Roboticist'],
   'Mechatronic Engineer': BASEICONS['Roboticist'],

--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -116,7 +116,7 @@ const ALTTITLES = {
   'Commanding Officer': BASEICONS['Captain'],
   'Site Manager': BASEICONS['Captain'],
   'Criminally Underpaid Babysitter': BASEICONS['Captain'],
-  'Head of Command': BASEICONS['Captain'], //Monkestation Addition: Head of _
+  'Head of Command': BASEICONS['Captain'],
   Princess: BASEICONS['Captain'],
   // Cargo Technician - box
   'Warehouse Technician': BASEICONS['Cargo Technician'],
@@ -243,7 +243,7 @@ const ALTTITLES = {
   'Research Supervisor': BASEICONS['Research Director'],
   'Chief Science Officer': BASEICONS['Research Director'],
   'Chief Artificer': BASEICONS['Research Director'],
-  'Head of Science': BASEICONS['Research Director'], // Monkestation Addition: Head of _
+  'Head of Science': BASEICONS['Research Director'],
   // Roboticist - battery-half
   'Biomechanical Engineer': BASEICONS['Roboticist'],
   'Mechatronic Engineer': BASEICONS['Roboticist'],


### PR DESCRIPTION

## About The Pull Request
Adds Head of Science and Head of Command as alternative titles for Research director and Captain at bounty request.
## Why It's Good For The Game
All other heads of staff members have alternative titles with the format head of _. Finish the trend. Finish what is not compelete
## Changelog
:cl:
add: Added Head of Command and Head of Science as alternative titles for Captain and Research Director.
/:cl:
