### PR TITLE
Fix cleaner slimes not targeting other types of trash

### DIFF
--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
@@ -72,9 +72,15 @@
 	action_cooldown = 3 SECONDS
 
 /datum/ai_behavior/find_and_set/in_list/clean_targets/search_tactic(datum/ai_controller/controller, locate_paths, search_range)
-	var/list/found = typecache_filter_list(oview(search_range, controller.pawn), locate_paths)
+	var/list/found = view(search_range, controller.pawn) // monkestation edit: don't pre-filter with typecache, so we can check for TRAIT_TRASH_ITEM
 	var/list/ignore_list = controller.blackboard[BB_TEMPORARY_IGNORE_LIST]
-	for(var/atom/found_item in found)
+	for(var/atom/found_item as anything in found)
+		// monkestation start: check for TRAIT_TRASH_ITEM
+		if(QDELETED(found_item))
+			continue
+		if(!is_type_in_typecache(found_item, locate_paths) && !HAS_TRAIT(found_item, TRAIT_TRASH_ITEM))
+			continue
+		// monkestation end
 		if(LAZYACCESS(ignore_list, REF(found_item)))
 			continue
 		var/list/path = get_path_to(controller.pawn, found_item, max_distance = BOT_CLEAN_PATH_LIMIT, access = controller.get_access())

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
@@ -72,7 +72,7 @@
 	action_cooldown = 3 SECONDS
 
 /datum/ai_behavior/find_and_set/in_list/clean_targets/search_tactic(datum/ai_controller/controller, locate_paths, search_range)
-	var/list/found = view(search_range, controller.pawn) // monkestation edit: don't pre-filter with typecache, so we can check for TRAIT_TRASH_ITEM
+	var/list/found = oview(search_range, controller.pawn) // monkestation edit: don't pre-filter with typecache, so we can check for TRAIT_TRASH_ITEM
 	var/list/ignore_list = controller.blackboard[BB_TEMPORARY_IGNORE_LIST]
 	for(var/atom/found_item as anything in found)
 		// monkestation start: check for TRAIT_TRASH_ITEM

--- a/monkestation/code/modules/slimecore/slime_traits/cleaner.dm
+++ b/monkestation/code/modules/slimecore/slime_traits/cleaner.dm
@@ -90,7 +90,8 @@
 		is_type_in_typecache(target, cleanable_decals) \
 		|| is_type_in_typecache(target, cleanable_blood) \
 		|| is_type_in_typecache(target, huntable_pests) \
-		|| is_type_in_typecache(target, huntable_trash)
+		|| is_type_in_typecache(target, huntable_trash) \
+		|| HAS_TRAIT(target, TRAIT_TRASH_ITEM)
 
 	if(target_is_dissolvable)
 		parent.balloon_alert_to_viewers("cleaned")


### PR DESCRIPTION

## About The Pull Request

https://github.com/Monkestation/Monkestation2.0/pull/5657 unintentionally removed the `TRAIT_TRASH_ITEM` check, which broke the ability for cleaner slimes to target things like used ammo, used mutation syringes, emptied drink bottles, burnt matches, and such.

## Why It's Good For The Game

bugfix

## Changelog
:cl:
fix: Cleaner slimes now properly target other types of trash (used ammo, used mutation syringes, emptied drink bottles, burnt matches, etc) again.
/:cl:
