### PR TITLE
Add more flowers to seed vendor

### DIFF
--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -64,6 +64,7 @@
 				/obj/item/seeds/poppy = 3,
 				/obj/item/seeds/rose = 3,
 				/obj/item/seeds/sunflower = 3,
+				/obj/item/seeds/harebell = 3,
 			),
 		),
 

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -64,6 +64,8 @@
 				/obj/item/seeds/poppy = 3,
 				/obj/item/seeds/rose = 3,
 				/obj/item/seeds/sunflower = 3,
+				/obj/item/seeds/harebell = 3,
+				/obj/item/seeds/lily = 3,
 			),
 		),
 

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -65,7 +65,7 @@
 				/obj/item/seeds/rose = 3,
 				/obj/item/seeds/sunflower = 3,
 				/obj/item/seeds/harebell = 3,
-				/obj/item/seeds/lily = 3,
+				/obj/item/seeds/poppy/lily = 3,
 			),
 		),
 

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -64,7 +64,6 @@
 				/obj/item/seeds/poppy = 3,
 				/obj/item/seeds/rose = 3,
 				/obj/item/seeds/sunflower = 3,
-				/obj/item/seeds/harebell = 3,
 			),
 		),
 


### PR DESCRIPTION

## About The Pull Request
Adds both Harebells and Lilys to the MegaSeed Servitor.
## Why It's Good For The Game
Both for adding more to the botanist available plants, as well as making it easier to heretics to obtain these flowers needed in certain rituals.
## Changelog
:cl:
add: Adds Harebells and Lilys to the MegaSeed Servitor
/:cl:
