### PR TITLE
Guys they might be evil, (Void Heretic balancing)

### DIFF
--- a/code/modules/antagonists/heretic/heretic_monsters.dm
+++ b/code/modules/antagonists/heretic/heretic_monsters.dm
@@ -7,7 +7,7 @@
 	job_rank = ROLE_HERETIC
 	antag_hud_name = "heretic_beast"
 	suicide_cry = "MY MASTER SMILES UPON ME!!"
-	show_in_antagpanel = FALSE
+	show_in_antagpanel = TRUE
 	antag_flags = parent_type::antag_flags | FLAG_ANTAG_CAP_IGNORE // monkestation addition
 	/// Our master (a heretic)'s mind.
 	var/datum/mind/master

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -216,6 +216,8 @@
 	var/datum/weather/void_storm/storm
 	///The storm where there are actual effects
 	var/datum/proximity_monitor/advanced/void_storm/heavy_storm
+	COOLDOWN_DECLARE(block_cooldown)
+	var/deflect_cooldown = 2 SECONDS //monke edit start
 
 /datum/heretic_knowledge/ultimate/void_final/recipe_snowflake_check(mob/living/user, list/atoms, list/selected_atoms, turf/loc)
 	if(!isopenturf(loc))
@@ -314,6 +316,8 @@
 		return FALSE
 	if(!isturf(ascended_heretic.loc))
 		return FALSE
+	if(!COOLDOWN_FINISHED(src, block_cooldown))
+		return FALSE
 	return TRUE
 
 /datum/heretic_knowledge/ultimate/void_final/proc/hit_by_projectile(mob/living/ascended_heretic, obj/projectile/hitting_projectile, def_zone)
@@ -326,6 +330,7 @@
 		span_danger("The void storm surrounding [ascended_heretic] deflects [hitting_projectile]!"),
 		span_userdanger("The void storm protects you from [hitting_projectile]!"),
 	)
+	COOLDOWN_START(src, block_cooldown, deflect_cooldown)// monke edit start
 	playsound(ascended_heretic, pick('sound/magic/voiddeflect01.ogg', 'sound/magic/voiddeflect02.ogg', 'sound/magic/voiddeflect03.ogg'), 75, TRUE)
 	hitting_projectile.firer = ascended_heretic
 	if(prob(75))

--- a/code/modules/antagonists/heretic/magic/void_conduit.dm
+++ b/code/modules/antagonists/heretic/magic/void_conduit.dm
@@ -28,7 +28,7 @@
 	icon_state = "void_conduit"
 	anchored = TRUE
 	density = TRUE
-	max_integrity = 150
+	max_integrity = 60
 
 	///Overlay to apply to the tiles in range of the conduit
 	var/static/image/void_overlay = image(icon = 'icons/turf/overlays.dmi', icon_state = "voidtile")

--- a/code/modules/antagonists/heretic/magic/void_conduit.dm
+++ b/code/modules/antagonists/heretic/magic/void_conduit.dm
@@ -28,7 +28,7 @@
 	icon_state = "void_conduit"
 	anchored = TRUE
 	density = TRUE
-	max_integrity = 60
+	max_integrity = 75
 
 	///Overlay to apply to the tiles in range of the conduit
 	var/static/image/void_overlay = image(icon = 'icons/turf/overlays.dmi', icon_state = "voidtile")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Eldritch horrors will now show in the orbit menu.
- Waltz at the end of time now has a deflect cooldown of 2 seconds.
- Void conduit has had its max durability nerfed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
### Eldritch horrors
Eldritch horrors antagonists (Ones from heretics) only show through heretic summons. They are known evils and if one is summoned, then the ghosts are already going to know as they get polled to become one. Keep the dead entertained with some interesting spectate targets.
### Waltz at the End of Time Cooldown. (Void ascension)
This ascension is overturned at the moment. The benefits it provides to my understanding are the follows.

- Gives the ascended hyperspace movement.
- Turns the ascended into a mini void conduit, destroying all windows and airlocks in a 10 tile range
- Passively applies void chill stacks onto anyone in a 10-tile range. Which while stacked prevents warming back up.
- Additionally, it passively applies direct body temperature lowering on top of the void chill. (Our temperature works differently)
- Passively makes what air there is colder over time.
- Passively mutes anyone near them from 2-20 seconds after leaving.
- And the cherry on top is they are immune to all projectiles. Full stop.

All of this is not countered by antimagic and its effects are only reduced by holy water.

While I understand the sentiment that ascensions should be powerful. They usually have some gap or lapse in their strengths. Void ascension manages to shut down all range combat by blocking all projectiles. And melee combat by applying their chill and direct body temperature lowering. Which nerfs the hell out of your speed. Being a decent bit faster than your opponent is huge for such as having a faster speed than your opponent lets you control the pace of the fight better.

So to knock it a peg, I want to nerf their least thematical part of their ascension, the storm deflecting all bullets somehow. Instead, move it to a cooldown so they still have to somewhat respect sheer firepower if confronted. But still helping with a rouge chemist trying to surprise inject a mute toxin + death mix into them.

### Void conduit.
This ability is surprisingly strong and annoying for what it offers.

As per before creates a loud AOE that breaks all airlocks and windows in a given area unless broken. Applying void stacks to anyone hit by its effects. 
The core issue is for that it is its durable. Being strong as a reinforced window in integrity (150). Meanwhile, while you try to destroy it it's killing you and the environment around you. Not to mention the heretic is still an active threat.

If dropped, it should either force people to come and break it, which should be reasonable without dying to void chill alone. And potentially forcing them into a bad positioning in the process. Or back the hell off to let its do its effects. 

It being a glass cannon should encourage better placement about the spell as it already transmit it effects without line of sight/through walls.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Eldritch horrors (from heretics summons) now show in the orbit menu
balance: Waltz at the end of time has a 2-second block cooldown. (Was None.)
balance: Void conduit has had its integrity nerfed to 75. (Was 150)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
