### PR TITLE
Adds new item to all uplinks misc. gear; Xenomorph Hive Node Implanter 

### DIFF
--- a/monkestation/code/modules/cybernetics/implant_items/autosurgeons.dm
+++ b/monkestation/code/modules/cybernetics/implant_items/autosurgeons.dm
@@ -24,7 +24,7 @@
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/mantis/l
 
 
-/obj/item/autosurgeon/syndicate/organ/hivenode1
+/obj/item/autosurgeon/syndicate/organ/hivenode
 	starting_organ = /obj/item/organ/internal/alien/hivenode
 	uses = 1
 

--- a/monkestation/code/modules/cybernetics/implant_items/autosurgeons.dm
+++ b/monkestation/code/modules/cybernetics/implant_items/autosurgeons.dm
@@ -23,6 +23,9 @@
 /obj/item/autosurgeon/organ/mantis_blade/l
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/mantis/l
 
+/obj/item/autosurgeon/organ/hivenode
+	starting_organ = /obj/item/organ/internal/alien/hivenode
+
 /obj/item/autosurgeon/organ/syndicate/syndie_mantis
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/syndie_mantis
 

--- a/monkestation/code/modules/cybernetics/implant_items/autosurgeons.dm
+++ b/monkestation/code/modules/cybernetics/implant_items/autosurgeons.dm
@@ -23,8 +23,10 @@
 /obj/item/autosurgeon/organ/mantis_blade/l
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/mantis/l
 
-/obj/item/autosurgeon/organ/syndicate/hivenode
+
+/obj/item/autosurgeon/syndicate/organ/hivenode1
 	starting_organ = /obj/item/organ/internal/alien/hivenode
+	uses = 1
 
 /obj/item/autosurgeon/organ/syndicate/syndie_mantis
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/syndie_mantis

--- a/monkestation/code/modules/cybernetics/implant_items/autosurgeons.dm
+++ b/monkestation/code/modules/cybernetics/implant_items/autosurgeons.dm
@@ -23,7 +23,7 @@
 /obj/item/autosurgeon/organ/mantis_blade/l
 	starting_organ = /obj/item/organ/internal/cyberimp/arm/item_set/mantis/l
 
-/obj/item/autosurgeon/organ/hivenode
+/obj/item/autosurgeon/organ/syndicate/hivenode
 	starting_organ = /obj/item/organ/internal/alien/hivenode
 
 /obj/item/autosurgeon/organ/syndicate/syndie_mantis

--- a/monkestation/code/modules/uplink/uplink_items/misc.dm
+++ b/monkestation/code/modules/uplink/uplink_items/misc.dm
@@ -80,3 +80,17 @@
 	surplus = 0
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	item = /obj/item/storage/briefcase/evilbundle
+
+/datum/uplink_item/device_tools/Hivenode_Implanter
+	name = "Hive Node Implanter"
+	desc = "Have Nanotrasens finest allowed yet another captive xenomorph to escape? Or do you want to assist one in breaking out? \
+			Regardless if the infestation started because of The Companies negligence, or if its a wild infestation, this hive node \
+			will allow you to appear as an ally to these creatures. By mimicking the psionic communication commonly found between \
+			a Queen and her kin, you are able to control and weaponize brutal infestations."
+	cost = 10
+	lock_other_purchases = FALSE
+	cant_discount = FALSE
+	illegal_tech = FALSE
+	surplus = 0
+	purchasable_from = ~ALL
+	item = /obj/item/autosurgeon/organ/hivenode

--- a/monkestation/code/modules/uplink/uplink_items/misc.dm
+++ b/monkestation/code/modules/uplink/uplink_items/misc.dm
@@ -83,14 +83,6 @@
 
 /datum/uplink_item/device_tools/Hivenode_Implanter
 	name = "Hive Node Implanter"
-	desc = "Have Nanotrasens finest allowed yet another captive xenomorph to escape? Or do you want to assist one in breaking out? \
-			Regardless if the infestation started because of The Companies negligence, or if its a wild infestation, this hive node \
-			will allow you to appear as an ally to these creatures. By mimicking the psionic communication commonly found between \
-			a Queen and her kin, you are able to control and weaponize brutal infestations."
-	cost = 10
-	lock_other_purchases = FALSE
-	cant_discount = FALSE
-	illegal_tech = FALSE
-	surplus = 0
-	purchasable_from = ~ALL
-	item = /obj/item/autosurgeon/organ/hivenode
+	desc = "A Xenomorph hive node. When implanted, allows connection to any Xenomorphs in nearby psionic networks."
+	cost = 5 //similar price to binary translator
+	item = /obj/item/autosurgeon/organ/syndicate/hivenode

--- a/monkestation/code/modules/uplink/uplink_items/misc.dm
+++ b/monkestation/code/modules/uplink/uplink_items/misc.dm
@@ -85,4 +85,4 @@
 	name = "Hive Node Implanter"
 	desc = "A Xenomorph hive node. When implanted, allows connection to any Xenomorphs in nearby psionic networks."
 	cost = 5 //similar price to binary translator
-	item = /obj/item/autosurgeon/syndicate/organ/hivenode1
+	item = /obj/item/autosurgeon/syndicate/organ/hivenode

--- a/monkestation/code/modules/uplink/uplink_items/misc.dm
+++ b/monkestation/code/modules/uplink/uplink_items/misc.dm
@@ -85,4 +85,4 @@
 	name = "Hive Node Implanter"
 	desc = "A Xenomorph hive node. When implanted, allows connection to any Xenomorphs in nearby psionic networks."
 	cost = 5 //similar price to binary translator
-	item = /obj/item/autosurgeon/organ/syndicate/hivenode
+	item = /obj/item/autosurgeon/syndicate/organ/hivenode1

--- a/monkestation/code/modules/uplink/uplink_items/misc.dm
+++ b/monkestation/code/modules/uplink/uplink_items/misc.dm
@@ -81,7 +81,7 @@
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 	item = /obj/item/storage/briefcase/evilbundle
 
-/datum/uplink_item/device_tools/Hivenode_Implanter
+/datum/uplink_item/device_tools/hivenode_implanter
 	name = "Hive Node Implanter"
 	desc = "A Xenomorph hive node. When implanted, allows connection to any Xenomorphs in nearby psionic networks."
 	cost = 5 //similar price to binary translator


### PR DESCRIPTION
## About The Pull Request

Adds a new item to all uplinks misc. gear; Xenomorph Hive Node Implanter for 5tc (One-use syndicate autosurgeon)

## Why It's Good For The Game

Why it exists; There are ways to purchase binary translators and syndicate communications to talk with cyborgs and syndicate respectively. Traitors should also be able to communicate with present xenomorphs, if they purchase the equipment.

Why the price; It's the same price as the binary translator. 5tc seemed balanced, however, it may need to be adjusted.

## Changelog

:cl:
add: New Traitor Misc. Gear; Xenomorph Hive Node Implanter for 5tc.
/:cl:
