### PR TITLE
Remove chaplain role lock from ratvar plushie.

### DIFF
--- a/monkestation/code/modules/loadouts/items/plushies.dm
+++ b/monkestation/code/modules/loadouts/items/plushies.dm
@@ -41,7 +41,6 @@ GLOBAL_LIST_INIT(loadout_plushies, generate_loadout_items(/datum/loadout_item/pl
 /datum/loadout_item/plushies/ratvar
 	name = "Ratvar Plushie"
 	item_path = /obj/item/toy/plush/ratplush
-	restricted_roles = list(JOB_CHAPLAIN)
 
 /datum/loadout_item/plushies/rouny
 	name = "Rouny Plushie"


### PR DESCRIPTION
## About The Pull Request
Title
## Why It's Good For The Game
pros:
- silly goober
- funny interaction when stabbed
- good for rp prolly
- the superior outer deity

cons:
- technically a minor clock buff. (clock isnt even in rotation right now anyways so its fine) 
## Changelog
:cl: Anonymous Clock Cultist
balance: Ratvar plush is no longer chaplain restricted in loadout menu.
/:cl:
