### PR TITLE
Fix monster hunter UI not properly displaying objective completion

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -525,20 +525,23 @@ GLOBAL_LIST_EMPTY(cached_antag_previews)
 	SET_PLANE_EXPLICIT(hud, ABOVE_GAME_PLANE, hud_loc)
 	return hud
 
-///generic helper to send objectives as data through tgui.
-/datum/antagonist/proc/get_objectives()
+/// Generic helper to send objectives as data through tgui.
+///
+/// If the `full_checks` argument is true,
+/// then it will use the objective's `check_completion` proc instead of the `completed` var
+/// to check to see if the objective is complete.
+/datum/antagonist/proc/get_objectives(full_checks = FALSE)
+	. = list()
 	var/objective_count = 1
-	var/list/objective_data = list()
 	//all obj
 	for(var/datum/objective/objective in objectives)
-		objective_data += list(list(
+		. += list(list(
 			"count" = objective_count,
 			"name" = objective.objective_name,
 			"explanation" = objective.explanation_text,
-			"complete" = objective.completed,
+			"complete" = full_checks ? objective.check_completion() : objective.completed,
 		))
 		objective_count++
-	return objective_data
 
 /// Used to create objectives for the antagonist.
 /datum/antagonist/proc/forge_objectives()

--- a/code/modules/antagonists/monster_hunters/hunter_datum.dm
+++ b/code/modules/antagonists/monster_hunters/hunter_datum.dm
@@ -139,6 +139,7 @@
 		"rabbits_remaining" = length(rabbits),
 		"all_completed" = completed,
 		"apocalypse" = apocalypse,
+		"objectives" = get_objectives(full_checks = TRUE),
 	)
 
 /datum/antagonist/monsterhunter/ui_static_data(mob/user)
@@ -151,10 +152,7 @@
 			"icon" = trick_weapon::icon,
 			"icon_state" = trick_weapon::icon_state_preview || trick_weapon::icon_state,
 		))
-	return list(
-		"objectives" = get_objectives(),
-		"weapons" = weapons,
-	)
+	return list("weapons" = weapons)
 
 /datum/antagonist/monsterhunter/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

so when refactoring this UI, I didn't realize that `/datum/antagonist/proc/get_objectives()` only checks the `objective.completed` var, rather than `objective.check_completion()`

I've added a `full_checks` argument to `get_objectives`, which will use `objective.check_completion()` instead of the var `objective.completed`, and used this for the MH UI - moving objectives from `ui_static_data` to `ui_data` as a result.

## Changelog
:cl:
fix: Fixed the Monster Hunter UI always showing a red X next to objectives, regardless of if they are actually completed or not.
/:cl:
