### PR TITLE
Oldstation Updates

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -103,9 +103,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/south{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/beta/hall)
 "aA" = (
@@ -325,9 +323,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/bridge)
 "bk" = (
@@ -451,9 +447,7 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/east{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/bridge)
 "bQ" = (
@@ -1274,13 +1268,11 @@
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
 /obj/structure/rack,
 /obj/item/assembly/prox_sensor,
 /obj/item/stack/cable_coil,
 /obj/item/assembly/prox_sensor,
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/iron/white,
 /area/ruin/space/ancientstation/delta/rnd)
 "eE" = (
@@ -1368,9 +1360,7 @@
 /obj/item/storage/backpack/old,
 /obj/effect/spawner/random/clothing/backpack,
 /obj/effect/spawner/random/clothing/backpack,
-/obj/machinery/camera/autoname/directional/south{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/dorms)
 "eU" = (
@@ -1581,9 +1571,7 @@
 /obj/machinery/duct,
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/hall)
 "fK" = (
@@ -2086,9 +2074,7 @@
 /obj/structure/alien/weeds,
 /obj/structure/cable,
 /obj/effect/decal/cleanable/blood/tracks,
-/obj/machinery/camera/autoname/directional/east{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/east,
 /turf/open/floor/iron/dark,
 /area/ruin/space/ancientstation/delta/ai)
 "hM" = (
@@ -2148,7 +2134,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/computer/security/hos,
+/obj/machinery/computer/security/old,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/bridge)
 "hW" = (
@@ -2449,10 +2435,8 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
 /obj/effect/decal/cleanable/cobweb,
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/plating,
 /area/ruin/space/ancientstation/charlie/storage)
 "iV" = (
@@ -2478,9 +2462,7 @@
 "iY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/east{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/hall)
 "je" = (
@@ -2586,9 +2568,7 @@
 /area/ruin/space/ancientstation/charlie/hall)
 "jw" = (
 /obj/structure/alien/weeds/node,
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/iron/dark,
 /area/ruin/space/ancientstation/delta/ai)
 "jx" = (
@@ -2807,9 +2787,7 @@
 /obj/item/shard,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/broken_flooring/singular/directional/east,
-/obj/machinery/camera/autoname/directional/east{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/east,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/beta/hall)
 "ko" = (
@@ -3112,9 +3090,7 @@
 	name = "N2 Input"
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/machinery/camera/autoname/directional/south{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/beta/atmos)
 "li" = (
@@ -3241,9 +3217,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/east{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/engie)
 "lM" = (
@@ -3252,9 +3226,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/rnd)
 "lO" = (
@@ -3365,9 +3337,7 @@
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/hall)
 "mn" = (
-/obj/machinery/camera/autoname/directional/south{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/south,
 /turf/open/floor/iron/white/corner{
 	dir = 4
 	},
@@ -3678,9 +3648,7 @@
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/beta/atmos)
 "nm" = (
@@ -3862,9 +3830,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/camera/autoname/directional/east{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/hall)
 "oa" = (
@@ -3944,9 +3910,7 @@
 "om" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/energy_accumulator/tesla_coil,
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/plating,
 /area/ruin/space/ancientstation/beta/supermatter)
 "oo" = (
@@ -4078,9 +4042,7 @@
 	icon_state = "medium"
 	},
 /obj/structure/broken_flooring/side/directional/south,
-/obj/machinery/camera/autoname/directional/east{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/east,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ancientstation/beta/hall)
 "oQ" = (
@@ -4169,9 +4131,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/hall)
 "ph" = (
@@ -4182,9 +4142,7 @@
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/effect/mapping_helpers/apc/no_charge,
 /obj/structure/cable,
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/dorms)
 "pi" = (
@@ -4390,9 +4348,7 @@
 "qH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/plumbing/input,
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/engine,
 /area/ruin/space/ancientstation/delta/biolab)
 "qK" = (
@@ -4466,9 +4422,7 @@
 "rJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/hall)
 "rQ" = (
@@ -4580,18 +4534,14 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/east{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/sec)
 "sn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/hall)
 "sq" = (
@@ -4668,7 +4618,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/computer/security{
+/obj/machinery/computer/security/old{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -4703,22 +4653,16 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/mapping_helpers/airalarm/all_access,
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/iron/diagonal,
 /area/ruin/space/ancientstation/beta/gravity)
 "ta" = (
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/engine/airless,
 /area/ruin/space/ancientstation/beta/supermatter)
 "tc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/east{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/hall)
 "td" = (
@@ -4856,9 +4800,7 @@
 /obj/item/clothing/suit/toggle/labcoat/science,
 /obj/item/reagent_containers/cup/soda_cans/dr_gibb,
 /obj/item/mmi/posibrain,
-/obj/machinery/camera/autoname/directional/south{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/south,
 /turf/open/floor/iron/dark,
 /area/ruin/space/ancientstation/delta/ai)
 "uj" = (
@@ -5071,9 +5013,7 @@
 /area/ruin/space/ancientstation/delta/rnd)
 "vy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/south{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/south,
 /turf/open/floor/engine,
 /area/ruin/space/ancientstation/delta/biolab)
 "vA" = (
@@ -5245,9 +5185,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
-/obj/machinery/camera/autoname/directional/south{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/south,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/biolab)
 "wn" = (
@@ -5538,9 +5476,7 @@
 "yG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/alien/weeds,
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/iron/dark,
 /area/ruin/space/ancientstation/delta/hall)
 "yO" = (
@@ -5643,9 +5579,7 @@
 "zq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/beta/hall)
 "zr" = (
@@ -5787,9 +5721,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 10
 	},
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/hall)
 "Ax" = (
@@ -5854,9 +5786,7 @@
 "AS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/hall)
 "AV" = (
@@ -6038,9 +5968,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/east{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/engie)
 "Ci" = (
@@ -6350,9 +6278,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/hall)
 "Fa" = (
@@ -6673,7 +6599,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /obj/item/card/id/away/old/robo{
-	assignment = "Charlie Station Roboticist";
+	assignment = "Delta Station Roboticist";
 	name = "Ash Holm";
 	registered_name = "Ash Holm"
 	},
@@ -6808,9 +6734,7 @@
 /obj/structure/alien/weeds,
 /obj/item/robot_suit/prebuilt,
 /obj/structure/alien/weeds,
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/iron/dark,
 /area/ruin/space/ancientstation/delta/ai)
 "Ii" = (
@@ -6870,9 +6794,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 1
 	},
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/hydro)
 "IM" = (
@@ -6946,9 +6868,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/hall)
 "Jd" = (
@@ -7189,9 +7109,7 @@
 /area/ruin/space/ancientstation/delta/rnd)
 "Ku" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/iron/white,
 /area/ruin/space/ancientstation/delta/rnd)
 "Kv" = (
@@ -7399,9 +7317,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/secure_closet/freezer/fridge/open,
 /obj/machinery/light/small/directional/north,
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/ruin/space/ancientstation/charlie/kitchen)
 "LD" = (
@@ -7409,9 +7325,7 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/camera/autoname/directional/east{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/east,
 /turf/open/floor/iron/white/textured_edge{
 	dir = 8
 	},
@@ -7660,9 +7574,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/beta/medbay)
 "NE" = (
@@ -7702,10 +7614,8 @@
 	dir = 1
 	},
 /obj/item/pickaxe/drill,
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
 /obj/item/pickaxe/drill,
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/beta/mining)
 "NQ" = (
@@ -8532,9 +8442,7 @@
 "Tv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/east{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/east,
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/delta/hall)
 "Tw" = (
@@ -8694,9 +8602,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/mapping_helpers/apc/no_charge,
-/obj/machinery/camera/autoname/directional/north{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/north,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/ancientstation/delta/proto)
 "UG" = (
@@ -8945,9 +8851,7 @@
 "Ww" = (
 /obj/structure/alien/weeds,
 /mob/living/basic/alien/drone,
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/iron/dark,
 /area/ruin/space/ancientstation/delta/ai)
 "WA" = (
@@ -9133,9 +9037,7 @@
 /area/ruin/space/ancientstation/charlie/kitchen)
 "Yc" = (
 /obj/structure/alien/weeds,
-/obj/machinery/camera/autoname/directional/west{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/west,
 /turf/open/floor/iron/dark,
 /area/ruin/space/ancientstation/delta/ai)
 "Yg" = (
@@ -9374,9 +9276,7 @@
 /area/ruin/space/ancientstation/delta/hall)
 "ZV" = (
 /obj/structure/alien/weeds,
-/obj/machinery/camera/autoname/directional/east{
-	status = 0
-	},
+/obj/machinery/camera/autoname/old/directional/east,
 /turf/open/floor/iron/dark,
 /area/ruin/space/ancientstation/delta/ai)
 "ZY" = (

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -6599,7 +6599,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/glass,
 /obj/item/card/id/away/old/robo{
-	assignment = "Delta Station Roboticist";
+	assignment = "Charlie Station Roboticist";
 	name = "Ash Holm";
 	registered_name = "Ash Holm"
 	},
@@ -8096,7 +8096,8 @@
 	bot_mode_flags = 12;
 	name = "Ramboo";
 	pixel_x = -2;
-	pixel_y = 5
+	pixel_y = 5;
+	bot_access_flags = 1
 	},
 /turf/open/floor/plating{
 	initial_gas_mix = "co2=6;o2=16;n2=82;TEMP=293.15"

--- a/code/__DEFINES/access.dm
+++ b/code/__DEFINES/access.dm
@@ -549,7 +549,7 @@
 
 /// MONKESTATION ADDITION - Adds Charlie Station region, for the Charlie Station ID console.
 /// Name for the Charlie Station region.
-#define REGION_CHARLIE_STATION "Charlie Station"
+#define REGION_CHARLIE_STATION "Ancient Station"
 /// Used to seed the accesses_by_region list in SSid_access. A list of all ACCESS_AWAY regional accesses.
 #define REGION_ACCESS_CHARLIE_STATION list( \
 	ACCESS_AWAY_GENERAL, \

--- a/code/controllers/subsystem/id_access.dm
+++ b/code/controllers/subsystem/id_access.dm
@@ -326,18 +326,18 @@ SUBSYSTEM_DEF(id_access)
 	desc_by_access["[ACCESS_BIT_DEN]"] = "Bitrunner Den"
 	desc_by_access["[ACCESS_PERMABRIG]"] = "Permabrig" // monkestation edit: add permabrig-only access
 	//MONKESTATION ADDITION - Adds descriptions to Charlie Station access levels. Used for Charlie Station ID Console.
-	desc_by_access["[ACCESS_AWAY_GENERAL]"] = "Charlie Station General"
-	desc_by_access["[ACCESS_AWAY_SCIENCE]"] = "Charlie Station Science"
+	desc_by_access["[ACCESS_AWAY_GENERAL]"] = "Station General Access"
+	desc_by_access["[ACCESS_AWAY_SCIENCE]"] = "Delta Station Science"
 	desc_by_access["[ACCESS_AWAY_MAINTENANCE]"] = "Charlie Station Maintenance"
-	desc_by_access["[ACCESS_AWAY_SUPPLY]"] = "Charlie Station Supply"
-	desc_by_access["[ACCESS_AWAY_GENERIC1]"] = "Charlie Station Generic 1"
-	desc_by_access["[ACCESS_AWAY_GENERIC2]"] = "Charlie Station Generic 2"
-	desc_by_access["[ACCESS_AWAY_GENERIC3]"] = "Charlie Station Generic 3"
-	desc_by_access["[ACCESS_AWAY_GENERIC4]"] = "Charlie Station Generic 4"
+	desc_by_access["[ACCESS_AWAY_SUPPLY]"] = "Alpha Station Supply"
+	desc_by_access["[ACCESS_AWAY_GENERIC1]"] = "Station Generic 1"
+	desc_by_access["[ACCESS_AWAY_GENERIC2]"] = "Station Generic 2"
+	desc_by_access["[ACCESS_AWAY_GENERIC3]"] = "Station Generic 3"
+	desc_by_access["[ACCESS_AWAY_GENERIC4]"] = "Station Generic 4"
 	desc_by_access["[ACCESS_AWAY_COMMAND]"] = "Charlie Station Command"
-	desc_by_access["[ACCESS_AWAY_MEDICAL]"] = "Charlie Station Medical"
+	desc_by_access["[ACCESS_AWAY_MEDICAL]"] = "Beta Station Medical"
 	desc_by_access["[ACCESS_AWAY_SEC]"] = "Charlie Station Security"
-	desc_by_access["[ACCESS_AWAY_ENGINEERING]"] = "Charlie Station Engineering"
+	desc_by_access["[ACCESS_AWAY_ENGINEERING]"] = "Beta Station Engineering"
 	//END OF ADDITION
 
 /**

--- a/code/datums/id_trim/ruins.dm
+++ b/code/datums/id_trim/ruins.dm
@@ -42,7 +42,7 @@
 		ACCESS_AWAY_GENERAL,
 		ACCESS_AWAY_SCIENCE
 	)
-	assignment = "Charlie Station Scientist"
+	assignment = "Delta Station Scientist"
 
 /// Trim for the oldstation ruin/Charlie station
 /datum/id_trim/job/away/old/eng
@@ -67,7 +67,7 @@
 		ACCESS_ENGINEERING,
 		ACCESS_ENGINE_EQUIP
 	)
-	assignment = "Charlie Station Engineer"
+	assignment = "Beta Station Engineer"
 
 /// Trim for the oldstation ruin/Charlie station to access APCs and other equipment
 /datum/id_trim/job/away/old/equipment

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -48,6 +48,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/autoname, 0)
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/emp_proof, 0)
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/motion, 0)
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/xray, 0)
+MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/autoname/old, 0)
 
 /datum/armor/machinery_camera
 	melee = 50

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -49,6 +49,10 @@
 /obj/machinery/camera/autoname
 	var/number = 0 //camera number in area
 
+/obj/machinery/camera/autoname/old
+	network = list("Alpha", "Beta", "Charlie", "Delta",)
+	status = 0
+
 //This camera type automatically sets it's name to whatever the area that it's in is called.
 /obj/machinery/camera/autoname/Initialize(mapload)
 	..()

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -225,4 +225,10 @@
 	network = list("mine", "auxbase", "vault")
 	circuit = null
 
+/obj/machinery/computer/security/old
+	name = "\improper worn camera console"
+	desc = "A security console with access to the station's camera network. The screen barley flickers to life."
+	network = list("Alpha", "Beta", "Charlie", "Delta",)
+	circuit = null
+
 #undef DEFAULT_MAP_SIZE

--- a/code/game/objects/items/cards/card_ids.dm
+++ b/code/game/objects/items/cards/card_ids.dm
@@ -1,6 +1,6 @@
 /obj/item/card/id/away/old/cmo
-	name = "Charlie Station Chief Medical Officer's ID card"
-	desc = "A faded Charlie Station ID card. You can make out the rank \"Chief Medical Officer\"."
+	name = "Beta Station Chief Medical Officer's ID card"
+	desc = "A faded Beta Station ID card. You can make out the rank \"Chief Medical Officer\"."
 	trim = /datum/id_trim/job/away/old/cmo
 
 /obj/item/card/id/away/old/chef
@@ -9,6 +9,6 @@
 	trim = /datum/id_trim/job/away/old/chef
 
 /obj/item/card/id/away/old/explorer
-	name = "Charlie Station Explorer's ID card"
-	desc = "A faded Charlie Station ID card. You can make out the rank \"Explorer\"."
+	name = "Beta Station Explorer's ID card"
+	desc = "A faded Beta Station ID card. You can make out the rank \"Explorer\"."
 	trim = /datum/id_trim/job/away/old/explorer

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -877,13 +877,13 @@
 	trim = /datum/id_trim/job/away/old/sec /// MONKESTATION EDIT - Turns all Charlie Station trims into /datum/id_trim/job trims
 
 /obj/item/card/id/away/old/sci
-	name = "Charlie Station Scientist's ID card"
-	desc = "A faded Charlie Station ID card. You can make out the rank \"Scientist\"."
+	name = "Delta Station Scientist's ID card"
+	desc = "A faded Delta Station ID card. You can make out the rank \"Scientist\"."
 	trim = /datum/id_trim/job/away/old/sci /// MONKESTATION EDIT - Turns all Charlie Station trims into /datum/id_trim/job trims
 
 /obj/item/card/id/away/old/eng
-	name = "Charlie Station Engineer's ID card"
-	desc = "A faded Charlie Station ID card. You can make out the rank \"Station Engineer\"."
+	name = "Beta Station Engineer's ID card"
+	desc = "A faded Beta Station ID card. You can make out the rank \"Station Engineer\"."
 	trim = /datum/id_trim/job/away/old/eng /// MONKESTATION EDIT - Turns all Charlie Station trims into /datum/id_trim/job trims
 
 /obj/item/card/id/away/old/equipment

--- a/monkestation/code/datums/id_trim/ruins.dm
+++ b/monkestation/code/datums/id_trim/ruins.dm
@@ -27,7 +27,7 @@
 		ACCESS_ENGINEERING,
 		ACCESS_ENGINE_EQUIP
 	)
-	assignment = "Charlie Station Chief Medical Officer"
+	assignment = "Beta Station Chief Medical Officer"
 	sechud_icon_state = SECHUD_CHIEF_MEDICAL_OFFICER_AWAY
 
 /datum/id_trim/job/away/old/chef
@@ -77,7 +77,7 @@
 		ACCESS_ENGINEERING,
 		ACCESS_ENGINE_EQUIP
 	)
-	assignment = "Charlie Station Explorer"
+	assignment = "Beta Station Explorer"
 	sechud_icon_state = SECHUD_EXPLORER_AWAY
 
 /datum/id_trim/job/away/old/sci

--- a/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
+++ b/monkestation/code/modules/oldstation_idconsole/oldstation_idconsole.dm
@@ -50,7 +50,7 @@
 
 /datum/computer_file/program/card_mod/old
 	filename = "charliestationidwriter"
-	filedesc = "Charlie Station Access Management"
+	filedesc = "Station Access Management"
 	available_on_ntnet = FALSE //charlie station only fools
 
 	//every access i could find on charlie station ids
@@ -87,7 +87,7 @@
 
 /datum/computer_file/program/card_mod/old/ui_static_data(mob/user)
 	var/list/data = list()
-	data["station_name"] = "Charlie Station" //we arent ss13, don't show as such (despite the fact this isn't shown anywhere??)
+	data["station_name"] = "Station" //we arent ss13, don't show as such (despite the fact this isn't shown anywhere??)
 	data["centcom_access"] = is_centcom
 	data["minor"] = target_dept || minor ? TRUE : FALSE
 
@@ -125,7 +125,7 @@
 	trim_state = null
 
 /datum/id_trim/job/away/old/custom
-	assignment = "Charlie Station Crew"
+	assignment = "Station Crew"
 	minimal_access = list(
 		ACCESS_AWAY_GENERAL,
 		ACCESS_ROBOTICS,
@@ -147,5 +147,5 @@
 	)
 
 /obj/item/card/id/away/old/custom
-	name = "Charlie Station ID card"
-	desc = "A card used to provide ID and determine access across Charlie Station."
+	name = "Station ID card"
+	desc = "A card used to provide ID and determine access across the Station."


### PR DESCRIPTION
## About The Pull Request
Updates Ancient station camera network so it runs on 'alpha' 'beta' 'charlie' 'delta' camera networks

Renames various things labelled as 'Charlie Station', more appropriately according to their location on the Ancient station.

Ramboo now has their access panel opened. Akin to how the note from Ash describes.
## Why It's Good For The Game
### Oldstation Camera network
Before anytime Oldstation would roll, it would flood the "ss13" camera network. Becoming a hassle for any warden/hos's/ect. that who wanted to use their cameras conveniently. Ancient station now runs on their own networks to avoid this issue.

### Incorrect Charlie station labelling. 
Even I've been guilty of this, but the station is not named Charlie station. In code, its known as Oldstation or Ancient station. And theres no reference to the stations actual name ingame. (Who would name the new station 'Old' afterall.) "Charlie Station" is simply 1/4th of the orginal station.

I've dug through and renamed any associated items that wouldn't be on Charlie section to which of the four they would be found on. And if on none, then to a more generic name. Such as scientists and roboticists working for Delta Station. Or engineering being part of the Beta station primarily.

### Final act.
Finally in Ash Holm's note they list Ramboo the cleanbot being unlocked with their ID. Currently this is false, and has been adjusted.
## Changelog
:cl:
qol: Oldstations cameras now run on a separate camera network.
fix: Various things have been renamed from Charlie station to where their more appriopate name would be.
fix: Ramboo the cleanbot is now unlocked natively.
/:cl:
