### PR TITLE
Mod suit gear items now get placed into storage units when deactivated

### DIFF
--- a/code/modules/mod/modules/modules_general.dm
+++ b/code/modules/mod/modules/modules_general.dm
@@ -28,6 +28,7 @@
 	modstorage.set_real_location(src)
 	modstorage.allow_big_nesting = big_nesting
 	modstorage.locked = STORAGE_NOT_LOCKED
+	atom_storage.locked = FALSE
 	RegisterSignal(mod.chestplate, COMSIG_ITEM_PRE_UNEQUIP, PROC_REF(on_chestplate_unequip))
 
 /obj/item/mod/module/storage/on_uninstall(deleting = FALSE)


### PR DESCRIPTION
[had to remake this](https://github.com/Monkestation/Monkestation2.0/pull/6876)

i dunno wtf rust_g.dll even is
## Why It's Good For The Game

fixes [6871](https://github.com/Monkestation/Monkestation2.0/issues/6871) 

## Changelog
:cl:
fix: Mod suit gear items now get placed into storage units when deactivated
/:cl:
