### PR TITLE
Stabilized rainbow extracts now use signals to activate

### DIFF
--- a/monkestation/code/modules/slimecore/crossbreeding/stabilized.dm
+++ b/monkestation/code/modules/slimecore/crossbreeding/stabilized.dm
@@ -4,26 +4,36 @@
 	regencore = null
 	return ..()
 
-/datum/status_effect/stabilized/rainbow/tick()
-	if(owner.health <= 0)
-		var/obj/item/slimecross/stabilized/rainbow/extract = linked_extract
-		if(!istype(extract) || QDELING(extract) || QDELETED(extract.regencore))
-			return
-		// bypasses cooldowns, but also removes any existing regen effects
-		owner.remove_status_effect(/datum/status_effect/regenerative_extract)
-		owner.remove_status_effect(/datum/status_effect/slime_regen_cooldown)
-		owner.visible_message(span_hypnophrase("[owner] flashes a rainbow of colors, and [owner.p_their()] skin is coated in a milky regenerative goo!"))
-		playsound(owner, 'sound/effects/splat.ogg', vol = 40, vary = TRUE)
-		apply_regen(extract.regencore)
-		QDEL_NULL(linked_extract)
-		qdel(src)
+/datum/status_effect/stabilized/rainbow/on_apply()
+	RegisterSignal(owner, SIGNAL_ADDTRAIT(TRAIT_CRITICAL_CONDITION), PROC_REF(on_enter_critical))
+	RegisterSignal(owner, COMSIG_LIVING_HEALTH_UPDATE, PROC_REF(on_health_update))
+	return TRUE
+
+/datum/status_effect/stabilized/rainbow/on_remove()
+	UnregisterSignal(owner, list(SIGNAL_ADDTRAIT(TRAIT_CRITICAL_CONDITION), COMSIG_LIVING_HEALTH_UPDATE))
+
+/datum/status_effect/stabilized/rainbow/proc/on_enter_critical(datum/source)
+	SIGNAL_HANDLER
+	activate()
+
+/datum/status_effect/stabilized/rainbow/proc/on_health_update(datum/source)
+	SIGNAL_HANDLER
+	if(owner.health <= owner.hardcrit_threshold)
+		activate()
+
+/datum/status_effect/stabilized/rainbow/proc/activate()
+	var/obj/item/slimecross/stabilized/rainbow/extract = linked_extract
+	if(QDELETED(src) || !istype(extract) || QDELING(extract) || QDELETED(extract.regencore))
 		return
-	return ..()
-
-
-/datum/status_effect/stabilized/rainbow/proc/apply_regen(obj/item/slimecross/regenerative/regen_core)
-	regen_core.core_effect_before(owner, owner)
-	regen_core.apply_effect(owner)
-	regen_core.core_effect(owner, owner)
-	qdel(regen_core)
+	// bypasses cooldowns, but also removes any existing regen effects
+	owner.remove_status_effect(/datum/status_effect/regenerative_extract)
+	owner.remove_status_effect(/datum/status_effect/slime_regen_cooldown)
+	owner.visible_message(span_hypnophrase("[owner] flashes a rainbow of colors, and [owner.p_their()] skin is coated in a milky regenerative goo!"))
+	playsound(owner, 'sound/effects/splat.ogg', vol = 40, vary = TRUE)
+	extract.regencore.core_effect_before(owner, owner)
+	extract.regencore.apply_effect(owner)
+	extract.regencore.core_effect(owner, owner)
+	QDEL_NULL(extract.regencore)
+	QDEL_NULL(linked_extract)
+	qdel(src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this changes stabilized rainbows from just checking if `health < 0`, to instead activating on `SIGNAL_ADDTRAIT(TRAIT_CRITICAL_CONDITION)`, or on `COMSIG_LIVING_HEALTH_UPDATE` if their health is below their usual hardcrit threshold.

therefore, these won't be fucked over by lag.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Stabilized rainbow extracts now use signals to detect when the user enters crit, preventing dumb things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
