### PR TITLE
Bloodsucker cloaking now hides your identity.

### DIFF
--- a/monkestation/code/modules/bloodsuckers/powers/cloak.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/cloak.dm
@@ -38,7 +38,7 @@
 	was_running = ((user.m_intent == MOVE_INTENT_RUN) || user.m_intent == MOVE_INTENT_SPRINT)
 	if(was_running)
 		user.set_move_intent(MOVE_INTENT_WALK)
-	ADD_TRAIT(user, TRAIT_NO_SPRINT, BLOODSUCKER_TRAIT)
+	user.add_traits(list(TRAIT_NO_SPRINT, TRAIT_UNKNOWN), REF(src))
 	user.AddElement(/datum/element/digitalcamo)
 	user.balloon_alert(user, "cloak turned on.")
 
@@ -74,5 +74,5 @@
 	if(was_running && user.m_intent == MOVE_INTENT_WALK)
 		user.set_move_intent(MOVE_INTENT_RUN)
 	user.balloon_alert(user, "cloak turned off.")
-	REMOVE_TRAIT(user, TRAIT_NO_SPRINT, BLOODSUCKER_TRAIT)
+	user.remove_traits(list(TRAIT_NO_SPRINT, TRAIT_UNKNOWN), REF(src))
 	return ..()

--- a/monkestation/code/modules/bloodsuckers/powers/tremere/auspex.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/tremere/auspex.dm
@@ -85,10 +85,12 @@
 
 /datum/action/cooldown/bloodsucker/targeted/tremere/auspex/ActivatePower(trigger_flags)
 	. = ..()
+	ADD_TRAIT(owner, TRAIT_UNKNOWN, REF(src))
 	owner.AddElement(/datum/element/digitalcamo)
 	animate(owner, alpha = 15, time = 1 SECONDS)
 
 /datum/action/cooldown/bloodsucker/targeted/tremere/auspex/DeactivatePower()
+	REMOVE_TRAIT(owner, TRAIT_UNKNOWN, REF(src))
 	animate(owner, alpha = 255, time = 1 SECONDS)
 	owner.RemoveElement(/datum/element/digitalcamo)
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so Cloak of Darkness and Auspex now hide your identity while cloaked - your name shows up as "Unknown", and examining will just show the "You're struggling to make out any details..." message.

## Why It's Good For The Game

it makes sense. you're cloaked, why the hell would anyone be able to see anything useful from examining you?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Bloodsucker cloaking (Cloak of Darkness or Auspex) now hides your identity while active.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
