### PR TITLE
Removes a harmful stereotype from the meatbun by replacing it with cannibalism, which is barely frowned upon in SS13

### DIFF
--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -594,7 +594,7 @@
 
 /obj/item/food/meatbun
 	name = "meat bun"
-	desc = "Has the potential to not be dog."
+	desc = "Has the potential to not be human."
 	icon = 'icons/obj/food/meat.dmi'
 	icon_state = "meatbun"
 	food_reagents = list(


### PR DESCRIPTION
## About The Pull Request
Closes #6004 by changing the meatbun's description, which was most likely perpetuating a harmful stereotype
## Why It's Good For The Game
Meat buns and dumplings are a pretty common food type in asian cuisine. There quite a few different types across different cuisines.
There is an enduring stereotype towards asian people that continues to hurt them abroad about capturing, killing and cooking pets. It's the reason asian restaurants receive discrimination western countries.
Cannibalism do be funnier
## Changelog
:cl:
add: Added a Rimworld reference
del: Removed a potential harmful stereotype
/:cl:
