### PR TITLE
Mapping fixes so we dont reach 1k issues

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_inevitable.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_inevitable.dmm
@@ -285,6 +285,7 @@
 /obj/machinery/airalarm/directional/south{
 	req_access = list("syndicate")
 	},
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/testlab)
 "It" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_inevitable.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_inevitable.dmm
@@ -107,6 +107,7 @@
 /obj/item/stock_parts/manipulator/femto,
 /obj/item/stock_parts/manipulator/femto,
 /obj/structure/rack,
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/testlab)
 "hJ" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_unlikely.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1/mistake_unlikely.dmm
@@ -23,6 +23,7 @@
 /obj/machinery/airalarm/directional/north{
 	req_access = list("syndicate")
 	},
+/obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron/dark,
 /area/ruin/syndicate_lava_base/testlab)
 "d" = (

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -58187,6 +58187,7 @@
 "llg" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lli" = (

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -51343,7 +51343,6 @@
 /area/station/security/brig)
 "jUQ" = (
 /obj/structure/extinguisher_cabinet/directional/north,
-/mob/living/basic/pet/poppy,
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/main)

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -49945,6 +49945,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/bed/dogbed{
+	anchored = 1;
+	name = "Daisy's bed"
+	},
+/mob/living/basic/rabbit/daisy,
 /turf/open/floor/carpet,
 /area/station/service/library/printer)
 "jHQ" = (
@@ -96559,11 +96564,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/mob/living/basic/rabbit/daisy,
-/obj/structure/bed/dogbed{
-	anchored = 1;
-	name = "Daisy's bed"
-	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/private)
 "sJP" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -60584,6 +60584,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/textured,
 /area/station/science/xenobiology)
 "tCM" = (

--- a/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
+++ b/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
@@ -12903,7 +12903,6 @@
 "gmE" = (
 /obj/structure/table/reinforced,
 /obj/item/surgery_tray,
-/obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "gmL" = (
@@ -19224,8 +19223,13 @@
 /turf/open/floor/iron/white/diagonal,
 /area/station/service/kitchen)
 "jgV" = (
-/obj/effect/spawner/random/trash/box,
-/turf/open/floor/plating,
+/obj/structure/rack,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/iron/fifty,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted,
+/obj/structure/sign/poster/contraband/free_drone/directional/north,
+/turf/open/floor/iron/dark,
 /area/station/maintenance/department/engine/atmos)
 "jhe" = (
 /obj/structure/disposalpipe/segment,
@@ -24304,6 +24308,16 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"lFI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/drone_dispenser/preloaded,
+/obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/maintenance/department/engine/atmos)
 "lFV" = (
 /turf/open/floor/iron/stairs/left,
 /area/station/hallway/primary/central/fore)
@@ -133104,7 +133118,7 @@ lVE
 lVE
 lAv
 nSe
-fpt
+lFI
 ixh
 jvn
 pRz

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -45990,9 +45990,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "nvb" = (
-/obj/structure/closet/secure_closet/tac{
-	req_access = list("captain")
-	},
+/obj/structure/closet/secure_closet/tac,
 /obj/item/clothing/head/helmet/toggleable/riot{
 	pixel_y = 6;
 	pixel_x = 7

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -84,6 +84,9 @@
 /obj/structure/bed/medical/anchored
 	anchored = TRUE
 
+/obj/structure/bed/medical/anchored/Initialize(mapload) //loaded subtype for mapping use
+	update_appearance()
+
 /obj/structure/bed/medical/emergency
 	name = "emergency medical bed"
 	desc = "A compact medical bed. This emergency version can be folded and carried for quick transport."


### PR DESCRIPTION

## About The Pull Request

- Anchored medical beds now should have their lights on round start
- Boxstation Xenobio now has a disposals system that is somewhat functional and doesnt explode
- Blueshift Atmospherics now has a air alarm
- Poppy the paradox clone has been killed from blueshift.
- Maintenance drones can now suffer on lead poisoning.
- Syndicate lavaland base now has more air alarms
## Why It's Good For The Game
## Changelog
:cl:
fix: Anchored medical beds now should have their brake lights on.
map: Boxstation Xenobio now should have connected deathsposals.
map: Blueshift Atmospherics now has a air alarm.
map: Blueshift Engineering no longer has a paradox clone Poppy
map: Lead poisoning now allows maintenance drones to additionally suffer.
map: Syndicate Biolab has a few more access helpers for air alarms.
/:cl:
