### PR TITLE
Changeling 'Birth Teratoma' change

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -53,6 +53,8 @@
 	var/list/innate_powers = list()
 	/// Associated list of all powers we have evolved / bought from the emporium. [path] = [instance of path]
 	var/list/purchased_powers = list()
+	/// The amount of offspring spawned from the changling. To prevent refreshing the amount by buying the power again.
+	var/births = 0
 
 	/// The voice we're mimicing via the changeling voice ability.
 	var/mimicing = ""

--- a/monkestation/code/modules/antagonists/changeling/powers/teratomas.dm
+++ b/monkestation/code/modules/antagonists/changeling/powers/teratomas.dm
@@ -23,7 +23,7 @@
 	if(!ling)
 		return FALSE
 	if(ling.births >= ling.true_absorbs)
-		to_chat(user, span_warning("You must absorb another creature to devide yourself further."))
+		to_chat(user, span_warning("You must absorb another creature to divide yourself further."))
 		return FALSE
 	ling.adjust_chemicals(-chemical_cost)
 	var/list/candidates = SSpolling.poll_ghost_candidates(

--- a/monkestation/code/modules/antagonists/changeling/powers/teratomas.dm
+++ b/monkestation/code/modules/antagonists/changeling/powers/teratomas.dm
@@ -1,11 +1,12 @@
 /datum/action/changeling/teratoma
 	name = "Birth Teratoma"
 	desc = "Our form divides, creating an egg that will soon hatch into a living tumor, fixated on causing mayhem. Costs 60 chemicals."
-	helptext = "The tumor will not be loyal to us or our cause. Requires 3 changeling absorptions."
+	helptext = "The tumor will not be loyal to us or our cause. Requires an changeling absorption for each tumor created."
 	button_icon_state = "spread_infestation"
 	chemical_cost = 60
 	dna_cost = 2
-	req_absorbs = 3
+	req_absorbs = 1
+
 
 /datum/action/changeling/teratoma/sting_action(mob/living/user)
 	..()
@@ -20,6 +21,9 @@
 /datum/action/changeling/teratoma/proc/create_teratoma(mob/living/user)
 	var/datum/antagonist/changeling/ling = user?.mind?.has_antag_datum(/datum/antagonist/changeling)
 	if(!ling)
+		return FALSE
+	if(ling.births >= ling.true_absorbs)
+		to_chat(user, span_warning("You must absorb another creature to devide yourself further."))
 		return FALSE
 	ling.adjust_chemicals(-chemical_cost)
 	var/list/candidates = SSpolling.poll_ghost_candidates(
@@ -41,7 +45,7 @@
 		to_chat(user, span_warning("You fail at creating a tumor. Perhaps you should try again later?"))
 		ling.adjust_chemicals(chemical_cost)
 		return FALSE
-
+	ling.births++
 	var/datum/mind/goober_mind = new(candidate.key)
 	goober_mind.active = TRUE
 	var/mob/living/carbon/human/species/teratoma/goober = new(user.drop_location())


### PR DESCRIPTION

## About The Pull Request
Changes how the ability birth teratoma works.

Previously only 3 'true absorbs' Aka bodies husked were needed to spawn near infinite teratomas. One every two minutes if thats all they dedicate their chemicals to assuming normal rates

This changes the amount of true absorbs to purchase the ability to one. However. Only for every teratoma to be birthed, a body needs to be husked.

Effectively
If you've husked 5 corspes?
You get 5 teratomas.
## Why It's Good For The Game
Pictured is a round where 21 teratomas were spawned. 
![Screenshot 2025-04-27 012432](https://github.com/user-attachments/assets/6389b1b7-7456-4547-83ef-bca086016f4a)
21 grief machines with no value to their lifes as they are effectively cheap. You can suicide bomb yourself to little consequence as its non factor when theres another egg you can go inhabit and instantly start again. 

Your still as welcome as always go welder bomb an assistant, sabotage the engine, or n20 flood medical. All that changes is if your going to die in the process make sure your living your best life. As it may be your only.

I'm willing to hear the ratio of bodies husked to teratomas spawned be adjusted, such as two teratomas for every husk be discussed. But a minimum floor of three for infinite seems problematic.
## Changelog
:cl:
balance: Birth teratoma is reduced to 1 absorb needed to purchase
balance: Birth teratoma can only be used once for each changeling absorption.
/:cl:
