### PR TITLE
List testmerge changelogs in reverse order

### DIFF
--- a/tgui/packages/tgui/interfaces/Changelog.tsx
+++ b/tgui/packages/tgui/interfaces/Changelog.tsx
@@ -212,7 +212,7 @@ const Testmerges = (_props) => {
         </h4>
       </Section>
       <Stack vertical>
-        {testmerges.map((testmerge) => {
+        {testmerges.toReversed().map((testmerge) => {
           const title = (
             <a href={testmerge.link}>
               #{testmerge.number}: &quot;{testmerge.title}&quot; by{' '}

--- a/tgui/packages/tgui/interfaces/Changelog.tsx
+++ b/tgui/packages/tgui/interfaces/Changelog.tsx
@@ -212,7 +212,7 @@ const Testmerges = (_props) => {
         </h4>
       </Section>
       <Stack vertical>
-        {testmerges.toReversed().map((testmerge) => {
+        {testmerges.reverse().map((testmerge) => {
           const title = (
             <a href={testmerge.link}>
               #{testmerge.number}: &quot;{testmerge.title}&quot; by{' '}


### PR DESCRIPTION
## Changelog
:cl:
qol: Testmerge changelogs are now listed in reverse order, so that more recent testmerges are at the top.
/:cl:
