### PR TITLE
Martial arts properly dodge/counter Kindle

### DIFF
--- a/monkestation/code/modules/antagonists/clock_cult/scriptures/servitude/kindle.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/scriptures/servitude/kindle.dm
@@ -124,19 +124,12 @@
 		dodge = TRUE
 	if(counter)
 		target.visible_message(
-			span_danger("[target] twists [user]'s arm, sending [user.p_their()] [invoking_slab] flying!"),
-			span_userdanger("Making sure to avoid [user]'s [name], you twist [user.p_their()] arm, sending [user.p_their()] [invoking_slab] flying!"),
+			span_danger("[target] twists [user]'s arm, forcing [user.p_them()] to drop [user.p_their()] [invoking_slab]!"),
+			span_userdanger("Making sure to avoid [user]'s [name], you twist [user.p_their()] arm, forcing [user.p_them()] to drop [user.p_their()] [invoking_slab]!"),
 			ignored_mobs = list(user)
 		)
-		to_chat(user, span_userdanger("As you attempt to stun [target] with the spell, [target.p_they()] twist[target.p_s()] your arm and send[target.p_s()] your [invoking_slab] flying!"), type = MESSAGE_TYPE_COMBAT)
+		to_chat(user, span_userdanger("As you attempt to stun [target] with the spell, [target.p_they()] twist[target.p_s()] your arm, forcing you to drop your [invoking_slab]!"), type = MESSAGE_TYPE_COMBAT)
 		user.dropItemToGround(invoking_slab, force = TRUE, silent = TRUE)
-		invoking_slab.launch_item(
-			user.drop_location(),
-			fly_angle = get_angle(user, target) + rand(-25, 25),
-			horizontal_multiplier = 5,
-			vertical_multiplier = 5,
-		)
-		INVOKE_ASYNC(user, TYPE_PROC_REF(/mob, emote), "scream")
 		return TRUE
 	else if(dodge)
 		target.visible_message(

--- a/monkestation/code/modules/antagonists/clock_cult/scriptures/servitude/kindle.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/scriptures/servitude/kindle.dm
@@ -27,6 +27,9 @@
 	if(IS_CLOCK(hit_mob))
 		return FALSE
 
+	if(snowflake_martial_arts_handler(hit_mob, invoker))
+		return TRUE
+
 	// Chaplains are understandably 100% immune
 	if(hit_mob.can_block_magic(MAGIC_RESISTANCE_HOLY))
 		hit_mob.mob_light(color = LIGHT_COLOR_HOLY_MAGIC, range = 2, duration = 10 SECONDS)
@@ -99,5 +102,53 @@
 
 	playsound(invoker, 'sound/magic/staff_animation.ogg', 50, TRUE)
 	return TRUE
+
+// copy-pasted from blood cult code lol
+/datum/scripture/slab/kindle/proc/snowflake_martial_arts_handler(mob/living/target, mob/living/carbon/user)
+	var/datum/martial_art/martial_art = target?.mind?.martial_art
+	if(!martial_art?.can_use())
+		return FALSE
+	var/counter = FALSE
+	var/dodge = FALSE
+	if(istype(martial_art, /datum/martial_art/cqc))
+		counter = TRUE
+	else if(istype(martial_art, /datum/martial_art/the_sleeping_carp))
+		var/datum/martial_art/the_sleeping_carp/eepy_carp = martial_art
+		if(eepy_carp.can_deflect(target, check_intent = FALSE))
+			if(eepy_carp.counter)
+				counter = TRUE
+				INVOKE_ASYNC(target, TYPE_PROC_REF(/atom/movable, say), message = "PATHETIC!", language = /datum/language/common, ignore_spam = TRUE, forced = martial_art)
+			else
+				dodge = TRUE
+	else if(istype(martial_art, /datum/martial_art/the_tunnel_arts))
+		dodge = TRUE
+	if(counter)
+		target.visible_message(
+			span_danger("[target] twists [user]'s arm, sending [user.p_their()] [invoking_slab] flying!"),
+			span_userdanger("Making sure to avoid [user]'s [name], you twist [user.p_their()] arm, sending [user.p_their()] [invoking_slab] flying!"),
+			ignored_mobs = list(user)
+		)
+		to_chat(user, span_userdanger("As you attempt to stun [target] with the spell, [target.p_they()] twist[target.p_s()] your arm and send[target.p_s()] your [invoking_slab] flying!"), type = MESSAGE_TYPE_COMBAT)
+		user.dropItemToGround(invoking_slab, force = TRUE, silent = TRUE)
+		invoking_slab.launch_item(
+			user.drop_location(),
+			fly_angle = get_angle(user, target) + rand(-25, 25),
+			horizontal_multiplier = 5,
+			vertical_multiplier = 5,
+		)
+		INVOKE_ASYNC(user, TYPE_PROC_REF(/mob, emote), "scream")
+		return TRUE
+	else if(dodge)
+		target.visible_message(
+			span_danger("[target] carefully dodges [user]'s [name]!"),
+			span_userdanger("You take great care to remain untouched by [user]'s [name]!"),
+			ignored_mobs = list(user),
+		)
+		to_chat(user, span_userdanger("[target] carefully dodges your [name], remaining completely untouched!"), type = MESSAGE_TYPE_COMBAT)
+		target.balloon_alert(user, "miss!")
+		playsound(target, 'monkestation/sound/effects/miss.ogg', vol = 50, vary = TRUE, extrarange = SHORT_RANGE_SOUND_EXTRARANGE)
+		return TRUE
+	return FALSE
+
 
 #undef EFFECT_TIME


### PR DESCRIPTION
## About The Pull Request

this makes it so cogger Kindle is also dodged/countered by martial arts, like the blood cult stun and mansus grasp

the counter is a bit different tho - as it's being channeled through a physical object, instead of hitting the attacker with their own spell, they'll be forced to drop the slab instead.

## Why It's Good For The Game

consistency.

## Changelog
:cl:
balance: Kindle is now dodged/countered by martial arts, consistent with the mansus grasp and blood cult stun.
/:cl:
