### PR TITLE
Logging QoL - Reagent Explosions, Mech Weaponry, etc is now bomber-logged

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -324,6 +324,10 @@ SUBSYSTEM_DEF(explosions)
 	var/who_did_it = "N/A"
 	var/who_did_it_game_log = "N/A"
 
+	//monkestation edit start
+	var/mob/bomber_log_person = null // I hate this. log_bomber does not take names, it takes the mob as an input.
+	//monkestation edit end
+
 	// Projectiles have special handling. They rely on a firer var and not fingerprints. Check special cases for firer being
 	// mecha, mob or an object such as the gun itself. Handle each uniquely.
 	if(isprojectile(explosion_cause))
@@ -337,14 +341,17 @@ SUBSYSTEM_DEF(explosions)
 				for(var/mob/driver in drivers)
 					who_did_it += " [ADMIN_LOOKUPFLW(driver)]"
 					who_did_it_game_log = " [key_name(driver)]"
+					bomber_log_person = driver
 				who_did_it += "\]"
 				who_did_it_game_log += "\]"
 		else if(ismob(fired_projectile.firer))
 			who_did_it = "\[Projectile firer: [ADMIN_LOOKUPFLW(fired_projectile.firer)]\]"
 			who_did_it_game_log = "\[Projectile firer: [key_name(fired_projectile.firer)]\]"
+			bomber_log_person = fired_projectile.firer
 		else
 			who_did_it = "\[Projectile firer: [ADMIN_LOOKUPFLW(fired_projectile.firer.fingerprintslast)]\]"
 			who_did_it_game_log = "\[Projectile firer: [key_name(fired_projectile.firer.fingerprintslast)]\]"
+			bomber_log_person = fired_projectile.firer.fingerprintslast
 	// Otherwise if the explosion cause is an atom, try get the fingerprints.
 	else if(istype(explosion_cause))
 		who_did_it = ADMIN_LOOKUPFLW(explosion_cause.fingerprintslast)
@@ -356,6 +363,8 @@ SUBSYSTEM_DEF(explosions)
 	//monkestation edit start
 		deadchat_broadcast("Explosion with size: Devast: [devastation_range], Heavy: [heavy_impact_range], Light: [light_impact_range], Flame: [flame_range].", \
 						turf_target = epicenter, message_type = DEADCHAT_ANNOUNCEMENT)
+		if(bomber_log_person)
+			log_bomber(bomber_log_person, "Explosion with size (Devast: [devastation_range], Heavy: [heavy_impact_range], Light: [light_impact_range], Flame: [flame_range]) in [ADMIN_VERBOSEJMP(epicenter)]. Possible cause: [explosion_cause]. Last fingerprints: [who_did_it].")
 	//monkestation edit end
 
 	var/x0 = epicenter.x

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -301,6 +301,12 @@
 		if(!istype(holder.my_atom, /obj/machinery/plumbing)) //excludes standard plumbing equipment from spamming admins with this shit
 			message_admins("Reagent explosion reaction occurred at [ADMIN_VERBOSEJMP(T)][inside_msg]. Last Fingerprint: [touch_msg].")
 		log_game("Reagent explosion reaction occurred at [AREACOORD(T)]. Last Fingerprint: [lastkey ? lastkey : "N/A"]." )
+
+		// monkestation edit start
+		if(lastkey) // This is a sad way to do it. But a way to do it none the lesser.
+			log_bomber(get_mob_by_key(lastkey), "Reagent explosion reaction occurred at [AREACOORD(T)]. Last Fingerprint: [touch_msg] Source: [holder.my_atom]")
+		// monkestation edit end
+
 		var/datum/effect_system/reagents_explosion/e = new()
 		e.set_up(power , T, 0, 0)
 		e.start(holder.my_atom)


### PR DESCRIPTION

## About The Pull Request

Bombers List update. There isnt much to write.
## Why It's Good For The Game

Veth wanted it.
## Changelog

Bombers-List will now display reagent explosions (Gunpowder cigarettes for example), explosive weaponry, etc. 
:cl:
admin: Bombers List now logs reagent explosions, explosive ammunition, etc.
/:cl:
