### PR TITLE
Fix a flaky icebox runtime with charlie station

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -99,7 +99,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/autoname/old, 0)
 
 	LAZYADD(myarea.cameras, src)
 
-	if(mapload && is_station_level(z) && prob(3) && !start_active)
+	if(mapload && should_break_roundstart())
 		toggle_cam()
 	else //this is handled by toggle_camera, so no need to update it twice.
 		update_appearance()
@@ -123,6 +123,17 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/autoname/old, 0)
 /obj/machinery/camera/proc/set_area_motion(area/A)
 	area_motion = A
 	create_prox_monitor()
+
+/obj/machinery/camera/proc/should_break_roundstart()
+	if(start_active)
+		return FALSE
+	if(!prob(3)) // only 3% chance to break roundstart
+		return FALSE
+	if(!is_station_level(z))
+		return FALSE
+	if(istype(get_area(src), /area/ruin))
+		return FALSE
+	return TRUE
 
 /obj/machinery/camera/Destroy()
 	if(can_use())

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -498,9 +498,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/camera/autoname/old, 0)
 	var/change_msg = "deactivates"
 	if(status)
 		change_msg = "reactivates"
-		triggerCameraAlarm()
-		if(!QDELETED(src)) //We'll be doing it anyway in destroy
-			addtimer(CALLBACK(src, PROC_REF(cancelCameraAlarm)), 100)
+		if(!QDELETED(alarm_manager))
+			triggerCameraAlarm()
+			if(!QDELETED(src)) //We'll be doing it anyway in destroy
+				addtimer(CALLBACK(src, PROC_REF(cancelCameraAlarm)), 10 SECONDS)
 	if(displaymessage)
 		if(user)
 			visible_message(span_danger("[user] [change_msg] [src]!"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this makes it so cameras on ruins that are on the station z-level won't roll the random "break at roundstart" chance that should only roll for on-station cameras anyways

also this makes it so camera alarms won't be thrown if `alarm_manager` doesn't exist anyways (which would runtime)

## Why It's Good For The Game

less flaky test failures / runtimes

## Changelog

no player-facing changes