### PR TITLE
Bugfix - Blueshield Bogseo case now has ammoboxes instead of loose rounds

### DIFF
--- a/monkestation/code/modules/blueshift/items/company_guns.dm
+++ b/monkestation/code/modules/blueshift/items/company_guns.dm
@@ -404,7 +404,7 @@
 // Evil .585 smg that blueshields spawn with that will throw your screen like hell but itll sure kill whoever threatens a head really good
 
 /obj/item/gun/ballistic/automatic/xhihao_smg
-	name = "\improper Bogseo Submachine Gun"
+	name = "\improper Bogseo Heavy Submachine Gun"
 	desc = "A weapon that could hardly be called a 'sub' machinegun, firing the hefty .585 cartridge. \
 		It provides enough kick to bruise a shoulder pretty bad if used without protection."
 

--- a/monkestation/code/modules/blueshift/items/gunset.dm
+++ b/monkestation/code/modules/blueshift/items/gunset.dm
@@ -283,7 +283,7 @@
 	new weapon_to_spawn (src)
 
 	generate_items_inside(list(
-		/obj/item/ammo_casing/c585trappiste/incapacitator = 2,
+		/obj/item/ammo_box/c585trappiste/incapacitator = 2,
 		/obj/item/ammo_box/c585trappiste = 1,
 		/obj/item/ammo_box/magazine/c585trappiste_pistol/spawns_empty = 3,
 	), src)


### PR DESCRIPTION

## About The Pull Request
Fixes the Blueshield Bogseo case to now spawn with 2 boxes of .585 incapacitator instead of 2 loose rounds. Also changes the name to the Bogseo Heavy Submachine Gun, to remind people that it has been changed.
## Why It's Good For The Game
I done goofed, now tis fixed.
## Changelog
:cl:
fix: Blueshield Bogseo case now spawns with 2 ammoboxes instead of 2 loose rounds
/:cl:
