### PR TITLE
Bloodsucker Sol level up Cap

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_sol.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_sol.dm
@@ -21,8 +21,10 @@
 ///Ranks the Bloodsucker up, called by Sol.
 /datum/antagonist/bloodsucker/proc/sol_rank_up(atom/source)
 	SIGNAL_HANDLER
-
-	INVOKE_ASYNC(src, PROC_REF(RankUp))
+	if(bloodsucker_level < 3)
+		INVOKE_ASYNC(src, PROC_REF(RankUp))
+	else
+		to_chat(owner.current, span_announce("You have already got as powerful as you can through surviving Sol."))
 
 ///Called when Sol is near starting.
 /datum/antagonist/bloodsucker/proc/sol_near_start(atom/source)


### PR DESCRIPTION
## About The Pull Request

This PR makes Bloodsuckers only able to reach rank 3 from sol, they cannot exceed this limit except through other means of levelling.

This PR is meant to be a complimentary PR to my other two PR's currently up, but especially to [this](https://github.com/Monkestation/Monkestation2.0/pull/6182)
## Why It's Good For The Game

One of the primary complaints with Bloodsuckers is that it's a do nothing get strong antagonist. They do nothing but wait and then become nigh unkillable when they reach high ranks with 0 effort on their behalf.

When combined with the PR mentioned above, this makes it so that bloodsuckers are forced to level through sucking the blood of the crew or other means (such as tremere levelling or ventrue levelling) and therefore by being active as an antagonist.
## Changelog
:cl:
balance: Bloodsuckers can only rank up till level 3 via Sol. Any further levels must be gained through other means.
/:cl:
