### PR TITLE
Lets cats knock things off reinforced tables

### DIFF
--- a/monkestation/code/modules/blueshift/structures/flipped_table.dm
+++ b/monkestation/code/modules/blueshift/structures/flipped_table.dm
@@ -113,10 +113,11 @@
 		return FALSE
 	if(!isturf(table.loc))
 		return FALSE
-	if(!table.can_flip)
-		return FALSE
-	if(!iscat(src) && !can_hold_items())
-		return FALSE
+	if(!iscat(src))
+		if(!table.can_flip)
+			return FALSE
+		if(!can_hold_items())
+			return FALSE
 	if(full_checks)
 		if(TIMER_COOLDOWN_CHECK(src, REF(table)))
 			return FALSE


### PR DESCRIPTION

## About The Pull Request

this lets cats knock things off of reinforced tables and such - they pass the `table.can_flip` check, since they technically aren't doing anything to the table itself...

technically this is a fix bc i intended for cats to be able to knock things off all tables

## Why It's Good For The Game

half the tables on the station are reinforced, i wanna knock shit off them dammit

## Changelog
:cl:
qol: Cats can now knock things off reinforced tables.
/:cl:
