### PR TITLE
Makes it so icemoon openspace turfs can't spawn on top of station turfs, in preparation for CraterStation

### DIFF
--- a/code/game/turfs/open/openspace.dm
+++ b/code/game/turfs/open/openspace.dm
@@ -183,6 +183,11 @@
 	//I wonder if I should error here
 	if(!T)
 		return
+	// MONKESTATION ADDITION START: Don't fucking bust open the station from the ceiling lmao.
+	if(istype(T.loc, /area/station) && protect_station)
+		ChangeTurf(replacement_turf, null, CHANGETURF_IGNORE_AIR)
+		return
+	// MONKESTATION ADDITION END
 	if(T.turf_flags & NO_RUINS && protect_ruin)
 		ChangeTurf(replacement_turf, null, CHANGETURF_IGNORE_AIR)
 		return

--- a/monkestation/code/game/turfs/open/openspace.dm
+++ b/monkestation/code/game/turfs/open/openspace.dm
@@ -1,0 +1,5 @@
+/turf/open/openspace/icemoon
+	var/protect_station = TRUE
+
+/turf/open/openspace/icemoon/station
+	protect_station = FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6258,6 +6258,7 @@
 #include "monkestation\code\game\objects\structures\crates_lockers\closets\secure\nanotrasen_rep.dm"
 #include "monkestation\code\game\objects\structures\crates_lockers\closets\secure\security.dm"
 #include "monkestation\code\game\objects\structures\crates_lockers\crates\secure.dm"
+#include "monkestation\code\game\turfs\open\openspace.dm"
 #include "monkestation\code\game\turfs\open\water.dm"
 #include "monkestation\code\game\turfs\open\floor\misc_floor.dm"
 #include "monkestation\code\modules\_nightmare\nightmare_equipment.dm"


### PR DESCRIPTION

## About The Pull Request

Title, pretty much just adds a check for the turf below being a station turf.
Also adds an additional subtype for icemoon openspace that IS allowed above the station. (for mappers)
## Why It's Good For The Game

As it turns out, opening holes into the icemoon surface at roundstart isn't the best, lmao.
