### PR TITLE
Evil Disease Cures

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -925,6 +925,8 @@ GLOBAL_LIST_INIT(layers_to_offset, list(
 #define HEAL_CC_STATUS (1<<18)
 /// Deletes any restraints on the mob (handcuffs / legcuffs)
 #define HEAL_RESTRAINTS (1<<19)
+/// Heals any postive diseases
+#define HEAL_POSTIVE_DISEASES (1<<20)
 
 /// Combination flag to only heal the main damage types.
 #define HEAL_DAMAGE (HEAL_BRUTE|HEAL_BURN|HEAL_TOX|HEAL_OXY|HEAL_CLONE|HEAL_STAM)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -439,7 +439,7 @@
 
 /obj/item/storage/box/syndie_kit/chemical/Initialize(mapload)
 	. = ..()
-	atom_storage.max_slots = 14
+	atom_storage.max_slots = 15
 
 /obj/item/storage/box/syndie_kit/chemical/PopulateContents()
 	new /obj/item/reagent_containers/cup/bottle/polonium(src)
@@ -455,6 +455,7 @@
 	new /obj/item/reagent_containers/cup/bottle/coniine(src)
 	new /obj/item/reagent_containers/cup/bottle/curare(src)
 	new /obj/item/reagent_containers/cup/bottle/amanitin(src)
+	new /obj/item/reagent_containers/cup/bottle/antipathogenic_changeling(src)
 	new /obj/item/reagent_containers/syringe(src)
 
 /obj/item/storage/box/syndie_kit/nuke

--- a/code/modules/antagonists/monster_hunters/tools/blood_vial.dm
+++ b/code/modules/antagonists/monster_hunters/tools/blood_vial.dm
@@ -77,6 +77,7 @@
 /datum/status_effect/cursed_blood/on_apply()
 	to_chat(owner, span_warning("You feel a great power surging through you!"))
 	owner.add_movespeed_modifier(/datum/movespeed_modifier/cursed_blood)
+	owner.fully_heal(HEAL_NEGATIVE_DISEASES)
 	return TRUE
 
 /datum/status_effect/cursed_blood/on_remove()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -939,6 +939,12 @@
 			if(disease.severity != DISEASE_SEVERITY_POSITIVE)
 				disease.cure(FALSE)
 
+	if(heal_flags & HEAL_POSTIVE_DISEASES)
+		for(var/datum/disease/disease as anything in diseases)
+			if(disease.severity == DISEASE_SEVERITY_POSITIVE)
+				disease.cure(FALSE)
+		for(var/)
+
 	if(heal_flags & HEAL_WOUNDS)
 		for(var/datum/wound/wound as anything in all_wounds)
 			wound.remove_wound()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -943,7 +943,6 @@
 		for(var/datum/disease/disease as anything in diseases)
 			if(disease.severity == DISEASE_SEVERITY_POSITIVE)
 				disease.cure(FALSE)
-		for(var/)
 
 	if(heal_flags & HEAL_WOUNDS)
 		for(var/datum/wound/wound as anything in all_wounds)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2832,6 +2832,7 @@
 		drinker.adjustBruteLoss(-2 * REM * seconds_per_tick, FALSE)
 		drinker.adjustFireLoss(-2 * REM * seconds_per_tick, FALSE)
 		drinker.cause_pain(BODY_ZONES_ALL, -5 * REM * seconds_per_tick) // MONKESTATION ADDITION
+		drinker.fully_heal(HEAL_NEGATIVE_DISEASES)
 		if(drinker.blood_volume < BLOOD_VOLUME_NORMAL)
 			drinker.blood_volume += 3 * REM * seconds_per_tick
 	else
@@ -2840,6 +2841,7 @@
 		drinker.adjustFireLoss(2 * REM * seconds_per_tick, FALSE)
 		drinker.adjustOxyLoss(2 * REM * seconds_per_tick, FALSE)
 		drinker.adjustBruteLoss(2 * REM * seconds_per_tick, FALSE)
+		drinker.fully_heal(HEAL_NEGATIVE_DISEASES)
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -2841,7 +2841,7 @@
 		drinker.adjustFireLoss(2 * REM * seconds_per_tick, FALSE)
 		drinker.adjustOxyLoss(2 * REM * seconds_per_tick, FALSE)
 		drinker.adjustBruteLoss(2 * REM * seconds_per_tick, FALSE)
-		drinker.fully_heal(HEAL_NEGATIVE_DISEASES)
+		drinker.fully_heal(HEAL_POSTIVE_DISEASES)
 	..()
 	return TRUE
 

--- a/code/modules/reagents/reagent_containers/cups/bottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/bottle.dm
@@ -527,3 +527,9 @@
 	name = "bottle of laugh syrup"
 	desc = "A pump bottle containing laugh syrup. The product of juicing Laughin' Peas. Fizzy, and seems to change flavour based on what it's used with!"
 	list_reagents = list(/datum/reagent/consumable/laughsyrup = 50)
+
+//Changeling stuff
+/obj/item/reagent_containers/cup/bottle/antipathogenic_changeling
+	name = "Changeling Immunoglobulin bottle"
+	desc = "A small bottle. Contains Changeling Immunoglobulin."
+	list_reagents = list(/datum/reagent/medicine/antipathogenic/changeling = 30)


### PR DESCRIPTION
## About The Pull Request
Adds onto already existing medicinal options for different antagonists to be able to rapidly cure different diseases.

- Traitors & anyone with similar uplinks - Chemical Kits now come with Changeling Immunoglobulin bottle.
- Monster hunters - Blood vials now purge them of any negative disease. 
- Heretics - Eldritch flasks now cures heretics of any negative disease, while heathens who consume it get rid of the positive.
## Why It's Good For The Game
Diseases can be very painful to deal with currently depending on a variety of factors. While writing a guide, I noticed some antagonists had some potential to deal with diseases that could be useful if implemented.

- Syndicate chemical gain the chemical Changeling Immunoglobulin. This used to be how changelings previously removed diseases before being transformed into a status effect (Changeling Pancea). Now the syndicate have begun harvesting the chemical through unknown means from the hivemind.
The most powerful antipathogen that cures all antibody-based diseases. Prevents reinfection. Can be used to cure oneself of a dangerous disease. Or a victim of anything pathogens that may keep them alive.

- Heretics' Eldritch flask keeps with the theme of being good for the heretic, bad for the heathen. When drinking eldritch essence, cures the heretic of any bad diseases. The heathen of any positive ones, this does not give antibodies and allows for reinfection.

- Monster hunters' Blood vials now cure of any negative diseases. Simple as. It can only be recharged through their visit to Wonderland, so it still has to be used sparingly. Mostly to keep in line of giving it's targets and the other medium threats options to cure bad diseases also. (Bloodsuckers natural immunity, Changelings' Panacea ability, and Heretics' new flask change.)
## Changelog
:cl:
add: Chemical kits now come with a new chemical vial. Changeling Immunoglobulin, harvested from its namesake, a powerful antipathogen that can instantly cure most diseases.
balance: Heretic Eldritch Flask now cleanses heretics of negative diseases and heathens of any positive ones. Reinfection is still possible in both cases.
balance: Monster Hunter blood flask now cures the drinker of any negative diseases upon consumption. Reinfection is still possible.
/:cl:
