### PR TITLE
Refactor armaments and imports to use `DmIcon`

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -795,6 +795,7 @@
 	name = "sabre sheath"
 	desc = "An ornate sheath designed to hold an officer's blade."
 	icon_state = "sheath"
+	icon_state_preview = "sheath-sabre" // monkestation edit: add preview icon state
 	inhand_icon_state = "sheath"
 	worn_icon_state = "sheath"
 	w_class = WEIGHT_CLASS_BULKY

--- a/monkestation/code/modules/blueshift/components/armament.dm
+++ b/monkestation/code/modules/blueshift/components/armament.dm
@@ -113,7 +113,8 @@
 					continue
 				subcategory_items += list(list(
 					"ref" = REF(armament_entry),
-					"icon" = armament_entry.cached_base64,
+					"icon" = armament_entry.item_type::icon,
+					"icon_state" = armament_entry.item_type::icon_state_preview || armament_entry.item_type::icon_state,
 					"name" = armament_entry.name,
 					"cost" = armament_entry.cost,
 					"buyable_ammo" = armament_entry.magazine ? TRUE : FALSE,
@@ -390,7 +391,8 @@
 
 				subcategory_items += list(list(
 					"ref" = REF(armament_entry),
-					"icon" = armament_entry.cached_base64,
+					"icon" = armament_entry.item_type::icon,
+					"icon_state" = armament_entry.item_type::icon_state_preview || armament_entry.item_type::icon_state,
 					"name" = armament_entry.name,
 					"cost" = cost_calculate(armament_entry.cost),
 					"buyable_ammo" = armament_entry.magazine ? TRUE : FALSE,

--- a/monkestation/code/modules/blueshift/items/knives.dm
+++ b/monkestation/code/modules/blueshift/items/knives.dm
@@ -21,6 +21,7 @@
 	desc = "A dressed-up leather sheath featuring a brass tip. It has a large pocket clip right in the center, for ease of carrying an otherwise burdensome knife."
 	icon = 'monkestation/code/modules/blueshift/icons/bowiepocket.dmi'
 	icon_state = "bowiesheath"
+	icon_state_preview = "bowiesheathe-knife"
 	slot_flags = ITEM_SLOT_POCKETS
 	w_class = WEIGHT_CLASS_BULKY
 	resistance_flags = FLAMMABLE

--- a/monkestation/code/modules/blueshift/subsystems/armament.dm
+++ b/monkestation/code/modules/blueshift/subsystems/armament.dm
@@ -98,8 +98,6 @@ SUBSYSTEM_DEF(armaments)
 	var/cost = 0
 	/// Defines what slot we will try to equip this item to.
 	var/slot_to_equip = ITEM_SLOT_HANDS
-	/// Our cached image.
-	var/cached_base64
 	/// The maximum amount of this item that can be equipped.
 	var/max_purchase = 1
 	/// Do we have magazines for purchase?
@@ -110,13 +108,10 @@ SUBSYSTEM_DEF(armaments)
 	var/restricted = FALSE
 
 /datum/armament_entry/proc/setup()
-	var/obj/item/test_item = new item_type()
-	if(istype(test_item, /obj/item/gun/ballistic))
-		var/obj/item/gun/ballistic/ballistic_test = test_item
-		if(!ballistic_test.internal_magazine)
-			magazine = ballistic_test.spawn_magazine_type
-	cached_base64 = icon2base64(getFlatIcon(test_item, no_anim = TRUE))
-	qdel(test_item)
+	if(ispath(item_type, /obj/item/gun/ballistic))
+		var/obj/item/gun/ballistic/ballistic_type = item_type
+		if(!ballistic_type::internal_magazine)
+			magazine = ballistic_type::spawn_magazine_type
 
 /// This proc handles how the item should be equipped to the player. This needs to return either TRUE or FALSE, TRUE being that it was able to equip the item.
 /datum/armament_entry/proc/equip_to_human(mob/living/carbon/human/equipping_human, obj/item/item_to_equip)

--- a/tgui/packages/tgui/interfaces/ArmamentStation.jsx
+++ b/tgui/packages/tgui/interfaces/ArmamentStation.jsx
@@ -1,5 +1,14 @@
 import { useBackend, useLocalState } from '../backend';
-import { Section, Stack, Box, Divider, Button, NoticeBox } from '../components';
+import {
+  Section,
+  Stack,
+  Box,
+  Divider,
+  Button,
+  NoticeBox,
+  DmIcon,
+  Icon,
+} from '../components';
 import { Window } from '../layouts';
 
 export const ArmamentStation = (props) => {
@@ -83,12 +92,13 @@ export const ArmamentStation = (props) => {
                                 key={item.ref}
                                 onClick={() => setArmament(item.ref)}
                               >
-                                <img
-                                  src={`data:image/jpeg;base64,${item.icon}`}
-                                  style={{
-                                    'vertical-align': 'middle',
-                                    'horizontal-align': 'middle',
-                                  }}
+                                <DmIcon
+                                  icon={item.icon}
+                                  icon_state={item.icon_state}
+                                  fallback={<Icon mr={1} name="spinner" spin />}
+                                  height={'32px'}
+                                  width={'32px'}
+                                  verticalAlign="middle"
                                 />
                                 &nbsp;{item.name}
                               </Button>
@@ -108,20 +118,16 @@ export const ArmamentStation = (props) => {
                     subcat.items.map(
                       (item) =>
                         item.ref === weapon && (
-                          <Stack vertical>
+                          <Stack vertical key={item.ref}>
                             <Stack.Item>
                               <Box key={item.ref}>
-                                <img
+                                <DmIcon
+                                  icon={item.icon}
+                                  icon_state={item.icon_state}
+                                  fallback={<Icon mr={1} name="spinner" spin />}
                                   height="100%"
                                   width="100%"
-                                  src={`data:image/jpeg;base64,${item.icon}`}
-                                  style={{
-                                    'vertical-align': 'middle',
-                                    'horizontal-align': 'middle',
-                                    '-ms-interpolation-mode':
-                                      'nearest-neighbor',
-                                    'image-rendering': 'pixelated',
-                                  }}
+                                  verticalAlign="middle"
                                 />
                               </Box>
                             </Stack.Item>

--- a/tgui/packages/tgui/interfaces/CargoImportConsole.jsx
+++ b/tgui/packages/tgui/interfaces/CargoImportConsole.jsx
@@ -1,5 +1,13 @@
 import { useBackend, useLocalState } from '../backend';
-import { Section, Stack, Box, Divider, Button } from '../components';
+import {
+  Section,
+  Stack,
+  Box,
+  Divider,
+  Button,
+  DmIcon,
+  Icon,
+} from '../components';
 import { Window } from '../layouts';
 
 export const CargoImportConsole = (props) => {
@@ -78,12 +86,11 @@ export const CargoImportConsole = (props) => {
                                 key={item.ref}
                                 onClick={() => setArmament(item.ref)}
                               >
-                                <img
-                                  src={`data:image/jpeg;base64,${item.icon}`}
-                                  style={{
-                                    'vertical-align': 'middle',
-                                    'horizontal-align': 'middle',
-                                  }}
+                                <DmIcon
+                                  icon={item.icon}
+                                  icon_state={item.icon_state}
+                                  fallback={<Icon mr={1} name="spinner" spin />}
+                                  verticalAlign="middle"
                                 />
                                 &nbsp;{item.name}
                               </Button>
@@ -103,20 +110,16 @@ export const CargoImportConsole = (props) => {
                     subcat.items.map(
                       (item) =>
                         item.ref === weapon && (
-                          <Stack vertical>
+                          <Stack vertical key={item.ref}>
                             <Stack.Item>
                               <Box key={item.ref}>
-                                <img
+                                <DmIcon
+                                  icon={item.icon}
+                                  icon_state={item.icon_state}
+                                  fallback={<Icon mr={1} name="spinner" spin />}
                                   height="100%"
                                   width="100%"
-                                  src={`data:image/jpeg;base64,${item.icon}`}
-                                  style={{
-                                    'vertical-align': 'middle',
-                                    'horizontal-align': 'middle',
-                                    '-ms-interpolation-mode':
-                                      'nearest-neighbor',
-                                    'image-rendering': 'pixelated',
-                                  }}
+                                  verticalAlign="middle"
                                 />
                               </Box>
                             </Stack.Item>


### PR DESCRIPTION

## About The Pull Request

This makes it so armaments + imports just fully use `DmIcon` for UI rendering.

This saves a second or so of init time, due to not needing to do a bunch of `icon2base64(getFlatIcon(...))` in init, and also heavily reduces the amount of data sent to users when opening the UIs.

## Why It's Good For The Game

Reduced init time, less garbage being sent in `ui_data`

## Changelog
:cl:
refactor: The cargo imports console and assault op armaments uplink now use a more efficient method of displaying icons.
/:cl:
