### PR TITLE
When a hive node is implanted, automatically learn Xenocommon

### DIFF
--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -109,7 +109,7 @@
 /obj/item/organ/internal/alien/hivenode/Remove(mob/living/carbon/organ_owner, special = FALSE)
 	organ_owner.faction -= ROLE_ALIEN
 	REMOVE_TRAIT(organ_owner, TRAIT_XENO_IMMUNE, ORGAN_TRAIT)
-	organ_owner.remove_language(/datum/language/xenocommon)
+	organ_owner.remove_language(/datum/language/xenocommon, TRUE, TRUE, LANGUAGE_GLAND)
 	return ..()
 
 //When the alien queen dies, all aliens suffer a penalty as punishment for failing to protect her.

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -109,7 +109,8 @@
 /obj/item/organ/internal/alien/hivenode/Remove(mob/living/carbon/organ_owner, special = FALSE)
 	organ_owner.faction -= ROLE_ALIEN
 	REMOVE_TRAIT(organ_owner, TRAIT_XENO_IMMUNE, ORGAN_TRAIT)
-	organ_owner.remove_language(/datum/language/xenocommon, TRUE, TRUE, LANGUAGE_GLAND)
+	if(!QDELING(organ_owner))
+		organ_owner.remove_language(/datum/language/xenocommon, TRUE, TRUE, LANGUAGE_GLAND)
 	return ..()
 
 //When the alien queen dies, all aliens suffer a penalty as punishment for failing to protect her.

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -104,7 +104,7 @@
 	. = ..()
 	organ_owner.faction |= ROLE_ALIEN
 	ADD_TRAIT(organ_owner, TRAIT_XENO_IMMUNE, ORGAN_TRAIT)
-	organ_owner.grant_language(/datum/language/xenocommon)
+	organ_owner.grant_language(/datum/language/xenocommon, TRUE, TRUE, LANGUAGE_GLAND)
 
 /obj/item/organ/internal/alien/hivenode/Remove(mob/living/carbon/organ_owner, special = FALSE)
 	organ_owner.faction -= ROLE_ALIEN

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -104,6 +104,7 @@
 	. = ..()
 	organ_owner.faction |= ROLE_ALIEN
 	ADD_TRAIT(organ_owner, TRAIT_XENO_IMMUNE, ORGAN_TRAIT)
+	organ_owner.grant_language(/datum/language/xenocommon)
 
 /obj/item/organ/internal/alien/hivenode/Remove(mob/living/carbon/organ_owner, special = FALSE)
 	organ_owner.faction -= ROLE_ALIEN

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -109,6 +109,7 @@
 /obj/item/organ/internal/alien/hivenode/Remove(mob/living/carbon/organ_owner, special = FALSE)
 	organ_owner.faction -= ROLE_ALIEN
 	REMOVE_TRAIT(organ_owner, TRAIT_XENO_IMMUNE, ORGAN_TRAIT)
+	organ_owner.remove_language(/datum/language/xenocommon)
 	return ..()
 
 //When the alien queen dies, all aliens suffer a penalty as punishment for failing to protect her.


### PR DESCRIPTION

## About The Pull Request

When a Hive Node is implanted, automatically teach them Xenocommon, the language of Xenomorphs. If the node is removed, this ability is lost.

## Why It's Good For The Game

It makes sense that the hive node, which is the psionic link between Xenomorphs, would grant the ability to understand spoken word as well. 

If someone is getting the Hive Node implanted, they are probably going to be communicating with / being around Xenomorphs, so it makes sense to give them the benefit of understanding speech.

## Changelog
:cl:
add: When something is implanted with a hive node, grant them the ability to speak Xenocommon
/:cl:
