### PR TITLE
Surgery rooms, tram, and cassettes

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10667,6 +10667,7 @@
 	dir = 1
 	},
 /obj/machinery/iv_drip,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "diT" = (
@@ -35167,8 +35168,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "liz" = (
-/obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "liI" = (
@@ -55992,7 +55993,6 @@
 	pixel_x = 22
 	},
 /obj/machinery/vending/wallmed/directional/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/table/glass,
 /obj/item/book/manual/wiki/surgery{
@@ -67502,7 +67502,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "vzR" = (
-/obj/structure/cable,
 /obj/machinery/light/directional/east,
 /obj/machinery/button/door/directional/south{
 	id = "surgery";
@@ -74670,6 +74669,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/closet/secure_closet/medical2,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "xMQ" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10663,15 +10663,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
 "diR" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/surgery{
-	pixel_x = -4;
-	pixel_y = 3
-	},
-/obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "diT" = (
@@ -41381,6 +41376,9 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/structure/table/glass,
+/obj/item/stack/sticky_tape/surgical,
+/obj/item/stack/medical/bone_gel,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "niu" = (
@@ -41708,7 +41706,6 @@
 /turf/open/openspace,
 /area/station/science/ordnance/office)
 "nmC" = (
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
@@ -55790,6 +55787,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/table/glass,
+/obj/item/stack/sticky_tape/surgical,
+/obj/item/stack/medical/bone_gel,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "rGl" = (
@@ -55993,10 +55993,13 @@
 	},
 /obj/machinery/vending/wallmed/directional/south,
 /obj/structure/cable,
-/obj/structure/table/glass,
-/obj/item/stack/sticky_tape/surgical,
-/obj/item/stack/medical/bone_gel,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/surgery{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "rKZ" = (
@@ -62830,10 +62833,8 @@
 /area/mine/eva/lower)
 "tYA" = (
 /obj/structure/cable,
-/obj/structure/table/glass,
-/obj/item/stack/sticky_tape/surgical,
-/obj/item/stack/medical/bone_gel,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/iv_drip,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
 "tYJ" = (
@@ -67501,15 +67502,17 @@
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "vzR" = (
-/obj/structure/closet/secure_closet/medical2,
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/light/directional/east,
 /obj/machinery/button/door/directional/south{
 	id = "surgery";
 	name = "Surgery Shutter Control"
 	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
+/obj/machinery/computer/operating{
+	dir = 8
+	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "vzS" = (
@@ -70234,7 +70237,6 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
 "wuv" = (
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/fore)
@@ -74663,13 +74665,11 @@
 /turf/open/floor/plating/elevatorshaft,
 /area/mine/storage)
 "xMM" = (
-/obj/machinery/computer/operating{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/aft)
 "xMQ" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3937,7 +3937,12 @@
 	},
 /area/centcom/central_command_areas/hall)
 "akJ" = (
-/obj/structure/chair/stool/bar/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/table/wood,
+/obj/item/instrument/piano_synth/headphones,
+/obj/item/instrument/piano_synth/headphones,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/arcade)
 "akK" = (
@@ -7787,7 +7792,7 @@
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/borbop)
 "auY" = (
-/obj/structure/table/wood/poker,
+/obj/structure/chair/wood/wings,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/arcade)
 "auZ" = (
@@ -8522,7 +8527,23 @@
 /area/centcom/central_command_areas/admin)
 "awZ" = (
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/chair/stool/bar/directional/north,
+/obj/structure/table/wood,
+/obj/item/device/walkman{
+	pixel_y = 7;
+	pixel_x = -8
+	},
+/obj/item/device/walkman{
+	pixel_y = 7;
+	pixel_x = -8
+	},
+/obj/item/device/walkman{
+	pixel_y = 7;
+	pixel_x = -8
+	},
+/obj/item/device/walkman{
+	pixel_y = 7;
+	pixel_x = -8
+	},
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/arcade)
 "axb" = (
@@ -11831,6 +11852,8 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
 	},
+/obj/structure/table/wood,
+/obj/machinery/cassette/adv_cassette_deck,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/arcade)
 "aFR" = (
@@ -11923,11 +11946,9 @@
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "aGg" = (
-/obj/structure/table/wood/poker,
-/obj/item/flashlight/lamp/green{
-	pixel_y = 8;
-	pixel_x = 16
-	},
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/table/wood,
+/obj/structure/cassette_rack/prefilled,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/arcade)
 "aGh" = (
@@ -14574,6 +14595,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/cassette/mailbox,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/arcade)
 "aNp" = (
@@ -26816,6 +26838,19 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/adminroom)
+"qAK" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/structure/table/wood,
+/obj/item/device/cassette_tape/blank,
+/obj/item/device/cassette_tape/blank,
+/obj/item/device/cassette_tape/blank,
+/obj/item/device/cassette_tape/blank,
+/obj/item/device/cassette_tape/blank,
+/obj/item/device/cassette_tape/blank,
+/turf/open/floor/wood/parquet,
+/area/centcom/central_command_areas/arcade)
 "qBw" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -30157,6 +30192,16 @@
 /obj/effect/decal/cleanable/piss_stain,
 /turf/open/misc/sandy_dirt,
 /area/centcom/central_command_areas/admin)
+"xHo" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/item/chair/wood/wings{
+	pixel_x = 11;
+	pixel_y = -2
+	},
+/turf/open/floor/wood/parquet,
+/area/centcom/central_command_areas/arcade)
 "xHG" = (
 /obj/structure/sign{
 	name = "wall";
@@ -66370,8 +66415,8 @@ aPq
 aEf
 aHv
 aYf
-aYf
-akR
+xHo
+akJ
 aFR
 aaa
 aaa
@@ -66626,8 +66671,8 @@ aZg
 ayL
 aPq
 aPq
-akJ
-aGg
+aPq
+aPq
 awZ
 aFR
 aaa
@@ -66883,9 +66928,9 @@ aKA
 ayL
 aPq
 aPq
-akJ
+aPq
 auY
-awZ
+aGg
 aFR
 aaa
 aaa
@@ -67141,7 +67186,7 @@ asp
 asp
 asp
 aNo
-asp
+qAK
 aFQ
 aFR
 aaa

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3938,11 +3938,12 @@
 /area/centcom/central_command_areas/hall)
 "akJ" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 10
+	dir = 8
 	},
-/obj/structure/table/wood,
-/obj/item/instrument/piano_synth/headphones,
-/obj/item/instrument/piano_synth/headphones,
+/obj/item/chair/wood/wings{
+	pixel_x = 11;
+	pixel_y = -2
+	},
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/arcade)
 "akK" = (
@@ -8528,22 +8529,8 @@
 "awZ" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood,
-/obj/item/device/walkman{
-	pixel_y = 7;
-	pixel_x = -8
-	},
-/obj/item/device/walkman{
-	pixel_y = 7;
-	pixel_x = -8
-	},
-/obj/item/device/walkman{
-	pixel_y = 7;
-	pixel_x = -8
-	},
-/obj/item/device/walkman{
-	pixel_y = 7;
-	pixel_x = -8
-	},
+/obj/item/instrument/piano_synth/headphones,
+/obj/item/instrument/piano_synth/headphones,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/arcade)
 "axb" = (
@@ -11946,7 +11933,9 @@
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "aGg" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
 /obj/structure/table/wood,
 /obj/structure/cassette_rack/prefilled,
 /turf/open/floor/wood/parquet,
@@ -23488,6 +23477,14 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/admin)
+"iTY" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
+	},
+/obj/structure/table/wood,
+/obj/machinery/cassette/adv_cassette_deck,
+/turf/open/floor/wood/parquet,
+/area/centcom/central_command_areas/arcade)
 "iUK" = (
 /obj/machinery/button/door/directional/east{
 	name = "IPC Repair Shutters";
@@ -25181,6 +25178,31 @@
 /obj/structure/falsewall/wood,
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
+"mPL" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/table/wood,
+/obj/item/device/walkman{
+	pixel_y = 7;
+	pixel_x = -8
+	},
+/obj/item/device/walkman{
+	pixel_y = 7;
+	pixel_x = -8
+	},
+/obj/item/device/walkman{
+	pixel_y = 7;
+	pixel_x = -8
+	},
+/obj/item/device/walkman{
+	pixel_y = 7;
+	pixel_x = -8
+	},
+/obj/item/device/cassette_tape/blank{
+	pixel_x = 7;
+	pixel_y = 0
+	},
+/turf/open/floor/wood/parquet,
+/area/centcom/central_command_areas/arcade)
 "mQh" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/carpet/red,
@@ -26838,19 +26860,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/centcom/central_command_areas/adminroom)
-"qAK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/table/wood,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/obj/item/device/cassette_tape/blank,
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
 "qBw" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -30192,16 +30201,6 @@
 /obj/effect/decal/cleanable/piss_stain,
 /turf/open/misc/sandy_dirt,
 /area/centcom/central_command_areas/admin)
-"xHo" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/item/chair/wood/wings{
-	pixel_x = 11;
-	pixel_y = -2
-	},
-/turf/open/floor/wood/parquet,
-/area/centcom/central_command_areas/arcade)
 "xHG" = (
 /obj/structure/sign{
 	name = "wall";
@@ -66415,8 +66414,8 @@ aPq
 aEf
 aHv
 aYf
-xHo
 akJ
+iTY
 aFR
 aaa
 aaa
@@ -66673,7 +66672,7 @@ aPq
 aPq
 aPq
 aPq
-awZ
+mPL
 aFR
 aaa
 aaa
@@ -66930,7 +66929,7 @@ aPq
 aPq
 aPq
 auY
-aGg
+awZ
 aFR
 aaa
 aaa
@@ -67186,7 +67185,7 @@ asp
 asp
 asp
 aNo
-qAK
+aGg
 aFQ
 aFR
 aaa

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -34964,7 +34964,7 @@
 /area/station/maintenance/starboard/lesser)
 "jVp" = (
 /obj/machinery/light/small/directional/west,
-/turf/open/misc/asteroid/airless,
+/turf/open/misc/asteroid,
 /area/station/asteroid)
 "jVw" = (
 /turf/open/floor/iron/white,
@@ -42394,11 +42394,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/hallway/primary/tram/center)
-"mhG" = (
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
-/turf/open/floor/grass,
-/area/station/asteroid/tram/pet)
 "mhQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
@@ -47011,11 +47006,6 @@
 /obj/structure/industrial_lift/public,
 /turf/open/floor/plating/elevatorshaft,
 /area/station/hallway/secondary/service)
-"nGR" = (
-/mob/living/basic/butterfly/lavaland,
-/obj/structure/cable,
-/turf/open/floor/grass,
-/area/station/asteroid/tram/pet)
 "nGX" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -55079,6 +55069,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/generic_maintenance_landmark,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/plating,
 /area/station/asteroid/tram/pet)
 "qjw" = (
@@ -55400,7 +55391,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/asteroid/tram/pet)
 "qoX" = (
@@ -131370,7 +131360,7 @@ qPe
 uuK
 uNZ
 qxm
-aac
+abM
 oys
 oys
 oys
@@ -131627,7 +131617,7 @@ ruy
 opy
 jYY
 qxm
-aac
+abM
 jVp
 aak
 aaa
@@ -131884,8 +131874,8 @@ ldg
 sYP
 ecO
 qxm
-aac
-aac
+abM
+abM
 aak
 aaa
 aaa
@@ -132141,9 +132131,9 @@ pAf
 oAw
 eqw
 qxm
-aac
-aac
-aac
+abM
+abM
+abM
 aaa
 aaa
 aaa
@@ -132398,7 +132388,7 @@ rGx
 pzs
 lEo
 qxm
-aac
+abM
 aaa
 aaa
 aaa
@@ -132655,7 +132645,7 @@ lFH
 eHL
 aAj
 qxm
-aac
+abM
 aaa
 aaa
 aaa
@@ -132912,8 +132902,8 @@ iMf
 ruy
 ecO
 qxm
-aac
-aac
+abM
+abM
 aaa
 aaa
 aaa
@@ -133169,8 +133159,8 @@ asR
 asR
 qxm
 qxm
-aac
-aac
+abM
+abM
 aaa
 aaa
 aaa
@@ -133426,8 +133416,8 @@ aaa
 aaa
 aaa
 aaa
-aac
-aac
+abM
+abM
 aaa
 aaa
 aaa
@@ -133683,7 +133673,7 @@ aaa
 aaa
 aaa
 aaa
-aac
+abM
 aaa
 aaa
 aaa
@@ -133940,7 +133930,7 @@ aaa
 aaa
 aaa
 aaa
-aac
+abM
 aaa
 aaa
 aaa
@@ -134197,8 +134187,8 @@ aaa
 aaa
 aaa
 aaa
-aac
-aac
+abM
+abM
 aaa
 aaa
 aaa
@@ -134454,9 +134444,9 @@ aaa
 aaa
 aaa
 aaa
-aac
-aac
-aac
+abM
+abM
+abM
 aaa
 aaa
 aaa
@@ -185349,8 +185339,8 @@ sJF
 xTG
 fCF
 xTG
-nGR
-mhG
+gcr
+xTG
 fCF
 xTG
 xip


### PR DESCRIPTION
## About The Pull Request

- Makes it easier to put surgery patients on Icebox on the table
- Tramstation no longer has a sealed area spaced.
- Central now has a few machines to make cassettes
- Tram pet sanctuary should no longer be disconnected roundstart
## Why It's Good For The Game
## Changelog
:cl:
add: Cassettes can be made on central command
map: Icebox surgery is more spacious
map: Tramstation no longer has a spaced sealed area in its rock 
fix: Tramstation pet sanctuary apc is no longer disconnected roundstart
/:cl:
