### PR TITLE
[PORT] Fax checks contents for blacklists

### DIFF
--- a/code/modules/paperwork/fax.dm
+++ b/code/modules/paperwork/fax.dm
@@ -217,11 +217,11 @@ GLOBAL_VAR_INIT(nt_fax_department, pick("NT HR Department", "NT Legal Department
  * This list expands if you snip a particular wire.
  */
 /obj/machinery/fax/proc/is_allowed_type(obj/item/item)
-	if (is_type_in_list(item, allowed_types))
-		return TRUE
-	if (!allow_exotic_faxes)
-		return FALSE
-	return is_type_in_list(item, exotic_types)
+	var/list/checked_list = allow_exotic_faxes ? (allowed_types | exotic_types) : allowed_types
+	for(var/atom/movable/thing in item.get_all_contents())
+		if(!is_type_in_list(thing, checked_list))
+			return FALSE
+	return TRUE
 
 /obj/machinery/fax/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION

## About The Pull Request
Ports [#90649](https://github.com/tgstation/tgstation/pull/90649) from TG
When checking for "can we fax this item", the item (and all its contents (recursively)) are checked if they are fax-able as well
## Why It's Good For The Game
The end of an era of teleporter-like faxes
## Changelog
🆑 Melbert
fix: You can't fax unfaxable things by putting them in faxable things
/:cl:
