### PR TITLE
Disable some unneeded debug logs during production

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -95,6 +95,10 @@
 /// If this is uncommented, /proc/icon_exists will attempt to load an initial cache from icon_exists_cache.json
 // #define PRELOAD_ICON_EXISTS_CACHE
 
+/// If this is uncommented, additional logging (such as more in-depth tgui logging) will be enabled.alist
+/// These logs prolly don't matter during production.
+// #define EXTENDED_DEBUG_LOGGING
+
 // OpenDream currently doesn't support byondapi, so automatically disable it on OD,
 // unless CIBUILDING is defined - we still want to lint dreamluau-related code.
 // Get rid of this whenever it does have support.

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -100,8 +100,10 @@ SUBSYSTEM_DEF(tgui)
 			window_found = TRUE
 			break
 	if(!window_found)
+#ifdef EXTENDED_DEBUG_LOGGING
 		log_tgui(user, "Error: Pool exhausted",
 			context = "SStgui/request_pooled_window")
+#endif
 		return null
 	return window
 
@@ -113,7 +115,9 @@ SUBSYSTEM_DEF(tgui)
  * required user mob
  */
 /datum/controller/subsystem/tgui/proc/force_close_all_windows(mob/user)
+#ifdef EXTENDED_DEBUG_LOGGING
 	log_tgui(user, context = "SStgui/force_close_all_windows")
+#endif
 	if(user.client)
 		user.client.tgui_windows = list()
 		for(var/i in 1 to TGUI_WINDOW_HARD_LIMIT)
@@ -129,7 +133,9 @@ SUBSYSTEM_DEF(tgui)
  * required window_id string
  */
 /datum/controller/subsystem/tgui/proc/force_close_window(mob/user, window_id)
+#ifdef EXTENDED_DEBUG_LOGGING
 	log_tgui(user, context = "SStgui/force_close_window")
+#endif
 	// Close all tgui datums based on window_id.
 	for(var/datum/tgui/ui in user.tgui_open_uis)
 		if(ui.window && ui.window.id == window_id)

--- a/code/modules/tgui/external.dm
+++ b/code/modules/tgui/external.dm
@@ -213,9 +213,11 @@
 	if(window_id)
 		window = usr.client.tgui_windows[window_id]
 		if(!window)
+#ifdef EXTENDED_DEBUG_LOGGING
 			log_tgui(usr,
 				"Error: Couldn't find the window datum, force closing.",
 				context = window_id)
+#endif
 			SStgui.force_close_window(usr, window_id)
 			return TRUE
 

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -55,9 +55,11 @@
  * return datum/tgui The requested UI.
  */
 /datum/tgui/New(mob/user, datum/src_object, interface, title, ui_x, ui_y)
+#ifdef EXTENDED_DEBUG_LOGGING
 	log_tgui(user,
 		"new [interface] fancy [user?.client?.prefs.read_preference(/datum/preference/toggle/tgui_fancy)]",
 		src_object = src_object)
+#endif
 	src.user = user
 	src.src_object = src_object
 	src.window_key = "[REF(src_object)]-main"
@@ -289,9 +291,11 @@
 		return
 	// Validate ping
 	if(!initialized && world.time - opened_at > TGUI_PING_TIMEOUT)
+#ifdef EXTENDED_DEBUG_LOGGING
 		log_tgui(user, "Error: Zombie window detected, closing.",
 			window = window,
 			src_object = src_object)
+#endif
 		close(can_be_suspended = FALSE)
 		return
 	// Update through a normal call to ui_interact

--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -78,9 +78,11 @@
 		inline_html = "",
 		inline_js = "",
 		inline_css = "")
+#ifdef EXTENDED_DEBUG_LOGGING
 	log_tgui(client,
 		context = "[id]/initialize",
 		window = src)
+#endif
 	if(QDELETED(client))
 		return
 	src.initial_fancy = fancy
@@ -238,16 +240,20 @@
 	if(mouse_event_macro_set)
 		remove_mouse_macro()
 	if(can_be_suspended && can_be_suspended())
+#ifdef EXTENDED_DEBUG_LOGGING
 		log_tgui(client,
 			context = "[id]/close (suspending)",
 			window = src)
+#endif
 		visible = FALSE
 		status = TGUI_WINDOW_READY
 		send_message("suspend")
 		return
+#ifdef EXTENDED_DEBUG_LOGGING
 	log_tgui(client,
 		context = "[id]/close",
 		window = src)
+#endif
 	release_lock()
 	visible = FALSE
 	status = TGUI_WINDOW_CLOSED


### PR DESCRIPTION

## About The Pull Request

This disables various tgui logs by default, however they can be re-enabled with the `EXTENDED_DEBUG_LOGGING` define. Actual tgui actions are still logged.

## Why It's Good For The Game

Logging is somewhat performance-intensive, and these logs get spammed way too much.

The option to re-enable them is still there, behind a compile-time flag.

## Changelog

no user-facing changes