### PR TITLE
Allow antag tokens to be used for revenants (if configured)

### DIFF
--- a/code/modules/events/ghost_role/revenant_event.dm
+++ b/code/modules/events/ghost_role/revenant_event.dm
@@ -35,23 +35,13 @@
 
 	var/mob/dead/observer/selected = pick_n_take(candidates)
 
-	var/list/spawn_locs = list()
-
-	for(var/mob/living/L in GLOB.dead_mob_list) //look for any dead bodies
-		var/turf/T = get_turf(L)
-		if(T && is_station_level(T.z))
-			spawn_locs += T
-	if(!spawn_locs.len || spawn_locs.len < 15) //look for any morgue trays, crematoriums, ect if there weren't alot of dead bodies on the station to pick from
-		for(var/obj/structure/bodycontainer/bc in GLOB.bodycontainers)
-			var/turf/T = get_turf(bc)
-			if(T && is_station_level(T.z))
-				spawn_locs += T
-	if(!spawn_locs.len) //If we can't find any valid spawnpoints, try the carp spawns
-		spawn_locs += find_space_spawn()
-	if(!spawn_locs.len) //If we can't find either, just spawn the revenant at the player's location
+	// monkestation start: refactor to use shared find_possible_revenant_spawns proc
+	var/list/spawn_locs = find_possible_revenant_spawns()
+	if(!length(spawn_locs)) //If we can't find either, just spawn the revenant at the player's location
 		spawn_locs += get_turf(selected)
-	if(!spawn_locs.len) //If we can't find THAT, then just give up and cry
+	if(!length(spawn_locs)) //If we can't find THAT, then just give up and cry
 		return MAP_ERROR
+	// monkestation end
 
 	var/mob/living/basic/revenant/revvie = new(pick(spawn_locs))
 	revvie.key = selected.key

--- a/monkestation/code/modules/antagonists/revenant/revenant_antag.dm
+++ b/monkestation/code/modules/antagonists/revenant/revenant_antag.dm
@@ -1,0 +1,34 @@
+/datum/antagonist/revenant/antag_token(datum/mind/hosts_mind, mob/spender)
+	var/spender_key = spender.key
+	if(!spender_key)
+		CRASH("wtf, spender had no key")
+	var/turf/spawn_loc = get_turf(spender)
+	if(!is_station_level(spawn_loc?.z))
+		var/list/possible_spawn_locs = find_possible_revenant_spawns()
+		if(!length(possible_spawn_locs))
+			message_admins("Failed to find valid spawn location for [ADMIN_LOOKUPFLW(spender)], who spent a revenant antag token")
+			CRASH("Failed to find valid spawn location for revenant antag token")
+		spawn_loc = pick(possible_spawn_locs)
+	if(isliving(spender) && hosts_mind)
+		hosts_mind.current.unequip_everything()
+		new /obj/effect/holy(hosts_mind.current.loc)
+		QDEL_IN(hosts_mind.current, 1 SECOND)
+	var/mob/living/basic/revenant/revenant = new(spawn_loc)
+	revenant.key = spender_key
+	if(isobserver(spender))
+		qdel(spender)
+	message_admins("[ADMIN_LOOKUPFLW(revenant)] has been made into a revenant by using an antag token.")
+
+/proc/find_possible_revenant_spawns()
+	. = list()
+	for(var/mob/living/mob in GLOB.dead_mob_list) //look for any dead bodies
+		var/turf/mob_turf = get_turf(mob)
+		if(is_station_level(mob_turf?.z))
+			. += mob_turf
+	if(length(.) < 15) //look for any morgue trays, crematoriums, ect if there weren't alot of dead bodies on the station to pick from
+		for(var/obj/structure/bodycontainer/container in GLOB.bodycontainers)
+			var/turf/container_turf = get_turf(container)
+			if(is_station_level(container_turf?.z))
+				. += container_turf
+	if(!length(.)) //If we can't find any valid spawnpoints, try the carp spawns
+		. += find_space_spawn()

--- a/monkestation/code/modules/client/verbs.dm
+++ b/monkestation/code/modules/client/verbs.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST(antag_token_config)
 		return
 
 	if(isobserver(mob))
-		to_chat(src, span_notice("NOTE: You will be spawned where ever your ghost is when approved, so becareful where you are."))
+		to_chat(src, span_notice("NOTE: You will be spawned where ever your ghost is when approved, so be careful where you are."))
 
 	if(!client_token_holder)
 		if(!prefs?.loaded)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6563,6 +6563,7 @@
 #include "monkestation\code\modules\antagonists\nukeop\equipment\nuclear_bomb\bee_nuke.dm"
 #include "monkestation\code\modules\antagonists\obsessed\obsessed.dm"
 #include "monkestation\code\modules\antagonists\pirate\pirate_outfits.dm"
+#include "monkestation\code\modules\antagonists\revenant\revenant_antag.dm"
 #include "monkestation\code\modules\antagonists\space_ninja\space_ninja.dm"
 #include "monkestation\code\modules\antagonists\teratoma\teratoma.dm"
 #include "monkestation\code\modules\antagonists\traitor\traitor_objective.dm"


### PR DESCRIPTION

## About The Pull Request

This adds code for properly spawning a revenant if someone uses a token to become one.

THIS DOES NOT ADD THEM TO THE ANTAG TOKEN CONFIG, THAT NEEDS TO BE DONE SERVER-SIDE, THIS JUST MAKES IT SO IT WORKS AS EXPECTED WHEN THEY ARE

![image](https://github.com/user-attachments/assets/d737237b-bd1e-42c6-b4f1-9bfac89e5a70)

## Changelog

No changelog, as this requires server-side config changes, and it will likely confuse players as a result.