### PR TITLE
Fixes sticky movement keys caused by TGUI passthrough

### DIFF
--- a/tgui/packages/tgui/backend.ts
+++ b/tgui/packages/tgui/backend.ts
@@ -16,11 +16,7 @@ import { createAction } from 'common/redux';
 import { setupDrag } from './drag';
 import { globalEvents } from './events';
 import { focusMap } from './focus';
-import {
-  releaseHeldKeys,
-  startKeyPassthrough,
-  stopKeyPassthrough,
-} from './hotkeys';
+
 import { createLogger } from './logging';
 import { resumeRenderer, suspendRenderer } from './renderer';
 
@@ -232,8 +228,6 @@ export const backendMiddleware = (store) => {
       Byond.winset(Byond.windowId, {
         'is-visible': false,
       });
-      stopKeyPassthrough();
-      releaseHeldKeys();
       setTimeout(() => focusMap());
     }
 
@@ -260,7 +254,6 @@ export const backendMiddleware = (store) => {
       logger.log('backend/update', payload);
       // Signal renderer that we have resumed
       resumeRenderer();
-      startKeyPassthrough();
       // Setup drag
       setupDrag();
       // We schedule this for the next tick here because resizing and unhiding

--- a/tgui/packages/tgui/events.ts
+++ b/tgui/packages/tgui/events.ts
@@ -60,12 +60,14 @@ const stealFocus = (node: HTMLElement) => {
   releaseStolenFocus();
   focusStolenBy = node;
   focusStolenBy.addEventListener('blur', releaseStolenFocus);
+  globalEvents.emit('input-focus');
 };
 
 const releaseStolenFocus = () => {
   if (focusStolenBy) {
     focusStolenBy.removeEventListener('blur', releaseStolenFocus);
     focusStolenBy = null;
+    globalEvents.emit('input-blur');
   }
 };
 
@@ -117,27 +119,47 @@ window.addEventListener('mousemove', (e) => {
 // Focus event hooks
 // --------------------------------------------------------
 
-window.addEventListener('focusin', (e) => {
-  lastVisitedNode = null;
-  focusedNode = e.target as HTMLElement;
+// Handle stealing focus for textbox elements
+document.addEventListener(
+  'focus',
+  (e: FocusEvent) => {
+    // Window
+    if (!(e.target instanceof Element)) {
+      lastVisitedNode = null;
+      focusedNode = null;
+      return;
+    }
+    lastVisitedNode = null;
+    focusedNode = e.target as HTMLElement;
+    if (canStealFocus(e.target as HTMLElement)) {
+      stealFocus(e.target as HTMLElement);
+    }
+  },
+  true,
+);
+
+// When we click on any element on the page, untrack the last
+// visited node.
+document.addEventListener(
+  'blur',
+  (e) => {
+    lastVisitedNode = null;
+  },
+  true,
+);
+
+// Handle setting the window focus
+window.addEventListener('focus', () => {
   setWindowFocus(true);
-  if (canStealFocus(e.target as HTMLElement)) {
-    stealFocus(e.target as HTMLElement);
-    return;
-  }
 });
 
-window.addEventListener('focusout', (e) => {
-  lastVisitedNode = null;
-  setWindowFocus(false, true);
-});
-
+// If we blur any element, the window may have unfocused if we didn't
+// click on the background
 window.addEventListener('blur', (e) => {
-  lastVisitedNode = null;
   setWindowFocus(false, true);
 });
 
-window.addEventListener('beforeunload', (e) => {
+window.addEventListener('close', (e) => {
   setWindowFocus(false);
 });
 

--- a/tgui/packages/tgui/hotkeys.ts
+++ b/tgui/packages/tgui/hotkeys.ts
@@ -185,22 +185,9 @@ export const setupHotKeys = () => {
   globalEvents.on('window-blur', () => {
     releaseHeldKeys();
   });
-  startKeyPassthrough();
-};
-
-export const startKeyPassthrough = () => {
-  globalEvents.on('key', keyEvent);
-};
-
-export const stopKeyPassthrough = () => {
-  globalEvents.off('key', keyEvent);
-};
-
-const keyEvent = (key: KeyEvent) => {
-  for (const keyListener of keyListeners) {
-    keyListener(key);
-  }
-  handlePassthrough(key);
+  globalEvents.on('input-focus', () => {
+    releaseHeldKeys();
+  });
 };
 
 /**


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ports https://github.com/BeeStation/BeeStation-Hornet/pull/12834

> TGUI has a feature where it passes through hotkeys to the game. When the user clicks off of a window, the TGUI window needs to know that it should send a 'keyup' event to Byond, so that transfer can be passed over to Byond. If the TGUI window cannot correctly determine whether or not the user has it in focus, then the keyup command will not be sent to Byond, resulting in a stuck movement key.
> 
> This PR refactors the logic for how TGUI windows determine if they are in focus. It now seperates the window focus, from an element such as a textbox stealing focus. It also stops using events that aren't fully supported in Javascript, as this change in behaviour is what results in the difference in behaviour between 515 and 516.

## Why It's Good For The Game

> Sticky keys are really, really annoying and common.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Absolucy, PowerfulBacon
fix: Fixes movement keys being stuck.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
