### PR TITLE
fixes windows being colored when they shouldnt

### DIFF
--- a/monkestation/code/modules/aesthetics/objects/windows.dm
+++ b/monkestation/code/modules/aesthetics/objects/windows.dm
@@ -57,7 +57,7 @@
 
 /obj/structure/grille/window_sill/atom_break()
 	. = ..()
-	qdel()
+	qdel(src)
 
 /obj/structure/grille/update_overlays(updates=ALL)
 	. = ..()

--- a/monkestation/code/modules/aesthetics/objects/windows.dm
+++ b/monkestation/code/modules/aesthetics/objects/windows.dm
@@ -57,9 +57,19 @@
 
 /obj/structure/grille/window_sill/atom_break()
 	. = ..()
-	qdel(src)
+	Destroy()
 
 /obj/structure/grille/update_overlays(updates=ALL)
 	. = ..()
 	if((updates & UPDATE_SMOOTHING) && (smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK)))
 		QUEUE_SMOOTH(src)
+
+//windows that shouldnt be colored, whoever added this originally forgot to do this
+/obj/structure/window/reinforced/plasma/plastitanium
+	uses_color = FALSE
+
+/obj/structure/window/reinforced/shuttle
+	uses_color = FALSE
+
+/obj/structure/window/fulltile/colony_fabricator
+	uses_color = FALSE

--- a/monkestation/code/modules/aesthetics/objects/windows.dm
+++ b/monkestation/code/modules/aesthetics/objects/windows.dm
@@ -57,7 +57,7 @@
 
 /obj/structure/grille/window_sill/atom_break()
 	. = ..()
-	Destroy()
+	qdel()
 
 /obj/structure/grille/update_overlays(updates=ALL)
 	. = ..()

--- a/monkestation/code/modules/aesthetics/objects/windows.dm
+++ b/monkestation/code/modules/aesthetics/objects/windows.dm
@@ -73,3 +73,6 @@
 
 /obj/structure/window/fulltile/colony_fabricator
 	uses_color = FALSE
+
+/obj/structure/window/reinforced/fulltile/ice
+	uses_color = FALSE


### PR DESCRIPTION
## About The Pull Request

windows like plastitanium glass and titanium glass dont really seem like they're meant to be colored, whoever added window colors forgot to disable coloring on them, let me know if i missed any other windows that shouldnt be colored please

## Why It's Good For The Game

the default window color is ugly as fuck on plastitanium glass and i hate it.

## Changelog

:cl:
fix: Certain windows like plastitanium glass and titanium glass are no longer colored automatically.
/:cl:
