### PR TITLE
Fixes metastation artsci access

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -11690,7 +11690,7 @@
 	id = "xeno_blastdoor";
 	name = "Biohazard Containment Door"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/effect/mapping_helpers/airlock/access/all/science/general,
 /turf/open/floor/iron/white,
 /area/station/science/breakroom)
 "ejJ" = (


### PR DESCRIPTION

## About The Pull Request
Removes the unneeded xenobio access on artsci
## Why It's Good For The Game
Maint crawl bad. Fixes:#6859
## Changelog
:cl:
map: Meta station Artsci is now accessible without xenobio access
/:cl:
