### PR TITLE
[PORT] Fixes active conveyor belts not moving movables spawned on top of them.

### DIFF
--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -46,7 +46,7 @@
 /**
 	Base proc for all `/mineral` subtype machines to use. Place your item pickup behavior in this proc when you override it for your specific machine.
 
-	Called when the COMSIG_ATOM_ENTERED and COMSIG_ATOM_INITIALIZED_ON signals are sent.
+	Called when the COMSIG_ATOM_ENTERED and COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON signals are sent.
 
 	Arguments:
 	* source - the turf that is listening for the signals.

--- a/code/modules/recycling/conveyor.dm
+++ b/code/modules/recycling/conveyor.dm
@@ -90,7 +90,7 @@ GLOBAL_LIST_EMPTY(conveyors_by_id)
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_EXITED = PROC_REF(conveyable_exit),
 		COMSIG_ATOM_ENTERED = PROC_REF(conveyable_enter),
-		COMSIG_ATOM_INITIALIZED_ON = PROC_REF(conveyable_enter)
+		COMSIG_ATOM_AFTER_SUCCESSFUL_INITIALIZED_ON = PROC_REF(conveyable_enter)
 	)
 	AddElement(/datum/element/connect_loc, loc_connections)
 	update_move_direction()


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/77104

> There's one instance of the old signal I've missed from tgstation/76376, all because lists treat undefined keys like text strings.

## Why It's Good For The Game

bugfix

## Changelog

:cl: Absolucy, Ghommie
fix: Fixed active conveyor belts not moving movables spawned on top of them.
/:cl:
