### PR TITLE
Cortical Borer Egg fixes

### DIFF
--- a/monkestation/code/modules/antagonists/borers/code/abilities/spawn_offspring.dm
+++ b/monkestation/code/modules/antagonists/borers/code/abilities/spawn_offspring.dm
@@ -23,7 +23,7 @@
 	if(!(cortical_owner.upgrade_flags & BORER_ALONE_PRODUCTION) && !cortical_owner.inside_human())
 		owner.balloon_alert(owner, "host required")
 		return
-	else()
+	if((cortical_owner.upgrade_flags & BORER_ALONE_PRODUCTION) && !cortical_owner.inside_human())
 		cortical_owner.chemical_storage -= chemical_cost
 		no_host_egg()
 		StartCooldown()

--- a/monkestation/code/modules/antagonists/borers/code/abilities/spawn_offspring.dm
+++ b/monkestation/code/modules/antagonists/borers/code/abilities/spawn_offspring.dm
@@ -24,12 +24,12 @@
 		owner.balloon_alert(owner, "host required")
 		return
 	else()
+		cortical_owner.chemical_storage -= chemical_cost
 		no_host_egg()
 		StartCooldown()
-		cortical_owner.chemical_storage -= chemical_cost
 		return
-	produce_egg()
 	cortical_owner.chemical_storage -= chemical_cost
+	produce_egg()
 	var/obj/item/organ/internal/brain/victim_brain = cortical_owner.human_host.get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(victim_brain)
 		cortical_owner.human_host.adjustOrganLoss(ORGAN_SLOT_BRAIN, 25 * cortical_owner.host_harm_multiplier, maximum = BRAIN_DAMAGE_SEVERE)

--- a/monkestation/code/modules/antagonists/borers/code/abilities/spawn_offspring.dm
+++ b/monkestation/code/modules/antagonists/borers/code/abilities/spawn_offspring.dm
@@ -23,7 +23,7 @@
 	if(!(cortical_owner.upgrade_flags & BORER_ALONE_PRODUCTION) && !cortical_owner.inside_human())
 		owner.balloon_alert(owner, "host required")
 		return
-	if((cortical_owner.upgrade_flags & BORER_ALONE_PRODUCTION) && !cortical_owner.inside_human())
+	else()
 		no_host_egg()
 		StartCooldown()
 		cortical_owner.chemical_storage -= chemical_cost

--- a/monkestation/code/modules/antagonists/borers/code/abilities/spawn_offspring.dm
+++ b/monkestation/code/modules/antagonists/borers/code/abilities/spawn_offspring.dm
@@ -7,7 +7,6 @@
 	cooldown_time = 1 MINUTES
 	button_icon_state = "reproduce"
 	chemical_cost = 100
-	needs_living_host = TRUE
 	ability_explanation = "\
 	Forces your host to produce a borer egg inside of their stomach, then vomit it up\n\
 	Be carefull as the egg is fragile and can be broken very easily by any human, along with being extremelly noticable\n\
@@ -24,12 +23,13 @@
 	if(!(cortical_owner.upgrade_flags & BORER_ALONE_PRODUCTION) && !cortical_owner.inside_human())
 		owner.balloon_alert(owner, "host required")
 		return
-	cortical_owner.chemical_storage -= chemical_cost
 	if((cortical_owner.upgrade_flags & BORER_ALONE_PRODUCTION) && !cortical_owner.inside_human())
 		no_host_egg()
 		StartCooldown()
+		cortical_owner.chemical_storage -= chemical_cost
 		return
 	produce_egg()
+	cortical_owner.chemical_storage -= chemical_cost
 	var/obj/item/organ/internal/brain/victim_brain = cortical_owner.human_host.get_organ_slot(ORGAN_SLOT_BRAIN)
 	if(victim_brain)
 		cortical_owner.human_host.adjustOrganLoss(ORGAN_SLOT_BRAIN, 25 * cortical_owner.host_harm_multiplier, maximum = BRAIN_DAMAGE_SEVERE)


### PR DESCRIPTION
## About The Pull Request
Hive lord self reproduction ability is now functional. Fixes an old bug. Fixes:#4334
Chemical costs for producing a egg is now subtracted after the egg is produced.
## Why It's Good For The Game
So it checked for a host when the proc itself has interal checks for hosts. And this made self reproduction nonfunctional. This allows for specialized Hivelords to self-reproduce as intended

And the chemical cost has been moved to reflect only when an egg is to be reproduced, not beforehand. Stopping chemical loss for nothing.
## Changelog
:cl:
fix: Hivelords Borers now can self reproduce as intended.
fix: Stopped an edge case where borers would lose chemicals but produce no eggs
/:cl:
