### PR TITLE
Small holiday checks

### DIFF
--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -68,7 +68,7 @@
 
 /datum/outfit/job/prisoner/pre_equip(mob/living/carbon/human/H)
 	..()
-	if(prob(1)) // D BOYYYYSSSSS
+	if(prob(1) || check_holidays(APRIL_FOOLS)) // D BOYYYYSSSSS
 		head = /obj/item/clothing/head/beanie/black/dboy
 
 /datum/outfit/job/prisoner/post_equip(mob/living/carbon/human/new_prisoner, visualsOnly)

--- a/monkestation/code/modules/factory_type_beat/mobs/node_drone.dm
+++ b/monkestation/code/modules/factory_type_beat/mobs/node_drone.dm
@@ -87,7 +87,7 @@
 	var/funny_ending = FALSE
 	flying_state = FLY_OUT_STATE
 	update_appearance(UPDATE_ICON_STATE)
-	if(prob(1))
+	if(prob(1) || check_holidays(APRIL_FOOLS))
 		say("I have to go now, my planet needs me.")
 		funny_ending = TRUE
 	visible_message(span_notice("The drone flies away to safety as the vent is secured."))


### PR DESCRIPTION

## About The Pull Request
_"Being a Class D in the Foundation is not a part of one's punishment. We are not picking those who are guiltier than the rest, not at all. Our filters work like this: First we get death row inmates (a rare commodity in our country), then we get to those who aren't likely to get anything but life sentence. And out of these we pick inmates with no next of kin,[ who aren't likely to be noticed if they go missing](https://scp-wiki.wikidot.com/class-d-recruiting)."_

[Their people need them.
](https://youtu.be/4tvAjX5ACPo)
## Why It's Good For The Game
## Changelog
:cl:
add: Adds holiday checks for events that aren't too spammy in their nature
/:cl:
