### PR TITLE
Makes both detective revolvers detective revolvers.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -167,7 +167,7 @@
 	new /obj/item/reagent_containers/spray/pepper(src)
 	new /obj/item/clothing/suit/armor/vest/det_suit(src)
 	new /obj/item/storage/belt/holster/detective/full(src)
-	new /obj/item/storage/belt/holster/detective/bis/full(src) // Monkestation edit : Adding some substance to the detective role
+	new /obj/item/storage/belt/holster/detective/full(src) // Monkestation edit : Adding some substance to the detective role
 	new /obj/item/pinpointer/crew(src)
 	new /obj/item/binoculars(src)
 	new /obj/item/storage/box/rxglasses/spyglasskit(src)


### PR DESCRIPTION


## Why It's Good For The Game

I get why the person that added a second detective slot wanted only one copy of an objective item, but honestly two copies is better than the current solution. Every tot that wants to engage in thievery RP with the det basically has to flip a coin on whether they're carrying THE detective's revolver or just a detective revolver. Also having two identical items in literally every way except for the name and that mattering for an objective hilarious.

## Changelog



:cl:

qol: Both detective's revolvers are now actual Detective's Revolvers.

/:cl: