### PR TITLE
PDA Alert level

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -857,7 +857,7 @@
 #define ALERT_RELEVANCY_PERTINENT 2 /// * 2: Danger is around and the user is responsible for handling it.
 /obj/item/modular_computer/proc/get_security_level_relevancy()
 	switch(SSsecurity_level.get_current_level_as_number()) // all-hands-on-deck situations, everyone is responsible for combatting a threat
-		if(SEC_LEVEL_DELTA, SEC_LEVEL_RED, SEC_LEVEL_EPSILON, SEC_LEVEL_GAMMA)
+		if(SEC_LEVEL_DELTA, SEC_LEVEL_RED, SEC_LEVEL_EPSILON, SEC_LEVEL_GAMMA, SEC_LEVEL_LAMBDA,)
 			return ALERT_RELEVANCY_PERTINENT
 		if(SEC_LEVEL_AMBER) // Ongoing medical threat. Medical staff are to contribute.
 			if((ACCESS_SECURITY in computer_id_slot?.access) || (ACCESS_MEDICAL in computer_id_slot?.access))

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -850,3 +850,35 @@
 ///Returns a string of what to send at the end of messenger's messages.
 /obj/item/modular_computer/proc/get_messenger_ending()
 	return "Sent from my PDA"
+
+/// Returns how relevant the current security level is:
+#define ALERT_RELEVANCY_SAFE 0 /// * 0: User is not in immediate danger and not needed for some station-critical task.
+#define ALERT_RELEVANCY_WARN 1 /// * 1: Danger is around, but the user is not directly needed to handle it.
+#define ALERT_RELEVANCY_PERTINENT 2 /// * 2: Danger is around and the user is responsible for handling it.
+/obj/item/modular_computer/proc/get_security_level_relevancy()
+	switch(SSsecurity_level.get_current_level_as_number()) // all-hands-on-deck situations, everyone is responsible for combatting a threat
+		if(SEC_LEVEL_DELTA, SEC_LEVEL_RED, SEC_LEVEL_EPSILON, SEC_LEVEL_GAMMA)
+			return ALERT_RELEVANCY_PERTINENT
+		if(SEC_LEVEL_AMBER) // Ongoing medical threat. Medical staff are to contribute.
+			if((ACCESS_SECURITY in computer_id_slot?.access) || (ACCESS_MEDICAL in computer_id_slot?.access))
+				return ALERT_RELEVANCY_PERTINENT
+			else
+				return ALERT_RELEVANCY_WARN
+		if(SEC_LEVEL_YELLOW) // Ongoing engineering issues. Engineering staff are to contribute.
+			if((ACCESS_SECURITY in computer_id_slot?.access) || (ACCESS_ENGINEERING in computer_id_slot?.access))
+				return ALERT_RELEVANCY_PERTINENT
+			else
+				return ALERT_RELEVANCY_WARN
+		if(SEC_LEVEL_BLUE) // suspected threat. security needs to be alert and possibly preparing for it, no further concerns
+			if(ACCESS_SECURITY in computer_id_slot?.access)
+				return ALERT_RELEVANCY_PERTINENT
+			else
+				return ALERT_RELEVANCY_WARN
+		if(SEC_LEVEL_GREEN) // no threats, no concerns
+			return ALERT_RELEVANCY_SAFE
+
+	return 0
+
+#undef ALERT_RELEVANCY_SAFE
+#undef ALERT_RELEVANCY_WARN
+#undef ALERT_RELEVANCY_PERTINENT

--- a/code/modules/modular_computers/computers/item/computer_ui.dm
+++ b/code/modules/modular_computers/computers/item/computer_ui.dm
@@ -112,6 +112,10 @@
 			"alert" = program.alert_pending,
 		))
 
+	data["alert_style"] = get_security_level_relevancy()
+	data["alert_color"] = SSsecurity_level?.current_security_level?.announcement_color
+	data["alert_name"] = SSsecurity_level?.current_security_level?.name_shortform
+
 	return data
 
 // Handles user's GUI input

--- a/code/modules/security_levels/security_level_datums.dm
+++ b/code/modules/security_levels/security_level_datums.dm
@@ -9,6 +9,8 @@
 /datum/security_level
 	/// The name of this security level.
 	var/name = "not set"
+	/// A three-letter shortform of the security level.
+	var/name_shortform = "not set"
 	/// The color of our announcement divider.
 	var/announcement_color = "default"
 	/// The numerical level of this security level, see defines for more information.
@@ -48,6 +50,7 @@
  */
 /datum/security_level/green
 	name = "green"
+	name_shortform = "GRN"
 	announcement_color = "green"
 	sound = 'sound/misc/notice2.ogg' // Friendly beep
 	number_level = SEC_LEVEL_GREEN
@@ -62,6 +65,7 @@
  */
 /datum/security_level/blue
 	name = "blue"
+	name_shortform = "BLU"
 	announcement_color = "blue"
 	sound = 'sound/misc/notice1.ogg' // Angry alarm
 	number_level = SEC_LEVEL_BLUE
@@ -77,6 +81,7 @@
  */
 /datum/security_level/red
 	name = "red"
+	name_shortform = "RED"
 	announcement_color = "red"
 	sound = 'sound/misc/notice3.ogg' // More angry alarm
 	number_level = SEC_LEVEL_RED
@@ -91,6 +96,7 @@
  */
 /datum/security_level/delta
 	name = "delta"
+	name_shortform = "Δ"
 	announcement_color = "purple"
 	sound = 'sound/misc/airraid.ogg' // Air alarm to signify importance
 	number_level = SEC_LEVEL_DELTA
@@ -106,6 +112,7 @@
  */
 /datum/security_level/epsilon
 	name = "epsilon"
+	name_shortform = "ε"
 	announcement_color = "grey" //this was painful
 	number_level = SEC_LEVEL_EPSILON
 	sound = 'monkestation/sound/misc/epsilon.ogg'
@@ -120,6 +127,7 @@
  */
 /datum/security_level/yellow
 	name = "yellow"
+	name_shortform =  "Ylw"
 	announcement_color = "yellow"
 	number_level = SEC_LEVEL_YELLOW
 	sound = 'sound/misc/notice1.ogg' // Its just a more spesific blue alert
@@ -135,6 +143,7 @@
  */
 /datum/security_level/amber
 	name = "amber"
+	name_shortform = "Amb"
 	announcement_color = "amber" //I see now why adding grey was painful. WATER IN THE FIRE, WHY?! (Thank you Absolucy for helping add more colors)
 	number_level = SEC_LEVEL_AMBER
 	sound = 'sound/misc/notice1.ogg' // Its just a more spesific blue alert v2
@@ -150,6 +159,7 @@
  */
 /datum/security_level/gamma
 	name = "gamma"
+	name_shortform = "γ"
 	announcement_color = "pink" //Its like red, but diffrent.
 	number_level = SEC_LEVEL_GAMMA
 	sound = 'monkestation/sound/misc/gamma.ogg' // Its just the star wars death star alert, but pitched lower and slowed down ever so slightly.
@@ -165,6 +175,7 @@
  */
 /datum/security_level/lambda
 	name = "lambda"
+	name_shortform = "λ"
 	announcement_color = "crimson" //Thanking Absolucy for having a bigger brain than me in figuring out colors.
 	number_level = SEC_LEVEL_LAMBDA
 	sound = 'monkestation/sound/misc/lambda.ogg' // Ported over the current (as of this codes time) ss14 gamma alert, renamed because it fits better. Old gamma was better :(

--- a/tgui/packages/tgui/constants.ts
+++ b/tgui/packages/tgui/constants.ts
@@ -63,6 +63,8 @@ export const CSS_COLORS = [
   'pink',
   'brown',
   'grey',
+  'amber',
+  'crimson',
   'good',
   'average',
   'bad',

--- a/tgui/packages/tgui/interfaces/NtosMain.jsx
+++ b/tgui/packages/tgui/interfaces/NtosMain.jsx
@@ -2,9 +2,18 @@ import { useBackend } from '../backend';
 import { Button, ColorBox, Stack, Section, Table } from '../components';
 import { NtosWindow } from '../layouts';
 
+export const alert_relevancies = {
+  ALERT_RELEVANCY_SAFE: 0,
+  ALERT_RELEVANCY_WARN: 1,
+  ALERT_RELEVANCY_PERTINENT: 2,
+};
+
 export const NtosMain = (props) => {
   const { act, data } = useBackend();
   const {
+    alert_style,
+    alert_color,
+    alert_name,
     PC_device_theme,
     show_imprint,
     programs = [],
@@ -43,11 +52,34 @@ export const NtosMain = (props) => {
                     onClick={() =>
                       act('PC_runprogram', {
                         name: app.name,
+                        w,
                       })
                     }
                   />
                 </Stack.Item>
               ))}
+              <Stack.Item right={0}>
+                <Button
+                  className={
+                    alert_style === alert_relevancies.ALERT_RELEVANCY_PERTINENT
+                      ? 'alertIndicator alertBlink'
+                      : 'alertIndicator'
+                  }
+                  textColor={
+                    alert_style === alert_relevancies.ALERT_RELEVANCY_SAFE
+                      ? alert_color
+                      : '#000000'
+                  }
+                  backgroundColor={
+                    alert_style === alert_relevancies.ALERT_RELEVANCY_SAFE
+                      ? '#0000000'
+                      : alert_color
+                  }
+                  tooltip="The current alert level. Indicator becomes more intense when there is a threat, moreso if your department is responsible for handling it."
+                >
+                  {alert_name}
+                </Button>
+              </Stack.Item>
             </Stack>
             <Stack>
               {removable_media.map((device) => (

--- a/tgui/packages/tgui/interfaces/NtosMain.jsx
+++ b/tgui/packages/tgui/interfaces/NtosMain.jsx
@@ -52,7 +52,6 @@ export const NtosMain = (props) => {
                     onClick={() =>
                       act('PC_runprogram', {
                         name: app.name,
-                        w,
                       })
                     }
                   />

--- a/tgui/packages/tgui/styles/colors.scss
+++ b/tgui/packages/tgui/styles/colors.scss
@@ -24,6 +24,10 @@ $brown: #a5673f !default;
 $grey: #767676 !default;
 $light-grey: #aaa !default;
 
+//monkestation addition:
+$amber: #b26800 !default;
+$crimson: #750b20 !default;
+
 $primary: #4972a1 !default;
 $good: #5baa27 !default;
 $average: #f08f11 !default;
@@ -60,6 +64,8 @@ $_gen_map: (
   'brown': $brown,
   'grey': $grey,
   'light-grey': $light-grey,
+  'amber': $amber,
+  'crimson': $crimson,
   'good': $good,
   'average': $average,
   'bad': $bad,

--- a/tgui/packages/tgui/styles/layouts/NtosHeader.scss
+++ b/tgui/packages/tgui/styles/layouts/NtosHeader.scss
@@ -18,3 +18,31 @@
   margin-bottom: -0.5em;
   vertical-align: middle;
 }
+
+.alertIndicator {
+  font-weight: bold;
+  right: '0px';
+  text-align: 'center';
+  vertical-align: 'center';
+  font-family: 'Courier New';
+}
+
+.alertBlink {
+  color: #ffffff;
+  animation: alertBlinkAnimation 1s infinite;
+}
+
+@keyframes alertBlinkAnimation {
+  0% {
+    color: #dddddd;
+  }
+  49% {
+    color: #dddddd;
+  }
+  50% {
+    color: #333333;
+  }
+  100% {
+    color: #333333;
+  }
+}


### PR DESCRIPTION
## About The Pull Request
Ports alert levels will showing on PDAS from [#89173](https://github.com/tgstation/tgstation/pull/89173) 
The intensity will also change depending on how relevant it is to the users access.
![Screenshot 2025-04-23 020611](https://github.com/user-attachments/assets/6a7a7aae-fbcf-4132-85ca-1947799299ca)

## Why It's Good For The Game
Visual communication of ongoing levels is great. Also lets me know if I can slip a security officer for having a gun out on green alert.
## Changelog
:cl:
qol: Alert levels now show on pda's
/:cl:
