### PR TITLE
Changes Deep Storage to a syndicate blackbox - makes the self-destruct slightly less cheesable

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -247,8 +247,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "aP" = (
-/obj/effect/spawner/structure/electrified_grille,
-/turf/open/floor/plating,
+/turf/closed/wall/mineral/plastitanium/explosive,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "aQ" = (
 /turf/closed/wall/r_wall,
@@ -2666,6 +2665,10 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"kM" = (
+/obj/effect/spawner/structure/electrified_grille,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/crusher)
 "lf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/chemical,
@@ -2721,6 +2724,13 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
+"nC" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/electrified_grille,
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/structure/window/reinforced/plasma/spawner/directional/south,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/crusher)
 "on" = (
 /obj/machinery/corral_corner{
 	mapping_id = "s2"
@@ -3253,13 +3263,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"Nl" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/electrified_grille,
-/obj/structure/window/reinforced/plasma/spawner/directional/north,
-/obj/structure/window/reinforced/plasma/spawner/directional/south,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage/crusher)
 "Nw" = (
 /obj/machinery/corral_corner{
 	mapping_id = "s1"
@@ -4713,7 +4716,7 @@ Iy
 ab
 ab
 CA
-aP
+kM
 OD
 ah
 ao
@@ -4765,7 +4768,7 @@ aa
 ab
 ab
 CA
-aP
+kM
 OD
 ai
 ap
@@ -4817,7 +4820,7 @@ aa
 ab
 ab
 CA
-aP
+kM
 OD
 ai
 aq
@@ -4869,7 +4872,7 @@ ab
 ab
 ab
 CA
-aP
+kM
 OD
 ah
 ar
@@ -4921,7 +4924,7 @@ ab
 ab
 ab
 CA
-aP
+kM
 Ob
 Ob
 Ob
@@ -4973,7 +4976,7 @@ ab
 ab
 ab
 CA
-aP
+kM
 Ob
 sa
 as
@@ -5025,7 +5028,7 @@ aa
 ab
 ab
 CA
-aP
+kM
 Ob
 ak
 at
@@ -5077,12 +5080,12 @@ aa
 aa
 ab
 CA
-aP
+kM
 Ob
 al
 au
 De
-Ob
+aP
 bf
 bz
 cF
@@ -5129,8 +5132,8 @@ aa
 aa
 ab
 CA
-aP
-Nl
+kM
+nC
 am
 sQ
 aE
@@ -5181,7 +5184,7 @@ aa
 ab
 ab
 CA
-aP
+kM
 Ob
 AZ
 rz
@@ -5233,8 +5236,8 @@ aa
 ab
 ab
 CA
-aP
-aP
+kM
+kM
 Ob
 Ob
 Ob
@@ -5286,10 +5289,10 @@ ab
 ab
 CA
 CA
-aP
-aP
-aP
-aP
+kM
+kM
+kM
+kM
 aQ
 bj
 bC

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -2066,6 +2066,7 @@
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 6
 	},
+/obj/effect/turf_decal/bot_red/right,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "fR" = (
@@ -2109,6 +2110,7 @@
 "fV" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "fW" = (
@@ -2558,6 +2560,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot_white,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "ho" = (
@@ -2665,10 +2668,6 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
-"kM" = (
-/obj/effect/spawner/structure/electrified_grille,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage/crusher)
 "lf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/chemical,
@@ -2724,13 +2723,6 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
-"nC" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/electrified_grille,
-/obj/structure/window/reinforced/plasma/spawner/directional/north,
-/obj/structure/window/reinforced/plasma/spawner/directional/south,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/deepstorage/crusher)
 "on" = (
 /obj/machinery/corral_corner{
 	mapping_id = "s2"
@@ -3051,6 +3043,10 @@
 /obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
+"Bg" = (
+/obj/effect/spawner/structure/electrified_grille,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/crusher)
 "Bw" = (
 /mob/living/basic/carp/mega,
 /turf/open/misc/asteroid/airless,
@@ -3085,6 +3081,13 @@
 /obj/machinery/computer/slime_market,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"CY" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/electrified_grille,
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/structure/window/reinforced/plasma/spawner/directional/south,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/crusher)
 "CZ" = (
 /obj/machinery/plumbing/ooze_sucker{
 	mapping_id = "s1"
@@ -3536,8 +3539,9 @@
 "YY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/porta_turret/syndicate/energy{
-	dir = 8
+	dir = 9
 	},
+/obj/effect/turf_decal/bot_red/left,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "Zx" = (
@@ -4716,7 +4720,7 @@ Iy
 ab
 ab
 CA
-kM
+Bg
 OD
 ah
 ao
@@ -4768,7 +4772,7 @@ aa
 ab
 ab
 CA
-kM
+Bg
 OD
 ai
 ap
@@ -4820,7 +4824,7 @@ aa
 ab
 ab
 CA
-kM
+Bg
 OD
 ai
 aq
@@ -4872,7 +4876,7 @@ ab
 ab
 ab
 CA
-kM
+Bg
 OD
 ah
 ar
@@ -4924,7 +4928,7 @@ ab
 ab
 ab
 CA
-kM
+Bg
 Ob
 Ob
 Ob
@@ -4976,7 +4980,7 @@ ab
 ab
 ab
 CA
-kM
+Bg
 Ob
 sa
 as
@@ -5028,7 +5032,7 @@ aa
 ab
 ab
 CA
-kM
+Bg
 Ob
 ak
 at
@@ -5080,7 +5084,7 @@ aa
 aa
 ab
 CA
-kM
+Bg
 Ob
 al
 au
@@ -5132,8 +5136,8 @@ aa
 aa
 ab
 CA
-kM
-nC
+Bg
+CY
 am
 sQ
 aE
@@ -5184,7 +5188,7 @@ aa
 ab
 ab
 CA
-kM
+Bg
 Ob
 AZ
 rz
@@ -5236,8 +5240,8 @@ aa
 ab
 ab
 CA
-kM
-kM
+Bg
+Bg
 Ob
 Ob
 Ob
@@ -5289,10 +5293,10 @@ ab
 ab
 CA
 CA
-kM
-kM
-kM
-kM
+Bg
+Bg
+Bg
+Bg
 aQ
 bj
 bC

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -40,6 +40,7 @@
 /obj/effect/turf_decal/stripes/red/corner{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "an" = (
@@ -75,6 +76,9 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/emergency,
 /obj/structure/sign/warning/explosives/alt/directional/west,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "at" = (
@@ -112,6 +116,9 @@
 "aB" = (
 /obj/structure/table,
 /obj/item/folder/syndicate/red,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "aC" = (
@@ -236,18 +243,12 @@
 /obj/machinery/door/airlock/highsecurity{
 	name = "Self-Destruct"
 	},
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "aP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/highsecurity{
-	name = "Self-Destruct"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/electrified_grille,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "aQ" = (
 /turf/closed/wall/r_wall,
@@ -377,6 +378,15 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/turretid{
+	control_area = "/area/ruin/space/has_grav/deepstorage/crusher";
+	dir = 1;
+	icon_state = "control_kill";
+	lethal = 1;
+	name = "self-destruct turret controls";
+	pixel_y = 30;
+	req_access = list("syndicate")
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "bg" = (
@@ -2475,7 +2485,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "hb" = (
-/obj/machinery/blackbox_recorder,
+/obj/machinery/syndicate_blackbox_recorder,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "hc" = (
@@ -2773,8 +2783,10 @@
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "rz" = (
-/obj/structure/filingcabinet,
-/obj/item/folder/syndicate/mining,
+/obj/machinery/porta_turret/syndicate/energy{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot_red/left,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "rD" = (
@@ -2786,7 +2798,11 @@
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "sa" = (
-/turf/closed/wall,
+/obj/structure/table,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "sx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -2808,6 +2824,7 @@
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 8
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "tk" = (
@@ -3019,6 +3036,9 @@
 /turf/closed/wall/r_wall/syndicate,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "Bb" = (
+/obj/structure/filingcabinet,
+/obj/item/folder/syndicate/mining,
+/obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/deepstorage/crusher)
 "Bw" = (
@@ -3233,6 +3253,13 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"Nl" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/electrified_grille,
+/obj/structure/window/reinforced/plasma/spawner/directional/north,
+/obj/structure/window/reinforced/plasma/spawner/directional/south,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/deepstorage/crusher)
 "Nw" = (
 /obj/machinery/corral_corner{
 	mapping_id = "s1"
@@ -3494,7 +3521,7 @@
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/deepstorage/dorm)
 "Ya" = (
-/turf/closed/wall,
+/turf/closed/wall/r_wall/syndicate/nodiagonal,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
 "Yo" = (
 /obj/structure/table,
@@ -4685,8 +4712,8 @@ aa
 Iy
 ab
 ab
-ab
-ab
+CA
+aP
 OD
 ah
 ao
@@ -4737,8 +4764,8 @@ aa
 aa
 ab
 ab
-ab
-ab
+CA
+aP
 OD
 ai
 ap
@@ -4789,8 +4816,8 @@ aa
 aa
 ab
 ab
-ab
-ab
+CA
+aP
 OD
 ai
 aq
@@ -4841,8 +4868,8 @@ aa
 ab
 ab
 ab
-ab
-ab
+CA
+aP
 OD
 ah
 ar
@@ -4893,13 +4920,13 @@ aa
 ab
 ab
 ab
-ab
-ab
 CA
-sa
-sa
-sa
-sa
+aP
+Ob
+Ob
+Ob
+Ob
+Ob
 bd
 bx
 bO
@@ -4945,13 +4972,13 @@ aa
 ab
 ab
 ab
-ab
-ab
+CA
+aP
 Ob
 sa
 as
 aB
-sa
+Ob
 yQ
 yQ
 yQ
@@ -4997,8 +5024,8 @@ aa
 aa
 ab
 ab
-ab
-ab
+CA
+aP
 Ob
 ak
 at
@@ -5049,13 +5076,13 @@ Iy
 aa
 aa
 ab
-ab
-ab
+CA
+aP
 Ob
 al
 au
 De
-aP
+Ob
 bf
 bz
 cF
@@ -5101,9 +5128,9 @@ Iy
 aa
 aa
 ab
-ab
-ab
-Ob
+CA
+aP
+Nl
 am
 sQ
 aE
@@ -5151,10 +5178,10 @@ ab
 Iy
 wQ
 aa
-aa
 ab
 ab
-ab
+CA
+aP
 Ob
 AZ
 rz
@@ -5203,15 +5230,15 @@ ab
 ab
 aa
 aa
-aa
-aa
 ab
 ab
-ab
+CA
+aP
+aP
 Ob
 Ob
 Ob
-aQ
+Ya
 bi
 bC
 sL
@@ -5255,14 +5282,14 @@ ab
 ab
 aa
 aa
-aa
-aa
 ab
 ab
-ab
-ab
-ab
-ab
+CA
+CA
+aP
+aP
+aP
+aP
 aQ
 bj
 bC
@@ -5310,11 +5337,11 @@ aa
 ab
 ab
 ab
-ab
-ab
-ab
-ab
-ab
+CA
+CA
+CA
+CA
+CA
 aQ
 FI
 bC


### PR DESCRIPTION
## About The Pull Request

deep storage gets stronger reinforcements around the self-destruct, including a turret, and some turf decals and a syndie blackbox
## Why It's Good For The Game

syndicate blackbox makes sense, plus makes it harder to cheese

## Changelog
:cl:
add: Deep Storage has been reinforced by Johnson & Co Architecture's finest engineers, and should now be slightly (keyword slightly) harder to cheese.
fix: Deep Storage now has the correct type of blackbox, because I forgot to give it a syndicate blackbox last time oopsies.
/:cl:
