### PR TITLE
The storm from void ascension and the void chill debuff both now respect antimagic.

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -265,6 +265,8 @@
 			if(IS_HERETIC_OR_MONSTER(close_carbon))
 				close_carbon.apply_status_effect(/datum/status_effect/void_conduit)
 				continue
+			if(close_carbon.can_block_magic())
+				continue
 			close_carbon.adjust_silence_up_to(2 SECONDS, 20 SECONDS)
 			close_carbon.apply_status_effect(/datum/status_effect/void_chill, 1)
 			close_carbon.adjust_eye_blur(rand(0 SECONDS, 2 SECONDS))

--- a/code/modules/antagonists/heretic/status_effects/void_chill.dm
+++ b/code/modules/antagonists/heretic/status_effects/void_chill.dm
@@ -29,6 +29,8 @@
 	return ..()
 
 /datum/status_effect/void_chill/on_apply()
+	if(owner.can_block_magic())
+		return FALSE
 	if(issilicon(owner))
 		return FALSE
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
The storm from void ascension and the void chill debuff both now respect antimagic.

Closes: https://github.com/Monkestation/Monkestation2.0/pull/6804
## Why It's Good For The Game
This was an oversight on my part.
Antimagic should block magic
## Changelog
:cl:
fix: Void ascension storm now respects antimagic
fix: Void chill can no longer be applied to people with antimagic
/:cl:
