### PR TITLE
Fixes old DNA data disks not rolling species-specific mutations

### DIFF
--- a/monkestation/code/game/machinery/dna_scanner.dm
+++ b/monkestation/code/game/machinery/dna_scanner.dm
@@ -51,11 +51,11 @@
 		var/weight = isnull(mutation::species_allowed) ? 2 : 3
 		switch(mutation::quality)
 			if(POSITIVE)
-				good |= mutation
+				good[mutation] = weight
 			if(MINOR_NEGATIVE)
-				neutral |= mutation
+				neutral[mutation] = weight
 			if(NEGATIVE)
-				bad |= mutation
+				bad[mutation] = weight
 	.[good] = POSITIVE_WEIGHT
 	.[neutral] = NEUTRAL_WEIGHT
 	.[bad] = NEGATIVE_WEIGHT

--- a/monkestation/code/game/machinery/dna_scanner.dm
+++ b/monkestation/code/game/machinery/dna_scanner.dm
@@ -42,17 +42,23 @@
 /obj/item/disk/data/random/proc/initialize_mutation_weights() as /list
 	RETURN_TYPE(/list)
 	. = list()
-	.[get_non_random_locked_mutations(GLOB.good_mutations)] = POSITIVE_WEIGHT
-	.[get_non_random_locked_mutations(GLOB.not_good_mutations)] = NEUTRAL_WEIGHT
-	.[get_non_random_locked_mutations(GLOB.bad_mutations)] = NEGATIVE_WEIGHT
-
-/// Returns a list of the typepaths of mutations in the given list without the random_locked var enabled.
-/obj/item/disk/data/random/proc/get_non_random_locked_mutations(list/mutations) as /list
-	RETURN_TYPE(/list)
-	. = list()
-	for(var/datum/mutation/human/mutation as anything in mutations)
-		if(!mutation.random_locked)
-			.[mutation.type] = isnull(mutation.species_allowed) ? 2 : 3
+	var/list/good = list()
+	var/list/neutral = list()
+	var/list/bad = list()
+	for(var/datum/mutation/human/mutation as anything in GLOB.all_mutations)
+		if(mutation::random_locked)
+			continue
+		var/weight = isnull(mutation::species_allowed) ? 2 : 3
+		switch(mutation::quality)
+			if(POSITIVE)
+				good |= mutation
+			if(MINOR_NEGATIVE)
+				neutral |= mutation
+			if(NEGATIVE)
+				bad |= mutation
+	.[good] = POSITIVE_WEIGHT
+	.[neutral] = NEUTRAL_WEIGHT
+	.[bad] = NEGATIVE_WEIGHT
 
 #undef STABILIZER_PROB
 #undef CHROMOSOME_PROB


### PR DESCRIPTION

## About The Pull Request

old dna data disks were intended to have a slightly higher chance of rolling species-specific mutations compared to normal mutations, but due to how it was initialized, it never actually considered any species-specific mutations. this fixes that.

## Changelog
:cl:
fix: Fixed old DNA data disks not rolling species-specific mutations.
/:cl:
