### PR TITLE
Lowers depot TC from 25 to 5

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -1607,7 +1607,6 @@
 /obj/effect/mapping_helpers/apc/cell_10k,
 /obj/structure/safe,
 /obj/item/stack/telecrystal/five,
-/obj/item/stack/telecrystal/twenty,
 /obj/effect/mapping_helpers/apc/cut_AI_wire,
 /obj/item/card/id/advanced/chameleon,
 /obj/item/card/id/advanced/chameleon,


### PR DESCRIPTION
## About The Pull Request
Lowers amount of TC in the depot safe from 25 TC to 5 TC

## Why It's Good For The Game
This was after discussion with quite a few people including addust who made the depot.

25 TC is absured and over tots starting TC for free with a fairly often spawning space ruin. People hit up the depot nearly every chance they get in my experience, which is a lot of chances.
Depot has plenty of reasons to visit and work with them outside of giving them a insane amount of TC, this gives them a little bit but not a ton instead.

## Changelog

:cl:
balance: Depot Safe TC lowered from 25 to 5
/:cl:

