### PR TITLE
Fix the regenerator component (i.e teratomas) sometimes not triggering

### DIFF
--- a/monkestation/code/datums/components/regenerator.dm
+++ b/monkestation/code/datums/components/regenerator.dm
@@ -1,0 +1,12 @@
+/datum/component/regenerator/RegisterWithParent()
+	. = ..()
+	RegisterSignals(parent, COMSIG_LIVING_ADJUST_ALL_DAMAGE_TYPES, PROC_REF(on_adjust_damage))
+
+/datum/component/regenerator/UnregisterFromParent()
+	. = ..()
+	UnregisterSignal(parent, COMSIG_LIVING_ADJUST_ALL_DAMAGE_TYPES)
+
+/datum/component/regenerator/proc/on_adjust_damage(datum/source, damagetype, damage)
+	SIGNAL_HANDLER
+	if(damage > 0)
+		on_take_damage(source, damage, damagetype)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6003,6 +6003,7 @@
 #include "monkestation\code\datums\components\multi_hit.dm"
 #include "monkestation\code\datums\components\pathology_glasses.dm"
 #include "monkestation\code\datums\components\pixel_shift.dm"
+#include "monkestation\code\datums\components\regenerator.dm"
 #include "monkestation\code\datums\components\shoesteps.dm"
 #include "monkestation\code\datums\components\throw_bounce.dm"
 #include "monkestation\code\datums\components\turf_checker_complex.dm"


### PR DESCRIPTION

## About The Pull Request

This makes it so `/datum/component/regenerator` also registers `COMSIG_LIVING_ADJUST_ALL_DAMAGE_TYPES`, to ensure it always knows any incoming damage.

## Why It's Good For The Game

having to punch yourself to start healing as a teratoma is stupid

## Changelog
:cl:
fix: Fixed the regenerator component (i.e teratomas) sometimes not triggering.
/:cl:
