### PR TITLE
Fix forcefully reconnecting/disconnecting the chatbox websocket

### DIFF
--- a/tgui/packages/tgui-panel/settings/SettingsPanel.tsx
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.tsx
@@ -487,7 +487,7 @@ const ExperimentalSettings = (props, context) => {
                 icon={'globe'}
                 color={'good'}
                 onClick={() => {
-                  dispatch(reconnectWebsocket());
+                  dispatch(reconnectWebsocket({}));
                 }}
               />
               <Button
@@ -496,7 +496,7 @@ const ExperimentalSettings = (props, context) => {
                 icon={'globe'}
                 color={'bad'}
                 onClick={() => {
-                  dispatch(disconnectWebsocket());
+                  dispatch(disconnectWebsocket({}));
                 }}
               />
             </LabeledList.Item>


### PR DESCRIPTION
## Changelog
:cl:
fix: Forcefully reconnecting or disconnecting the chatbox websocket now properly works.
/:cl:
