### PR TITLE
Charlie/Delta Station on icebox are no longer considered station areas

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -583,7 +583,7 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 /// Generates the global station area list, filling it with typepaths of unique areas found on the station Z.
 /datum/controller/subsystem/mapping/proc/generate_station_area_list()
 	for(var/area/station/station_area in GLOB.areas)
-		if (!(station_area.area_flags & UNIQUE_AREA))
+		if (!(station_area.area_flags & UNIQUE_AREA) || istype(station_area, /area/ruin))
 			continue
 		if (is_station_level(station_area.z))
 			GLOB.the_station_areas += station_area.type


### PR DESCRIPTION
## Changelog
:cl:
fix: Charlie/Delta Station on icebox are no longer considered station areas.
/:cl:
