### PR TITLE
Fix ooze suckers being weird with pumping adjacent turfs

### DIFF
--- a/monkestation/code/modules/slimecore/machines/ooze_sucker.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_sucker.dm
@@ -172,13 +172,15 @@ GLOBAL_LIST_EMPTY_TYPED(ooze_suckers, /obj/machinery/plumbing/ooze_sucker)
 	// but overall try to pump the same volume regardless of number of affected tiles
 	var/turf/local_turf = get_turf(src)
 	var/list/turf/candidate_turfs = local_turf.get_atmos_adjacent_turfs(alldir = TRUE)
-	candidate_turfs += local_turf
-
 	var/list/turf/affected_turfs = list()
 
-	for(var/turf/candidate as anything in candidate_turfs)
-		if(isturf(candidate))
-			affected_turfs += candidate
+	for(var/turf/candidate in local_turf.get_atmos_adjacent_turfs(alldir = TRUE) + local_turf)
+		// don't bother considering turfs that don't even have slime ooze
+		if(!candidate.liquids?.liquid_group?.total_reagent_volume)
+			continue
+		if(!candidate.liquids.liquid_group.reagents?.has_reagent(/datum/reagent/slime_ooze, check_subtypes = TRUE))
+			continue
+		affected_turfs += candidate
 
 	if(!length(affected_turfs))
 		return

--- a/monkestation/code/modules/slimecore/machines/ooze_sucker.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_sucker.dm
@@ -213,9 +213,9 @@ GLOBAL_LIST_EMPTY_TYPED(ooze_suckers, /obj/machinery/plumbing/ooze_sucker)
 	if(QDELETED(targeted_group))
 		return
 
-	var/target_value = seconds_per_tick * (drain_flat + (targeted_group.total_reagent_volume * drain_percent)) * multiplier
+	var/target_value = round(seconds_per_tick * (drain_flat + (targeted_group.total_reagent_volume * drain_percent)) * multiplier, CHEMICAL_VOLUME_ROUNDING)
 	//Free space handling
-	var/free_space = reagents.maximum_volume - reagents.total_volume
+	var/free_space = round(reagents.maximum_volume - reagents.total_volume, CHEMICAL_VOLUME_ROUNDING)
 	if(target_value > free_space && (SUCKER_UPGRADE_DISPOSER in upgrades))
 		if (SUCKER_UPGRADE_BALANCER in upgrades)
 			reagents.remove_reagent(reagents.get_master_reagent_id(), target_value - free_space)

--- a/monkestation/code/modules/slimecore/machines/ooze_sucker.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_sucker.dm
@@ -171,7 +171,6 @@ GLOBAL_LIST_EMPTY_TYPED(ooze_suckers, /obj/machinery/plumbing/ooze_sucker)
 	// Determine what tiles should be pumped. We grab from a 3x3 area,
 	// but overall try to pump the same volume regardless of number of affected tiles
 	var/turf/local_turf = get_turf(src)
-	var/list/turf/candidate_turfs = local_turf.get_atmos_adjacent_turfs(alldir = TRUE)
 	var/list/turf/affected_turfs = list()
 
 	for(var/turf/candidate in local_turf.get_atmos_adjacent_turfs(alldir = TRUE) + local_turf)


### PR DESCRIPTION

## About The Pull Request

ooze suckers would sometimes be funky about pumping adjacent turfs, due to how they processed

this also makes it so they just skip turfs without slime ooze entirely.

## Why It's Good For The Game

things working less weirdly is good

## Changelog
:cl:
fix: Fixed ooze suckers being weird with pumping adjacent turfs.
/:cl:
