### PR TITLE
fix runtimestation's gravgen running out of power

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -65,9 +65,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/power/terminal{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron,
@@ -112,6 +109,9 @@
 	},
 /obj/structure/closet/radiation,
 /obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
 "aH" = (


### PR DESCRIPTION

## About The Pull Request

i made a whoopsie during https://github.com/Monkestation/Monkestation2.0/pull/6422 and put the terminal on the output side of the smes, instead of the input. so yeah this fixes that

## Why It's Good For The Game

having grav not go out while testing something is nice

## Changelog

no player-facing changes