### PR TITLE
Double Monkecoin from Challenges fix

### DIFF
--- a/monkestation/code/modules/coin-events/challenges/challenge_controller.dm
+++ b/monkestation/code/modules/coin-events/challenges/challenge_controller.dm
@@ -25,6 +25,3 @@ SUBSYSTEM_DEF(challenges)
 		if(new_challenge.processes)
 			processing_challenges += processing_challenges
 		new_challenge.on_apply(owner)
-		LAZYADD(owner.applied_challenges, new_challenge)
-
-


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes https://github.com/Monkestation/Monkestation2.0/issues/6368

![image](https://github.com/user-attachments/assets/c2f9da55-52f1-43be-8fb2-46fecd5a01c8)


i didnt test it but the code lazyadd 2 times, so probably this pr fix it

sorry for my bad english
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes are good for games. no bug allowed
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Rengan
fix: fixes getting double monkecoins from challenges
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
