### PR TITLE
Prevent dummies from becoming hearing-sensitive

### DIFF
--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -32,6 +32,8 @@
 		for(var/datum/mind/crew_mind in get_crewmember_minds())
 			if(crew_mind.current)
 				humans += crew_mind.current
+		if(!length(humans))
+			return FALSE
 		speaker = pick(humans)
 
 	// Time to generate a message.

--- a/code/modules/hallucination/fake_chat.dm
+++ b/code/modules/hallucination/fake_chat.dm
@@ -36,6 +36,9 @@
 			return FALSE
 		speaker = pick(humans)
 
+	if(!speaker)
+		return FALSE
+
 	// Time to generate a message.
 	// Spans of our message
 	var/spans = list(speaker.speech_span)

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -14,6 +14,10 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	in_use = FALSE
 	return ..()
 
+// no reason for these to ever be hearing sensitive, it just wastes time on spatial grid stuff
+/mob/living/carbon/human/dummy/become_hearing_sensitive(trait_source)
+	return
+
 /mob/living/carbon/human/dummy/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	return
 
@@ -23,10 +27,6 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 /mob/living/carbon/human/dummy/set_species(datum/species/mrace, icon_update = TRUE, pref_load = FALSE)
 	harvest_organs()
 	return ..()
-
-// no reason for these to ever be hearing sensitive, it just wastes time on spatial grid stuff
-/mob/living/carbon/human/dummy/become_hearing_sensitive(trait_source)
-	return
 
 /*
 	MONKESTATION EDIT START

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -24,6 +24,10 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	harvest_organs()
 	return ..()
 
+// no reason for these to ever be hearing sensitive, it just wastes time on spatial grid stuff
+/mob/living/carbon/human/dummy/become_hearing_sensitive(trait_source)
+	return
+
 /*
 	MONKESTATION EDIT START
 	This causes a problem with tall players as some of their overlays will go outside of the 32x32 range which the mob's icon is restricted to


### PR DESCRIPTION

## About The Pull Request

this makes it so `/mob/living/carbon/human/dummy` instances can never become hearing-sensitive, so they are never added to the spatial grid.

spatial grid stuff seems to take up a bit of processing time with prefs dummies, so let's just... get rid of that.

![image](https://github.com/user-attachments/assets/52e395e8-a438-40d8-ab2d-767156f7a1a4)

## Changelog

no player-facing changes