### PR TITLE
Fixes basic mobs not idling due to nearby ghosts

### DIFF
--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -179,10 +179,10 @@ multiple modular subtrees with behaviors
 	if(should_idle())
 		set_ai_status(AI_STATUS_IDLE)
 
-/datum/ai_controller/proc/on_client_enter(datum/source, atom/target)
+/datum/ai_controller/proc/on_client_enter(datum/source, list/target_list)
 	SIGNAL_HANDLER
 
-	if (!isliving(target))
+	if (!(locate(/mob/living) in target_list))
 		return
 
 	if(ai_status == AI_STATUS_IDLE)

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -169,7 +169,7 @@ multiple modular subtrees with behaviors
 		return FALSE
 
 	for(var/datum/spatial_grid_cell/grid as anything in our_cells.member_cells)
-		if(length(grid.client_contents))
+		if(locate(/mob/living) in grid.client_contents)
 			return FALSE
 	return TRUE
 
@@ -181,6 +181,9 @@ multiple modular subtrees with behaviors
 
 /datum/ai_controller/proc/on_client_enter(datum/source, atom/target)
 	SIGNAL_HANDLER
+
+	if (!isliving(target))
+		return
 
 	if(ai_status == AI_STATUS_IDLE)
 		set_ai_status(AI_STATUS_ON)

--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -243,7 +243,7 @@ multiple modular subtrees with behaviors
 		SSai_controllers.ai_controllers_by_zlevel[old_turf.z] -= src
 	if(new_turf)
 		SSai_controllers.ai_controllers_by_zlevel[new_turf.z] += src
-		var/new_level_clients = SSmobs.clients_by_zlevel[new_turf.z].len
+		var/new_level_clients = length(SSmobs.clients_by_zlevel[new_turf.z]) // monkestation edit: x.len -> length(x)
 		if(new_level_clients)
 			set_ai_status(AI_STATUS_IDLE)
 		else


### PR DESCRIPTION

## About The Pull Request

Ports the following PRs from tg:
- https://github.com/tgstation/tgstation/pull/90021
- https://github.com/tgstation/tgstation/pull/90047

> `client_contents` contains all mobs with clients, just like you'd expect. This includes observers, which results in any observer going over lavaland at full speed disturbing all the mobs on it. locate() is only marginally more expensive than length on a (most likely) 0-1 length list, so potential perf impact shouldn't be of any concern.

## Changelog
:cl: Absolucy, SmArtKar, Ben10Omintrix
fix: Fixed basic mobs not idling due to nearby ghosts.
/:cl:
