### PR TITLE
Adds another wheelchair sitting point to the nova arrivals shuttle

### DIFF
--- a/_maps/shuttles/nova/arrival_nova.dmm
+++ b/_maps/shuttles/nova/arrival_nova.dmm
@@ -6,7 +6,9 @@
 /area/shuttle/arrival)
 "b" = (
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron/shuttle/arrivals,
+/turf/open/floor/iron/shuttle/arrivals{
+	icon_state = "sign_3"
+	},
 /area/shuttle/arrival)
 "c" = (
 /obj/structure/chair/sofa/bench/right{


### PR DESCRIPTION

## About The Pull Request

we dont have the interlink so there's no arrivals shuttle computer so there's always been that empty space there nobody makes use of, so im just gonna put a wheelchair spot on it

## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/857108ef-92f6-44fa-baac-48bd255c1357)
more support for disabled people

## Changelog
:cl:
add: An additional wheelchair marker has been added to the Nova arrivals shuttle (used on Blueshift and Voidraptor)
/:cl:
