### PR TITLE
Nitrium adds 2 units of reagent so to prevent sleep properly

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -586,7 +586,7 @@
 		breather.reagents.add_reagent(/datum/reagent/nitrium_low_metabolization, max(0, 2 - existing))
 	if (nitrium_pp > 10)
 		var/existing = breather.reagents.get_reagent_amount(/datum/reagent/nitrium_high_metabolization)
-		breather.reagents.add_reagent(/datum/reagent/nitrium_high_metabolization, max(0, 1 - existing))
+		breather.reagents.add_reagent(/datum/reagent/nitrium_high_metabolization, max(0, 2 - existing))
 
 /// Radioactive, green gas. Toxin damage, and a radiation chance
 /obj/item/organ/internal/lungs/proc/too_much_tritium(mob/living/carbon/breather, datum/gas_mixture/breath, trit_pp, old_trit_pp)


### PR DESCRIPTION

## About The Pull Request
Ports: https://github.com/tgstation/tgstation/pull/90345
## Why It's Good For The Game
Makes the nitrium + healium synergy actually synzergize
## Changelog
:cl: Unit2E, Xander3359
fix: Mobs should no longer fall asleep when breathing in enough Nitrium to provide sleep immunity.
/:cl:
