### PR TITLE
Fix the shuttle only taking 5 minutes during yellow and amber alert

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -340,7 +340,7 @@
 		switch(security_num)
 			if(SEC_LEVEL_GREEN)
 				set_coefficient = 2
-			if(SEC_LEVEL_BLUE)
+			if(SEC_LEVEL_BLUE, SEC_LEVEL_YELLOW, SEC_LEVEL_AMBER) // monkestation: yellow and amber alert
 				set_coefficient = 1
 			else
 				set_coefficient = 0.5


### PR DESCRIPTION

## Changelog
:cl:
fix: The shuttle now takes 10 minutes to arrive on Yellow and Amber alert as intended, rather than being a free redcall.
/:cl:
