### PR TITLE
Minor heliostation xenobio fixes

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -21657,6 +21657,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
 /obj/structure/cable,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/science/xenobiology)
 "cqW" = (
@@ -24198,6 +24199,7 @@
 /obj/effect/turf_decal/tile/neutral/half,
 /obj/effect/turf_decal/arrows,
 /obj/structure/cable,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/textured_half,
 /area/station/science/xenobiology)
 "cLZ" = (
@@ -31506,6 +31508,7 @@
 /obj/machinery/door/airlock/research/glass{
 	name = "Xenobiology Lab"
 	},
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/science/xenobiology)
 "eYW" = (
@@ -39367,6 +39370,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/any/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/textured_half,
 /area/station/science/xenobiology)
 "idQ" = (
@@ -47300,6 +47304,7 @@
 /obj/machinery/door/airlock/research/glass{
 	name = "Xenobiology Lab"
 	},
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white/smooth_half,
 /area/station/science/xenobiology)
 "lfj" = (
@@ -50514,6 +50519,7 @@
 	name = "Containment Pen #5";
 	req_access = list("research")
 	},
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -62940,6 +62946,7 @@
 	name = "Containment Pen #6";
 	req_access = list("research")
 	},
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/dark/textured_half{
 	dir = 1
 	},
@@ -123600,7 +123607,7 @@ ske
 sJH
 jhd
 vcS
-eqc
+wzb
 cnz
 szr
 cpI
@@ -124114,7 +124121,7 @@ kay
 uBf
 sin
 xIW
-wzb
+eqc
 cnz
 cpI
 wPm


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/6864

i just swapped the position of the biomass recycler and the market pad, allowing the pad to be directly adjacent to the market console.

also added liquid barriers below all the doors, to prevent the dreaded ooze flood lagfests, like on other maps.

## Why It's Good For The Game

bugfix good. and preventing laggy ooze floods is also good

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: Swapped the position of the biomass recycler and the intergalactic market pad in xenobio on HelioStation, allowing the pad to automatically link to the market roundstart.
map: Added liquid barriers to all the entrances to xenobio on HelioStation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
