### PR TITLE
fix byond-tracy not actually setting `trace_path`

### DIFF
--- a/code/modules/debugging/tracy.dm
+++ b/code/modules/debugging/tracy.dm
@@ -39,6 +39,7 @@ GLOBAL_REAL(Tracy, /datum/tracy)
 	if(length(init_result) != 0 && init_result[1] == ".") // if first character is ., then it returned the output filename
 		SEND_TEXT(world.log, "byond-tracy initialized (logfile: [init_result])")
 		enabled = TRUE
+		trace_path = init_result
 		return TRUE
 	else if(init_result == "already initialized") // not gonna question it.
 		enabled = TRUE


### PR DESCRIPTION
## About The Pull Request

ports https://github.com/tgstation/tgstation/pull/90964

during https://github.com/tgstation/tgstation/pull/90288 I accidentally forgot to make enabling tracy set `trace_path`, so `tracy.loc` would never be written.

## Why It's Good For The Game

`tracy.loc` - the file that links a specific round ID to a specific utracy file - never gets written currently. and that's annoying.

## Changelog

no user-facing changes