### PR TITLE
[Code Bounty] Fab-o-vend and command clothing restockers and express pod edit

### DIFF
--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -6,7 +6,7 @@
 	icon_screen = "supply_express"
 	circuit = /obj/item/circuitboard/computer/cargo/express
 	blockade_warning = "Bluespace instability detected. Delivery impossible."
-	req_access = list(ACCESS_QM) //MONKESTATION EDIT
+	req_access = list(ACCESS_CARGO)
 	is_express = TRUE
 	interface_type = "CargoExpress"
 

--- a/code/modules/cargo/packs/vending_restock.dm
+++ b/code/modules/cargo/packs/vending_restock.dm
@@ -26,7 +26,7 @@
 	contains = list(/obj/item/vending_refill/dinnerware)
 	crate_name = "dinnerware supply crate"
 
-/datum/supply_pack/vending/dinnerware
+/datum/supply_pack/vending/fab_o_vend
 	name = "Fab-o-Vend Supply Crate"
 	desc = "Restock that Fab-o-Vend."
 	cost = CARGO_CRATE_VALUE * 2
@@ -224,9 +224,9 @@
 				)
 	crate_name = "security department supply crate"
 
-/datum/supply_pack/vending/wardrobes/security
+/datum/supply_pack/vending/wardrobes/comm_wardrobe
 	name = "Command Wardrobe Supply Crate"
 	desc = "This crate contains refills for the Command Outfitting Station"
 	cost = CARGO_CRATE_VALUE * 7
 	contains = list(/obj/item/vending_refill/wardrobe/comm_wardrobe)
-	crate_name = "security department supply crate"
+	crate_name = "command outfitting station supply crate"

--- a/code/modules/cargo/packs/vending_restock.dm
+++ b/code/modules/cargo/packs/vending_restock.dm
@@ -26,6 +26,13 @@
 	contains = list(/obj/item/vending_refill/dinnerware)
 	crate_name = "dinnerware supply crate"
 
+/datum/supply_pack/vending/dinnerware
+	name = "Fab-o-Vend Supply Crate"
+	desc = "Restock that Fab-o-Vend."
+	cost = CARGO_CRATE_VALUE * 2
+	contains = list(/obj/item/vending_refill/barbervend)
+	crate_name = "Fab-o-Vend supply crate"
+
 /datum/supply_pack/vending/science/modularpc
 	name = "Deluxe Silicate Selections Restock"
 	desc = "What's a computer? Contains a Deluxe Silicate Selections restocking unit."
@@ -215,4 +222,11 @@
 					/obj/item/vending_refill/wardrobe/det_wardrobe,
 					/obj/item/vending_refill/wardrobe/law_wardrobe,
 				)
+	crate_name = "security department supply crate"
+
+/datum/supply_pack/vending/wardrobes/security
+	name = "Command Wardrobe Supply Crate"
+	desc = "This crate contains refills for the Command Outfitting Station"
+	cost = CARGO_CRATE_VALUE * 7
+	contains = list(/obj/item/vending_refill/wardrobe/comm_wardrobe)
 	crate_name = "security department supply crate"

--- a/tgui/packages/tgui/interfaces/CargoExpress.tsx
+++ b/tgui/packages/tgui/interfaces/CargoExpress.tsx
@@ -30,7 +30,7 @@ export const CargoExpress = (props) => {
   return (
     <Window width={600} height={700}>
       <Window.Content scrollable>
-        <InterfaceLockNoticeBox accessText="a QM-level ID card" />
+        <InterfaceLockNoticeBox accessText="an ID with cargo access" />
         {!locked && <CargoExpressContent />}
       </Window.Content>
     </Window>


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds restocking unit for fab-o-vend and command outfitting station to cargo 

Express console now only requires cargo access to unlock 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As per bountier

"Allows cargo to be more efficient/Proactive and more potential antag shenanigans can come of it, and the vendors stock were missing this is just a correction"

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Express console can now be unlocked by cargo access
add: Fab-o-vend and command clothing vender restocking units in cargo
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
