### PR TITLE
Use `sleep(world.tick_lag)` instead of `stoplag()` in `UNTIL` and `UNTIL_WHILE_EXISTS`

### DIFF
--- a/code/__DEFINES/_helpers.dm
+++ b/code/__DEFINES/_helpers.dm
@@ -15,7 +15,7 @@
 #define subtypesof(typepath) ( typesof(typepath) - typepath )
 
 /// Until a condition is true, sleep
-#define UNTIL(X) while(!(X)) stoplag()
+#define UNTIL(X) while(!(X)) sleep(world.tick_lag)
 
 /// Sleep if we haven't been deleted
 /// Otherwise, return

--- a/code/__DEFINES/~monkestation/_helpers.dm
+++ b/code/__DEFINES/~monkestation/_helpers.dm
@@ -3,6 +3,6 @@
 #define UNTIL_WHILE_EXISTS(Src, Condition) \
 	while(!(Condition)) { \
 		if(QDELETED(Src)) return; \
-		stoplag(); \
+		sleep(world.tick_lag); \
 	} \
 	if(QDELETED(Src)) return;


### PR DESCRIPTION
ports https://github.com/DaedalusDock/daedalusdock/pull/925