### PR TITLE
fix a runtime with modlink calls

### DIFF
--- a/code/modules/mod/mod_link.dm
+++ b/code/modules/mod/mod_link.dm
@@ -43,8 +43,10 @@ GLOBAL_LIST_INIT(scryer_auto_link_freqs, zebra_typecacheof(list(
 	QDEL_NULL(mod_link.visual)
 
 /proc/on_user_set_dir_generic(datum/mod_link/mod_link, newdir)
-	var/atom/other_visual = mod_link.get_other()?.visual
 	if(!newdir) //can sometimes be null or 0
+		return
+	var/atom/other_visual = mod_link.get_other()?.visual
+	if(QDELETED(other_visual))
 		return
 	other_visual.setDir(SOUTH)
 	other_visual.pixel_x = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this fixes a very common runtime here:
```
[2025-05-06 21:04:36.850] runtime error: Cannot execute null.setDir().
 - proc name: on user set dir generic (/proc/on_user_set_dir_generic)
 -   source file: code/modules/mod/mod_link.dm,49
 -   usr: Oliver Botan (/mob/living/carbon/human)
 -   src: null
 -   usr.loc: the floor (128,126,4) (/turf/open/floor/iron)
```

## Changelog

no player-facing changes