### PR TITLE
Giving captive xenomorphs a purpose 

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -78,6 +78,8 @@ SUBSYSTEM_DEF(research)
 	var/list/scientific_partners = list()
 
 	var/list/slime_core_prices = list()
+	// the amount of captive xenos for bonus research point generation
+	var/xeno_count
 
 	var/static/list/default_core_prices = list(
 		SLIME_VALUE_TIER_1,
@@ -106,6 +108,13 @@ SUBSYSTEM_DEF(research)
 		if(!techweb_list.should_generate_points)
 			continue
 		var/list/bitcoins = list()
+		var/datum/team/xeno/captive/captive_team = locate(/datum/team/xeno/captive) in GLOB.antagonist_teams
+		if(captive_team) // if there are captive xenos there will be a captive team which contains all the captive xenos
+			xeno_count = 1 //start off with 1 as the base so having 1 xeno produces 2 research per second
+			for(var/datum/mind/alien_mind in captive_team.members)
+				if(captive_team.check_captivity(alien_mind.current) == "captive_xeno_failed") //if the xeno in question is safely contained
+					xeno_count++
+				techweb_list.income_modifier = xeno_count
 		for(var/obj/machinery/rnd/server/miner as anything in techweb_list.techweb_servers)
 			if(miner.working)
 				bitcoins = single_server_income.Copy()

--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -88,7 +88,7 @@
 	explanation_text = "Escape from captivity."
 
 /datum/objective/escape_captivity/check_completion()
-	if(!istype(get_area(owner), SScommunications.captivity_area))
+	if(!istype(get_area(owner), /area/station/science/xenobiology))
 		return TRUE
 
 /datum/objective/advance_hive
@@ -147,7 +147,7 @@
 	if(!captive_alien || captive_alien.stat == DEAD)
 		return CAPTIVE_XENO_DEAD
 
-	if(istype(get_area(captive_alien), SScommunications.captivity_area))
+	if(istype(get_area(captive_alien), /area/station/science/xenobiology))
 		return CAPTIVE_XENO_FAIL
 
 	return CAPTIVE_XENO_PASS
@@ -156,7 +156,7 @@
 /mob/living/carbon/alien/mind_initialize()
 	..()
 	if(!mind.has_antag_datum(/datum/antagonist/xeno))
-		if(SScommunications.xenomorph_egg_delivered && istype(get_area(src), SScommunications.captivity_area))
+		if(istype(get_area(src), /area/station/science/xenobiology)) //ANY XENO which is born in the captive area (xenobiology) is considered captive
 			mind.add_antag_datum(/datum/antagonist/xeno/captive)
 		else
 			mind.add_antag_datum(/datum/antagonist/xeno)


### PR DESCRIPTION
## About The Pull Request

I fucked up the other pr so i had to remake it :L sorry

**CURRENTLY;** 

Any xenomorph which is born in Xenobiology (bursts out of their host) counts as a captive xenomorph. EVEN IF there was no egg delivery that round.

As long as the Xenomorph remains in Xenobiology, they generate research points. If a xenomorph isnt born in xenobiology they wont be considered a captive xeno and thus wont ever generate research points. 

EXAMPLE; If we have 1 captive xenomorph, then we generate 2 research points per second. 2 captive xenos generates 3, and so on, with no cap. (The only cap, in this instance, would be the souls willing to be a xenomorph and the scientists own risk tolerance to speed through RND at the expense of generating an army) 

**TODO**

Potentially give xenomorphs the ability to somehow escape on their own. Currently, with default containment setups, xenomorphs can be contained indefinitely unless something sets them free. The 'indefinite' containment should only happen when players create something actually impenetrable. 

Potentially making a new area specific to the xenobiology cell so that the whole of xenobiology doesn't count as containment

Potentially any xenomorph which enters containment area becomes 'captive'.

## Why It's Good For The Game

For as long as I can remember, Captive xenomorphs were always just there to break out eventually. The current 'gameplay' involving captive xenos is to grow them, watch them for a bit, and then die to them when they escape. This always bugged me, because it seemed like a massive wasted opportunity. 

Exploring ways to make it viable and interesting for both the xenomorph players and crew alike


## Changelog
:cl:
change: any xeno born in xenobiology counts as a captive xenomorph
change: any contained captive xenomorphs provide multiplier to passive research gain
/:cl:
