### PR TITLE
fix oozelings duping translation gloves and limbs on revival

### DIFF
--- a/monkestation/code/modules/surgery/organs/internal/brain.dm
+++ b/monkestation/code/modules/surgery/organs/internal/brain.dm
@@ -52,7 +52,7 @@
 		/obj/item/organ/external/snout,
 		/obj/item/organ/external/antennae,
 		/obj/item/organ/external/spines,
-		/obj/item/organ/internal/eyes/robotic/glow
+		/obj/item/organ/internal/eyes/robotic/glow,
 	))
 	//Quirks that roll unique effects or gives items to each new body should be saved between bodies.
 	var/static/list/saved_quirks = typecacheof(list(
@@ -72,6 +72,12 @@
 		/datum/quirk/item_quirk/allergic,
 		/datum/quirk/item_quirk/brainproblems,
 		/datum/quirk/item_quirk/junkie,
+	))
+	/// Quirks that should just be completely skipped.
+	var/static/list/skip_quirks = typecacheof(list(
+		/datum/quirk/drg_callout, // skillchips are in the brain anyways
+		/datum/quirk/prosthetic_limb,
+		/datum/quirk/quadruple_amputee,
 	))
 
 	var/rebuilt = TRUE
@@ -180,9 +186,10 @@
 	var/mob/living/basic/mining/legion/legionbody = victim.loc
 
 	for(var/datum/quirk/quirk in victim.quirks) // Store certain quirks safe to transfer between bodies.
-		if(is_type_in_typecache(quirk, saved_quirks))
-			quirk.remove_from_current_holder(quirk_transfer = TRUE)
-			stored_quirks |= quirk
+		if(!is_type_in_typecache(quirk, saved_quirks) || is_type_in_typecache(quirk, skip_quirks))
+			continue
+		quirk.remove_from_current_holder(quirk_transfer = TRUE)
+		stored_quirks |= quirk
 
 	process_items(victim) // Start moving items before anything else can touch them.
 
@@ -380,7 +387,7 @@
 			for(var/datum/quirk/quirk in stored_quirks)
 				quirk.add_to_holder(new_body, quirk_transfer = TRUE) // Return their old quirk to them.
 			stored_quirks.Cut()
-		SSquirks.AssignQuirks(new_body, brainmob.client) // Still need to copy over the rest of their quirks.
+		SSquirks.AssignQuirks(new_body, brainmob.client, blacklist = assoc_to_keys(skip_quirks)) // Still need to copy over the rest of their quirks.
 	var/obj/item/organ/internal/brain/new_body_brain = new_body.get_organ_slot(ORGAN_SLOT_BRAIN)
 	qdel(new_body_brain)
 	forceMove(new_body)

--- a/monkestation/code/modules/surgery/organs/internal/brain.dm
+++ b/monkestation/code/modules/surgery/organs/internal/brain.dm
@@ -66,7 +66,7 @@
 		/datum/quirk/item_quirk/musician,
 		/datum/quirk/item_quirk/poster_boy,
 		/datum/quirk/item_quirk/tagger,
-		//datum/quirk/item_quirk/signer, // Needs to "add component" on proc add not on_unique
+		/datum/quirk/item_quirk/signer,
 		/datum/quirk/phobia,
 		/datum/quirk/indebted,
 		/datum/quirk/item_quirk/allergic,


### PR DESCRIPTION
## Changelog
:cl:
fix: Fixed oozelings duping translation gloves and prosthetic limbs when revived.
/:cl:
