### PR TITLE
Bloodsuckers can now overfeed and doing so gives regen.

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
@@ -59,6 +59,7 @@
 	var/bloodsucker_level = 0
 	var/bloodsucker_level_unspent = 1
 	var/additional_regen
+	var/blood_over_cap = 0
 	var/bloodsucker_regen_rate = 0.3
 
 	// Used for Bloodsucker Objectives

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
@@ -135,8 +135,6 @@
 		else if(overfireheal > 0 && heal_amount > 0)
 			heal_amount /= 1.5 // Burn should be more difficult to heal
 			user.adjustFireLoss(-heal_amount, forced=TRUE)
-		else
-			return
 
 /datum/antagonist/bloodsucker/proc/check_limbs(costMult = 1)
 	var/limb_regen_cost = 50 * -costMult

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
@@ -34,7 +34,8 @@
  * ## BLOOD STUFF
  */
 /datum/antagonist/bloodsucker/proc/AddBloodVolume(value)
-	bloodsucker_blood_volume = clamp(bloodsucker_blood_volume + value, 0, max_blood_volume)
+	bloodsucker_blood_volume = clamp(bloodsucker_blood_volume + value, 0, max_blood_volume * 2)
+	blood_over_cap = max(bloodsucker_blood_volume - max_blood_volume, 0) // Gets how much blood we have over the cap.
 
 /datum/antagonist/bloodsucker/proc/AddHumanityLost(value)
 	if(humanity_lost >= 500)
@@ -63,6 +64,7 @@
 	//if (!iscarbon(target)) // Penalty for Animals (they're junk food)
 	// Apply to Volume
 	AddBloodVolume(blood_taken)
+	OverfeedHealing(blood_taken)
 	// Reagents (NOT Blood!)
 	if(target.reagents?.total_volume)
 		target.reagents.trans_to(owner.current, INGEST, 1) // Run transfer of 1 unit of reagent from them to me.
@@ -94,6 +96,8 @@
 	var/bruteheal = min(user.getBruteLoss_nonProsthetic(), actual_regen) // BRUTE: Always Heal
 	var/fireheal = 0 // BURN: Heal in Coffin while Fakedeath, or when damage above maxhealth (you can never fully heal fire)
 	// Checks if you're in a coffin here, additionally checks for Torpor right below it.
+	if (blood_over_cap > 0)
+		costMult += round(blood_over_cap / 1000, 0.1) // effectively 1 (normal) + 0.1 for every 100 blood you are over cap
 	if(in_torpor)
 		if(istype(user.loc, /obj/structure/closet/crate/coffin))
 			if(HAS_TRAIT(owner.current, TRAIT_MASQUERADE) && (COOLDOWN_FINISHED(src, bloodsucker_spam_healing)))
@@ -117,6 +121,22 @@
 		user.heal_overall_damage(brute = bruteheal * mult, burn = fireheal * mult) // Heal BRUTE / BURN in random portions throughout the body.
 		AddBloodVolume(((bruteheal * -0.5) + (fireheal * -1)) * costMult * mult) // Costs blood to heal
 		return TRUE
+
+// Manages healing if we are exceeding blood cap
+/datum/antagonist/bloodsucker/proc/OverfeedHealing(drunk_blood)
+	var/mob/living/carbon/user = owner.current
+	if(blood_over_cap > 0) //Checks if you are over your blood cap
+		var/overbruteheal = user.getBruteLoss_nonProsthetic()
+		var/overfireheal = user.getFireLoss_nonProsthetic()
+		var/heal_amount = drunk_blood / 3
+		if(overbruteheal > 0 && heal_amount > 0)
+			user.adjustBruteLoss(-heal_amount, forced=TRUE) // Heal BRUTE / BURN in random portions throughout the body; prioritising BRUTE.
+			heal_amount = (heal_amount - overbruteheal) // Removes the amount of BRUTE we've healed from the heal amount
+		else if(overfireheal > 0 && heal_amount > 0)
+			heal_amount /= 1.5 // Burn should be more difficult to heal
+			user.adjustFireLoss(-heal_amount, forced=TRUE)
+		else
+			return
 
 /datum/antagonist/bloodsucker/proc/check_limbs(costMult = 1)
 	var/limb_regen_cost = 50 * -costMult
@@ -241,8 +261,11 @@
 		additional_regen = 0.3
 	else if(bloodsucker_blood_volume < BS_BLOOD_VOLUME_MAX_REGEN)
 		additional_regen = 0.4
-	else
+	else if(bloodsucker_blood_volume < max_blood_volume)
 		additional_regen = 0.5
+	else if(bloodsucker_blood_volume > max_blood_volume)
+		additional_regen = 1 + round((blood_over_cap / 1000) * 2, 0.1)
+		AddBloodVolume(-1 - blood_over_cap / 100)
 
 /// Makes your blood_volume look like your bloodsucker blood, unless you're Masquerading.
 /datum/antagonist/bloodsucker/proc/update_blood()

--- a/monkestation/code/modules/bloodsuckers/powers/feed.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/feed.dm
@@ -188,7 +188,7 @@
 			owner.balloon_alert(owner, "your victim's blood is at an unsafe level.")
 		warning_target_bloodvol = feed_target.blood_volume
 
-	if(bloodsuckerdatum_power.GetBloodVolume() >= bloodsuckerdatum_power.max_blood_volume && !notified_overfeeding)
+	if(bloodsuckerdatum_power.bloodsucker_blood_volume >= bloodsuckerdatum_power.max_blood_volume && !notified_overfeeding)
 		user.balloon_alert(owner, "full on blood! Anything more we drink now will be burnt on quicker healing")
 		notified_overfeeding = TRUE
 	if(feed_target.blood_volume <= 0)

--- a/monkestation/code/modules/bloodsuckers/powers/feed.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/feed.dm
@@ -28,6 +28,8 @@
 	var/started_alive = TRUE
 	///Are we feeding with passive grab or not?
 	var/silent_feed = TRUE
+	///Have we notified you already that you are at maximum blood?
+	var/notified_overfeeding = FALSE
 
 /datum/action/cooldown/bloodsucker/feed/can_use(mob/living/carbon/user, trigger_flags)
 	. = ..()
@@ -67,6 +69,7 @@
 	blood_taken = 0
 	REMOVE_TRAIT(user, TRAIT_IMMOBILIZED, FEED_TRAIT)
 	REMOVE_TRAIT(user, TRAIT_MUTE, FEED_TRAIT)
+	notified_overfeeding = initial(notified_overfeeding)
 	return ..()
 
 /datum/action/cooldown/bloodsucker/feed/ActivatePower(trigger_flags)
@@ -185,10 +188,9 @@
 			owner.balloon_alert(owner, "your victim's blood is at an unsafe level.")
 		warning_target_bloodvol = feed_target.blood_volume
 
-	if(bloodsuckerdatum_power.bloodsucker_blood_volume >= bloodsuckerdatum_power.max_blood_volume)
-		user.balloon_alert(owner, "full on blood!")
-		DeactivatePower()
-		return PROCESS_KILL
+	if(bloodsuckerdatum_power.GetBloodVolume() >= bloodsuckerdatum_power.max_blood_volume && !notified_overfeeding)
+		user.balloon_alert(owner, "full on blood! Anything more we drink now will be burnt on quicker healing")
+		notified_overfeeding = TRUE
 	if(feed_target.blood_volume <= 0)
 		user.balloon_alert(owner, "no blood left!")
 		DeactivatePower()

--- a/monkestation/code/modules/bloodsuckers/powers/feed.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/feed.dm
@@ -12,7 +12,9 @@
 		While feeding, you can't speak, as your mouth is covered.\n\
 		Feeding while nearby (2 tiles away from) a mortal who is unaware of Bloodsuckers' existence, will cause a Masquerade Infraction\n\
 		If you get too many Masquerade Infractions, you will break the Masquerade.\n\
-		If you are in desperate need of blood, mice can be fed off of, at a cost."
+		If you are in desperate need of blood, mice can be fed off of, at a cost.\n\
+		You can drink more blood than your capacity, doing so increases your health regeneration and gives some minor instant healing.\n\
+		However, healing whilst above blood capacity cost more blood and your blood loss over time is drastically increased."
 	power_flags = BP_AM_TOGGLE | BP_AM_STATIC_COOLDOWN
 	check_flags = BP_CANT_USE_IN_TORPOR | BP_CANT_USE_WHILE_STAKED | BP_CANT_USE_WHILE_INCAPACITATED | BP_CANT_USE_WHILE_UNCONSCIOUS
 	purchase_flags = BLOODSUCKER_CAN_BUY | BLOODSUCKER_DEFAULT_POWER


### PR DESCRIPTION
## About The Pull Request
[Port of this PR of mine on Bubber](https://github.com/Bubberstation/Bubberstation/pull/1189)
Makes Bloodsucker's able to feed blood from people even whilst at their normal limit.
<!-- Please make sure to actually test your PRs. If you have not tested your PR mention it. -->

## Why It's Good For The Game

One of the most powerful abilities bloodsuckers have is their feed ability. This is however rendered obsolete the moment you get to your blood cap for no reason. This PR does the following:

When you reach your old blood cap, now referred to as your "Normal" Blood cap, nothing happens. 
If you exceed your blood cap you get a boost to your normal health regeneration that is gradually more expensive in terms of blood depending upon how greatly you exceed your blood limit.
There is a small amount of instant healing when you drink from a target whilst you are over the blood limit.
It's worth mentioning that you cannot access the boosted passive healing till you exceed 700 blood.
## Proof Of Testing

Code has been tested locally on my Monkestation branch with no issues and with it working as intended. Small amount of instant healing (tested by drinking garlic to disable passive regen) and the additional regen also works as designed.
<!-- Compile and run your code locally. Make sure it works. This is the place to show off your changes! We are not responsible for testing your features. -->

## Changelog
:cl:
add: Added new healing systems for bloodsuckers. They can now exceed their blood capacity with their feed ability, doing so gives them minor instant healing and a medium boost to their passive healing over time, their blood drain is dramatically increased until they are back under capacity though.
/:cl:
<!-- By opening a pull request. You have read and understood the repository rules located on the main README.md on this project. -->
