### PR TITLE
Prevent bloodsuckers and IPCs from being cloned

### DIFF
--- a/monkestation/code/game/machinery/cloning.dm
+++ b/monkestation/code/game/machinery/cloning.dm
@@ -137,9 +137,13 @@
 		return NONE
 	if(mess || attempting)
 		return NONE
+	if(!isnull(mrace) && (mrace::inherent_biotypes & MOB_ROBOTIC)) // no cloning IPCs
+		return NONE
 	if(!empty) //Doesn't matter if we're just making a copy
 		clonemind = locate(mindref) in SSticker.minds
 		if(!istype(clonemind))	//not a mind
+			return NONE
+		if(clonemind.has_antag_datum(/datum/antagonist/bloodsucker)) // no cloning bloodsuckers.
 			return NONE
 		if(!QDELETED(clonemind.current))
 			if(clonemind.current.stat != DEAD)	//mind is associated with a non-dead body

--- a/monkestation/code/game/machinery/computer/cloning.dm
+++ b/monkestation/code/game/machinery/computer/cloning.dm
@@ -538,6 +538,10 @@
 
 	if(isbrain(mob_occupant))
 		dna = B.stored_dna
+	if((mob_occupant.mob_biotypes & MOB_ROBOTIC) || (dna?.species?.inherent_biotypes & MOB_ROBOTIC))
+		scantemp = "<font class='bad'>Unable to locate valid genetic data.</font>"
+		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
+		return
 	if(!body_only && HAS_TRAIT(mob_occupant, TRAIT_SUICIDED))
 		scantemp = "<font class='bad'>Subject's brain is not responding to scanning stimuli.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
@@ -86,6 +86,7 @@
 	/// Traits that don't get removed by Masquerade
 	var/static/list/always_traits = list(
 		TRAIT_NO_MINDSWAP, // mindswapping bloodsuckers is buggy af and I'm too lazy to properly fix it. ~Absolucy
+		TRAIT_NO_DNA_COPY, // no, you can't cheat your curse with a cloner.
 	)
 	///Default Bloodsucker traits
 	var/static/list/bloodsucker_traits = list(


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/4933

This prevents IPCs, androids, and bloodsuckers from being clone scanned or cloned.

By extension, this ALSO fixes an exploit/oversight (unsure which) where a bloodsucker could give a changeling infinite free absorbs using Veil of Many Faces.

## Why It's Good For The Game

none of these are supposed to be cloneable (and Dexee said that cloning bloodsuckers is considered an exploit), so let's fix that.

## Changelog
:cl:
fix: IPCs, androids, and bloodsuckers can no longer be cloned.
fix: Bloodsuckers can no longer give changelings infinite free absorbs using Veil of Many Faces.
/:cl:
