### PR TITLE
Blueshift MedSec outpost access, tramstation pipes, and roundstart turfs

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/turretedoutpost.dmm
@@ -190,7 +190,7 @@
 "mf" = (
 /obj/structure/lattice,
 /obj/structure/girder,
-/turf/open/floor/plating/rust,
+/turf/open/floor/plating/airless,
 /area/template_noop)
 "my" = (
 /obj/effect/turf_decal/trimline/red/line{
@@ -204,7 +204,7 @@
 /area/ruin/space/has_grav/turretedoutpost)
 "nd" = (
 /obj/structure/girder/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/turretedoutpost)
 "no" = (
 /obj/machinery/light/dim/directional/west,
@@ -447,6 +447,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/has_grav/turretedoutpost)
+"BG" = (
+/obj/structure/girder,
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/turretedoutpost)
 "BU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -511,6 +516,9 @@
 /obj/effect/decal/cleanable/fuel_pool,
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/turretedoutpost)
+"Hu" = (
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/turretedoutpost)
 "Hv" = (
 /obj/structure/tank_holder,
@@ -699,6 +707,10 @@
 /obj/machinery/porta_turret_construct,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/turretedoutpost)
+"Vu" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/ruin/space/has_grav/turretedoutpost)
 "Vx" = (
 /obj/structure/chair/office,
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -718,7 +730,7 @@
 /obj/structure/girder/displaced,
 /obj/structure/grille/broken,
 /obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/turretedoutpost)
 "VO" = (
 /obj/machinery/porta_turret/syndicate/energy/ruin,
@@ -901,7 +913,7 @@ ro
 ro
 ro
 nd
-up
+Hu
 ro
 ro
 ro
@@ -928,12 +940,12 @@ jM
 jM
 ro
 ro
-ID
-cD
-ID
-ID
+BG
+Vu
+BG
+BG
 VB
-ID
+BG
 pO
 ro
 ro
@@ -958,8 +970,8 @@ Ci
 bU
 ro
 ro
-ID
-ID
+BG
+BG
 ro
 ro
 ro
@@ -988,8 +1000,8 @@ jM
 jM
 jM
 ro
-ID
-ID
+BG
+BG
 ro
 ro
 sy
@@ -1019,7 +1031,7 @@ jM
 jM
 jM
 ro
-ID
+BG
 ro
 ro
 hr
@@ -1050,7 +1062,7 @@ jM
 jM
 jM
 ro
-ID
+BG
 ro
 Pf
 aH
@@ -1081,7 +1093,7 @@ bU
 jM
 rK
 ro
-ID
+BG
 ro
 gn
 aH

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -64643,7 +64643,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/medical/general,
+/obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/white/side,
 /area/station/security/checkpoint/medical)
 "mzP" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1606,7 +1606,7 @@
 	id = "shitbreaker"
 	},
 /obj/machinery/shipbreaker,
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron,
 /area/station/engineering/shipbreaker_hut)
 "aDA" = (
 /obj/machinery/light/small/directional/south,
@@ -12160,7 +12160,7 @@
 	dir = 6;
 	id = "shitbreaker"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron,
 /area/station/engineering/shipbreaker_hut)
 "erF" = (
 /obj/structure/cable,
@@ -23110,7 +23110,7 @@
 	id = "shitbreaker"
 	},
 /obj/structure/window/spawner/directional/south,
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron,
 /area/station/engineering/shipbreaker_hut)
 "iio" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
@@ -25966,7 +25966,7 @@
 /obj/machinery/conveyor{
 	id = "shitbreaker"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron,
 /area/station/engineering/shipbreaker_hut)
 "jbR" = (
 /obj/effect/turf_decal/siding/wood{
@@ -39544,7 +39544,7 @@
 	id = "shitbreaker"
 	},
 /obj/structure/window/spawner/directional/south,
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron,
 /area/station/engineering/shipbreaker_hut)
 "nDS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53837,7 +53837,7 @@
 /area/station/security/warden)
 "szm" = (
 /obj/machinery/computer/shipbreaker,
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron,
 /area/station/engineering/shipbreaker_hut)
 "szp" = (
 /turf/closed/wall,
@@ -55044,7 +55044,7 @@
 	id = "shitbreaker"
 	},
 /obj/structure/window/spawner/directional/south,
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron,
 /area/station/engineering/shipbreaker_hut)
 "sVc" = (
 /obj/effect/decal/cleanable/cobweb,

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -1595,7 +1595,13 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "azH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/duct,
+/obj/effect/turf_decal/tile/green/half/contrasted{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "azI" = (
@@ -3191,6 +3197,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aWx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /obj/machinery/duct,
 /turf/open/floor/iron/stairs/medium,
 /area/station/science/xenobiology)
@@ -4920,11 +4929,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
-"bwH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/space)
 "bwL" = (
 /obj/effect/turf_decal/tile/dark{
 	dir = 1
@@ -7551,6 +7555,10 @@
 /turf/open/floor/plating/airless,
 /area/station/solars/port/aft)
 "clx" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -15285,9 +15293,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"evV" = (
-/turf/open/floor/glass/reinforced,
-/area/station/science/xenobiology)
 "ewb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17262,6 +17267,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/shower/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -24903,9 +24909,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"hsa" = (
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "hsc" = (
 /obj/machinery/computer/records/security{
 	dir = 4
@@ -27971,13 +27974,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
-"inP" = (
-/obj/structure/flora/bush/pale{
-	pixel_y = -3;
-	pixel_x = -6
-	},
-/turf/open/floor/grass,
-/area/station/science/xenobiology)
 "inS" = (
 /obj/effect/mob_spawn/corpse/human/clown,
 /obj/effect/decal/cleanable/blood/innards,
@@ -29599,10 +29595,16 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/lesser)
 "iLM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/effect/turf_decal/tile/orange/half/contrasted{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "iLO" = (
@@ -33597,15 +33599,6 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"jUa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
 "jUk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
 	dir = 5
@@ -40371,7 +40364,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green/half/contrasted{
+/obj/machinery/duct,
+/obj/effect/turf_decal/tile/orange/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -48085,15 +48079,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/carpet,
 /area/station/service/bar)
-"obK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/orange/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "obO" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -48917,9 +48902,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/lower)
-"ooT" = (
-/turf/open/floor/grass,
-/area/station/science/xenobiology)
 "ooV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -50555,11 +50537,6 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/security/checkpoint/medical)
-"oOh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/space/nearstation)
 "oOn" = (
 /obj/structure/cable,
 /turf/open/floor/iron/stairs/medium,
@@ -54143,6 +54120,10 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "pUY" = (
+/obj/structure/flora/bush/pale{
+	pixel_y = -3;
+	pixel_x = -6
+	},
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/grass,
 /area/station/science/xenobiology)
@@ -55873,7 +55854,6 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/autoname/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology/hallway)
 "qrS" = (
@@ -63646,12 +63626,6 @@
 /obj/effect/mapping_helpers/mail_sorting/supply/cargo_bay,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"sCV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/stairs/medium,
-/area/station/science/xenobiology)
 "sCZ" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/east,
@@ -66161,6 +66135,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/closet/secure_closet/cytology,
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology/hallway)
@@ -74266,7 +74241,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology/hallway)
 "vAO" = (
@@ -80546,13 +80520,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"xse" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
-	},
-/turf/open/floor/glass/reinforced,
-/area/station/science/xenobiology)
 "xsi" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/lockbox/loyalty{
@@ -82301,15 +82268,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
-"xTE" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/science/xenobiology)
 "xTQ" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 6
@@ -105123,25 +105081,25 @@ lpg
 vmR
 afe
 aWx
-azH
+lLM
 iLM
-azH
-azH
+lLM
+hee
 azH
 azH
 azH
 azH
 clx
-azH
-azH
-azH
-azH
-hsa
-ooT
+iNS
+iNS
+iNS
+iNS
+isk
+jpT
 pUY
 eei
 nhC
-lcz
+lXw
 nhC
 nhC
 nhC
@@ -105377,25 +105335,25 @@ fNN
 jPd
 khx
 ktR
-evV
-xse
-sCV
-obK
-obK
-obK
-hee
-lLM
-lLM
-lLM
-lLM
-xTE
-isk
-isk
-isk
-iNS
-isk
-jpT
-inP
+eei
+yiH
+ybc
+iZm
+iZm
+vqH
+mhO
+mfk
+iZm
+iZm
+iHT
+srf
+xhl
+iZm
+iZm
+jds
+xWO
+kkg
+eei
 eei
 nhC
 lXw
@@ -105634,26 +105592,26 @@ oXf
 cJJ
 ban
 pFC
-eei
+lav
 yiH
-ybc
+vUc
+rlj
+gbL
 iZm
-iZm
-vqH
 mhO
-mfk
+pXe
 iZm
+luB
 iZm
-iHT
 srf
-xhl
 iZm
+fXj
 iZm
-jds
-xWO
-kkg
+hYb
+iZm
 eei
-bwH
+eei
+nhC
 nhC
 lXw
 nhC
@@ -105891,27 +105849,27 @@ tUq
 cJJ
 lOB
 pFC
-lav
+sbR
 yiH
-vUc
-rlj
-gbL
 iZm
+rcq
+jds
+jds
 mhO
-pXe
 iZm
-luB
-iZm
+qgD
+jds
+jds
 srf
 iZm
-fXj
 iZm
-hYb
+mim
+jds
 iZm
-eei
-eei
-lcz
-lcz
+pHU
+pHU
+lXw
+lXw
 lXw
 nhC
 nhC
@@ -106148,28 +106106,28 @@ mrj
 ltY
 tgz
 pFC
-sbR
+tPh
 yiH
+wYs
 iZm
-rcq
-jds
-jds
-mhO
+mRf
 iZm
-qgD
-jds
-jds
-srf
+icN
+bul
 iZm
+eIu
 iZm
-mim
-jds
+daC
+iZm
+lzT
+iZm
+usb
 iZm
 pHU
-plQ
 lXw
-nPn
-nPn
+lXw
+nhC
+nhC
 nhC
 nhC
 nhC
@@ -106405,26 +106363,26 @@ hDx
 sSS
 bXk
 bjo
-tPh
+lvW
 yiH
-wYs
+pvb
 iZm
-mRf
+qXC
+pvb
+vXe
+tDn
 iZm
-icN
-bul
+qXC
+tDn
+bRQ
+xWO
 iZm
-eIu
 iZm
-daC
-iZm
-lzT
-iZm
-usb
-iZm
+qXC
+xWO
 pHU
 lXw
-nPn
+nhC
 nhC
 nhC
 nhC
@@ -106662,23 +106620,23 @@ erC
 bjo
 bjo
 bjo
-lvW
+eei
 yiH
-pvb
-iZm
-qXC
-pvb
-vXe
-tDn
-iZm
-qXC
-tDn
-bRQ
-xWO
-iZm
-iZm
-qXC
-xWO
+pHU
+pHU
+pHU
+pHU
+pHU
+pHU
+pHU
+pHU
+pHU
+pHU
+pHU
+pHU
+pHU
+pHU
+pHU
 pHU
 lXw
 nhC
@@ -106918,25 +106876,25 @@ sVP
 dHA
 fep
 toQ
-pFC
-oOh
-jUa
-plQ
-plQ
-plQ
-plQ
-plQ
-plQ
-plQ
-plQ
-plQ
-plQ
-plQ
-plQ
-plQ
-plQ
-plQ
-plQ
+iuR
+mGL
+kfq
+jvO
+lXw
+lXw
+lXw
+lXw
+lXw
+lXw
+lXw
+lXw
+lXw
+lXw
+lXw
+lXw
+lXw
+lXw
+lXw
 lXw
 nhC
 nhC
@@ -107175,8 +107133,8 @@ pKZ
 edl
 vAM
 qrQ
-iuR
-mGL
+pFC
+lXw
 kfq
 jvO
 lXw

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -1595,13 +1595,7 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "azH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/duct,
-/obj/effect/turf_decal/tile/green/half/contrasted{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "azI" = (
@@ -3197,9 +3191,6 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aWx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/duct,
 /turf/open/floor/iron/stairs/medium,
 /area/station/science/xenobiology)
@@ -4929,6 +4920,11 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/carpet/blue,
 /area/station/service/lawoffice)
+"bwH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space)
 "bwL" = (
 /obj/effect/turf_decal/tile/dark{
 	dir = 1
@@ -7555,10 +7551,6 @@
 /turf/open/floor/plating/airless,
 /area/station/solars/port/aft)
 "clx" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -15293,6 +15285,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
+"evV" = (
+/turf/open/floor/glass/reinforced,
+/area/station/science/xenobiology)
 "ewb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17267,7 +17262,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/shower/directional/east,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -24909,6 +24903,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
+"hsa" = (
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "hsc" = (
 /obj/machinery/computer/records/security{
 	dir = 4
@@ -27974,6 +27971,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
+"inP" = (
+/obj/structure/flora/bush/pale{
+	pixel_y = -3;
+	pixel_x = -6
+	},
+/turf/open/floor/grass,
+/area/station/science/xenobiology)
 "inS" = (
 /obj/effect/mob_spawn/corpse/human/clown,
 /obj/effect/decal/cleanable/blood/innards,
@@ -29595,16 +29599,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/lesser)
 "iLM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/orange/half/contrasted{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "iLO" = (
@@ -33599,6 +33597,15 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"jUa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "jUk" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/hidden{
 	dir = 5
@@ -40364,8 +40371,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/duct,
-/obj/effect/turf_decal/tile/orange/half/contrasted{
+/obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -48079,6 +48085,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/carpet,
 /area/station/service/bar)
+"obK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/orange/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "obO" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -48902,6 +48917,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/lower)
+"ooT" = (
+/turf/open/floor/grass,
+/area/station/science/xenobiology)
 "ooV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -50537,6 +50555,11 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/security/checkpoint/medical)
+"oOh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "oOn" = (
 /obj/structure/cable,
 /turf/open/floor/iron/stairs/medium,
@@ -54120,10 +54143,6 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
 "pUY" = (
-/obj/structure/flora/bush/pale{
-	pixel_y = -3;
-	pixel_x = -6
-	},
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/grass,
 /area/station/science/xenobiology)
@@ -55854,6 +55873,7 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/autoname/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology/hallway)
 "qrS" = (
@@ -63626,6 +63646,12 @@
 /obj/effect/mapping_helpers/mail_sorting/supply/cargo_bay,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"sCV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/stairs/medium,
+/area/station/science/xenobiology)
 "sCZ" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/east,
@@ -66135,7 +66161,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/closet/secure_closet/cytology,
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology/hallway)
@@ -74241,6 +74266,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology/hallway)
 "vAO" = (
@@ -80520,6 +80546,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai_upload)
+"xse" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/turf/open/floor/glass/reinforced,
+/area/station/science/xenobiology)
 "xsi" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/lockbox/loyalty{
@@ -82268,6 +82301,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/gravity_generator)
+"xTE" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/duct,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/science/xenobiology)
 "xTQ" = (
 /obj/effect/turf_decal/trimline/neutral/line{
 	dir = 6
@@ -105081,25 +105123,25 @@ lpg
 vmR
 afe
 aWx
-lLM
+azH
 iLM
-lLM
-hee
+azH
+azH
 azH
 azH
 azH
 azH
 clx
-iNS
-iNS
-iNS
-iNS
-isk
-jpT
+azH
+azH
+azH
+azH
+hsa
+ooT
 pUY
 eei
 nhC
-lXw
+lcz
 nhC
 nhC
 nhC
@@ -105335,25 +105377,25 @@ fNN
 jPd
 khx
 ktR
-eei
-yiH
-ybc
-iZm
-iZm
-vqH
-mhO
-mfk
-iZm
-iZm
-iHT
-srf
-xhl
-iZm
-iZm
-jds
-xWO
-kkg
-eei
+evV
+xse
+sCV
+obK
+obK
+obK
+hee
+lLM
+lLM
+lLM
+lLM
+xTE
+isk
+isk
+isk
+iNS
+isk
+jpT
+inP
 eei
 nhC
 lXw
@@ -105592,26 +105634,26 @@ oXf
 cJJ
 ban
 pFC
-lav
+eei
 yiH
-vUc
-rlj
-gbL
+ybc
 iZm
+iZm
+vqH
 mhO
-pXe
+mfk
 iZm
-luB
 iZm
+iHT
 srf
+xhl
 iZm
-fXj
 iZm
-hYb
-iZm
+jds
+xWO
+kkg
 eei
-eei
-nhC
+bwH
 nhC
 lXw
 nhC
@@ -105849,27 +105891,27 @@ tUq
 cJJ
 lOB
 pFC
-sbR
+lav
 yiH
+vUc
+rlj
+gbL
 iZm
-rcq
-jds
-jds
 mhO
+pXe
 iZm
-qgD
-jds
-jds
+luB
+iZm
 srf
 iZm
+fXj
 iZm
-mim
-jds
+hYb
 iZm
-pHU
-pHU
-lXw
-lXw
+eei
+eei
+lcz
+lcz
 lXw
 nhC
 nhC
@@ -106106,28 +106148,28 @@ mrj
 ltY
 tgz
 pFC
-tPh
+sbR
 yiH
-wYs
 iZm
-mRf
+rcq
+jds
+jds
+mhO
 iZm
-icN
-bul
+qgD
+jds
+jds
+srf
 iZm
-eIu
 iZm
-daC
-iZm
-lzT
-iZm
-usb
+mim
+jds
 iZm
 pHU
+plQ
 lXw
-lXw
-nhC
-nhC
+nPn
+nPn
 nhC
 nhC
 nhC
@@ -106363,26 +106405,26 @@ hDx
 sSS
 bXk
 bjo
-lvW
+tPh
 yiH
-pvb
+wYs
 iZm
-qXC
-pvb
-vXe
-tDn
+mRf
 iZm
-qXC
-tDn
-bRQ
-xWO
+icN
+bul
 iZm
+eIu
 iZm
-qXC
-xWO
+daC
+iZm
+lzT
+iZm
+usb
+iZm
 pHU
 lXw
-nhC
+nPn
 nhC
 nhC
 nhC
@@ -106620,23 +106662,23 @@ erC
 bjo
 bjo
 bjo
-eei
+lvW
 yiH
-pHU
-pHU
-pHU
-pHU
-pHU
-pHU
-pHU
-pHU
-pHU
-pHU
-pHU
-pHU
-pHU
-pHU
-pHU
+pvb
+iZm
+qXC
+pvb
+vXe
+tDn
+iZm
+qXC
+tDn
+bRQ
+xWO
+iZm
+iZm
+qXC
+xWO
 pHU
 lXw
 nhC
@@ -106876,25 +106918,25 @@ sVP
 dHA
 fep
 toQ
-iuR
-mGL
-kfq
-jvO
-lXw
-lXw
-lXw
-lXw
-lXw
-lXw
-lXw
-lXw
-lXw
-lXw
-lXw
-lXw
-lXw
-lXw
-lXw
+pFC
+oOh
+jUa
+plQ
+plQ
+plQ
+plQ
+plQ
+plQ
+plQ
+plQ
+plQ
+plQ
+plQ
+plQ
+plQ
+plQ
+plQ
+plQ
 lXw
 nhC
 nhC
@@ -107133,8 +107175,8 @@ pKZ
 edl
 vAM
 qrQ
-pFC
-lXw
+iuR
+mGL
 kfq
 jvO
 lXw

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -1047,6 +1047,8 @@
 	},
 /obj/machinery/duct,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison)
 "adp" = (
@@ -1092,6 +1094,8 @@
 	name = "Prison Showers"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "adv" = (
@@ -3195,7 +3199,6 @@
 	},
 /obj/effect/decal/cleanable/oil,
 /obj/item/clothing/glasses/welding,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/port/central)
@@ -5992,7 +5995,8 @@
 	},
 /obj/structure/sign/poster/official/enlist/directional/east,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "aPm" = (
@@ -7002,6 +7006,7 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/escapepodbay)
 "beZ" = (
@@ -7537,12 +7542,12 @@
 /turf/open/misc/asteroid/airless,
 /area/station/asteroid)
 "boN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/escapepodbay)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/eva)
 "boS" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 10
@@ -9221,7 +9226,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "bNV" = (
@@ -10107,6 +10111,7 @@
 	name = "Private Quarters R"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet,
 /area/station/commons/dorms)
 "cbs" = (
@@ -10559,6 +10564,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
@@ -12209,8 +12215,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_blue/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "cKg" = (
@@ -12441,10 +12445,6 @@
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
 	},
-/obj/machinery/power/shuttle_engine/propulsion{
-	desc = "A standard reliable bluespace engine used by many forms of shuttles. This one has the bluespace core removed.";
-	name = "inactive propulsion engine"
-	},
 /obj/effect/decal/cleanable/oil,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -12630,8 +12630,6 @@
 /turf/open/floor/carpet/grimey,
 /area/station/security/detectives_office)
 "cRW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
@@ -12816,8 +12814,6 @@
 /obj/structure/sign/warning/secure_area{
 	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 10
 	},
@@ -13061,6 +13057,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/stone,
 /area/station/science/xenobiology)
 "cZH" = (
@@ -15347,6 +15346,8 @@
 	name = "EVA Maintenance Hatch"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/eva)
 "dLN" = (
@@ -15516,14 +15517,14 @@
 /area/station/command/teleporter)
 "dOJ" = (
 /obj/effect/turf_decal/stripes/end,
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
-	dir = 4
-	},
 /obj/structure/railing{
 	layer = 3.1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/cargo)
@@ -18822,8 +18823,6 @@
 /obj/machinery/door/airlock/command/glass{
 	name = "Secure External Operations"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/access/any/command/eva,
@@ -19047,9 +19046,6 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Security - Isolation Chambers"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "eUo" = (
@@ -19104,7 +19100,6 @@
 	c_tag = "Medical - Chief Medical Officer's Office";
 	network = list("ss13","medbay")
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "eUN" = (
@@ -19852,8 +19847,6 @@
 /obj/machinery/door/airlock{
 	name = "Prison Showers"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "fhL" = (
@@ -22185,6 +22178,8 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/structure/ghost_critter_spawn,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/eva)
 "fSH" = (
@@ -22303,6 +22298,8 @@
 /obj/item/clothing/mask/cigarette/pipe{
 	pixel_x = -5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/nt_rep)
 "fVg" = (
@@ -23041,7 +23038,6 @@
 /obj/item/hfr_box/corner,
 /obj/item/hfr_box/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "gjs" = (
@@ -23445,7 +23441,7 @@
 	id = "shitbreaker"
 	},
 /obj/structure/window/spawner/directional/south,
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron,
 /area/station/engineering/shipbreaker_hut)
 "gpH" = (
 /obj/effect/turf_decal/siding/thinplating,
@@ -23754,11 +23750,13 @@
 /turf/closed/wall,
 /area/station/security/prison)
 "gvO" = (
-/obj/machinery/duct,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/freezer,
-/area/station/security/prison/shower)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/shuttle_engine/propulsion{
+	desc = "A standard reliable bluespace engine used by many forms of shuttles. This one has the bluespace core removed.";
+	name = "inactive propulsion engine"
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/port/central)
 "gvQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24353,9 +24351,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/arrow_cw{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "gFA" = (
@@ -25877,10 +25873,14 @@
 /area/station/commons/fitness/recreation)
 "hfe" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/security/prison)
+/area/station/security/execution/transfer)
 "hft" = (
 /obj/structure/bed{
 	dir = 8
@@ -26098,13 +26098,13 @@
 "hiQ" = (
 /obj/structure/sign/clock/directional/south,
 /obj/item/paper/crumpled/bloody,
+/obj/structure/table/glass,
 /obj/item/radio/intercom/directional/east{
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_x = 0
 	},
-/obj/structure/table/glass,
 /turf/open/floor/iron/dark/small,
 /area/ruin/powered/clownplanet)
 "hiR" = (
@@ -27817,13 +27817,11 @@
 	name = "HIGH SECURITY STORAGE";
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "hMU" = (
@@ -30137,7 +30135,7 @@
 	},
 /obj/structure/window/spawner/directional/south,
 /obj/structure/window/spawner/directional/north,
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron,
 /area/station/engineering/shipbreaker_hut)
 "iws" = (
 /obj/effect/turf_decal/delivery,
@@ -30157,7 +30155,6 @@
 /area/station/science/server)
 "iwP" = (
 /obj/structure/sign/departments/vault/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/carpet/grimey,
 /area/station/ai_monitored/command/nuke_storage)
@@ -31178,15 +31175,10 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "iNe" = (
-/obj/effect/turf_decal/trimline/dark_blue/arrow_ccw{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/dark_blue/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/hop)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/security)
 "iNo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -31397,7 +31389,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "iQZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/button/door/directional/north{
@@ -32737,7 +32728,6 @@
 	network = list("ss13","secure")
 	},
 /obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/carpet/grimey,
 /area/station/ai_monitored/command/nuke_storage)
@@ -34274,6 +34264,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/eva)
 "jKb" = (
@@ -34975,7 +34967,7 @@
 /area/station/maintenance/starboard/lesser)
 "jVp" = (
 /obj/machinery/light/small/directional/west,
-/turf/open/misc/asteroid,
+/turf/open/misc/asteroid/airless,
 /area/station/asteroid)
 "jVw" = (
 /turf/open/floor/iron/white,
@@ -34991,13 +34983,11 @@
 	name = "HIGH SECURITY STORAGE";
 	pixel_y = 32
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "jVK" = (
@@ -36388,8 +36378,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
 	},
@@ -39080,6 +39068,8 @@
 	dir = 1
 	},
 /obj/machinery/station_map/engineering/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "leV" = (
@@ -43773,6 +43763,8 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
 /obj/modular_map_connector,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/medical)
 "mFF" = (
@@ -43976,6 +43968,7 @@
 	dir = 4
 	},
 /obj/structure/railing,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "mHZ" = (
@@ -47729,7 +47722,6 @@
 	},
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -47807,8 +47799,6 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/cargo)
 "nTm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
@@ -48917,7 +48907,9 @@
 	dir = 5
 	},
 /obj/machinery/status_display/ai/directional/north,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "olR" = (
@@ -51410,6 +51402,12 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "pfR" = (
@@ -52245,7 +52243,6 @@
 	capacity = 9e+006;
 	charge = 10000
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Atmospherics Incinerator";
@@ -53816,6 +53813,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -55247,6 +55245,8 @@
 	id = "hopqueuestart";
 	name = "HoP Queue Shutters"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "qle" = (
@@ -57187,6 +57187,8 @@
 "qPV" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "qPW" = (
@@ -58884,6 +58886,8 @@
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/starboard/central)
 "rpG" = (
@@ -59714,10 +59718,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "rEq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -62217,7 +62218,6 @@
 "svo" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
@@ -62810,6 +62810,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "sEZ" = (
@@ -62921,6 +62923,7 @@
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "sGO" = (
@@ -63139,10 +63142,9 @@
 /turf/open/floor/iron,
 /area/station/cargo/sorting)
 "sJW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/disposal/incinerator)
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
+/area/station/engineering)
 "sKg" = (
 /turf/closed/wall,
 /area/station/commons/fitness)
@@ -64854,8 +64856,6 @@
 	id = "hopqueueendbottom";
 	name = "HoP Queue Shutters"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "tkj" = (
@@ -65177,13 +65177,11 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
 "tpp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/west,
 /obj/effect/turf_decal/tile/bar{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/escapepodbay)
 "tpr" = (
@@ -65573,6 +65571,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/small/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "tuu" = (
@@ -65910,11 +65909,13 @@
 /turf/open/floor/glass/reinforced,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
 "tAF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/trash/food_packaging,
 /obj/structure/cable,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/command)
+/turf/open/floor/catwalk_floor,
+/area/station/maintenance/department/eva)
 "tAH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -66179,13 +66180,11 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/tram/right)
 "tFe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	pixel_x = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/maintenance/disposal/incinerator)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/freezer,
+/area/station/security/prison/shower)
 "tFg" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Civilian - Chapel East"
@@ -66831,8 +66830,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
 "tQN" = (
@@ -67473,6 +67474,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "ubx" = (
@@ -71014,6 +71018,8 @@
 	dir = 1
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/starboard/central)
 "vcp" = (
@@ -72213,7 +72219,7 @@
 	id = "shitbreaker"
 	},
 /obj/structure/window/spawner/directional/north,
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron,
 /area/station/engineering/shipbreaker_hut)
 "vsI" = (
 /obj/effect/landmark/event_spawn,
@@ -74827,7 +74833,7 @@
 /obj/machinery/conveyor{
 	id = "shitbreaker"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron,
 /area/station/engineering/shipbreaker_hut)
 "wiI" = (
 /obj/machinery/door/airlock/security/glass{
@@ -76574,7 +76580,7 @@
 	id = "shitbreaker"
 	},
 /obj/structure/window/spawner/directional/south,
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron,
 /area/station/engineering/shipbreaker_hut)
 "wJM" = (
 /obj/structure/lattice/catwalk,
@@ -76692,11 +76698,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/greater)
-"wMt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall,
-/area/station/command/heads_quarters/hop)
 "wMu" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/tile/brown/fourcorners,
@@ -79456,7 +79457,6 @@
 "xMz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 8
@@ -79704,9 +79704,6 @@
 /area/station/command/heads_quarters/rd)
 "xPZ" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/ladder,
 /obj/structure/railing{
 	layer = 3.1
@@ -79739,7 +79736,7 @@
 	id = "shitbreaker"
 	},
 /obj/machinery/shipbreaker,
-/turf/open/floor/plating/airless,
+/turf/open/floor/iron,
 /area/station/engineering/shipbreaker_hut)
 "xQK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -80295,8 +80292,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/primary/tram/left)
 "xZV" = (
@@ -94689,7 +94684,7 @@ abm
 abf
 abf
 hhu
-boN
+adG
 acN
 acT
 acA
@@ -95169,7 +95164,7 @@ pJb
 rEz
 tnB
 eTl
-wei
+hfe
 pvY
 eOc
 ong
@@ -100597,7 +100592,7 @@ gpp
 gpp
 gpp
 gpp
-gpp
+gvO
 ahS
 tYK
 gCq
@@ -102629,7 +102624,7 @@ szM
 pDu
 ado
 adu
-gvO
+vyo
 nof
 euX
 euX
@@ -102884,9 +102879,9 @@ xxv
 cNl
 epF
 wkp
-hfe
+ubC
 fhJ
-vyo
+tFe
 adI
 adI
 aea
@@ -107070,7 +107065,7 @@ cDN
 sim
 ney
 vNH
-leW
+sJW
 leW
 leW
 uXK
@@ -120176,7 +120171,7 @@ ozd
 vHy
 kbw
 xbf
-tFe
+hUf
 wlM
 xWc
 gqV
@@ -120433,8 +120428,8 @@ bsf
 rtO
 sHv
 xbf
-sJW
-gqV
+hUf
+vde
 pGM
 tTK
 xWj
@@ -121204,7 +121199,7 @@ tOe
 qWU
 qWU
 qWU
-rRy
+qWU
 rRy
 rRy
 rRy
@@ -131449,7 +131444,7 @@ qPe
 uuK
 uNZ
 qxm
-abM
+aac
 oys
 oys
 oys
@@ -131706,7 +131701,7 @@ ruy
 opy
 jYY
 qxm
-abM
+aac
 jVp
 aak
 aaa
@@ -131963,8 +131958,8 @@ ldg
 sYP
 ecO
 qxm
-abM
-abM
+aac
+aac
 aak
 aaa
 aaa
@@ -132220,9 +132215,9 @@ pAf
 oAw
 eqw
 qxm
-abM
-abM
-abM
+aac
+aac
+aac
 aaa
 aaa
 aaa
@@ -132477,7 +132472,7 @@ rGx
 pzs
 lEo
 qxm
-abM
+aac
 aaa
 aaa
 aaa
@@ -132734,7 +132729,7 @@ lFH
 eHL
 aAj
 qxm
-abM
+aac
 aaa
 aaa
 aaa
@@ -132991,8 +132986,8 @@ iMf
 ruy
 ecO
 qxm
-abM
-abM
+aac
+aac
 aaa
 aaa
 aaa
@@ -133248,8 +133243,8 @@ asR
 asR
 qxm
 qxm
-abM
-abM
+aac
+aac
 aaa
 aaa
 aaa
@@ -133505,8 +133500,8 @@ aaa
 aaa
 aaa
 aaa
-abM
-abM
+aac
+aac
 aaa
 aaa
 aaa
@@ -133762,7 +133757,7 @@ aaa
 aaa
 aaa
 aaa
-abM
+aac
 aaa
 aaa
 aaa
@@ -134019,7 +134014,7 @@ aaa
 aaa
 aaa
 aaa
-abM
+aac
 aaa
 aaa
 aaa
@@ -134276,8 +134271,8 @@ aaa
 aaa
 aaa
 aaa
-abM
-abM
+aac
+aac
 aaa
 aaa
 aaa
@@ -134533,9 +134528,9 @@ aaa
 aaa
 aaa
 aaa
-abM
-abM
-abM
+aac
+aac
+aac
 aaa
 aaa
 aaa
@@ -157894,11 +157889,11 @@ gDE
 osk
 aaa
 osk
-jta
-jta
-jta
+boN
+boN
+boN
 fSv
-jta
+boN
 jJX
 kIZ
 kIZ
@@ -158151,7 +158146,7 @@ jta
 osk
 aaa
 osk
-jta
+boN
 osk
 osk
 osk
@@ -158408,7 +158403,7 @@ bTy
 osk
 aaa
 osk
-isf
+tAF
 osk
 rlv
 rlv
@@ -158665,7 +158660,7 @@ jta
 osk
 aaa
 osk
-jta
+boN
 osk
 rlv
 rlv
@@ -158922,7 +158917,7 @@ jta
 osk
 osk
 osk
-jta
+boN
 osk
 rlv
 rlv
@@ -159179,7 +159174,7 @@ jta
 jta
 jta
 jta
-jta
+boN
 osk
 rlv
 rlv
@@ -161753,8 +161748,8 @@ bNJ
 bNJ
 bNJ
 bNJ
-bNJ
-bNJ
+dIY
+dIY
 dIY
 dlb
 aBH
@@ -162542,7 +162537,7 @@ lcS
 cem
 eqv
 mof
-iNe
+eqv
 cKd
 niO
 rRK
@@ -162801,7 +162796,7 @@ fKO
 jvf
 fKO
 tki
-wMt
+jvf
 ook
 mGQ
 yiM
@@ -167145,8 +167140,8 @@ pLg
 nSV
 aPk
 sGG
-tAF
-tAF
+uoO
+uoO
 svc
 svc
 svc
@@ -174600,8 +174595,8 @@ ehP
 klx
 ehP
 ehP
-vdh
-vdh
+iNe
+iNe
 bGU
 eLv
 eLv
@@ -184149,7 +184144,7 @@ whz
 whz
 whz
 iLn
-vNN
+iLn
 iLn
 vnJ
 iLn
@@ -200070,8 +200065,8 @@ may
 uCy
 may
 uCy
-aac
-aaa
+jhd
+jhd
 jhd
 jhd
 jhd
@@ -200327,7 +200322,7 @@ may
 uCy
 may
 uCy
-aac
+jhd
 jhd
 jhd
 jhd

--- a/_maps/~monkestation/RandomBars/Tram/tram_bar_cult.dmm
+++ b/_maps/~monkestation/RandomBars/Tram/tram_bar_cult.dmm
@@ -1,4 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ab" = (
+/obj/structure/cable,
+/obj/structure/chair/wood,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/cult,
+/area/station/commons/lounge)
 "ad" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -626,6 +633,8 @@
 "nw" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/cult,
 /area/station/commons/lounge)
 "nx" = (
@@ -777,6 +786,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/cult,
+/area/station/commons/lounge)
+"qT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/cult,
 /area/station/commons/lounge)
 "rg" = (
@@ -1108,6 +1123,7 @@
 "AI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/cult,
 /area/station/commons/lounge)
 "AU" = (
@@ -1435,6 +1451,8 @@
 "FM" = (
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance/east_offset,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/cult,
 /area/station/commons/lounge)
 "FW" = (
@@ -1483,6 +1501,7 @@
 "GM" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/cult,
 /area/station/commons/lounge)
 "GN" = (
@@ -2894,9 +2913,9 @@ Vd
 Vd
 Vd
 Vi
-if
+qT
 GM
-YX
+if
 AI
 Ub
 lL
@@ -2951,7 +2970,7 @@ Qi
 nx
 fG
 FY
-uV
+ab
 XS
 fG
 FY
@@ -2978,7 +2997,7 @@ Qi
 cr
 qm
 FY
-uV
+ab
 YQ
 cr
 FY
@@ -3005,7 +3024,7 @@ Vd
 tk
 tk
 Vd
-Hv
+AI
 tk
 KW
 oj

--- a/_maps/~monkestation/RandomBars/Tram/tram_bar_ocean.dmm
+++ b/_maps/~monkestation/RandomBars/Tram/tram_bar_ocean.dmm
@@ -180,6 +180,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/fake_seafloor/ironsand,
 /area/station/service/kitchen)
+"gB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/fake_seafloor,
+/area/station/commons/lounge)
 "gE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -260,6 +266,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/kitchen,
 /turf/open/floor/fake_seafloor/ironsand,
 /area/station/service/kitchen)
+"kj" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/fake_seafloor/spawning,
+/area/station/commons/lounge)
 "kP" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/assistant,
@@ -770,6 +783,12 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/fake_seafloor,
 /area/station/commons/lounge)
+"Hs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/fake_seafloor/spawning,
+/area/station/commons/lounge)
 "HW" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/hangover,
@@ -982,6 +1001,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable,
 /turf/open/floor/fake_seafloor/spawning,
 /area/station/commons/lounge)
 "Rp" = (
@@ -1136,6 +1156,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/fake_seafloor/spawning,
 /area/station/commons/lounge)
 "Ys" = (
@@ -1221,7 +1242,7 @@ fE
 NY
 pR
 AF
-aw
+gB
 pR
 MN
 mG
@@ -1248,7 +1269,7 @@ mG
 za
 pR
 AF
-aw
+gB
 pR
 tV
 mG
@@ -1275,7 +1296,7 @@ aw
 aw
 aw
 aw
-aw
+gB
 aw
 aw
 aw
@@ -1302,7 +1323,7 @@ AF
 AF
 AF
 AF
-AF
+Hs
 AF
 AF
 AF
@@ -1329,7 +1350,7 @@ AF
 AF
 AF
 AF
-AF
+Hs
 AF
 Ir
 AF
@@ -1356,7 +1377,7 @@ AF
 AF
 AF
 AF
-AF
+Hs
 nM
 AF
 AF
@@ -1383,17 +1404,17 @@ zC
 zC
 zC
 zC
-zC
-zC
-zC
-zC
-zC
+kj
+kj
+kj
+kj
+kj
 Rj
 Rj
 Rj
 Rj
 Yn
-jT
+Hs
 Um
 lL
 lL


### PR DESCRIPTION
## About The Pull Request
Changes Medsec outpost on blueshift from medical access to security access.

Improved transition distro piping, including connecting areas such as Bridge/Vault/Forge ect. to the distro.

Removed more roundstart turf issues on other maps!
As they never end...
## Why It's Good For The Game
Security door should have security access closes: #6573

The AI can plasmaflood the captain as a treat.

And the game doesn't like it when the air is funky. Eats time.
## Changelog
:cl:
map: Blueshift Medsec outpost is no longer accessible via medical access.
map: Tramstation distribution has been improved. Connecting areas such as bridge, vault, and forge to the distro.
map: Less roundstart turf differences. Makes game happy.
/:cl:
