### PR TITLE
Fixing digitgrade limbs. Actually this time

### DIFF
--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -41,6 +41,23 @@
 
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT, CLONE = DEFAULT_CLONE_EXAMINE_TEXT)
 	disabling_threshold_percentage = 1
+	var/adjusted = FALSE
+
+/obj/item/bodypart/arm/left/robot/wrench_act(mob/living/user, obj/item/wrench)
+	. = ..()
+	if(.)
+		return TRUE
+	wrench.play_tool_sound(src)
+	if(adjusted)
+		bodytype &= ~(BODYTYPE_DIGITIGRADE)
+		bodytype |= (BODYTYPE_HUMANOID)
+		adjusted = FALSE
+
+	else
+		bodytype &= ~(BODYTYPE_HUMANOID)
+		bodytype |= (BODYTYPE_DIGITIGRADE)
+		adjusted = TRUE
+	to_chat(user, span_notice("You modify [src] to be installed on a [adjusted == TRUE ? "digitigrade" : "humanoid"] body."))
 
 /obj/item/bodypart/arm/right/robot
 	name = "cyborg right arm"
@@ -73,6 +90,23 @@
 	biological_state = (BIO_ROBOTIC|BIO_JOINTED)
 
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT, CLONE = DEFAULT_CLONE_EXAMINE_TEXT)
+	var/adjusted = FALSE
+
+/obj/item/bodypart/arm/right/robot/wrench_act(mob/living/user, obj/item/wrench)
+	. = ..()
+	if(.)
+		return TRUE
+	wrench.play_tool_sound(src)
+	if(adjusted)
+		bodytype &= ~(BODYTYPE_DIGITIGRADE)
+		bodytype |= (BODYTYPE_HUMANOID)
+		adjusted = FALSE
+
+	else
+		bodytype &= ~(BODYTYPE_HUMANOID)
+		bodytype |= (BODYTYPE_DIGITIGRADE)
+		adjusted = TRUE
+	to_chat(user, span_notice("You modify [src] to be installed on a [adjusted == TRUE ? "digitigrade" : "humanoid"] body."))
 
 /obj/item/bodypart/leg/left/robot
 	name = "cyborg left leg"
@@ -105,6 +139,23 @@
 	biological_state = (BIO_ROBOTIC|BIO_JOINTED)
 
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT, CLONE = DEFAULT_CLONE_EXAMINE_TEXT)
+	var/adjusted = FALSE
+
+/obj/item/bodypart/leg/left/robot/wrench_act(mob/living/user, obj/item/wrench)
+	. = ..()
+	if(.)
+		return TRUE
+	wrench.play_tool_sound(src)
+	if(adjusted)
+		bodytype &= ~(BODYTYPE_DIGITIGRADE)
+		bodytype |= (BODYTYPE_HUMANOID)
+		adjusted = FALSE
+
+	else
+		bodytype &= ~(BODYTYPE_HUMANOID)
+		bodytype |= (BODYTYPE_DIGITIGRADE)
+		adjusted = TRUE
+	to_chat(user, span_notice("You modify [src] to be installed on a [adjusted == TRUE ? "digitigrade" : "humanoid"] body."))
 
 /obj/item/bodypart/leg/right/robot
 	name = "cyborg right leg"
@@ -137,6 +188,23 @@
 	biological_state = (BIO_ROBOTIC|BIO_JOINTED)
 
 	damage_examines = list(BRUTE = ROBOTIC_BRUTE_EXAMINE_TEXT, BURN = ROBOTIC_BURN_EXAMINE_TEXT, CLONE = DEFAULT_CLONE_EXAMINE_TEXT)
+	var/adjusted = FALSE
+
+/obj/item/bodypart/leg/right/robot/wrench_act(mob/living/user, obj/item/wrench)
+	. = ..()
+	if(.)
+		return TRUE
+	wrench.play_tool_sound(src)
+	if(adjusted)
+		bodytype &= ~(BODYTYPE_DIGITIGRADE)
+		bodytype |= (BODYTYPE_HUMANOID)
+		adjusted = FALSE
+
+	else
+		bodytype &= ~(BODYTYPE_HUMANOID)
+		bodytype |= (BODYTYPE_DIGITIGRADE)
+		adjusted = TRUE
+	to_chat(user, span_notice("You modify [src] to be installed on a [adjusted == TRUE ? "digitigrade" : "humanoid"] body."))
 
 /obj/item/bodypart/chest/robot
 	name = "cyborg torso"
@@ -170,6 +238,24 @@
 
 	var/wired = FALSE
 	var/obj/item/stock_parts/cell/cell = null
+	var/adjusted = FALSE
+
+/obj/item/bodypart/chest/robot/wrench_act(mob/living/user, obj/item/wrench)
+	. = ..()
+	if(.)
+		return TRUE
+	wrench.play_tool_sound(src)
+	if(adjusted)
+		bodytype &= ~(BODYTYPE_DIGITIGRADE)
+		bodytype |= (BODYTYPE_HUMANOID)
+		adjusted = FALSE
+
+	else
+		bodytype &= ~(BODYTYPE_HUMANOID)
+		bodytype |= (BODYTYPE_DIGITIGRADE)
+		adjusted = TRUE
+	to_chat(user, span_notice("You modify [src] to be installed on a [adjusted == TRUE ? "digitigrade" : "humanoid"] body."))
+
 
 /obj/item/bodypart/chest/robot/get_cell()
 	return cell
@@ -281,6 +367,23 @@
 
 	var/obj/item/assembly/flash/handheld/flash1 = null
 	var/obj/item/assembly/flash/handheld/flash2 = null
+	var/adjusted = FALSE
+
+/obj/item/bodypart/head/robot/wrench_act(mob/living/user, obj/item/wrench)
+	. = ..()
+	if(.)
+		return TRUE
+	wrench.play_tool_sound(src)
+	if(adjusted)
+		bodytype &= ~(BODYTYPE_DIGITIGRADE)
+		bodytype |= (BODYTYPE_HUMANOID)
+		adjusted = FALSE
+
+	else
+		bodytype &= ~(BODYTYPE_HUMANOID)
+		bodytype |= (BODYTYPE_DIGITIGRADE)
+		adjusted = TRUE
+	to_chat(user, span_notice("You modify [src] to be installed on a [adjusted == TRUE ? "digitigrade" : "humanoid"] body."))
 
 /obj/item/bodypart/head/robot/Exited(atom/movable/gone, direction)
 	. = ..()

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/ornithid.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/ornithid.dm
@@ -25,7 +25,7 @@ GLOBAL_LIST_EMPTY(tails_list_avian)
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/ornithid,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/ornithid,
-		BODY_ZONE_HEAD = /obj/item/bodypart/head, // just because they are still *partially* human, or otherwise human resembling
+		BODY_ZONE_HEAD = /obj/item/bodypart/head/ornithid, // just because they are still *partially* human, or otherwise human resembling
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/ornithid,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/ornithid,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/ornithid,
@@ -48,56 +48,6 @@ GLOBAL_LIST_EMPTY(tails_list_avian)
 	human.hairstyle = "Half-banged Hair"
 	human.set_haircolor(COLOR_BROWNER_BROWN)
 	human.update_body(TRUE)
-
-// defines limbs/bodyparts.
-
-/obj/item/bodypart/arm/left/ornithid
-	limb_id = SPECIES_ORNITHID
-	icon_greyscale = 'monkestation/code/modules/the_bird_inside_of_me/icons/ornithid_parts_greyscale.dmi'
-	unarmed_attack_verb = "slash"
-	unarmed_attack_effect = ATTACK_EFFECT_CLAW
-	unarmed_attack_sound = 'sound/weapons/slice.ogg'
-	unarmed_miss_sound = 'sound/weapons/slashmiss.ogg'
-
-
-/obj/item/bodypart/arm/right/ornithid
-	limb_id = SPECIES_ORNITHID
-	icon_greyscale = 'monkestation/code/modules/the_bird_inside_of_me/icons/ornithid_parts_greyscale.dmi'
-	unarmed_attack_verb = "slash"
-	unarmed_attack_effect = ATTACK_EFFECT_CLAW
-	unarmed_attack_sound = 'sound/weapons/slice.ogg'
-	unarmed_miss_sound = 'sound/weapons/slashmiss.ogg'
-
-/obj/item/bodypart/chest/ornithid
-	acceptable_bodytype = BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
-
-/obj/item/bodypart/leg/left/ornithid
-	limb_id = SPECIES_ORNITHID
-	digitigrade_id = SPECIES_ORNITHID
-	icon_greyscale = 'monkestation/code/modules/the_bird_inside_of_me/icons/ornithid_parts_greyscale.dmi'
-	bodytype = BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
-	bodypart_traits = list(TRAIT_HARD_SOLES, TRAIT_NON_IMPORTANT_SHOE_BLOCK)
-	step_sounds = list(
-		'sound/effects/footstep/hardclaw1.ogg',
-		'sound/effects/footstep/hardclaw2.ogg',
-		'sound/effects/footstep/hardclaw3.ogg',
-		'sound/effects/footstep/hardclaw4.ogg',
-		'sound/effects/footstep/hardclaw1.ogg',
-	)
-
-/obj/item/bodypart/leg/right/ornithid
-	limb_id = SPECIES_ORNITHID
-	digitigrade_id = SPECIES_ORNITHID
-	icon_greyscale = 'monkestation/code/modules/the_bird_inside_of_me/icons/ornithid_parts_greyscale.dmi'
-	bodytype = BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
-	bodypart_traits = list(TRAIT_HARD_SOLES, TRAIT_NON_IMPORTANT_SHOE_BLOCK)
-	step_sounds = list(
-		'sound/effects/footstep/hardclaw1.ogg',
-		'sound/effects/footstep/hardclaw2.ogg',
-		'sound/effects/footstep/hardclaw3.ogg',
-		'sound/effects/footstep/hardclaw4.ogg',
-		'sound/effects/footstep/hardclaw1.ogg',
-	)
 
 // section for lore/perk descs
 /datum/species/ornithid/get_species_lore()

--- a/monkestation/code/modules/surgery/bodyparts/ornithid_bodyparts.dm
+++ b/monkestation/code/modules/surgery/bodyparts/ornithid_bodyparts.dm
@@ -1,0 +1,55 @@
+
+// defines limbs/bodyparts.
+/obj/item/bodypart/head/ornithid
+	limb_id = SPECIES_ORNITHID
+	bodytype = BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
+
+/obj/item/bodypart/arm/left/ornithid
+	limb_id = SPECIES_ORNITHID
+	icon_greyscale = 'monkestation/code/modules/the_bird_inside_of_me/icons/ornithid_parts_greyscale.dmi'
+	unarmed_attack_verb = "slash"
+	unarmed_attack_effect = ATTACK_EFFECT_CLAW
+	unarmed_attack_sound = 'sound/weapons/slice.ogg'
+	unarmed_miss_sound = 'sound/weapons/slashmiss.ogg'
+	bodytype = BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
+
+
+/obj/item/bodypart/arm/right/ornithid
+	limb_id = SPECIES_ORNITHID
+	icon_greyscale = 'monkestation/code/modules/the_bird_inside_of_me/icons/ornithid_parts_greyscale.dmi'
+	unarmed_attack_verb = "slash"
+	unarmed_attack_effect = ATTACK_EFFECT_CLAW
+	unarmed_attack_sound = 'sound/weapons/slice.ogg'
+	unarmed_miss_sound = 'sound/weapons/slashmiss.ogg'
+	bodytype = BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
+
+/obj/item/bodypart/chest/ornithid
+	bodytype = BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
+
+/obj/item/bodypart/leg/left/ornithid
+	limb_id = SPECIES_ORNITHID
+	digitigrade_id = SPECIES_ORNITHID
+	icon_greyscale = 'monkestation/code/modules/the_bird_inside_of_me/icons/ornithid_parts_greyscale.dmi'
+	bodytype = BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
+	bodypart_traits = list(TRAIT_HARD_SOLES, TRAIT_NON_IMPORTANT_SHOE_BLOCK)
+	step_sounds = list(
+		'sound/effects/footstep/hardclaw1.ogg',
+		'sound/effects/footstep/hardclaw2.ogg',
+		'sound/effects/footstep/hardclaw3.ogg',
+		'sound/effects/footstep/hardclaw4.ogg',
+		'sound/effects/footstep/hardclaw1.ogg',
+	)
+
+/obj/item/bodypart/leg/right/ornithid
+	limb_id = SPECIES_ORNITHID
+	digitigrade_id = SPECIES_ORNITHID
+	icon_greyscale = 'monkestation/code/modules/the_bird_inside_of_me/icons/ornithid_parts_greyscale.dmi'
+	bodytype = BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
+	bodypart_traits = list(TRAIT_HARD_SOLES, TRAIT_NON_IMPORTANT_SHOE_BLOCK)
+	step_sounds = list(
+		'sound/effects/footstep/hardclaw1.ogg',
+		'sound/effects/footstep/hardclaw2.ogg',
+		'sound/effects/footstep/hardclaw3.ogg',
+		'sound/effects/footstep/hardclaw4.ogg',
+		'sound/effects/footstep/hardclaw1.ogg',
+	)

--- a/monkestation/code/modules/surgery/bodyparts/satyr_bodyparts.dm
+++ b/monkestation/code/modules/surgery/bodyparts/satyr_bodyparts.dm
@@ -3,6 +3,7 @@
 	limb_id = SPECIES_SATYR
 	is_dimorphic = TRUE
 	head_flags = HEAD_HAIR | HEAD_FACIAL_HAIR | HEAD_EYESPRITES | HEAD_EYECOLOR | HEAD_EYEHOLES | HEAD_DEBRAIN
+	bodytype = BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
 
 /obj/item/bodypart/chest/satyr
 	icon_greyscale = 'monkestation/code/modules/ranching/icons/bodyparts.dmi'
@@ -13,10 +14,12 @@
 /obj/item/bodypart/arm/left/satyr
 	icon_greyscale = 'monkestation/code/modules/ranching/icons/bodyparts.dmi'
 	limb_id = SPECIES_SATYR
+	bodytype = BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
 
 /obj/item/bodypart/arm/right/satyr
 	icon_greyscale = 'monkestation/code/modules/ranching/icons/bodyparts.dmi'
 	limb_id = SPECIES_SATYR
+	bodytype = BODYTYPE_ORGANIC | BODYTYPE_DIGITIGRADE
 
 /obj/item/bodypart/leg/left/satyr
 	icon_greyscale = 'monkestation/code/modules/ranching/icons/bodyparts.dmi'

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8526,6 +8526,7 @@
 #include "monkestation\code\modules\surgery\bodyparts\ipc_bodyparts.dm"
 #include "monkestation\code\modules\surgery\bodyparts\monkey_bodyparts.dm"
 #include "monkestation\code\modules\surgery\bodyparts\oozeling_bodyparts.dm"
+#include "monkestation\code\modules\surgery\bodyparts\ornithid_bodyparts.dm"
 #include "monkestation\code\modules\surgery\bodyparts\satyr_bodyparts.dm"
 #include "monkestation\code\modules\surgery\bodyparts\teratoma_bodyparts.dm"
 #include "monkestation\code\modules\surgery\organs\augments.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- All of the bird and satyr limbs are BODYTYPE_DIGITIGRADE by default. Meaning they can reattach all their limbs.
- Robotic limbs can be adjusted to fit BODYTYPE_DIGITGRADE or BODYTYPE_HUMANIOD via using a wrench on the limb. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes losing a arm as either of these races much, much, less painful
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Robotic limbs can now be adjusted to fit satyrs and orthinid's by using a wrench on the limbs
fix: All of satyrs and orthinids limbs will now fit, a satyr or orthinid
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
