### PR TITLE
Anomaly cores can no longer be recycled by autolathes

### DIFF
--- a/code/modules/research/anomaly/anomaly_core.dm
+++ b/code/modules/research/anomaly/anomaly_core.dm
@@ -7,6 +7,7 @@
 	lefthand_file = 'icons/mob/inhands/items/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items/devices_righthand.dmi'
 	resistance_flags = FIRE_PROOF
+	custom_materials = null
 	var/anomaly_type = /obj/effect/anomaly
 
 /obj/item/assembly/signaler/anomaly/receive_signal(datum/signal/signal)


### PR DESCRIPTION

## About The Pull Request
Due to refined anomaly cores being a subtype of signalers, they are made of iron and glass... which doesn't mix well with autolathes. So, this PR fixes that by making anomaly cores contain no materials!
## Why It's Good For The Game
You wouldn't want your anomaly core to be turned into iron and glass, would you?
## Changelog
:cl:
fix: fixed refined anomaly cores getting recycled into iron and glass
/:cl:
