### PR TITLE
Refactors the Heavy Bleeder challenge

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -94,12 +94,8 @@
 	for(var/obj/item/bodypart/iter_part as anything in bodyparts)
 		var/iter_bleed_rate = iter_part.get_modified_bleed_rate()
 		temp_bleed += iter_bleed_rate * seconds_per_tick
-		if(HAS_TRAIT(src, TRAIT_HEAVY_BLEEDER))
-			temp_bleed *= 2
 
 		if(iter_part.generic_bleedstacks) // If you don't have any bleedstacks, don't try and heal them
-			if(HAS_TRAIT(src, TRAIT_HEAVY_BLEEDER))
-				iter_part.adjustBleedStacks(-1, minimum = 0) /// we basically double up on bleedstacks
 			iter_part.adjustBleedStacks(-1, 0)
 
 	if(temp_bleed)

--- a/code/modules/mob/living/carbon/human/init_signals.dm
+++ b/code/modules/mob/living/carbon/human/init_signals.dm
@@ -1,10 +1,22 @@
 /mob/living/carbon/human/register_init_signals()
 	. = ..()
 
+	RegisterSignal(src, SIGNAL_ADDTRAIT(TRAIT_HEAVY_BLEEDER), PROC_REF(on_gain_heavy_bleeder_trait))
+	RegisterSignal(src, SIGNAL_REMOVETRAIT(TRAIT_HEAVY_BLEEDER), PROC_REF(on_lose_heavy_bleeder_trait))
 	RegisterSignals(src, list(SIGNAL_ADDTRAIT(TRAIT_UNKNOWN), SIGNAL_REMOVETRAIT(TRAIT_UNKNOWN)), PROC_REF(on_unknown_trait))
 	RegisterSignals(src, list(SIGNAL_ADDTRAIT(TRAIT_DWARF), SIGNAL_REMOVETRAIT(TRAIT_DWARF)), PROC_REF(on_dwarf_trait))
 	RegisterSignals(src, list(SIGNAL_ADDTRAIT(TRAIT_GIANT)), PROC_REF(on_gain_giant_trait))
 	RegisterSignals(src, list(SIGNAL_REMOVETRAIT(TRAIT_GIANT)), PROC_REF(on_lose_giant_trait))
+
+/// Gaining [TRAIT_HEAVY_BLEEDER] doubles our bleed_mod.
+/mob/living/carbon/human/proc/on_gain_heavy_bleeder_trait(datum/source)
+	SIGNAL_HANDLER
+	physiology?.bleed_mod *= 2
+
+/// Losing [TRAIT_HEAVY_BLEEDER] halves our bleed_mod.
+/mob/living/carbon/human/proc/on_lose_heavy_bleeder_trait(datum/source)
+	SIGNAL_HANDLER
+	physiology?.bleed_mod /= 2
 
 /// Gaining or losing [TRAIT_UNKNOWN] updates our name and our sechud
 /mob/living/carbon/human/proc/on_unknown_trait(datum/source)


### PR DESCRIPTION

## About The Pull Request

this reworks/refactors how the heavy bleeder challenge works: `TRAIT_HEAVY_BLEEDER` now just doubles your `bleed_mod` when applied, instead of having snowflake checks in bleed code.

## Changelog
:cl:
refactor: Refactored how the Heavy Bleeder challenge works.
fix: The Heavy Bleeder challenge should no longer instantly drain all of your blood when wounded.
/:cl:
