### PR TITLE
Fixes crew melting into the floor from eating APCs by coating said machinery in non-tasty paint

### DIFF
--- a/code/modules/food_and_drinks/machinery/deep_fryer.dm
+++ b/code/modules/food_and_drinks/machinery/deep_fryer.dm
@@ -12,6 +12,7 @@ GLOBAL_LIST_INIT(oilfry_blacklisted_items, typecacheof(list(
 	/obj/item/his_grace,
 	/obj/item/bodybag/bluespace,
 	/obj/item/mod/control,
+	/obj/machinery/power/apc, //i cant believe im doing this
 )))
 
 /obj/machinery/deepfryer


### PR DESCRIPTION

## About The Pull Request
Closes #6352 by blacklisting APCs from getting deepfried...... yeah what am I doing with my life
## Why It's Good For The Game
People getting melted into the floor (being unable to move) from experimenting with Matter Eater mutations sounds too punishing
## Changelog
:cl:
fix: To discourage mutated crew from eating APCs, NanoTrasen has coated all APCs in the patented "Non-Tasty NanoPaint"!
/:cl:
