### PR TITLE
'They seem unresponsive' Fix

### DIFF
--- a/monkestation/code/modules/flavor_text/flavor_examine.dm
+++ b/monkestation/code/modules/flavor_text/flavor_examine.dm
@@ -68,7 +68,7 @@
 
 	// if the mob doesn't have a client, show how long they've been disconnected for.
 	if(!client && last_connection_time && stat != DEAD)
-		var/formatted_afk_time = span_bold("[round((world.time - last_connection_time) / (60*60), 0.1)]")
+		var/formatted_afk_time = span_bold("[round((world.time - lastclienttime) / (1 MINUTES), 0.1)]")
 		expanded_examine += span_italics("\n[p_Theyve()] been unresponsive for [formatted_afk_time] minute(s).\n")
 
 	if(length(expanded_examine))


### PR DESCRIPTION

## About The Pull Request
Fixes the time code behind the _"They have been unresponsive for X minutes"_
## Why It's Good For The Game
Old code was telling around a 10th of the actual time scale. Meaning someone ssd for three minutes was ssd for 30. 

This brings it up to speed.
Pun intended
## Changelog
:cl:
fix: "They seem unresponsive" Time will now be much more accurate
/:cl:
