### PR TITLE
Birth Teratoma compensation

### DIFF
--- a/monkestation/code/modules/antagonists/changeling/powers/teratomas.dm
+++ b/monkestation/code/modules/antagonists/changeling/powers/teratomas.dm
@@ -3,7 +3,7 @@
 	desc = "Our form divides, creating an egg that will soon hatch into a living tumor, fixated on causing mayhem. Costs 50 chemicals."
 	helptext = "The tumor will not be loyal to us or our cause. Requires an changeling absorption for every two tumors created."
 	button_icon_state = "spread_infestation"
-	chemical_cost = 60
+	chemical_cost = 50
 	dna_cost = 2
 	req_absorbs = 1
 

--- a/monkestation/code/modules/antagonists/changeling/powers/teratomas.dm
+++ b/monkestation/code/modules/antagonists/changeling/powers/teratomas.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/teratoma
 	name = "Birth Teratoma"
-	desc = "Our form divides, creating an egg that will soon hatch into a living tumor, fixated on causing mayhem. Costs 60 chemicals."
-	helptext = "The tumor will not be loyal to us or our cause. Requires an changeling absorption for each tumor created."
+	desc = "Our form divides, creating an egg that will soon hatch into a living tumor, fixated on causing mayhem. Costs 50 chemicals."
+	helptext = "The tumor will not be loyal to us or our cause. Requires an changeling absorption for every two tumors created."
 	button_icon_state = "spread_infestation"
 	chemical_cost = 60
 	dna_cost = 2
@@ -22,7 +22,7 @@
 	var/datum/antagonist/changeling/ling = user?.mind?.has_antag_datum(/datum/antagonist/changeling)
 	if(!ling)
 		return FALSE
-	if(ling.births >= ling.true_absorbs)
+	if(ling.births >= (ling.true_absorbs * 2))
 		to_chat(user, span_warning("You must absorb another creature to divide yourself further."))
 		return FALSE
 	ling.adjust_chemicals(-chemical_cost)


### PR DESCRIPTION
## About The Pull Request
Ling births per husk 1 -> 2
Chemical cost 60 -> 50 
## Why It's Good For The Game

A response to a mixture of my orginal PR #6494 and  #6712
Since they are less grief machines, and less influential mechanically and rules-wise, we can make them overall cheaper for lings.
## Changelog
:cl:
balance: True husks now allow for two teratomas spawned.
balance: Birth Teratoma now costs 50 chemicals. (From 60) 
/:cl:
