### PR TITLE
optimize replay turf marking

### DIFF
--- a/code/__DEFINES/overlays.dm
+++ b/code/__DEFINES/overlays.dm
@@ -24,7 +24,8 @@
 		} \
 	} \
 	if(isturf(changed_on)) { \
-		SSdemo.marked_turfs?[changed_on] = TRUE; \
+		var/_maxx = world.maxx; \
+		SSdemo.marked_turfs_by_z[changed_on.z][XY_TO_INDEX(changed_on.x, changed_on.y, _maxx)] = TRUE; \
 	} else if(isobj(changed_on) || ismob(changed_on)) { \
 		SSdemo.mark_dirty(changed_on); \
 	}

--- a/code/__DEFINES/turfs.dm
+++ b/code/__DEFINES/turfs.dm
@@ -17,15 +17,15 @@
 
 #define RECT_TURFS(H_RADIUS, V_RADIUS, CENTER) \
 	block( \
-	locate(max((CENTER).x-(H_RADIUS),1), max((CENTER).y-(V_RADIUS),1), (CENTER).z), \
-	locate(min((CENTER).x+(H_RADIUS),world.maxx), min((CENTER).y+(V_RADIUS),world.maxy), (CENTER).z) \
+	(CENTER).x - (H_RADIUS), (CENTER).y - (V_RADIUS), (CENTER).z, \
+	(CENTER).x + (H_RADIUS), (CENTER).y + (V_RADIUS), (CENTER).z \
 	)
 
 ///Returns all turfs in a zlevel
-#define Z_TURFS(ZLEVEL) block(locate(1,1,ZLEVEL), locate(world.maxx, world.maxy, ZLEVEL))
+#define Z_TURFS(ZLEVEL) block(1, 1, ZLEVEL, world.maxx, world.maxy, ZLEVEL)
 
 ///Returns all currently loaded turfs
-#define ALL_TURFS(...) block(locate(1, 1, 1), locate(world.maxx, world.maxy, world.maxz))
+#define ALL_TURFS(...) block(1, 1, 1, world.maxx, world.maxy, world.maxz)
 
 #define TURF_FROM_COORDS_LIST(List) (locate(List[1], List[2], List[3]))
 
@@ -33,7 +33,7 @@
 #define CORNER_BLOCK(corner, width, height) CORNER_BLOCK_OFFSET(corner, width, height, 0, 0)
 
 /// Returns a list of turfs similar to CORNER_BLOCK but with offsets
-#define CORNER_BLOCK_OFFSET(corner, width, height, offset_x, offset_y) ((block(locate(corner.x + offset_x, corner.y + offset_y, corner.z), locate(min(corner.x + (width - 1) + offset_x, world.maxx), min(corner.y + (height - 1) + offset_y, world.maxy), corner.z))))
+#define CORNER_BLOCK_OFFSET(corner, width, height, offset_x, offset_y) ((block(corner.x + offset_x, corner.y + offset_y, corner.z, corner.x + (width - 1) + offset_x, corner.y + (height - 1) + offset_y, corner.z)))
 
 /// Returns an outline (neighboring turfs) of the given block
 #define CORNER_OUTLINE(corner, width, height) ( \

--- a/code/__DEFINES/~monkestation/replays.dm
+++ b/code/__DEFINES/~monkestation/replays.dm
@@ -1,0 +1,12 @@
+#define XY_TO_INDEX(x, y, maxx) ((y - 1) * maxx + x)
+#define INDEX_TO_X(idx, maxx) (((idx - 1) % maxx) + 1)
+#define INDEX_TO_Y(idx, maxx) ((idx - 1) / maxx) + 1
+#define INDEX_TO_XY(idx, x_name, y_name, maxx) \
+	var/_i_1 = idx - 1; \
+	var/x_name = (_i_1 % maxx) + 1; \
+	var/y_name = (_i_1 / maxx) + 1;
+
+#define MARK_TURF_CACHED(turf, mark_list, maxx, z) \
+	mark_list[z][XY_TO_INDEX(turf.x, turf.y, maxx)] = TRUE;
+
+#define MARK_SINGLE_TURF(turf) MARK_TURF_CACHED(turf, SSdemo.marked_turfs_by_z, world.maxx, turf.z)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -13,7 +13,7 @@
 	// monkestation start: REPLAYS
 	SSdemo.mark_dirty(src)
 	if(isturf(target))
-		SSdemo.marked_turfs?[target] = TRUE
+		MARK_SINGLE_TURF(target)
 	else
 		SSdemo.mark_dirty(target)
 	// monkestation end: REPLAYS

--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -168,9 +168,12 @@
 
 ///Clears the affected_turfs lazylist, removing from its contents the effects of being near the light.
 /datum/component/overlay_lighting/proc/clean_old_turfs()
-	var/list/marked_turfs = SSdemo.marked_turfs
+	var/list/marked_turfs_by_z = SSdemo.marked_turfs_by_z
+	var/maxx = world.maxx
+	var/z
 	for(var/turf/lit_turf as anything in affected_turfs)
-		marked_turfs?[lit_turf] = TRUE
+		z ||= lit_turf.z
+		MARK_TURF_CACHED(lit_turf, marked_turfs_by_z, maxx, z) // monkestation edit: replays
 		lit_turf.dynamic_lumcount -= lum_power
 	affected_turfs = null
 
@@ -180,10 +183,13 @@
 	if(!current_holder)
 		return
 	. = list()
-	var/list/marked_turfs = SSdemo.marked_turfs
-	for(var/turf/lit_turf in view(lumcount_range, get_turf(current_holder)))
+	var/turf/holder_turf = get_turf(current_holder)
+	var/z = holder_turf.z
+	var/list/marked_turfs_by_z = SSdemo.marked_turfs_by_z
+	var/maxx = world.maxx
+	for(var/turf/lit_turf in view(lumcount_range, holder_turf))
 		lit_turf.dynamic_lumcount += lum_power
-		marked_turfs?[lit_turf] = TRUE
+		MARK_TURF_CACHED(lit_turf, marked_turfs_by_z, maxx, z) // monkestation edit: replays
 		. += lit_turf
 	if(length(.))
 		affected_turfs = .

--- a/code/game/turfs/change_turf.dm
+++ b/code/game/turfs/change_turf.dm
@@ -198,7 +198,7 @@ GLOBAL_LIST_INIT(blacklisted_automated_baseturfs, typecacheof(list(
 		QUEUE_SMOOTH_NEIGHBORS(src)
 		QUEUE_SMOOTH(src)
 
-	SSdemo.marked_turfs?[new_turf] = TRUE // Monkestation Edit: REPLAYS
+	MARK_SINGLE_TURF(new_turf) // monkestation edit: replays
 	return new_turf
 
 /turf/open/ChangeTurf(path, list/new_baseturfs, flags) //Resist the temptation to make this default to keeping air.

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -463,6 +463,7 @@ GLOBAL_PROTECT(tracy_init_reason)
 			locate(maxx, maxy, zlevel))
 
 		global_area.turfs_by_zlevel[zlevel] += to_add
+	SSdemo.update_map_xyz() // monkestation edit: replays
 
 /world/proc/increase_max_y(new_maxy, map_load_z_cutoff = maxz)
 	if(new_maxy <= maxy)
@@ -478,11 +479,13 @@ GLOBAL_PROTECT(tracy_init_reason)
 			locate(1, old_maxy + 1, 1),
 			locate(maxx, maxy, map_load_z_cutoff))
 		global_area.turfs_by_zlevel[zlevel] += to_add
+	SSdemo.update_map_xyz() // monkestation edit: replays
 
 /world/proc/incrementMaxZ()
 	maxz++
 	SSmobs.MaxZChanged()
 	SSai_controllers.on_max_z_changed()
+	SSdemo.update_map_xyz() // monkestation edit: replays
 
 /world/proc/change_fps(new_value = 20)
 	if(new_value <= 0)

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -195,7 +195,10 @@
 /datum/light_source/proc/remove_lum()
 	SETUP_CORNERS_REMOVAL_CACHE(src)
 	applied = FALSE
-	var/list/marked_turfs = SSdemo.marked_turfs
+	// monkestation start: replays
+	var/list/marked_turfs_by_z = SSdemo.marked_turfs_by_z
+	var/maxx = world.maxx
+	// monkestation end
 	for (var/datum/lighting_corner/corner as anything in effect_str)
 		if(isnull(corner))
 			continue
@@ -203,11 +206,10 @@
 		LAZYREMOVE(corner.affecting, src)
 
 		// monkestation start: REPLAYS
-		if(!isnull(marked_turfs))
-			marked_turfs[corner.master_NE] = TRUE
-			marked_turfs[corner.master_SE] = TRUE
-			marked_turfs[corner.master_SW] = TRUE
-			marked_turfs[corner.master_NW] = TRUE
+		MARK_TURF_CACHED(corner.master_NE, marked_turfs_by_z, maxx, corner.master_NE.z)
+		MARK_TURF_CACHED(corner.master_SE, marked_turfs_by_z, maxx, corner.master_SE.z)
+		MARK_TURF_CACHED(corner.master_SW, marked_turfs_by_z, maxx, corner.master_SW.z)
+		MARK_TURF_CACHED(corner.master_NW, marked_turfs_by_z, maxx, corner.master_NW.z)
 		// monkestation end: REPLAYS
 
 	effect_str = null
@@ -322,7 +324,10 @@
 		return //nothing's changed
 
 	var/list/datum/lighting_corner/corners = list()
-	var/list/marked_turfs = SSdemo.marked_turfs
+	// monkestation start: replays
+	var/list/marked_turfs_by_z = SSdemo.marked_turfs_by_z
+	var/maxx = world.maxx
+	// monkestation end
 
 	if (source_turf)
 		var/uses_multiz = !!GET_LOWEST_STACK_OFFSET(source_turf.z)
@@ -339,7 +344,7 @@
 				corners[T.lighting_corner_SE] = 0
 				corners[T.lighting_corner_SW] = 0
 				corners[T.lighting_corner_NW] = 0
-				marked_turfs?[T] = TRUE // Monkestation Edit: REPLAYS
+				MARK_TURF_CACHED(T, marked_turfs_by_z, maxx, T.z) // monkestation edit: replays
 		else
 			for(var/turf/T in view(CEILING(light_outer_range, 1), source_turf))
 				if(IS_OPAQUE_TURF(T))
@@ -351,7 +356,7 @@
 				corners[T.lighting_corner_SE] = 0
 				corners[T.lighting_corner_SW] = 0
 				corners[T.lighting_corner_NW] = 0
-				marked_turfs?[T] = TRUE // Monkestation Edit: REPLAYS
+				MARK_TURF_CACHED(T, marked_turfs_by_z, maxx, T.z) // monkestation edit: replays
 
 				var/turf/below = GET_TURF_BELOW(T)
 				var/turf/previous = T
@@ -373,7 +378,7 @@
 					corners[below.lighting_corner_SE] = 0
 					corners[below.lighting_corner_SW] = 0
 					corners[below.lighting_corner_NW] = 0
-					marked_turfs?[below] = TRUE // Monkestation Edit: REPLAYS
+					MARK_TURF_CACHED(below, marked_turfs_by_z, maxx, below.z) // monkestation edit: replays
 					// ANNND then we add the one below it
 					previous = below
 					below = GET_TURF_BELOW(below)
@@ -390,7 +395,7 @@
 					corners[above.lighting_corner_SE] = 0
 					corners[above.lighting_corner_SW] = 0
 					corners[above.lighting_corner_NW] = 0
-					marked_turfs?[above] = TRUE // Monkestation Edit: REPLAYS
+					MARK_TURF_CACHED(above, marked_turfs_by_z, maxx, above.z) // monkestation edit: replays
 					above = GET_TURF_ABOVE(above)
 
 		source_turf.luminosity = oldlum

--- a/monkestation/code/modules/replays/hooks/generic_hooks.dm
+++ b/monkestation/code/modules/replays/hooks/generic_hooks.dm
@@ -22,7 +22,7 @@
 
 /turf/setDir()
 	. = ..()
-	SSdemo.marked_turfs?[src] = TRUE
+	MARK_SINGLE_TURF(src)
 
 /atom/movable/setDir()
 	. = ..()

--- a/monkestation/code/modules/replays/subsystem/replay.dm
+++ b/monkestation/code/modules/replays/subsystem/replay.dm
@@ -251,9 +251,9 @@ SUBSYSTEM_DEF(demo)
 		for(var/z = 1 to length(marked_turfs_by_z))
 			var/list/z_marked_turfs = marked_turfs_by_z[z]
 			for(var/idx in 1 to map_size)
-				if(!z_marked_turfs[idx])
+				if(isnull(z_marked_turfs[idx]))
 					continue
-				z_marked_turfs[idx] = FALSE
+				z_marked_turfs[idx] = null
 				INDEX_TO_XY(idx, x, y, maxx)
 				var/turf/turf = locate(x, y, z)
 				if(isnull(turf))

--- a/monkestation/code/modules/replays/subsystem/replay.dm
+++ b/monkestation/code/modules/replays/subsystem/replay.dm
@@ -63,7 +63,6 @@ SUBSYSTEM_DEF(demo)
 	log_world("Writing turfs...")
 	WRITE_LOG_NO_FORMAT(GLOB.demo_log, "init [world.maxx] [world.maxy] [world.maxz]\n")
 
-	rustg_time_reset("demos")
 	for(var/z in 1 to maxz)
 		var/row_list = list()
 		var/last_appearance
@@ -95,9 +94,6 @@ SUBSYSTEM_DEF(demo)
 			row_list += rle_count
 		WRITE_LOG_NO_FORMAT(GLOB.demo_log, jointext(row_list, ",") + "\n")
 		marked_turfs_by_z[z] = new /list(maxx * maxy) // completely clear the list as a whole
-
-	var/time = round(rustg_time_milliseconds("demos") / 1000, 0.01)
-	log_world("Turfs took [DisplayTimeText(time)]")
 
 	CHECK_TICK
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -467,6 +467,7 @@
 #include "code\__DEFINES\~monkestation\power.dm"
 #include "code\__DEFINES\~monkestation\projectiles.dm"
 #include "code\__DEFINES\~monkestation\quirk_costs.dm"
+#include "code\__DEFINES\~monkestation\replays.dm"
 #include "code\__DEFINES\~monkestation\robots.dm"
 #include "code\__DEFINES\~monkestation\skills.dm"
 #include "code\__DEFINES\~monkestation\slimes.dm"


### PR DESCRIPTION

## About The Pull Request

this refactors how turf overlays are tracked by `SSdemo`

instead of being an assoc list of `[turf] = TRUE`
it is instead now a 2d list - one list for every z-level, with the index calculate by x/y.

## Why It's Good For The Game

hopefully improves performance even more regarding them

## Changelog
:cl:
refactor: Refactored how turf updates are tracked for replays.
/:cl:
