### PR TITLE
Nerfs the Depot and Deep Storage because people can't be trusted

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -438,8 +438,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/item/circuitboard/machine/techfab/department/science,
 /obj/item/mod/module/jetpack,
+/obj/item/flatpacked_machine,
+/obj/item/flatpacked_machine/ore_silo,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/storage)
 "bn" = (
@@ -1368,6 +1369,19 @@
 /obj/structure/cable,
 /obj/effect/mapping_helpers/apc/cell_5k,
 /obj/effect/mapping_helpers/apc/syndicate_access,
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/mug/britcup{
+	pixel_x = 8;
+	pixel_y = 11
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = -5;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = -8;
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
 "dW" = (
@@ -1971,10 +1985,10 @@
 	chamber_id = "deepo2";
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/power)
 "fD" = (
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/deepstorage/power)
 "fE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2028,12 +2042,12 @@
 /obj/machinery/air_sensor{
 	chamber_id = "deepo2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/power)
 "fM" = (
 /obj/machinery/atmospherics/miner/oxygen,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/power)
 "fN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2281,7 +2295,7 @@
 	chamber_id = "deepn2";
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/deepstorage/power)
 "gw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -2353,12 +2367,12 @@
 /obj/machinery/air_sensor{
 	chamber_id = "deepn2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/deepstorage/power)
 "gE" = (
 /obj/machinery/atmospherics/miner/nitrogen,
 /obj/machinery/light/small/directional/east,
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/deepstorage/power)
 "gF" = (
 /turf/closed/wall/r_wall,
@@ -2386,7 +2400,7 @@
 /area/ruin/space/has_grav/deepstorage/power)
 "gL" = (
 /obj/machinery/door/airlock/highsecurity{
-	name = "RTG Observation"
+	name = "RTG Chamber"
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
@@ -2408,7 +2422,7 @@
 	chamber_id = "deepn2";
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/n2,
 /area/ruin/space/has_grav/deepstorage/power)
 "gQ" = (
 /obj/machinery/door/airlock/highsecurity{
@@ -2473,14 +2487,14 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "gZ" = (
-/obj/machinery/power/rtg/advanced,
 /obj/structure/cable,
+/obj/machinery/power/rtg/portable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "ha" = (
-/obj/machinery/power/rtg/advanced,
 /obj/machinery/light/small/directional/south,
 /obj/structure/cable,
+/obj/machinery/power/rtg/portable,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/deepstorage/power)
 "hb" = (
@@ -2672,7 +2686,7 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "lj" = (
-/turf/closed/wall,
+/turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/power)
 "lB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -2761,7 +2775,7 @@
 	chamber_id = "deepo2";
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/deepstorage/power)
 "qM" = (
 /obj/effect/turf_decal/stripes{
@@ -2970,6 +2984,15 @@
 	},
 /turf/open/floor/light,
 /area/ruin/space/has_grav/deepstorage/hydroponics)
+"xn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/power)
 "xI" = (
 /obj/machinery/firealarm/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -3187,6 +3210,15 @@
 "Iy" = (
 /turf/open/misc/asteroid/airless,
 /area/ruin/space)
+"Jp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/pink/visible{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage/power)
 "JC" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -3264,6 +3296,18 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
+"Nl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/structure/table,
+/obj/machinery/coffeemaker/impressa,
+/obj/item/storage/box/coffeepack,
+/obj/item/storage/box/coffeepack/robusta,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "Nw" = (
 /obj/machinery/corral_corner{
 	mapping_id = "s1"
@@ -4525,7 +4569,7 @@ cH
 cT
 dk
 dD
-dU
+Nl
 pP
 eE
 eR
@@ -5208,9 +5252,9 @@ LO
 fo
 fA
 fJ
-gb
+xn
 gk
-fA
+Jp
 gC
 gb
 gW
@@ -5261,7 +5305,7 @@ ZP
 fB
 fK
 hq
-lj
+ZP
 fB
 fK
 hq
@@ -5313,7 +5357,7 @@ ZP
 fC
 fL
 qm
-lj
+ZP
 gv
 gD
 gP
@@ -5362,10 +5406,10 @@ de
 hW
 LO
 ZP
-fD
-fM
-fD
 lj
+fM
+lj
+ZP
 fD
 gE
 fD

--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -332,6 +332,19 @@
 	dir = 8
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/reagent_containers/cup/glass/mug/britcup{
+	pixel_x = -8;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = -7;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/cup/glass/mug{
+	pixel_x = -5;
+	pixel_y = 0
+	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "dZ" = (
@@ -1063,6 +1076,26 @@
 	},
 /turf/open/floor/engine/airless,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
+"lx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/coffeemaker/impressa,
+/obj/item/storage/box/coffeepack/robusta{
+	pixel_x = 7;
+	pixel_y = -12
+	},
+/obj/item/storage/box/coffeepack/robusta{
+	pixel_x = 7;
+	pixel_y = -14
+	},
+/obj/item/storage/box/coffeepack{
+	pixel_x = 7;
+	pixel_y = -17
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "lz" = (
 /obj/machinery/growing/tray,
 /turf/open/misc/dirt/station,
@@ -1340,11 +1373,10 @@
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "oz" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/office/tactical{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
 "oO" = (
@@ -1606,7 +1638,6 @@
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/effect/mapping_helpers/apc/cell_10k,
 /obj/structure/safe,
-/obj/item/stack/telecrystal/five,
 /obj/effect/mapping_helpers/apc/cut_AI_wire,
 /obj/item/card/id/advanced/chameleon,
 /obj/item/card/id/advanced/chameleon,
@@ -1920,8 +1951,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_depot/shipbreaking_control)
 "uX" = (
-/obj/machinery/rnd/production/protolathe/offstation,
-/obj/structure/railing{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
@@ -2606,7 +2636,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
-/obj/structure/table/reinforced/plastitaniumglass,
+/obj/machinery/rnd/production/colony_lathe,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "CG" = (
@@ -2953,6 +2983,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/assembler,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
 "HN" = (
@@ -3174,13 +3205,13 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "Kd" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "syndicate_depot_manufacturing";
-	pixel_x = -12;
-	pixel_y = 0
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
 "Kg" = (
@@ -3264,6 +3295,15 @@
 /obj/item/circuitboard/machine/quantumpad,
 /obj/item/storage/toolbox/electrical,
 /obj/item/circuitboard/machine/spaceship_navigation_beacon,
+/obj/item/manipulator_filter,
+/obj/item/manipulator_filter,
+/obj/item/manipulator_filter,
+/obj/item/manipulator_filter/cargo,
+/obj/item/manipulator_filter/cargo,
+/obj/item/circuitboard/machine/big_manipulator,
+/obj/item/circuitboard/machine/big_manipulator,
+/obj/item/circuitboard/machine/big_manipulator,
+/obj/item/circuitboard/machine/big_manipulator,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "KP" = (
@@ -3419,12 +3459,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "MV" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
 "MZ" = (
@@ -3634,13 +3673,15 @@
 "PG" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/apc/syndicate_access,
 /obj/machinery/firealarm/directional/east,
 /obj/effect/mapping_helpers/apc/cut_AI_wire,
-/obj/machinery/rnd/production/circuit_imprinter/offstation,
+/obj/machinery/conveyor_switch/oneway{
+	id = "syndicate_depot_manufacturing";
+	pixel_x = 10;
+	pixel_y = 0
+	},
+/obj/machinery/autolathe/hacked,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
 "PL" = (
@@ -3670,6 +3711,9 @@
 	fax_name = "Syndicate Depot Cargo Bay"
 	},
 /obj/structure/table/reinforced/plastitaniumglass,
+/obj/item/paper/crumpled{
+	default_raw_text = "Fucking maniacs! Stop directly hitting Nanotrasen! If their navy takes notice to this we'll all get shot down!"
+	},
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "PR" = (
@@ -3730,15 +3774,10 @@
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "Qz" = (
-/obj/machinery/autolathe/hacked,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
 "QC" = (
@@ -3883,13 +3922,13 @@
 	name = "Manufacturing"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/syndicate/general,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "syndicate_depot_lockdown";
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/cutaiwire,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
 "So" = (
@@ -4363,6 +4402,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
+/obj/machinery/assembler,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/manufacturing)
 "Xz" = (
@@ -7444,7 +7484,7 @@ jw
 eC
 dn
 MZ
-HU
+lx
 dU
 HU
 EJ

--- a/code/modules/mob_spawn/ghost_roles/space_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/space_roles.dm
@@ -190,7 +190,7 @@
 	prompt_name = "a syndicate science technician"
 	you_are_text = "You are a syndicate science technician, employed in a remote research bunker developing biological weapons."
 	flavour_text = "Unfortunately, your hated enemy, Nanotrasen, has a station in this sector. Continue your research as best you can, and try to keep a low profile."
-	important_text = "DO NOT abandon the base or let it fall into enemy hands! However, you may freely explore your surrounding within your current space quadrant (Z-Level). Do not directly interfere with the Nanotrasen station without the express permission of Syndicate Command."
+	important_text = "DO NOT abandon the base or let it fall into enemy hands! However, you may freely explore your surrounding within your current space quadrant (Z-Level). Do not directly interfere with the Nanotrasen station without the express permission of Syndicate Command. Do not test bioweapons on the Nanotrasen station without Syndicate Command's approval either."
 	outfit = /datum/outfit/deepstorage_syndicate
 
 /datum/outfit/deepstorage_syndicate

--- a/code/modules/mob_spawn/ghost_roles/space_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/space_roles.dm
@@ -180,7 +180,7 @@
 	prompt_name = "a syndicate comms agent"
 	you_are_text = "You are a syndicate comms agent, employed in a remote research bunker."
 	flavour_text = "Unfortunately, your hated enemy, Nanotrasen, has a station in this sector. Monitor enemy activity as best you can, and try to keep a low profile. Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!"
-	important_text = "DO NOT abandon the base. However, you may freely explore your surrounding within your current space quadrant (Z-Level)"
+	important_text = "DO NOT abandon the base. However, you may freely explore your surrounding within your current space quadrant (Z-Level). Do not directly interfere with the Nanotrasen station without the express permission of Syndicate Command."
 	outfit = /datum/outfit/lavaland_syndicate/comms
 
 /obj/effect/mob_spawn/ghost_role/human/lavaland_syndicate/deepstorage
@@ -190,7 +190,7 @@
 	prompt_name = "a syndicate science technician"
 	you_are_text = "You are a syndicate science technician, employed in a remote research bunker developing biological weapons."
 	flavour_text = "Unfortunately, your hated enemy, Nanotrasen, has a station in this sector. Continue your research as best you can, and try to keep a low profile."
-	important_text = "DO NOT abandon the base or let it fall into enemy hands! However, you may freely explore your surrounding within your current space quadrant (Z-Level)"
+	important_text = "DO NOT abandon the base or let it fall into enemy hands! However, you may freely explore your surrounding within your current space quadrant (Z-Level). Do not directly interfere with the Nanotrasen station without the express permission of Syndicate Command."
 	outfit = /datum/outfit/deepstorage_syndicate
 
 /datum/outfit/deepstorage_syndicate

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -5,7 +5,7 @@
 	prompt_name = "a syndicate depot worker"
 	you_are_text = "You are a depot worker, employed at a Syndicate depot."
 	flavour_text = "Produce and move supplies for Syndicate bases in the region, as well as ensure they are safely evacuated should they be lost. Do not let the base fall into enemy hands!"
-	important_text = "DO NOT abandon the base or approach active Nanotrasen installations. Remember that you still need to satisfy escalation requirements in order to send bombs or grenades to the NT installation. However, you may freely explore your surrounding within your current space quadrant (Z-Level), and may fly to other Syndicate bases in space to deliver and move supplies with the permission of the Quartermaster."
+	important_text = "DO NOT abandon the base or approach active Nanotrasen installations. Do not interfere with Nanotrasen operations outside of self-defence, and do not directly interfere with the station without express approval of Syndicate Command. However, you may freely explore your surrounding within your current space quadrant (Z-Level), and may fly to other Syndicate bases in space to deliver and move supplies with the permission of the Quartermaster."
 	outfit = /datum/outfit/syndicate_empty/depot
 	spawner_job_path = /datum/job/lavaland_syndicate/space
 
@@ -23,7 +23,7 @@
 	prompt_name = "a syndicate depot guard"
 	you_are_text = "You are a security guard, employed at a Syndicate depot."
 	flavour_text = "Protect the depot from enemy forces and prevent its destruction at all costs."
-	important_text = "DO NOT abandon the base or approach active Nanotrasen installations.  Remember that you still need to satisfy escalation requirements in order to send bombs or grenades to the NT installation. You are here to protect it, and cannot perform deliveries."
+	important_text = "DO NOT abandon the base or approach active Nanotrasen installations.  Do not interfere with Nanotrasen operations outside of self-defence, and do not directly interfere with the station without express approval of Syndicate Command. You are here to protect the depot, and cannot perform deliveries except in an emergency."
 	outfit = /datum/outfit/syndicate_empty/depot/guard
 
 /datum/outfit/syndicate_empty/depot/guard
@@ -41,7 +41,7 @@
 	prompt_name = "a syndicate depot quartermaster"
 	you_are_text = "You are a Quartermaster, in charge of a Syndicate depot."
 	flavour_text = "Operate the depot to ensure it continues to safely ship supplies for the Coalition's outposts in nearby space. Protect it to the last, and do not let the base fall into enemy hands!"
-	important_text = "DO NOT abandon the base or approach active Nanotrasen installations.  Remember that you still need to satisfy escalation requirements in order to send bombs or grenades to the NT installation. You can, however, authorise depot workers to perform deliveries outside the local quadrant (Z-level) to other space outposts (but not go yourself), and may freely explore the local quadrant (Z-level) alongside them."
+	important_text = "DO NOT abandon the base or approach active Nanotrasen installations.  Do not interfere with Nanotrasen operations outside of self-defence, and do not directly interfere with the station without express approval of Syndicate Command. You can, however, authorise depot workers to perform deliveries outside the local quadrant (Z-level) to other space outposts (but not go yourself), and may freely explore the local quadrant (Z-level) alongside them."
 	outfit = /datum/outfit/syndicate_empty/depot/quartermaster
 
 /datum/outfit/syndicate_empty/depot/quartermaster


### PR DESCRIPTION
# If you abuse the cool toys, you lose the cool toys
- faustbyte, 06/06/2025

the depot no longer has:
- telecrystals
- ancient protolathe and imprinter (replaced with colony lathe)

it has been given factorio assemblers and arm parts so that manufacturing isnt a dud and i added coffee machine

deep storage no longer has:
- science techfab

in exchange, i gave them flatpack colony shit again and flatpack RTGs which are more powerful at the cost of OH MY FUCKING GOD CANCER (radsuits provided)
## Why It's Good For The Game

![image](https://github.com/user-attachments/assets/4ce59488-40f6-45b0-b7f1-777b45d7728f)
you people cant be fucking trusted i swear to god

nerf at request of an admin
## Changelog
:cl:
balance: The Syndicate Depot and Deep Storage have had their budgets reduced (and some equipment confiscated by J&C) due to bad behaviour.
balance: This means no more depot telecrystals, no more depot imprinter or lathe, and no more deep storage techfab either. You've been given frontier surplus as compensation.
/:cl:
