### PR TITLE
Fix cleanbots getting stuck on broken bottles

### DIFF
--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
@@ -70,6 +70,8 @@
 
 /datum/ai_behavior/find_and_set/in_list/clean_targets
 	action_cooldown = 3 SECONDS
+	/// Whether to also consider anything with TRAIT_TRASH_ITEM (monkestation addition)
+	var/check_trash_trait = FALSE
 
 /datum/ai_behavior/find_and_set/in_list/clean_targets/search_tactic(datum/ai_controller/controller, locate_paths, search_range)
 	var/list/found = oview(search_range, controller.pawn) // monkestation edit: don't pre-filter with typecache, so we can check for TRAIT_TRASH_ITEM
@@ -78,7 +80,7 @@
 		// monkestation start: check for TRAIT_TRASH_ITEM
 		if(QDELETED(found_item))
 			continue
-		if(!is_type_in_typecache(found_item, locate_paths) && !HAS_TRAIT(found_item, TRAIT_TRASH_ITEM))
+		if(!is_type_in_typecache(found_item, locate_paths) && (check_trash_trait && !HAS_TRAIT(found_item, TRAIT_TRASH_ITEM)))
 			continue
 		// monkestation end
 		if(LAZYACCESS(ignore_list, REF(found_item)))

--- a/monkestation/code/modules/slimecore/mobs/ai_controller/behaviours/clean_target.dm
+++ b/monkestation/code/modules/slimecore/mobs/ai_controller/behaviours/clean_target.dm
@@ -2,3 +2,4 @@
 
 /datum/ai_behavior/find_and_set/in_list/clean_targets/slime
 	action_cooldown = 1.2 SECONDS
+	check_trash_trait = TRUE


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Cleanbots no longer get eternally stuck trying to clean broken bottles.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
