### PR TITLE
drones are now capable of using the crafting menu

### DIFF
--- a/code/modules/mob/living/basic/drone/_drone.dm
+++ b/code/modules/mob/living/basic/drone/_drone.dm
@@ -182,6 +182,7 @@
 	AddElement(/datum/element/dextrous, hud_type = hud_type)
 	AddComponent(/datum/component/basic_inhands, y_offset = getItemPixelShiftY())
 	AddComponent(/datum/component/simple_access, SSid_access.get_region_access_list(list(REGION_ALL_GLOBAL)))
+	AddComponent(/datum/component/personal_crafting) //MONKESTATION ADDITION
 
 	if(default_storage)
 		var/obj/item/storage = new default_storage(src)


### PR DESCRIPTION
## About The Pull Request

see title

## Why It's Good For The Game

people tend to like crafting and cooking things

## Changelog

:cl:
qol: Drones can now use the crafting menu.
/:cl: