### PR TITLE
[DNM] [TMO] thederelict and oldstation are now less likely to spawn near telecomm relays

### DIFF
--- a/code/_experiments.dm
+++ b/code/_experiments.dm
@@ -18,5 +18,5 @@
 #endif
 
 #if DM_VERSION >= 517
-	#error "Remove all 517 experiments"
+	//#error "Remove all 517 experiments" FUCK OFF
 #endif

--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -36,3 +36,7 @@
 	mappath = prefix + suffix
 	..(path = mappath)
 
+//proc thats called when this map tries to load, fill with checks unique to this ruin or whatever the fuck
+//useful for relocating your ruin if certain conditions are not met
+/datum/map_template/ruin/proc/run_ruin_checks(zLevel, list/placed_ruins, list/z_levels)
+	return zLevel

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -214,6 +214,30 @@
 	name = "Kosmicheskaya Stantsiya 13"
 	description = "The true fate of Kosmicheskaya Stantsiya 13 is an open question to this day. Most corporations deny its existence, for fear of questioning on what became of its crew."
 
+/datum/map_template/ruin/space/thederelict/run_ruin_checks(zLevel, list/placed_ruins, list/z_levels)
+	var/list/undesirable_ruins = list(
+		"djstation",
+		"spacerealhotel",
+		"deep-storage",
+		"listeningstation",
+		"syndicate_depot",
+	)
+	var/list/original_zLevel = zLevel
+	while(TRUE)
+		var/unwanted_zLevel = FALSE
+		for(var/undesirable in undesirable_ruins)
+			if(undesirable in placed_ruins)
+				if(placed_ruins[undesirable] == zLevel)
+					unwanted_zLevel = TRUE
+					break
+		if(unwanted_zLevel)
+			z_levels -= zLevel
+			if(!length(z_levels))
+				return original_zLevel
+			zLevel = pick(z_levels)
+		else
+			return zLevel
+
 /datum/map_template/ruin/space/abandonedteleporter
 	id = "abandonedteleporter"
 	suffix = "abandonedteleporter.dmm"
@@ -276,6 +300,30 @@
 	name = "Ancient Space Station"
 	description = "The crew of a space station awaken one hundred years after a crisis. Awaking to a derelict space station on the verge of collapse, and a hostile force of invading \
 	hivebots. Can the surviving crew overcome the odds and survive and rebuild, or will the cold embrace of the stars become their new home?"
+
+/datum/map_template/ruin/space/oldstation/run_ruin_checks(zLevel, list/placed_ruins, list/z_levels)
+	var/list/undesirable_ruins = list(
+		"djstation",
+		"spacerealhotel",
+		"deep-storage",
+		"listeningstation",
+		"syndicate_depot",
+	)
+	var/list/original_zLevel = zLevel
+	while(TRUE)
+		var/unwanted_zLevel = FALSE
+		for(var/undesirable in undesirable_ruins)
+			if(undesirable in placed_ruins)
+				if(placed_ruins[undesirable] == zLevel)
+					unwanted_zLevel = TRUE
+					break
+		if(unwanted_zLevel)
+			z_levels -= zLevel
+			if(!length(z_levels))
+				return original_zLevel
+			zLevel = pick(z_levels)
+		else
+			return zLevel
 
 /datum/map_template/ruin/space/gondoland
 	id = "gondolaasteroid"


### PR DESCRIPTION
## About The Pull Request

adds a bunch of shitcode that tries to make thederelict and oldstation avoid spawning near relays
please give code suggestions im probably going to mess a lot of shit up with this and not realize

## Why It's Good For The Game

both are supposed to be isolated
hearing the curator screaming in my ears while playing charlie station kinda ruins the vibe
also if you try to setup ntsl scripts on charlie station with a relay nearby (really niche scenario but still) it will repeat messages, there is nothing you can do to fix this other than track down the relay, and if its a syndicate relay, good luck turning it off or filtering out your frequency

## Changelog

:cl:
balance: thederelict (KS13) and oldstation (Charlie Station) are now less likely to spawn near telecommunication relays.
/:cl:
