### PR TITLE
stalebot moment

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,11 +20,12 @@ jobs:
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: "This PR has been inactive for long enough to be automatically marked as stale. This means it is at risk of being auto closed in ~ 7 days, please address any outstanding review items and ensure your PR is finished, if these are all true and you are auto-staled anyway, you need to actively ask maintainers if your PR will be merged. Once you have done any of the previous actions then you should request a maintainer remove the stale label on your PR, to reset the stale timer. If you feel no maintainer will respond in that time, you may wish to close this PR youself, while you seek maintainer comment, as you will then be able to reopen the PR yourself"
-        days-before-stale: 7
+        days-before-stale: 14
         days-before-close: 7
         stale-pr-label: 'Stale'
         days-before-issue-stale: -1
         stale-issue-label: 'Cleanup Flagged'
         remove-issue-stale-when-updated: false
-        exempt-pr-labels: 'RED LABEL,Good First PR'
+        exempt-pr-labels: 'RED LABEL,Good First PR,Process: should testmerge,Process: testmerge only'
         operations-per-run: 300
+        exempt-draft-pr: true


### PR DESCRIPTION
adds testmerge-related labels to stalebot config
exempts draft PRs
and makes it 14 days before stale

i have no clue how this action was even re-enabled