### PR TITLE
Some bloodsucker tweaks

### DIFF
--- a/monkestation/code/modules/bloodsuckers/powers/feed.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/feed.dm
@@ -87,7 +87,7 @@
 
 	owner.balloon_alert(owner, "feeding off [feed_target]...")
 	started_alive = (feed_target.stat < HARD_CRIT)
-	to_chat(feed_target, span_userdanger("[owner] beings slipping their fangs into you!"))
+	to_chat(feed_target, span_userdanger("[owner] begins slipping [owner.p_their()] fangs into you!"))
 	if(!do_after(owner, feed_timer, feed_target, NONE, TRUE))
 		owner.balloon_alert(owner, "feed stopped")
 		DeactivatePower()

--- a/monkestation/code/modules/bloodsuckers/powers/feed.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/feed.dm
@@ -87,7 +87,7 @@
 
 	owner.balloon_alert(owner, "feeding off [feed_target]...")
 	started_alive = (feed_target.stat < HARD_CRIT)
-	feed_target.visible_message(span_userdanger("[owner] beings slipping their fangs into you!"))
+	to_chat(feed_target, span_userdanger("[owner] beings slipping their fangs into you!"))
 	if(!do_after(owner, feed_timer, feed_target, NONE, TRUE))
 		owner.balloon_alert(owner, "feed stopped")
 		DeactivatePower()

--- a/monkestation/code/modules/bloodsuckers/powers/feed.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/feed.dm
@@ -56,7 +56,7 @@
 	if(!QDELETED(feed_target))
 		log_combat(user, feed_target, "fed on blood", addition="(and took [blood_taken] blood)")
 		to_chat(user, span_notice("You slowly release [feed_target]."))
-		to_chat(feed_target, span_warning("Huh? What just happened? You don't remember the last few moments"))
+		to_chat(feed_target, span_reallybig(span_hypnophrase("Huh? What just happened? You don't remember the last few moments")))
 		if(feed_target.stat == DEAD && !started_alive)
 			user.add_mood_event("drankkilled", /datum/mood_event/drankkilled)
 			bloodsuckerdatum_power.AddHumanityLost(10)
@@ -87,6 +87,7 @@
 
 	owner.balloon_alert(owner, "feeding off [feed_target]...")
 	started_alive = (feed_target.stat < HARD_CRIT)
+	feed_target.visible_message(span_userdanger("[owner] beings slipping their fangs into you!"))
 	if(!do_after(owner, feed_timer, feed_target, NONE, TRUE))
 		owner.balloon_alert(owner, "feed stopped")
 		DeactivatePower()

--- a/monkestation/code/modules/bloodsuckers/powers/feed.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/feed.dm
@@ -1,4 +1,4 @@
-#define FEED_NOTICE_RANGE 2
+#define FEED_NOTICE_RANGE 5
 #define FEED_DEFAULT_TIMER (10 SECONDS)
 
 /datum/action/cooldown/bloodsucker/feed

--- a/monkestation/code/modules/bloodsuckers/powers/go_home.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/go_home.dm
@@ -1,4 +1,4 @@
-#define GOHOME_CANCELED -1
+
 #define GOHOME_START 0
 #define GOHOME_FLICKER_ONE 2
 #define GOHOME_FLICKER_TWO 4
@@ -11,14 +11,13 @@
  */
 /datum/action/cooldown/bloodsucker/gohome
 	name = "Vanishing Act"
-	desc = "As dawn aproaches, disperse into mist and return directly to your Lair.<br><b>WARNING:</b> You will drop <b>ALL</b> of your possessions if observed by mortals.\
-	If you are harmed during this unstable time, you will be knocked out of this mist form!"
+	desc = "As dawn aproaches, disperse into mist and return directly to your Lair.<br><b>WARNING:</b> You will drop <b>ALL</b> of your possessions if observed by mortals."
 	button_icon_state = "power_gohome"
 	active_background_icon_state = "vamp_power_off_oneshot"
 	base_background_icon_state = "vamp_power_off_oneshot"
 	power_explanation = "Vanishing Act: \n\
 		Activating Vanishing Act will, after a short delay, teleport the user to their Claimed Coffin. \n\
-		The power will cancel out if the Claimed Coffin is somehow destroyed or the user is harmed in this time. \n\
+		The power will cancel out if the Claimed Coffin is somehow destroyed. \n\
 		Immediately after activating, lights around the user will begin to flicker. \n\
 		Once the user teleports to their coffin, in their place will be a Rat or Bat."
 	power_flags = BP_AM_TOGGLE | BP_AM_SINGLEUSE | BP_AM_STATIC_COOLDOWN
@@ -29,8 +28,6 @@
 	cooldown_time = 100 SECONDS
 	///What stage of the teleportation are we in
 	var/teleporting_stage = GOHOME_START
-	//How much damage we've taken, more than 15 will cancel this power
-	var/damage_sustained = 0
 	///The types of mobs that will drop post-teleportation.
 	var/static/list/spawning_mobs = list(
 		/mob/living/basic/mouse = 3,
@@ -50,8 +47,6 @@
 /datum/action/cooldown/bloodsucker/gohome/ActivatePower(trigger_flags)
 	. = ..()
 	owner.balloon_alert(owner, "preparing to teleport...")
-	owner.visible_message(span_notice("[owner] begins turning to mist!."))
-	RegisterSignal (owner, COMSIG_MOB_APPLY_DAMAGE, PROC_REF(on_damaged))
 
 /datum/action/cooldown/bloodsucker/gohome/process(seconds_per_tick)
 	. = ..()
@@ -85,17 +80,6 @@
 	for(var/obj/machinery/light/nearby_lights in view(flicker_range, get_turf(owner)))
 		nearby_lights.flicker(5)
 	playsound(get_turf(owner), 'sound/effects/singlebeat.ogg', beat_volume, 1)
-
-/datum/action/cooldown/bloodsucker/gohome/proc/on_damaged(datum/source, damage, damagetype)
-	SIGNAL_HANDLER
-
-	damage_sustained += damage
-
-	if(damage_sustained < 15)
-		return FALSE
-
-	owner.balloon_alert(owner, "you've taken to much damage, your teleport has been canceled.")
-	return TRUE
 
 /datum/action/cooldown/bloodsucker/gohome/proc/teleport_to_coffin(mob/living/carbon/user)
 	var/drop_item = FALSE
@@ -138,7 +122,6 @@
 /datum/effect_system/steam_spread/bloodsucker
 	effect_type = /obj/effect/particle_effect/fluid/smoke/vampsmoke
 
-#undef GOHOME_CANCELED
 #undef GOHOME_START
 #undef GOHOME_FLICKER_ONE
 #undef GOHOME_FLICKER_TWO

--- a/monkestation/code/modules/bloodsuckers/powers/go_home.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/go_home.dm
@@ -20,7 +20,7 @@
 		Immediately after activating, lights around the user will begin to flicker. \n\
 		Once the user teleports to their coffin, in their place will be a Rat or Bat."
 	power_flags = BP_AM_TOGGLE | BP_AM_SINGLEUSE | BP_AM_STATIC_COOLDOWN
-	check_flags = BP_CANT_USE_IN_FRENZY | BP_CANT_USE_WHILE_STAKED
+	check_flags = BP_CANT_USE_IN_TORPOR | BP_CANT_USE_WHILE_STAKED | BP_CANT_USE_WHILE_INCAPACITATED | BP_CANT_USE_WHILE_UNCONSCIOUS | BP_CANT_USE_IN_FRENZY
 	purchase_flags = NONE
 	bloodcost = 100
 	constant_bloodcost = 2

--- a/monkestation/code/modules/bloodsuckers/powers/veil.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/veil.dm
@@ -12,20 +12,9 @@
 	bloodcost = 15
 	constant_bloodcost = 0.1
 	cooldown_time = 10 SECONDS
-	// Outfit Vars
-//	var/list/original_items = list()
-	// Identity Vars
-	var/prev_gender
-	var/prev_skin_tone
-	var/prev_hair_style
-	var/prev_facial_hair_style
-	var/prev_hair_color
-	var/prev_facial_hair_color
-	var/prev_underwear
-	var/prev_undershirt
-	var/prev_socks
+	var/datum/dna/originalDNA
+	var/originalname
 	var/prev_disfigured
-	var/list/prev_features // For lizards and such
 
 /datum/action/cooldown/bloodsucker/veil/ActivatePower(trigger_flags)
 	. = ..()
@@ -42,81 +31,32 @@
 */
 
 /datum/action/cooldown/bloodsucker/veil/proc/veil_user()
-	// Change Name/Voice
+	if(!ishuman(owner))
+		return
 	var/mob/living/carbon/human/user = owner
-	user.name_override = user.dna.species.random_name(user.gender)
-	user.name = user.name_override
-	user.SetSpecialVoice(user.name_override)
 	to_chat(owner, span_warning("You mystify the air around your person. Your identity is now altered."))
-
-	// Store Prev Appearance
-	prev_gender = user.gender
-	prev_skin_tone = user.skin_tone
-	prev_hair_style = user.hairstyle
-	prev_facial_hair_style = user.facial_hairstyle
-	prev_hair_color = user.hair_color
-	prev_facial_hair_color = user.facial_hair_color
-	prev_underwear = user.underwear
-	prev_undershirt = user.undershirt
-	prev_socks = user.socks
-//	prev_eye_color
+	originalDNA = new user.dna.type
+	originalname = user.real_name
+	user.dna.copy_dna(originalDNA)
+	randomize_human(user)
 	prev_disfigured = HAS_TRAIT(user, TRAIT_DISFIGURED) // I was disfigured! //prev_disabilities = user.disabilities
-	prev_features = user.dna.features
-
-	// Change Appearance
-	user.gender = pick(MALE, FEMALE, PLURAL)
-	user.skin_tone = random_skin_tone()
-	user.hairstyle = random_hairstyle(user.gender)
-	user.facial_hairstyle = pick(random_facial_hairstyle(user.gender), "Shaved")
-	user.hair_color = random_short_color()
-	user.facial_hair_color = user.hair_color
-	user.underwear = random_underwear(user.gender)
-	user.undershirt = random_undershirt(user.gender)
-	user.socks = random_socks(user.gender)
-	//user.eye_color = random_eye_color()
 	if(prev_disfigured)
 		REMOVE_TRAIT(user, TRAIT_DISFIGURED, null)
-	user.dna.features = random_features()
-
-	// Apply Appearance
-	user.update_body() // Outfit and underware, also body.
-	user.update_mutant_bodyparts() // Lizard tails etc
-	user.update_hair()
-	user.update_body_parts()
 
 /datum/action/cooldown/bloodsucker/veil/DeactivatePower()
 	. = ..()
 	if(!ishuman(owner))
 		return
 	var/mob/living/carbon/human/user = owner
-
-	// Revert Identity
-	user.UnsetSpecialVoice()
-	user.name_override = null
-	user.name = user.real_name
-
-	// Revert Appearance
-	user.gender = prev_gender
-	user.skin_tone = prev_skin_tone
-	user.hairstyle = prev_hair_style
-	user.facial_hairstyle = prev_facial_hair_style
-	user.hair_color = prev_hair_color
-	user.facial_hair_color = prev_facial_hair_color
-	user.underwear = prev_underwear
-	user.undershirt = prev_undershirt
-	user.socks = prev_socks
-
+	to_chat(user, span_notice("You return to your old form."))
+	originalDNA.transfer_identity(user)
+	user.real_name = originalname
+	user.update_name_tag(originalname) // monkestation edit: name tags
+	user.updateappearance(mutcolor_update=1)
 	//user.disabilities = prev_disabilities // Restore HUSK, CLUMSY, etc.
 	if(prev_disfigured)
 		//We are ASSUMING husk. // user.status_flags |= DISFIGURED // Restore "Unknown" disfigurement
 		ADD_TRAIT(user, TRAIT_DISFIGURED, TRAIT_HUSK)
-	user.dna.features = prev_features
-
-	// Apply Appearance
-	user.update_body() // Outfit and underware, also body.
-	user.update_hair()
-	user.update_body_parts() // Body itself, maybe skin color?
-
 	cast_effect() // POOF
 	owner.balloon_alert(owner, "veil turned off.")
 

--- a/monkestation/code/modules/bloodsuckers/powers/veil.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/veil.dm
@@ -4,8 +4,7 @@
 	button_icon_state = "power_veil"
 	power_explanation = "Veil of Many Faces: \n\
 		Activating Veil of Many Faces will shroud you in smoke and forge you a new identity.\n\
-		Your name and appearance will be completely randomized, and turning the ability off again will undo it all.\n\
-		Clothes, gear, and Security/Medical HUD status is kept the same while this power is active."
+		Your name and appearance will be completely randomized, and turning the ability off again will undo it all."
 	power_flags = BP_AM_TOGGLE
 	check_flags = BP_CANT_USE_IN_FRENZY | BP_CANT_USE_DURING_SOL
 	purchase_flags = BLOODSUCKER_DEFAULT_POWER | VASSAL_CAN_BUY

--- a/monkestation/code/modules/bloodsuckers/powers/veil.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/veil.dm
@@ -58,7 +58,7 @@
 		//We are ASSUMING husk. // user.status_flags |= DISFIGURED // Restore "Unknown" disfigurement
 		ADD_TRAIT(user, TRAIT_DISFIGURED, TRAIT_HUSK)
 	cast_effect() // POOF
-	owner.balloon_alert(owner, "veil turned off.")
+	user.balloon_alert(owner, "veil turned off.")
 
 
 // CAST EFFECT // General effect (poof, splat, etc) when you cast. Doesn't happen automatically!


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request and Why It's Good For The Game (easier to explain both at once)
Fixes Veil of many faces(now properly randomizes you)
Veil of many faces now tricks sec huds and beepsky.
This power was kinda bad, along with buggy. With the changes to feed this power was buffed a little to allow vamps to use it while they go out to feed as its harder to do now not being able to stealth it as they could before.
Honestly possible it changing hud status makes it a little to free with vamps being able to infinitely pull a new fake look however person won't be on manifest or have a matching ID so I think that balances it out quite a bit.


Feed is no longer silent, now giving a message to person being fed on, range people around can tell you are feeding on someone is increased from 2 to 5 tiles, still wipes memories of being fed on when successful(made message bigger so people don't miss it).
Feed being silent with 0 giveaway, took away basically all risk from feeding. The person you fed on couldn't even tell they were being fed on sometimes leading to a vamp in frenzy running up to someone, sucking all the blood out of their body, and walking off the guy not even realizing what had happened until after. Along with https://github.com/Monkestation/Monkestation2.0/pull/6182 which is a cool addition but kinda meh since vamps can just stand next to people in bars or type bait via having conversations while they feed off them.
This makes vamps need to be a little more active when they want to get blood requiring them to use mesmerize and drag people off or similar stuff instead of just walking up, draining a possibly lethal amount of blood and leaving 0 interaction.

Go home power can no longer be used while stunned, or dead.
Vampires being instantly able to teleport to coffin regardless of condition is quite busted, as it is a total get out of jail free card with 0 counter. To add this power is granted around and during sol, meaning if you fight near sol(what is supposed to be a vamps weakness) you will always have a get out of jail card even if you die. 
Im considering weakening this power further by making it cancelable but I think this is enough for now. I have another vamps tweak PR I wanna do soon.

![attachment (1)](https://github.com/user-attachments/assets/9583939b-f9f8-42a8-916b-573740fd18ff)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: veil of many faces now works properly
balance: veil of many faces now changes hud status
balance: feed now has a message for the person being fed on, increased range people can tell you are feeding
balance: Go home power can no longer be used while dead
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
