### PR TITLE
UwUification capitalization

### DIFF
--- a/code/__HELPERS/~monkestation-helpers/uwuify.dm
+++ b/code/__HELPERS/~monkestation-helpers/uwuify.dm
@@ -8,7 +8,7 @@
 		rustg_setup_acreplace( \
 			UWUIFY_ACREPLACE_KEY, \
 			list( "ne",  "Ne",  "nE",  "NE",  "nu",  "Nu",  "nU",  "NU",  "na",  "Na",  "nA",  "NA",  "no",  "No",  "nO",  "NO", "ove", "Ove", "oVe", "OVe", "ovE", "OvE", "oVE", "OVE", "r", "R", "l", "L"), \
-			list("nye", "Nye", "nYe", "NYe", "nyu", "Nyu", "nYu", "NYu", "nya", "Nya", "nYa", "NYa", "nyo", "Nyo", "nYo", "NYo",  "uv",  "Uv",  "uV",  "UV",  "uv",  "Uv",  "uV",  "UV", "w", "W", "w", "W") \
+			list("nye", "Nye", "nYE", "NYE", "nyu", "Nyu", "nYU", "NYU", "nya", "Nya", "nYA", "NYA", "nyo", "Nyo", "nYO", "NYO",  "uv",  "Uv",  "uV",  "UV",  "uv",  "Uv",  "uV",  "UV", "w", "W", "w", "W") \
 		)
 		acreplace_setup = TRUE
 	return rustg_acreplace(UWUIFY_ACREPLACE_KEY, "[text]")


### PR DESCRIPTION

## About The Pull Request
Makes capitalization on UwUification make a little more sense.

Changes made by 'aritepes', I'm just making the pull for them.
## Why It's Good For The Game
Screaming "NO" as "NYo" Rather than "NYO" Looks a little awkward once full caps sentences get applied
## Changelog
:cl: Aritepes
fix: UwUifcation speech now better applies capitalization
/:cl:
