### PR TITLE
[PORT] Bumps the sleep on the map_popup load hack from 0.1 seconds to 0.2 seconds.

### DIFF
--- a/code/_onclick/hud/map_popups.dm
+++ b/code/_onclick/hud/map_popups.dm
@@ -26,9 +26,9 @@
 			// Why the fuck does this work? This is some byond bug and I honestly have no fucking clue why this works.
 			// I don't think plane master will be affected, I hope.
 			// We're stuck in the belly of this awful machine.
-			sleep(0.1 SECONDS) // If it's too fast, it has a chance to fail? Idk. This seems like a good number.
+			sleep(0.2 SECONDS) // If it's too fast, it has a chance to fail? Idk. This seems like a good number.
 			screen_loc = "[assigned_map]:[x+100]:[px],[y+100]:[py]"
-			sleep(0.1 SECONDS)
+			sleep(0.2 SECONDS)
 			screen_loc = "[assigned_map]:[x]:[px],[y]:[py]"
 	else
 		screen_loc = "[x]:[px],[y]:[py]"


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/90083

> Bumps the sleep time from 0.1 seconds to 0.2 seconds on #89933 so it more consistantly fixes the zoom on your character in the creator.

## Why It's Good For The Game

> I know it's a little more ugly with a slight increase in time, but it will be more consistant since players are needing to close and reopen their UI still. This is way more intrusive then a brief pause before it loads.

## Changelog

> Not really needed.