### PR TITLE
Raises the earliest start time for Teratoma Crash to 40 minutes

### DIFF
--- a/monkestation/code/modules/storytellers/converted_events/solo/ghosts/teratoma.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/ghosts/teratoma.dm
@@ -9,6 +9,7 @@
 	track = EVENT_TRACK_MAJOR
 	weight = 5
 	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_OUTSIDER_ANTAG, TAG_EXTERNAL, TAG_ALIEN)
+	earliest_start = 40 MINUTES
 	checks_antag_cap = TRUE
 	dont_spawn_near_roundend = TRUE
 


### PR DESCRIPTION

## About The Pull Request

yeah this raises the `earliest_start` for Teratoma Crash from 20 minutes to 40 minutes. simple enough.

## Why It's Good For The Game

the 4 teratomas being podded onto the station 20 minutes into a wizard round because the storyteller decided to do a little trolling

![coming-in-hot](https://github.com/user-attachments/assets/c215c129-41cb-46b0-a6fa-5790bf0c62cd)

## Changelog
:cl:
balance: The Teratoma Crash event can only occur at least 40 minutes into the round now (up to 20 minutes)
/:cl:
