### PR TITLE
Plague rats healing

### DIFF
--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -43,6 +43,9 @@
 
 	var/chooses_bodycolor = TRUE
 
+	///can they heal for eating non-cheese
+	var/hungry = FALSE
+
 //MONKESTATION EDIT START
 /mob/living/basic/mouse/get_scream_sound()
 	return 'sound/effects/mousesqueek.ogg'
@@ -171,6 +174,9 @@
 			return //mice savour cheese differently
 		var/datum/component/edible/edible = attack_target.GetComponent(/datum/component/edible)
 		edible.UseByMouse(edible, src)
+		if(hungry)
+			if(prob(90)) //Same chance as cheese heal
+				adjust_health(-4)
 
 		for(var/datum/reagent/target_reagent in attack_target.reagents.reagent_list)
 			if(istype(target_reagent, /datum/reagent/toxin))

--- a/code/modules/mob/living/basic/vermin/mouse.dm
+++ b/code/modules/mob/living/basic/vermin/mouse.dm
@@ -174,9 +174,8 @@
 			return //mice savour cheese differently
 		var/datum/component/edible/edible = attack_target.GetComponent(/datum/component/edible)
 		edible.UseByMouse(edible, src)
-		if(hungry)
-			if(prob(90)) //Same chance as cheese heal
-				adjust_health(-4)
+		if(hungry && prob(90))
+			adjust_health(-4)
 
 		for(var/datum/reagent/target_reagent in attack_target.reagents.reagent_list)
 			if(istype(target_reagent, /datum/reagent/toxin))

--- a/monkestation/code/modules/virology/disease/plague_rat/antagonist.dm
+++ b/monkestation/code/modules/virology/disease/plague_rat/antagonist.dm
@@ -37,7 +37,7 @@
 
 /datum/antagonist/plague_rat/greet()
 	. = ..()
-	to_chat(owner.current, span_warning("<B>You are a [name]! Carrier of a dangerous Bacteria!</B><BR>Try and spread your contagion across the station!"))
+	to_chat(owner.current, span_warning("<B>You are a [name]! Carrier of a dangerous Bacteria!</B><BR>Try and spread your contagion across the station!</B><BR> With a bit of food can help heal your wounds, always keep an eye out for cheese."))
 
 /datum/antagonist/plague_rat/get_team()
 	return rats_rats_we_are_the_rats

--- a/monkestation/code/modules/virology/disease/plague_rat/antagonist.dm
+++ b/monkestation/code/modules/virology/disease/plague_rat/antagonist.dm
@@ -37,7 +37,7 @@
 
 /datum/antagonist/plague_rat/greet()
 	. = ..()
-	to_chat(owner.current, span_warning("<B>You are a [name]! Carrier of a dangerous Bacteria!</B><BR>Try and spread your contagion across the station!</B><BR> With a bit of food can help heal your wounds, always keep an eye out for cheese."))
+	to_chat(owner.current, span_warning("<B>You are a [name]! Carrier of a dangerous Bacteria!</B><BR>Try and spread your contagion across the station!</B><BR> Eating some food can help heal your wounds, always keep an eye out for cheese."))
 
 /datum/antagonist/plague_rat/get_team()
 	return rats_rats_we_are_the_rats

--- a/monkestation/code/modules/virology/disease/plague_rat/plague_rat.dm
+++ b/monkestation/code/modules/virology/disease/plague_rat/plague_rat.dm
@@ -13,6 +13,7 @@
 	melee_damage_upper = 7
 	chooses_bodycolor = FALSE
 	pass_flags = PASSTABLE|PASSGRILLE|PASSMOB|PASSDOORS
+	hungry = TRUE
 
 /mob/living/basic/mouse/plague/Initialize(mapload, tame, new_body_color)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Plague rats can now eat non-cheese foods to heal off a bit of their injuries.
## Why It's Good For The Game
Relevant image
![image](https://github.com/user-attachments/assets/78934432-65c5-4848-8fb2-5cd5bbc9b716)
## Changelog
:cl:
qol: Clarified in plague rat greet text what heals a rat.
balance: Eating normal food now heals a plague rat. albeit a much lesser amount and function than cheese
/:cl:
