### PR TITLE
Unrestricts the Sindano SMG when being bought by traitors

### DIFF
--- a/monkestation/code/modules/blueshift/items/company_guns.dm
+++ b/monkestation/code/modules/blueshift/items/company_guns.dm
@@ -1052,6 +1052,8 @@
 
 /obj/item/gun/ballistic/automatic/sol_smg/no_mag
 	spawnwithmagazine = FALSE
+/obj/item/gun/ballistic/automatic/sol_smg/evil/unrestricted
+	pin = /obj/item/firing_pin
 
 // Sindano (evil)
 

--- a/monkestation/code/modules/blueshift/opfor/equipment/guns.dm
+++ b/monkestation/code/modules/blueshift/opfor/equipment/guns.dm
@@ -158,7 +158,7 @@
 	item_type = /obj/item/storage/toolbox/guncase/nova/pistol/opfor/sindano
 
 /obj/item/storage/toolbox/guncase/nova/pistol/opfor/sindano/PopulateContents()
-	new /obj/item/gun/ballistic/automatic/sol_smg/evil(src)
+	new /obj/item/gun/ballistic/automatic/sol_smg/evil/unrestricted(src)
 	new /obj/item/ammo_box/magazine/c35sol_pistol/stendo(src)
 	new /obj/item/ammo_box/magazine/c35sol_pistol/stendo(src)
 	new /obj/item/storage/box/syndie_kit/weapons_auth(src)


### PR DESCRIPTION

## About The Pull Request
Closes #6410 by making said gun, when bought through the opfor crate, have a regular firing pin instead of the Syndicate one
## Why It's Good For The Game
It isn't cool that you have to be a nukie/true syndicate to use the SMG you bought from your traitor uplink, is it?
## Changelog
:cl:
fix: after a small mishap with the Sindano SMG shipments for traitor uplinks, the Syndicate now gives the unrestricted version to their agents.
/:cl:
