### PR TITLE
Fix freerange radios/intercoms  being able to broadcast over the radio frequency

### DIFF
--- a/code/__HELPERS/radio.dm
+++ b/code/__HELPERS/radio.dm
@@ -1,5 +1,5 @@
 /// Ensure the frequency is within bounds of what it should be sending/receiving at
-/proc/sanitize_frequency(frequency, free = FALSE, syndie = FALSE)
+/proc/sanitize_frequency(frequency, free = FALSE, syndie = FALSE, radio_host = FALSE)
 	frequency = round(frequency)
 	if(free)
 		. = clamp(frequency, MIN_FREE_FREQ, MAX_FREE_FREQ)
@@ -8,6 +8,9 @@
 	if(!(. % 2)) // Ensure the last digit is an odd number
 		. += 1
 	if(. == FREQ_SYNDICATE && !syndie) // Prevents people from picking (or rounding up) into the syndie frequency
+		. = FREQ_COMMON
+	// monkestation start: prevents people from picking (or rounding up) into the radio frequency
+	if(. == FREQ_RADIO && !radio_host)
 		. = FREQ_COMMON
 
 /// Format frequency by moving the decimal.

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -320,7 +320,7 @@
 		freq = frequency
 		channel = null
 
-	// monkestation start: prevent non-radio mics from broadcasting over the radioc hannel
+	// monkestation start: prevent non-radio mics from broadcasting over the radio channel
 	if(freq == FREQ_RADIO && !radio_host)
 		return
 	// monkestation end

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -113,7 +113,7 @@
 	perform_update_icon = FALSE
 	set_listening(listening)
 	set_broadcasting(broadcasting)
-	set_frequency(sanitize_frequency(frequency, freerange, syndie))
+	set_frequency(sanitize_frequency(frequency, freerange, syndie, radio_host))
 	set_on(on)
 	perform_update_icon = TRUE
 
@@ -292,8 +292,6 @@
 	if(istype(get_area(src), /area/centcom/heretic_sacrifice))
 		return
 	//MONKESTATION EDIT STOP
-	if(channel == FREQ_RADIO && !radio_host)
-		return
 
 	if(use_command)
 		spans |= SPAN_COMMAND
@@ -321,6 +319,11 @@
 	else
 		freq = frequency
 		channel = null
+
+	// monkestation start: prevent non-radio mics from broadcasting over the radioc hannel
+	if(freq == FREQ_RADIO && !radio_host)
+		return
+	// monkestation end
 
 	// Nearby active jammers prevent the message from transmitting
 	if(is_within_radio_jammer_range(src) && !syndie)
@@ -468,7 +471,7 @@
 				tune = tune * 10
 				. = TRUE
 			if(.)
-				set_frequency(sanitize_frequency(tune, freerange, syndie))
+				set_frequency(sanitize_frequency(tune, freerange, syndie, radio_host))
 		if("listen")
 			set_listening(!listening)
 			. = TRUE


### PR DESCRIPTION
## About The Pull Request

This fixes the check to prevent radios/intercoms without the `radio_host` var from broadcasting over the radio frequency (136.1) and adds some extra checks to prevent any edge-cases.

## Why It's Good For The Game

Same reasoning as https://github.com/Monkestation/Monkestation2.0/pull/3708

## Changelog
:cl:
fix: Fixed freerange radios/intercoms being able to broadcast over the radio frequency.
/:cl:
