### PR TITLE
reorganize some Plexora TGS shutdown notification stuff

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -346,10 +346,11 @@ GLOBAL_VAR(restart_counter)
 			shutdown_logging() // See comment below.
 			QDEL_NULL(Tracy)
 			QDEL_NULL(Debugger)
+			SSplexora.notify_shutdown(PLEXORA_SHUTDOWN_KILLDD)
 			TgsEndProcess()
 			return ..()
 
-	SSplexora._Shutdown() // Monkestation edit: plexora
+	SSplexora.notify_shutdown()
 	log_world("World rebooted at [time_stamp()]")
 
 	shutdown_logging() // Past this point, no logging procs can be used, at risk of data loss.

--- a/code/modules/admin/verbs/server.dm
+++ b/code/modules/admin/verbs/server.dm
@@ -80,10 +80,10 @@
 				world.Reboot(fast_track = TRUE)
 			if("Server Restart (Kill and restart DD)")
 				// monkestation start - plexora
-				SSplexora.restart_type = PLEXORA_SHUTDOWN_KILLDD
 				SSplexora.restart_requester = usr
 				// monkestation end
 				to_chat(world, "Server restart - [init_by]")
+				SSplexora.notify_shutdown(PLEXORA_SHUTDOWN_KILLDD)
 				world.TgsEndProcess()
 
 /* uncomment this when/if we port the the admin verb refactor

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -21,6 +21,7 @@ GLOBAL_VAR_INIT(total_runtimes_skipped, 0)
 
 	else if(copytext(E.name, 1, 18) == "Out of resources!")//18 == length() of that string + 1
 		log_world("BYOND out of memory. Restarting ([E?.file]:[E?.line])")
+		SSplexora.notify_shutdown(PLEXORA_SHUTDOWN_KILLDD)
 		TgsEndProcess()
 		. = ..()
 		Reboot(reason = 1)

--- a/code/modules/tgs/core/core.dm
+++ b/code/modules/tgs/core/core.dm
@@ -133,8 +133,6 @@
 	return list()
 
 /world/TgsEndProcess()
-	SSplexora.restart_type = PLEXORA_SHUTDOWN_KILLDD
-	SSplexora._Shutdown()
 	var/datum/tgs_api/api = TGS_READ_GLOBAL(tgs)
 	if(api)
 		api.EndProcess()

--- a/monkestation/code/controllers/subsystem/plexora.dm
+++ b/monkestation/code/controllers/subsystem/plexora.dm
@@ -148,7 +148,7 @@ SUBSYSTEM_DEF(plexora)
 		"round_timer" = ROUND_TIME(),
 		"map" = SSmapping.current_map?.map_name,
 		"playercount" = length(GLOB.clients),
-		"restart_type" = restart_type_override || restart_type,
+		"restart_type" = isnull(restart_type_override) ? restart_type : restart_type_override,
 		"requestedby" = usr?.ckey,
 		"requestedby_stealthed" = usr?.client?.holder?.fakekey,
 	))

--- a/monkestation/code/controllers/subsystem/plexora.dm
+++ b/monkestation/code/controllers/subsystem/plexora.dm
@@ -134,10 +134,10 @@ SUBSYSTEM_DEF(plexora)
 		default_headers
 	).begin_async()
 
-/datum/controller/subsystem/plexora/proc/_Shutdown()
+/datum/controller/subsystem/plexora/proc/notify_shutdown(restart_type_override)
 	var/static/server_restart_sent = FALSE
 
-	if (server_restart_sent)
+	if(server_restart_sent)
 		return
 
 	server_restart_sent = TRUE
@@ -148,7 +148,7 @@ SUBSYSTEM_DEF(plexora)
 		"round_timer" = ROUND_TIME(),
 		"map" = SSmapping.current_map?.map_name,
 		"playercount" = length(GLOB.clients),
-		"restart_type" = restart_type,
+		"restart_type" = restart_type_override || restart_type,
 		"requestedby" = usr?.ckey,
 		"requestedby_stealthed" = usr?.client?.holder?.fakekey,
 	))


### PR DESCRIPTION

## About The Pull Request

Removes the Plexora changes to `/world/TgsEndProcess()` and moves them to whatever calls that instead

Also renames `SSplexora._Shutdown()` to `SSplexora.notify_shutdown()`

## Why It's Good For The Game

so DMAPI updates don't nuke the plexora shutdown notification

## Changelog

no user-facing changes