### PR TITLE
Nosferatu bloodsucker stuff

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
@@ -19,9 +19,10 @@
 			to_chat(owner.current, span_notice("The power of your blood begins knitting your wounds..."))
 			COOLDOWN_START(src, bloodsucker_spam_healing, BLOODSUCKER_SPAM_HEALING)
 	// Standard Updates
+
+	update_blood()
 	SEND_SIGNAL(src, COMSIG_BLOODSUCKER_ON_LIFETICK)
 	INVOKE_ASYNC(src, PROC_REF(HandleStarving))
-	INVOKE_ASYNC(src, PROC_REF(update_blood))
 	INVOKE_ASYNC(src, PROC_REF(update_hud))
 
 /datum/antagonist/bloodsucker/proc/on_death(mob/living/source, gibbed)

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_misc_procs.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_misc_procs.dm
@@ -26,16 +26,17 @@
 	power.Remove(owner.current)
 
 ///When a Bloodsucker breaks the Masquerade, they get their HUD icon changed, and Malkavian Bloodsuckers get alerted.
-/datum/antagonist/bloodsucker/proc/break_masquerade(mob/admin)
+/datum/antagonist/bloodsucker/proc/break_masquerade(mob/admin, silent = FALSE)
 	if(broke_masquerade)
 		return
-	owner.current.playsound_local(null, 'monkestation/sound/bloodsuckers/lunge_warn.ogg', 100, FALSE, pressure_affected = FALSE)
-	to_chat(owner.current, span_cultboldtalic("You have broken the Masquerade!"))
-	to_chat(owner.current, span_warning("Bloodsucker Tip: When you break the Masquerade, you become open for termination by fellow Bloodsuckers, and your Vassals are no longer completely loyal to you, as other Bloodsuckers can steal them for themselves!"))
+	if(!silent)
+		owner.current.playsound_local(null, 'monkestation/sound/bloodsuckers/lunge_warn.ogg', 100, FALSE, pressure_affected = FALSE)
+		to_chat(owner.current, span_cultboldtalic("You have broken the Masquerade!"))
+		to_chat(owner.current, span_warning("Bloodsucker Tip: When you break the Masquerade, you become open for termination by fellow Bloodsuckers, and your Vassals are no longer completely loyal to you, as other Bloodsuckers can steal them for themselves!"))
+		SEND_GLOBAL_SIGNAL(COMSIG_BLOODSUCKER_BROKE_MASQUERADE, src)
 	broke_masquerade = TRUE
 	antag_hud_name = "masquerade_broken"
 	add_team_hud(owner.current)
-	SEND_GLOBAL_SIGNAL(COMSIG_BLOODSUCKER_BROKE_MASQUERADE, src)
 
 ///This is admin-only of reverting a broken masquerade, sadly it doesn't remove the Malkavian objectives yet.
 /datum/antagonist/bloodsucker/proc/fix_masquerade(mob/admin)

--- a/monkestation/code/modules/bloodsuckers/clans/_clan_base.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/_clan_base.dm
@@ -28,6 +28,9 @@
 	///How we will drink blood using Feed.
 	var/blood_drink_type = BLOODSUCKER_DRINK_NORMAL
 
+	/// A list of typepaths of powers that will never be eligible for ranks.
+	var/list/banned_powers
+
 /datum/bloodsucker_clan/New(datum/antagonist/bloodsucker/owner_datum)
 	. = ..()
 	src.bloodsuckerdatum = owner_datum
@@ -46,6 +49,11 @@
 	RegisterSignal(bloodsuckerdatum, BLOODSUCKER_EXITS_FRENZY, PROC_REF(on_exit_frenzy))
 
 	give_clan_objective()
+
+	for(var/banned_power in banned_powers)
+		var/datum/action/power = locate(banned_power) in bloodsuckerdatum.powers
+		if(power)
+			bloodsuckerdatum.RemovePower(power)
 
 /datum/bloodsucker_clan/Destroy(force)
 	UnregisterSignal(bloodsuckerdatum, list(
@@ -147,8 +155,13 @@
 	// Purchase Power Prompt
 	var/list/options = list()
 	for(var/datum/action/cooldown/bloodsucker/power as anything in bloodsuckerdatum.all_bloodsucker_powers)
-		if(initial(power.purchase_flags) & BLOODSUCKER_CAN_BUY && !(locate(power) in bloodsuckerdatum.powers))
-			options[initial(power.name)] = power
+		if(!(power::purchase_flags & BLOODSUCKER_CAN_BUY))
+			continue
+		if(locate(power) in bloodsuckerdatum.powers)
+			continue
+		if(power in banned_powers)
+			continue
+		options[power::name] = power
 
 	if(length(options) < 1)
 		to_chat(bloodsuckerdatum.owner.current, span_notice("You grow more ancient by the night!"))

--- a/monkestation/code/modules/bloodsuckers/clans/nosferatu.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/nosferatu.dm
@@ -1,7 +1,7 @@
 /datum/bloodsucker_clan/nosferatu
 	name = CLAN_NOSFERATU
 	description = "The Nosferatu Clan is unable to blend in with the crew, with no abilities such as Masquerade and Veil. \n\
-		Additionally, has a permanent bad back and looks like a Bloodsucker upon a simple examine, and is entirely unidentifiable, \n\
+		Additionally, has a permanent bad back and looks like a Bloodsucker upon a simple examine by those in touch with the occult, and is entirely unidentifiable, \n\
 		they can fit in the vents regardless of their form and equipment. \n\
 		The Favorite Vassal is permanetly disfigured, and can also ventcrawl, but only while entirely nude."
 	clan_objective = /datum/objective/bloodsucker/kindred
@@ -9,15 +9,14 @@
 	join_description = "You are permanetly disfigured, look like a Bloodsucker to all who examine you, \
 		lose your Masquerade ability, but gain the ability to Ventcrawl even while clothed."
 	blood_drink_type = BLOODSUCKER_DRINK_INHUMANELY
+	banned_powers = list(/datum/action/cooldown/bloodsucker/masquerade, /datum/action/cooldown/bloodsucker/veil)
 
 /datum/bloodsucker_clan/nosferatu/New(datum/antagonist/bloodsucker/owner_datum)
 	. = ..()
-	for(var/datum/action/cooldown/bloodsucker/power as anything in bloodsuckerdatum.powers)
-		if(istype(power, /datum/action/cooldown/bloodsucker/masquerade) || istype(power, /datum/action/cooldown/bloodsucker/veil))
-			bloodsuckerdatum.RemovePower(power)
 	if(!bloodsuckerdatum.owner.current.has_quirk(/datum/quirk/badback))
 		bloodsuckerdatum.owner.current.add_quirk(/datum/quirk/badback)
 	bloodsuckerdatum.owner.current.add_traits(list(TRAIT_VENTCRAWLER_ALWAYS, TRAIT_DISFIGURED), BLOODSUCKER_TRAIT)
+	bloodsuckerdatum.break_masquerade(silent = TRUE) // malks won't immediately try to kill them
 
 /datum/bloodsucker_clan/nosferatu/Destroy(force)
 	for(var/datum/action/cooldown/bloodsucker/power in bloodsuckerdatum.powers)


### PR DESCRIPTION
## About The Pull Request

this makes it so nosferatu bloodsuckers are more accurate to their description - not very stealthy and such. i'm too lazy to write a more detailed description, read the changelog.

![2025-05-12 (1747035019) ~ dreamseeker](https://github.com/user-attachments/assets/9aca9544-141d-4d5d-bd34-d8ba54fa2e65)

## Changelog
:cl:
balance: Nosferatu bloodsuckers will always have a broken masquerade (albeit they will not give malkavian bloodsuckers a kill objective)
fix: Nosferatu bloodsuckers can no longer buy the Masquerade and Veil of Many Faces Abilities, which they weren't intended to have anyways.
fix: Nosferatu bloodsuckers now always resemble a crushed, empty juice pouch, as intended.
/:cl:
