### PR TITLE
Changes the sec/janitor roundstart bonus to 425 monkecoins

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -539,10 +539,10 @@ SUBSYSTEM_DEF(ticker)
 		SSchallenges.apply_challenges(persistent_client)
 		for(var/processing_reward_bitflags in bitflags_to_reward)//you really should use department bitflags if possible
 			if(living.mind.assigned_role.departments_bitflags & processing_reward_bitflags)
-				persistent_client.roundend_monkecoin_bonus += 150
+				persistent_client.roundend_monkecoin_bonus += 425
 		for(var/processing_reward_jobs in jobs_to_reward)//just in case you really only want to reward a specific job
 			if(living.job == processing_reward_jobs)
-				persistent_client.roundend_monkecoin_bonus += 150
+				persistent_client.roundend_monkecoin_bonus += 425
 
 /datum/controller/subsystem/ticker/proc/transfer_characters()
 	var/list/livings = list()


### PR DESCRIPTION
## About The Pull Request
Gives 425 monkecoins instead of 125 monkecoins to janitors or security personnels that weren't late for their work. The commit that changes the bonus for this only changed new_player `AttemptLateSpawn()` while the bonus for roundstart people were set in the ticker `transfer_single_character()` leaving it unchanged, this changes that

there's no tweak tag for the changelog so just gonna leave that as fix

## Why It's Good For The Game
don't think this was supposed to happen when increasing the job bonus and also causes more confusion, should be in the same line somewhere which would be more optimized but oh well
original commit: https://github.com/Monkestation/Monkestation2.0/pull/698/commits/bc391b580eef97f8027ec55938dfb3a432550001

## Changelog

:cl:
fix: you now get 425 monkecoins instead of 150 monkecoins for playing a whole round as a roundstart security / janitor to keep parity with latejoining
/:cl: