### PR TITLE
Making more antagonists tokenable

### DIFF
--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -709,7 +709,6 @@ monkestation end */
 			if(ROLE_NIGHTMARE)
 				var/datum/antagonist/nightmare/antag_datum = new
 				assign_admin_objective_and_antag(player, antag_datum)
-				player.set_species(/datum/species/shadow/nightmare)
 
 	else if(isAI(player))
 		var/datum/antagonist/malf_ai/antag_datum = new

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -59,6 +59,17 @@
 	outfit = /datum/outfit/abductor/scientist/onemanteam
 	role_job = /datum/job/abductor_solo
 
+/datum/antagonist/abductor/scientist/onemanteam/antag_token(datum/mind/hosts_mind, mob/spender)
+	team = new
+	if(isliving(spender) && hosts_mind)
+		hosts_mind.current.unequip_everything()
+		new /obj/effect/holy(hosts_mind.current.loc)
+		hosts_mind.add_antag_datum(/datum/antagonist/abductor/scientist/onemanteam, team)
+	if(isobserver(spender))
+		var/mob/living/carbon/human/new_mob = spender.change_mob_type(/mob/living/carbon/human, delete_old_mob = TRUE)
+		var/datum/mind/new_mind = new_mob.mind
+		new_mind.add_antag_datum(/datum/antagonist/abductor/scientist/onemanteam, team
+	
 /datum/antagonist/abductor/create_team(datum/team/abductor_team/new_team)
 	if(!new_team)
 		return
@@ -125,6 +136,7 @@
 		team = current_teams[choice]
 	else
 		return
+	new_owner.current.unequip_everything() //Adding the datum kidnaps the person to the ship. Best they dont bring artifacts with them.
 	new_owner.add_antag_datum(src)
 	log_admin("[key_name(usr)] made [key_name(new_owner)] [name] on [choice]!")
 	message_admins("[key_name_admin(usr)] made [key_name_admin(new_owner)] [name] on [choice] !")

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -68,8 +68,8 @@
 	if(isobserver(spender))
 		var/mob/living/carbon/human/new_mob = spender.change_mob_type(/mob/living/carbon/human, delete_old_mob = TRUE)
 		var/datum/mind/new_mind = new_mob.mind
-		new_mind.add_antag_datum(/datum/antagonist/abductor/scientist/onemanteam, team
-	
+		new_mind.add_antag_datum(/datum/antagonist/abductor/scientist/onemanteam, team)
+
 /datum/antagonist/abductor/create_team(datum/team/abductor_team/new_team)
 	if(!new_team)
 		return

--- a/code/modules/events/ghost_role/nightmare.dm
+++ b/code/modules/events/ghost_role/nightmare.dm
@@ -37,10 +37,6 @@
 
 	var/mob/living/carbon/human/S = new (spawn_loc)
 	player_mind.transfer_to(S)
-	player_mind.set_assigned_role(SSjob.GetJobType(/datum/job/nightmare))
-	player_mind.special_role = ROLE_NIGHTMARE
-	player_mind.add_antag_datum(/datum/antagonist/nightmare)
-	S.set_species(/datum/species/shadow/nightmare)
 	playsound(S, 'sound/magic/ethereal_exit.ogg', 50, TRUE, -1)
 	message_admins("[ADMIN_LOOKUPFLW(S)] has been made into a Nightmare by an event.")
 	S.log_message("was spawned as a Nightmare by an event.", LOG_GAME)

--- a/config/monkestation/antag-tokens.toml
+++ b/config/monkestation/antag-tokens.toml
@@ -1,3 +1,3 @@
-low = ["traitor", "florida_man", "paradox_clone", "cortical_borer"]
-medium = ["heretic", "bloodsucker", "cortical_borer/hivemind"]
+low = ["traitor", "florida_man", "paradox_clone", "cortical_borer", "obsessed", "traitor/contractor", "abductor/scientist/onemanteam"]
+medium = ["heretic", "bloodsucker", "cortical_borer/hivemind", "reverant", "nightmare", "slasher"]
 high = ["cult", "rev/head", "wizard", "clock_cultist", "ninja"]

--- a/monkestation/code/modules/antagonists/contractor/datums/contractor_datum.dm
+++ b/monkestation/code/modules/antagonists/contractor/datums/contractor_datum.dm
@@ -106,11 +106,14 @@
 			continue
 		spawn_locs += carp_spawn.loc
 	if(!spawn_locs.len)
-		message_admins("No valid spawn locations found, aborting...")
+		message_admins("Failed to find valid spawn location for [ADMIN_LOOKUPFLW(spender)], who spent a drifting contractor antag token")
 		CRASH("Failed to find valid spawn location for drifting contractor antag token")
 
 	//spawn the contractor and assign the candidate
 	var/mob/living/carbon/human/contractor = new(pick(spawn_locs))
 	contractor.PossessByPlayer(spender_key)
 	contractor.mind.add_antag_datum(/datum/antagonist/traitor/contractor)
+	if(isobserver(spender))
+		qdel(spender)
+	message_admins("[ADMIN_LOOKUPFLW(contractor)] has been made into a contractor by using an antag token.")
 

--- a/monkestation/code/modules/antagonists/contractor/datums/contractor_datum.dm
+++ b/monkestation/code/modules/antagonists/contractor/datums/contractor_datum.dm
@@ -89,3 +89,28 @@
 
 /datum/job/drifting_contractor
 	title = ROLE_DRIFTING_CONTRACTOR
+
+/datum/antagonist/traitor/contractor/antag_token(datum/mind/hosts_mind, mob/spender)
+	var/spender_key = spender.key
+	if(!spender_key)
+		CRASH("wtf, spender had no key")
+	if(isliving(spender) && hosts_mind)
+		hosts_mind.current.unequip_everything()
+		new /obj/effect/holy(hosts_mind.current.loc)
+		QDEL_IN(hosts_mind.current, 20)
+
+	var/list/spawn_locs = list()
+	for(var/obj/effect/landmark/carpspawn/carp_spawn in GLOB.landmarks_list)
+		if(!isturf(carp_spawn.loc))
+			stack_trace("Carp spawn found not on a turf: [carp_spawn.type] on [isnull(carp_spawn.loc) ? "null" : carp_spawn.loc.type]")
+			continue
+		spawn_locs += carp_spawn.loc
+	if(!spawn_locs.len)
+		message_admins("No valid spawn locations found, aborting...")
+		CRASH("Failed to find valid spawn location for drifting contractor antag token")
+
+	//spawn the contractor and assign the candidate
+	var/mob/living/carbon/human/contractor = new(pick(spawn_locs))
+	contractor.PossessByPlayer(spender_key)
+	contractor.mind.add_antag_datum(/datum/antagonist/traitor/contractor)
+

--- a/monkestation/code/modules/antagonists/obsessed/obsessed.dm
+++ b/monkestation/code/modules/antagonists/obsessed/obsessed.dm
@@ -94,7 +94,6 @@
 		if(!istype(C))
 			message_admins("Tokener isn't a carbon mob, aborting...")
 			CRASH("Obsessed antag token was spent on a noncarbon.")
-			return
 		if(!C.get_organ_by_type(/obj/item/organ/internal/brain)) // If only I had a brain
 			message_admins("Tokener doesn't have a brain for a brain trauma, aborting...")
 			CRASH("Couldn't find a brain trauma for obsessed antag token")

--- a/monkestation/code/modules/antagonists/obsessed/obsessed.dm
+++ b/monkestation/code/modules/antagonists/obsessed/obsessed.dm
@@ -87,3 +87,19 @@
 	else
 		message_admins("WARNING! [ADMIN_LOOKUPFLW(owner)] obsessed objectives forged without an obsession!")
 		explanation_text = "Free Objective"
+
+/datum/antagonist/obsessed/antag_token(datum/mind/hosts_mind, mob/spender)
+	if(isliving(spender) && hosts_mind)
+		var/mob/living/carbon/C = hosts_mind.current
+		if(!istype(C))
+			message_admins("Tokener isn't a carbon mob, aborting...")
+			CRASH("Obsessed antag token was spent on a noncarbon.")
+			return
+		if(!C.get_organ_by_type(/obj/item/organ/internal/brain)) // If only I had a brain
+			message_admins("Tokener doesn't have a brain for a brain trauma, aborting...")
+			CRASH("Couldn't find a brain trauma for obsessed antag token")
+		C.gain_trauma(/datum/brain_trauma/special/obsessed)//ZAP
+	if(isobserver(spender))
+		var/mob/living/carbon/human/new_mob = spender.change_mob_type(/mob/living/carbon/human, delete_old_mob = TRUE)
+		new_mob.equipOutfit(/datum/outfit/job/assistant)
+		new_mob.gain_trauma(/datum/brain_trauma/special/obsessed)//ZAP

--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/slasher_datum.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/slasher_datum.dm
@@ -546,3 +546,22 @@
 	explanation_text = "Use your traps to slow down your victims."
 	admin_grantable = TRUE
 
+
+/datum/antagonist/slasher/antag_token(datum/mind/hosts_mind, mob/spender)
+	var/spender_key = spender.key
+	if(!spender_key)
+		CRASH("wtf, spender had no key")
+	var/turf/spawn_loc = find_safe_turf_in_maintenance()//Used for the Drop Pod type of spawn for maints only
+	if(isnull(spawn_loc))
+		message_admins("Failed to find valid spawn location for [ADMIN_LOOKUPFLW(spender)], who spent a slasher antag token")
+		CRASH("Failed to find valid spawn location for slasher antag token")
+	if(isliving(spender) && hosts_mind)
+		hosts_mind.current.unequip_everything()
+		new /obj/effect/holy(hosts_mind.current.loc)
+		QDEL_IN(hosts_mind.current, 1 SECOND)
+	var/mob/living/carbon/human/slasher = new (spawn_loc)
+	slasher.PossessByPlayer(spender_key)
+	slasher.mind.add_antag_datum(/datum/antagonist/slasher)
+	if(isobserver(spender))
+		qdel(spender)
+	message_admins("[ADMIN_LOOKUPFLW(slasher)] has been made into a slasher by using an antag token.")


### PR DESCRIPTION
## About The Pull Request
Adds the ***FUNTIONALITY*** to token any of the following

![image](https://github.com/user-attachments/assets/6eda514b-7445-4be6-95cf-111d7792d5f1)

- Obsessed
- Drifting contractors
- Solo abductors
- Slashers
- Nightmares

The actual change will need to be made on the config/server side. But this makes them functional as they involve something extra than just their datum. (Spawn points, brain traumas, gear.)

Other changes include

- Moved a bit of the nightmare code from the event to the On_gain(). This also means giving someone the nightmare datum will transform them into a nightmare now.
- Admin giving abductor datum's will now strip the user before making them into an abductor. This stops issues with missing items/smuggling others into the ship.
## Why It's Good For The Game
More options to how to spend tokens is nice. 
## Changelog
:cl:
add: Adds the functionality for obsessed, drifting contractors, solo abductors, nightmares, and slashers
fix: Making someone into an abductor will no longer smuggle their previous items into the ship.
code: Moved some nightmare code from the event into the antagonist datum.
/:cl:
