### PR TITLE
fix a window on top of a windoor in the icebox library

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -19955,7 +19955,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gnH" = (
-/obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/sign/painting/large/library{
 	dir = 1
 	},


### PR DESCRIPTION
## Changelog
:cl:
map: Fixed a window on top of a windoor (which prevented interacting with the windoor) in the Icebox library.
/:cl:
