### PR TITLE
Gives admins byond member features, except the icon in ooc

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -113,7 +113,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		load_path(parent_ckey)
 		if(load_and_save && !fexists(path))
 			try_savefile_type_migration()
-		unlock_content = !!parent.IsByondMember()
+		unlock_content = !!parent.IsByondMember() || is_admin(parent)
 		// monke edit: more save slots
 		//if(unlock_content)
 		//	max_save_slots = 8

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -74,7 +74,7 @@ GLOBAL_VAR_INIT(normal_ooc_colour, "#002eb8")
 	mob.log_talk(raw_msg, LOG_OOC)
 
 	var/keyname = key
-	if(prefs.unlock_content)
+	if(!!IsByondMember())
 		if(prefs.toggles & MEMBER_PUBLIC)
 			keyname = "<font color='[prefs.read_preference(/datum/preference/color/ooc_color) || GLOB.normal_ooc_colour]'>[icon2html('icons/ui_icons/chat/member_content.dmi', world, "blag")][keyname]</font>"
 	if(prefs.hearted)


### PR DESCRIPTION

## About The Pull Request
Gives admins most of the features of being a byond member (that we can control) except the byond icon in ooc.
## Why It's Good For The Game
Admins already get donator features, and most of the member features, this just finishes it out
## Changelog
:cl:
admin: grants admins access to member only features like changing their ghost
/:cl:
