### PR TITLE
Fix Recolorable Oversized Jacket Not Being Recolorable On Lizards

### DIFF
--- a/code/modules/clothing/suits/jacket.dm
+++ b/code/modules/clothing/suits/jacket.dm
@@ -33,6 +33,7 @@
 	icon_state = "jacket_oversized"
 	greyscale_config = /datum/greyscale_config/jacket_oversized
 	greyscale_config_worn = /datum/greyscale_config/jacket_oversized_worn
+	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 	greyscale_colors = "#414344"
 	flags_1 = IS_PLAYER_COLORABLE_1
 


### PR DESCRIPTION
## About The Pull Request

Fix Recolorable Oversized Jacket Not Being Recolorable On Lizards

If there are any other recolorable items that need fixing, let me know, I looked at quite a few.

## Changelog

:cl:
fix: Fixed the Recolorable Oversized Jacket not being recolorable on lizards.
/:cl:

