### PR TITLE
Seed Meshes can no longer yield gatfruit or evil seedlings

### DIFF
--- a/monkestation/code/modules/blueshift/items/ash_walker.dm
+++ b/monkestation/code/modules/blueshift/items/ash_walker.dm
@@ -59,7 +59,7 @@
 	desc = "A little mesh that, when paired with sand, has the possibility of filtering out large seeds."
 	icon = 'monkestation/code/modules/blueshift/icons/misc_tools.dmi'
 	icon_state = "mesh"
-	var/list/static/seeds_blacklist = list(
+	var/static/list/seeds_blacklist = list(
 		/obj/item/seeds/lavaland, // abstract type
 		/obj/item/seeds/spliced, // not supposed to exist on its own, as its "managed" by splicers
 		/obj/item/seeds/gatfruit,

--- a/monkestation/code/modules/blueshift/items/ash_walker.dm
+++ b/monkestation/code/modules/blueshift/items/ash_walker.dm
@@ -60,7 +60,10 @@
 	icon = 'monkestation/code/modules/blueshift/icons/misc_tools.dmi'
 	icon_state = "mesh"
 	var/list/static/seeds_blacklist = list(
-		/obj/item/seeds/lavaland,
+		/obj/item/seeds/lavaland, // abstract type
+		/obj/item/seeds/spliced, // not supposed to exist on its own, as its "managed" by splicers
+		/obj/item/seeds/gatfruit,
+		/obj/item/seeds/seedling/evil,
 	)
 
 /obj/item/seed_mesh/attackby(obj/item/attacking_item, mob/user, params)


### PR DESCRIPTION

## About The Pull Request

this blacklists gatfruit and evil seedling seeds from seed meshes

also spliced seeds bc those aren't meant to exist without being "set up" by a splicer anyways.
## Why It's Good For The Game

![2025-05-20 (1747713981) ~ dreamseeker](https://github.com/user-attachments/assets/f5955189-0145-4d71-8ab8-4f787bdceace)

![2025-05-20 (1747713996) ~ dreamseeker](https://github.com/user-attachments/assets/085850f6-b04a-420c-b829-44fe91dedf35)

## Changelog
:cl:
balance: Seed Meshes can no longer yield gatfruit or evil seedlings.
/:cl:
