### PR TITLE
Blocks the clone pod from creating MOB_ROBOTIC mobs

### DIFF
--- a/monkestation/code/game/machinery/cloning.dm
+++ b/monkestation/code/game/machinery/cloning.dm
@@ -133,9 +133,13 @@
 
 //Start growing a human clone in the pod!
 /obj/machinery/clonepod/proc/growclone(clonename, ui, mutation_index, mindref, blood_type, datum/species/mrace, list/features, factions, list/quirks, datum/bank_account/insurance, list/traumas, empty)
+	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src)
+	H.hardset_dna(ui, mutation_index, null, clonename, blood_type, mrace, features)
 	if(panel_open)
 		return NONE
 	if(mess || attempting)
+		return NONE
+	if(H.mob_biotypes & MOB_ROBOTIC) // MONKESTATION ADDITION - no cloning robots.
 		return NONE
 	if(!empty) //Doesn't matter if we're just making a copy
 		clonemind = locate(mindref) in SSticker.minds
@@ -154,10 +158,6 @@
 		current_insurance = insurance
 	attempting = TRUE //One at a time!!
 	countdown.start()
-
-	var/mob/living/carbon/human/H = new /mob/living/carbon/human(src)
-
-	H.hardset_dna(ui, mutation_index, null, clonename, blood_type, mrace, features)
 
 	if(!HAS_TRAIT(H, TRAIT_RADIMMUNE))//dont apply mutations if the species is Mutation proof.
 		if(efficiency > 2)


### PR DESCRIPTION

## About The Pull Request

Seems a bit silly that the clone pod can clone MOB_ROBOTIC, this fixes that

## Why It's Good For The Game

Fixes a bit of a bug/oversight - while you technically can't scan an IPC body, you can scan the brain. And if you do a clone from a brain scan it can spit out an IPC body. This fixes that.

## Changelog

:cl:
fix: Clone pods can no longer create MOB_ROBOTIC bodies
/:cl: