### PR TITLE
Makes IPC monitor shenanigans on death/revival a little more sane

### DIFF
--- a/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
@@ -155,10 +155,12 @@
  * * screen_name - The name of the screen to switch the ipc_screen mutant bodypart to. Defaults to BSOD.
  */
 /datum/species/ipc/proc/bsod_death(mob/living/carbon/human/transformer, screen_name = "BSOD")
-	saved_screen = change_screen // remember the old screen in case of revival
-	switch_to_screen(transformer, screen_name)
-	addtimer(CALLBACK(src, PROC_REF(switch_to_screen), transformer, "Blank"), 5 SECONDS)
-
+	if(!transformer.get_bodypart(BODY_ZONE_HEAD))
+		return
+	else
+		saved_screen = change_screen // remember the old screen in case of revival
+		switch_to_screen(transformer, screen_name)
+		addtimer(CALLBACK(src, PROC_REF(switch_to_screen), transformer, "Blank"), 5 SECONDS)
 
 /datum/species/ipc/on_species_loss(mob/living/carbon/target)
 	. = ..()
@@ -189,10 +191,13 @@
 	H.update_body()
 
 /datum/species/ipc/spec_revival(mob/living/carbon/human/H)
+	if(H.stat == DEAD)
+		return
 	H.notify_ghost_cloning("You have been repaired!")
 	H.grab_ghost()
-	H.dna.features["ipc_screen"] = "BSOD"
-	H.update_body()
+	if(H.get_bodypart(BODY_ZONE_HEAD))
+		H.dna.features["ipc_screen"] = "BSOD"
+		H.update_body()
 	playsound(H, 'monkestation/sound/voice/dialup.ogg', 25)
 	H.say("Reactivating [pick("core systems", "central subroutines", "key functions")]...")
 	sleep(3 SECONDS)
@@ -207,10 +212,11 @@
 	if(H.stat == DEAD)
 		return
 	H.say("Unit [H.real_name] is fully functional. Have a nice day.")
-	switch_to_screen(H, "Console")
-	addtimer(CALLBACK(src, PROC_REF(switch_to_screen), H, saved_screen), 5 SECONDS)
+	if(H.get_bodypart(BODY_ZONE_HEAD))
+		switch_to_screen(H, "Console")
+		addtimer(CALLBACK(src, PROC_REF(switch_to_screen), H, saved_screen), 5 SECONDS)
+		H.visible_message(span_notice("[H]'s [change_screen ? "monitor lights up" : "eyes flicker to life"]!"), span_notice("All systems nominal. You're back online!"))
 	playsound(H.loc, 'sound/machines/chime.ogg', 50, TRUE)
-	H.visible_message(span_notice("[H]'s [change_screen ? "monitor lights up" : "eyes flicker to life"]!"), span_notice("All systems nominal. You're back online!"))
 	return
 
 /datum/species/ipc/replace_body(mob/living/carbon/target, datum/species/new_species)


### PR DESCRIPTION

## About The Pull Request

Previously, this didn't check to see if they had a screen before it would try to display things on that screen. Now it does!

## Why It's Good For The Game

It was an oversight, and was not a problem before I moved their brain to their chest recently. Whoops.

## Changelog
:cl:
fix: IPC death/revival screen manipulation now checks if they have a screen first.
/:cl:
