### PR TITLE
Fix nanite cloud IDs getting reset

### DIFF
--- a/monkestation/code/modules/research/nanites/nanite_cloud_controller.dm
+++ b/monkestation/code/modules/research/nanites/nanite_cloud_controller.dm
@@ -58,6 +58,7 @@
 	var/datum/component/nanites/cloud_copy = backup.AddComponent(/datum/component/nanites)
 	backup.cloud_id = cloud_id
 	backup.nanites = cloud_copy
+	cloud_copy.cloud_id = cloud_id
 	investigate_log("[key_name(user)] created a new nanite cloud backup with id #[cloud_id]", INVESTIGATE_NANITES)
 
 /obj/machinery/computer/nanite_cloud_controller/ui_interact(mob/user, datum/tgui/ui)

--- a/monkestation/code/modules/research/nanites/nanite_cloud_controller.dm
+++ b/monkestation/code/modules/research/nanites/nanite_cloud_controller.dm
@@ -55,10 +55,9 @@
 		return
 
 	var/datum/nanite_cloud_backup/backup = new(src)
-	var/datum/component/nanites/cloud_copy = backup.AddComponent(/datum/component/nanites)
+	var/datum/component/nanites/cloud_copy = backup.AddComponent(/datum/component/nanites, cloud_id = cloud_id)
 	backup.cloud_id = cloud_id
 	backup.nanites = cloud_copy
-	cloud_copy.cloud_id = cloud_id
 	investigate_log("[key_name(user)] created a new nanite cloud backup with id #[cloud_id]", INVESTIGATE_NANITES)
 
 /obj/machinery/computer/nanite_cloud_controller/ui_interact(mob/user, datum/tgui/ui)


### PR DESCRIPTION

## About The Pull Request

i accidentally broke nanite cloud syncing in https://github.com/Monkestation/Monkestation2.0/pull/6848 due to making it so cloud IDs also get synced... but the nanite component in the actual cloud backup didn't have the `cloud_id` var set

## Why It's Good For The Game

bugfix good

## Changelog
:cl:
fix: Fixed nanite cloud IDs getting reset to 0.
/:cl:
