### PR TITLE
Fix a runtime with clockwork slabs

### DIFF
--- a/monkestation/code/modules/antagonists/clock_cult/scriptures/_scripture.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/scriptures/_scripture.dm
@@ -311,7 +311,8 @@ GLOBAL_LIST_EMPTY(clock_scriptures_by_type)
 	pointed_spell.parent_scripture = src
 
 /datum/scripture/slab/Destroy()
-	progress?.end_progress()
+	if(!QDELETED(progress))
+		progress.end_progress()
 
 	if(!QDELETED(pointed_spell))
 		QDEL_NULL(pointed_spell)
@@ -320,7 +321,7 @@ GLOBAL_LIST_EMPTY(clock_scriptures_by_type)
 
 
 /datum/scripture/slab/invoke()
-	progress = new(invoker, use_time)
+	progress = new(invoker, use_time, invoking_slab)
 	uses_left = uses
 	time_left = use_time
 	invoking_slab.charge_overlay = slab_overlay


### PR DESCRIPTION

## About The Pull Request

clockwork slab scripture invocations didn't pass an actual target to `/datum/progressbar`, which caused runtime. this fixes that

also this changes `/datum/scripture/slab/Destroy()` to be consistent with how other things call `end_progress()`

## Why It's Good For The Game

bugfix

## Changelog

no player-facing changes as i think slab still had working progress bar anyways