### PR TITLE
Roundremoving bitrunners... Is a bad thing

### DIFF
--- a/_maps/virtual_domains/psyker_shuffle.dmm
+++ b/_maps/virtual_domains/psyker_shuffle.dmm
@@ -72,7 +72,7 @@
 /turf/open/indestructible/dark,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "s" = (
-/mob/living/basic/mimic/crate/crate,
+/mob/living/basic/mimic/crate,
 /turf/open/indestructible/dark,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "t" = (

--- a/_maps/virtual_domains/psyker_shuffle.dmm
+++ b/_maps/virtual_domains/psyker_shuffle.dmm
@@ -9,9 +9,11 @@
 /area/ruin/space/has_grav/powered/virtual_domain)
 "e" = (
 /obj/item/gun/ballistic/shotgun/lethal,
+/obj/structure/closet/crate/preopen,
 /turf/open/indestructible/dark,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "h" = (
+/obj/structure/closet/crate/preopen,
 /obj/item/gun/ballistic/automatic/mini_uzi,
 /obj/item/gun/ballistic/revolver{
 	pixel_x = 2;
@@ -69,6 +71,10 @@
 /mob/living/basic/mimic/crate,
 /turf/open/indestructible/dark,
 /area/ruin/space/has_grav/powered/virtual_domain)
+"s" = (
+/mob/living/basic/mimic/crate/crate,
+/turf/open/indestructible/dark,
+/area/ruin/space/has_grav/powered/virtual_domain)
 "t" = (
 /turf/template_noop,
 /area/virtual_domain/safehouse)
@@ -79,6 +85,7 @@
 "x" = (
 /obj/item/gun/ballistic/shotgun/lethal,
 /obj/item/gun/ballistic/revolver/mateba,
+/obj/structure/closet/crate/preopen,
 /turf/open/indestructible/dark,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "B" = (
@@ -131,6 +138,7 @@
 /area/virtual_domain/safehouse)
 "X" = (
 /obj/item/gun/ballistic/shotgun/lethal,
+/obj/structure/closet/crate/preopen,
 /obj/projectile/bullet/shotgun_frag12,
 /obj/projectile/bullet/shotgun_frag12,
 /obj/projectile/bullet/shotgun_frag12,
@@ -873,7 +881,7 @@ Y
 Q
 Q
 Q
-Q
+s
 M
 Q
 Q
@@ -911,7 +919,7 @@ Q
 F
 Q
 Y
-Q
+s
 Q
 Q
 a
@@ -984,11 +992,11 @@ o
 Y
 a
 Q
-Q
+s
 Y
 Y
 Y
-Q
+s
 Q
 Q
 Q

--- a/_maps/virtual_domains/psyker_shuffle.dmm
+++ b/_maps/virtual_domains/psyker_shuffle.dmm
@@ -9,11 +9,9 @@
 /area/ruin/space/has_grav/powered/virtual_domain)
 "e" = (
 /obj/item/gun/ballistic/shotgun/lethal,
-/obj/structure/closet/crate/preopen,
 /turf/open/indestructible/dark,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "h" = (
-/obj/structure/closet/crate/preopen,
 /obj/item/gun/ballistic/automatic/mini_uzi,
 /obj/item/gun/ballistic/revolver{
 	pixel_x = 2;
@@ -71,10 +69,6 @@
 /mob/living/basic/mimic/crate,
 /turf/open/indestructible/dark,
 /area/ruin/space/has_grav/powered/virtual_domain)
-"s" = (
-/mob/living/basic/mimic/crate/crate,
-/turf/open/indestructible/dark,
-/area/ruin/space/has_grav/powered/virtual_domain)
 "t" = (
 /turf/template_noop,
 /area/virtual_domain/safehouse)
@@ -85,7 +79,6 @@
 "x" = (
 /obj/item/gun/ballistic/shotgun/lethal,
 /obj/item/gun/ballistic/revolver/mateba,
-/obj/structure/closet/crate/preopen,
 /turf/open/indestructible/dark,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "B" = (
@@ -138,7 +131,6 @@
 /area/virtual_domain/safehouse)
 "X" = (
 /obj/item/gun/ballistic/shotgun/lethal,
-/obj/structure/closet/crate/preopen,
 /obj/projectile/bullet/shotgun_frag12,
 /obj/projectile/bullet/shotgun_frag12,
 /obj/projectile/bullet/shotgun_frag12,
@@ -881,7 +873,7 @@ Y
 Q
 Q
 Q
-s
+Q
 M
 Q
 Q
@@ -919,7 +911,7 @@ Q
 F
 Q
 Y
-s
+Q
 Q
 Q
 a
@@ -992,11 +984,11 @@ o
 Y
 a
 Q
-s
+Q
 Y
 Y
 Y
-s
+Q
 Q
 Q
 Q

--- a/_maps/virtual_domains/psyker_zombies.dmm
+++ b/_maps/virtual_domains/psyker_zombies.dmm
@@ -9,7 +9,7 @@
 /area/ruin/space/has_grav/powered/virtual_domain)
 "c" = (
 /obj/structure/sign/warning/directional/west,
-/turf/open/chasm/lavaland,
+/turf/open/lava/smooth,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "h" = (
 /obj/structure/rack,
@@ -17,7 +17,7 @@
 /area/ruin/space/has_grav/powered/virtual_domain)
 "i" = (
 /obj/structure/sign/warning/directional/east,
-/turf/open/chasm/lavaland,
+/turf/open/lava/smooth,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "o" = (
 /turf/template_noop,
@@ -73,7 +73,7 @@
 /turf/template_noop,
 /area/virtual_domain/safehouse)
 "Q" = (
-/turf/open/chasm/lavaland,
+/turf/open/lava/smooth,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "R" = (
 /obj/effect/mine/explosive/light,

--- a/_maps/virtual_domains/psyker_zombies.dmm
+++ b/_maps/virtual_domains/psyker_zombies.dmm
@@ -9,7 +9,7 @@
 /area/ruin/space/has_grav/powered/virtual_domain)
 "c" = (
 /obj/structure/sign/warning/directional/west,
-/turf/open/lava/smooth,
+/turf/open/chasm/lavaland,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "h" = (
 /obj/structure/rack,
@@ -17,7 +17,7 @@
 /area/ruin/space/has_grav/powered/virtual_domain)
 "i" = (
 /obj/structure/sign/warning/directional/east,
-/turf/open/lava/smooth,
+/turf/open/chasm/lavaland,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "o" = (
 /turf/template_noop,
@@ -73,7 +73,7 @@
 /turf/template_noop,
 /area/virtual_domain/safehouse)
 "Q" = (
-/turf/open/lava/smooth,
+/turf/open/chasm/lavaland,
 /area/ruin/space/has_grav/powered/virtual_domain)
 "R" = (
 /obj/effect/mine/explosive/light,

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -132,6 +132,10 @@
 		. += lid
 	. += ..()
 
+/obj/structure/closet/crate/preopen
+	opened = TRUE
+	icon_state = "crateopen"
+
 /obj/structure/closet/crate/coffin
 	name = "coffin"
 	desc = "It's a burial receptacle for the dearly departed."


### PR DESCRIPTION
## About The Pull Request
Fixes up both of the bitrunning physker levels
For zombies

Chasms and bitrunning do not play nice
I do not know how to fix it but I know how to map.
So chasms are replaced with lava.  Closes:#6281 Not fixed

For physkers we had some crate/mimic types that just don't exist. So tried to clean those up
## Why It's Good For The Game
Won't this ruin the aesthetic?
Its a Psyker level. If you can see, you'd appreciate being able to see anything. Ugly or not
## Changelog
:cl:
fix: Psyker Zombie no longer has round removing chasms.
fix: Psyker shuffle has more appriopate totally real crates and preopened ones.
/:cl:
