### PR TITLE
[BALANCE] Make the Super syndie kittie not a freedom implant anymore.

### DIFF
--- a/monkestation/code/modules/mapfluff/ruins/spaceruin_code/mrow_thats_right.dm
+++ b/monkestation/code/modules/mapfluff/ruins/spaceruin_code/mrow_thats_right.dm
@@ -101,6 +101,7 @@
 /datum/action/cooldown/spell/shapeshift/kitty/syndie
 	name = "SYNDICATE KITTY POWER!!"
 	desc = "Take on the shape of an kitty cat, clad in blood-red armor! Gain their powers at a loss of vitality."
+	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_IMMOBILE|AB_CHECK_CONSCIOUS
 	possible_shapes = list(/mob/living/simple_animal/hostile/syndicat/super)
 
 /mob/living/simple_animal/hostile/syndicat/super


### PR DESCRIPTION
## About The Pull Request

Until now the Syndicate Kitten that was added here https://github.com/Monkestation/Monkestation2.0/pull/5290 could transform while cuffed, rendering useless any non-lethal forms with them. Now, they will have some checks to stop it.

## Why It's Good For The Game

It will make the cat not able to bypass any security non-lethal means, which in turns mean security won't be forced to lethal them everytime they see it.

## Changelog



:cl:

balance: rebalanced the kitten ears so they can't break free while being cuffed, unconcious, with their hands blocked.
/:cl:

