### PR TITLE
Giving drones Faction Slime 

### DIFF
--- a/code/modules/mob/living/basic/drone/_drone.dm
+++ b/code/modules/mob/living/basic/drone/_drone.dm
@@ -41,7 +41,7 @@
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	hud_possible = list(DIAG_STAT_HUD, DIAG_HUD, ANTAG_HUD)
 	unique_name = TRUE
-	faction = list(FACTION_NEUTRAL,FACTION_SILICON,FACTION_TURRET)
+	faction = list(FACTION_NEUTRAL,FACTION_SILICON,FACTION_TURRET,FACTION_SLIME)
 	hud_type = /datum/hud/dextrous/drone
 	dexterous = TRUE
 	// Going for a sort of pale green here


### PR DESCRIPTION

## About The Pull Request
closes: #6693
Makes it so drones have the slime faction, and thus aren't harassed by slimes
## Why It's Good For The Game
RP wise?
Drones are mechanical beings. They don't have nutriment or anything of substance to absorb.
Mechanical wise?
A decent portion of ways to remove a slime involve breaking their own laws to not harm anything. Slimes included. Or getting outside help. Either way, best to avoid the hassle and make them ignored by slimes.
## Changelog
:cl:
fix: Slimes now ignore drones.
/:cl:
