### PR TITLE
Bogseo balance fix

### DIFF
--- a/monkestation/code/modules/blueshift/items/ammo.dm
+++ b/monkestation/code/modules/blueshift/items/ammo.dm
@@ -685,8 +685,8 @@
 /obj/projectile/bullet/c585trappiste/incapacitator
 	name = ".585 Trappiste flathead bullet"
 	damage = 9
-	stamina = 40
-	wound_bonus = 10
+	stamina = 35
+	wound_bonus = -20
 
 	weak_against_armour = TRUE
 

--- a/monkestation/code/modules/blueshift/items/company_guns.dm
+++ b/monkestation/code/modules/blueshift/items/company_guns.dm
@@ -423,7 +423,7 @@
 	weapon_weight = WEAPON_HEAVY
 	slot_flags = ITEM_SLOT_SUITSTORE | ITEM_SLOT_BELT
 
-	accepted_magazine_type = /obj/item/ammo_box/magazine/miecz
+	accepted_magazine_type = /obj/item/ammo_box/magazine/c585trappiste_pistol
 
 	fire_sound = 'monkestation/code/modules/blueshift/sounds/smg_heavy.ogg'
 	can_suppress = TRUE

--- a/monkestation/code/modules/blueshift/items/company_guns.dm
+++ b/monkestation/code/modules/blueshift/items/company_guns.dm
@@ -405,7 +405,7 @@
 
 /obj/item/gun/ballistic/automatic/xhihao_smg
 	name = "\improper Bogseo Submachine Gun"
-	desc = "A weapon that could hardly be called a 'sub' machinegun, firing the .27-54 cartridge. \
+	desc = "A weapon that could hardly be called a 'sub' machinegun, firing the hefty .585 cartridge. \
 		It provides enough kick to bruise a shoulder pretty bad if used without protection."
 
 	icon = 'monkestation/code/modules/blueshift/icons/obj/company_and_or_faction_based/xhihao_light_arms/guns32x.dmi'
@@ -439,6 +439,7 @@
 	// Hope you didn't need to see anytime soon
 	recoil = 2
 	wield_recoil = 1
+	projectile_wound_bonus = -5
 
 /obj/item/gun/ballistic/automatic/xhihao_smg/give_manufacturer_examine()
 	AddElement(/datum/element/manufacturer_examine, COMPANY_XHIHAO)

--- a/monkestation/code/modules/blueshift/items/gunset.dm
+++ b/monkestation/code/modules/blueshift/items/gunset.dm
@@ -205,6 +205,22 @@
 	weapon_to_spawn = /obj/item/gun/ballistic/automatic/sol_grenade_launcher/no_mag
 	extra_to_spawn = /obj/item/ammo_box/magazine/c980_grenade/starts_empty
 
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/kiboko_magfull  //monke addition
+	name = "\improper Carwo 'Kiboko' gunset"
+
+	weapon_to_spawn = /obj/item/gun/ballistic/automatic/sol_grenade_launcher/no_mag
+	extra_to_spawn = /obj/item/ammo_box/magazine/c980_grenade/starts_empty
+
+/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/kiboko_magfull/PopulateContents()
+	new weapon_to_spawn (src)
+
+	generate_items_inside(list(
+		/obj/item/gun/ballistic/automatic/sol_grenade_launcher/no_mag,
+		/obj/item/ammo_box/magazine/c980_grenade/starts_empty = 3,
+		/obj/item/ammo_box/c980grenade/shrapnel = 2,
+		/obj/item/ammo_box/c980grenade/smoke = 1,
+		/obj/item/ammo_box/c980grenade/riot = 2,
+	), src)
 
 /obj/structure/closet/secure_closet/armory_kiboko
 	name = "heavy equipment locker"
@@ -215,10 +231,7 @@
 	. = ..()
 
 	generate_items_inside(list(
-		/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/kiboko_magless = 1,
-		/obj/item/ammo_box/c980grenade/shrapnel = 2, //monke edit, practice to shrapnel
-		/obj/item/ammo_box/c980grenade/smoke = 1,
-		/obj/item/ammo_box/c980grenade/riot = 1,
+		/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/kiboko_magfull = 1 //monke edit,
 		/obj/item/storage/toolbox/guncase/skyrat/quarad_guncase = 1, //monke edit
 	), src)
 
@@ -268,9 +281,9 @@
 	new weapon_to_spawn (src)
 
 	generate_items_inside(list(
-		/obj/item/ammo_box/c27_54cesarzowa/rubber = 2,
-		/obj/item/ammo_box/c27_54cesarzowa = 1,
-		/obj/item/ammo_box/magazine/miecz/spawns_empty = 3,
+		/obj/item/ammo_casing/c585trappiste/incapacitator = 2,
+		/obj/item/ammo_box/c585trappiste = 1,
+		/obj/item/ammo_box/magazine/c585trappiste_pistol/spawns_empty = 3,
 	), src)
 
 // Base yellow with symbol trappiste case

--- a/monkestation/code/modules/blueshift/items/gunset.dm
+++ b/monkestation/code/modules/blueshift/items/gunset.dm
@@ -233,7 +233,7 @@
 	. = ..()
 
 	generate_items_inside(list(
-		/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/kiboko_magfull = 1 //monke edit,
+		/obj/item/storage/toolbox/guncase/skyrat/carwo_large_case/kiboko_magfull = 1, //monke edit
 		/obj/item/storage/toolbox/guncase/skyrat/quarad_guncase = 1, //monke edit
 	), src)
 

--- a/monkestation/code/modules/blueshift/items/gunset.dm
+++ b/monkestation/code/modules/blueshift/items/gunset.dm
@@ -215,12 +215,14 @@
 	new weapon_to_spawn (src)
 
 	generate_items_inside(list(
-		/obj/item/gun/ballistic/automatic/sol_grenade_launcher/no_mag,
+		/obj/item/gun/ballistic/automatic/sol_grenade_launcher/no_mag = 1,
 		/obj/item/ammo_box/magazine/c980_grenade/starts_empty = 3,
 		/obj/item/ammo_box/c980grenade/shrapnel = 2,
 		/obj/item/ammo_box/c980grenade/smoke = 1,
 		/obj/item/ammo_box/c980grenade/riot = 2,
+		/obj/item/clothing/mask/gas/sechailer/swat = 1,
 	), src)
+
 
 /obj/structure/closet/secure_closet/armory_kiboko
 	name = "heavy equipment locker"

--- a/monkestation/code/modules/projectiles/guns/ballistic/machine_guns.dm
+++ b/monkestation/code/modules/projectiles/guns/ballistic/machine_guns.dm
@@ -94,12 +94,14 @@
 	extra_to_spawn = /obj/item/ammo_box/magazine/c65xeno_drum
 	var/extra_to_spawn2 = /obj/item/ammo_box/magazine/c65xeno_drum/pierce
 	var/extra_to_spawn3 = /obj/item/ammo_box/magazine/c65xeno_drum/incendiary
+	var/extra_to_spawn4 = /obj/item/clothing/head/helmet/toggleable/riot
 
 /obj/item/storage/toolbox/guncase/skyrat/quarad_guncase/PopulateContents()
 	new weapon_to_spawn (src)
 	new extra_to_spawn (src)
 	new extra_to_spawn2 (src)
 	new extra_to_spawn3 (src)
+	new extra_to_spawn4 (src)
 
 /obj/item/storage/toolbox/guncase/skyrat/quarad_guncase/evil   ///Currently unavailable, exists for easy testing and admeming
 	name = "\improper EVIL Quarad light machinegun storage case"


### PR DESCRIPTION
## About The Pull Request
Rechambers the Bogseo SMG back to .585 trappiste, and tweaks what spawns in the heavy weapons locker.
## Why It's Good For The Game
The Bogseo as it is before this PR is flat out WORSE than the Sol smg.
Slower fire rate. Higher recoil. Less wound bonus.

This changes it back to firing .585 trappiste, which deal 25 damage per round instead of 15.
I have NO CLUE what the hell the person who last rebalanced the Bogseo was thinking.

Stats are below, it now merely fires .585 and has -5 wound from before.
	burst_size = 2
	fire_delay = 0.5 SECONDS (1.5 seconds longer than sol smg)
	spread = 14.5 (7 higher than sol smg)
	recoil = 2 (0.5 more than the LANCA)
	projectile_wound_bonus = -5
	
Trappiste is 25 damage, -10 wound, no AP.
It WAS firing .27-54, which deals 15 damage with 15 AP and -10 wound. Sol short is 15 damage no AP *-5 wound*. 

ADDITIONALLY, this PR nerfs .585 trappiste ammunition from:
9 damage - 40 stamina damage - 10 wound
to:
9 damage - 35 stamina damage - 20 negative wound

The armory heavy weapons locker has been changed so the grenade launcher now comes in a case as well.
Additionally, the Quarad now spawns with a riot helmet, and the Kiboko a swat mask.
Both are essential to use each weapon in its intended role. (Xeno protection for the Quarad, Swat mask so you can use the tear gas.)
I believe having the heavy locker contain kits that the warden can hand out to an officer is better than a pile of guns and magazines. 
## Changelog
:cl:
balance: Bogseo has been rechambered to .585 trappiste
balance: The heavy weapons locker now has a riot helmet and SWAT mask
balance: The heavy weapons locker now has kits instead of a loose pile of ammo and guns
balance: .585 trappiste non-lethal rounds mildly nerfed
/:cl:
