### PR TITLE
Ongoing pathology fixes changes

### DIFF
--- a/monkestation/code/modules/virology/disease/premades/flu.dm
+++ b/monkestation/code/modules/virology/disease/premades/flu.dm
@@ -1,6 +1,6 @@
 /datum/disease/acute/premade/cold
 	name = "Common Cold"
-	form = "Virus"
+	form = "Viral Infection"
 	category = DISEASE_COLD
 
 	symptoms = list(

--- a/monkestation/code/modules/virology/disease/symtoms/annoying/cough.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/annoying/cough.dm
@@ -19,6 +19,6 @@
 	strength = round(strength / length(victim.diseases))
 	var/i = 1
 	while (strength > 0 && i < 10) //stronger viruses create more clouds at once, max limit of 10 clouds
-		new /obj/effect/pathogen_cloud/core(get_turf(src), victim, virus_copylist(victim.diseases))
+		new /obj/effect/pathogen_cloud/core(get_turf(mob), victim, virus_copylist(victim.diseases)) // We need to call where the mob is, not where the source is as the source has no idea where the mob is
 		strength -= 30
 		i++

--- a/monkestation/code/modules/virology/disease/symtoms/helpful/longevity.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/helpful/longevity.dm
@@ -13,12 +13,12 @@
 			wound.remove_wound()
 			break
 
-	var/heal_amt = 5 * multiplier
+	var/heal_amt = 4 * multiplier
 	var/current_health = mob.getBruteLoss()
 	if(current_health >= heal_amt)
-		total_healed += heal_amt * 0.2
+		total_healed += heal_amt * 0.5
 	else
-		total_healed += (heal_amt - current_health) * 0.2
+		total_healed += (heal_amt - current_health) * 0.5
 	mob.heal_overall_damage(brute = heal_amt, burn = heal_amt)
 	if(!(HAS_TRAIT(mob, TRAIT_TOXINLOVER) || HAS_TRAIT(mob, TRAIT_TOXIMMUNE)))
 		mob.adjustToxLoss(-heal_amt)

--- a/monkestation/code/modules/virology/disease/symtoms/helpful/longevity.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/helpful/longevity.dm
@@ -20,7 +20,8 @@
 	else
 		total_healed += (heal_amt - current_health) * 0.2
 	mob.heal_overall_damage(brute = heal_amt, burn = heal_amt)
-	mob.adjustToxLoss(-heal_amt)
+	if(!(HAS_TRAIT(mob, TRAIT_TOXINLOVER) || HAS_TRAIT(mob, TRAIT_TOXIMMUNE)))
+		mob.adjustToxLoss(-heal_amt)
 
 /datum/symptom/immortal/deactivate(mob/living/carbon/mob)
 	if(ishuman(mob))

--- a/tgui/packages/tgui/interfaces/Extrapolator.tsx
+++ b/tgui/packages/tgui/interfaces/Extrapolator.tsx
@@ -1,6 +1,6 @@
 import { useBackend, useLocalState } from '../backend';
 import { Window } from '../layouts';
-import { Section, Button, Tabs, LabeledList, Stack } from '../components';
+import { Section, Tabs, Stack } from '../components';
 
 type ExtrapolatorData = {
   varients: string[];
@@ -19,8 +19,8 @@ type SymptomListData = {
 };
 
 export const Extrapolator = (props) => {
-  const { act, data } = useBackend<ExtrapolatorData>();
-  const { varients, diseases } = data;
+  const { data } = useBackend<ExtrapolatorData>();
+  const { diseases } = data;
 
   // State for selected disease and symptom
   const [selectedDisease, setSelectedDisease] = useLocalState<string | ''>(
@@ -33,7 +33,7 @@ export const Extrapolator = (props) => {
   );
 
   return (
-    <Window title="Extrapolator" width={600} height={200}>
+    <Window title="Extrapolator" width={325} height={200}>
       <Window.Content>
         <Stack grow>
           <Stack.Item>
@@ -69,32 +69,6 @@ export const Extrapolator = (props) => {
                     ))}
                 </Tabs>
               </Section>
-            </Stack.Item>
-          )}
-
-          {selectedSymptom && (
-            <Stack.Item>
-              <Stack grow>
-                <Section title="Variants">
-                  <LabeledList>
-                    {varients.map((variant, index) => (
-                      <LabeledList.Item key={index}>
-                        <Button
-                          onClick={() =>
-                            act('add_varient', {
-                              varient_name: variant,
-                              disease_ref: selectedDisease,
-                              symptom_ref: selectedSymptom,
-                            })
-                          }
-                        >
-                          {variant}
-                        </Button>
-                      </LabeledList.Item>
-                    ))}
-                  </LabeledList>
-                </Section>
-              </Stack>
             </Stack.Item>
           )}
         </Stack>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Virus extrapolators have had their need and related code to scanning modules/variants removed. Most importantly, just an informational tool (To hopefully improve on) in the future
- The common cold is a 'viral infection' not a virus
- Longevity syndrome no longer processes on toxin lovers, recoil has been increased by over two times, and
- Amina syndrome will actually create pathogen clouds now

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
### Virus extraplators
Currently their alternative mode dont serve much purpose since we removed variants from ever appearing naturally. It can give a little information about diseases and its symptoms without having to lug an antibody scanner around. Ideally, it would give other information like disease stage. But future PR's and I hate TGUI. So I'll avoid it where I can.
### Amina syndrome
Simple bug fix. It would call the source of the symptom for its location (Which did not exist). Now calls the location of the infected mob. Allowing pathogen clouds to be created when you breathe
### Longevity syndrome does not affect toxin lovers.
This will be the most controversial of the changes but I feel like overall change that is healthier for an oozeling players or the like. Reading through the code and description of longevity it is meant to be a fountain of youth. Keeping whoever is infected forever young. And when they get cured? Suffer all those years they cheated through the disease. Unlike say, antitox syndrome which heals specifically toxins and seems intended to have that effect.

A key thing is how the toxins lovers work. Whenever they revert to a core they lose their body. Which also reverts their antibodies back to the start. Leaving them more vulnerable. 

Either way to help balance out these changes I've gave a small nerf to their overall healing 5x to 4x. Small but adds up in the long run, and increased backlash from 0.2 of total healing to 0.5 of total healing. Meaning now more often than not, curing can result in a fatality if used as a crutch.
### Anima syndrome fix
Simple bug fix. It would call for the location of the syndrome, not the user, meaning that they will never spawn in the first place as its nullspace or something.
 <!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Extrapolators secondary feature now can be used to see some minor disease information.
balance: Longevity syndrome no longer heals toxins on toxins lovers or toxin immune.
balance: Longevity syndrome has received a slight healing nerf. (5 brute/burn -> 4)
balance: Longevity syndrome cure backlack has been significantly increased. (0.2 of damage healed -> 0.5)
fix: Anima syndrome will now actually create pathogenic clouds
fix: The common cold is a 'Viral infection', not a virus. Also good for clarity as they function differently ingame.
code: Extrapolators can no longer be used to retrieve variants or use scanners in code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
