### PR TITLE
Holofans can project on doors

### DIFF
--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -18,6 +18,11 @@
 	var/creation_time = 0 //time to create a holosign in deciseconds.
 	var/holosign_type = /obj/structure/holosign/wetsign
 	var/holocreator_busy = FALSE //to prevent placing multiple holo barriers at once
+	/// List of special things we can project holofans under/through.
+	var/list/projectable_through = list(
+		/obj/machinery/door,
+		/obj/structure/mineral_door,
+	)
 
 /obj/item/holosign_creator/Initialize(mapload)
 	. = ..()
@@ -44,7 +49,7 @@
 	if(target_holosign)
 		qdel(target_holosign)
 		return .
-	if(target_turf.is_blocked_turf(TRUE)) //can't put holograms on a tile that has dense stuff
+	if(target_turf.is_blocked_turf(TRUE, ignore_atoms = projectable_through, type_list = TRUE)) //can't put holograms on a tile that has dense stuff
 		return .
 	if(holocreator_busy)
 		to_chat(user, span_notice("[src] is busy creating a hologram."))
@@ -61,7 +66,7 @@
 		holocreator_busy = FALSE
 		if(LAZYLEN(signs) >= max_signs)
 			return .
-		if(target_turf.is_blocked_turf(TRUE)) //don't try to sneak dense stuff on our tile during the wait.
+		if(target_turf.is_blocked_turf(TRUE, ignore_atoms = projectable_through, type_list = TRUE)) //don't try to sneak dense stuff on our tile during the wait.
 			return .
 	target_holosign = create_holosign(target, user)
 	return .
@@ -136,6 +141,12 @@
 	holosign_type = /obj/structure/holosign/barrier/atmos
 	creation_time = 0
 	max_signs = 6
+	projectable_through = list(
+		/obj/machinery/door,
+		/obj/structure/mineral_door,
+		/obj/structure/window,
+		/obj/structure/grille,
+	)
 	/// Clearview holograms don't catch clicks and are more transparent
 	var/clearview = FALSE
 	/// Timer for auto-turning off clearview


### PR DESCRIPTION

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/89781
## Why It's Good For The Game
Just some holofan qol, makes it possible to just slap it on a door instead of having to open the door before you can drop it.
## Changelog
:cl: Xander3359 Hatterhat
qol: Holosigns (engineering holobarriers, janitor holosigns, PENLITE holobarriers, etc.) can now be projected onto doors.
qol: Holofans from ATMOS holoprojectors can now be projected onto doors, windows, and grilles.
/:cl:
