### PR TITLE
heretic sacrifices no longer spawn and then delete a human just to spawn gib effects

### DIFF
--- a/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -376,7 +376,7 @@
 	if (!gave_any)
 		return
 
-	new /obj/effect/gibspawner/human/bodypartless(get_turf(sac_target))
+	new /obj/effect/gibspawner/human/bodypartless(get_turf(sac_target), sac_target)
 	sac_target.visible_message(span_boldwarning("Several organs force themselves out of [sac_target]!"))
 
 /**
@@ -580,7 +580,7 @@
 		span_userdanger("Your organs are violently pulled out of your chest by shadowy hands!")
 	)
 
-	new /obj/effect/gibspawner/human/bodypartless(get_turf(sac_target))
+	new /obj/effect/gibspawner/human/bodypartless(get_turf(sac_target), sac_target)
 
 #undef SACRIFICE_SLEEP_DURATION
 #undef SACRIFICE_REALM_DURATION


### PR DESCRIPTION
## About The Pull Request

ports my own upstream PR, https://github.com/tgstation/tgstation/pull/91294

> this makes it so heretic sacrificing actually uses the sac target as the reference for the `/obj/effect/gibspawner/human/bodypartless`, instead of spawning a human, calling `get_blood_dna_list()` on it, then immediately deleting said human.

## Why It's Good For The Game

> this was a waste of performance without a shadow of a doubt.

## Changelog

> no player-facing changes.