### PR TITLE
Makeshift radio jammers!

### DIFF
--- a/code/datums/components/crafting/tools.dm
+++ b/code/datums/components/crafting/tools.dm
@@ -46,3 +46,13 @@
 	)
 	result = /obj/item/pickaxe/improvised
 	category = CAT_TOOLS
+
+/datum/crafting_recipe/makeshift_radio_jammer
+	name = "Makeshift Radio Jammer"
+	result = /obj/item/jammer/makeshift
+	reqs = list(
+		/obj/item/universal_scanner = 1,
+		/obj/item/encryptionkey = 1,
+		/obj/item/stack/cable_coil = 5,
+	)
+	category = CAT_TOOLS

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -300,7 +300,13 @@ effective or pretty fucking useless.
 	icon = 'icons/obj/device.dmi'
 	icon_state = "jammer"
 	var/active = FALSE
+	/// The range of devices to disable while active
 	var/range = 12
+
+	/// The range of the disruptor wave, disabling radios
+	var/disruptor_range = 7
+
+	/// The delay between using the disruptor wave
 	var/jam_cooldown_duration = 15 SECONDS
 	COOLDOWN_DECLARE(jam_cooldown)
 
@@ -321,8 +327,8 @@ effective or pretty fucking useless.
 
 	user.balloon_alert(user, "distruptor wave released!")
 	to_chat(user, span_notice("You release a distruptor wave, disabling all nearby radio devices."))
-	for (var/atom/potential_owner in view(7, user))
-		disable_radios_on(potential_owner)
+	for (var/atom/potential_owner in view(disruptor_range, user))
+		disable_radios_on(potential_owner, ignore_syndie = TRUE)
 	COOLDOWN_START(src, jam_cooldown, jam_cooldown_duration)
 
 /obj/item/jammer/attack_self_secondary(mob/user, modifiers)
@@ -345,7 +351,7 @@ effective or pretty fucking useless.
 	if(.)
 		return
 
-	if (!(target in view(7, user)))
+	if (!(target in view(disruptor_range, user)))
 		user.balloon_alert(user, "out of reach!")
 		return
 
@@ -353,12 +359,19 @@ effective or pretty fucking useless.
 	to_chat(user, span_notice("You release a directed distruptor wave, disabling all radio devices on [target]."))
 	disable_radios_on(target)
 
-/obj/item/jammer/proc/disable_radios_on(atom/target)
+/obj/item/jammer/proc/disable_radios_on(atom/target, ignore_syndie = FALSE)
 	for (var/obj/item/radio/radio in target.get_all_contents() + target)
+		if(ignore_syndie && radio.syndie)
+			continue
 		radio.set_broadcasting(FALSE)
-	// MONKESTATION EDIT: Radio jammers turn body cameras off too.
-	for(var/obj/item/bodycam_upgrade/bodycamera in target.get_all_contents() + target)
+	for (var/obj/item/bodycam_upgrade/bodycamera in target.get_all_contents() + target)
 		bodycamera.turn_off()
+
+/obj/item/jammer/makeshift
+	name = "makeshift radio jammer"
+	desc = "A jury-rigged device that disrupts nearby radio communication. Its crude construction provides a significantly smaller area of effect compared to its Syndicate counterpart."
+	range = 5
+	disruptor_range = 3
 
 /obj/item/storage/toolbox/emergency/turret
 	desc = "You feel a strange urge to hit this with a wrench."

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -360,11 +360,12 @@ effective or pretty fucking useless.
 	disable_radios_on(target)
 
 /obj/item/jammer/proc/disable_radios_on(atom/target, ignore_syndie = FALSE)
-	for (var/obj/item/radio/radio in target.get_all_contents() + target)
+	var/list/target_contents = target.get_all_contents() + target
+	for (var/obj/item/radio/radio in target_contents)
 		if(ignore_syndie && radio.syndie)
 			continue
 		radio.set_broadcasting(FALSE)
-	for (var/obj/item/bodycam_upgrade/bodycamera in target.get_all_contents() + target)
+	for (var/obj/item/bodycam_upgrade/bodycamera in target_contents)
 		bodycamera.turn_off()
 
 /obj/item/jammer/makeshift

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -85,7 +85,7 @@
 	name = "Radio Jammer"
 	desc = "This device will disrupt any nearby outgoing radio communication when activated. Does not affect binary chat."
 	item = /obj/item/jammer
-	cost = 5
+	cost = 1
 
 /datum/uplink_item/stealthy_tools/smugglersatchel
 	name = "Smuggler's Satchel"


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/89442 and https://github.com/tgstation/tgstation/pull/89829

> Makes makeshift radio jammers craftable with:
> 1. Universal scanner
> 2. Headset encryption key (it doesn't steal the one from your headset don't worry)
> 3. Cable coil
> 
> Makeshift radio jammers are the same as Syndicate ones, except with a smaller active range (12 -> 5) and smaller disruptor range (7 -> 3)
> 
> Lowers the cost of radio jammers from 5 TC to 1 TC.

## Why It's Good For The Game

> This is intended as a potentially overkill solution to the problem of people shouting that they are being killed right away. Common is not going away, but we need to do something to aide this style of gameplay over going loud etc. By making radio jammers craftable, we allow all antagonists to use this instead of just traitors.

## Changelog
:cl: Absolucy, Mothblocks
add: You can now craft makeshift radio jammers.
balance: Radio jammers have had their cost lowered from 5 TC to 1 TC.
fix: Syndicate encryption keys properly protect against AoE radio jamming again.
/:cl:
