### PR TITLE
Reduces the range of some higher pitched emote sounds

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -62,6 +62,10 @@
 	var/can_message_change = FALSE
 	/// How long is the cooldown on the audio of the emote, if it has one?
 	var/audio_cooldown = 2 SECONDS
+	/// The falloff exponent for audible emotes.
+	var/falloff_exponent = SOUND_FALLOFF_EXPONENT
+	/// The extra range for audible emites.
+	var/extra_range = 0
 
 /datum/emote/New()
 	switch(mob_type_allowed_typecache)
@@ -110,11 +114,16 @@
 	var/tmp_sound = get_sound(user)
 	if(tmp_sound && should_play_sound(user, intentional) && !TIMER_COOLDOWN_CHECK(user, type))
 		TIMER_COOLDOWN_START(user, type, audio_cooldown)
-		//MONKESTATION EDIT START - Allows sounds to vary based on their calling conditions.
-		//playsound(user, tmp_sound, 50, vary, mixer_channel = CHANNEL_MOB_SOUNDS) //MONKESTATION EDIT ORIGINAL
 		var/tmp_vary = should_vary(user)
-		playsound(user, tmp_sound, 50, tmp_vary, mixer_channel = get_mixer_channel(user, params, type_override, intentional))
-		//MONKESTATION EDIT END
+		playsound(
+			source = user,
+			soundin = tmp_sound,
+			vol = 50,
+			vary = tmp_vary,
+			extrarange = extra_range,
+			falloff_exponent = falloff_exponent,
+			mixer_channel = get_mixer_channel(user, params, type_override, intentional)
+		)
 
 	var/user_turf = get_turf(user)
 	if (user.client)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -64,7 +64,7 @@
 	var/audio_cooldown = 2 SECONDS
 	/// The falloff exponent for audible emotes.
 	var/falloff_exponent = SOUND_FALLOFF_EXPONENT
-	/// The extra range for audible emites.
+	/// The extra range for audible emotes.
 	var/extra_range = 0
 
 /datum/emote/New()

--- a/monkestation/code/modules/emotes/code/emote.dm
+++ b/monkestation/code/modules/emotes/code/emote.dm
@@ -237,6 +237,8 @@
 	message_param = "barks at %t!"
 	emote_type = EMOTE_AUDIBLE
 	audio_cooldown = 1.5 SECONDS
+	falloff_exponent = 10
+	extra_range = MEDIUM_RANGE_SOUND_EXTRARANGE
 
 /datum/emote/living/bark/can_run_emote(mob/user, status_check = TRUE, intentional = FALSE)
 	return ..() && HAS_TRAIT(user, TRAIT_ANIME)
@@ -285,6 +287,8 @@
 	message_mime = "squeals silently!"
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
+	falloff_exponent = 10
+	extra_range = MEDIUM_RANGE_SOUND_EXTRARANGE
 
 /datum/emote/living/squeal/get_sound(mob/living/user)
 	return 'monkestation/sound/voice/lizard/squeal.ogg' //This is from Bay
@@ -492,6 +496,8 @@
 	mob_type_blacklist_typecache = list(/mob/living/brain)
 	audio_cooldown = 2 SECONDS
 	vary = TRUE
+	falloff_exponent = 10
+	extra_range = SHORT_RANGE_SOUND_EXTRARANGE
 
 /datum/emote/spin/speen/get_sound(mob/living/user)
 	return 'monkestation/sound/voice/speen.ogg'

--- a/monkestation/code/modules/mob/living/basic/space_fauna/slugcat/slugcat.dm
+++ b/monkestation/code/modules/mob/living/basic/space_fauna/slugcat/slugcat.dm
@@ -28,8 +28,10 @@
 	message_mime = "wawa's silently!"
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
-	cooldown = 10
-	audio_cooldown = 10
+	cooldown = 1 SECONDS
+	audio_cooldown = 1 SECONDS
+	falloff_exponent = 10
+	extra_range = SHORT_RANGE_SOUND_EXTRARANGE
 
 /datum/emote/living/wawa/get_sound(mob/living/user)
 	return pick(
@@ -52,6 +54,8 @@
 	emote_type = EMOTE_AUDIBLE
 	vary = TRUE
 	audio_cooldown = 1.8 SECONDS
+	falloff_exponent = 10
+	extra_range = SHORT_RANGE_SOUND_EXTRARANGE
 
 /datum/emote/living/wa/get_sound(mob/living/user)
 	return pick(


### PR DESCRIPTION

## About The Pull Request

this raises the falloff exponent and lowers the range of some specific audible emotes, mostly higher-pitched, more ear-piercing ones.

falloff raised + range reduced: wa, wawa, speen
range reduced slightly: bark, squeal

## Why It's Good For The Game

these sounds can be genuinely uncomfortable to hear when spammed, so as a compromise, I'm reducing the range of the audio

## Changelog
:cl:
sound: Reduced the range of the audio of some emotes that had higher-pitched audio, such as speen and wawa.
/:cl:
