### PR TITLE
Fix xenobio UI scrolling on BYOND 516

### DIFF
--- a/tgui/packages/tgui/interfaces/SlimePenController.jsx
+++ b/tgui/packages/tgui/interfaces/SlimePenController.jsx
@@ -37,8 +37,10 @@ export const SlimePenController = (_) => {
             Corral Data
           </Tabs.Tab>
         </Tabs>
-        <Box>{tabIndex === 1 && <SlimeData />}</Box>
-        <Box>{tabIndex === 2 && <StoreViewer />}</Box>
+        <Section fill scrollable>
+          {tabIndex === 1 && <SlimeData />}
+          {tabIndex === 2 && <StoreViewer />}
+        </Section>
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/XenobioMarket.jsx
+++ b/tgui/packages/tgui/interfaces/XenobioMarket.jsx
@@ -41,9 +41,11 @@ export const XenobioMarket = (_) => {
             {points}
           </Button>
         </Tabs>
-        <Box>{tabIndex === 1 && <SlimeMarket />}</Box>
-        <Box>{tabIndex === 2 && <RequestViewer />}</Box>
-        <Box>{tabIndex === 3 && <StoreViewer />}</Box>
+        <Section fill scrollable>
+          {tabIndex === 1 && <SlimeMarket />}
+          {tabIndex === 2 && <RequestViewer />}
+          {tabIndex === 3 && <StoreViewer />}
+        </Section>
       </Window.Content>
     </Window>
   );


### PR DESCRIPTION

## About The Pull Request

Simple fix for not being able to scroll thru the xenobio market and slime pen controller on BYOND 516

![2025-03-24 (1742831593)](https://github.com/user-attachments/assets/99a78c06-ecf2-4c75-99d8-01f5d372e2f6)

## Why It's Good For The Game

i like being able to scroll, thank u very much

## Changelog
:cl:
fix: Fixed not being able to scroll thru the slime market console and slime pen controller UIs on BYOND 516.
/:cl:
