### PR TITLE
Fix plague rats appearing twice on the roundend report

### DIFF
--- a/monkestation/code/modules/virology/disease/plague_rat/antagonist.dm
+++ b/monkestation/code/modules/virology/disease/plague_rat/antagonist.dm
@@ -34,4 +34,7 @@
 
 /datum/antagonist/plague_rat/greet()
 	. = ..()
-	to_chat(owner.current, " <span class='warning'><B>You are a [name]! Carrier of a dangerous Bacteria!</B><BR>Try and spread your contagion across the station!</span>")
+	to_chat(owner.current, span_warning("<B>You are a [name]! Carrier of a dangerous Bacteria!</B><BR>Try and spread your contagion across the station!"))
+
+/datum/antagonist/plague_rat/get_team()
+	return rats_rats_we_are_the_rats


### PR DESCRIPTION
## Changelog
:cl:
fix: Fixed plague rats appearing twice on the roundend report.
/:cl:
