### PR TITLE
Mining RND #5 - PKShockwave Rework!

### DIFF
--- a/code/game/machinery/computer/orders/order_items/mining/order_pka.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_pka.dm
@@ -14,7 +14,7 @@
 	cost_per_order = 1250
 
 /datum/orderable_item/accelerator/gun/shockwave //monke edit
-	item_path = /obj/item/gun/energy/recharge/kinetic_accelerator/shockwave
+	item_path = /obj/item/storage/box/shockwave
 	cost_per_order = 1250
 
 /datum/orderable_item/accelerator/gun/glock //monke edit

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -12,7 +12,7 @@
 	knife_x_offset = 20
 	knife_y_offset = 12
 	var/mob/holder
-	var/max_mod_capacity = 100
+	var/max_mod_capacity = 10
 	var/list/modkits = list()
 	gun_flags = NOT_A_REAL_GUN
 	var/disablemodification = FALSE //monkeedit - stops removal and addition of mods

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -12,7 +12,7 @@
 	knife_x_offset = 20
 	knife_y_offset = 12
 	var/mob/holder
-	var/max_mod_capacity = 10
+	var/max_mod_capacity = 100
 	var/list/modkits = list()
 	gun_flags = NOT_A_REAL_GUN
 	var/disablemodification = FALSE //monkeedit - stops removal and addition of mods

--- a/monkestation/code/modules/mining/accelerators/shockwave.dm
+++ b/monkestation/code/modules/mining/accelerators/shockwave.dm
@@ -1,27 +1,77 @@
 /obj/item/gun/energy/recharge/kinetic_accelerator/shockwave
 	name = "proto-kinetic shockwave"
-	desc = "Quite frankly, we have no idea how the Mining Research and Development team came up with this one, all we know is that alot of \
-	beer was involved. This proto-kinetic design will slam the ground, creating a shockwave around the user, with the same power as the base PKA.\
-	The only downside is the lowered mod capacity, the lack of range it offers, and the higher cooldown, but its pretty good for clearing rocks."
+	desc = "Innovating on the mining blast mod, Mining Research and Development has managed to overclock the performance of the mod to the extreme.\
+	The result is a specialized accelerator frame that when equipped with the accompanying modkit grants a fairly punchy, large blast that is excellent\
+	for clearing large amounts of rocks and crowded fauna.\
+	The only downside is the lowered mod capacity, lack of range, required mod, and longer cooldown... but its pretty good for clearing rocks.\
+	A warning label is stuck to the side : Weapon will underperform without accompanying mod (Should be included with purchase)."
 	icon = 'monkestation/icons/obj/guns/guns.dmi'
 	icon_state = "kineticshockwave"
 	base_icon_state = "kineticshockwave"
 	recharge_time = 2 SECONDS
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/shockwave)
 	can_bayonet = FALSE
-	max_mod_capacity = 60
-	pin = /obj/item/firing_pin/explorer/unremovable
+	max_mod_capacity = 90 //bumped up to 90 to compensate for the 30 you need to spend on the AOE mod that gives it its functionality
 
 /obj/item/ammo_casing/energy/kinetic/shockwave
 	projectile_type = /obj/projectile/kinetic/shockwave
-	pellets = 8
-	variance = 360
 	fire_sound = 'sound/weapons/gun/general/cannon.ogg'
 
 /obj/projectile/kinetic/shockwave
 	name = "concussive kinetic force"
-	damage = 5 //turning this down since miners are using it to point blank enemies. might not be enough damage to break walls anymore but /shrug. until we can fix shitcode to prevent the shockwave from being able to do a point blank, this is all I can do.
-	range = 1
+	damage = 50
+	range = 0
 
-/obj/item/firing_pin/explorer/unremovable
-	pin_removable = FALSE
+/obj/item/borg/upgrade/modkit/aoe/turfs/shockwave
+	name = "Shockwave modkit"
+	desc = "A special version of the AOE modkit that gives the PK-Shockwave all of its unique properties. \
+	It had to be shipped uninstalled from the actual PK-Shockwave due to technical issues, but installation is simple. \
+	It does not fit into any other PK weapon."
+	maximum_of_type = 1
+	modifier = 1
+
+/obj/item/storage/box/shockwave
+	name = "PK-Shockwave Box"
+	desc = "A box containing a PK-Shockwave and the Shockwave modkit. Designed to create large blasts of powerful kinetic energy for clearing large amounts of rock, or fauna"
+	icon_state = "cyber_implants"
+
+/obj/item/storage/box/shockwave/Initialize(mapload)
+	. = ..()
+	atom_storage.max_slots = 2
+	atom_storage.max_specific_storage = WEIGHT_CLASS_BULKY
+	atom_storage.max_total_storage = 2
+
+/obj/item/storage/box/shockwave/PopulateContents()
+	new /obj/item/gun/energy/recharge/kinetic_accelerator/shockwave(src)
+	new /obj/item/borg/upgrade/modkit/aoe/turfs/shockwave(src)
+
+/obj/item/borg/upgrade/modkit/aoe/turfs/shockwave/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/recharge/kinetic_accelerator/KA)
+	if(stats_stolen)
+		return
+	new /obj/effect/temp_visual/explosion/fast(target_turf)
+	if(turf_aoe)
+		for(var/T in RANGE_TURFS(2, target_turf) - target_turf)
+			if(ismineralturf(T))
+				var/turf/closed/mineral/M = T
+				M.gets_drilled(K.firer, TRUE)
+	if(modifier)
+		for(var/mob/living/L in range(2, target_turf) - K.firer - target)
+			var/armor = L.run_armor_check(K.def_zone, K.armor_flag, "", "", K.armour_penetration)
+			L.apply_damage(K.damage*modifier, K.damage_type, K.def_zone, armor)
+			to_chat(L, span_userdanger("You're struck by a [K.name]!"))
+
+/obj/item/borg/upgrade/modkit/aoe/turfs/shockwave/install(obj/item/gun/energy/recharge/kinetic_accelerator/KA, mob/user)
+	if(istype(KA, /obj/item/gun/energy/recharge/kinetic_accelerator/shockwave))
+		. = ..()
+		if(.)
+			for(var/obj/item/borg/upgrade/modkit/aoe/AOE in KA.modkits) //make sure only one of the aoe modules has values if somebody has multiple
+				if(AOE.stats_stolen || AOE == src)
+					continue
+				modifier += AOE.modifier //take its modifiers
+				AOE.modifier = 0
+				turf_aoe += AOE.turf_aoe
+				AOE.turf_aoe = FALSE
+				AOE.stats_stolen = TRUE
+	else
+		to_chat(user, span_warning("[src] does not fit in [KA]. It will only fit in a Shockwave!"))
+		return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
I have returned after a year! And with me Mining RND is back too!
I saw that there were issues with the Shockwave which I should have seen coming, so I have come up with a solution.
To take it easy on the megafauna, and improve the performance somewhat in other areas, the shockwave will now function differently but still fulfill the original role as a out of the box mass rock clearer (now quite literally out of the box!)

Now instead of firing 8 projectiles with 360 degrees of random spread it fires one projectile directly infront of you.
Terrible I know, however upon purchase, you also get a special modkit that only fits in the shockwave, that grants this single projectiles a 2 tile wide mining and damaging blast! Allowing you to clear tons of rocks, and small crowds of fauna as well, without being able to bully mega fauna! Hopefully the pick rate goes up! Happy mining.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
The shockwave was weird, the way it was created meant sometimes you would not get the full 360 spread, and that you could point blank mega fauna for a ton of damage (or so i hear). So to prevent this I have reworked the shockwave from a projectile rng machine to an actual blast radius!

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Mining RND is back, and the PK-Shockwave has been reworked, now coming in a box on purchase with a special modkit that grants it a 2 tile offensive mining blast! The modkit only fits in the shockwave, but it should work good for clearing lots of rock or fauna at once!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
