### PR TITLE
[PORT] Deleting characters

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -237,6 +237,25 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			character_preview_view?.update_body()
 
 			return TRUE
+		if ("remove_slot")
+			var/picked_slot = params["slot"]
+			var/confidence_check = tgui_input_text(usr, "To confirm the deletion of a character, type the name of the character.", "Character Deletion")
+			if(confidence_check != params["name"])
+				return FALSE
+
+			if(!remove_character(picked_slot))
+				return FALSE
+
+			if (!load_character(params["slotToJump"]))
+				randomise_appearance_prefs()
+				save_character()
+
+			for (var/datum/preference_middleware/preference_middleware as anything in middleware)
+				preference_middleware.on_new_character(usr)
+
+			tainted_character_profiles = TRUE
+			character_preview_view.update_body();
+			return TRUE
 		if ("rotate")
 			character_preview_view.dir = turn(character_preview_view.dir, -90)
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -224,37 +224,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		if ("change_slot")
 			// Save existing character
 			save_character()
-
-			// SAFETY: `load_character` performs sanitization the slot number
-			if (!load_character(params["slot"]))
-				tainted_character_profiles = TRUE
-				randomise_appearance_prefs()
-				save_character()
-
-			for (var/datum/preference_middleware/preference_middleware as anything in middleware)
-				preference_middleware.on_new_character(usr)
-
-			character_preview_view?.update_body()
-
+			// SAFETY: `switch_to_slot` performs sanitization on the slot number
+			switch_to_slot(params["slot"])
 			return TRUE
-		if ("remove_slot")
-			var/picked_slot = params["slot"]
-			var/confidence_check = tgui_input_text(usr, "To confirm the deletion of a character, type the name of the character.", "Character Deletion")
-			if(confidence_check != params["name"])
-				return FALSE
-
-			if(!remove_character(picked_slot))
-				return FALSE
-
-			if (!load_character(params["slotToJump"]))
-				randomise_appearance_prefs()
-				save_character()
-
-			for (var/datum/preference_middleware/preference_middleware as anything in middleware)
-				preference_middleware.on_new_character(usr)
-
-			tainted_character_profiles = TRUE
-			character_preview_view.update_body();
+		if ("remove_current_slot")
+			remove_current_slot()
 			return TRUE
 		if ("rotate")
 			character_preview_view.dir = turn(character_preview_view.dir, -90)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -379,6 +379,16 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	return TRUE
 
+/datum/preferences/proc/remove_character(slot)
+	SHOULD_NOT_SLEEP(TRUE)
+	if(!slot)
+		return FALSE
+	slot = sanitize_integer(slot, 1, max_save_slots, initial(default_slot))
+
+	var/tree_key = "character[slot]"
+	savefile.remove_entry(tree_key)
+	return TRUE
+
 /datum/preferences/proc/sanitize_be_special(list/input_be_special)
 	var/list/output = list()
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -379,15 +379,42 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	return TRUE
 
-/datum/preferences/proc/remove_character(slot)
-	SHOULD_NOT_SLEEP(TRUE)
-	if(!slot)
-		return FALSE
-	slot = sanitize_integer(slot, 1, max_save_slots, initial(default_slot))
+/datum/preferences/proc/switch_to_slot(new_slot)
+	// SAFETY: `load_character` performs sanitization on the slot number
+	if (!load_character(new_slot))
+		tainted_character_profiles = TRUE
+		randomise_appearance_prefs()
+		save_character()
 
-	var/tree_key = "character[slot]"
-	savefile.remove_entry(tree_key)
-	return TRUE
+	for (var/datum/preference_middleware/preference_middleware as anything in middleware)
+		preference_middleware.on_new_character(usr)
+
+	character_preview_view.update_body()
+
+/datum/preferences/proc/remove_current_slot()
+	PRIVATE_PROC(TRUE)
+
+	var/closest_slot
+	for (var/other_slot in default_slot - 1 to 1 step -1)
+		var/save_data = savefile.get_entry("character[other_slot]")
+		if (!isnull(save_data))
+			closest_slot = other_slot
+			break
+
+	if (isnull(closest_slot))
+		for (var/other_slot in default_slot + 1 to max_save_slots)
+			var/save_data = savefile.get_entry("character[other_slot]")
+			if (!isnull(save_data))
+				closest_slot = other_slot
+				break
+
+	if (isnull(closest_slot))
+		stack_trace("remove_current_slot() being called when there are no slots to go to, the client should prevent this")
+		return
+
+	savefile.remove_entry("character[default_slot]")
+	tainted_character_profiles = TRUE
+	switch_to_slot(closest_slot)
 
 /datum/preferences/proc/sanitize_be_special(list/input_be_special)
 	var/list/output = list()

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
@@ -102,9 +102,39 @@ export const CharacterPreferenceWindow = (props) => {
               profiles={data.character_profiles}
             />
           </Stack.Item>
+          <Stack.Item align="center">
+            <Button
+              color="red"
+              disabled={
+                Object.values(data.character_profiles).filter((val) => val)
+                  .length < 2
+              } // check if existing chars more than one
+              onClick={() => {
+                let choicedSlot = data.active_slot - 1;
+                let availableSlots = Object.keys(data.character_profiles)
+                  .filter((slot) => data.character_profiles[slot] !== null)
+                  .map((slot) => parseInt(slot, 10)); // get all busy slots as num
 
+                availableSlots.splice(availableSlots.indexOf(choicedSlot), 1); // remove our slot(which we want to delete)
+
+                let slotToJump = availableSlots.reduce((prev, curr) => {
+                  return Math.abs(curr - choicedSlot) <
+                    Math.abs(prev - choicedSlot)
+                    ? curr
+                    : prev;
+                }); // get nearest slot
+
+                act('remove_slot', {
+                  slot: data.active_slot,
+                  name: Object.values(data.character_profiles)[choicedSlot],
+                  slotToJump: slotToJump + 1,
+                });
+              }}
+            >
+              Delete Character
+            </Button>
+          </Stack.Item>
           <Stack.Divider />
-
           <Stack.Item>
             <Stack fill>
               <Stack.Item grow>
@@ -167,9 +197,7 @@ export const CharacterPreferenceWindow = (props) => {
               </Stack.Item>
             </Stack>
           </Stack.Item>
-
           <Stack.Divider />
-
           <Stack.Item>{pageContents}</Stack.Item>
         </Stack>
       </Window.Content>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
@@ -102,38 +102,6 @@ export const CharacterPreferenceWindow = (props) => {
               profiles={data.character_profiles}
             />
           </Stack.Item>
-          <Stack.Item align="center">
-            <Button
-              color="red"
-              disabled={
-                Object.values(data.character_profiles).filter((val) => val)
-                  .length < 2
-              } // check if existing chars more than one
-              onClick={() => {
-                let choicedSlot = data.active_slot - 1;
-                let availableSlots = Object.keys(data.character_profiles)
-                  .filter((slot) => data.character_profiles[slot] !== null)
-                  .map((slot) => parseInt(slot, 10)); // get all busy slots as num
-
-                availableSlots.splice(availableSlots.indexOf(choicedSlot), 1); // remove our slot(which we want to delete)
-
-                let slotToJump = availableSlots.reduce((prev, curr) => {
-                  return Math.abs(curr - choicedSlot) <
-                    Math.abs(prev - choicedSlot)
-                    ? curr
-                    : prev;
-                }); // get nearest slot
-
-                act('remove_slot', {
-                  slot: data.active_slot,
-                  name: Object.values(data.character_profiles)[choicedSlot],
-                  slotToJump: slotToJump + 1,
-                });
-              }}
-            >
-              Delete Character
-            </Button>
-          </Stack.Item>
           <Stack.Divider />
           <Stack.Item>
             <Stack fill>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/DeleteCharacterPopup.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/DeleteCharacterPopup.tsx
@@ -50,7 +50,11 @@ export class DeleteCharacterPopup extends Component<
           </Stack.Item>
 
           <Stack.Item maxWidth="300px">
-            <Box>{`You're about to delete ${data.character_preferences.names[data.name_to_use]} forever. Are you sure you want to do this?`}</Box>
+            <Box>
+              {`You're about to delete `}
+              <b>{data.character_preferences.names[data.name_to_use]}</b>{' '}
+              {`forever. Are you sure you want to do this?`}
+            </Box>
           </Stack.Item>
 
           <Stack.Item>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/DeleteCharacterPopup.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/DeleteCharacterPopup.tsx
@@ -1,0 +1,82 @@
+import { Component } from 'inferno';
+import { useBackend } from '../../backend';
+
+import { Box, Button, Modal, Stack } from '../../components';
+import { PreferencesMenuData } from './data';
+
+interface DeleteCharacterPopupProps {
+  close: () => void;
+}
+
+interface DeleteCharacterPopupState {
+  secondsLeft: number;
+}
+
+export class DeleteCharacterPopup extends Component<
+  DeleteCharacterPopupProps,
+  DeleteCharacterPopupState
+> {
+  private interval: NodeJS.Timeout | null = null;
+
+  state: DeleteCharacterPopupState = {
+    secondsLeft: 3,
+  };
+
+  public componentDidMount(): void {
+    this.interval = setInterval(() => {
+      this.setState((prevState) => ({
+        secondsLeft: prevState.secondsLeft - 1,
+      }));
+    }, 1000);
+  }
+
+  public componentWillUnmount(): void {
+    if (this.interval !== null) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  public render() {
+    const { close } = this.props;
+    const { act, data } = useBackend<PreferencesMenuData>();
+    const { secondsLeft } = this.state;
+
+    return (
+      <Modal>
+        <Stack vertical textAlign="center" align="center">
+          <Stack.Item>
+            <Box fontSize="3em">Wait!</Box>
+          </Stack.Item>
+
+          <Stack.Item maxWidth="300px">
+            <Box>{`You're about to delete ${data.character_preferences.names[data.name_to_use]} forever. Are you sure you want to do this?`}</Box>
+          </Stack.Item>
+
+          <Stack.Item>
+            <Stack fill>
+              <Stack.Item>
+                {/* Explicit width so that the layout doesn't shift */}
+                <Button
+                  color="danger"
+                  disabled={secondsLeft > 0}
+                  width="80px"
+                  onClick={() => {
+                    act('remove_current_slot');
+                    close();
+                  }}
+                >
+                  {secondsLeft <= 0 ? 'Delete' : `Delete (${secondsLeft})`}
+                </Button>
+              </Stack.Item>
+
+              <Stack.Item>
+                <Button onClick={close}>{"No, don't delete"}</Button>
+              </Stack.Item>
+            </Stack>
+          </Stack.Item>
+        </Stack>
+      </Modal>
+    );
+  }
+}

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/MainPage.tsx
@@ -17,6 +17,7 @@ import {
   PreferencesMenuData,
   RandomSetting,
 } from './data';
+import { DeleteCharacterPopup } from './DeleteCharacterPopup';
 import { CharacterPreview } from '../common/CharacterPreview';
 import { RandomizationButton } from './RandomizationButton';
 import { ServerPreferencesFetcher } from './ServerPreferencesFetcher';
@@ -30,6 +31,7 @@ import {
 import { filterMap, sortBy } from 'common/collections';
 import { useRandomToggleState } from './useRandomToggleState';
 import { createSearch } from 'common/string';
+import { InfernoNode } from 'inferno';
 
 const CLOTHING_CELL_SIZE = 64;
 const CLOTHING_SIDEBAR_ROWS = 10;
@@ -468,6 +470,7 @@ const PreferenceList = (props: {
   act: typeof sendAct;
   preferences: Record<string, unknown>;
   randomizations: Record<string, RandomSetting>;
+  children?: InfernoNode;
 }) => {
   return (
     <Stack.Item
@@ -524,6 +527,7 @@ const PreferenceList = (props: {
           },
         )}
       </LabeledList>
+      {props.children}
     </Stack.Item>
   );
 };
@@ -533,6 +537,10 @@ export const MainPage = (props: { openSpecies: () => void }) => {
   const [currentClothingMenu, setCurrentClothingMenu] = useLocalState<
     string | null
   >('currentClothingMenu', null);
+  const [deleteCharacterPopupOpen, setDeleteCharacterPopupOpen] = useLocalState(
+    'deleteCharacterPopupOpen',
+    false,
+  );
   const [multiNameInputOpen, setMultiNameInputOpen] = useLocalState(
     'multiNameInputOpen',
     false,
@@ -633,6 +641,12 @@ export const MainPage = (props: { openSpecies: () => void }) => {
               />
             )}
 
+            {deleteCharacterPopupOpen && (
+              <DeleteCharacterPopup
+                close={() => setDeleteCharacterPopupOpen(false)}
+              />
+            )}
+
             <Stack height={`${CLOTHING_SIDEBAR_ROWS * CLOTHING_CELL_SIZE}px`}>
               <Stack.Item fill>
                 <Stack vertical fill>
@@ -722,7 +736,21 @@ export const MainPage = (props: { openSpecies: () => void }) => {
                     act={act}
                     randomizations={getRandomization(nonContextualPreferences)}
                     preferences={nonContextualPreferences}
-                  />
+                  >
+                    <Box my={0.5}>
+                      <Button
+                        color="red"
+                        disabled={
+                          Object.values(data.character_profiles).filter(
+                            (name) => name,
+                          ).length < 2
+                        } // check if existing chars more than one
+                        onClick={() => setDeleteCharacterPopupOpen(true)}
+                      >
+                        Delete Character
+                      </Button>
+                    </Box>
+                  </PreferenceList>
                 </Stack>
               </Stack.Item>
             </Stack>

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/MainPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/MainPage.tsx
@@ -46,6 +46,8 @@ const CharacterControls = (props: {
   gender: Gender;
   setGender: (gender: Gender) => void;
   showGender: boolean;
+  canDeleteCharacter: boolean;
+  handleDeleteCharacter: () => void;
 }) => {
   return (
     <Stack>
@@ -77,6 +79,18 @@ const CharacterControls = (props: {
           />
         </Stack.Item>
       )}
+
+      <Stack.Item>
+        <Button
+          onClick={props.handleDeleteCharacter}
+          fontSize="22px"
+          icon="trash"
+          color="red"
+          tooltip="Delete character"
+          tooltipPosition="top"
+          disabled={!props.canDeleteCharacter}
+        />
+      </Stack.Item>
     </Stack>
   );
 };
@@ -661,6 +675,14 @@ export const MainPage = (props: { openSpecies: () => void }) => {
                       showGender={
                         currentSpeciesData ? !!currentSpeciesData.sexes : true
                       }
+                      canDeleteCharacter={
+                        Object.values(data.character_profiles).filter(
+                          (name) => name,
+                        ).length > 1
+                      }
+                      handleDeleteCharacter={() =>
+                        setDeleteCharacterPopupOpen(true)
+                      }
                     />
                   </Stack.Item>
 
@@ -736,21 +758,7 @@ export const MainPage = (props: { openSpecies: () => void }) => {
                     act={act}
                     randomizations={getRandomization(nonContextualPreferences)}
                     preferences={nonContextualPreferences}
-                  >
-                    <Box my={0.5}>
-                      <Button
-                        color="red"
-                        disabled={
-                          Object.values(data.character_profiles).filter(
-                            (name) => name,
-                          ).length < 2
-                        } // check if existing chars more than one
-                        onClick={() => setDeleteCharacterPopupOpen(true)}
-                      >
-                        Delete Character
-                      </Button>
-                    </Box>
-                  </PreferenceList>
+                  />
                 </Stack>
               </Stack.Item>
             </Stack>


### PR DESCRIPTION
## About The Pull Request

Ports the following PRs:
- https://github.com/tgstation/tgstation/pull/83989
- https://github.com/tgstation/tgstation/pull/84158

> Adds a button to delete characters, and when deleted it flips to the nearest character, wow(the last character can't be deleted(I guess)).

In addition, I also changed the layout, to make the button easier to find.

![2025-04-02 (1743601751)](https://github.com/user-attachments/assets/44ba01ee-6dfd-4543-996a-9e0955a2888a)

## Why It's Good For The Game

> Once you know how to create characters, you sometimes want to be able to delete them.
> The reasons for this can be... as simple as freeing up a slot, or deleting them in order to remake them.
> I think this is quite a useful feature that should have been there before.

## Changelog
:cl: Absolucy, Vishenka0704, Mothblocks
qol: You can now delete your characters in preferences.
/:cl:
