### PR TITLE
Adds artifact zapper board to research and printers. Also vatgrown queen bee fix.

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -1157,6 +1157,16 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING //Monkestation edit: Engi circuit
 
+/datum/design/board/artifact_zapper
+	name = "Artifact Zapper Board"
+	desc = "The circuit board for a machine designed to induce electric current in artifacts"
+	id = "artifact_zapper"
+	build_path = /obj/item/circuitboard/machine/artifactzapper
+	category = list(
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_RESEARCH
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING //Monkestation edit: Engi circuit
+
 /datum/design/board/fishing_portal_generator
 	name = "Fishing Portal Generator Board"
 	desc = "The circuit board for the fishing portal generator"

--- a/code/modules/research/techweb/research_nodes.dm
+++ b/code/modules/research/techweb/research_nodes.dm
@@ -118,11 +118,12 @@
 /datum/techweb_node/artifact
 	id = "artifact_research"
 	display_name = "Artifact Research"
-	description = "Properly concuct research on the various artifacts found around."
+	description = "Properly conduct research on the various artifacts found around."
 	prereq_ids = list("base")
 	design_ids = list(
 		"artifact_heater",
 		"artifact_xray",
+		"artifact_zapper",
 		"disk_artifact",
 		"artifact_wand"
 	)

--- a/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
+++ b/code/modules/research/xenobiology/vatgrowing/samples/cell_lines/common.dm
@@ -654,7 +654,7 @@
 		/datum/reagent/drug/nicotine = -1)
 
 	virus_suspectibility = 0
-	resulting_atoms = list(/obj/item/queen_bee = 1)
+	resulting_atoms = list(/obj/item/queen_bee/bought = 1)
 
 /datum/micro_organism/cell_line/queen_bee/fuck_up_growing(obj/machinery/plumbing/growing_vat/vat) //we love job hazards
 	vat.visible_message(span_warning("You hear angry buzzing coming from the inside of the vat!"))


### PR DESCRIPTION

## About The Pull Request
Adds the last artifact research machine to the node and let's you use cytology grown bees in apiaries.
## Why It's Good For The Game
Science can now fully rebuild their lab after blowing it up.
## Changelog
:cl: EssentialTomato
add: Added the ability to research and print artifact zapper boards
fix: Vatgrown queen bees can now be used in the apiary
/:cl:
