### PR TITLE
Gives atropine medipens sanguarite

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -285,7 +285,7 @@
 	icon_state = "atropen"
 	inhand_icon_state = "atropen"
 	base_icon_state = "atropen"
-	list_reagents = list(/datum/reagent/medicine/atropine = 10)
+	list_reagents = list(/datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/coagulant = 2.5)
 
 /obj/item/reagent_containers/hypospray/medipen/snail
 	name = "snail shot"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -285,7 +285,7 @@
 	icon_state = "atropen"
 	inhand_icon_state = "atropen"
 	base_icon_state = "atropen"
-	list_reagents = list(/datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/coagulant = 2.5)
+	list_reagents = list(/datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/coagulant = 2)
 
 /obj/item/reagent_containers/hypospray/medipen/snail
 	name = "snail shot"


### PR DESCRIPTION
## About The Pull Request

Gives atropine medipens (The ones supplied to nukies, also the ones in the advanced medkit) 2u sanguarite (the same amount in epi pens)

## Why It's Good For The Game

Atropine medipens are strange because they do what epi pens do, but worse. Atropine is stronger than epinepherine, but has side effects and also has the mechanic of stopping the microbombs. But, they lack the coagulant. This leaves bleeds to be an absolute killer of nukies, because they don't have a default way of dealing with bleeds. This especially affects lone ops, who don't have access to the medical vendors on the nukie ship. 

Every crewmember has an epipen with coagulant. Everyone spawns with one. We can all agree that the epipen needs coagulant. Why are the syndicate pens any different? Aren't the syndicate items supposed to (generally) just be better than their nanotrasen counterparts? 

Newer players might also believe the 'medipen in the survival box' helps with bleeds and this makes it true for every survival box.
:cl:
add: 2u sanguarite to atropens
/:cl:
