### PR TITLE
Slime Link QoL touchups

### DIFF
--- a/code/datums/components/mind_linker.dm
+++ b/code/datums/components/mind_linker.dm
@@ -22,6 +22,8 @@
 	var/speech_action_background_icon_state = "bg_alien"
 	/// The border icon state for the speech action handed out.
 	var/speech_action_overlay_state = "bg_alien_border"
+	/// Whether messages should show a balloon alert or not.
+	var/show_balloon_alert = FALSE
 	/// The master's speech action. The owner of the link shouldn't lose this as long as the link remains.
 	VAR_FINAL/datum/action/innate/linked_speech/master_speech
 	/// An assoc list of [mob/living]s to [datum/action/innate/linked_speech]s. All the mobs that are linked to our network.
@@ -38,6 +40,7 @@
 	// Optional
 	signals_which_destroy_us,
 	datum/callback/post_unlink_callback,
+	show_balloon_alert,
 )
 
 	if(!isliving(parent))
@@ -60,16 +63,12 @@
 	src.speech_action_icon_state = speech_action_icon_state
 	src.speech_action_background_icon_state = speech_action_background_icon_state
 
-/*
-	master_speech = new(src)
-	master_speech.Grant(owner)
-*/
+	if(!isnull(show_balloon_alert))
+		src.show_balloon_alert = show_balloon_alert
 
-//MONKESTATION EDIT - NIFs
 	if(speech_action)
 		master_speech = new(src)
 		master_speech.Grant(owner)
-//MONKESTATION EDIT END
 
 	to_chat(owner, span_boldnotice("You establish a [network_name], allowing you to link minds to communicate telepathically."))
 
@@ -184,6 +183,7 @@
 	// Optional
 	signals_which_destroy_us,
 	datum/callback/post_unlink_callback,
+	show_balloon_alert,
 	// Optional for this subtype
 	link_message,
 	unlink_message,
@@ -286,6 +286,8 @@
 	for(var/mob/living/recipient as anything in all_who_can_hear)
 		var/avoid_highlighting = (recipient == owner) || (recipient == linker_parent)
 		to_chat(recipient, formatted_message, type = MESSAGE_TYPE_RADIO, avoid_highlighting = avoid_highlighting)
+		if(linker.show_balloon_alert)
+			recipient.balloon_alert(recipient, "you hear a voice from your [linker.network_name]")
 
 	for(var/mob/recipient as anything in GLOB.dead_mob_list)
 		to_chat(recipient, "[FOLLOW_LINK(recipient, owner)] [formatted_message]", type = MESSAGE_TYPE_RADIO)

--- a/code/datums/components/mind_linker.dm
+++ b/code/datums/components/mind_linker.dm
@@ -286,7 +286,7 @@
 	for(var/mob/living/recipient as anything in all_who_can_hear)
 		var/avoid_highlighting = (recipient == owner) || (recipient == linker_parent)
 		to_chat(recipient, formatted_message, type = MESSAGE_TYPE_RADIO, avoid_highlighting = avoid_highlighting)
-		if(linker.show_balloon_alert)
+		if(linker.show_balloon_alert && recipient != owner)
 			recipient.balloon_alert(recipient, "you hear a voice from your [linker.network_name]")
 
 	for(var/mob/recipient as anything in GLOB.dead_mob_list)

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -566,8 +566,10 @@
 	grant_to.AddComponent( \
 		/datum/component/mind_linker/active_linking, \
 		network_name = "Slime Link", \
+		chat_color = "#00ced1", \
 		signals_which_destroy_us = list(COMSIG_SPECIES_LOSS), \
 		linker_action_path = /datum/action/innate/link_minds, \
+		show_balloon_alert = TRUE, \
 	)
 
 //Species datums don't normally implement destroy, but JELLIES SUCK ASS OUT OF A STEEL STRAW


### PR DESCRIPTION

## About The Pull Request

this changes the Slime Link's color slightly (to match what it is on Bee, `#00ced1`) and adds a balloon alert when someone talks over the slime link.

![2025-05-20 (1747794948) ~ dreamseeker](https://github.com/user-attachments/assets/b27aa259-e32b-44e1-a1e4-1ba421689c1e)

## Why It's Good For The Game

the current colors and such are hard to see, so this makes it easier to notice.

## Changelog
:cl:
qol: Changed the Slime Link message color to a slightly brighter shade of blue.
qol: Slime Link messages now notify listeners with a balloon alert.
/:cl:
