### PR TITLE
Thrown eggs will now break

### DIFF
--- a/code/game/objects/items/food/egg.dm
+++ b/code/game/objects/items/food/egg.dm
@@ -78,6 +78,8 @@ GLOBAL_VAR_INIT(chicks_from_eggs, 0)
 		GLOB.chicks_from_eggs++
 
 	reagents?.expose(hit_atom, TOUCH)
+	if(src)
+		qdel(src)
 
 /obj/item/food/egg/attackby(obj/item/item, mob/user, params)
 	if(istype(item, /obj/item/toy/crayon))

--- a/code/game/objects/items/food/egg.dm
+++ b/code/game/objects/items/food/egg.dm
@@ -78,7 +78,7 @@ GLOBAL_VAR_INIT(chicks_from_eggs, 0)
 		GLOB.chicks_from_eggs++
 
 	reagents?.expose(hit_atom, TOUCH)
-	if(src)
+	if(!QDELETED(src))
 		qdel(src)
 
 /obj/item/food/egg/attackby(obj/item/item, mob/user, params)


### PR DESCRIPTION
## About The Pull Request
It seems that the egg deletion was removed from the egg throw_impact proc presumably in favor of deleting the egg in hatch proc. However, this causes thrown eggs to only break when the chick hatch chance rolls.

This also allows people to keep throwing an egg until it hatches to guarantee a chick, it also creates a lot of mess.

This pr readds the deletion back into the throw_impact
Fixes #6464 
## Why It's Good For The Game
Fixes a bug, I doubt this is an intended mechanic.
## Changelog
:cl:
fix: Thrown eggs break on impact again
/:cl:
