### PR TITLE
Unnerfs Sleeping Carp

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -11,7 +11,7 @@
 	COOLDOWN_DECLARE(block_cooldown)
 	var/list/scarp_traits = list(TRAIT_NOGUNS, TRAIT_HARDLY_WOUNDED, TRAIT_NODISMEMBER, TRAIT_HEAVY_SLEEPER, TRAIT_THROW_GUNS)
 	var/deflect_cooldown = 3 SECONDS //monke edit start
-	var/deflect_stamcost = 15 //how much stamina it costs per bullet deflected
+	var/deflect_stamcost = 0 //how much stamina it costs per bullet deflected
 	var/log_name = "Sleeping Carp"
 	var/damage = 30
 	var/kick_speed = 0 //how fast you get punted into the stratosphere on launchkick

--- a/code/modules/uplink/uplink_items/stealthy.dm
+++ b/code/modules/uplink/uplink_items/stealthy.dm
@@ -83,7 +83,7 @@
 			and gain the ability to swat bullets from the air, but you will also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/book/granter/martial/carp
 	progression_minimum = 30 MINUTES
-	cost = 12 //monke edit
+	cost = 14 //monke edit
 	surplus = 30 //monkestation edit: from 0 to 30
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes Stamina Drain from projectile deflects, and also raises the cost back to 14tc from 12tc. 

## Why It's Good For The Game

The entire gimmick around Sleeping Carp is ranged immunity. Being able to just sprint away from a carp user while shooting at them being a legitimate counter is one of the most asinine things Ive ever heard of. Carp already has counters in the form of throwing weapons, flashabangs, grenades in general, forged spears with 2 tile melee distance, and bolas. Particularly e-bolas, which at some point in the history of bright minded TG coders was changed to be uncatchable, making them the hardest counter in existence to carp users outside of a maxcap suicide bomb. Let carp users enjoy their bullet immunity, considering there are plenty of counters against them,

Also whoever thought that lowering the cost to 12tc so that you can roundstart purchase carp AND gloves of the north star was smoking some good shit at the time and I want them to pass it to me. At least this way you need to do at least one optional objective or get lucky with discounts, as it used to be. 

I'm not touching the stamina drain on ascarp though because that thing is terrifying and needs something to keep it reigned in.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:Helixsix

balance: Removes stamina drain off sleeping carp, raises TC cost back to 14

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
