### PR TITLE
Radio jammers now jam suit sensors

### DIFF
--- a/monkestation/code/game/machinery/computer/crew.dm
+++ b/monkestation/code/game/machinery/computer/crew.dm
@@ -10,7 +10,7 @@
 	return NTNET_NO_SIGNAL
 
 /datum/crewmonitor/proc/get_tracking_level(tracked_mob, tracker_z, nt_net, validation=TRUE)
-	if(!tracked_mob)
+	if(isnull(tracked_mob))
 		if (validation)
 			stack_trace("Null entry in suit sensors or nanite sensors list.")
 		return SENSOR_OFF
@@ -21,9 +21,13 @@
 	var/turf/pos = get_turf(tracked_living_mob)
 
 	// Is our target in nullspace for some reason?
-	if(!pos)
+	if(isnull(pos))
 		if (validation)
 			stack_trace("Tracked mob has no loc and is likely in nullspace: [tracked_living_mob] ([tracked_living_mob.type])")
+		return SENSOR_OFF
+
+	// Radio jammers block sensors.
+	if(is_within_radio_jammer_range(pos))
 		return SENSOR_OFF
 
 	// Machinery and the target should be on the same level or different levels of the same station

--- a/monkestation/code/game/machinery/computer/crew.dm
+++ b/monkestation/code/game/machinery/computer/crew.dm
@@ -9,7 +9,7 @@
 		return NTNET_LOW_SIGNAL
 	return NTNET_NO_SIGNAL
 
-/datum/crewmonitor/proc/get_tracking_level(mob/tracked_mob, tracker_z, nt_net, validation=TRUE)
+/datum/crewmonitor/proc/get_tracking_level(tracked_mob, tracker_z, nt_net, validation=TRUE)
 	if(isnull(tracked_mob))
 		if(validation)
 			stack_trace("Null entry in suit sensors or nanite sensors list.")

--- a/monkestation/code/game/machinery/computer/crew.dm
+++ b/monkestation/code/game/machinery/computer/crew.dm
@@ -15,9 +15,6 @@
 			stack_trace("Null entry in suit sensors or nanite sensors list.")
 		return SENSOR_OFF
 
-	if(QDELING(tracked_mob)) // meh, this is fine, don't stack trace here.
-		return SENSOR_OFF
-
 	var/mob/living/tracked_living_mob = tracked_mob
 
 	// Check if z-level is correct

--- a/monkestation/code/game/machinery/computer/crew.dm
+++ b/monkestation/code/game/machinery/computer/crew.dm
@@ -11,10 +11,11 @@
 
 /datum/crewmonitor/proc/get_tracking_level(tracked_mob, tracker_z, nt_net, validation=TRUE)
 	if(isnull(tracked_mob))
-		if(validation)
+		if (validation)
 			stack_trace("Null entry in suit sensors or nanite sensors list.")
 		return SENSOR_OFF
-	else if(QDELING(tracked_mob)) // meh, this is fine, don't stack trace here.
+
+	if(QDELING(tracked_mob)) // meh, this is fine, don't stack trace here.
 		return SENSOR_OFF
 
 	var/mob/living/tracked_living_mob = tracked_mob
@@ -24,7 +25,7 @@
 
 	// Is our target in nullspace for some reason?
 	if(isnull(pos))
-		if(validation)
+		if (validation)
 			stack_trace("Tracked mob has no loc and is likely in nullspace: [tracked_living_mob] ([tracked_living_mob.type])")
 		return SENSOR_OFF
 
@@ -44,22 +45,20 @@
 
 	// Check their humanity.
 	if(!ishuman(tracked_human))
-		if(validation)
+		if (validation)
 			stack_trace("Non-human mob is in suit_sensors_list: [tracked_living_mob] ([tracked_living_mob.type])")
 		return SENSOR_OFF
 
 	// Check they have a uniform
 	var/obj/item/clothing/under/uniform = tracked_human.w_uniform
-	if(!istype(uniform))
-		if(validation)
+	if (!istype(uniform))
+		if (validation)
 			stack_trace("Human without a suit sensors compatible uniform is in suit_sensors_list: [tracked_human] ([tracked_human.type]) ([uniform?.type])")
-		return SENSOR_OFF
-	else if(QDELING(uniform)) // this is also fine.
 		return SENSOR_OFF
 
 	// Check if their uniform is in a compatible mode.
 	if((uniform.has_sensor <= NO_SENSORS) || !uniform.sensor_mode)
-		if(validation)
+		if (validation)
 			stack_trace("Human without active suit sensors is in suit_sensors_list: [tracked_human] ([tracked_human.type]) ([uniform.type])")
 		return SENSOR_OFF
 

--- a/monkestation/code/game/machinery/computer/crew.dm
+++ b/monkestation/code/game/machinery/computer/crew.dm
@@ -15,6 +15,9 @@
 			stack_trace("Null entry in suit sensors or nanite sensors list.")
 		return SENSOR_OFF
 
+	if(QDELING(tracked_mob)) // meh, this is fine, don't stack trace here.
+		return SENSOR_OFF
+
 	var/mob/living/tracked_living_mob = tracked_mob
 
 	// Check if z-level is correct

--- a/monkestation/code/game/machinery/computer/crew.dm
+++ b/monkestation/code/game/machinery/computer/crew.dm
@@ -11,11 +11,10 @@
 
 /datum/crewmonitor/proc/get_tracking_level(tracked_mob, tracker_z, nt_net, validation=TRUE)
 	if(isnull(tracked_mob))
-		if (validation)
+		if(validation)
 			stack_trace("Null entry in suit sensors or nanite sensors list.")
 		return SENSOR_OFF
-
-	if(QDELING(tracked_mob)) // meh, this is fine, don't stack trace here.
+	else if(QDELING(tracked_mob)) // meh, this is fine, don't stack trace here.
 		return SENSOR_OFF
 
 	var/mob/living/tracked_living_mob = tracked_mob
@@ -25,7 +24,7 @@
 
 	// Is our target in nullspace for some reason?
 	if(isnull(pos))
-		if (validation)
+		if(validation)
 			stack_trace("Tracked mob has no loc and is likely in nullspace: [tracked_living_mob] ([tracked_living_mob.type])")
 		return SENSOR_OFF
 
@@ -45,20 +44,22 @@
 
 	// Check their humanity.
 	if(!ishuman(tracked_human))
-		if (validation)
+		if(validation)
 			stack_trace("Non-human mob is in suit_sensors_list: [tracked_living_mob] ([tracked_living_mob.type])")
 		return SENSOR_OFF
 
 	// Check they have a uniform
 	var/obj/item/clothing/under/uniform = tracked_human.w_uniform
-	if (!istype(uniform))
-		if (validation)
+	if(!istype(uniform))
+		if(validation)
 			stack_trace("Human without a suit sensors compatible uniform is in suit_sensors_list: [tracked_human] ([tracked_human.type]) ([uniform?.type])")
+		return SENSOR_OFF
+	else if(QDELING(uniform)) // this is also fine.
 		return SENSOR_OFF
 
 	// Check if their uniform is in a compatible mode.
 	if((uniform.has_sensor <= NO_SENSORS) || !uniform.sensor_mode)
-		if (validation)
+		if(validation)
 			stack_trace("Human without active suit sensors is in suit_sensors_list: [tracked_human] ([tracked_human.type]) ([uniform.type])")
 		return SENSOR_OFF
 

--- a/monkestation/code/game/machinery/computer/crew.dm
+++ b/monkestation/code/game/machinery/computer/crew.dm
@@ -9,7 +9,7 @@
 		return NTNET_LOW_SIGNAL
 	return NTNET_NO_SIGNAL
 
-/datum/crewmonitor/proc/get_tracking_level(tracked_mob, tracker_z, nt_net, validation=TRUE)
+/datum/crewmonitor/proc/get_tracking_level(mob/tracked_mob, tracker_z, nt_net, validation=TRUE)
 	if(isnull(tracked_mob))
 		if(validation)
 			stack_trace("Null entry in suit sensors or nanite sensors list.")


### PR DESCRIPTION

## About The Pull Request

this makes it so active radio jammers will also jam suit sensors within range

this does not disable sensors on the suit itself, rather it just makes them not show up while in the range of an active jammer

## Why It's Good For The Game

Makes radio jammers even more useful for antags.

## Changelog
:cl:
balance: Radio jammers now also jam suit sensors within range.
/:cl:
