### PR TITLE
Fix some stacked atmos pipes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedunknownsite1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedunknownsite1.dmm
@@ -196,7 +196,6 @@
 "aL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/glass/plastitanium/screws,

--- a/_maps/~monkestation/RandomBars/Icebox/Drunkopsbar.dmm
+++ b/_maps/~monkestation/RandomBars/Icebox/Drunkopsbar.dmm
@@ -1098,8 +1098,6 @@
 "Zz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4

--- a/_maps/~monkestation/RandomBars/Icebox/Magbar.dmm
+++ b/_maps/~monkestation/RandomBars/Icebox/Magbar.dmm
@@ -50,7 +50,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron{
 	base_icon_state = "basalt12";
 	icon_state = "basalt12";

--- a/_maps/~monkestation/RandomBars/Tram/tram_bar_cult.dmm
+++ b/_maps/~monkestation/RandomBars/Tram/tram_bar_cult.dmm
@@ -788,12 +788,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/cult,
 /area/station/commons/lounge)
-"qT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/cult,
-/area/station/commons/lounge)
 "rg" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /obj/machinery/disposal/bin,
@@ -2913,7 +2907,7 @@ Vd
 Vd
 Vd
 Vi
-qT
+if
 GM
 if
 AI


### PR DESCRIPTION

## About The Pull Request

this fixes some stacked atmos pipes like these, which were responsible for some flaky test failures:

![2025-05-28 (1748407836) ~ strongdmm](https://github.com/user-attachments/assets/5026d27b-33ff-4d8d-ac94-914c55bf6e93)

## Changelog
:cl:
fix: Fixed some stacked atmos pipes on some icebox/tram bars and and a space ruin.
/:cl:
