### PR TITLE
Add a warning to the admin "Shake" VV

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1537,13 +1537,17 @@
 
 	// monkestation edit start: forced shake
 	if(href_list[VV_HK_SHAKE] && check_rights(R_FUN))
-		var/pixelshiftx = input(usr, "Choose amount of pixels to shift on X axis","Shake Atom") as null|num
-		var/pixelshifty = input(usr, "Choose amount of pixels to shift on Y axis","Shake Atom") as null|num
+		var/pixelshiftx = input(usr, "Choose amount of pixels to shift on X axis", "Shake Atom") as null|num
+		var/pixelshifty = input(usr, "Choose amount of pixels to shift on Y axis", "Shake Atom") as null|num
 		if(isnull(pixelshiftx) || isnull(pixelshifty))
 			return
 
-		var/duration = input(usr, "Duration? (In seconds)","Shake Atom") as null|num
-		var/shake_interval = input(usr, "Shake interval (In seconds) - Default: 0.02", "Shake Atom", 0.02) as null|num
+		var/duration = input(usr, "Duration? (in seconds)", "Shake Atom") as null|num
+		if(duration > 20)
+			var/confirmation = input(usr, "Durations longer than 20 seconds are HIGHLY LIKELY to cause lag! Are you REALLY sure?", "Shake Atom: LAG ALERT") in list("I'm sure!", "Nope.")
+			if(confirmation != "I'm sure!")
+				return
+		var/shake_interval = input(usr, "Shake interval (in seconds) - Default: 0.02", "Shake Atom", 0.02) as null|num
 		if(isnull(shake_interval) || isnull(duration))
 			return
 


### PR DESCRIPTION

## About The Pull Request

this adds a warning to the Shake VV when the duration is over 20 seconds, asking the admin if they're REALLY sure, to hopefully reduce lagspike incidents.

## Why It's Good For The Game

Shake is a VERY laggy proc with high durations, which isn't immediately obvious (it's typically something you learn the hard way), so this should reduce lag incidents.

## Changelog
:cl:
admin: Added a warning for admins using the "Shake" VV when doing so might accidentally cause a bunch of lag.
/:cl:
