### PR TITLE
fix runtime spam with autocloners

### DIFF
--- a/monkestation/code/game/machinery/computer/cloning.dm
+++ b/monkestation/code/game/machinery/computer/cloning.dm
@@ -519,6 +519,8 @@
 
 /obj/machinery/computer/cloning/proc/scan_occupant(occupant, mob/M, body_only)
 	var/mob/living/mob_occupant = get_mob_or_brainmob(occupant)
+	if(QDELETED(mob_occupant))
+		return
 	var/datum/dna/dna
 	var/datum/bank_account/has_bank_account
 


### PR DESCRIPTION

## About The Pull Request

this makes it so `/obj/machinery/computer/cloning/proc/scan_occupant` won't try to scan if `get_mob_or_brainmob(occupant)` returns null

## Why It's Good For The Game

runtime spam bad

## Changelog

no player-facing changes