### PR TITLE
PDA arcade games are no longer louder than an actual arcade machine

### DIFF
--- a/code/modules/modular_computers/file_system/programs/arcade.dm
+++ b/code/modules/modular_computers/file_system/programs/arcade.dm
@@ -28,7 +28,7 @@
 	user?.mind?.adjust_experience(/datum/skill/gaming, 1)
 	if(boss_hp <= 0)
 		heads_up = "You have crushed [boss_name]! Rejoice!"
-		playsound(computer.loc, 'sound/arcade/win.ogg', 50)
+		playsound(computer.loc, 'sound/arcade/win.ogg', 50, extrarange = SHORT_RANGE_SOUND_EXTRARANGE, falloff_exponent = 10)
 		game_active = FALSE
 		program_icon_state = "arcade_off"
 		if(istype(computer))
@@ -39,7 +39,7 @@
 		sleep(1 SECONDS)
 	else if(player_hp <= 0 || player_mp <= 0)
 		heads_up = "You have been defeated... how will the station survive?"
-		playsound(computer.loc, 'sound/arcade/lose.ogg', 50)
+		playsound(computer.loc, 'sound/arcade/lose.ogg', 50, extrarange = SHORT_RANGE_SOUND_EXTRARANGE, falloff_exponent = 10)
 		game_active = FALSE
 		program_icon_state = "arcade_off"
 		if(istype(computer))
@@ -60,17 +60,17 @@
 		return
 	if (boss_mp <= 5)
 		heads_up = "[boss_mpamt] magic power has been stolen from you!"
-		playsound(computer.loc, 'sound/arcade/steal.ogg', 50, TRUE)
+		playsound(computer.loc, 'sound/arcade/steal.ogg', 50, TRUE, extrarange = SHORT_RANGE_SOUND_EXTRARANGE, falloff_exponent = 10)
 		player_mp -= boss_mpamt
 		boss_mp += boss_mpamt
 	else if(boss_mp > 5 && boss_hp <12)
 		heads_up = "[boss_name] heals for [bossheal] health!"
-		playsound(computer.loc, 'sound/arcade/heal.ogg', 50, TRUE)
+		playsound(computer.loc, 'sound/arcade/heal.ogg', 50, TRUE, extrarange = SHORT_RANGE_SOUND_EXTRARANGE, falloff_exponent = 10)
 		boss_hp += bossheal
 		boss_mp -= boss_mpamt
 	else
 		heads_up = "[boss_name] attacks you for [boss_attackamt] damage!"
-		playsound(computer.loc, 'sound/arcade/hit.ogg', 50, TRUE)
+		playsound(computer.loc, 'sound/arcade/hit.ogg', 50, TRUE, extrarange = SHORT_RANGE_SOUND_EXTRARANGE, falloff_exponent = 10)
 		player_hp -= boss_attackamt
 
 	pause_state = FALSE
@@ -107,7 +107,7 @@
 				attackamt = rand(2,6) + rand(0, gamerSkill)
 			pause_state = TRUE
 			heads_up = "You attack for [attackamt] damage."
-			playsound(computer.loc, 'sound/arcade/hit.ogg', 50, TRUE)
+			playsound(computer.loc, 'sound/arcade/hit.ogg', 50, TRUE, extrarange = SHORT_RANGE_SOUND_EXTRARANGE, falloff_exponent = 10)
 			boss_hp -= attackamt
 			sleep(1 SECONDS)
 			game_check()
@@ -124,7 +124,7 @@
 				healcost = rand(1, maxPointCost)
 			pause_state = TRUE
 			heads_up = "You heal for [healamt] damage."
-			playsound(computer.loc, 'sound/arcade/heal.ogg', 50, TRUE)
+			playsound(computer.loc, 'sound/arcade/heal.ogg', 50, TRUE, extrarange = SHORT_RANGE_SOUND_EXTRARANGE, falloff_exponent = 10)
 			player_hp += healamt
 			player_mp -= healcost
 			sleep(1 SECONDS)
@@ -137,7 +137,7 @@
 				rechargeamt = rand(4,7) + rand(0, gamerSkill)
 			pause_state = TRUE
 			heads_up = "You regain [rechargeamt] magic power."
-			playsound(computer.loc, 'sound/arcade/mana.ogg', 50, TRUE)
+			playsound(computer.loc, 'sound/arcade/mana.ogg', 50, TRUE, extrarange = SHORT_RANGE_SOUND_EXTRARANGE, falloff_exponent = 10)
 			player_mp += rechargeamt
 			sleep(1 SECONDS)
 			game_check()


### PR DESCRIPTION

## About The Pull Request

for some reason, the sounds from arcade machines had reduced range, while PDA arcade sounds had the default range

i both reduced the range and increased the falloff of the sounds for the PDA arcade program

## Why It's Good For The Game

I DON'T WANNA HEAR YOUR PDA GAME FROM LITERALLY 2 ROOMS AWAY

## Changelog
:cl:
qol: Playing games on a PDA is no longer louder than playing an actual full-sized arcade machine.
/:cl:
