### PR TITLE
Adds Harebell to MegaSeed vendor

### DIFF
--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -64,6 +64,7 @@
 				/obj/item/seeds/poppy = 3,
 				/obj/item/seeds/rose = 3,
 				/obj/item/seeds/sunflower = 3,
+				/obj/item/seeds/harebell = 3,
 			),
 		),
 


### PR DESCRIPTION

## About The Pull Request
This adds the flower "Harebell" to the MegaSeed vendor.
## Why It's Good For The Game
This plant is used specifically for heretics in getting their codex, and can sometimes be part of knowledge rituals too. Often people struggle (Myself included) to find this flower around the map as it cannot be currently made in botany. I believe giving this flower to botany not only makes sense thematically as its just another flower, but also will make that specific ritual easier to access for heretics.
## Changelog
:cl:
add: Adds Harebells to MegaSeed Servitors
/:cl:
