### PR TITLE
Antags will no longer roll after the emergency shuttle is past the point of no return

### DIFF
--- a/monkestation/code/modules/storytellers/converted_events/_base_event.dm
+++ b/monkestation/code/modules/storytellers/converted_events/_base_event.dm
@@ -122,11 +122,12 @@
 
 /datum/round_event_control/antagonist/can_spawn_event(players_amt, allow_magic = FALSE, fake_check = FALSE)
 	. = ..()
-	if(!check_required())
-		return FALSE
-
 	if(!.)
 		return
+	if(EMERGENCY_PAST_POINT_OF_NO_RETURN)
+		return FALSE
+	if(!check_required())
+		return FALSE
 
 /datum/round_event_control/antagonist/solo
 	typepath = /datum/round_event/antagonist/solo


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: The storyteller will no longer roll antags after the emergency shuttle is past the point of no return.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
