### PR TITLE
Firelocks now skip checking uninitialized turfs

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -282,10 +282,7 @@
 /obj/machinery/door/firedoor/proc/check_atmos(turf/checked_turf)
 	var/datum/gas_mixture/environment = checked_turf.return_air()
 	if(!environment)
-		var/a1 = !!(checked_turf.flags_1 & INITIALIZED_1)
-		var/a2 = SSatoms.initializing_something()
-		stack_trace("We tried to check a gas_mixture that doesn't exist for its firetype, what are you DOING (debug: a1=[a1], a2=[a2])")
-		return
+		CRASH("We tried to check a gas_mixture that doesn't exist for its firetype, what are you DOING")
 
 	if(environment.temperature >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST)
 		return FIRELOCK_ALARM_TYPE_HOT
@@ -301,6 +298,8 @@
 			return
 
 	var/turf/checked_turf = source
+	if(!(checked_turf.flags_1 & INITIALIZED_1)) // uninitialized turfs won't have atmos setup anyways, so check_atmos would just complain and not work
+		return
 	var/result = check_atmos(checked_turf)
 
 	if(result && TURF_SHARES(checked_turf))


### PR DESCRIPTION
## About The Pull Request

Ports my own upstream PR, https://github.com/tgstation/tgstation/pull/91221

> this makes it so `/obj/machinery/door/firedoor/proc/process_results()` now returns early if the source turf is uninitialized, which usually happens as a result of holodeck loading.

## Why It's Good For The Game

> gets rid of an error, and processing uninitialized turfs feels like a recipe for jank anyways

## Changelog
:cl:
fix: Firelocks now skip checking uninitialized turfs, which caused errors with the holodeck.
/:cl:
