### PR TITLE
Slimes properly copy nanites when splitting again

### DIFF
--- a/monkestation/code/modules/datums/components/nanites.dm
+++ b/monkestation/code/modules/datums/components/nanites.dm
@@ -144,8 +144,10 @@
 				SNP.copy_programming(NP, copy_activation)
 				break
 	if(full_overwrite)
-		for(var/X in programs_to_remove)
-			qdel(X)
+		QDEL_LIST(programs_to_remove)
+		cloud_id = source.cloud_id
+		cloud_active = source.cloud_active
+		safety_threshold = source.safety_threshold
 	for(var/X in programs_to_add)
 		var/datum/nanite_program/SNP = X
 		add_program(null, SNP.copy())

--- a/monkestation/code/modules/slimecore/mobs/_base_slime.dm
+++ b/monkestation/code/modules/slimecore/mobs/_base_slime.dm
@@ -372,6 +372,12 @@
 		new_slime.add_trait(trait.type)
 	SEND_SIGNAL(src, COMSIG_FRIENDSHIP_PASS_FRIENDSHIP, new_slime)
 	new_slime.recompile_ai_tree()
+	var/datum/component/nanites/nanites = GetComponent(/datum/component/nanites)
+	if(nanites)
+		//copying over nanite programs/cloud sync with 50% saturation in host and spare
+		nanites.nanite_volume *= 0.5
+		new_slime.AddComponent(/datum/component/nanites, nanites.nanite_volume)
+		SEND_SIGNAL(new_slime, COMSIG_NANITE_SYNC, nanites, TRUE, TRUE) //The trues are to copy activation as well
 
 /mob/living/basic/slime/proc/start_mutating(random = FALSE)
 	if(!pick_mutation(random))


### PR DESCRIPTION

## About The Pull Request

this makes it so slime splitting also copies nanites to the new slime. this apparently was a thing before but was accidentally removed during the xenobio rework

also makes it so a "full overwrite" nanite sync also copies safety threshold and cloud ID.

## Why It's Good For The Game

fixes a bug and mild qol change

## Changelog
:cl:
fix: Slimes now properly copy nanites when splitting again.
qol: Nanites now also copy cloud ID and safety thresholds when "syncing" with a full overwrite.
/:cl:
