### PR TITLE
Update SpacemanDMM suite to 1.10

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -14,7 +14,7 @@ export RUST_G_VERSION=3.6.0
 export NODE_VERSION_LTS=22.11.0
 
 # SpacemanDMM git tag
-export SPACEMAN_DMM_VERSION=suite-1.9
+export SPACEMAN_DMM_VERSION=suite-1.10
 
 # Python version for mapmerge and other tools
 export PYTHON_VERSION=3.9.0


### PR DESCRIPTION
## About The Pull Request

Updates `SPACEMAN_DMM_VERSION` to `suite-1.10` in `dependencies.sh`, for the new https://github.com/SpaceManiac/SpacemanDMM/releases/tag/suite-1.10 release

## Why It's Good For The Game

WE CAN FINALLY USE SOME 516 FEATURES WITHOUT BREAKING LINTERS, YAYYY! (~~barring opendream~~)

## Changelog

No user-facing changes.