### PR TITLE
You cannot pick up yourself in a bodybag

### DIFF
--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -20,6 +20,12 @@
 		if(isopenturf(target))
 			deploy_bodybag(user, target)
 
+/obj/item/bodybag/attempt_pickup(mob/user)
+	// can't pick ourselves up if we are inside of the bodybag, else very weird things may happen
+	if(contains(user))
+		return TRUE
+	return ..()
+
 /**
  * Creates a new body bag item when unfolded, at the provided location, replacing the body bag item.
  * * mob/user: User opening the body bag.

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -158,7 +158,7 @@
 			to_chat(content, span_userdanger("You're suddenly forced into a tiny, compressed space!"))
 		if(iscarbon(content))
 			var/mob/living/carbon/mob = content
-			if (mob.dna.get_mutation(/datum/mutation/human/dwarfism))
+			if (mob.dna?.get_mutation(/datum/mutation/human/dwarfism))
 				max_weight_of_contents = max(WEIGHT_CLASS_NORMAL, max_weight_of_contents)
 				continue
 		if(!isitem(content))


### PR DESCRIPTION
## About The Pull Request
Fixes #1058
Fixes #1631

By porting:
https://github.com/tgstation/tgstation/pull/77240
https://github.com/tgstation/tgstation/pull/77067

I built and tested it and I was unable to pick myself up when I was in a bluespace bodybag folded on the ground.
## Why It's Good For The Game
You should not be able to pick yourself up.
## Changelog
:cl:
fix: (distributivgesetz) Fixed a rare bug that let you spam bluespace bodybags everywhere.
fix: (Sealed101) Fixed bluespace bodybags consuming xenomorphs when folded.
/:cl:
