### PR TITLE
Fix tgui-say chat history on BYOND 516

### DIFF
--- a/tgui/packages/common/keys.ts
+++ b/tgui/packages/common/keys.ts
@@ -19,6 +19,10 @@
  */
 export enum KEY {
   Alt = 'Alt',
+  ArrowDown = 'ArrowDown',
+  ArrowLeft = 'ArrowLeft',
+  ArrowRight = 'ArrowRight',
+  ArrowUp = 'ArrowUp',
   Backspace = 'Backspace',
   Control = 'Control',
   Delete = 'Delete',

--- a/tgui/packages/tgui-say/TguiSay.tsx
+++ b/tgui/packages/tgui-say/TguiSay.tsx
@@ -83,10 +83,10 @@ export class TguiSay extends Component<{}, State> {
     Byond.subscribeTo('open', this.handleOpen);
   }
 
-  handleArrowKeys(direction: KEY.Up | KEY.Down) {
+  handleArrowKeys(direction: KEY.Up | KEY.Down | KEY.ArrowUp | KEY.ArrowDown) {
     const currentValue = this.innerRef.current?.value;
 
-    if (direction === KEY.Up) {
+    if (direction === KEY.Up || direction === KEY.ArrowUp) {
       if (this.chatHistory.isAtLatest() && currentValue) {
         // Save current message to temp history if at the most recent message
         this.chatHistory.saveTemp(currentValue);
@@ -263,6 +263,8 @@ export class TguiSay extends Component<{}, State> {
     switch (event.key) {
       case KEY.Up:
       case KEY.Down:
+      case KEY.ArrowUp:
+      case KEY.ArrowDown:
         event.preventDefault();
         this.handleArrowKeys(event.key);
         break;


### PR DESCRIPTION
## Changelog
:cl:
fix: Going through your past few messages in tgui-say using the arrow keys now works on BYOND 516 again.
/:cl:
