### PR TITLE
Fix the Teratoma Syndrome symptom not working

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/harmful/teratoma.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/harmful/teratoma.dm
@@ -7,27 +7,56 @@
 	COOLDOWN_DECLARE(organ_cooldown)
 
 /datum/symptom/teratoma/activate(mob/living/carbon/mob)
-	if(!COOLDOWN_FINISHED(src, organ_cooldown))
+	if(ismouse(mob))
+		var/mob/living/basic/mouse/mouse = mob
+		mouse.splat() //tumors are bad for you, tumors equal to your body in size doubley so
+		return
+	if(!iscarbon(mob) || !COOLDOWN_FINISHED(src, organ_cooldown))
 		return
 	COOLDOWN_START(src, organ_cooldown, 2 MINUTES)
-	var/fail_counter = 0
-	var/not_passed = TRUE
-	var/obj/item/organ/spawned_organ
-	while(not_passed && fail_counter <= 10)
-		var/organ_type = pick(mob?.organs)
-		spawned_organ = new organ_type(get_turf(mob))
-		if(spawned_organ.status != ORGAN_ORGANIC)
-			qdel(spawned_organ)
-			fail_counter++
-			continue
-		not_passed = FALSE
 
-	if(!not_passed)
-		if(ismouse(mob))
-			var/mob/living/basic/mouse/mouse = mob
-			mouse.splat() //tumors are bad for you, tumors equal to your body in size doubley so
-		if(ismonkey(mob)) //monkeys are smaller and thus have less space for human-organ sized tumors
-			mob.adjustBruteLoss(15)
-		if(mob.bruteloss <= 50)
-			mob.adjustBruteLoss(5)
-		mob.visible_message(span_warning("\A [spawned_organ.name] is extruded from \the [mob]'s body and falls to the ground!"),span_warning("\A [spawned_organ.name] is extruded from your body and falls to the ground!"))
+	var/list/eligible_organs = get_eligible_organs(mob)
+	if(!length(eligible_organs))
+		return
+	var/organ_type = pick(eligible_organs)
+	var/obj/item/organ/spawned_organ = new organ_type(mob.drop_location())
+
+	var/damage = 0
+	if(ismonkey(mob)) //monkeys are smaller and thus have less space for human-organ sized tumors
+		damage += 15
+	if(mob.getBruteLoss() <= 50)
+		damage += 5
+	if(damage > 0)
+		mob.take_overall_damage(brute = damage)
+	mob.visible_message(
+		span_warning("\A [spawned_organ] is extruded from \the [mob]'s body and falls to the ground!"),
+		span_warning("\A [spawned_organ] is extruded from your body and falls to the ground!")
+	)
+
+/datum/symptom/teratoma/proc/get_eligible_organs(mob/living/carbon/target)
+	// blacklist, mostly for jank organs that shouldn't exist on their own
+	var/static/list/blacklisted_organs
+	if(isnull(blacklisted_organs))
+		blacklisted_organs = typecacheof(list(
+			/obj/item/organ/external/anime_bottom,
+			/obj/item/organ/external/anime_head,
+			/obj/item/organ/external/anime_middle,
+			/obj/item/organ/external/floran_leaves,
+			/obj/item/organ/internal/body_egg,
+			/obj/item/organ/internal/borer_body,
+			/obj/item/organ/internal/empowered_borer_egg,
+			// these are just for the parent types specifically, we allow subtypes of these, just like bioscramblers
+			/obj/item/organ/external/wings,
+			/obj/item/organ/external/wings/functional,
+		)) - subtypesof(/obj/item/organ/external/wings/functional) - typesof(/obj/item/organ/external/wings/moth)
+
+	. = list()
+	if(!iscarbon(target))
+		return
+	for(var/obj/item/organ/organ in target.organs)
+		if(is_type_in_typecache(organ, blacklisted_organs))
+			continue
+		if(organ.organ_flags & ORGAN_SYNTHETIC)
+			continue
+		. |= organ.type
+

--- a/monkestation/code/modules/virology/disease/symtoms/harmful/teratoma.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/harmful/teratoma.dm
@@ -42,13 +42,15 @@
 			/obj/item/organ/external/anime_head,
 			/obj/item/organ/external/anime_middle,
 			/obj/item/organ/external/floran_leaves,
+			/obj/item/organ/external/wings,
+			/obj/item/organ/external/wings/functional,
 			/obj/item/organ/internal/body_egg,
 			/obj/item/organ/internal/borer_body,
 			/obj/item/organ/internal/empowered_borer_egg,
-			// these are just for the parent types specifically, we allow subtypes of these, just like bioscramblers
-			/obj/item/organ/external/wings,
-			/obj/item/organ/external/wings/functional,
-		)) - subtypesof(/obj/item/organ/external/wings/functional) - typesof(/obj/item/organ/external/wings/moth)
+		))
+		// we only want to blacklist the "parent" wing types, which should not exist on their own - the bioscrambler blacklist does the same thing.
+		blacklisted_organs -= subtypesof(/obj/item/organ/external/wings/functional)
+		blacklisted_organs -= typesof(/obj/item/organ/external/wings/moth)
 
 	. = list()
 	if(!iscarbon(target))


### PR DESCRIPTION

## About The Pull Request

Teratoma Syndrome is supposed to result in duplicates of the mob's organs being spit out. But it tried to create them using an _instance_ of the organ, rather than the actual type, which just runtimed instead of doing anything.

This fixes that, and I also cleaned up the code a bit, plus added a blacklist to stop "jank" organs that shouldn't exist on their own from being duplicated.

## Why It's Good For The Game

things working is nice

## Changelog
:cl:
fix: Fix the Teratoma Syndrome symptom not working.
/:cl:
