### PR TITLE
IPC death / revival fixes

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -656,11 +656,6 @@
 	if(burn)
 		set_burn_dam(round(max(burn_dam - burn, 0), DAMAGE_PRECISION))
 
-	if(HAS_TRAIT(owner, TRAIT_REVIVES_BY_HEALING) && !HAS_TRAIT(owner, TRAIT_DEFIB_BLACKLISTED)) //monkestation edit
-		if(owner.health > 0)
-			owner.revive(0)
-			owner.cure_husk(0) // If it has REVIVESBYHEALING, it probably can't be cloned. No husk cure.
-
 	if(owner)
 		if(can_be_disabled)
 			update_disabled()
@@ -668,9 +663,11 @@
 			owner.updatehealth()
 
 		//monkestation edit start
-		if(owner.stat == DEAD && HAS_TRAIT(owner, TRAIT_REVIVES_BY_HEALING))
-			if(!HAS_TRAIT(owner, TRAIT_DEFIB_BLACKLISTED) && owner.health > 50)
-				owner.revive(FALSE)
+		if(HAS_TRAIT(owner, TRAIT_REVIVES_BY_HEALING))
+			if(owner.stat == DEAD)
+				if(!HAS_TRAIT(owner, TRAIT_DEFIB_BLACKLISTED) && owner.health > 50)
+					owner.revive(FALSE)
+			owner.cure_husk(0) // If it has TRAIT_REVIVES_BY_HEALING, it probably can't be cloned. No husk cure, so we cure that here.
 		//monkestation edit end
 
 	cremation_progress = min(0, cremation_progress - ((brute_dam + burn_dam)*(100/max_damage)))

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -664,10 +664,9 @@
 
 		//monkestation edit start
 		if(HAS_TRAIT(owner, TRAIT_REVIVES_BY_HEALING))
-			if(owner.stat == DEAD)
-				if(!HAS_TRAIT(owner, TRAIT_DEFIB_BLACKLISTED) && owner.health > 50)
-					owner.revive(FALSE)
 			owner.cure_husk() // If it has TRAIT_REVIVES_BY_HEALING, it probably can't be cloned. No husk cure, so we cure that here.
+			if(owner.stat == DEAD && !HAS_TRAIT(owner, TRAIT_DEFIB_BLACKLISTED) && owner.health > 50)
+				owner.revive(FALSE)
 		//monkestation edit end
 
 	cremation_progress = min(0, cremation_progress - ((brute_dam + burn_dam)*(100/max_damage)))

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -667,7 +667,7 @@
 			if(owner.stat == DEAD)
 				if(!HAS_TRAIT(owner, TRAIT_DEFIB_BLACKLISTED) && owner.health > 50)
 					owner.revive(FALSE)
-			owner.cure_husk(0) // If it has TRAIT_REVIVES_BY_HEALING, it probably can't be cloned. No husk cure, so we cure that here.
+			owner.cure_husk() // If it has TRAIT_REVIVES_BY_HEALING, it probably can't be cloned. No husk cure, so we cure that here.
 		//monkestation edit end
 
 	cremation_progress = min(0, cremation_progress - ((brute_dam + burn_dam)*(100/max_damage)))

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
@@ -155,10 +155,12 @@
  * * screen_name - The name of the screen to switch the ipc_screen mutant bodypart to. Defaults to BSOD.
  */
 /datum/species/ipc/proc/bsod_death(mob/living/carbon/human/transformer, screen_name = "BSOD")
-	saved_screen = change_screen // remember the old screen in case of revival
-	switch_to_screen(transformer, screen_name)
-	addtimer(CALLBACK(src, PROC_REF(switch_to_screen), transformer, "Blank"), 5 SECONDS)
-
+	if(!transformer.get_bodypart(BODY_ZONE_HEAD))
+		return
+	else
+		saved_screen = change_screen // remember the old screen in case of revival
+		switch_to_screen(transformer, screen_name)
+		addtimer(CALLBACK(src, PROC_REF(switch_to_screen), transformer, "Blank"), 5 SECONDS)
 
 /datum/species/ipc/on_species_loss(mob/living/carbon/target)
 	. = ..()
@@ -194,23 +196,30 @@
 	H.dna.features["ipc_screen"] = "BSOD"
 	H.update_body()
 	playsound(H, 'monkestation/sound/voice/dialup.ogg', 25)
-	H.say("Reactivating [pick("core systems", "central subroutines", "key functions")]...")
+	H.say("Structural integity passing minimum threshold! Reboot confirmed. Asynchronously handing off [pick("core systems", "central subroutines", "key functions")] to internal subprocessor...")
+	INVOKE_ASYNC(src, PROC_REF(boot_sequence_fluff), H) //We have to hand this off to not stall the revive() on the sleep()s.
+	return
+
+/datum/species/ipc/proc/boot_sequence_fluff(mob/living/carbon/human/booting_ipc)
 	sleep(3 SECONDS)
-	if(H.stat == DEAD)
+	if(booting_ipc.stat == DEAD)
+		playsound(booting_ipc, 'sound/machines/buzz-two.ogg', 25)
 		return
-	H.say("Reinitializing [pick("personality matrix", "behavior logic", "morality subsystems")]...")
+	booting_ipc.say("Reinitializing [pick("personality matrix", "behavior logic", "morality subsystems")]...")
 	sleep(3 SECONDS)
-	if(H.stat == DEAD)
+	if(booting_ipc.stat == DEAD)
+		playsound(booting_ipc, 'sound/machines/buzz-two.ogg', 25)
 		return
-	H.say("Finalizing setup...")
+	booting_ipc.say("Finalizing setup...")
 	sleep(3 SECONDS)
-	if(H.stat == DEAD)
+	if(booting_ipc.stat == DEAD)
+		playsound(booting_ipc, 'sound/machines/buzz-two.ogg', 25)
 		return
-	H.say("Unit [H.real_name] is fully functional. Have a nice day.")
-	switch_to_screen(H, "Console")
-	addtimer(CALLBACK(src, PROC_REF(switch_to_screen), H, saved_screen), 5 SECONDS)
-	playsound(H.loc, 'sound/machines/chime.ogg', 50, TRUE)
-	H.visible_message(span_notice("[H]'s [change_screen ? "monitor lights up" : "eyes flicker to life"]!"), span_notice("All systems nominal. You're back online!"))
+	booting_ipc.say("Unit [booting_ipc.real_name] is fully functional. Have a nice day.")
+	if(booting_ipc.get_bodypart(BODY_ZONE_HEAD))
+		switch_to_screen(booting_ipc, "Console")
+		booting_ipc.visible_message(span_notice("[booting_ipc]'s [change_screen ? "monitor lights up" : "monitor flickers to life"]!"), span_notice("You're back online!"))
+	playsound(booting_ipc.loc, 'sound/machines/chime.ogg', 50, TRUE)
 	return
 
 /datum/species/ipc/replace_body(mob/living/carbon/target, datum/species/new_species)

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
@@ -184,19 +184,19 @@
 		return
 	if(!ishuman(owner))
 		return
-	var/mob/living/carbon/human/H = owner
-	H.dna.features["ipc_screen"] = screen_choice
-	H.eye_color_left = sanitize_hexcolor(color_choice)
-	H.update_body()
+	var/mob/living/carbon/human/screen_owner = owner
+	screen_owner.dna.features["ipc_screen"] = screen_choice
+	screen_owner.eye_color_left = sanitize_hexcolor(color_choice)
+	screen_owner.update_body()
 
-/datum/species/ipc/spec_revival(mob/living/carbon/human/H)
-	H.notify_ghost_cloning("You have been repaired!")
-	H.grab_ghost()
-	H.dna.features["ipc_screen"] = "BSOD"
-	H.update_body()
-	playsound(H, 'monkestation/sound/voice/dialup.ogg', 25)
-	H.say("Structural integity passing minimum threshold! Reboot confirmed. Asynchronously handing off [pick("core systems", "central subroutines", "key functions")] to internal subprocessor...")
-	INVOKE_ASYNC(src, PROC_REF(boot_sequence_fluff), H) //We have to hand this off to not stall the revive() on the sleep()s.
+/datum/species/ipc/spec_revival(mob/living/carbon/human/revived_ipc)
+	revived_ipc.notify_ghost_cloning("You have been repaired!")
+	revived_ipc.grab_ghost()
+	revived_ipc.dna.features["ipc_screen"] = "BSOD"
+	revived_ipc.update_body()
+	playsound(revived_ipc, 'monkestation/sound/voice/dialup.ogg', 25)
+	revived_ipc.say("Structural integity passing minimum threshold! Reboot confirmed. Asynchronously handing off [pick("core systems", "central subroutines", "key functions")] to internal subprocessor...")
+	INVOKE_ASYNC(src, PROC_REF(boot_sequence_fluff), revived_ipc) //We have to hand this off to not stall the revive() on the sleep()s.
 
 /datum/species/ipc/proc/boot_sequence_fluff(mob/living/carbon/human/booting_ipc)
 	sleep(3 SECONDS)

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
@@ -157,10 +157,9 @@
 /datum/species/ipc/proc/bsod_death(mob/living/carbon/human/transformer, screen_name = "BSOD")
 	if(!transformer.get_bodypart(BODY_ZONE_HEAD))
 		return
-	else
-		saved_screen = change_screen // remember the old screen in case of revival
-		switch_to_screen(transformer, screen_name)
-		addtimer(CALLBACK(src, PROC_REF(switch_to_screen), transformer, "Blank"), 5 SECONDS)
+	saved_screen = change_screen // remember the old screen in case of revival
+	switch_to_screen(transformer, screen_name)
+	addtimer(CALLBACK(src, PROC_REF(switch_to_screen), transformer, "Blank"), 5 SECONDS)
 
 /datum/species/ipc/on_species_loss(mob/living/carbon/target)
 	. = ..()
@@ -198,7 +197,6 @@
 	playsound(H, 'monkestation/sound/voice/dialup.ogg', 25)
 	H.say("Structural integity passing minimum threshold! Reboot confirmed. Asynchronously handing off [pick("core systems", "central subroutines", "key functions")] to internal subprocessor...")
 	INVOKE_ASYNC(src, PROC_REF(boot_sequence_fluff), H) //We have to hand this off to not stall the revive() on the sleep()s.
-	return
 
 /datum/species/ipc/proc/boot_sequence_fluff(mob/living/carbon/human/booting_ipc)
 	sleep(3 SECONDS)

--- a/monkestation/code/modules/surgery/organs/internal/brain.dm
+++ b/monkestation/code/modules/surgery/organs/internal/brain.dm
@@ -421,9 +421,9 @@
 	name = "compact positronic brain"
 	slot = ORGAN_SLOT_BRAIN
 	zone = BODY_ZONE_CHEST
-	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
+	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES | ORGAN_VITAL
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD
-	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. It has an IPC serial number engraved on the top. It is usually slotted into the chest of synthetic crewmembers."
+	desc = "A cube of shining metal, four inches to a side and covered in shallow grooves. It has an IPC serial number engraved on the top. It is usually slotted into the chest of synthetic crewmembers. It is not compatible with standard Posibrain/MMI interfaces, and must be placed into an MMI to be made compatible." // to inform the user that this is, in fact, not a real posibrain, but is an organ posibrain.
 	icon = 'monkestation/code/modules/smithing/icons/ipc_organ.dmi'
 	icon_state = "posibrain-ipc"
 	/// The last time (in ticks) a message about brain damage was sent. Don't touch.


### PR DESCRIPTION

## About The Pull Request

IPCs have a bug with their revival due to spec_revival: https://github.com/Monkestation/Monkestation2.0/issues/5956 This fixes it and tunes up the spec_revival process.

## Why It's Good For The Game

Fixing bugs and cleaning up code in prep for IPC body construction.

## Changelog
:cl:
fix: IPCs now die without a brain
fix: IPCs are no longer sent to null space in some revival circumstances
fix: IPC death/revival screen manipulation now checks if they have a screen first.
/:cl:
