### PR TITLE
Ensures a World Topic key is set to be valid.

### DIFF
--- a/code/datums/world_topic.dm
+++ b/code/datums/world_topic.dm
@@ -26,7 +26,7 @@
 	var/require_comms_key = FALSE
 
 /datum/world_topic/proc/TryRun(list/input)
-	key_valid = config && (CONFIG_GET(string/comms_key) == input["key"])
+	key_valid = (CONFIG_GET(string/comms_key) == input["key"]) && CONFIG_GET(string/comms_key) && input["key"]
 	input -= "key"
 	if(require_comms_key && !key_valid)
 		. = "Bad Key"


### PR DESCRIPTION
## About The Pull Request
If you don't have your comms key config set, the server will accept any world.Export() calls into world.Topic()

This is a /tg/ issue that hasn't been patched here that I've noticed exists here. https://github.com/tgstation/tgstation/pull/88367

I don't know the repo for Vanderlin so this should be checked there as well since that is 2019 /tg/ code. 

## Why It's Good For The Game

world topic exploits are very bad. 


