### PR TITLE
You can now attach internals to Vims without any

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -237,6 +237,7 @@
 	return air_contents.remove(amount)
 
 /obj/item/tank/return_air()
+	RETURN_TYPE(/datum/gas_mixture)
 	START_PROCESSING(SSobj, src)
 	return air_contents
 

--- a/code/modules/mob/living/simple_animal/bot/construction.dm
+++ b/code/modules/mob/living/simple_animal/bot/construction.dm
@@ -620,14 +620,17 @@
 				build_step++
 
 		if(ASSEMBLY_SIXTH_STEP)
-			if(istype(part, /obj/item/tank/internals/emergency_oxygen))
+			if(istype(part, /obj/item/tank/internals))
+				var/obj/item/tank/internals/tank = part
+				if(tank.return_air()?.return_pressure() <= HAZARD_LOW_PRESSURE)
+					balloon_alert(user, "not enough air in tank!")
+					return
 				if(!user.temporarilyRemoveItemFromInventory(part))
 					return
 				balloon_alert(user, "assembly finished!")
-				var/obj/item/tank/internals/emergency_oxygen/assembly_tank = part
 				var/obj/vehicle/sealed/car/vim/new_vim = new(drop_location())
 				new_vim.name = created_name
-				new_vim.tank = assembly_tank
-				assembly_tank.forceMove(new_vim)
+				new_vim.tank = tank
+				tank.forceMove(new_vim)
 				qdel(src)
 		//MONKESTATION EDIT STOP

--- a/code/modules/vehicles/cars/vim.dm
+++ b/code/modules/vehicles/cars/vim.dm
@@ -21,9 +21,7 @@
 	///Maximum size of a mob trying to enter the mech
 	var/maximum_mob_size = MOB_SIZE_SMALL
 	COOLDOWN_DECLARE(sound_cooldown)
-	//monkestation additions
-	var/obj/item/tank/internals/emergency_oxygen/tank
-	explode_on_destruction = FALSE
+	explode_on_destruction = FALSE // monkestation edit: don't boom
 
 /datum/armor/car_vim
 	melee = 70
@@ -49,13 +47,6 @@
 	new /obj/effect/decal/cleanable/oil(get_turf(src))
 	do_sparks(5, TRUE, src)
 	visible_message(span_boldannounce("[src] blows apart!"))
-	//MONKESTATION EDIT START
-	new /obj/effect/decal/cleanable/robot_debris/limb(get_turf(src))
-	var/turf/T = get_turf(src)
-	if(tank)
-		tank.forceMove(T)
-		tank = null
-	//MONKESTATION EDIT STOP
 	return ..()
 
 /obj/vehicle/sealed/car/vim/mob_try_enter(mob/entering)
@@ -124,17 +115,6 @@
 		. += piloted_overlay
 	if(headlights_toggle)
 		. += headlights_overlay
-
-//MONKESTATION EDIT START
-/obj/vehicle/sealed/car/vim/return_air()
-	if(tank)
-		return tank.return_air()
-	else
-		return loc.return_air()
-
-/obj/vehicle/sealed/car/vim/return_analyzable_air()
-	return tank?.return_analyzable_air()
-//MONKESTATION EDIT STOP
 
 /obj/item/circuit_component/vim
 	display_name = "Vim"

--- a/monkestation/code/modules/vehicles/cars/vim.dm
+++ b/monkestation/code/modules/vehicles/cars/vim.dm
@@ -10,7 +10,7 @@
 		. += span_notice("You could attach an oxygen tank, to make it spaceworthy.")
 
 /obj/vehicle/sealed/car/vim/atom_destruction(damage_flag)
-	new /obj/effect/decal/cleanable/robot_debris/limb(drop_location()) // monkestation edit: drop the robot arm on destruction
+	new /obj/effect/decal/cleanable/robot_debris/limb(drop_location())
 	tank?.forceMove(drop_location())
 	tank = null
 	return ..()

--- a/monkestation/code/modules/vehicles/cars/vim.dm
+++ b/monkestation/code/modules/vehicles/cars/vim.dm
@@ -1,0 +1,49 @@
+/obj/vehicle/sealed/car/vim
+	/// Air tank used for internals.
+	var/obj/item/tank/internals/tank
+
+/obj/vehicle/sealed/car/vim/examine(mob/user)
+	. = ..()
+	if(!QDELETED(tank))
+		. += span_notice("[icon2html(tank, user)] It has \a [tank] mounted onto it.")
+	else
+		. += span_notice("You could attach an oxygen tank, to make it spaceworthy.")
+
+/obj/vehicle/sealed/car/vim/atom_destruction(damage_flag)
+	new /obj/effect/decal/cleanable/robot_debris/limb(drop_location()) // monkestation edit: drop the robot arm on destruction
+	tank?.forceMove(drop_location())
+	tank = null
+	return ..()
+
+/obj/vehicle/sealed/car/vim/return_air()
+	return tank?.return_air() || loc?.return_air()
+
+/obj/vehicle/sealed/car/vim/return_analyzable_air()
+	return tank?.return_analyzable_air()
+
+/obj/vehicle/sealed/car/vim/attackby(obj/item/attacking_item, mob/user, params)
+	if((user.istate & ISTATE_HARM) || !istype(attacking_item, /obj/item/tank/internals))
+		return ..()
+	if(!QDELETED(tank))
+		to_chat(user, span_warning("[src] already has \the [tank]!"))
+		return
+	var/obj/item/tank/internals/tank_to_attach = attacking_item
+	if(tank_to_attach.return_air()?.return_pressure() <= HAZARD_LOW_PRESSURE)
+		to_chat(user, span_warning("[src] does not have enough air!"))
+		return
+	if(DOING_INTERACTION_WITH_TARGET(user, src))
+		return
+	user.balloon_alert_to_viewers("attaching air tank...")
+	if(!do_after(user, 5 SECONDS, src))
+		return
+	if(!user.transferItemToLoc(tank_to_attach, src))
+		return
+	tank = tank_to_attach
+	user.balloon_alert_to_viewers("attached air tank")
+
+// Spawns in with a tank.
+/obj/vehicle/sealed/car/vim/with_tank
+
+/obj/vehicle/sealed/car/vim/with_tank/Initialize(mapload)
+	. = ..()
+	tank = new /obj/item/tank/internals/oxygen(src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8521,6 +8521,7 @@
 #include "monkestation\code\modules\uplink\uplink_items\weapons.dm"
 #include "monkestation\code\modules\vehicles\monkey_ball.dm"
 #include "monkestation\code\modules\vehicles\wheelchair.dm"
+#include "monkestation\code\modules\vehicles\cars\vim.dm"
 #include "monkestation\code\modules\vehicles\mecha\mecha_actions.dm"
 #include "monkestation\code\modules\vehicles\mecha\equipment\tools\other_tools.dm"
 #include "monkestation\code\modules\vehicles\mecha\working\ripley.dm"


### PR DESCRIPTION

## About The Pull Request

Vims can be created through the crafting menu... which will result in them having no internals.

This allows you to attach an internals tank yourself if there is none.

In addition, this prevents you from using empty tanks - a tank must have a somewhat habitable pressure.

Also, I cleaned up and modularized the code quite a bit.

## Why It's Good For The Game

;(

## Changelog
:cl:
add: You can now attach an internals tank to Vims if they don't have one already.
qol: You can no longer use empty tanks (or any tank with pressure below the habitable threshold) for a Vim.
/:cl:
