### PR TITLE
Fixes h (prevent unintentionally switching say to OOC)

### DIFF
--- a/tgui/packages/tgui-say/ChannelIterator.ts
+++ b/tgui/packages/tgui-say/ChannelIterator.ts
@@ -55,8 +55,8 @@ export class ChannelIterator {
     return this.channels[this.index] === 'Say';
   }
 
-  public isVisible(): boolean {
-    return !this.quiet.includes(this.channels[this.index]);
+  public isVisible(channel?: Channel): boolean {
+    return !this.quiet.includes(channel || this.channels[this.index]);
   }
 
   public reset(): void {

--- a/tgui/packages/tgui-say/TguiSay.tsx
+++ b/tgui/packages/tgui-say/TguiSay.tsx
@@ -39,6 +39,7 @@ export class TguiSay extends Component<{}, State> {
   private lightMode: boolean;
   private maxLength: number;
   private messages: typeof byondMessages;
+  private active: boolean;
   state: State;
 
   constructor(props: never) {
@@ -51,6 +52,7 @@ export class TguiSay extends Component<{}, State> {
     this.lightMode = false;
     this.maxLength = 1024;
     this.messages = byondMessages;
+    this.active = false;
     this.state = {
       buttonContent: '',
       size: WINDOW_SIZES.small,
@@ -140,6 +142,7 @@ export class TguiSay extends Component<{}, State> {
     this.chatHistory.reset();
     this.channelIterator.reset();
     this.currentPrefix = null;
+    this.active = false;
     windowClose();
   }
 
@@ -265,10 +268,18 @@ export class TguiSay extends Component<{}, State> {
     }, 0);
 
     const { channel } = data;
+    if (
+      this.active &&
+      this.channelIterator.isVisible() !==
+        this.channelIterator.isVisible(channel)
+    ) {
+      return;
+    }
     // Catches the case where the modal is already open
     if (this.channelIterator.isSay()) {
       this.channelIterator.set(channel);
     }
+    this.active = true;
     this.setState({ buttonContent: this.channelIterator.current() });
 
     windowOpen(this.channelIterator.current());


### PR DESCRIPTION

## About The Pull Request

This prevents the in-game hotkeys from switching tgui-say to OOC, if tgui-say is currently open with a non-OOC channel selected.

## Why It's Good For The Game

no more accidental ick ock or h

## Changelog
:cl:
fix: Added an experimental check to try to prevent unintentionally switching your say prompt to OOC.
/:cl:
