### PR TITLE
Drops support for 515, bumps compile ands tests to 516

### DIFF
--- a/.github/alternate_byond_versions.txt
+++ b/.github/alternate_byond_versions.txt
@@ -7,6 +7,4 @@
 # 500.1337: runtimestation
 # 516.1638: runtimestation;516
 # Lowest supported version
-515.1642: runtimestation
-# Beta version
-516.1652: runtimestation;516
+516.1648: runtimestation

--- a/.github/max_required_byond_client.txt
+++ b/.github/max_required_byond_client.txt
@@ -2,7 +2,7 @@
 # If the compiled world requires clients use a version higher than this, ci will fail.
 #   for instance: if this is set to 514, and a pr uses a 515 client feature, an alert will trigger
 # If you have to update this number for your pr, you should make it VERY CLEAR in the pr body that you did so.
-#   (Requiring clients update to connect to the game server is not something we like to spring on them with no notice, 
+#   (Requiring clients update to connect to the game server is not something we like to spring on them with no notice,
 #   especially for beta builds where the pager/updater won't let them update without additional configuration.)
 
-514
+516

--- a/.tgs.yml
+++ b/.tgs.yml
@@ -3,7 +3,7 @@
 version: 1
 # The BYOND version to use (kept in sync with dependencies.sh by the "TGS Test Suite" CI job)
 # Must be interpreted as a string, keep quoted
-byond: "515.1647"
+byond: "516.1659"
 # Folders to create in "<instance_path>/Configuration/GameStaticFiles/"
 static_files:
   # Config directory should be static

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -11,7 +11,7 @@
 
 // 516.1660 broke (x in vars), which breaks a lot of things.
 #if (DM_VERSION == 516 && DM_BUILD == 1660)
-#error This version of BYOND (516.1660) has a bug which prevents this codebase from loading properly. Visit www.byond.com/download/build to download a newer release of BYOND.
+#error This version of BYOND (516.1660) has a bug which prevents this codebase from loading properly. If possible, update your BYOND version. Otherwise, visit www.byond.com/download/build to download an older release.
 #endif
 
 // Keep savefile compatibilty at minimum supported level

--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -1,17 +1,17 @@
 // This file contains defines allowing targeting byond versions newer than the supported
 
 //Update this whenever you need to take advantage of more recent byond features
-#define MIN_COMPILER_VERSION 515
-#define MIN_COMPILER_BUILD 1642
+#define MIN_COMPILER_VERSION 516
+#define MIN_COMPILER_BUILD 1648
 #if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM) && !defined(OPENDREAM)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
-#error You need version 515.1642 or higher
+#error You need version 516.1648 or higher
 #endif
 
-// Unable to compile this version thanks to mutable appearance changes
-#if (DM_VERSION == 515 && DM_BUILD == 1643)
-#error This version of BYOND (515.1643) has a bug which prevents this codebase from compiling properly. Visit www.byond.com/download/build to download 515.1642, or upgrade to a newer version if one has released by now.
+// 516.1660 broke (x in vars), which breaks a lot of things.
+#if (DM_VERSION == 516 && DM_BUILD == 1660)
+#error This version of BYOND (516.1660) has a bug which prevents this codebase from loading properly. Visit www.byond.com/download/build to download a newer release of BYOND.
 #endif
 
 // Keep savefile compatibilty at minimum supported level

--- a/code/_globalvars/bitfields.dm
+++ b/code/_globalvars/bitfields.dm
@@ -416,19 +416,6 @@ DEFINE_BITFIELD(vis_flags, list(
 	"VIS_UNDERLAY" = VIS_UNDERLAY,
 ))
 
-// I am so sorry. Required because vis_flags is both undefinable and unreadable on mutable_appearance
-// But we need to display them anyway. See /mutable_appearance/appearance_mirror
-DEFINE_BITFIELD(_vis_flags, list(
-	"VIS_HIDE" = VIS_HIDE,
-	"VIS_INHERIT_DIR" = VIS_INHERIT_DIR,
-	"VIS_INHERIT_ICON" = VIS_INHERIT_ICON,
-	"VIS_INHERIT_ICON_STATE" = VIS_INHERIT_ICON_STATE,
-	"VIS_INHERIT_ID" = VIS_INHERIT_ID,
-	"VIS_INHERIT_LAYER" = VIS_INHERIT_LAYER,
-	"VIS_INHERIT_PLANE" = VIS_INHERIT_PLANE,
-	"VIS_UNDERLAY" = VIS_UNDERLAY,
-))
-
 DEFINE_BITFIELD(zap_flags, list(
 	"ZAP_ALLOW_DUPLICATES" = ZAP_ALLOW_DUPLICATES,
 	"ZAP_MACHINE_EXPLOSIVE" = ZAP_MACHINE_EXPLOSIVE,

--- a/code/_onclick/hud/hud.dm
+++ b/code/_onclick/hud/hud.dm
@@ -105,10 +105,6 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 
 	var/list/team_finder_arrows = list()
 
-	/// The BYOND version of the client that was last logged into this mob.
-	/// Currently used to rebuild all plane master groups when going between 515<->516.
-	var/last_byond_version
-
 /datum/hud/New(mob/owner)
 	mymob = owner
 
@@ -151,17 +147,6 @@ GLOBAL_LIST_INIT(available_ui_styles, list(
 /datum/hud/proc/client_refresh(datum/source)
 	SIGNAL_HANDLER
 	var/client/client = mymob.canon_client
-	var/new_byond_version = client.byond_version
-#if MIN_COMPILER_VERSION > 515
-	#warn Fully change default relay_loc to "1,1", rather than changing it based on client version
-#endif
-	if(!isnull(last_byond_version) && new_byond_version != last_byond_version)
-		var/new_relay_loc = (new_byond_version > 515) ? "1,1" : "CENTER"
-		for(var/group_key as anything in master_groups)
-			var/datum/plane_master_group/group = master_groups[group_key]
-			group.relay_loc = new_relay_loc
-			group.rebuild_hud()
-	last_byond_version = new_byond_version
 	RegisterSignal(client, COMSIG_CLIENT_SET_EYE, PROC_REF(on_eye_change))
 	on_eye_change(null, null, client.eye)
 

--- a/code/_onclick/hud/rendering/plane_master_group.dm
+++ b/code/_onclick/hud/rendering/plane_master_group.dm
@@ -15,7 +15,7 @@
 	var/map = ""
 	/// Controls the screen_loc that owned plane masters will use when generating relays. Due to a Byond bug, relays using the CENTER positional loc
 	/// Will be improperly offset
-	var/relay_loc = "CENTER"
+	var/relay_loc = "1,1"
 
 /datum/plane_master_group/New(key, map = "")
 	. = ..()
@@ -50,18 +50,10 @@
 		stack_trace("Hey brother, our key [key] is already in use by a plane master group on the passed in hud, belonging to [viewing_hud.mymob]. Ya fucked up, why are there dupes")
 		return
 
-#if MIN_COMPILER_VERSION > 516
-	#warn Fully change default relay_loc to "1,1", rather than changing it based on client version
-#endif
-
 	set_hud(viewing_hud)
 	our_hud.master_groups[key] = src
 	show_hud()
 	transform_lower_turfs(our_hud, active_offset)
-
-	if(viewing_hud.mymob?.client?.byond_version > 515)
-		relay_loc = "1,1"
-		rebuild_plane_masters()
 
 /// Well, refresh our group, mostly useful for plane specific updates
 /datum/plane_master_group/proc/refresh_hud()
@@ -194,17 +186,6 @@
 /// This is because it's annoying to get turfs to position inside it correctly
 /// If you wanna try someday feel free, but I can't manage it
 /datum/plane_master_group/popup
-
-/// Note do not use return ..() because it will cause client crush when screen gets deleted
-/// TOOD: Remove this entirely when 516 is stable
-/datum/plane_master_group/popup/attach_to(datum/hud/viewing_hud)
-	if(viewing_hud.master_groups[key])
-		stack_trace("[key] is already in use by a plane master group on the passed in hud, belonging to [viewing_hud.mymob]!")
-		return
-	relay_loc = "1,1"
-	rebuild_plane_masters()
-	set_hud(viewing_hud)
-	show_hud()
 
 /datum/plane_master_group/popup/transform_lower_turfs(datum/hud/source, new_offset, use_scale = TRUE)
 	return ..(source, new_offset, FALSE)

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -307,10 +307,7 @@
  * Other vars such as alpha will automatically be applied with the render source
  */
 /atom/movable/screen/plane_master/proc/generate_render_relays()
-#if MIN_COMPILER_VERSION > 516
-	#warn Fully change default relay_loc to "1,1"
-#endif
-	var/relay_loc = home?.relay_loc || "CENTER"
+	var/relay_loc = home?.relay_loc || "1,1"
 	// If we're using a submap (say for a popup window) make sure we draw onto it
 	if(home?.map)
 		relay_loc = "[home.map]:[relay_loc]"
@@ -344,7 +341,7 @@
 	if(!length(relays) && !initial(render_target))
 		render_target = OFFSET_RENDER_TARGET(get_plane_master_render_base(name), offset)
 	if(!relay_loc)
-		relay_loc = (show_to?.byond_version > 515) ? "1,1" : "CENTER"
+		relay_loc = "1,1"
 		// If we're using a submap (say for a popup window) make sure we draw onto it
 		if(home?.map)
 			relay_loc = "[home.map]:[relay_loc]"

--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -414,7 +414,7 @@ GLOBAL_PROTECT(href_token)
 	return combined_flags
 
 /datum/admins/proc/try_give_devtools()
-	if(isnull(owner) || !(rank_flags() & R_DEBUG) || owner.byond_version < 516)
+	if(isnull(owner) || !(rank_flags() & R_DEBUG))
 		return
 	winset(owner, null, list("browser-options" = "+devtools"))
 

--- a/code/modules/admin/view_variables/debug_variable_appearance.dm
+++ b/code/modules/admin/view_variables/debug_variable_appearance.dm
@@ -34,22 +34,10 @@
 /mutable_appearance/appearance_mirror
 	// So people can see where it came from
 	var/appearance_ref
-	// vis flags can't be displayed by mutable appearances cause it don't make sense as overlays, but appearances do carry them
-	// can't use the name either for byond reasons
-	var/_vis_flags
-
-#if (MIN_COMPILER_VERSION > 515 || MIN_COMPILER_BUILD > 1643)
-#warn vis_flags should now be supported by mutable appearances so we can safely remove the weird copying in this code
-#endif
-// all alone at the end of the universe
-GLOBAL_DATUM_INIT(pluto, /atom/movable, new /atom/movable(null))
 
 // arg is actually an appearance, typed as mutable_appearance as closest mirror
 /mutable_appearance/appearance_mirror/New(mutable_appearance/appearance_father)
 	. = ..() // /mutable_appearance/New() copies over all the appearance vars MAs care about by default
-	// We copy over our appearance onto an atom. This is done so we can read vars carried by but not accessible on appearances
-	GLOB.pluto.appearance = appearance_father
-	_vis_flags = GLOB.pluto.vis_flags
 	appearance_ref = REF(appearance_father)
 
 // This means if the appearance loses refs before a click it's gone, but that's consistent to other datums so it's fine
@@ -66,27 +54,6 @@ GLOBAL_DATUM_INIT(pluto, /atom/movable, new /atom/movable(null))
 		return FALSE
 	if(var_name == NAMEOF(src, realized_underlays))
 		return FALSE
-
-#if (MIN_COMPILER_VERSION >= 515 && MIN_COMPILER_BUILD >= 1643)
-#warn X/Y/Z and contents are now fully unviewable on our supported versions, remove the below check
-#endif
-
-// lummy removed these from the the MA/image type
-#if (DM_VERSION <= 515 && DM_BUILD < 1643)
-	// Filtering out the stuff I know we don't care about
-	if(var_name == NAMEOF(src, x))
-		return FALSE
-	if(var_name == NAMEOF(src, y))
-		return FALSE
-	if(var_name == NAMEOF(src, z))
-		return FALSE
-	#ifndef SPACEMAN_DMM // Spaceman doesn't believe in contents on appearances, sorry lads
-	if(var_name == NAMEOF(src, contents))
-		return FALSE
-	#endif
-	if(var_name == NAMEOF(src, loc))
-		return FALSE
-#endif
 	// Could make an argument for this but I think they will just confuse people, so yeeet
 	if(var_name == NAMEOF(src, vis_contents))
 		return FALSE

--- a/code/modules/asset_cache/asset_cache_client.dm
+++ b/code/modules/asset_cache/asset_cache_client.dm
@@ -36,10 +36,7 @@
 	var/job = ++last_asset_job
 	var/t = 0
 	var/timeout_time = timeout
-	if(byond_version < 516)
-		src << browse({"<script>window.location.href="byond://?asset_cache_confirm_arrival=[job]"</script>"}, "window=asset_cache_browser&file=asset_cache_send_verify.htm")
-	else
-		src << browse({"<script>var xhr = new XMLHttpRequest(); xhr.open('GET', 'byond://?asset_cache_confirm_arrival=[job]', true); xhr.send(null);</script>"}, "window=asset_cache_browser&file=asset_cache_send_verify.htm")
+	src << browse({"<script>var xhr = new XMLHttpRequest(); xhr.open('GET', 'byond://?asset_cache_confirm_arrival=[job]', true); xhr.send(null);</script>"}, "window=asset_cache_browser&file=asset_cache_send_verify.htm")
 
 	while(!completed_asset_jobs["[job]"] && t < timeout_time) // Reception is handled in Topic()
 		stoplag(1) // Lock up the caller until this is received.

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -248,8 +248,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 		persistent_client.byond_build = byond_build
 		persistent_client.byond_version = byond_version
 
-	if(byond_version >= 516)
-		winset(src, null, list("browser-options" = "find,refresh,byondstorage"))
+	winset(src, null, list("browser-options" = "find,refresh,byondstorage"))
 
 	// Instantiate stat panel
 	stat_panel = new(src, "statbrowser")
@@ -1424,8 +1423,6 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 
 /// This grabs the DPI of the user per their skin
 /client/proc/acquire_dpi()
-	if(byond_version < 516) // why won't you update
-		return
 	window_scaling = text2num(winget(src, null, "dpi"))
 
 	debug_admins("scalies: [window_scaling]")

--- a/code/modules/client/preferences/tgui.dm
+++ b/code/modules/client/preferences/tgui.dm
@@ -70,8 +70,3 @@
 
 	INVOKE_ASYNC(client, TYPE_VERB_REF(/client, refresh_tgui))
 	client.tgui_say?.load()
-
-/datum/preference/toggle/ui_scale/is_accessible(datum/preferences/preferences)
-	if(preferences?.parent?.byond_version < 516)
-		return FALSE
-	return ..()

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -4,8 +4,8 @@
 #Final authority on what's required to fully build the project
 
 # byond version
-export BYOND_MAJOR=515
-export BYOND_MINOR=1647
+export BYOND_MAJOR=516
+export BYOND_MINOR=1659
 
 #rust_g git tag
 export RUST_G_VERSION=3.6.0

--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/abilities/slasher_regenerate.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/abilities/slasher_regenerate.dm
@@ -37,7 +37,6 @@
 	if(!ishuman(owner))
 		return
 	var/mob/living/carbon/human/human_owner = owner
-	var/turf/below_turf = get_turf(human_owner) // the turf below the person throwing
 	human_owner.AdjustAllImmobility(-20 * seconds_per_tick)
 	human_owner.stamina.adjust(20, TRUE)
 	human_owner.adjustBruteLoss(-35)


### PR DESCRIPTION

## About The Pull Request

Ports the following PRs:
- https://github.com/tgstation/tgstation/pull/90460
- https://github.com/tgstation/tgstation/pull/90523

Also fixed an unused var warning in slasher code.

## Why It's Good For The Game

> There is no reason for it to exist if connecting from 515 is not allowed

## Changelog

No player-facing changes (the server is already on 516, and cannot be connected to on 515)
