### PR TITLE
[BALANCE] Smite the boots from the maint pool

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -380,7 +380,7 @@ GLOBAL_LIST_INIT(rarity_loot, list(//rare: really good items
 
 GLOBAL_LIST_INIT(oddity_loot, list(//oddity: strange or crazy items
 		/* /obj/effect/rune/teleport = 1, */ // monkestation removal: this should really only have /obj/items
-		/obj/item/clothing/head/helmet/abductor = 1,,
+		/obj/item/clothing/head/helmet/abductor = 1,
 		/obj/item/clothing/suit/armor/reactive/table = 1,
 		/obj/item/dice/d20/fate/stealth/cursed = 1, //Only rolls 1
 		/obj/item/dice/d20/fate/stealth/one_use = 1, //Looks like a d20, keep the d20 in the uncommon pool.

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -380,8 +380,7 @@ GLOBAL_LIST_INIT(rarity_loot, list(//rare: really good items
 
 GLOBAL_LIST_INIT(oddity_loot, list(//oddity: strange or crazy items
 		/* /obj/effect/rune/teleport = 1, */ // monkestation removal: this should really only have /obj/items
-		/obj/item/clothing/head/helmet/abductor = 1,
-		/obj/item/clothing/shoes/jackboots/fast = 1,
+		/obj/item/clothing/head/helmet/abductor = 1,,
 		/obj/item/clothing/suit/armor/reactive/table = 1,
 		/obj/item/dice/d20/fate/stealth/cursed = 1, //Only rolls 1
 		/obj/item/dice/d20/fate/stealth/one_use = 1, //Looks like a d20, keep the d20 in the uncommon pool.


### PR DESCRIPTION
## About The Pull Request

Maybe I am exaggerating, but everytime I play, I see some people having these speedy jackboots. It doesn't improve the roleplay, it doesn't do anything, there's a reason why it's only used in CTF.

Hell, I just saw one guy fucking meme on assops due to that.

I'm removing them from the loot table

## Why It's Good For The Game

It's mere existence within regular rounds is unfair to whoever is fighting against them. It's the only logical step to remove them, the fun should be for everyone, not someone.

## Changelog

:cl:

balance: rebalanced maintenance loot pools by removing the speedy jackboots.

/:cl:

