### PR TITLE
Remember how to breathe - Pathology

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -78,6 +78,8 @@
 		var/obj/location_as_object = loc
 		location_as_object.handle_internal_lifeform(src, 0)
 
+	breath_airborne_diseases()
+
 /mob/living/carbon/proc/breathe(seconds_per_tick, times_fired, next_breath = 4)
 	var/datum/gas_mixture/environment = loc?.return_air()
 	var/datum/gas_mixture/breath


### PR DESCRIPTION
After all these years
## About The Pull Request
Fixes airborne virus''s


Airborne virus's work off the proc  ```breath_airborne_diseases()```. Only issue is this was not called in our code anywhere except for mice. This will make mask usage/no_breathe/plagues a lot more prevalent and airborne virus's an actual spread type. 
## Why It's Good For The Game

I forgot how to breathe.
## Changelog
:cl:
fix: Airborne diseases now work. Reminder to wear masks
/:cl:
