### PR TITLE
Adds some realism to the anime quirk

### DIFF
--- a/monkestation/code/datums/quirks/neutral_quirks/anime.dm
+++ b/monkestation/code/datums/quirks/neutral_quirks/anime.dm
@@ -14,6 +14,7 @@
 
 /datum/quirk/anime/add(client/client_source)
 	var/mob/living/carbon/human/quirk_holder = src.quirk_holder
+	quirk_holder.nutrition = NUTRITION_LEVEL_FAT
 	RegisterSignal(quirk_holder, COMSIG_SPECIES_GAIN_PRE, PROC_REF(on_species_gain))
 
 	var/datum/species/species = quirk_holder?.dna?.species


### PR DESCRIPTION

## About The Pull Request
Anime quirk now makes you obese

## Why It's Good For The Game
as of https://github.com/Monkestation/Monkestation2.0/pull/5124 we made anime users hate showers, this adds to that with a bit more realism, all anime quirk users are now obese roundstart, ethereals beware.

## Changelog

:cl:
add: Anime quirk users are now obese
/:cl:

