### PR TITLE
Kills `seconds_per_tick` from status effect `tick`, replaces it with `seconds_between_ticks` to clarify some things

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -480,17 +480,17 @@
 	tick_interval = 0.4 SECONDS
 	alert_type = /atom/movable/screen/alert/status_effect/nest_sustenance
 
-/datum/status_effect/nest_sustenance/tick(seconds_per_tick, times_fired)
+/datum/status_effect/nest_sustenance/tick(seconds_between_ticks, times_fired)
 	. = ..()
 
 	if(owner.stat == DEAD) //If the victim has died due to complications in the nest
 		qdel(src)
 		return
 
-	owner.adjustBruteLoss(-2 * seconds_per_tick, updating_health = FALSE)
-	owner.adjustFireLoss(-2 * seconds_per_tick, updating_health = FALSE)
-	owner.adjustOxyLoss(-4 * seconds_per_tick, updating_health = FALSE)
-	owner.stamina.adjust(4 * seconds_per_tick)
+	owner.adjustBruteLoss(-2 * seconds_between_ticks, updating_health = FALSE)
+	owner.adjustFireLoss(-2 * seconds_between_ticks, updating_health = FALSE)
+	owner.adjustOxyLoss(-4 * seconds_between_ticks, updating_health = FALSE)
+	owner.stamina.adjust(4 * seconds_between_ticks)
 	owner.adjust_bodytemperature(INFINITY, max_temp = owner.standard_body_temperature) //Won't save you from the void of space, but it will stop you from freezing or suffocating in low pressure
 
 

--- a/code/datums/status_effects/debuffs/blindness.dm
+++ b/code/datums/status_effects/debuffs/blindness.dm
@@ -100,7 +100,7 @@
 /datum/status_effect/temporary_blindness/on_remove()
 	owner.cure_blind(id)
 
-/datum/status_effect/temporary_blindness/tick(seconds_per_tick, times_fired)
+/datum/status_effect/temporary_blindness/tick(seconds_between_ticks, times_fired)
 	if(owner.stat == DEAD)
 		return
 
@@ -116,7 +116,7 @@
 		return
 
 	// Otherwise add a chance to let them know that it's working
-	else if(SPT_PROB(5, seconds_per_tick))
+	else if(SPT_PROB(5, seconds_between_ticks))
 		var/obj/item/thing_covering_eyes = owner.is_eyes_covered()
 		// "Your blindfold soothes your eyes", for example
 		to_chat(owner, span_green("Your [thing_covering_eyes?.name || "eye covering"] soothes your eyes."))

--- a/code/datums/status_effects/debuffs/choke.dm
+++ b/code/datums/status_effects/debuffs/choke.dm
@@ -267,23 +267,23 @@
 		victim.adjustBruteLoss(0.2)
 	return TRUE
 
-/datum/status_effect/choke/tick(seconds_per_tick)
+/datum/status_effect/choke/tick(seconds_between_ticks)
 	if(!should_do_effects())
 		return
 
-	deal_damage(seconds_per_tick)
+	deal_damage(seconds_between_ticks)
 
 	var/client/client_owner = owner.client
 	if(client_owner)
 		do_vfx(client_owner)
 
-/datum/status_effect/choke/proc/deal_damage(seconds_per_tick)
-	owner.losebreath += 1 * seconds_per_tick // 1 breath loss a second. This will deal additional breath damage, and prevent breathing
+/datum/status_effect/choke/proc/deal_damage(seconds_between_ticks)
+	owner.losebreath += 1 * seconds_between_ticks // 1 breath loss a second. This will deal additional breath damage, and prevent breathing
 	if(flaming)
 		var/obj/item/bodypart/head = owner.get_bodypart(BODY_ZONE_HEAD)
 		if(head)
-			head.receive_damage(0, 2 * seconds_per_tick)
-		owner.stamina.adjust(-2 * seconds_per_tick)
+			head.receive_damage(0, 2 * seconds_between_ticks)
+		owner.stamina.adjust(-2 * seconds_between_ticks)
 
 /datum/status_effect/choke/proc/do_vfx(client/vfx_on)
 	var/old_x = delta_x

--- a/code/datums/status_effects/debuffs/drowsiness.dm
+++ b/code/datums/status_effects/debuffs/drowsiness.dm
@@ -27,7 +27,7 @@
 
 	remove_duration(rand(4 SECONDS, 6 SECONDS))
 
-/datum/status_effect/drowsiness/tick(seconds_per_tick)
+/datum/status_effect/drowsiness/tick(seconds_between_ticks)
 	// You do not feel drowsy while unconscious or in stasis
 	if(owner.stat >= UNCONSCIOUS || HAS_TRAIT(owner, TRAIT_STASIS))
 		return

--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -143,7 +143,7 @@
 	/// Cached particle type
 	var/cached_state
 
-/datum/status_effect/fire_handler/fire_stacks/tick(seconds_per_tick, times_fired)
+/datum/status_effect/fire_handler/fire_stacks/tick(seconds_between_ticks, times_fired)
 	var/turf/source_turf = get_turf(owner)
 	if(istype(source_turf, /turf/open/floor/plating/ocean))
 		qdel(src)
@@ -157,11 +157,11 @@
 		return TRUE
 
 	if(HAS_TRAIT(owner, TRAIT_HUSK))
-		adjust_stacks(-2 * seconds_per_tick)
+		adjust_stacks(-2 * seconds_between_ticks)
 		if(stacks <= 0)
 			extinguish()
 	else
-		adjust_stacks(owner.fire_stack_decay_rate * seconds_per_tick)
+		adjust_stacks(owner.fire_stack_decay_rate * seconds_between_ticks)
 
 	if(stacks <= 0)
 		qdel(src)
@@ -172,7 +172,7 @@
 		qdel(src)
 		return TRUE
 
-	deal_damage(seconds_per_tick)
+	deal_damage(seconds_between_ticks)
 
 /datum/status_effect/fire_handler/fire_stacks/update_particles()
 	if (!on_fire)
@@ -197,23 +197,23 @@
  * Proc that handles damage dealing and all special effects
  *
  * Arguments:
- * - seconds_per_tick
+ * - seconds_between_ticks
  * - times_fired
  *
  */
 
-/datum/status_effect/fire_handler/fire_stacks/proc/deal_damage(seconds_per_tick, times_fired, no_protection = FALSE)
-	owner.on_fire_stack(seconds_per_tick, times_fired, src)
+/datum/status_effect/fire_handler/fire_stacks/proc/deal_damage(seconds_between_ticks, times_fired, no_protection = FALSE)
+	owner.on_fire_stack(seconds_between_ticks, times_fired, src)
 
 	var/turf/location = get_turf(owner)
-	location.hotspot_expose(700, 25 * seconds_per_tick, TRUE)
+	location.hotspot_expose(700, 25 * seconds_between_ticks, TRUE)
 
 	if(ishuman(owner) && !no_protection)
 		var/mob/living/carbon/human/victim = owner
 		if(victim.get_thermal_protection() >= FIRE_SUIT_MAX_TEMP_PROTECT)
 			return
 
-	owner.adjust_bodytemperature((stacks KELVIN) * seconds_per_tick)
+	owner.adjust_bodytemperature((stacks KELVIN) * seconds_between_ticks)
 	switch(ticks_on_fire)
 		if(0 to 3)
 			owner.apply_damage(0.10 * stacks, BURN)
@@ -223,7 +223,7 @@
 			owner.apply_damage(0.30 * stacks, BURN)
 		if(10 to INFINITY)
 			owner.apply_damage(0.50 * stacks, BURN)
-	ticks_on_fire += 1 * seconds_per_tick
+	ticks_on_fire += 1 * seconds_between_ticks
 
 /**
  * Handles mob ignition, should be the only way to set on_fire to TRUE
@@ -311,7 +311,7 @@
 	. = ..()
 	owner.remove_shared_particles(/particles/droplets)
 
-/datum/status_effect/fire_handler/wet_stacks/tick(seconds_per_tick)
-	adjust_stacks(-0.5 * seconds_per_tick)
+/datum/status_effect/fire_handler/wet_stacks/tick(seconds_between_ticks)
+	adjust_stacks(-0.5 * seconds_between_ticks)
 	if(stacks <= 0)
 		qdel(src)

--- a/code/datums/status_effects/debuffs/genetic_damage.dm
+++ b/code/datums/status_effects/debuffs/genetic_damage.dm
@@ -31,17 +31,17 @@
 	. = ..()
 	src.total_damage += total_damage
 
-/datum/status_effect/genetic_damage/tick(seconds_per_tick, times_fired)
-	if(ismonkey(owner) && total_damage >= GORILLA_MUTATION_MINIMUM_DAMAGE && SPT_PROB(GORILLA_MUTATION_CHANCE_PER_SECOND, seconds_per_tick))
+/datum/status_effect/genetic_damage/tick(seconds_between_ticks, times_fired)
+	if(ismonkey(owner) && total_damage >= GORILLA_MUTATION_MINIMUM_DAMAGE && SPT_PROB(GORILLA_MUTATION_CHANCE_PER_SECOND, seconds_between_ticks))
 		var/mob/living/carbon/carbon_owner = owner
 		carbon_owner.gorillize()
 		qdel(src)
 		return
 
 	if(total_damage >= minimum_before_tox_damage)
-		owner.adjustToxLoss(toxin_damage_per_second * seconds_per_tick)
+		owner.adjustToxLoss(toxin_damage_per_second * seconds_between_ticks)
 
-	total_damage -= remove_per_second * seconds_per_tick
+	total_damage -= remove_per_second * seconds_between_ticks
 	if(total_damage <= 0)
 		qdel(src)
 		return

--- a/code/datums/status_effects/debuffs/hallucination.dm
+++ b/code/datums/status_effects/debuffs/hallucination.dm
@@ -68,7 +68,7 @@
 	source.cause_hallucination(/datum/hallucination/shock, "hallucinated shock from [bumped]",)
 	return STOP_BUMP
 
-/datum/status_effect/hallucination/tick(seconds_per_tick, times_fired)
+/datum/status_effect/hallucination/tick(seconds_between_ticks, times_fired)
 	if(owner.stat == DEAD)
 		return
 	if(!COOLDOWN_FINISHED(src, hallucination_cooldown))
@@ -94,7 +94,7 @@
 /datum/status_effect/hallucination/sanity/refresh(...)
 	update_intervals()
 
-/datum/status_effect/hallucination/sanity/tick(seconds_per_tick, times_fired)
+/datum/status_effect/hallucination/sanity/tick(seconds_between_ticks, times_fired)
 	// Using psicodine / happiness / whatever to become fearless will stop sanity based hallucinations
 	if(HAS_TRAIT(owner, TRAIT_FEARLESS))
 		return

--- a/code/datums/status_effects/debuffs/screen_blur.dm
+++ b/code/datums/status_effects/debuffs/screen_blur.dm
@@ -31,7 +31,7 @@
 	var/atom/movable/plane_master_controller/game_plane_master_controller = owner.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	game_plane_master_controller.remove_filter("eye_blur")
 
-/datum/status_effect/eye_blur/tick(seconds_per_tick, times_fired)
+/datum/status_effect/eye_blur/tick(seconds_between_ticks, times_fired)
 	// Blur lessens the closer we are to expiring, so we update per tick.
 	update_blur()
 

--- a/code/datums/status_effects/debuffs/terrified.dm
+++ b/code/datums/status_effects/debuffs/terrified.dm
@@ -38,7 +38,7 @@
 	UnregisterSignal(owner, COMSIG_CARBON_HELPED)
 	owner.remove_fov_trait(id, FOV_270_DEGREES)
 
-/datum/status_effect/terrified/tick(seconds_per_tick, times_fired)
+/datum/status_effect/terrified/tick(seconds_between_ticks, times_fired)
 	if(check_surrounding_darkness())
 		if(terror_buildup < DARKNESS_TERROR_CAP)
 			terror_buildup += DARKNESS_TERROR_AMOUNT
@@ -50,14 +50,14 @@
 		return
 
 	if(terror_buildup >= TERROR_FEAR_THRESHOLD) //The onset, minor effects of terror buildup
-		owner.adjust_dizzy_up_to(10 SECONDS * seconds_per_tick, 10 SECONDS)
-		owner.adjust_stutter_up_to(10 SECONDS * seconds_per_tick, 10 SECONDS)
-		owner.adjust_jitter_up_to(10 SECONDS * seconds_per_tick, 10 SECONDS)
+		owner.adjust_dizzy_up_to(10 SECONDS * seconds_between_ticks, 10 SECONDS)
+		owner.adjust_stutter_up_to(10 SECONDS * seconds_between_ticks, 10 SECONDS)
+		owner.adjust_jitter_up_to(10 SECONDS * seconds_between_ticks, 10 SECONDS)
 
 	if(terror_buildup >= TERROR_PANIC_THRESHOLD) //If you reach this amount of buildup in an engagement, it's time to start looking for a way out.
 		owner.playsound_local(get_turf(owner), 'sound/health/slowbeat.ogg', 40, 0, channel = CHANNEL_HEARTBEAT, use_reverb = FALSE)
 		owner.add_fov_trait(id, FOV_270_DEGREES) //Terror induced tunnel vision
-		owner.adjust_eye_blur_up_to(10 SECONDS * seconds_per_tick, 10 SECONDS)
+		owner.adjust_eye_blur_up_to(10 SECONDS * seconds_between_ticks, 10 SECONDS)
 		if(prob(5)) //We have a little panic attack. Consider it GENTLE ENCOURAGEMENT to start running away.
 			freak_out(PANIC_ATTACK_TERROR_AMOUNT)
 			owner.visible_message(

--- a/code/modules/antagonists/heretic/magic/ash_ascension.dm
+++ b/code/modules/antagonists/heretic/magic/ash_ascension.dm
@@ -44,7 +44,7 @@
 	src.ring_radius = radius
 	return ..()
 
-/datum/status_effect/fire_ring/tick(seconds_per_tick, times_fired)
+/datum/status_effect/fire_ring/tick(seconds_between_ticks, times_fired)
 	if(QDELETED(owner) || owner.stat == DEAD)
 		qdel(src)
 		return
@@ -55,9 +55,9 @@
 	for(var/turf/nearby_turf as anything in RANGE_TURFS(1, owner))
 		var/obj/effect/hotspot/flame_tile = locate(nearby_turf) || new(nearby_turf)
 		flame_tile.alpha = 125
-		nearby_turf.hotspot_expose(750, 25 * seconds_per_tick, 1)
+		nearby_turf.hotspot_expose(750, 25 * seconds_between_ticks, 1)
 		for(var/mob/living/fried_living in nearby_turf.contents - owner)
-			fried_living.apply_damage(2.5 * seconds_per_tick, BURN)
+			fried_living.apply_damage(2.5 * seconds_between_ticks, BURN)
 
 /// Creates one, large, expanding ring of fire around the caster, which does not follow them.
 /datum/action/cooldown/spell/fire_cascade

--- a/code/modules/antagonists/heretic/magic/fire_blast.dm
+++ b/code/modules/antagonists/heretic/magic/fire_blast.dm
@@ -136,7 +136,7 @@
 
 	return TRUE
 
-/datum/status_effect/fire_blasted/tick(seconds_per_tick, times_fired)
+/datum/status_effect/fire_blasted/tick(seconds_between_ticks, times_fired)
 	owner.adjustFireLoss(tick_damage)
 	owner.stamina.adjust(-2 * tick_damage)
 

--- a/code/modules/antagonists/heretic/magic/realignment.dm
+++ b/code/modules/antagonists/heretic/magic/realignment.dm
@@ -71,7 +71,7 @@
 	owner.remove_traits(traits, TRAIT_STATUS_EFFECT(id))
 	owner.remove_filter(id)
 
-/datum/status_effect/realignment/tick(seconds_per_tick, times_fired)
+/datum/status_effect/realignment/tick(seconds_between_ticks, times_fired)
 	owner.stamina.adjust(15, TRUE)
 	owner.AdjustAllImmobility(-0.5 SECONDS)
 

--- a/code/modules/antagonists/heretic/magic/star_touch.dm
+++ b/code/modules/antagonists/heretic/magic/star_touch.dm
@@ -144,7 +144,7 @@
 		active = FALSE
 	return ..()
 
-/datum/status_effect/cosmic_beam/tick(seconds_per_tick, times_fired)
+/datum/status_effect/cosmic_beam/tick(seconds_between_ticks, times_fired)
 	if(!current_target)
 		lose_target()
 		return

--- a/code/modules/antagonists/heretic/status_effects/void_chill.dm
+++ b/code/modules/antagonists/heretic/status_effects/void_chill.dm
@@ -39,17 +39,17 @@
 	UnregisterSignal(owner, COMSIG_ATOM_UPDATE_OVERLAYS)
 	owner.update_icon(UPDATE_OVERLAYS)
 
-/datum/status_effect/void_chill/tick(seconds_per_ticks)
+/datum/status_effect/void_chill/tick(seconds_between_ticks)
 	if(owner.has_reagent(/datum/reagent/water/holywater))
 		//void chill is less effective
-		owner.adjust_bodytemperature(-3 KELVIN * stacks * seconds_per_ticks)
+		owner.adjust_bodytemperature(-3 KELVIN * stacks * seconds_between_ticks)
 		if(!COOLDOWN_FINISHED(src, chill_purge))
 			return FALSE
 		COOLDOWN_START(src, chill_purge, 2 SECONDS)
 		to_chat(owner, span_notice("You feel holy water warming you up."))
 		adjust_stacks(-1)
 	else
-		owner.adjust_bodytemperature(-12 KELVIN * stacks * seconds_per_ticks)
+		owner.adjust_bodytemperature(-12 KELVIN * stacks * seconds_between_ticks)
 	if (stacks == 0)
 		owner.remove_status_effect(/datum/status_effect/void_chill)
 

--- a/code/modules/antagonists/monster_hunters/tools/blood_vial.dm
+++ b/code/modules/antagonists/monster_hunters/tools/blood_vial.dm
@@ -82,15 +82,15 @@
 /datum/status_effect/cursed_blood/on_remove()
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/cursed_blood)
 
-/datum/status_effect/cursed_blood/tick(seconds_per_tick, times_fired)
+/datum/status_effect/cursed_blood/tick(seconds_between_ticks, times_fired)
 	var/needs_update = FALSE
 	if(ISINRANGE(owner.health, 0, 90))
-		needs_update += owner.adjustBruteLoss(-2 * seconds_per_tick, updating_health = FALSE)
-		needs_update += owner.adjustFireLoss(-2 * seconds_per_tick, updating_health = FALSE)
-		needs_update += owner.adjustToxLoss(-1 * seconds_per_tick, updating_health = FALSE, forced = TRUE)
-		needs_update += owner.adjustOxyLoss(-1 * seconds_per_tick, updating_health = FALSE)
-	owner.AdjustAllImmobility((-6 SECONDS) * seconds_per_tick)
-	owner.stamina.adjust(7 * seconds_per_tick, forced = TRUE)
+		needs_update += owner.adjustBruteLoss(-2 * seconds_between_ticks, updating_health = FALSE)
+		needs_update += owner.adjustFireLoss(-2 * seconds_between_ticks, updating_health = FALSE)
+		needs_update += owner.adjustToxLoss(-1 * seconds_between_ticks, updating_health = FALSE, forced = TRUE)
+		needs_update += owner.adjustOxyLoss(-1 * seconds_between_ticks, updating_health = FALSE)
+	owner.AdjustAllImmobility((-6 SECONDS) * seconds_between_ticks)
+	owner.stamina.adjust(7 * seconds_between_ticks, forced = TRUE)
 	if(needs_update)
 		owner.updatehealth()
 

--- a/code/modules/religion/burdened/psyker.dm
+++ b/code/modules/religion/burdened/psyker.dm
@@ -20,16 +20,16 @@
 	qdel(removed_from.GetComponent(/datum/component/echolocation))
 	qdel(removed_from.GetComponent(/datum/component/anti_magic))
 
-/obj/item/organ/internal/brain/psyker/on_life(seconds_per_tick, times_fired)
+/obj/item/organ/internal/brain/psyker/on_life(seconds_between_ticks, times_fired)
 	. = ..()
 	var/obj/item/bodypart/head/psyker/psyker_head = owner.get_bodypart(zone)
 	if(istype(psyker_head))
 		return
-	if(!SPT_PROB(2, seconds_per_tick))
+	if(!SPT_PROB(2, seconds_between_ticks))
 		return
 	to_chat(owner, span_userdanger("Your head hurts... It can't fit your brain!"))
-	owner.adjust_disgust(33 * seconds_per_tick)
-	apply_organ_damage(5 * seconds_per_tick, 199)
+	owner.adjust_disgust(33 * seconds_between_ticks)
+	apply_organ_damage(5 * seconds_between_ticks, 199)
 
 /obj/item/bodypart/head/psyker
 	limb_id = BODYPART_ID_PSYKER
@@ -295,7 +295,7 @@
 	game_plane_master_controller.remove_filter("psychic_blur")
 	game_plane_master_controller.remove_filter("psychic_wave")
 
-/datum/status_effect/psychic_projection/tick(seconds_per_tick, times_fired)
+/datum/status_effect/psychic_projection/tick(seconds_between_ticks, times_fired)
 	var/obj/item/gun/held_gun = owner?.is_holding_item_of_type(/obj/item/gun)
 	if(!held_gun)
 		return

--- a/monkestation/code/datums/status_effects/buffs.dm
+++ b/monkestation/code/datums/status_effects/buffs.dm
@@ -77,20 +77,20 @@
 
 	qdel(restraints)
 
-/datum/status_effect/mayhem/tick(seconds_per_tick, times_fired) // Replacement for the Adminordazine it used before.
+/datum/status_effect/mayhem/tick(seconds_between_ticks, times_fired) // Replacement for the Adminordazine it used before.
 	. = ..()
 
-	var/healing_amount = 5 * seconds_per_tick
+	var/healing_amount = 5 * seconds_between_ticks
 
-	owner.heal_overall_damage(healing_amount, healing_amount, STAMINA_MAX / 10 * seconds_per_tick, updating_health = FALSE)
+	owner.heal_overall_damage(healing_amount, healing_amount, STAMINA_MAX / 10 * seconds_between_ticks, updating_health = FALSE)
 	owner.adjustToxLoss(-healing_amount, updating_health = FALSE)
 	owner.adjustOxyLoss(-healing_amount, updating_health = FALSE)
 
-	owner.blood_volume = min(owner.blood_volume + BLOOD_VOLUME_NORMAL / 10 * seconds_per_tick, BLOOD_VOLUME_NORMAL)
+	owner.blood_volume = min(owner.blood_volume + BLOOD_VOLUME_NORMAL / 10 * seconds_between_ticks, BLOOD_VOLUME_NORMAL)
 
 	if(iscarbon(owner))
 		var/mob/living/carbon/user = owner
-		if(length(user.all_wounds) && SPT_PROB(20, seconds_per_tick))
+		if(length(user.all_wounds) && SPT_PROB(20, seconds_between_ticks))
 			qdel(pick(user.all_wounds))
 			to_chat(user, span_green("One of your ailments leaves you.")) // Static message so it gets collapsed in chat.
 

--- a/monkestation/code/datums/status_effects/changeling.dm
+++ b/monkestation/code/datums/status_effects/changeling.dm
@@ -49,11 +49,11 @@
 	remove_movespeed_modifier()
 	on_apply()
 
-/datum/status_effect/changeling_adrenaline/tick(seconds_per_tick, times_fired)
-	owner.AdjustAllImmobility(-1 SECOND * seconds_per_tick)
-	owner.stamina.adjust(STAMINA_MAX / 20 * seconds_per_tick)
+/datum/status_effect/changeling_adrenaline/tick(seconds_between_ticks, times_fired)
+	owner.AdjustAllImmobility(-1 SECOND * seconds_between_ticks)
+	owner.stamina.adjust(STAMINA_MAX / 20 * seconds_between_ticks)
 	owner.set_jitter_if_lower(10 SECONDS)
-	owner.adjustToxLoss(0.5 * seconds_per_tick) // 10 toxin damage total.
+	owner.adjustToxLoss(0.5 * seconds_between_ticks) // 10 toxin damage total.
 
 /datum/status_effect/changeling_adrenaline/proc/remove_movespeed_modifier()
 	deltimer(movespeed_timer)
@@ -99,16 +99,16 @@
 	duration = min(duration + initial(duration), world.time + initial(duration) * 2)
 	on_apply()
 
-/datum/status_effect/changeling_panacea/tick(seconds_per_tick, times_fired)
+/datum/status_effect/changeling_panacea/tick(seconds_between_ticks, times_fired)
 	. = ..()
-	owner.adjustToxLoss(-10 * seconds_per_tick)
-	owner.adjustCloneLoss(-20 * seconds_per_tick)
-	owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, -20 * seconds_per_tick)
-	owner.adjust_drunk_effect(-10 * seconds_per_tick)
-	owner.adjust_disgust(DISGUST_LEVEL_MAXEDOUT * -0.1 * seconds_per_tick)
+	owner.adjustToxLoss(-10 * seconds_between_ticks)
+	owner.adjustCloneLoss(-20 * seconds_between_ticks)
+	owner.adjustOrganLoss(ORGAN_SLOT_BRAIN, -20 * seconds_between_ticks)
+	owner.adjust_drunk_effect(-10 * seconds_between_ticks)
+	owner.adjust_disgust(DISGUST_LEVEL_MAXEDOUT * -0.1 * seconds_between_ticks)
 
 	if(length(owner.reagents?.reagent_list))
-		owner.reagents.remove_all(10 * length(owner.reagents.reagent_list) * seconds_per_tick)
+		owner.reagents.remove_all(10 * length(owner.reagents.reagent_list) * seconds_between_ticks)
 
 	handle_extra_effects()
 
@@ -195,14 +195,14 @@
 		owner.Paralyze(6 SECONDS)
 		INVOKE_ASYNC(owner, TYPE_PROC_REF(/mob, emote), "gasp")
 
-/datum/status_effect/changeling_muscles/tick(seconds_per_tick, times_fired)
+/datum/status_effect/changeling_muscles/tick(seconds_between_ticks, times_fired)
 	accumulation += DELTA_WORLD_TIME(SSprocessing)
 
 	if(accumulation > 40 && !warning_given)
 		to_chat(owner, span_userdanger("Our legs are really starting to hurt..."))
 		warning_given = TRUE
 
-	owner.stamina?.adjust(STAMINA_MAX * -0.001 * accumulation * seconds_per_tick)
+	owner.stamina?.adjust(STAMINA_MAX * -0.001 * accumulation * seconds_between_ticks)
 
 /datum/status_effect/changeling_muscles/proc/on_stamina_stun(mob/living/carbon/user)
 	SIGNAL_HANDLER

--- a/monkestation/code/game/objects/items/devices/broadcast_camera.dm
+++ b/monkestation/code/game/objects/items/devices/broadcast_camera.dm
@@ -47,7 +47,7 @@
 		return FALSE
 	return ..()
 
-/datum/status_effect/streamer/tick(seconds_per_tick, times_fired)
+/datum/status_effect/streamer/tick(seconds_between_ticks, times_fired)
 	if(extra_checks && !extra_checks.Invoke(src))
 		qdel(src)
 		return

--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/abilities/slasher_regenerate.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/abilities/slasher_regenerate.dm
@@ -32,12 +32,12 @@
 	REMOVE_TRAIT(owner, TRAIT_CANT_STAMCRIT, TRAIT_STATUS_EFFECT(id))
 	return ..()
 
-/datum/status_effect/bloody_heal/tick(seconds_per_tick, times_fired)
+/datum/status_effect/bloody_heal/tick(seconds_between_ticks, times_fired)
 	. = ..()
 	if(!ishuman(owner))
 		return
 	var/mob/living/carbon/human/human_owner = owner
-	human_owner.AdjustAllImmobility(-20 * seconds_per_tick)
+	human_owner.AdjustAllImmobility(-20 * seconds_between_ticks)
 	human_owner.stamina.adjust(20, TRUE)
 	human_owner.adjustBruteLoss(-35)
 	human_owner.adjustFireLoss(-5, FALSE)
@@ -56,4 +56,4 @@
 
 	for(var/i in human_owner.all_wounds)
 		var/datum/wound/iter_wound = i
-		iter_wound.on_xadone(4 * REM * seconds_per_tick) // plasmamen use plasma to reform their bones or whatever
+		iter_wound.on_xadone(4 * REM * seconds_between_ticks) // plasmamen use plasma to reform their bones or whatever

--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/slasher_datum.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/slasher_datum.dm
@@ -178,7 +178,7 @@
 	owner.current.playsound_local(null, 'monkestation/sound/ambience/antag/slasher.ogg', vol = 100, vary = FALSE, pressure_affected = FALSE)
 	owner.announce_objectives()
 
-/datum/antagonist/slasher/proc/LifeTick(mob/living/source, seconds_per_tick, times_fired)
+/datum/antagonist/slasher/proc/LifeTick(mob/living/source, seconds_between_ticks, times_fired)
 	SIGNAL_HANDLER
 
 	var/list/currently_beating = list()
@@ -252,7 +252,7 @@
 	. = ..()
 
 
-/datum/status_effect/slasher/stalking/tick(seconds_per_tick, times_fired)
+/datum/status_effect/slasher/stalking/tick(seconds_between_ticks, times_fired)
 	if(slasherdatum.stalked_human)
 		for(var/mob/living/mob in view(7, owner))
 			if(mob == owner)

--- a/monkestation/code/modules/brewin_and_chewin/chewing/food_effects/food_posioning.dm
+++ b/monkestation/code/modules/brewin_and_chewin/chewing/food_effects/food_posioning.dm
@@ -9,7 +9,7 @@
 	alert_type = /atom/movable/screen/alert/status_effect/food/food_poisoning
 	var/min_vomit_processes = 5
 
-/datum/status_effect/food/food_poisoning/tick(seconds_per_tick, times_fired)
+/datum/status_effect/food/food_poisoning/tick(seconds_between_ticks, times_fired)
 	. = ..()
 	owner.adjust_hallucinations(0.5 SECONDS)
 	owner.adjust_drugginess(0.75 SECONDS)

--- a/monkestation/code/modules/mob/living/basic/space_fauna/revenant/revenant_effects.dm
+++ b/monkestation/code/modules/mob/living/basic/space_fauna/revenant/revenant_effects.dm
@@ -65,42 +65,42 @@
 		UnregisterSignal(ghostie, COMSIG_QDELETING)
 		ghostie = null
 
-/datum/status_effect/revenant_blight/tick(seconds_per_tick, times_fired)
+/datum/status_effect/revenant_blight/tick(seconds_between_ticks, times_fired)
 	if(owner.reagents?.has_reagent(/datum/reagent/water/holywater))
-		remove_duration(HOLY_WATER_CURE_RATE * seconds_per_tick)
-	owner.mob_mood?.direct_sanity_drain(-rand(2, 10) * seconds_per_tick)
+		remove_duration(HOLY_WATER_CURE_RATE * seconds_between_ticks)
+	owner.mob_mood?.direct_sanity_drain(-rand(2, 10) * seconds_between_ticks)
 	if(!finalstage)
-		if(owner.body_position == LYING_DOWN && owner.IsSleeping() && SPT_PROB(3 * stage, seconds_per_tick)) // Make sure they are sleeping laying down.
+		if(owner.body_position == LYING_DOWN && owner.IsSleeping() && SPT_PROB(3 * stage, seconds_between_ticks)) // Make sure they are sleeping laying down.
 			qdel(src) // Cure the Status effect.
 			return FALSE
-		if(SPT_PROB(1.5 * stage, seconds_per_tick))
+		if(SPT_PROB(1.5 * stage, seconds_between_ticks))
 			to_chat(owner, span_revennotice("You suddenly feel [pick("sick and tired", "disoriented", "tired and confused", "nauseated", "faint", "dizzy")]..."))
 			owner.adjust_confusion(4 SECONDS)
-			owner.stamina.adjust(-21 * seconds_per_tick)
+			owner.stamina.adjust(-21 * seconds_between_ticks)
 			new /obj/effect/temp_visual/revenant(owner.loc)
 		if(stagedamage < stage)
 			stagedamage++
-			owner.adjustToxLoss(1 * stage * seconds_per_tick) //should, normally, do about 30 toxin damage.
+			owner.adjustToxLoss(1 * stage * seconds_between_ticks) //should, normally, do about 30 toxin damage.
 			new /obj/effect/temp_visual/revenant(owner.loc)
-		if(SPT_PROB(25, seconds_per_tick))
-			owner.stamina.adjust(-(stage * 2) * seconds_per_tick)
+		if(SPT_PROB(25, seconds_between_ticks))
+			owner.stamina.adjust(-(stage * 2) * seconds_between_ticks)
 
 	switch(stage)
 		if(2)
-			if(owner.stat == CONSCIOUS && SPT_PROB(2.5, seconds_per_tick))
+			if(owner.stat == CONSCIOUS && SPT_PROB(2.5, seconds_between_ticks))
 				owner.emote("pale")
 		if(3)
-			if(owner.stat == CONSCIOUS && SPT_PROB(5, seconds_per_tick))
+			if(owner.stat == CONSCIOUS && SPT_PROB(5, seconds_between_ticks))
 				owner.emote(pick("pale","shiver"))
 		if(4)
-			if(owner.stat == CONSCIOUS && SPT_PROB(7.5, seconds_per_tick))
+			if(owner.stat == CONSCIOUS && SPT_PROB(7.5, seconds_between_ticks))
 				owner.emote(pick("pale","shiver","cries"))
 		if(5)
 			if(!finalstage)
 				finalstage = TRUE
 				ADD_TRAIT(owner, TRAIT_SOFTSPOKEN, TRAIT_STATUS_EFFECT(id))
 				to_chat(owner, span_revenbignotice("You feel like [pick("nothing's worth it anymore", "nobody ever needed your help", "nothing you did mattered", "everything you tried to do was worthless")]."))
-				owner.stamina.adjust(-22.5 * seconds_per_tick, forced = TRUE)
+				owner.stamina.adjust(-22.5 * seconds_between_ticks, forced = TRUE)
 				new /obj/effect/temp_visual/revenant(owner.loc)
 				if(ishuman(owner))
 					var/mob/living/carbon/human/human = owner
@@ -111,7 +111,7 @@
 				owner.add_atom_colour(COLOR_REVENANT, TEMPORARY_COLOUR_PRIORITY)
 				QDEL_IN(src, 10 SECONDS) // Automatically call qdel and removing status on timer.
 
-	if(SPT_PROB(CHANCE_TO_WORSEN, seconds_per_tick)) // Finally check if we should increase the stage.
+	if(SPT_PROB(CHANCE_TO_WORSEN, seconds_between_ticks)) // Finally check if we should increase the stage.
 		adjust_stage(1)
 
 /datum/status_effect/revenant_blight/proc/remove_when_ghost_dies(datum/source)

--- a/monkestation/code/modules/slimecore/crossbreeding/regenerative/effect.dm
+++ b/monkestation/code/modules/slimecore/crossbreeding/regenerative/effect.dm
@@ -39,8 +39,8 @@
 	owner.apply_status_effect(/datum/status_effect/slime_regen_cooldown, diminishing_multiplier, diminish_time)
 	owner.cause_pain(BODY_ZONE_CHEST, pain_amount, BRUTE)
 
-/datum/status_effect/regenerative_extract/tick(seconds_per_tick, times_fired)
-	var/heal_amt = base_healing_amt * seconds_per_tick * multiplier
+/datum/status_effect/regenerative_extract/tick(seconds_between_ticks, times_fired)
+	var/heal_amt = base_healing_amt * seconds_between_ticks * multiplier
 	heal_act(heal_amt)
 	owner.updatehealth()
 


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/77219

> `status_effect/proc/tick(seconds_per_tick)` is wildly misleading and I feel like I should address it
> 
> For a majority of status effects, they process on fast processing but do not tick every fastprocessing tick 
> 
> This means that using `seconds_per_tick` here is not giving you the seconds between status effect ticks, it's giving you seconds between processing ticks (`0.2`)
> 
> This is how it's misleading - If you have a tick interval of `1 SECONDS`, you'd think `seconds_per_tick` is, well, one. But it's actually one-fifth. So all of your effects are now 80% weaker. 
> 
> I have replaced the use of `seconds_per_tick` in tick with `seconds_between_ticks`.
> 
> This number is, quite simply, the initial tick interval of the status effect divided by ten. 
> 
> An effect with the tick interval of `1 SECONDS` has a `seconds_between_ticks` of 1. 
> 
> As a consequence, some things which were inadvertently made weaker, such as fire and some heretic things (at a glance), are now a little stronger. 

## Why It's Good For The Game

> See above. Makes it more clear what you're doing when working with effects. 

## Changelog

:cl: Absolucy, Melbert
code: Updated some status effect tick code to be more clear of how long is elapsing between ticks. Some effects that were inadvertently weakened are now stronger as a result (fire and some heretic effects). 
/:cl:

