### PR TITLE
Makes CentCom more visually consistent + slightly fancier (github died on me edition)

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -109,7 +109,6 @@
 	dir = 8
 	},
 /obj/effect/landmark/ert_spawn,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
 "aas" = (
@@ -504,11 +503,11 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/borbop)
 "abm" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/carpet/red,
+/area/centcom/central_command_areas/admin)
 "abn" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/records/security/laptop/syndie,
@@ -533,7 +532,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/armory)
 "abq" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/dark{
@@ -674,10 +673,10 @@
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
 "abH" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/armory)
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/vg_decals/numbers/three,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supplypod/pod_storage)
 "abI" = (
 /obj/structure/closet/secure_closet/ert_com,
 /obj/structure/sign/directions/command{
@@ -686,7 +685,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/status_display/ai/directional/east,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/armory)
 "abJ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -967,7 +966,7 @@
 /obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/briefing)
 "acy" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 8
@@ -1930,12 +1929,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "afa" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/obj/structure/sign/warning/secure_area,
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/briefing)
 "afb" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/directional/south,
@@ -1960,7 +1956,7 @@
 /obj/machinery/status_display/evac/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/briefing)
 "afg" = (
 /obj/structure/table/optable{
 	dir = 0
@@ -1980,7 +1976,6 @@
 	dir = 8
 	},
 /obj/effect/landmark/ert_spawn,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
@@ -2055,8 +2050,7 @@
 /turf/open/floor/iron/dark,
 /area/centcom/tdome/observation)
 "afw" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "afx" = (
 /obj/effect/light_emitter{
@@ -2807,7 +2801,7 @@
 /obj/machinery/newscaster/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/briefing)
 "ahz" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -5006,7 +5000,7 @@
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/briefing)
 "ank" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -5814,23 +5808,27 @@
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/hall)
 "apB" = (
+/obj/machinery/light/floor/has_bulb,
 /obj/effect/turf_decal/stripes/line{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supplypod/loading/ert)
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/admin)
 "apC" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supplypod/loading/ert)
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/retirement_yard)
 "apD" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supplypod/loading/ert)
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/admin)
 "apE" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
@@ -5966,15 +5964,17 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range)
 "apT" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/white{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supplypod/loading/ert)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/retirement_yard)
 "apU" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supplypod/loading/ert)
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/ferry)
 "apV" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -5985,10 +5985,7 @@
 /turf/open/ai_visible,
 /area/centcom/ai_multicam_room)
 "apX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "apY" = (
 /obj/structure/frame/computer{
@@ -6216,15 +6213,21 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/medical)
 "aqF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "aqG" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supplypod/loading/ert)
+/obj/machinery/door/airlock/external/ruin{
+	name = "Ferry Airlock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/ferry)
 "aqH" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/machinery/vending/wardrobe/jani_wardrobe,
@@ -6375,11 +6378,10 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/borbop)
 "arb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supplypod/loading/ert)
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/ferry)
 "arc" = (
 /obj/structure/dresser,
 /obj/structure/noticeboard/directional/north,
@@ -6739,7 +6741,7 @@
 	name = "Orbital Drop Pod Loading"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "ase" = (
 /obj/effect/turf_decal/siding/white{
@@ -7170,16 +7172,16 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/central_command_areas/evacuation/ship)
 "atn" = (
+/obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/structure/sign/warning/secure_area/directional/east,
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/south,
-/obj/structure/sign/warning/secure_area/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "ato" = (
 /obj/machinery/computer/shuttle/ferry{
@@ -7225,7 +7227,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "atv" = (
 /obj/effect/turf_decal/siding/wood,
@@ -7951,7 +7957,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/briefing)
 "avn" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical/old,
@@ -8016,7 +8022,7 @@
 "avz" = (
 /obj/machinery/door/poddoor/shutters/cc/xcc,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "avA" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -8037,39 +8043,47 @@
 /obj/item/clothing/mask/gas,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/status_display/ai/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "avC" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "avD" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/flora/bush/fullgrass/style_3,
+/obj/structure/flora/bush/large/style_3,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/retirement_yard)
 "avE" = (
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/obj/machinery/button/door/indestructible{
+	id = "XCCFerry";
+	name = "Hangar Bay Shutters";
+	pixel_x = -8;
+	pixel_y = 24
+	},
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "avF" = (
 /obj/machinery/door/airlock/centcom{
-	name = "AdminLand"
+	name = "Office Complex Access"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/admin/captain,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "avG" = (
@@ -8246,10 +8260,10 @@
 /turf/open/floor/carpet,
 /area/centcom/central_command_areas/hall)
 "awh" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/vg_decals/numbers/six,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supplypod/pod_storage)
 "awi" = (
 /obj/structure/table/glass/plasmaglass,
 /obj/item/screwdriver{
@@ -8327,24 +8341,23 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range_checkpoint_control)
 "awr" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/admin_hangout)
 "aws" = (
 /obj/structure/closet/cardboard/metal,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron,
 /area/centcom/syndicate_mothership/control)
 "awt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	pixel_y = 0;
+	pixel_x = 0
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "awu" = (
 /obj/machinery/door/firedoor,
@@ -8358,7 +8371,10 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "awv" = (
 /obj/machinery/door/poddoor/shutters{
@@ -8368,49 +8384,47 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "aww" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 9
+	},
 /obj/machinery/button/door/indestructible{
 	id = "XCCFerry";
-	name = "Hanger Bay Shutters";
+	name = "Hangar Bay Shutters";
 	pixel_y = 24;
 	req_access = list("cent_general")
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "awx" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "awy" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/vg_decals/numbers/four,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supplypod/pod_storage)
 "awz" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/retirement_yard)
 "awA" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/green{
+/obj/structure/fans/tiny/forcefield{
+	color = "#276c87";
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/turf/closed/indestructible/grille,
+/area/centcom/central_command_areas/admin)
 "awB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "awC" = (
 /obj/effect/turf_decal/tile/hot_pink/full,
@@ -8591,40 +8605,41 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/botany)
 "axc" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "Ferry Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/vg_decals/numbers/two,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supplypod/pod_storage)
+"axd" = (
+/obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
-"axd" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
-"axe" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/retirement_yard)
+"axe" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "axf" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/glass/reinforced,
 /area/centcom/central_command_areas/ferry)
 "axg" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4;
+	pixel_y = 0;
+	pixel_x = 0
+	},
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "axh" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -8636,23 +8651,22 @@
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/ferry)
 "axi" = (
-/obj/item/kirbyplants{
-	icon_state = "plant-21"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
-"axj" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/ferry)
+"axj" = (
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "axk" = (
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
+/obj/machinery/light/floor/has_bulb{
+	pixel_x = 16;
+	pixel_y = 0
 	},
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "axl" = (
 /obj/effect/turf_decal/siding/wood{
@@ -8853,28 +8867,26 @@
 /turf/open/misc/grass,
 /area/centcom/central_command_areas/admin)
 "axQ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/light/directional/south,
-/obj/machinery/status_display/ai/directional/south,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
-"axR" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
+	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/retirement_yard)
+"axR" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/vg_decals/numbers/five,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supplypod/pod_storage)
 "axS" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
 /obj/machinery/button/door/indestructible{
 	id = "XCCsec1";
 	name = "CC Shutter 1 Control";
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "axT" = (
 /obj/effect/turf_decal/siding/wood{
@@ -9096,7 +9108,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/armory)
 "aym" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -9114,9 +9126,13 @@
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "ayp" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/obj/structure/railing/wood{
+	dir = 1
+	},
+/obj/structure/hedge,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/wood/large,
+/area/centcom/tdome/observation)
 "ayq" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/dark{
@@ -9128,13 +9144,9 @@
 	},
 /area/centcom/central_command_areas/hall)
 "ayr" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Briefing Room"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "ays" = (
 /obj/structure/chair/sofa/middle{
 	color = "#ad96af"
@@ -10047,7 +10059,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/ert_spawn,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
@@ -10467,7 +10478,7 @@
 /area/centcom/central_command_areas/evacuation/ship)
 "aBS" = (
 /obj/structure/hedge,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "aBT" = (
 /obj/machinery/door/airlock{
@@ -11224,7 +11235,7 @@
 	},
 /obj/structure/fireaxecabinet/directional/north,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/armory)
 "aDZ" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -14486,11 +14497,11 @@
 /turf/open/floor/glass/reinforced/plasma,
 /area/centcom/central_command_areas/adminroom)
 "aMJ" = (
-/obj/structure/chair/office,
-/obj/effect/landmark/ert_spawn,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/briefing)
+/obj/effect/turf_decal/siding/wood{
+	dir = 6
+	},
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/ferry)
 "aMK" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/structure/railing/wood,
@@ -14783,10 +14794,10 @@
 /turf/open/floor/iron/white/herringbone,
 /area/centcom/central_command_areas/kitchen)
 "aNy" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/briefing)
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/cerulean,
+/turf/open/space/basic,
+/area/space)
 "aNz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -14811,16 +14822,18 @@
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/hall)
 "aNC" = (
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/briefing)
+/obj/structure/holosign/barrier/engineering,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/centcom/central_command_areas/admin)
 "aND" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "aNE" = (
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supplypod/pod_storage)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/centcom/central_command_areas/ferry)
 "aNF" = (
 /obj/structure/fake_stairs/wood/directional/south,
 /turf/open/floor/wood/large,
@@ -14863,8 +14876,6 @@
 /obj/item/kirbyplants{
 	icon_state = "plant-22"
 	},
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
@@ -14898,7 +14909,7 @@
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/briefing)
 "aNR" = (
 /obj/machinery/light/floor/has_bulb,
 /obj/effect/turf_decal/trimline/blue,
@@ -15292,10 +15303,12 @@
 	name = "Briefing Room"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/briefing)
 "aOR" = (
 /obj/effect/turf_decal/tile/brown/diagonal_centre,
 /obj/structure/table/reinforced,
@@ -15342,7 +15355,6 @@
 	dir = 1
 	},
 /obj/effect/landmark/ert_spawn,
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
 "aOZ" = (
@@ -15608,7 +15620,6 @@
 "aPM" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/ert_spawn,
-/obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
@@ -15922,10 +15933,11 @@
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
 "aQE" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/ferry)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/admin)
 "aQF" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
@@ -16332,11 +16344,10 @@
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/hall)
 "aRM" = (
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/armory)
+/turf/open/floor/wood/large{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/centcom/central_command_areas/admin)
 "aRN" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/effect/turf_decal/siding/purple{
@@ -16670,34 +16681,10 @@
 /turf/open/floor/stone,
 /area/centcom/central_command_areas/admin_hangout)
 "aSF" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/obj/machinery/button/door/indestructible{
-	id = "XCCsec3";
-	name = "XCC Shutter 3 Control";
-	pixel_x = -8;
-	pixel_y = 38
-	},
-/obj/machinery/button/door/indestructible{
-	id = "XCCsec1";
-	name = "CC Shutter 1 Control";
-	pixel_x = 8;
-	pixel_y = 38
-	},
-/obj/machinery/button/door/indestructible{
-	id = "XCCFerry";
-	name = "Hanger Bay Shutters";
-	pixel_x = -8;
-	pixel_y = 24
-	},
-/obj/machinery/button/door/indestructible{
-	id = "XCCsec3";
-	name = "CC Main Access Control";
-	pixel_x = 8;
-	pixel_y = 24
-	},
-/turf/open/floor/iron,
+/turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "aSG" = (
 /obj/effect/turf_decal/siding/red/corner{
@@ -16794,7 +16781,7 @@
 	},
 /area/centcom/syndicate_mothership/control)
 "aSR" = (
-/turf/open/floor/circuit/green,
+/turf/open/floor/circuit/green/anim,
 /area/centcom/central_command_areas/briefing)
 "aSS" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
@@ -16864,8 +16851,11 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/two)
 "aTd" = (
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/supplypod/supplypod_temp_holding)
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/ferry)
 "aTe" = (
 /obj/structure/closet/crate/engineering,
 /obj/item/stack/sheet/mineral/plasma{
@@ -16908,7 +16898,7 @@
 /obj/machinery/computer/records/medical/laptop,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/briefing)
 "aTk" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/bureaucracy/paper,
@@ -17149,9 +17139,11 @@
 /turf/open/floor/iron/dark/corner,
 /area/centcom/central_command_areas/hall)
 "aTK" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
+/obj/machinery/computer/old{
+	dir = 4;
+	desc = "An old computer. Data on various Nanotrasen drop pods flashes across its display."
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "aTL" = (
 /obj/machinery/growing/soil,
@@ -17868,7 +17860,7 @@
 /obj/structure/noticeboard/directional/north,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/armory)
 "aVF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -17916,11 +17908,12 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "aVO" = (
-/obj/machinery/door/poddoor/ert,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/armory)
+/obj/machinery/door/airlock/centcom{
+	name = "Drop Pod Storage Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/centcom/central_command_areas/ferry)
 "aVP" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /turf/open/floor/iron,
@@ -18318,7 +18311,10 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "aWR" = (
 /turf/open/floor/iron/dark,
@@ -18433,7 +18429,7 @@
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/armory)
 "aXf" = (
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
@@ -18599,17 +18595,16 @@
 /turf/open/floor/wood/large,
 /area/centcom/tdome/observation)
 "aXy" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "Ferry Airlock"
+/obj/machinery/button/door/directional/north{
+	name = "Emergency Assistants Fuck Off Button";
+	id = "donutstealthisid";
+	req_access = "cent_captain"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/admin)
 "aXz" = (
 /obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
@@ -19129,7 +19124,13 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "aZc" = (
 /turf/open/floor/iron/dark/small,
@@ -19228,7 +19229,7 @@
 /area/centcom/central_command_areas/adminroom)
 "aZs" = (
 /obj/machinery/shuttle_manipulator,
-/turf/open/floor/circuit/green,
+/turf/open/floor/circuit/green/anim,
 /area/centcom/central_command_areas/briefing)
 "aZt" = (
 /obj/structure/flora/rock/pile/style_random,
@@ -21078,11 +21079,16 @@
 /turf/open/floor/carpet/lone/star,
 /area/centcom/central_command_areas/adminroom)
 "efj" = (
-/obj/machinery/door/poddoor/shutters/indestructible/preopen{
-	id = "donutstealthisid"
+/obj/machinery/door/airlock/centcom{
+	name = "Drop Pod Storage Observation"
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/centcom/central_command_areas/retirement_yard)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/ferry)
 "efG" = (
 /obj/effect/turf_decal/weather,
 /obj/effect/turf_decal/weather/dirt{
@@ -23752,13 +23758,14 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/admin)
 "iPD" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
 /obj/machinery/door/poddoor/shutters/indestructible/preopen{
 	id = "donutstealthisid"
 	},
-/turf/open/floor/grass,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/centcom/central_command_areas/retirement_yard)
 "iQv" = (
 /obj/structure/flora/bush/large/style_3,
@@ -25182,7 +25189,13 @@
 	dir = 8;
 	id = "donutstealthisid"
 	},
-/turf/open/floor/wood/large,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/centcom/central_command_areas/admin)
 "mft" = (
 /obj/machinery/light/small/warm/directional/north,
@@ -26994,11 +27007,16 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "pXI" = (
-/obj/machinery/door/poddoor/shutters/indestructible/preopen{
-	id = "donutstealthisid"
-	},
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/retirement_yard)
+/obj/structure/closet/emcloset,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/ferry)
 "pYm" = (
 /obj/structure/railing/wood{
 	dir = 1
@@ -27117,14 +27135,11 @@
 /turf/open/floor/sandy_dirt,
 /area/centcom/central_command_areas/admin)
 "qiU" = (
-/obj/machinery/door/poddoor/shutters/indestructible/preopen{
-	id = "donutstealthisid"
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/obj/machinery/door/poddoor/shutters/indestructible/preopen{
-	id = "donutstealthisid"
-	},
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/retirement_yard)
+/area/centcom/central_command_areas/admin)
 "qja" = (
 /turf/closed/indestructible/wood,
 /area/centcom/central_command_areas/adminroom)
@@ -27299,14 +27314,10 @@
 /turf/open/floor/iron/white/small,
 /area/centcom/central_command_areas/medical)
 "qCm" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/indestructible/preopen{
-	id = "donutstealthisid"
-	},
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/retirement_yard)
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/vg_decals/numbers/one,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supplypod/pod_storage)
 "qCL" = (
 /obj/structure/closet/crate/cardboard,
 /obj/item/reagent_containers/cup/glass/bottle/champagne,
@@ -28222,8 +28233,17 @@
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
 "suo" = (
-/turf/closed/indestructible/riveted,
-/area/centcom/central_command_areas/supplypod/supplypod_temp_holding)
+/obj/machinery/door/airlock/external/ruin{
+	name = "Ferry Airlock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/ferry)
 "sxc" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -29869,17 +29889,12 @@
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
 "vZN" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/warning{
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/shutters/indestructible/preopen{
-	id = "donutstealthisid"
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/centcom/central_command_areas/retirement_yard)
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/admin)
 "vZP" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -31118,7 +31133,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/prison)
 "yjh" = (
-/turf/open/floor/wood,
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
 /area/centcom/central_command_areas/admin)
 "yjw" = (
 /obj/effect/turf_decal/siding/wood{
@@ -50006,8 +50022,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+ayr
+ayr
 aaa
 aaa
 aaa
@@ -50262,10 +50278,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+ayr
+ayr
+ayr
+ayr
 aaa
 aaa
 aaa
@@ -50519,11 +50535,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+yjh
+aRM
+aRM
+ayr
+ayr
 aaa
 aaa
 aaa
@@ -50776,11 +50792,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aOn
+aRM
+aRM
+aRM
+yjh
 aaa
 aaa
 aaa
@@ -51033,11 +51049,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aOn
+aRM
+qiU
+aRM
+yjh
 aaa
 aaa
 aaa
@@ -51290,11 +51306,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aOn
+aNC
+aNC
+aNC
+aOn
 aaa
 aaa
 aaa
@@ -51548,9 +51564,9 @@ kpH
 kpH
 kpH
 kpH
-aOn
-aOn
-aOn
+awA
+awA
+awA
 aOn
 aaa
 aaa
@@ -54632,9 +54648,9 @@ wYo
 osr
 tTd
 kpH
-aMc
-aMc
-aMc
+apD
+apD
+apD
 kpH
 pKm
 oDK
@@ -55146,9 +55162,9 @@ kpH
 kpH
 kpH
 kpH
-aMc
-adQ
-aMc
+aQE
+vZN
+aQE
 kpH
 kpH
 oiZ
@@ -55402,11 +55418,11 @@ ouw
 djd
 lvi
 kpH
-yjh
-yjh
-yjh
-yjh
-yjh
+aMc
+aMc
+aMc
+aMc
+aMc
 kpH
 mNJ
 mNJ
@@ -56463,7 +56479,7 @@ aaa
 aaa
 aaa
 aaa
-aKm
+aaa
 aaa
 aaa
 aaa
@@ -56719,9 +56735,9 @@ aaa
 aaa
 aaa
 aaa
-aGA
-axc
-aGA
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -56944,11 +56960,11 @@ dVl
 kqs
 muk
 kpH
-yjh
-yjh
-yjh
-yjh
-yjh
+aMc
+aMc
+aMc
+aMc
+aMc
 aOn
 aaa
 aOn
@@ -56973,15 +56989,15 @@ aaa
 aaa
 aaa
 aaa
+aNy
 aaa
 aaa
 aaa
-aGA
-axd
-aGA
 aaa
 aaa
 aaa
+aaa
+aNy
 aaa
 aaa
 aaa
@@ -57202,9 +57218,9 @@ kpH
 kpH
 kpH
 aOn
-aMc
-adQ
-aMc
+apD
+apB
+apD
 aOn
 aOn
 aOn
@@ -57230,15 +57246,15 @@ aaa
 aaa
 aaa
 aaa
+ayr
 aaa
 aaa
-aGA
-aGA
-aXy
-aGA
-aGA
 aaa
 aaa
+aaa
+aaa
+aaa
+ayr
 aaa
 aaa
 aaa
@@ -57487,15 +57503,15 @@ aaa
 aaa
 aaa
 aaa
+ayr
 aaa
 aaa
-aGA
-anp
-anp
-anp
-aGA
 aaa
 aaa
+aaa
+aaa
+aaa
+ayr
 aaa
 aaa
 aaa
@@ -57716,9 +57732,9 @@ aOn
 aOn
 aOn
 aOn
-oQo
-oQo
-oQo
+abm
+abm
+abm
 aOn
 aOn
 ahD
@@ -57744,15 +57760,15 @@ aaa
 aaa
 aaa
 aaa
+ayr
 aaa
 aaa
-aGA
-anp
-anp
-anp
-aGA
 aaa
 aaa
+aaa
+aaa
+aaa
+ayr
 aaa
 aaa
 aaa
@@ -58001,15 +58017,15 @@ aaa
 aaa
 aaa
 aaa
+ayr
 aaa
 aaa
-aGA
-anp
-anp
-anp
-aGA
 aaa
 aaa
+aaa
+aaa
+aaa
+ayr
 aaa
 aaa
 aaa
@@ -58258,15 +58274,15 @@ aaa
 aaa
 aaa
 aaa
+ayr
 aaa
 aaa
-aGA
-anp
-anp
-anp
-aGA
 aaa
 aaa
+aaa
+aaa
+aaa
+ayr
 aaa
 aaa
 aaa
@@ -58517,13 +58533,13 @@ amD
 aGA
 aGA
 aaa
-aGA
-anp
-anp
-anp
-aGA
 aaa
 aaa
+aKm
+aaa
+aaa
+aaa
+ayr
 aaa
 aaa
 aaa
@@ -58774,13 +58790,13 @@ ato
 aZN
 aGA
 aaa
+aaa
 aGA
-anp
-anp
-anp
+suo
 aGA
 aaa
 aaa
+ayr
 aaa
 aaa
 aaa
@@ -59031,13 +59047,13 @@ atp
 aXr
 amD
 aaa
+aaa
 aGA
-anp
-anp
-anp
+arb
 aGA
 aaa
 aaa
+ayr
 aaa
 aaa
 aaa
@@ -59289,12 +59305,12 @@ aIr
 amD
 avA
 aGA
-anp
-anp
-anp
+aGA
+aqG
+aGA
 aGA
 aaa
-aaa
+ayr
 aaa
 aaa
 aaa
@@ -59546,9 +59562,9 @@ aum
 amD
 avB
 aBS
-anp
-anp
-anp
+aBS
+apU
+pXI
 aGA
 ata
 aGA
@@ -59802,15 +59818,15 @@ ats
 aBy
 amD
 avC
-awr
 axe
-awr
+axe
+axe
 awx
 amD
-apB
-apT
-apT
-apT
+aqF
+apX
+aqF
+apX
 aqF
 aGA
 aaa
@@ -60058,17 +60074,17 @@ asu
 ats
 apR
 auO
-avD
-afw
+aSF
 axf
-afw
-ayp
+axf
+axf
+awB
 asd
-apC
-apU
-apU
-apU
-aqG
+apX
+apX
+apX
+apX
+apX
 aGA
 aaa
 aaa
@@ -60321,11 +60337,11 @@ axg
 awt
 atn
 amD
-apD
+aqF
 apX
+aqF
 apX
-apX
-arb
+aqF
 aGA
 aaa
 aaa
@@ -60576,8 +60592,8 @@ amD
 awu
 axh
 awu
-amD
-amD
+agO
+agO
 azT
 acn
 agO
@@ -60833,7 +60849,7 @@ amD
 awv
 awv
 awv
-amD
+agO
 acx
 aWN
 acb
@@ -61015,8 +61031,8 @@ kjO
 kjO
 erK
 aOn
-pXI
-afC
+iPD
+awz
 aCV
 cxr
 cxr
@@ -61090,7 +61106,7 @@ amD
 aWQ
 axh
 aWQ
-amD
+agO
 ahy
 aeF
 aeF
@@ -61273,7 +61289,7 @@ cQz
 rnC
 aOn
 iPD
-acd
+apC
 bjH
 dwU
 cxr
@@ -61341,13 +61357,13 @@ amD
 amD
 amD
 amD
-amD
+atu
 aqR
 amD
 aww
-axi
-awz
-aqR
+axe
+awx
+aMY
 aNQ
 aeF
 ahx
@@ -61529,8 +61545,8 @@ yhF
 yhF
 yhF
 uOq
-efj
-aYr
+iPD
+axQ
 aYr
 aYr
 aYr
@@ -61593,18 +61609,18 @@ vxh
 sae
 vxh
 gzt
+uXS
+qgW
+eka
 amD
-aTd
-aTd
-aTd
-aTd
-aTd
-aTd
+avC
+axe
+awx
 amD
-ass
+aSF
 axj
-afa
-amD
+awB
+agO
 aTj
 aeF
 aPX
@@ -61786,8 +61802,8 @@ oDI
 oDI
 oDI
 aOn
-vZN
-bTx
+iPD
+axd
 bTx
 bTx
 bTx
@@ -61850,18 +61866,18 @@ sMc
 gzt
 whz
 gzt
+wVL
+sho
+jFk
 amD
-aTd
-aTd
-aTd
-aTd
-aTd
-aTd
+aSF
+axj
+awB
 amD
-ass
+aSF
 afw
-atr
-agS
+awB
+afa
 avm
 aWR
 aRH
@@ -62043,8 +62059,8 @@ yhF
 yhF
 yhF
 hGa
-efj
-aYr
+iPD
+axQ
 aYr
 aYr
 aYr
@@ -62108,18 +62124,18 @@ fZx
 nia
 lNd
 amD
-suo
-suo
-suo
-aTd
-aTd
-aTd
 amD
-awx
-afw
+amD
+amD
+aSF
+axf
 awB
-ayr
-apR
+amD
+aSF
+axf
+awB
+aOQ
+aRH
 aRH
 aJW
 aeE
@@ -62300,8 +62316,8 @@ auh
 auh
 xjq
 aOn
-qCm
-gJY
+iPD
+apT
 iRM
 iRM
 iRM
@@ -62368,15 +62384,15 @@ uXS
 qgW
 eka
 amD
-aTd
-aTd
-aTd
+aSF
+axf
+awB
 avF
-awy
-aTK
-axQ
-amD
-apR
+aSF
+axf
+awB
+agO
+aRH
 aWy
 aSk
 aZs
@@ -62557,8 +62573,8 @@ erK
 erK
 uun
 aOn
-qiU
-afC
+iPD
+awz
 aGD
 aCV
 aYB
@@ -62625,15 +62641,15 @@ wVL
 sho
 jFk
 amD
-aTd
-aTd
-aTd
+aSF
+axf
+awB
 agS
-awz
-aTK
-axR
+aSF
+axf
+awB
 aOQ
-aQE
+aRH
 aPM
 aOm
 aSR
@@ -62815,7 +62831,7 @@ aOn
 aOn
 aft
 aft
-aAf
+avD
 aYB
 aGH
 aUy
@@ -62882,16 +62898,16 @@ vxh
 vxh
 vxh
 amD
-aTd
-aTd
-aTd
+aSF
+axj
+awB
 amD
-asu
+aSF
 afw
-awh
-agS
+awB
+afa
 anj
-aMJ
+aWy
 aTI
 aZl
 azz
@@ -63140,19 +63156,19 @@ qgW
 eka
 amD
 aTd
-aTd
-aTd
+awt
+aMJ
 amD
-asu
-afw
-abm
-amD
+aSF
+axk
+awB
+agO
 avm
-aNy
+aRH
 aar
 afi
 aar
-aNy
+aRH
 asx
 agO
 aaa
@@ -63402,12 +63418,12 @@ amD
 amD
 aSF
 afw
-ats
-aqR
+awB
+aMY
 aff
 aWR
 aRH
-aNC
+aWR
 aRH
 aWR
 adW
@@ -63653,18 +63669,18 @@ vxh
 vxh
 vxh
 amD
-aNE
-aNE
-aNE
+aBS
+aTK
+aBS
 amD
-asu
+aSF
 afw
-ats
-amD
-amD
+awB
+aYa
+aYa
 arY
 aST
-aVO
+aST
 aST
 arY
 aYa
@@ -63910,18 +63926,18 @@ vDH
 qgW
 eka
 amD
-aNE
-aNE
-aNE
-amD
-asu
-afw
-ats
-amD
+avC
+axi
+awx
+efj
+aSF
+axf
+awB
+aYa
 abp
 aZv
 asE
-abH
+asE
 asE
 aZv
 aVZ
@@ -64167,18 +64183,18 @@ wVL
 sho
 jFk
 amD
-aNE
-aNE
-aNE
-amD
-asu
+aTd
+awt
+aMJ
+agS
+aSF
 axf
-ats
-amD
+awB
+aYa
 aDY
-abH
-abH
-abH
+asE
+asE
+asE
 asE
 asE
 aVu
@@ -64424,16 +64440,16 @@ vxh
 vxh
 vxh
 amD
-aNE
-aNE
-aNE
+aGA
+aVO
+aGA
 aqR
-awA
-afw
-ats
-amD
+aSF
+axf
+awB
+aYa
 aVE
-abH
+asE
 aRV
 aSq
 agX
@@ -64681,16 +64697,16 @@ vDH
 qgW
 eka
 amD
+qCm
 aNE
-aNE
-aNE
+awy
 amD
-asu
+aSF
 afw
-ats
-amD
+awB
+aYa
 aXe
-abH
+asE
 abA
 abj
 aPt
@@ -64942,14 +64958,14 @@ aNE
 aNE
 aNE
 amD
-asu
-axk
-ats
-amD
+aSF
+axj
+awB
+aYa
 ayl
-abH
-abH
-abH
+asE
+asE
+asE
 asE
 asE
 aIK
@@ -65195,18 +65211,18 @@ vxh
 vxh
 kcI
 amD
+axc
 aNE
-aNE
-aNE
+axR
 amD
-awB
-axi
+aTd
+awt
 axS
-amD
+aYa
 abI
 aoL
 afj
-aRM
+asE
 aPE
 awl
 aVM
@@ -65459,8 +65475,8 @@ amD
 awu
 axh
 awu
-amD
-amD
+aYa
+aYa
 arY
 aYa
 aYa
@@ -65709,10 +65725,10 @@ wVL
 sho
 jFk
 amD
+abH
 aNE
-aNE
-aNE
-avz
+awh
+amD
 avz
 avz
 avz
@@ -65966,17 +65982,17 @@ amD
 amD
 amD
 amD
-aQC
-aQC
+amD
+amD
 amD
 amD
 aZb
-amD
+aGA
 aZb
 amD
 axG
 aMP
-aFR
+axZ
 obs
 aHj
 aHj
@@ -66233,7 +66249,7 @@ aaw
 aae
 aew
 aew
-aFR
+axZ
 atD
 amo
 ayh
@@ -66448,9 +66464,9 @@ ama
 aPZ
 aEd
 kpH
-qXd
-aMc
-aMc
+aXy
+apD
+apD
 kpH
 aVb
 azX
@@ -66962,9 +66978,9 @@ aaa
 aiA
 aiA
 aiA
-afB
-afB
-afB
+awr
+awr
+awr
 aiA
 aiA
 aiA
@@ -70599,7 +70615,7 @@ anP
 aTV
 aWb
 aMo
-apq
+ayp
 aew
 aew
 aQC

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -503,11 +503,14 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/borbop)
 "abm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/siding/white{
+	dir = 4
 	},
-/turf/open/floor/carpet/red,
-/area/centcom/central_command_areas/admin)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/retirement_yard)
 "abn" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/records/security/laptop/syndie,
@@ -673,10 +676,17 @@
 /turf/open/floor/plating,
 /area/centcom/syndicate_mothership/control)
 "abH" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/vg_decals/numbers/three,
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/warning{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/smooth_large,
-/area/centcom/central_command_areas/supplypod/pod_storage)
+/area/centcom/central_command_areas/retirement_yard)
 "abI" = (
 /obj/structure/closet/secure_closet/ert_com,
 /obj/structure/sign/directions/command{
@@ -1929,9 +1939,9 @@
 /turf/open/floor/mineral/plastitanium,
 /area/centcom/syndicate_mothership/expansion_bombthreat)
 "afa" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/indestructible/riveted,
-/area/centcom/central_command_areas/briefing)
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/ferry)
 "afb" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/directional/south,
@@ -5808,27 +5818,21 @@
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/hall)
 "apB" = (
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/centcom/central_command_areas/ferry)
+"apC" = (
 /obj/machinery/light/floor/has_bulb,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/admin)
-"apC" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/retirement_yard)
 "apD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/wood/large,
-/area/centcom/central_command_areas/admin)
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon/cerulean,
+/turf/open/space/basic,
+/area/space)
 "apE" = (
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner,
 /obj/effect/turf_decal/siding/thinplating_new/dark/corner{
@@ -5964,17 +5968,16 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range)
 "apT" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/supplypod/loading/ert)
+"apU" = (
+/obj/structure/railing/wood{
 	dir = 1
 	},
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/retirement_yard)
-"apU" = (
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/ferry)
+/obj/structure/hedge,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/wood/large,
+/area/centcom/tdome/observation)
 "apV" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -5985,8 +5988,12 @@
 /turf/open/ai_visible,
 /area/centcom/ai_multicam_room)
 "apX" = (
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/supplypod/loading/ert)
+/obj/structure/fans/tiny/forcefield{
+	color = "#276c87";
+	dir = 4
+	},
+/turf/closed/indestructible/grille,
+/area/centcom/central_command_areas/admin)
 "apY" = (
 /obj/structure/frame/computer{
 	dir = 1
@@ -6217,17 +6224,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/supplypod/loading/ert)
 "aqG" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "Ferry Airlock"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/ferry)
+/obj/structure/sign/warning/secure_area,
+/turf/closed/indestructible/riveted,
+/area/centcom/central_command_areas/briefing)
 "aqH" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/machinery/vending/wardrobe/jani_wardrobe,
@@ -6378,9 +6377,8 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/borbop)
 "arb" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
+/obj/machinery/light/small/directional/north,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/centcom/central_command_areas/ferry)
 "arc" = (
 /obj/structure/dresser,
@@ -8052,13 +8050,11 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "avD" = (
-/obj/structure/flora/bush/fullgrass/style_3,
-/obj/structure/flora/bush/large/style_3,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/grass,
-/area/centcom/central_command_areas/retirement_yard)
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/ferry)
 "avE" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/siding/wood{
@@ -8261,7 +8257,7 @@
 /area/centcom/central_command_areas/hall)
 "awh" = (
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/vg_decals/numbers/six,
+/obj/effect/turf_decal/vg_decals/numbers/three,
 /turf/open/floor/iron/dark/smooth_large,
 /area/centcom/central_command_areas/supplypod/pod_storage)
 "awi" = (
@@ -8341,11 +8337,8 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/firing_range_checkpoint_control)
 "awr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood/large,
-/area/centcom/central_command_areas/admin_hangout)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/centcom/central_command_areas/ferry)
 "aws" = (
 /obj/structure/closet/cardboard/metal,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -8399,31 +8392,37 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "awx" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 10
+/obj/machinery/light/floor/has_bulb,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/wood/large,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/admin)
 "awy" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/vg_decals/numbers/four,
-/turf/open/floor/iron/dark/smooth_large,
-/area/centcom/central_command_areas/supplypod/pod_storage)
-"awz" = (
+/obj/effect/turf_decal/siding/white{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/retirement_yard)
-"awA" = (
-/obj/structure/fans/tiny/forcefield{
-	color = "#276c87";
-	dir = 4
+"awz" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 10
 	},
-/turf/closed/indestructible/grille,
-/area/centcom/central_command_areas/admin)
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/ferry)
+"awA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/centcom/central_command_areas/retirement_yard)
 "awB" = (
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 5
+	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "awC" = (
@@ -8605,30 +8604,36 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/botany)
 "axc" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/vg_decals/numbers/two,
-/turf/open/floor/iron/dark/smooth_large,
-/area/centcom/central_command_areas/supplypod/pod_storage)
-"axd" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/flora/bush/fullgrass/style_3,
+/obj/structure/flora/bush/large/style_3,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/smooth_large,
+/turf/open/floor/grass,
 /area/centcom/central_command_areas/retirement_yard)
+"axd" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/vg_decals/numbers/one,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supplypod/pod_storage)
 "axe" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/obj/machinery/light/floor/has_bulb{
+	pixel_x = 16;
+	pixel_y = 0
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "axf" = (
-/turf/open/floor/glass/reinforced,
+/obj/machinery/door/airlock/external/ruin{
+	name = "Ferry Airlock"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "axg" = (
 /obj/effect/turf_decal/siding/wood{
@@ -8654,7 +8659,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
-/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "axj" = (
@@ -8662,12 +8666,10 @@
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
 "axk" = (
-/obj/machinery/light/floor/has_bulb{
-	pixel_x = 16;
-	pixel_y = 0
-	},
-/turf/open/floor/wood/large,
-/area/centcom/central_command_areas/ferry)
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/vg_decals/numbers/four,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supplypod/pod_storage)
 "axl" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -8868,15 +8870,17 @@
 /area/centcom/central_command_areas/admin)
 "axQ" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/centcom/central_command_areas/retirement_yard)
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/admin_hangout)
 "axR" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/vg_decals/numbers/five,
-/turf/open/floor/iron/dark/smooth_large,
-/area/centcom/central_command_areas/supplypod/pod_storage)
+/obj/machinery/door/airlock/centcom{
+	name = "Drop Pod Storage Bay"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/centcom/central_command_areas/ferry)
 "axS" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -9126,13 +9130,9 @@
 /turf/open/floor/iron/white/textured,
 /area/centcom/central_command_areas/medical)
 "ayp" = (
-/obj/structure/railing/wood{
-	dir = 1
-	},
-/obj/structure/hedge,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/wood/large,
-/area/centcom/tdome/observation)
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating/airless,
+/area/centcom/central_command_areas/admin)
 "ayq" = (
 /obj/structure/hedge,
 /obj/effect/turf_decal/siding/dark{
@@ -9144,9 +9144,16 @@
 	},
 /area/centcom/central_command_areas/hall)
 "ayr" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/door/airlock/centcom{
+	name = "Briefing Room"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/any/admin/general,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/centcom/central_command_areas/briefing)
 "ays" = (
 /obj/structure/chair/sofa/middle{
 	color = "#ad96af"
@@ -14497,11 +14504,11 @@
 /turf/open/floor/glass/reinforced/plasma,
 /area/centcom/central_command_areas/adminroom)
 "aMJ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 6
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "TEMP=2.7"
 	},
-/turf/open/floor/wood/large,
-/area/centcom/central_command_areas/ferry)
+/area/centcom/central_command_areas/admin)
 "aMK" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/structure/railing/wood,
@@ -14794,10 +14801,10 @@
 /turf/open/floor/iron/white/herringbone,
 /area/centcom/central_command_areas/kitchen)
 "aNy" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon/cerulean,
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/wood/large{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/centcom/central_command_areas/admin)
 "aNz" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -14822,17 +14829,20 @@
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/hall)
 "aNC" = (
-/obj/structure/holosign/barrier/engineering,
-/turf/open/floor/wood/large{
-	initial_gas_mix = "TEMP=2.7"
-	},
-/area/centcom/central_command_areas/admin)
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/vg_decals/numbers/six,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supplypod/pod_storage)
 "aND" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/engine/cult,
 /area/centcom/wizard_station)
 "aNE" = (
-/turf/open/floor/catwalk_floor/iron_dark,
+/obj/machinery/computer/old{
+	dir = 4;
+	desc = "An old computer. Data on various Nanotrasen drop pods flashes across its display."
+	},
+/turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/ferry)
 "aNF" = (
 /obj/structure/fake_stairs/wood/directional/south,
@@ -15299,16 +15309,16 @@
 /turf/open/floor/iron,
 /area/centcom/central_command_areas/supplypod/loading/one)
 "aOQ" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Briefing Room"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/any/admin/general,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/briefing)
+/obj/structure/closet/emcloset,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/ferry)
 "aOR" = (
 /obj/effect/turf_decal/tile/brown/diagonal_centre,
 /obj/structure/table/reinforced,
@@ -16344,10 +16354,12 @@
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/hall)
 "aRM" = (
-/turf/open/floor/wood/large{
-	initial_gas_mix = "TEMP=2.7"
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
 	},
-/area/centcom/central_command_areas/admin)
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/ferry)
 "aRN" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/effect/turf_decal/siding/purple{
@@ -16681,10 +16693,15 @@
 /turf/open/floor/stone,
 /area/centcom/central_command_areas/admin_hangout)
 "aSF" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/door/airlock/centcom{
+	name = "Drop Pod Storage Observation"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/wood/large,
+/turf/open/floor/iron,
 /area/centcom/central_command_areas/ferry)
 "aSG" = (
 /obj/effect/turf_decal/siding/red/corner{
@@ -16852,7 +16869,7 @@
 /area/centcom/central_command_areas/supplypod/loading/two)
 "aTd" = (
 /obj/effect/turf_decal/siding/wood{
-	dir = 5
+	dir = 6
 	},
 /turf/open/floor/wood/large,
 /area/centcom/central_command_areas/ferry)
@@ -17139,11 +17156,7 @@
 /turf/open/floor/iron/dark/corner,
 /area/centcom/central_command_areas/hall)
 "aTK" = (
-/obj/machinery/computer/old{
-	dir = 4;
-	desc = "An old computer. Data on various Nanotrasen drop pods flashes across its display."
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/glass/reinforced,
 /area/centcom/central_command_areas/ferry)
 "aTL" = (
 /obj/machinery/growing/soil,
@@ -17908,12 +17921,9 @@
 /turf/open/misc/asteroid/snow/airless,
 /area/centcom/syndicate_mothership)
 "aVO" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Drop Pod Storage Bay"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/centcom/central_command_areas/ferry)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "aVP" = (
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
 /turf/open/floor/iron,
@@ -18595,15 +18605,10 @@
 /turf/open/floor/wood/large,
 /area/centcom/tdome/observation)
 "aXy" = (
-/obj/machinery/button/door/directional/north{
-	name = "Emergency Assistants Fuck Off Button";
-	id = "donutstealthisid";
-	req_access = "cent_captain"
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/wood/large,
+/turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/admin)
 "aXz" = (
 /obj/structure/flora/bush/grassy/style_random,
@@ -21079,16 +21084,11 @@
 /turf/open/floor/carpet/lone/star,
 /area/centcom/central_command_areas/adminroom)
 "efj" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Drop Pod Storage Observation"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/mapping_helpers/airlock/access/any/admin/captain,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/iron,
-/area/centcom/central_command_areas/ferry)
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/admin)
 "efG" = (
 /obj/effect/turf_decal/weather,
 /obj/effect/turf_decal/weather/dirt{
@@ -23589,6 +23589,9 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/adminroom)
+"iDg" = (
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/ferry)
 "iDN" = (
 /obj/machinery/corral_corner{
 	mapping_id = "13"
@@ -23758,15 +23761,16 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/admin)
 "iPD" = (
-/obj/machinery/door/poddoor/shutters/indestructible/preopen{
-	id = "donutstealthisid"
+/obj/machinery/button/door/directional/north{
+	name = "Emergency Assistants Fuck Off Button";
+	id = "donutstealthisid";
+	req_access = "cent_captain"
 	},
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/centcom/central_command_areas/retirement_yard)
+/turf/open/floor/wood/large,
+/area/centcom/central_command_areas/admin)
 "iQv" = (
 /obj/structure/flora/bush/large/style_3,
 /obj/item/toy/plush/lizard_plushie,
@@ -24369,9 +24373,11 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/evacuation)
 "kcI" = (
-/obj/machinery/light/small/directional/south,
-/turf/closed/indestructible/riveted,
-/area/centcom/central_command_areas/prison)
+/obj/structure/holosign/barrier/engineering,
+/turf/open/floor/wood/large{
+	initial_gas_mix = "TEMP=2.7"
+	},
+/area/centcom/central_command_areas/admin)
 "kdH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -27007,16 +27013,10 @@
 /turf/open/floor/grass,
 /area/centcom/central_command_areas/evacuation)
 "pXI" = (
-/obj/structure/closet/emcloset,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/ferry)
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/vg_decals/numbers/two,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supplypod/pod_storage)
 "pYm" = (
 /obj/structure/railing/wood{
 	dir = 1
@@ -27135,11 +27135,10 @@
 /turf/open/floor/sandy_dirt,
 /area/centcom/central_command_areas/admin)
 "qiU" = (
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/wood/large{
-	initial_gas_mix = "TEMP=2.7"
-	},
-/area/centcom/central_command_areas/admin)
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/vg_decals/numbers/five,
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/supplypod/pod_storage)
 "qja" = (
 /turf/closed/indestructible/wood,
 /area/centcom/central_command_areas/adminroom)
@@ -27314,10 +27313,15 @@
 /turf/open/floor/iron/white/small,
 /area/centcom/central_command_areas/medical)
 "qCm" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/vg_decals/numbers/one,
-/turf/open/floor/iron/dark/smooth_large,
-/area/centcom/central_command_areas/supplypod/pod_storage)
+/obj/machinery/door/poddoor/shutters/indestructible/preopen{
+	id = "donutstealthisid"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/centcom/central_command_areas/retirement_yard)
 "qCL" = (
 /obj/structure/closet/crate/cardboard,
 /obj/item/reagent_containers/cup/glass/bottle/champagne,
@@ -28233,17 +28237,11 @@
 /turf/open/water/arena,
 /area/centcom/central_command_areas/admin)
 "suo" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "Ferry Airlock"
-	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/centcom/central_command_areas/ferry)
+/turf/open/floor/iron/dark/smooth_large,
+/area/centcom/central_command_areas/retirement_yard)
 "sxc" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -29889,12 +29887,17 @@
 /turf/open/floor/wood/parquet,
 /area/centcom/central_command_areas/admin)
 "vZN" = (
-/obj/machinery/light/floor/has_bulb,
+/obj/machinery/door/airlock/external/ruin{
+	name = "Ferry Airlock"
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/wood/large,
-/area/centcom/central_command_areas/admin)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/ferry)
 "vZP" = (
 /obj/effect/turf_decal/siding/wideplating_new/dark{
 	dir = 8
@@ -31133,9 +31136,10 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/prison)
 "yjh" = (
-/obj/structure/girder/reinforced,
-/turf/open/floor/plating/airless,
-/area/centcom/central_command_areas/admin)
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/dark,
+/area/centcom/central_command_areas/ferry)
 "yjw" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -50022,8 +50026,8 @@ aaa
 aaa
 aaa
 aaa
-ayr
-ayr
+aVO
+aVO
 aaa
 aaa
 aaa
@@ -50278,10 +50282,10 @@ aaa
 aaa
 aaa
 aaa
-ayr
-ayr
-ayr
-ayr
+aVO
+aVO
+aVO
+aVO
 aaa
 aaa
 aaa
@@ -50535,11 +50539,11 @@ aaa
 aaa
 aaa
 aaa
-yjh
-aRM
-aRM
-ayr
-ayr
+ayp
+aNy
+aNy
+aVO
+aVO
 aaa
 aaa
 aaa
@@ -50793,10 +50797,10 @@ aaa
 aaa
 aaa
 aOn
-aRM
-aRM
-aRM
-yjh
+aNy
+aNy
+aNy
+ayp
 aaa
 aaa
 aaa
@@ -51050,10 +51054,10 @@ aaa
 aaa
 aaa
 aOn
-aRM
-qiU
-aRM
-yjh
+aNy
+aMJ
+aNy
+ayp
 aaa
 aaa
 aaa
@@ -51307,9 +51311,9 @@ aaa
 aaa
 aaa
 aOn
-aNC
-aNC
-aNC
+kcI
+kcI
+kcI
 aOn
 aaa
 aaa
@@ -51564,9 +51568,9 @@ kpH
 kpH
 kpH
 kpH
-awA
-awA
-awA
+apX
+apX
+apX
 aOn
 aaa
 aaa
@@ -54648,9 +54652,9 @@ wYo
 osr
 tTd
 kpH
-apD
-apD
-apD
+efj
+efj
+efj
 kpH
 pKm
 oDK
@@ -55163,7 +55167,7 @@ kpH
 kpH
 kpH
 aQE
-vZN
+awx
 aQE
 kpH
 kpH
@@ -56989,7 +56993,7 @@ aaa
 aaa
 aaa
 aaa
-aNy
+apD
 aaa
 aaa
 aaa
@@ -56997,7 +57001,7 @@ aaa
 aaa
 aaa
 aaa
-aNy
+apD
 aaa
 aaa
 aaa
@@ -57218,9 +57222,9 @@ kpH
 kpH
 kpH
 aOn
-apD
-apB
-apD
+efj
+apC
+efj
 aOn
 aOn
 aOn
@@ -57246,7 +57250,7 @@ aaa
 aaa
 aaa
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -57254,7 +57258,7 @@ aaa
 aaa
 aaa
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -57503,7 +57507,7 @@ aaa
 aaa
 aaa
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -57511,7 +57515,7 @@ aaa
 aaa
 aaa
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -57732,9 +57736,9 @@ aOn
 aOn
 aOn
 aOn
-abm
-abm
-abm
+aXy
+aXy
+aXy
 aOn
 aOn
 ahD
@@ -57760,7 +57764,7 @@ aaa
 aaa
 aaa
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -57768,7 +57772,7 @@ aaa
 aaa
 aaa
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -58017,7 +58021,7 @@ aaa
 aaa
 aaa
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -58025,7 +58029,7 @@ aaa
 aaa
 aaa
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -58274,7 +58278,7 @@ aaa
 aaa
 aaa
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -58282,7 +58286,7 @@ aaa
 aaa
 aaa
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -58539,7 +58543,7 @@ aKm
 aaa
 aaa
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -58792,11 +58796,11 @@ aGA
 aaa
 aaa
 aGA
-suo
+vZN
 aGA
 aaa
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -59049,11 +59053,11 @@ amD
 aaa
 aaa
 aGA
-arb
+yjh
 aGA
 aaa
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -59306,11 +59310,11 @@ amD
 avA
 aGA
 aGA
-aqG
+axf
 aGA
 aGA
 aaa
-ayr
+aVO
 aaa
 aaa
 aaa
@@ -59563,8 +59567,8 @@ amD
 avB
 aBS
 aBS
-apU
-pXI
+iDg
+aOQ
 aGA
 ata
 aGA
@@ -59818,15 +59822,15 @@ ats
 aBy
 amD
 avC
-axe
-axe
-axe
-awx
+axi
+axi
+axi
+awz
 amD
 aqF
-apX
+apT
 aqF
-apX
+apT
 aqF
 aGA
 aaa
@@ -60074,17 +60078,17 @@ asu
 ats
 apR
 auO
-aSF
-axf
-axf
-axf
-awB
+avD
+aTK
+aTK
+aTK
+afa
 asd
-apX
-apX
-apX
-apX
-apX
+apT
+apT
+apT
+apT
+apT
 aGA
 aaa
 aaa
@@ -60338,9 +60342,9 @@ awt
 atn
 amD
 aqF
-apX
+apT
 aqF
-apX
+apT
 aqF
 aGA
 aaa
@@ -61031,8 +61035,8 @@ kjO
 kjO
 erK
 aOn
-iPD
-awz
+qCm
+awA
 aCV
 cxr
 cxr
@@ -61288,8 +61292,8 @@ cQz
 cQz
 rnC
 aOn
-iPD
-apC
+qCm
+abm
 bjH
 dwU
 cxr
@@ -61361,8 +61365,8 @@ atu
 aqR
 amD
 aww
-axe
-awx
+axi
+awz
 aMY
 aNQ
 aeF
@@ -61545,8 +61549,8 @@ yhF
 yhF
 yhF
 uOq
-iPD
-axQ
+qCm
+suo
 aYr
 aYr
 aYr
@@ -61614,12 +61618,12 @@ qgW
 eka
 amD
 avC
-axe
-awx
+axi
+awz
 amD
-aSF
+avD
 axj
-awB
+afa
 agO
 aTj
 aeF
@@ -61802,8 +61806,8 @@ oDI
 oDI
 oDI
 aOn
-iPD
-axd
+qCm
+abH
 bTx
 bTx
 bTx
@@ -61870,14 +61874,14 @@ wVL
 sho
 jFk
 amD
-aSF
+avD
 axj
-awB
-amD
-aSF
-afw
-awB
 afa
+amD
+avD
+afw
+afa
+aqG
 avm
 aWR
 aRH
@@ -62059,8 +62063,8 @@ yhF
 yhF
 yhF
 hGa
-iPD
-axQ
+qCm
+suo
 aYr
 aYr
 aYr
@@ -62127,14 +62131,14 @@ amD
 amD
 amD
 amD
-aSF
-axf
-awB
+avD
+aTK
+afa
 amD
-aSF
-axf
-awB
-aOQ
+avD
+aTK
+afa
+ayr
 aRH
 aRH
 aJW
@@ -62316,8 +62320,8 @@ auh
 auh
 xjq
 aOn
-iPD
-apT
+qCm
+awy
 iRM
 iRM
 iRM
@@ -62384,13 +62388,13 @@ uXS
 qgW
 eka
 amD
-aSF
-axf
-awB
+avD
+aTK
+afa
 avF
-aSF
-axf
-awB
+avD
+aTK
+afa
 agO
 aRH
 aWy
@@ -62573,8 +62577,8 @@ erK
 erK
 uun
 aOn
-iPD
-awz
+qCm
+awA
 aGD
 aCV
 aYB
@@ -62641,14 +62645,14 @@ wVL
 sho
 jFk
 amD
-aSF
-axf
-awB
+avD
+aTK
+afa
 agS
-aSF
-axf
-awB
-aOQ
+avD
+aTK
+afa
+ayr
 aRH
 aPM
 aOm
@@ -62831,7 +62835,7 @@ aOn
 aOn
 aft
 aft
-avD
+axc
 aYB
 aGH
 aUy
@@ -62898,14 +62902,14 @@ vxh
 vxh
 vxh
 amD
-aSF
+avD
 axj
-awB
-amD
-aSF
-afw
-awB
 afa
+amD
+avD
+afw
+afa
+aqG
 anj
 aWy
 aTI
@@ -63155,13 +63159,13 @@ vDH
 qgW
 eka
 amD
-aTd
-awt
-aMJ
-amD
-aSF
-axk
 awB
+awt
+aTd
+amD
+avD
+axe
+afa
 agO
 avm
 aRH
@@ -63416,9 +63420,9 @@ amD
 amD
 amD
 amD
-aSF
+avD
 afw
-awB
+afa
 aMY
 aff
 aWR
@@ -63670,12 +63674,12 @@ vxh
 vxh
 amD
 aBS
-aTK
+aNE
 aBS
 amD
-aSF
+avD
 afw
-awB
+afa
 aYa
 aYa
 arY
@@ -63927,12 +63931,12 @@ qgW
 eka
 amD
 avC
-axi
-awx
-efj
+aRM
+awz
 aSF
-axf
-awB
+avD
+aTK
+afa
 aYa
 abp
 aZv
@@ -64183,13 +64187,13 @@ wVL
 sho
 jFk
 amD
-aTd
-awt
-aMJ
-agS
-aSF
-axf
 awB
+awt
+aTd
+agS
+avD
+aTK
+afa
 aYa
 aDY
 asE
@@ -64441,12 +64445,12 @@ vxh
 vxh
 amD
 aGA
-aVO
+axR
 aGA
 aqR
-aSF
-axf
-awB
+avD
+aTK
+afa
 aYa
 aVE
 asE
@@ -64697,13 +64701,13 @@ vDH
 qgW
 eka
 amD
-qCm
-aNE
-awy
+axd
+awr
+axk
 amD
-aSF
+avD
 afw
-awB
+afa
 aYa
 aXe
 asE
@@ -64954,13 +64958,13 @@ wVL
 sho
 jFk
 amD
-aNE
-aNE
-aNE
+arb
+awr
+awr
 amD
-aSF
+avD
 axj
-awB
+afa
 aYa
 ayl
 asE
@@ -65209,13 +65213,13 @@ gRB
 lNd
 vxh
 vxh
-kcI
+vxh
 amD
-axc
-aNE
-axR
+pXI
+awr
+qiU
 amD
-aTd
+awB
 awt
 axS
 aYa
@@ -65468,9 +65472,9 @@ vDH
 qgW
 eka
 amD
-aNE
-aNE
-aNE
+awr
+awr
+apB
 amD
 awu
 axh
@@ -65725,9 +65729,9 @@ wVL
 sho
 jFk
 amD
-abH
-aNE
 awh
+awr
+aNC
 amD
 avz
 avz
@@ -66464,9 +66468,9 @@ ama
 aPZ
 aEd
 kpH
-aXy
-apD
-apD
+iPD
+efj
+efj
 kpH
 aVb
 azX
@@ -66978,9 +66982,9 @@ aaa
 aiA
 aiA
 aiA
-awr
-awr
-awr
+axQ
+axQ
+axQ
 aiA
 aiA
 aiA
@@ -70615,7 +70619,7 @@ anP
 aTV
 aWb
 aMo
-ayp
+apU
 aew
 aew
 aQC


### PR DESCRIPTION

## About The Pull Request

makes the ert shuttle dock hallway look more visually consistent with the ghost area of centcom, adds a little half-built/destroyed hallway bit at the holobarrier'd expansion point, shrinks the ert shuttle hallway

## Why It's Good For The Game

is the ert shuttle touching the border of the syndicate base good for the game?

also looks far nicer

## Changelog
:cl:
qol: Johnson & Co Architecture has broken into CentCom yet again in the name of upgrading it. Expect the ERT shuttle dock to look slightly more consistent with the rest of CentCom.
/:cl:
