### PR TITLE
Fix smithing minigame

### DIFF
--- a/monkestation/code/modules/smithing/minigame/anvil_minigame.dm
+++ b/monkestation/code/modules/smithing/minigame/anvil_minigame.dm
@@ -159,6 +159,7 @@
 			continue
 		anvil_presses -= note
 		anvil_hud.delete_note(note)
+		failed_notes++
 		if(!length(anvil_presses))
 			if(!notes_left)
 				end_minigame()


### PR DESCRIPTION
## About The Pull Request

>Be smithing 
>Start Minigame
>Do nothing
>Profit

Fixes #4666 

## Why It's Good For The Game

You are no longer able to smith perfect items by doing absolutely nothing.

## Changelog

:cl:
fix: Fixes smithing letting you make perfect items without doing anything.
/:cl: