### PR TITLE
Misc Mapping Power Cell Fixes (+ SMES loop unit test)

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -25790,7 +25790,6 @@
 /area/station/tcommsat/server)
 "inn" = (
 /obj/machinery/airalarm/directional/east,
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
@@ -27863,7 +27862,6 @@
 "iVh" = (
 /obj/machinery/light/directional/south,
 /obj/structure/sign/poster/contraband/missing_gloves/directional/east,
-/obj/structure/cable,
 /obj/machinery/power/terminal{
 	dir = 8
 	},
@@ -45283,6 +45281,7 @@
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/upgraded,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "oDy" = (
@@ -49984,7 +49983,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "qed" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -54419,6 +54417,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "rDA" = (
 /obj/machinery/computer/mech_bay_power_console,
+/obj/structure/cable,
 /turf/open/floor/circuit,
 /area/station/maintenance/department/electrical)
 "rDD" = (
@@ -55230,7 +55229,6 @@
 /obj/item/multitool,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom/directional/east,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "rRm" = (
@@ -55238,6 +55236,7 @@
 /area/station/service/kitchen)
 "rRt" = (
 /obj/machinery/mech_bay_recharge_port,
+/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "rRU" = (
@@ -63418,7 +63417,6 @@
 	dir = 4
 	},
 /obj/machinery/light/built/directional/south,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "uAv" = (
@@ -67402,6 +67400,11 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/execution)
+"vIq" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/maintenance/department/electrical)
 "vIv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/trash/garbage,
@@ -73623,6 +73626,7 @@
 "xJR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "xJY" = (
@@ -75100,10 +75104,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"yeV" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/electrical)
 "yfi" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -124371,7 +124371,7 @@ jxy
 pTI
 nbF
 bYW
-yeV
+lzT
 uAu
 jxy
 uyw
@@ -124886,7 +124886,7 @@ sfm
 lzT
 kDe
 kMR
-yeV
+lzT
 jxy
 uyw
 iLB
@@ -125400,7 +125400,7 @@ rRt
 oDn
 pZV
 nbF
-yeV
+lzT
 jxy
 tzc
 iLB
@@ -125654,7 +125654,7 @@ aij
 jxy
 jxy
 xzw
-nbF
+vIq
 qed
 wFZ
 vxs

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -66545,7 +66545,6 @@
 /area/station/maintenance/port/aft)
 "vxs" = (
 /obj/machinery/power/smes,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "vxD" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -40810,7 +40810,6 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/sign/warning/electric_shock/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
@@ -81986,7 +81985,6 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/structure/sign/warning/electric_shock/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10856,9 +10856,8 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "dmL" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/south,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/department/electrical)
 "dmR" = (
@@ -34860,7 +34859,6 @@
 	pixel_x = -8;
 	pixel_y = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "ldk" = (
@@ -37786,9 +37784,12 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/structure/sign/poster/contraband/missing_gloves/directional/east,
 /obj/machinery/light/directional/south,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/sign/poster/contraband/missing_gloves/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "maB" = (
@@ -56247,8 +56248,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rPu" = (
-/obj/machinery/power/smes,
 /obj/structure/cable,
+/obj/machinery/power/smes/engineering,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "rPL" = (
@@ -60872,7 +60873,6 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/mining)
 "tsR" = (
-/obj/structure/cable,
 /obj/structure/chair/stool/directional/south,
 /obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/plating,
@@ -65742,7 +65742,6 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "uXC" = (
@@ -73392,7 +73391,7 @@
 /turf/open/floor/wood,
 /area/station/commons/dorms)
 "xrm" = (
-/obj/structure/cable,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "xry" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -10855,11 +10855,6 @@
 /obj/structure/sign/poster/official/here_for_your_safety/directional/east,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"dmL" = (
-/obj/machinery/light_switch/directional/south,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/electrical)
 "dmR" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -65742,6 +65737,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "uXC" = (
@@ -254281,8 +254277,8 @@ kKL
 nwd
 epd
 oih
-dmL
-lUC
+glI
+fUc
 lUC
 dMH
 ait

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -14392,6 +14392,10 @@
 "ejt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal/incinerator)
 "ejx" = (
@@ -35532,10 +35536,6 @@
 	},
 /area/station/medical/medbay/lobby)
 "kxL" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/layer_manifold/green/visible{
 	dir = 4
 	},
@@ -57754,7 +57754,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
 "qSI" = (
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
 /obj/machinery/meter/layer4,
@@ -63532,7 +63531,6 @@
 /area/station/command/heads_quarters/nt_rep)
 "sCg" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /obj/structure/chair/office{
 	dir = 1
 	},

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -69,6 +69,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "av" = (
@@ -243,8 +244,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "bh" = (
@@ -2574,13 +2573,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"Wx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/gravity_generator)
 "WK" = (
 /obj/structure/money_bot,
 /turf/open/floor/iron/dark,
@@ -7758,7 +7750,7 @@ aI
 AR
 ak
 at
-Wx
+bh
 bh
 bh
 br

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -8367,9 +8367,6 @@
 /area/station/medical/pharmacy)
 "bzP" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/machinery/power/terminal{
 	dir = 4
 	},

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -7268,14 +7268,14 @@
 /turf/open/floor/wood/large,
 /area/station/service/barber)
 "bju" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 6
-	},
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/power/smes{
-	charge = 5e+006
+/obj/machinery/light/directional/east,
+/obj/structure/table,
+/obj/item/book/manual/wiki/engineering_guide{
+	pixel_x = -2
 	},
-/obj/structure/cable,
+/obj/item/radio/off,
+/obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "bjv" = (
@@ -8370,9 +8370,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/structure/cable,
 /obj/machinery/power/terminal{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
@@ -14226,13 +14229,9 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dsN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/table,
+/obj/machinery/light/directional/west,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "dsZ" = (
@@ -26215,6 +26214,12 @@
 /obj/structure/sink/directional/south,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison)
+"hkm" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/gravity_generator)
 "hkF" = (
 /obj/structure/table,
 /obj/item/aicard,
@@ -38434,7 +38439,10 @@
 /area/station/service/library/upper)
 "kWp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "kWq" = (
@@ -70133,7 +70141,6 @@
 "uPi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "uPv" = (
@@ -72527,7 +72534,11 @@
 /area/station/science/lobby)
 "vyD" = (
 /obj/machinery/airalarm/directional/east,
-/obj/structure/cable,
+/obj/machinery/airalarm/directional/east,
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_y = 5
+	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "vyF" = (
@@ -112878,7 +112889,7 @@ pcO
 iKr
 ofZ
 uKK
-ajF
+hkm
 kWp
 fal
 akK

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -205,6 +205,7 @@
 #include "simple_animal_freeze.dm"
 #include "siunit.dm"
 #include "slips.dm"
+#include "smes_connections.dm"
 #include "spawn_humans.dm"
 #include "spawn_mobs.dm"
 #include "species_change_clothing.dm"

--- a/code/modules/unit_tests/smes_connections.dm
+++ b/code/modules/unit_tests/smes_connections.dm
@@ -1,0 +1,9 @@
+/// Unit test that checks to ensure that SMESes don't have their input connected to their output.
+/datum/unit_test/smes_connections
+
+/datum/unit_test/smes_connections/Run()
+	for(var/obj/machinery/power/smes/smes as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/power/smes))
+		if(QDELETED(smes) || QDELETED(smes.powernet) || QDELETED(smes.terminal) || QDELETED(smes.terminal.powernet))
+			continue
+		if(smes.powernet == smes.terminal.powernet)
+			TEST_FAIL("SMES at [AREACOORD(smes)] has identical input and output powernets")


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/82845 and fixes it up for our maps, plus extending it to our own Box. I also removed a stupid random ugly wall in Icebox's aux power room.

I've also added a new unit test to prevent future mapping issues with SMES power loops.

I haven't fixed Theseus in this PR, as I believe Moberry is currently working on some fixes for it.

## Why It's Good For The Game

> This should improve Icebox in particular, and take a little pressure off some of the other maps for round start power.

## Changelog
:cl:
map: Disconnected aux power SMES from Box grid at roundstart.
fix: (Maurukas) Removed a power loop on Icebox.
map: (Maurukas) Disconnected aux power SMES from Icebox grid at roundstart.
map: (Maurukas) Removed some power cables connecting Deltastation's aux power
fix: (Maurukas) Fixed Tramstation's gravity generator SMES, now functions and charged at roundstart.
/:cl:
