### PR TITLE
AI Now takes 15 Hrs of borg instead of 3 to unlock.

### DIFF
--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -9,7 +9,7 @@
 	spawn_type = /mob/living/silicon/ai
 	req_admin_notify = TRUE
 	minimal_player_age = 30
-	exp_requirements = 180
+	exp_requirements = 1800
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_SILICON
 	exp_granted_type = EXP_TYPE_CREW

--- a/code/modules/jobs/job_types/ai.dm
+++ b/code/modules/jobs/job_types/ai.dm
@@ -9,7 +9,7 @@
 	spawn_type = /mob/living/silicon/ai
 	req_admin_notify = TRUE
 	minimal_player_age = 30
-	exp_requirements = 1800
+	exp_requirements = 900
 	exp_required_type = EXP_TYPE_CREW
 	exp_required_type_department = EXP_TYPE_SILICON
 	exp_granted_type = EXP_TYPE_CREW


### PR DESCRIPTION
Update ai.dm
## About The Pull Request
AI now takes 10x the amount of hours.
## Why It's Good For The Game
AI is the most powerful role on the station, and has a very low timelock.
To play AI, you will need more than 3 hours of experience, so that you understand how AI laws work.
Having such a high timelock is fine; as there's been a problem lately with AIs that just either:
a) Don't follow their laws.
b) Don't understand their laws.
c) Make obviously bad-faith interpretations of them.

Having a longer timelock lets us catch these bad actors earlier, and gives new players some time to understand borg laws.
## Changelog
:cl:
balance: AI now takes 15 hours of silicon to unlock instead of 3.
/:cl:
