### PR TITLE
Fix some antags still rolling after the emergency shuttle is past the point of no return

### DIFF
--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -17,6 +17,7 @@
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMBAT, TAG_COMMUNAL, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 //monkestation edit end
 
 /datum/round_event_control/pirates/preRunEvent()

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -58,6 +58,8 @@
 	var/can_run_post_roundstart = TRUE
 	/// If set then the type or list of types of storytellers we are restricted to being trigged by
 	var/list/allowed_storytellers
+	/// If TRUE, then this event will not roll if the emergency shuttle is past the point of no recall.
+	var/dont_spawn_near_roundend = FALSE
 	// monkestation end
 
 /datum/round_event_control/New()
@@ -99,6 +101,8 @@
 	SHOULD_CALL_PARENT(TRUE)
 // monkestation start: event groups and storyteller stuff
 	if(SSgamemode.current_storyteller?.disable_distribution || SSgamemode.halted_storyteller)
+		return FALSE
+	if(dont_spawn_near_roundend && EMERGENCY_PAST_POINT_OF_NO_RETURN)
 		return FALSE
 	if(event_group && !GLOB.event_groups[event_group].can_run())
 		return FALSE

--- a/code/modules/events/ghost_role/blob.dm
+++ b/code/modules/events/ghost_role/blob.dm
@@ -9,12 +9,6 @@
 	category = EVENT_CATEGORY_ENTITIES
 	description = "Spawns a new blob overmind."
 
-/datum/round_event_control/blob/can_spawn_event(players, allow_magic = FALSE, fake_check = FALSE) //MONKESTATION ADDITION: fake_check = FALSE
-	if(EMERGENCY_PAST_POINT_OF_NO_RETURN) // no blobs if the shuttle is past the point of no return
-		return FALSE
-
-	return ..()
-
 /datum/round_event/ghost_role/blob
 	announce_chance = 0
 	role_name = "blob overmind"

--- a/monkestation/code/modules/antagonists/florida_man/florida_events.dm
+++ b/monkestation/code/modules/antagonists/florida_man/florida_events.dm
@@ -6,6 +6,7 @@
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event/ghost_role/florida_man
 	minimum_required = 1

--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/ghost_role.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/ghost_role.dm
@@ -6,6 +6,7 @@
 	track = EVENT_TRACK_MODERATE
 	tags = list(TAG_SPOOKY, TAG_COMBAT, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event/ghost_role/slasher
 	minimum_required = 1

--- a/monkestation/code/modules/events/ghost_role/drifting_contractor.dm
+++ b/monkestation/code/modules/events/ghost_role/drifting_contractor.dm
@@ -10,6 +10,7 @@
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_OUTSIDER_ANTAG, TAG_SPACE, TAG_COMBAT)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event/ghost_role/contractor
 	minimum_required = 1

--- a/monkestation/code/modules/storytellers/converted_events/_base_event.dm
+++ b/monkestation/code/modules/storytellers/converted_events/_base_event.dm
@@ -64,6 +64,7 @@
 /datum/round_event_control/antagonist
 	checks_antag_cap = TRUE
 	track = EVENT_TRACK_ROLESET
+	dont_spawn_near_roundend = TRUE
 	///list of required roles, needed for this to form
 	var/list/exclusive_roles
 	/// Protected roles from the antag roll. People will not get those roles if a config is enabled
@@ -124,8 +125,6 @@
 	. = ..()
 	if(!.)
 		return
-	if(EMERGENCY_PAST_POINT_OF_NO_RETURN)
-		return FALSE
 	if(!check_required())
 		return FALSE
 

--- a/monkestation/code/modules/storytellers/converted_events/event_overrides.dm
+++ b/monkestation/code/modules/storytellers/converted_events/event_overrides.dm
@@ -2,6 +2,7 @@
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_TARGETED, TAG_SPOOKY, TAG_EXTERNAL, TAG_ALIEN, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/anomaly
 	track = EVENT_TRACK_MODERATE
@@ -12,6 +13,7 @@
 	track = EVENT_TRACK_ROLESET
 	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_EXTERNAL, TAG_ALIEN, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/aurora_caelus
 	track = EVENT_TRACK_MUNDANE
@@ -21,6 +23,7 @@
 	track = EVENT_TRACK_ROLESET
 	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_EXTERNAL, TAG_ALIEN, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/brain_trauma
 	track = EVENT_TRACK_MUNDANE
@@ -50,6 +53,7 @@
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMBAT, TAG_SPACE, TAG_EXTERNAL, TAG_ALIEN, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/communications_blackout
 	max_occurrences = 2
@@ -81,6 +85,7 @@
 /datum/round_event_control/fugitives
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMBAT, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/gravity_generator_blackout
 	track = EVENT_TRACK_MODERATE
@@ -129,11 +134,13 @@
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_EXTERNAL, TAG_ALIEN, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/nightmare
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_EXTERNAL, TAG_ALIEN, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/obsessed
 	weight = 0 // use storyteller variants instead
@@ -165,6 +172,7 @@
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_DESTRUCTIVE, TAG_SPOOKY, TAG_EXTERNAL, TAG_MAGICAL, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/sandstorm
 	track = EVENT_TRACK_MODERATE
@@ -188,11 +196,13 @@
 /datum/round_event_control/sentience
 	track = EVENT_TRACK_MUNDANE
 	tags = list(TAG_COMMUNAL, TAG_SPOOKY, TAG_MAGICAL)
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/sentient_disease
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_EXTERNAL, TAG_ALIEN, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/shuttle_catastrophe
 	track = EVENT_TRACK_MODERATE
@@ -206,6 +216,7 @@
 	track = EVENT_TRACK_MAJOR
 	tags = list(TAG_COMBAT, TAG_SPOOKY, TAG_EXTERNAL, TAG_MAGICAL, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/space_dust
 	track = EVENT_TRACK_MUNDANE
@@ -215,11 +226,13 @@
 	track = EVENT_TRACK_ROLESET
 	tags = list(TAG_COMBAT, TAG_SPACE, TAG_EXTERNAL, TAG_ALIEN, TAG_MAGICAL, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/space_ninja
 	track = EVENT_TRACK_ROLESET
 	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/spacevine
 	track = EVENT_TRACK_MAJOR
@@ -231,6 +244,7 @@
 	track = EVENT_TRACK_ROLESET
 	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_EXTERNAL, TAG_ALIEN, TAG_OUTSIDER_ANTAG)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/stray_cargo
 	track = EVENT_TRACK_MUNDANE

--- a/monkestation/code/modules/storytellers/converted_events/solo/ghosts/teratoma.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/ghosts/teratoma.dm
@@ -10,6 +10,7 @@
 	weight = 5
 	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_OUTSIDER_ANTAG, TAG_EXTERNAL, TAG_ALIEN)
 	checks_antag_cap = TRUE
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event/ghost_role/teratoma
 	minimum_required = 1

--- a/monkestation/code/modules/virology/disease/plague_rat/event.dm
+++ b/monkestation/code/modules/virology/disease/plague_rat/event.dm
@@ -12,6 +12,7 @@
 	min_wizard_trigger_potency = 6
 	max_wizard_trigger_potency = 7
 	tags = list(TAG_OUTSIDER_ANTAG, TAG_COMMUNAL, TAG_COMBAT, TAG_ALIEN)
+	dont_spawn_near_roundend = TRUE
 
 /datum/round_event/ghost_role/plague_rat
 	minimum_required = 1


### PR DESCRIPTION

## About The Pull Request

self-explanatory

i refactored it into a `dont_spawn_near_roundend` var on `/datum/round_event_control`

## Changelog
:cl:
fix: Fixed some antags still rolling after the emergency shuttle is past the point of no return.
/:cl:
