### PR TITLE
Fix not being able to use hypernob crystals and such on clothes with storage

### DIFF
--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer_items.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer_items.dm
@@ -5,6 +5,11 @@
 	icon_state = "hypernoblium_crystal"
 	var/uses = 1
 
+// monkestation start: allow using on storage items via right clicking or combat mode
+/obj/item/hypernoblium_crystal/attackby_storage_insert(datum/storage, atom/storage_holder, mob/living/user)
+	return !(user?.istate & (ISTATE_HARM | ISTATE_SECONDARY))
+// monkestation end
+
 /obj/item/hypernoblium_crystal/afterattack(obj/target_object, mob/user, proximity)
 	. = ..()
 	if(!proximity)
@@ -25,7 +30,7 @@
 		if(istype(worn_item, /obj/item/clothing/suit/space))
 			to_chat(user, span_warning("The [worn_item] is already pressure-resistant!"))
 			return
-		if(worn_item.min_cold_protection_temperature == SPACE_SUIT_MIN_TEMP_PROTECT && worn_item.clothing_flags & STOPSPRESSUREDAMAGE)
+		if(worn_item.min_cold_protection_temperature == SPACE_SUIT_MIN_TEMP_PROTECT && (worn_item.clothing_flags & STOPSPRESSUREDAMAGE))
 			to_chat(user, span_warning("[worn_item] is already pressure-resistant!"))
 			return
 		to_chat(user, span_notice("You see how the [worn_item] changes color, it's now pressure proof."))

--- a/code/modules/research/xenobiology/crossbreeding/_potions.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_potions.dm
@@ -107,6 +107,11 @@ Slimecrossing Potions
 	icon_state = "potblue"
 	var/uses = 2
 
+// monkestation start: allow using on storage items via right clicking or combat mode
+/obj/item/slimepotion/spaceproof/attackby_storage_insert(datum/storage, atom/storage_holder, mob/living/user)
+	return !(user?.istate & (ISTATE_HARM | ISTATE_SECONDARY))
+// monkestation end
+
 /obj/item/slimepotion/spaceproof/afterattack(obj/item/clothing/C, mob/user, proximity)
 	. = ..()
 	if(!uses)
@@ -150,6 +155,11 @@ Slimecrossing Potions
 	icon_state = "potred"
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	var/uses = 2
+
+// monkestation start: allow using on storage items via right clicking or combat mode
+/obj/item/slimepotion/lavaproof/attackby_storage_insert(datum/storage, atom/storage_holder, mob/living/user)
+	return !(user?.istate & (ISTATE_HARM | ISTATE_SECONDARY))
+// monkestation end
 
 /obj/item/slimepotion/lavaproof/afterattack(obj/item/C, mob/user, proximity)
 	. = ..()

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -908,6 +908,11 @@
 	resistance_flags = FIRE_PROOF
 	var/uses = 3
 
+// monkestation start: allow using on storage items via right clicking or combat mode
+/obj/item/slimepotion/fireproof/attackby_storage_insert(datum/storage, atom/storage_holder, mob/living/user)
+	return !(user?.istate & (ISTATE_HARM | ISTATE_SECONDARY))
+// monkestation end
+
 /obj/item/slimepotion/fireproof/afterattack(obj/item/clothing/clothing, mob/user, proximity)
 	. = ..()
 	if(!proximity)

--- a/monkestation/code/modules/clothing/durathread_weave.dm
+++ b/monkestation/code/modules/clothing/durathread_weave.dm
@@ -29,6 +29,9 @@ GLOBAL_LIST_INIT(durathread_weave_blacklist, typecacheof(list(
 	. = ..()
 	. += span_info("You can click on a piece of clothing, with an active welder in your offhand, in order to reinforce it!")
 
+/obj/item/stack/sheet/durathread/attackby_storage_insert(datum/storage, atom/storage_holder, mob/user)
+	return !isclothing(storage_holder) || !(user?.istate & (ISTATE_HARM | ISTATE_SECONDARY))
+
 /obj/item/stack/sheet/durathread/afterattack(obj/item/clothing/clothing, mob/living/user, proximity)
 	. = ..()
 	if(. || !isliving(user) || !proximity)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/5466

Currently, you're unable to use things like hypernob crystals, xenobio potions, or durathread reinforcement on things like jackboots, because trying to use an item on them always blocks afterattack, regardless of if the item fits or not.

This makes those items not try to insert into storage on attackby if you're in combat mode - allowing you to apply those items to things that'd normally just try to put them into storage instead.

This was fixed upstream when they nuked afterattack, but sadly that's prolly a long ways from being ported here, so this is the best we got.

## Why It's Good For The Game

bugfix good

## Changelog
:cl:
fix: You can now use hypernob crystals, durathread reinforcement, and fire/lava/pressure-proofing potions on clothing with storage, i.e jackboots, by clicking on it while in combat mode.
/:cl:
