### PR TITLE
Protogen addition to IPCs

### DIFF
--- a/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
@@ -6,7 +6,7 @@
 #define SYNTH_APC_MINIMUM_PERCENT 20
 
 /datum/species/ipc
-	name = "\improper Integrated Positronic Chassis"
+	name = "\improper Integrated Positronic Chassis" //Your day of recogning is soon approaching. Petition to chance IPC's into Protogens.
 	id = SPECIES_IPC
 	inherent_biotypes = MOB_ROBOTIC | MOB_HUMANOID
 	sexes = TRUE


### PR DESCRIPTION
## About The Pull Request

This PR aims to add some features to IPCs to allow them to present as protogens. This would be preferable instead of adding a whole new species, since we'd essentially be re-implementing everything IPCs do, so it's better to just add it on top of IPCs.

Yes, Ook was originally against this, but that was like a year ago, and the current spess society as it is, is changing, and I'd like to appeal to at least some of it. Those who think this is ERP motivated will be swiftly axed. You're weird. 

Okay, its furry related, so what? My argument is that we have the anime trait, and we have catgirls, and doggirls, and we have oozelings. So, fuck you! :) - Chen


Notes:
- Protogen variants will have digitigrade legs similar to lizards
- Head sprites will be replaced in favor of protogen head
- There will be at least 2 different kinds of protogen heads (Sharp and curved)
- Screens will be handled similarly but they will have a different list of screens for protogen heads.

Other notes:
- Since IPCs are a modularization thing, this will likely de-modularize IPCs in the process.

References:
- https://github.com/shiptest-ss13/Shiptest/pull/2513

## Why It's Good For The Game

Species diversity is nice! Plus we (Chen and oliver) have wanted to see at least some form of protogen in the game for a while

## Changelog
🆑Flleeppyy,OliverTheOtter
fix: You can't fax unfaxable things by putting them in faxable things
/:cl: