### PR TITLE
Removes the chicken spacing centcom

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -21802,7 +21802,7 @@
 /obj/structure/table/reinforced{
 	color = "#606060"
 	},
-/mob/living/basic/chicken/cotton_candy,
+/mob/living/basic/chicken/dreamsicle,
 /turf/open/floor/carpet/purple,
 /area/centcom/central_command_areas/adminroom)
 "fFh" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -21721,7 +21721,7 @@
 	color = "#55342b";
 	dir = 4
 	},
-/mob/living/basic/chicken/cotton_candy,
+/mob/living/basic/chicken/dreamsicle,
 /turf/open/floor/fakespace,
 /area/centcom/central_command_areas/adminroom)
 "fxn" = (


### PR DESCRIPTION

## About The Pull Request

In my last PR I updated my office to have a cotton candy chicken in it. Turns out those mf's can do some damage. This PR swaps them out with a chicken that wont space centcom

## Why It's Good For The Game
The admin area should probably not be spaced

## Changelog
:cl:
fix: Removes the cotton candy chicken from centcom
/:cl:
