### PR TITLE
Prevent malf AIs from destroying otherwise indestructible machines

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -1128,7 +1128,9 @@
 	return
 
 /obj/machinery/proc/can_be_overridden()
-	. = 1
+	if(resistance_flags & INDESTRUCTIBLE)
+		return FALSE
+	return TRUE
 
 /obj/machinery/zap_act(power, zap_flags)
 	if(prob(85) && (zap_flags & ZAP_MACHINE_EXPLOSIVE) && !(resistance_flags & INDESTRUCTIBLE))

--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -538,7 +538,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module))
 		to_chat(user, span_warning("You can only overload machines!"))
 		return FALSE
 	var/obj/machinery/clicked_machine = clicked_on
-	if(is_type_in_typecache(clicked_machine, GLOB.blacklisted_malf_machines))
+	if(is_type_in_typecache(clicked_machine, GLOB.blacklisted_malf_machines) || (clicked_machine.resistance_flags & INDESTRUCTIBLE))
 		to_chat(user, span_warning("You cannot overload that device!"))
 		return FALSE
 


### PR DESCRIPTION

## About The Pull Request

this makes it so having `INDESTRUCTIBLE` in `resistance_flags` prevents Overload Machine from being used on it, and also `/obj/machinery/proc/can_be_overridden()` returns `FALSE` with said flag.

## Why It's Good For The Game

Indestructible means indestructible, your special electrical powers doesn't somehow change the definition of that.

## Changelog
:cl:
fix: Fixed malf AIs being able to overload/destroy indestructible machines.
/:cl:
