### PR TITLE
Mod suit storage items now get placed in the storage unit when the chest undeploys.

### DIFF
--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -28,6 +28,7 @@
 	modstorage.set_real_location(src)
 	modstorage.allow_big_nesting = big_nesting
 	modstorage.locked = STORAGE_NOT_LOCKED
+	atom_storage.locked = FALSE
 	RegisterSignal(mod.chestplate, COMSIG_ITEM_PRE_UNEQUIP, PROC_REF(on_chestplate_unequip))
 
 /obj/item/mod/module/storage/on_uninstall(deleting = FALSE)


### PR DESCRIPTION
## About The Pull Request

fixes [6871](https://github.com/Monkestation/Monkestation2.0/issues/6871) allowing items on the equipment slot to be correctly placed back into inventory when undeployed because the atom storage was never unlocked.

## Why It's Good For The Game

No matter what the game would never automatically put gear items in the storage unit when undeployed, instead dropping them on the ground. 

## Changelog
:cl:
fix: Items in the gear slot of a modsuit now correctly get placed in the storage unit when undeploying
/:cl:
