### PR TITLE
Fix the "Open Map" button

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -734,3 +734,6 @@
 	default = 100
 	min_val = 0
 	max_val = 100
+
+/datum/config_entry/text/webmap_url
+	default = "https://maps.monkestation.com/maps/Monkestation/$map"

--- a/code/modules/escape_menu/home_page.dm
+++ b/code/modules/escape_menu/home_page.dm
@@ -84,8 +84,9 @@
 
 /datum/escape_menu/proc/open_map()
 	var/map_name = replacetext_char(trimtext(SSmapping.current_map.map_name), " ", "")
+	var/url = replacetext_char(CONFIG_GET(text/webmap_url), "$map", map_name)
 	if(client)
-		client << link("https://maps.monkestation.com/Monke/[map_name]")
+		client << link(url)
 
 /datum/escape_menu/proc/home_open_settings()
 	client?.prefs.ui_interact(client?.mob)

--- a/config/config.txt
+++ b/config/config.txt
@@ -570,3 +570,7 @@ CONFIG_ERRORS_RUNTIME
 ## Tgui payloads larger than the 2kb limit for BYOND topic requests are split into roughly 1kb chunks and sent in sequence.
 ## This config option limits the maximum chunk count for which the server will accept a payload, default is 32
 TGUI_MAX_CHUNK_COUNT 32
+
+# The URL for webmaps.
+# $map will be replaced with the current map's name (with spaces removed)
+WEBMAP_URL https://maps.monkestation.com/maps/Monkestation/$map


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix The "Open Maps" option in the escape menu now works again.
config: The webmap URL can now be set via the config.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
