### PR TITLE
Coffins now protect bloodsuckers from temperature and pressure, to prevent infinite torpor softlocks

### DIFF
--- a/code/__DEFINES/traits/monkestation/sources.dm
+++ b/code/__DEFINES/traits/monkestation/sources.dm
@@ -22,6 +22,8 @@
 #define BLOODSUCKER_TRAIT "bloodsucker_trait"
 /// Source trait for bloodsuckers in torpor.
 #define TORPOR_TRAIT "torpor_trait"
+/// Source trait for stuff related to bloodsuckers in coffins.
+#define BLOODSUCKER_COFFIN_TRAIT "bloodsucker_coffin_trait"
 /// Source trait for bloodsuckers using fortitude.
 #define FORTITUDE_TRAIT "fortitude_trait"
 /// Source trait for bloodsucker mesmerization.

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
@@ -86,9 +86,12 @@
 		return FALSE
 	if(!in_torpor && (HAS_TRAIT(owner.current, TRAIT_MASQUERADE) || owner.current.has_status_effect(/datum/status_effect/bloodsucker_sol)))
 		return FALSE
+	var/in_coffin = istype(owner.current.loc, /obj/structure/closet/crate/coffin)
 	var/actual_regen = bloodsucker_regen_rate + additional_regen
 	owner.current.adjustCloneLoss(-1 * (actual_regen * 4) * mult)
 	owner.current.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1 * (actual_regen * 4) * mult) //adjustBrainLoss(-1 * (actual_regen * 4) * mult, 0)
+	if(in_coffin && in_torpor) // if we're in a coffin, in torpor, stabilize our body temperature.
+		owner.current.update_homeostasis_level(type, owner.current.standard_body_temperature, 10 KELVIN)
 	if(!iscarbon(owner.current)) // Damage Heal: Do I have damage to ANY bodypart?
 		return
 	var/mob/living/carbon/user = owner.current
@@ -99,7 +102,7 @@
 	if (blood_over_cap > 0)
 		costMult += round(blood_over_cap / 1000, 0.1) // effectively 1 (normal) + 0.1 for every 100 blood you are over cap
 	if(in_torpor)
-		if(istype(user.loc, /obj/structure/closet/crate/coffin))
+		if(in_coffin)
 			if(HAS_TRAIT(owner.current, TRAIT_MASQUERADE) && (COOLDOWN_FINISHED(src, bloodsucker_spam_healing)))
 				to_chat(user, span_alert("You do not heal while your Masquerade ability is active."))
 				COOLDOWN_START(src, bloodsucker_spam_healing, BLOODSUCKER_SPAM_MASQUERADE)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/6378

This makes it so bloodsuckers in a coffin will gain temperature + pressure immunity, as a simple workaround to the softlock described in the issue linked above.

The bloodsucker loses those immunities as soon as they exit the coffin, so they'll still have to deal with how to get out of such a situation, but they won't be stuck in torpor infinitely healing while being damaged by the heat anymore.

I would like to clarify, this does **not** prevent the coffin itself from being destroyed by a plasma fire, which would ofc drop the bloodsucker out, removing the temperature/pressure protection it gave them.

In addition, being in torpor while in a coffin will rapidly stabilize their body temperature, adding further safeguards against such issues - altho I guess that is somewhat of a balance change, but it's also kind of a fix/safeguard? I don't know. I'm marking it as balance just to be safe.

## Why It's Good For The Game

softlocks aren't fun for players.

## Changelog
:cl:
fix: Coffins now protect bloodsuckers from temperature and heat, preventing a potential softlock from being stuck infinitely healing while being damaged, if your coffin was in a superheated room or something.
balance: Bloodsuckers in torpor while in a coffin will now have their body temperature rapidly stabilized.
/:cl:
