### PR TITLE
Fixes a potentially infinite research exploit

### DIFF
--- a/monkestation/code/modules/art_sci_overrides/artifact_items/artifact_manipulators.dm
+++ b/monkestation/code/modules/art_sci_overrides/artifact_items/artifact_manipulators.dm
@@ -57,6 +57,8 @@
 	var/turf/attempt_location = get_turf(get_step(user,user.dir))
 	if(attempt_location.density)
 		return
+	if(selected_mode >= 2 && selected_mode <=5)
+		return
 	visible_message(span_notice("[user] begins to summon an artifact using [src]!"),span_notice("You begin attempting to summon an artifact using [src]..."))
 	if(do_after(user,5 SECOND))
 		var/obj/new_artifact = spawn_artifact(attempt_location)

--- a/monkestation/code/modules/art_sci_overrides/artifact_items/artifact_manipulators.dm
+++ b/monkestation/code/modules/art_sci_overrides/artifact_items/artifact_manipulators.dm
@@ -57,7 +57,7 @@
 	var/turf/attempt_location = get_turf(get_step(user,user.dir))
 	if(attempt_location.density)
 		return
-	if(selected_mode >= 2 && selected_mode <=5)
+	if(ISINRANGE(selected_mode, 2, 5))
 		return
 	visible_message(span_notice("[user] begins to summon an artifact using [src]!"),span_notice("You begin attempting to summon an artifact using [src]..."))
 	if(do_after(user,5 SECOND))


### PR DESCRIPTION

## About The Pull Request
closes #5301 by making the artifact summon thing only work if you use it on non-disk modes
fixed version:

https://github.com/user-attachments/assets/517a7ece-9f31-47b4-a861-7e458a179f25
## Why It's Good For The Game
No more infinite research! 
## Changelog
:cl:
fix: fixed being able to make infinite research through faulty artifact spawners
/:cl:
