### PR TITLE
Fix the middle xenobio pens on Box being linked to the wrong ooze suckers

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -117929,7 +117929,7 @@ hNt
 xoG
 ogZ
 fck
-qbm
+dQL
 hNt
 xoG
 ogZ
@@ -119985,7 +119985,7 @@ hNt
 xoG
 ogZ
 fck
-dQL
+qbm
 hNt
 xoG
 ogZ


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/50a35571-16be-4439-bf95-ba79f303f5ca)

this fixes these two pens have their consoles linked to the ooze sucker on the opposite side

## Changelog
:cl:
map: The two middle xenobio pens on Box Station are now linked to their proper ooze suckers, instead of the opposite ones.
/:cl:
