### PR TITLE
Stabilized cerulean and oil extracts now use `COMSIG_LIVING_DEATH` instead of checking each tick

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -756,7 +756,8 @@
 /datum/status_effect/stabilized/cerulean/proc/create_clone()
 	var/typepath = owner.type
 	clone = new typepath(owner.loc)
-	clone.name = clone.real_name = owner.real_name
+	clone.real_name = owner.real_name
+	clone.name = clone.real_name
 	clone.update_name_tag(clone.real_name)
 	var/mob/living/carbon/carbon_owner = owner
 	var/mob/living/carbon/carbon_clone = clone

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -756,14 +756,13 @@
 /datum/status_effect/stabilized/cerulean/proc/create_clone()
 	var/typepath = owner.type
 	clone = new typepath(owner.loc)
+	clone.name = clone.real_name = owner.real_name
+	clone.update_name_tag(clone.real_name)
 	var/mob/living/carbon/carbon_owner = owner
 	var/mob/living/carbon/carbon_clone = clone
-	if(!istype(carbon_owner) || !istype(carbon_clone))
-		return
-	carbon_clone.real_name = carbon_owner.real_name
-	carbon_clone.update_name_tag(carbon_clone.real_name)
-	carbon_owner.dna.transfer_identity(carbon_clone)
-	carbon_clone.updateappearance(mutcolor_update = TRUE)
+	if(istype(carbon_owner) && istype(carbon_clone))
+		carbon_owner.dna.transfer_identity(carbon_clone)
+		carbon_clone.updateappearance(mutcolor_update = TRUE)
 
 /datum/status_effect/stabilized/cerulean/proc/on_owner_death(datum/source)
 	SIGNAL_HANDLER

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -740,36 +740,44 @@
 	var/mob/living/clone
 
 /datum/status_effect/stabilized/cerulean/on_apply()
-	var/typepath = owner.type
-	clone = new typepath(owner.loc)
-	var/mob/living/carbon/O = owner
-	var/mob/living/carbon/C = clone
-	if(istype(C) && istype(O))
-		C.real_name = O.real_name
-		C.update_name_tag(C.real_name) // monkestation edit: name tags
-		O.dna.transfer_identity(C)
-		C.updateappearance(mutcolor_update=1)
+	create_clone()
+	RegisterSignal(owner, COMSIG_LIVING_DEATH, PROC_REF(on_owner_death))
 	return ..()
 
-/datum/status_effect/stabilized/cerulean/tick()
-	if(owner.stat == DEAD)
-		if(clone && clone.stat != DEAD)
-			owner.visible_message(span_warning("[owner] blazes with brilliant light, [linked_extract] whisking [owner.p_their()] soul away."),
-				span_notice("You feel a warm glow from [linked_extract], and you open your eyes... elsewhere."))
-			if(owner.mind)
-				owner.mind.transfer_to(clone)
-			clone = null
-			qdel(linked_extract)
-		if(!clone || clone.stat == DEAD)
-			to_chat(owner, span_notice("[linked_extract] desperately tries to move your soul to a living body, but can't find one!"))
-			qdel(linked_extract)
-	..()
-
 /datum/status_effect/stabilized/cerulean/on_remove()
-	if(clone)
+	UnregisterSignal(owner, COMSIG_LIVING_DEATH)
+	if(!QDELETED(clone))
 		clone.visible_message(span_warning("[clone] dissolves into a puddle of goo!"))
 		clone.unequip_everything()
 		qdel(clone)
+	clone = null
+	return ..()
+
+/datum/status_effect/stabilized/cerulean/proc/create_clone()
+	var/typepath = owner.type
+	clone = new typepath(owner.loc)
+	var/mob/living/carbon/carbon_owner = owner
+	var/mob/living/carbon/carbon_clone = clone
+	if(!istype(carbon_owner) || !istype(carbon_clone))
+		return
+	carbon_clone.real_name = carbon_owner.real_name
+	carbon_clone.update_name_tag(carbon_clone.real_name)
+	carbon_owner.dna.transfer_identity(carbon_clone)
+	carbon_clone.updateappearance(mutcolor_update = TRUE)
+
+/datum/status_effect/stabilized/cerulean/proc/on_owner_death(datum/source)
+	SIGNAL_HANDLER
+	if(QDELETED(clone) || clone.stat == DEAD)
+		to_chat(owner, span_notice("[linked_extract] desperately tries to move your soul to a living body, but can't find one!"))
+		qdel(linked_extract)
+		return
+	owner.visible_message(
+		span_warning("[owner] blazes with brilliant light, [linked_extract] whisking [owner.p_their()] soul away."),
+		span_notice("You feel a warm glow from [linked_extract], and you open your eyes... elsewhere.")
+	)
+	owner.mind?.transfer_to(clone)
+	clone = null
+	QDEL_NULL(linked_extract)
 
 /datum/status_effect/stabilized/pyrite
 	id = "stabilizedpyrite"
@@ -928,10 +936,17 @@
 	id = "stabilizedoil"
 	colour = "oil"
 
-/datum/status_effect/stabilized/oil/tick()
-	if(owner.stat == DEAD)
-		explosion(owner, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 4, flame_range = 5, explosion_cause = src)
+/datum/status_effect/stabilized/oil/on_apply()
+	RegisterSignal(owner, COMSIG_LIVING_DEATH, PROC_REF(on_owner_death))
 	return ..()
+
+/datum/status_effect/stabilized/oil/on_remove()
+	UnregisterSignal(owner, COMSIG_LIVING_DEATH)
+	return ..()
+
+/datum/status_effect/stabilized/oil/proc/on_owner_death(datum/source)
+	SIGNAL_HANDLER
+	explosion(owner, devastation_range = 1, heavy_impact_range = 2, light_impact_range = 4, flame_range = 5, explosion_cause = src)
 
 /datum/status_effect/stabilized/oil/get_examine_text()
 	return span_warning("[owner.p_they(TRUE)] smell[owner.p_s()] of sulfur and oil!")


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/6898

This makes it so stable cerulean and oil extracts just trigger on `COMSIG_LIVING_DEATH` now, instead of checking if `owner.stat == DEAD` each tick.

## Why It's Good For The Game

allows them to still work properly in a few odd cases such as oozelings, such as, and means server lag won't fuck them over.

## Changelog
:cl:
code: Improved how stabilized cerulean and oil extracts trigger on death, allowing them to properly work for oozelings and such.
/:cl:
