### PR TITLE
[PORT] Prevents loot duping via corpse revival

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -420,9 +420,11 @@
 	. += "Health: [round((health / maxHealth) * 100)]%"
 
 /mob/living/simple_animal/proc/drop_loot()
-	if(loot.len)
-		for(var/i in loot)
-			new i(loc)
+	if (!length(loot))
+		return
+	for(var/i in loot)
+		new i(drop_location())
+	loot.Cut()
 
 /mob/living/simple_animal/death(gibbed)
 	drop_loot()


### PR DESCRIPTION

## About The Pull Request
Ports [#90114](https://github.com/tgstation/tgstation/pull/90114) from TG, tested localhost on an Ash Drake and it does work
Original PR info: "This may also apply to mobs other than ash drakes. The general idea is to put loot for non-del_on_death mobs into butcher_loot, but drakes are an exception. This PR solves this and ensures that this issue won't pop up again by clearing the loot list after dropping it, in case any mobs other than drake have this issue."
## Why It's Good For The Game
Duping is an exploit, I am pretty sure, and that is bad. 
## Changelog
:cl:
fix: You can no longer dupe loot by reviving certain mobs (like ash drakes)
/:cl:
