### PR TITLE
Some maints loot and trash piles tweaks

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -410,7 +410,7 @@ GLOBAL_LIST_INIT(maint_fauna, list(//fauna: there be critters living in yer main
 #define maint_common_weight 4497 //monkestation edit: from 4500 to 4497
 #define maint_uncommon_weight 900
 #define maint_rarity_weight 99
-#define maint_oddity_weight 4 //1 out of 10,000 would give metastation (180 spawns) a 2 in 111 chance of spawning an oddity per round, similar to xeno egg, monkestation edit: from 1 to 4
+#define maint_oddity_weight 1 //1 out of 10,000 would give metastation (180 spawns) a 2 in 111 chance of spawning an oddity per round, similar to xeno egg
 #define maint_holiday_weight 3500 // When holiday loot is enabled, it'll give every loot item a 25% chance of being a holiday item
 #define maint_fauna_weight 150 //monkestation edit: adds friendly maintenance bees, also allows for other maintenance fauna to be coded in.
 

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -41,6 +41,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Listener", "Deaf"),
 		list("Polyglot", "Listener"),
 		list("Polyglot", "Bilingual"),
+		list("Polyglot", "Foreigner"),
 		//might be fun to change this in the future. you can be a body purist but be forced to use implants regardless for medical reasons
 		list("Body Purist", "Hosed"),
 		list("Body Purist", "Neuralinked"),

--- a/monkestation/code/game/objects/structures/trash_pile.dm
+++ b/monkestation/code/game/objects/structures/trash_pile.dm
@@ -21,7 +21,7 @@
 
 	///Have we been searched yet?
 	var/searched = FALSE
-	///how many more pieces of trash they be thrown out while digging
+	///how many more pieces of trash can be thrown out while digging
 	var/list/remaining_trash_throws = list()
 
 	var/trash_delay = 0.5 SECONDS

--- a/monkestation/code/game/objects/structures/trash_pile.dm
+++ b/monkestation/code/game/objects/structures/trash_pile.dm
@@ -190,10 +190,7 @@
 		COOLDOWN_START(src, trash_cooldown, trash_delay * 0.5 + rand() * trash_delay) // x0.5 to x1.5
 		remaining_trash_throws[ckey]--
 		var/item_to_spawn
-		if(prob(3))
-			item_to_spawn = pick(GLOB.oddity_loot - typesof(/obj/item/dice/d20/fate)) // die of fate are blacklisted bc it will be automatically rolled due to the throw, likely insta-RRing the user without any counter
-		else
-			item_to_spawn = pick_weight_recursive(GLOB.trash_pile_loot)
+		item_to_spawn = pick_weight_recursive(GLOB.trash_pile_loot)
 		var/obj/item/spawned_item = new item_to_spawn(drop_location())
 		if(!QDELETED(spawned_item))
 			var/turf/throw_at = get_ranged_target_turf_direct(src, user, 7, rand(-60, 60))

--- a/monkestation/code/game/objects/structures/trash_pile.dm
+++ b/monkestation/code/game/objects/structures/trash_pile.dm
@@ -19,9 +19,9 @@
 	var/hide_person_time = 3 SECONDS
 	var/hide_item_time = 1 SECONDS
 
-	///Have we been searched yet?
-	var/searched = FALSE
-	///how many more pieces of trash can be thrown out while digging
+	/// Associative list of ckeys to TRUE if they have searched it.
+	var/list/searched_by_ckeys = list()
+	/// Associative list of ckeys to how many more pieces of trash they can throw out while digging.
 	var/list/remaining_trash_throws = list()
 
 	var/trash_delay = 0.5 SECONDS
@@ -108,7 +108,7 @@
 			balloon_alert(user, "found something!")
 			hidden.forceMove(drop_location())
 		return
-	if(searched == TRUE)
+	if(searched_by_ckeys[user.ckey])
 		balloon_alert(user, "empty...")
 		return
 	var/item_to_spawn = pick_weight_recursive(GLOB.maintenance_loot)
@@ -117,7 +117,7 @@
 		balloon_alert(user, "found [spawned_item]!")
 	else
 		balloon_alert(user, "found nothing...")
-	searched = TRUE
+	searched_by_ckeys[user.ckey] = TRUE
 
 /obj/structure/trash_pile/attackby(obj/item/attacking_item, mob/living/user, params)
 	if(user in contents)
@@ -174,21 +174,21 @@
 	if(QDELETED(src) || QDELETED(user)) //Check if valid.
 		return FALSE
 
-	var/trash_pile = src
-	if(searched == TRUE) //Don't spawn trash!
+	var/ckey = user.ckey
+	if(searched_by_ckeys[ckey]) //Don't spawn trash!
 		return TRUE
 
 	if(!user.CanReach(src)) //Distance check for TK fuckery
 		return FALSE
 
-	if(isnull(remaining_trash_throws[trash_pile]))
-		remaining_trash_throws[trash_pile] = MAXIMUM_TRASH_THROWS
-	else if(remaining_trash_throws[trash_pile] < 1)
+	if(isnull(remaining_trash_throws[ckey]))
+		remaining_trash_throws[ckey] = MAXIMUM_TRASH_THROWS
+	else if(remaining_trash_throws[ckey] < 1)
 		return TRUE
 
 	if(COOLDOWN_FINISHED(src, trash_cooldown))
 		COOLDOWN_START(src, trash_cooldown, trash_delay * 0.5 + rand() * trash_delay) // x0.5 to x1.5
-		remaining_trash_throws[trash_pile]--
+		remaining_trash_throws[ckey]--
 		var/item_to_spawn
 		if(prob(0.1))
 			item_to_spawn = pick(GLOB.oddity_loot - typesof(/obj/item/dice/d20/fate)) // die of fate are blacklisted bc it will be automatically rolled due to the throw, likely insta-RRing the user without any counter

--- a/monkestation/code/game/objects/structures/trash_pile.dm
+++ b/monkestation/code/game/objects/structures/trash_pile.dm
@@ -190,7 +190,7 @@
 		COOLDOWN_START(src, trash_cooldown, trash_delay * 0.5 + rand() * trash_delay) // x0.5 to x1.5
 		remaining_trash_throws[ckey]--
 		var/item_to_spawn
-		if(prob(0.1))
+		if(prob(3))
 			item_to_spawn = pick(GLOB.oddity_loot - typesof(/obj/item/dice/d20/fate)) // die of fate are blacklisted bc it will be automatically rolled due to the throw, likely insta-RRing the user without any counter
 		else
 			item_to_spawn = pick_weight_recursive(GLOB.trash_pile_loot)


### PR DESCRIPTION
## About The Pull Request
Lowered oddity maints loot weight back to 1 from 4

Trash piles only roll once with their set weight, instead of twice, one with a much higher chance rolling 7 times...

May PR that originally needle bit later, dont wanna mess with it rn. Also have some much greater ideas for it.
## Why It's Good For The Game
Trash piles put a INSANE amount of maints loot into the game, rolling for oddity items(polywand, speedboots, greytide spear, etc) twice. One of these two chances is a 1 in 1000, that rolls up to 7 times EVERY SINGLE TIME you use a trash pile. Between this and the fact everyone gets to use each one once, you see a oddity item at least every 3 rounds roughly, which is way too often as they are extremely OP and powerful round defining items for the most part.

you are rolling a 1 in 1k 7 times per lets just say there are 30(depends heavily on map) trash piles and every person on the server can use once, lets say only 5 assistants use these, they can pull 7 items from 30 trash piles, (5*7)30 thats 1050 items total for a 1 in 1k each time.

This PR tons all that down, making those cool OP items, not nearly every round. and a 1 in 10,000 chance that is rolled only a few hundred times between all maints loot + trash piles instead of 1 in 1000. still being seen every few days hopefully but not nearly everyday, sometimes every round, as it is now

## Changelog

:cl:
balance: Oddity maints loot is rarer again
balance: Trash piles only roll for oddity loot once
/:cl:

