### PR TITLE
Optimize roundend stuff

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -691,8 +691,9 @@ GLOBAL_LIST_EMPTY(species_list)
 /proc/get_mob_by_ckey(key)
 	if(!key)
 		return
-	var/list/mobs = sort_mobs()
-	for(var/mob/mob in mobs)
+	for(var/mob/mob as anything in GLOB.mob_list)
+		if(QDELETED(mob))
+			continue
 		if(mob.ckey == key)
 			return mob
 

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -692,8 +692,6 @@ GLOBAL_LIST_EMPTY(species_list)
 	if(!key)
 		return
 	for(var/mob/mob as anything in GLOB.mob_list)
-		if(QDELETED(mob))
-			continue
 		if(mob.ckey == key)
 			return mob
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -297,7 +297,6 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 
 	//stop collecting feedback during grifftime
 	SSblackbox.Seal()
-	save_datums() // we care about this for now
 
 	// monkestation start: token backups, monkecoin rewards, challenges, and roundend webhook
 	save_tokens()

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -229,6 +229,8 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 
 	popcount = gather_roundend_feedback()
 
+	var/list/rewards = calculate_rewards() // monkestation edit: immediately calculate everyones rewards
+
 	for(var/client/C in GLOB.clients)
 		C?.playtitlemusic(40)
 		if(speed_round && was_forced != ADMIN_FORCE_END_ROUND)
@@ -301,7 +303,7 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 	// monkestation start: token backups, monkecoin rewards, challenges, and roundend webhook
 	save_tokens()
 	refund_cassette()
-	distribute_rewards()
+	batch_update_metacoins(rewards)
 	sleep(5 SECONDS)
 	ready_for_reboot = TRUE
 	var/datum/discord_embed/embed = format_roundend_embed("<@&999008528595419278>")

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -229,8 +229,6 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 
 	popcount = gather_roundend_feedback()
 
-	var/list/rewards = calculate_rewards() // monkestation edit: immediately calculate everyones rewards
-
 	for(var/client/C in GLOB.clients)
 		C?.playtitlemusic(40)
 		if(speed_round && was_forced != ADMIN_FORCE_END_ROUND)
@@ -303,7 +301,7 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 	// monkestation start: token backups, monkecoin rewards, challenges, and roundend webhook
 	save_tokens()
 	refund_cassette()
-	batch_update_metacoins(rewards)
+	distribute_rewards()
 	sleep(5 SECONDS)
 	ready_for_reboot = TRUE
 	var/datum/discord_embed/embed = format_roundend_embed("<@&999008528595419278>")

--- a/code/__HELPERS/~monkestation-helpers/roundend.dm
+++ b/code/__HELPERS/~monkestation-helpers/roundend.dm
@@ -19,22 +19,14 @@
 		return
 	var/total_monkecoins = 0
 	var/list/reasons = list()
-	// donator_multiplier was true before, so i'm keeping it like this for consistency's sake, unless someone says not to
-	var/multiplier = 1
-	var/datum/player_details/details = client?.player_details || get_player_details(ckey)
-	switch(details?.patreon?.access_rank)
-		if(ACCESS_COMMAND_RANK)
-			multiplier = 1.5
-		if(ACCESS_TRAITOR_RANK)
-			multiplier = 2
-		if(ACCESS_NUKIE_RANK)
-			multiplier = 3
 	for(var/list/reward as anything in rewards)
 		if(length(reward) != 2)
 			stack_trace("wtf, reward length wasn't 2")
 			continue
-		var/amount = reward[1] * multiplier
+		var/amount = reward[1]
 		var/reason = reward[2]
+		if(!amount || !reason)
+			continue
 		total_monkecoins += amount
 		reasons += span_rose(span_bold("[amount] Monkecoins deposited to your account! Reason: [reason]"))
 	if(!total_monkecoins)

--- a/code/__HELPERS/~monkestation-helpers/roundend.dm
+++ b/code/__HELPERS/~monkestation-helpers/roundend.dm
@@ -28,7 +28,7 @@
 		if(!amount || !reason)
 			continue
 		total_monkecoins += amount
-		reasons += span_rose(span_bold("[amount] Monkecoins deposited to your account! Reason: [reward[2]]"))
+		reasons += span_rose(span_bold("[amount] Monkecoins deposited to your account! Reason: [reason]"))
 	if(!total_monkecoins)
 		return
 	client?.prefs?.metacoins += total_monkecoins

--- a/code/__HELPERS/~monkestation-helpers/roundend.dm
+++ b/code/__HELPERS/~monkestation-helpers/roundend.dm
@@ -1,20 +1,48 @@
 /datum/controller/subsystem/ticker/proc/save_tokens()
 	rustg_file_write(json_encode(GLOB.saved_token_values), "[GLOB.log_directory]/tokens.json")
 
-/datum/controller/subsystem/ticker/proc/distribute_rewards()
+/datum/controller/subsystem/ticker/proc/calculate_rewards()
 	var/hour = round((world.time - SSticker.round_start_time) / 36000)
 	var/minute = round(((world.time - SSticker.round_start_time) - (hour * 36000)) / 600)
 	var/added_xp = round(25 + (minute ** 0.85))
+	. = list()
 	for(var/client/client as anything in GLOB.clients)
-		distribute_rewards_to_client(client, added_xp)
+		handle_rewards_for_client(client, added_xp, .)
+	rustg_file_write(json_encode(.), "[GLOB.log_directory]/roundend_rewards.json") // remove this before full merge, this is just to make sure if this doesn't work, we can use this to give everyone their missed rewards
 
-/datum/controller/subsystem/ticker/proc/distribute_rewards_to_client(client/client, added_xp)
+/datum/controller/subsystem/ticker/proc/handle_rewards_for_client(client/client, added_xp, list/rewards_list)
+	var/ckey = client?.ckey
+	if(!ckey)
+		return
+	var/list/rewards = calculate_rewards_for_client(client, added_xp)
+	if(!length(rewards))
+		return
+	var/total_monkecoins = 0
+	var/list/reasons = list()
+	for(var/list/reward as anything in rewards)
+		if(length(reward) != 2)
+			stack_trace("wtf, reward length wasn't 2")
+			continue
+		var/amount = reward[1]
+		var/reason = reward[2]
+		if(!amount || !reason)
+			continue
+		total_monkecoins += amount
+		reasons += span_rose(span_bold("[amount] Monkecoins deposited to your account! Reason: [reward[2]]"))
+	if(!total_monkecoins)
+		return
+	client?.prefs?.metacoins += total_monkecoins
+	to_chat(client, jointext(reasons, "\n"), type = MESSAGE_TYPE_INFO)
+	rewards_list[ckey] = total_monkecoins
+
+/datum/controller/subsystem/ticker/proc/calculate_rewards_for_client(client/client, added_xp)
+	. = list()
 	if(!istype(client) || QDELING(client))
 		return
 	var/datum/player_details/details = get_player_details(client)
 	if(!QDELETED(client?.prefs))
 		var/round_end_bonus = 75
-		
+
 		// Patreon Flat Roundend Bonus
 		if((details?.patreon?.has_access(ACCESS_ASSISTANT_RANK)))
 			round_end_bonus += DONATOR_ROUNDEND_BONUS
@@ -23,18 +51,18 @@
 		if((details?.twitch?.has_access(ACCESS_TWITCH_SUB_TIER_1)))
 			round_end_bonus += DONATOR_ROUNDEND_BONUS
 
-		client?.prefs?.adjust_metacoins(client?.ckey, round_end_bonus, "Played a Round")
+		. += list(list(round_end_bonus, "Played a Round"))
 
 		if(world.port == MRP2_PORT)
-			client?.prefs?.adjust_metacoins(client?.ckey, 500, "Monkey 2 Seeding Subsidies")
+			. += list(list(500, "Monkey 2 Seeding Subsidies"))
 		var/special_bonus = details?.roundend_monkecoin_bonus
 		if(special_bonus)
-			client?.prefs?.adjust_metacoins(client?.ckey, special_bonus, "Special Bonus")
+			. += list(list(special_bonus, "Special Bonus"))
 		// WHYYYYYY
 		if(QDELETED(client))
 			return
 		if(client?.is_mentor())
-			client?.prefs?.adjust_metacoins(client?.ckey, 500, "Mentor Bonus")
+			. += list(list(500, "Mentor Bonus"))
 		// WHYYYYYYYYYYYYYYYY
 		if(QDELETED(client))
 			return
@@ -54,7 +82,7 @@
 				continue
 			total_payout += listed_challenge.challenge_payout
 		if(total_payout)
-			client?.prefs?.adjust_metacoins(client?.ckey, total_payout, "Challenge rewards")
+			. += list(list(total_payout, "Challenge Rewards"))
 
 /datum/controller/subsystem/ticker/proc/refund_cassette()
 	if(!length(GLOB.cassette_reviews))
@@ -83,3 +111,40 @@
 				message_admins("Balance not adjusted for Cassette:[review.submitted_tape.name], Balance for [client]; Previous:[prev_bal], Expected:[prev_bal + 5000], Current:[client?.prefs?.metacoins]. Issue logged.")
 				log_admin("Balance not adjusted for Cassette:[review.submitted_tape.name], Balance for [client]; Previous:[prev_bal], Expected:[prev_bal + 5000], Current:[client?.prefs?.metacoins].")
 			qdel(review)
+
+/proc/batch_update_metacoins(list/batch)
+	if(!length(batch))
+		return TRUE
+
+	var/join_query = ""
+	var/list/params = list()
+
+	var/i = 1
+	for(var/ckey in batch)
+		var/amount = batch[ckey]
+		if(!ckey || !amount)
+			continue
+		if(i > 1)
+			join_query += " UNION ALL "
+		i += 1
+
+		join_query += "SELECT :ckey[i] AS ckey, :amount[i] AS amount"
+		params["ckey[i]"] = ckey
+		params["amount[i]"] = amount
+
+	var/datum/db_query/query_batch_metacoins = SSdbcore.NewQuery(
+		"UPDATE [format_table_name("player")] AS p JOIN ([join_query]) AS u ON p.ckey = u.ckey SET p.metacoins = p.metacoins + u.amount",
+		params
+	)
+	if(!query_batch_metacoins.Execute())
+		QDEL_NULL(query_batch_metacoins)
+		stack_trace("Batch updating metacoins failed, we're doing it manually!")
+		for(var/ckey in batch)
+			var/client/client = GLOB.directory[ckey]
+			if(!client)
+				continue
+			var/amount = batch[ckey]
+			client?.prefs?.adjust_metacoins(ckey, amount, reason = "Normal roundend monkecoin update failed, doing it manually", announces = FALSE, donator_multiplier = FALSE)
+		return FALSE
+	qdel(query_batch_metacoins)
+	return TRUE

--- a/code/__HELPERS/~monkestation-helpers/roundend.dm
+++ b/code/__HELPERS/~monkestation-helpers/roundend.dm
@@ -19,14 +19,22 @@
 		return
 	var/total_monkecoins = 0
 	var/list/reasons = list()
+	// donator_multiplier was true before, so i'm keeping it like this for consistency's sake, unless someone says not to
+	var/multiplier = 1
+	var/datum/player_details/details = client?.player_details || get_player_details(ckey)
+	switch(details?.patreon?.access_rank)
+		if(ACCESS_COMMAND_RANK)
+			multiplier = 1.5
+		if(ACCESS_TRAITOR_RANK)
+			multiplier = 2
+		if(ACCESS_NUKIE_RANK)
+			multiplier = 3
 	for(var/list/reward as anything in rewards)
 		if(length(reward) != 2)
 			stack_trace("wtf, reward length wasn't 2")
 			continue
-		var/amount = reward[1]
+		var/amount = reward[1] * multiplier
 		var/reason = reward[2]
-		if(!amount || !reason)
-			continue
 		total_monkecoins += amount
 		reasons += span_rose(span_bold("[amount] Monkecoins deposited to your account! Reason: [reason]"))
 	if(!total_monkecoins)

--- a/code/datums/station_integrity.dm
+++ b/code/datums/station_integrity.dm
@@ -30,25 +30,24 @@
 			if(istype(T.loc, /area/shuttle))
 				continue
 
-			if(isfloorturf(T))
+			else if(isfloorturf(T))
 				var/turf/open/floor/TF = T
 				if(TF.burnt)
 					floor += 1
 				else
 					floor += 2
 
-			if(iswallturf(T))
+			else if(iswallturf(T))
 				wall += 1
+				if(istype(T, /turf/closed/wall/r_wall))
+					var/turf/closed/wall/r_wall/TRW = T
+					if(TRW.d_state == INTACT)
+						r_wall += 2
+					else
+						r_wall += 1
 
-			if(istype(T, /turf/closed/wall/r_wall))
-				var/turf/closed/wall/r_wall/TRW = T
-				if(TRW.d_state == INTACT)
-					r_wall += 2
-				else
-					r_wall += 1
 
-
-			for(var/obj/O in T.contents)
+			for(var/obj/O as anything in T.contents)
 				if(istype(O, /obj/structure/window))
 					window += 1
 				else if(istype(O, /obj/structure/grille))


### PR DESCRIPTION
## About The Pull Request

this optimizes a lot of shit related to the roundend process:
- ~~monkecoin rewards are calculated first, then the DB is _batch updated_ later - all rewards are updated with a single query~~
  - to avoid overcomplicating things, only going to implement this if the current changes aren't enough
- made the `get_mob_by_ckey` proc much less shit - `save_persistent_scars` took over a second due to that mess
- got rid of the `save_datums` call, saving around 2-3 seconds
- micro-optimized `/datum/station_state/proc/count`

## Why It's Good For The Game

main reason is hopefully less instances of people losing challenge rewards because of EORG

## Changelog
:cl:
code: Heavily optimized code related to the roundend process.
/:cl:
