### PR TITLE
fixes jukeboxes and lobby music not working on 516 i guess

### DIFF
--- a/monkestation/code/modules/cassettes/machines/media/HTML5_player.dm
+++ b/monkestation/code/modules/cassettes/machines/media/HTML5_player.dm
@@ -26,7 +26,7 @@ function SetVolume(volume, balance) {
 </script>
 </head>
 <body>
-	<audio id="player"></audio>
+	<audio id="player" crossOrigin="anonymous"></audio>
 </body>
 </html>
 "}

--- a/monkestation/code/modules/cassettes/machines/media/media_manager.dm
+++ b/monkestation/code/modules/cassettes/machines/media/media_manager.dm
@@ -122,7 +122,7 @@
 
 // Actually pop open the player in the background.
 /datum/media_manager/proc/open()
-	playerstyle = PLAYER_WMP_HTML
+	playerstyle = owner.byond_version >= 516 ? PLAYER_HTML5_HTML : PLAYER_WMP_HTML // i beg of ye, someone convert the html5 player to use a proper audio library with positional audio support
 	owner << browse(null, "window=[WINDOW_ID]")
 	owner << browse(playerstyle, "window=[WINDOW_ID]")
 	send_update()


### PR DESCRIPTION
## About The Pull Request

fixes https://github.com/Monkestation/Monkestation2.0/issues/6058

this doesn't support jukebox directional audio tho

the old Windows Media Player backend is still used on 515

## Testing Proof

***make sure to turn audio on, embedded videos on github are muted by default***

https://github.com/user-attachments/assets/c792a4a8-8c86-4060-bdac-a12ff400aacc

https://github.com/user-attachments/assets/dee6e86a-1efd-47b6-9c7a-6efd7249b6f3

## Changelog
:cl:
fix: Jukebox and lobby screen music should now play on BYOND 516. Jukeboxes won't have directional audio, however.
/:cl:
