### PR TITLE
Heretic void chill + ascension changes

### DIFF
--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -737,7 +737,7 @@
  * Checks if the passed human is a valid sacrifice for our ritual.
  */
 /datum/heretic_knowledge/ultimate/proc/is_valid_sacrifice(mob/living/carbon/human/sacrifice)
-	return ((sacrifice.stat == DEAD) && !ismonkey(sacrifice) && sacrifice.last_mind)
+	return ((sacrifice.stat == DEAD) && sacrifice.last_mind)
 
 /datum/heretic_knowledge/ultimate/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -737,7 +737,7 @@
  * Checks if the passed human is a valid sacrifice for our ritual.
  */
 /datum/heretic_knowledge/ultimate/proc/is_valid_sacrifice(mob/living/carbon/human/sacrifice)
-	return (sacrifice.stat == DEAD) && !ismonkey(sacrifice)
+	return ((sacrifice.stat == DEAD) && !ismonkey(sacrifice) && sacrifice.last_mind)
 
 /datum/heretic_knowledge/ultimate/on_finished_recipe(mob/living/user, list/selected_atoms, turf/loc)
 	var/datum/antagonist/heretic/heretic_datum = IS_HERETIC(user)

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -268,7 +268,10 @@
 			close_carbon.adjust_silence_up_to(2 SECONDS, 20 SECONDS)
 			close_carbon.apply_status_effect(/datum/status_effect/void_chill, 1)
 			close_carbon.adjust_eye_blur(rand(0 SECONDS, 2 SECONDS))
-			close_carbon.adjust_bodytemperature(-30 * TEMPERATURE_DAMAGE_COEFFICIENT)
+			if(close_carbon.has_reagent(/datum/reagent/water/holywater))
+				close_carbon.adjust_bodytemperature(-5 * TEMPERATURE_DAMAGE_COEFFICIENT)
+			else
+				close_carbon.adjust_bodytemperature(-30 * TEMPERATURE_DAMAGE_COEFFICIENT)
 
 		else if(istype(thing_in_range, /obj/machinery/door) || istype(thing_in_range, /obj/structure/door_assembly))
 			var/obj/affected_door = thing_in_range

--- a/code/modules/antagonists/heretic/status_effects/void_chill.dm
+++ b/code/modules/antagonists/heretic/status_effects/void_chill.dm
@@ -42,18 +42,18 @@
 	owner.update_icon(UPDATE_OVERLAYS)
 
 /datum/status_effect/void_chill/tick(seconds_per_ticks)
-	if (stacks == 0)
-		owner.remove_status_effect(/datum/status_effect/void_chill)
 	if(owner.has_reagent(/datum/reagent/water/holywater))
 		//void chill is less effective
 		owner.adjust_bodytemperature(-3 KELVIN * stacks * seconds_per_ticks)
 		if(!COOLDOWN_FINISHED(src, chill_purge))
 			return FALSE
-		COOLDOWN_START(src, chill_purge, 3 SECONDS)
+		COOLDOWN_START(src, chill_purge, 2 SECONDS)
 		to_chat(owner, span_notice("You feel holy water warming you up."))
 		adjust_stacks(-1)
 	else
 		owner.adjust_bodytemperature(-12 KELVIN * stacks * seconds_per_ticks)
+	if (stacks == 0)
+		owner.remove_status_effect(/datum/status_effect/void_chill)
 
 /datum/status_effect/void_chill/refresh(mob/living/new_owner, new_stacks, forced = FALSE)
 	. = ..()

--- a/code/modules/antagonists/heretic/status_effects/void_chill.dm
+++ b/code/modules/antagonists/heretic/status_effects/void_chill.dm
@@ -49,7 +49,7 @@
 		owner.adjust_bodytemperature(-3 KELVIN * stacks * seconds_per_ticks)
 		if(!COOLDOWN_FINISHED(src, chill_purge))
 			return FALSE
-		COOLDOWN_START(src, chill_purge, 2 SECONDS)
+		COOLDOWN_START(src, chill_purge, 3 SECONDS)
 		to_chat(owner, span_notice("You feel holy water warming you up."))
 		adjust_stacks(-1)
 	else
@@ -120,8 +120,6 @@
 	var/datum/status_effect/void_chill/chill_effect = attached_effect
 	if(chill_effect.stacks >= 5)
 		icon_state = "void_chill_oh_fuck"
-	else if (icon_state != initial(icon_state))
-		icon_state = initial(icon_state)
 
 /atom/movable/screen/alert/status_effect/void_chill/update_desc(updates)
 	. = ..()
@@ -130,5 +128,3 @@
 	var/datum/status_effect/void_chill/chill_effect = attached_effect
 	if(chill_effect.stacks >= 5)
 		desc = "You had your chance to run, now it's too late. You may never feel warmth again..."
-	else if (desc != initial(desc))
-		desc = initial(desc)

--- a/code/modules/antagonists/heretic/transmutation_rune.dm
+++ b/code/modules/antagonists/heretic/transmutation_rune.dm
@@ -159,6 +159,8 @@
 		loc.balloon_alert(user, "ritual failed, missing components!")
 		// Then let them know what they're missing
 		to_chat(user, span_hierophant_warning("You are missing [english_list(what_are_we_missing)] in order to complete the ritual \"[ritual.name]\"."))
+		if (istype(ritual, /datum/heretic_knowledge/ultimate))
+			to_chat(user, span_hierophant_warning("Reminder, that sacrifices need to have a soul in order to complete the ritual."))
 		return FALSE
 
 	// If we made it here, the ritual had all necessary components, and we can try to cast it.


### PR DESCRIPTION

## About The Pull Request

**Void chill changes**

Void chill had it's slowdown slightly reduced (0.5 multiplier -> 0.3)

Holy water now purges void chill stacks every 2 seconds and makes void storm and chill itself cool you down way slower

**Ascension change**

Ascension now require bodies that at any point had a mind in them. That means you can't just use spawned morgue corpses for the ritual and instead have to hope that morgue has actual people or be forced to stab stab to ascend.

## Why It's Good For The Game

Void chill changes are mostly from player complaints about slowdown being too big and void conduit being way too good of an ability. This also makes  ascended void heretics less ass to fight if you sip a bit of holy water and buy you some time (you will still die probably)

Ascension change comes from complaint about stealth ascensions being too common and ascension being too easy to achieve. This is aimed to force people to act in at least some way.

## Changelog

:cl:
balance: Void chill had it's slowdown reduced
add: Void chill stacks are now purged by holy water
add: Holy water reduces the cooling effect of void storm and void chill
balance: Ascension ritual now requires bodies that at any point had a mind.
/:cl:

