### PR TITLE
[PORT] Weapons that cannot fit into turrets also cannot fit into emitters.

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -362,10 +362,13 @@
 /obj/machinery/power/emitter/AltClick(mob/user)
 	return ..() // This hotkey is BLACKLISTED since it's used by /datum/component/simple_rotation
 
-/obj/machinery/power/emitter/proc/integrate(obj/item/gun/energy/energy_gun, mob/user)
-	if(!istype(energy_gun, /obj/item/gun/energy))
+/obj/machinery/power/emitter/proc/integrate(obj/item/gun/energy/, mob/user)
+	if(!istype(, /obj/item/gun/energy))
 		return
-	if(!user.transferItemToLoc(energy_gun, src))
+	if(!user.transferItemToLoc(, src))
+		return
+	if(energy_gun.gun_flags & TURRET_INCOMPATIBLE)
+		user.balloon_alert(user, "[energy_gun] won't fit!")
 		return
 	gun = energy_gun
 	gun_properties = gun.get_turret_properties()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/90960
Weapons that cannot fit into turrets can not fit into emitters. This only affects the dueling pistol as of writing.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prevents this:
![image](https://github.com/user-attachments/assets/0db1b1ce-2431-42f0-8fa4-095918a604b4)
or if you want a more descriptive example, this:

https://github.com/user-attachments/assets/7f8336ac-9a82-46fa-a56d-96a63ce37678

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Weapons that cannot fit into turrets also cannot fit into emitters.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
