### PR TITLE
Add colored names in chat based on ID trim

### DIFF
--- a/code/controllers/subsystem/id_access.dm
+++ b/code/controllers/subsystem/id_access.dm
@@ -450,6 +450,7 @@ SUBSYSTEM_DEF(id_access)
 	id_card.department_color_override = trim.department_color
 	id_card.department_state_override = trim.department_state
 	id_card.subdepartment_color_override = trim.subdepartment_color
+	id_card.trim_chat_span_override = trim.chat_span()
 
 	if(!check_forged || !id_card.forged)
 		id_card.assignment = trim.assignment
@@ -470,6 +471,7 @@ SUBSYSTEM_DEF(id_access)
 	id_card.department_color_override = null
 	id_card.department_state_override = null
 	id_card.subdepartment_color_override = null
+	id_card.trim_chat_span_override = null
 
 /**
  * Adds the accesses associated with a trim to an ID card.

--- a/code/datums/id_trim/_id_trim.dm
+++ b/code/datums/id_trim/_id_trim.dm
@@ -21,3 +21,12 @@
 	var/list/access = list()
 	/// Accesses that this trim unlocks on a card that require wildcard slots to apply. If a card cannot accept all a trim's wildcard accesses, the card is incompatible with the trim.
 	var/list/wildcard_access = list()
+
+/datum/id_trim/proc/chat_span()
+	if(sechud_icon_state == SECHUD_UNKNOWN)
+		return "job__unassigned"
+	var/trimmed_hud_state = copytext(sechud_icon_state, 4) // after the "hud" letters
+	if(trimmed_hud_state)
+		return "job__[trimmed_hud_state]"
+	else
+		return "job__unknown"

--- a/code/datums/id_trim/centcom.dm
+++ b/code/datums/id_trim/centcom.dm
@@ -111,6 +111,9 @@
 
 	access = list(ACCESS_CENT_GENERAL) | (SSid_access.get_region_access_list(list(REGION_ALL_STATION)) - ACCESS_CHANGE_IDS)
 
+/datum/id_trim/centcom/ert/chat_span()
+	return "job__ert"
+
 /// Trim for ERT Commanders. All station and centcom access.
 /datum/id_trim/centcom/ert/commander
 	assignment = JOB_ERT_COMMANDER
@@ -193,6 +196,9 @@
 	. = ..()
 
 	access = list(ACCESS_CENT_GENERAL, ACCESS_CENT_LIVING) | (SSid_access.get_region_access_list(list(REGION_ALL_STATION)) - ACCESS_CHANGE_IDS)
+
+/datum/id_trim/centcom/ert/clown/chat_span()
+	return "job__clown"
 
 /datum/id_trim/centcom/ert/militia
 	assignment = "Frontier Militia"

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -798,6 +798,9 @@
 /obj/item/card/id/RemoveID()
 	return src
 
+/obj/item/card/id/proc/chat_span()
+	return trim?.chat_span()
+
 /// Called on COMSIG_ATOM_UPDATED_ICON. Updates the visuals of the wallet this card is in.
 /obj/item/card/id/proc/update_in_wallet()
 	SIGNAL_HANDLER
@@ -963,6 +966,8 @@
 	var/trim_assignment_override
 	/// If this is set, will manually override the trim shown for SecHUDs. Intended for admins to VV edit and chameleon ID cards.
 	var/sechud_icon_state_override = null
+	/// If this is set, will manually override the chat span used for the wearer's name, normally set by the trim. Intended for admins to VV edit and chameleon ID cards.
+	var/trim_chat_span_override
 
 /obj/item/card/id/advanced/Initialize(mapload)
 	. = ..()
@@ -971,9 +976,10 @@
 
 /obj/item/card/id/advanced/Destroy()
 	UnregisterSignal(src, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
-
 	return ..()
 
+/obj/item/card/id/advanced/chat_span()
+	return trim_chat_span_override || ..()
 
 /obj/item/card/id/advanced/attackby(obj/item/W, mob/user, params)
 	. = ..()

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -101,7 +101,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		else if(visible_name)
 			namepart = "[human_speaker.get_visible_name()]"
 		if(!radio_freq)
-			var/id_span = astype(human_speaker.wear_id?.GetID(), /obj/item/card/id)?.trim?.chat_span()
+			var/id_span = astype(human_speaker.wear_id?.GetID(), /obj/item/card/id)?.chat_span()
 			spanpart2 = "<span class='name [id_span || "job__unknown"]'>"
 	//End name span.
 	var/endspanpart = "</span></a>"

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -100,7 +100,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 			namepart = "[human_speaker.get_face_name()]" //So "fake" speaking like in hallucinations does not give the speaker away if disguised
 		else if(visible_name)
 			namepart = "[human_speaker.get_visible_name()]"
-		if(!radio_freq)
+		if(!radio_freq && !HAS_TRAIT(human_speaker, TRAIT_UNKNOWN))
 			var/id_span = astype(human_speaker.wear_id?.GetID(), /obj/item/card/id)?.chat_span()
 			spanpart2 = "<span class='name [id_span || "job__unknown"]'>"
 	//End name span.

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -92,17 +92,19 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	//Radio freq/name display
 	var/freqpart = radio_freq ? "\[[get_radio_name(radio_freq)]\] " : ""
 	//Speaker name
-	var/realnamepart = "[speaker.GetVoice(TRUE)][speaker.get_alt_name()]" // MONKESTATION ADDITION -- NTSL
+	var/realnamepart = "[speaker.GetVoice(TRUE)][speaker.get_alt_name()]"
 	var/namepart = "[speaker.GetVoice()][speaker.get_alt_name()]"
-	if(face_name && ishuman(speaker))
-		var/mob/living/carbon/human/H = speaker
-		namepart = "[H.get_face_name()]" //So "fake" speaking like in hallucinations does not give the speaker away if disguised
-	else if(visible_name && ishuman(speaker))
+	if(ishuman(speaker))
 		var/mob/living/carbon/human/human_speaker = speaker
-		namepart = "[human_speaker.get_visible_name()]"
+		if(face_name)
+			namepart = "[human_speaker.get_face_name()]" //So "fake" speaking like in hallucinations does not give the speaker away if disguised
+		else if(visible_name)
+			namepart = "[human_speaker.get_visible_name()]"
+		if(!radio_freq)
+			var/id_span = astype(human_speaker.wear_id?.GetID(), /obj/item/card/id)?.trim?.chat_span()
+			spanpart2 = "<span class='name [id_span || "job__unknown"]'>"
 	//End name span.
-//	var/endspanpart = "</span>" // MONKESTATION EDIT OLD -- NTSL
-	var/endspanpart = "</span></a>" // MONKESTATION EDIT NEW
+	var/endspanpart = "</span></a>"
 
 	//Message
 	var/messagepart
@@ -118,9 +120,6 @@ GLOBAL_LIST_INIT(freqtospan, list(
 
 	messagepart = " <span class='message'>[say_emphasis(messagepart)]</span></span>"
 
-// MONKESTATION EDIT OLD -- NTSL down there
-//	return "[spanpart1][spanpart2][freqpart][languageicon][compose_track_href(speaker, namepart)][namepart][compose_job(speaker, message_language, raw_message, radio_freq)][endspanpart][messagepart]"
-// MONKESTATION EDIT NEW -- NTSL down there
 	return "[spanpart1][spanpart2][freqpart][languageicon][compose_track_href(speaker, realnamepart)][namepart][compose_job(speaker, message_language, raw_message, radio_freq)][endspanpart][messagepart]"
 
 /atom/movable/proc/compose_track_href(atom/movable/speaker, message_langs, raw_message, radio_freq)

--- a/tgui/packages/tgui-panel/chat/middleware.js
+++ b/tgui/packages/tgui-panel/chat/middleware.js
@@ -188,6 +188,7 @@ export const chatMiddleware = (store) => {
         nextSettings.highlightSettings,
         nextSettings.highlightSettingById,
       );
+      chatRenderer.setColoredNames(nextSettings.coloredNames);
 
       return;
     }

--- a/tgui/packages/tgui-panel/chat/renderer.jsx
+++ b/tgui/packages/tgui-panel/chat/renderer.jsx
@@ -77,6 +77,15 @@ const createReconnectedNode = () => {
   return node;
 };
 
+// Removes job formatting
+const stripColoredNames = (inputHtml) => {
+  const spanRegex = new RegExp(
+    '(<span[\\w| |\t|=]*[\'|"][\\w| ]*)(?:job__[a-z]+)([\'|"]>)',
+    'gi',
+  );
+  return inputHtml.replace(spanRegex, '$1$2');
+};
+
 const handleImageError = (e) => {
   setTimeout(() => {
     /** @type {HTMLImageElement} */
@@ -280,6 +289,14 @@ class ChatRenderer {
     });
   }
 
+  setColoredNames(newValue) {
+    if (newValue === this.coloredNames) {
+      return;
+    }
+    this.coloredNames = newValue;
+    this.rebuildChat();
+  }
+
   scrollToBottom() {
     this.tryFindScrollable();
     // scrollHeight is always bigger than scrollTop and is
@@ -392,7 +409,9 @@ class ChatRenderer {
         }
         // Payload is HTML
         else if (message.html) {
-          node.innerHTML = message.html;
+          node.innerHTML = this.coloredNames
+            ? message.html
+            : stripColoredNames(message.html);
         } else {
           logger.error('Error: message is missing text payload', message);
         }

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.jsx
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.jsx
@@ -85,7 +85,7 @@ export const SettingsPanel = (props, context) => {
 };
 
 export const SettingsGeneral = (props, context) => {
-  const { theme, fontFamily, fontSize, lineHeight } = useSelector(
+  const { theme, fontFamily, coloredNames, fontSize, lineHeight } = useSelector(
     context,
     selectSettings,
   );
@@ -186,6 +186,19 @@ export const SettingsGeneral = (props, context) => {
               </Stack>
             )}
           </Stack.Item>
+        </LabeledList.Item>
+        <LabeledList.Item label="High Contrast">
+          <Button.Checkbox
+            content="Colored Names"
+            checked={coloredNames}
+            onClick={() =>
+              dispatch(
+                updateSettings({
+                  coloredNames: !coloredNames,
+                }),
+              )
+            }
+          />
         </LabeledList.Item>
         <LabeledList.Item label="Font size" verticalAlign="middle">
           <Stack textAlign="center">

--- a/tgui/packages/tgui-panel/settings/reducer.js
+++ b/tgui/packages/tgui-panel/settings/reducer.js
@@ -30,6 +30,7 @@ const initialState = {
   // Keep these two state vars for compatibility with other servers
   highlightText: '',
   highlightColor: '#ffdd44',
+  coloredNames: true,
   // END compatibility state vars
   highlightSettings: [defaultHighlightSetting.id],
   highlightSettingById: {
@@ -100,6 +101,10 @@ export const settingsReducer = (state = initialState, action) => {
         nextState.highlightSettingById[defaultHighlightSetting.id];
       highlightSetting.highlightColor = nextState.highlightColor;
       highlightSetting.highlightText = nextState.highlightText;
+
+      if (nextState.coloredNames === undefined) {
+        nextState.coloredNames = true;
+      }
       return nextState;
     }
     case importSettings.type: {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -1391,3 +1391,78 @@ $border-width-px: $border-width * 1px;
   }
 }
 // monkestation addition end: kbity
+
+$job-colors: (
+  // Command
+  'rawcommand': #99afe9,
+  'captain': #ecc478,
+  'actingcaptain': #ecc478,
+  // Service
+  'rawservice': #abdaa2,
+  'assistant': #cccccc,
+  'headofpersonnel': #526bf8,
+  'bartender': #b2ceb3,
+  'botanist': #95de85,
+  'cook': #a2fbb9,
+  'chaplain': #8ab48c,
+  'curator': #88c999,
+  'janitor': #81dacb,
+  'lawyer': #c07d7d,
+  'mime': #bad3bb,
+  'clown': #ff83d7,
+  'explorer': #85d8b8,
+  'barber': #a58264,
+  // Cargo
+  'rawcargo': #d8bc8a,
+  'quartermaster': #c79c52,
+  'cargotechnician': #d3a372,
+  'shaftminer': #ce957e,
+  // Engineering
+  'rawengineering': #e0c595,
+  'chiefengineer': #cfbb72,
+  'stationengineer': #ebc27d,
+  'atmospherictechnician': #d4a07d,
+  'signaltech': #ff9f5f,
+  // Medical
+  'rawmedical': #99ccda,
+  'chiefmedicalofficer': #41defa,
+  'medicaldoctor': #6cb1c5,
+  'paramedic': #8fbeb4,
+  'virologist': #5ac5b0,
+  'chemist': #82bdce,
+  'psychiatrist': #88bac9,
+  // R&D
+  'rawscience': #dbafe6,
+  'researchdirector': #974ea9,
+  'scientist': #c772c7,
+  'roboticist': #ac71ba,
+  'geneticist': #83bbbf,
+  'xenobiologist': #ffacff,
+  // Security
+  'rawsecurity': #dbb6b6,
+  'headofsecurity': #ec3550,
+  'warden': #dd3944,
+  'securityofficer': #e6a3a3,
+  'detective': #c78b8b,
+  'brigphysician': #b16789,
+  'secass': #eed4d4,
+  // CentCom
+  'rawcentcom': #83ce6b,
+  'centcom': #59d62f,
+  'blueshield': #4444ff,
+  'ert': #23a7ff,
+  // MISC - job
+  'vip': #e4ce6c,
+  'king': #e4ce6c,
+  'prisoner': #d38a5c,
+  'syndicate': #a16363,
+  'notcentcom': #8d8cf0,
+  'unassigned': #e6dbd0,
+  'unknown': #cec9c1
+);
+
+@each $job-name, $job-color in $job-colors {
+  .job__#{$job-name} {
+    color: $job-color;
+  }
+}

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1357,3 +1357,78 @@ $border-width-px: $border-width * 1px;
   }
 }
 // monkestation addition end: kbity
+
+$job-colors: (
+  // Command
+  'rawcommand': #7584ad,
+  'captain': #d8aa53,
+  'actingcaptain': #cfa962,
+  // Service
+  'rawservice': #6ec959,
+  'assistant': #a1a1a1,
+  'headofpersonnel': #526bf8,
+  'bartender': #71a073,
+  'botanist': #7cb86f,
+  'cook': #54ce75,
+  'chaplain': #8ab48c,
+  'curator': #88c999,
+  'janitor': #2da792,
+  'lawyer': #c07d7d,
+  'clown': #ff83d7,
+  'mime': #6e9b6e,
+  'explorer': #85d8b8,
+  'barber': #836f5f,
+  // Cargo
+  'rawcargo': #d8b999,
+  'quartermaster': #c79c52,
+  'cargotechnician': #d3a372,
+  'shaftminer': #ce957e,
+  // Engineering
+  'rawengineering': #daa32d,
+  'chiefengineer': #cfbb72,
+  'stationengineer': #be953d,
+  'atmospherictechnician': #d4a07d,
+  'signaltech': #e79b69,
+  // Medical
+  'rawmedical': #47b6d8,
+  'chiefmedicalofficer': #67b7f8,
+  'medicaldoctor': #6cb1c5,
+  'paramedic': #8fbeb4,
+  'chemist': #82bdce,
+  'virologist': #5ac5b0,
+  'psychiatrist': #5394a8,
+  // R&D
+  'rawscience': #ce6fce,
+  'researchdirector': #974ea9,
+  'scientist': #c772c7,
+  'roboticist': #ac71ba,
+  'geneticist': #83bbbf,
+  'xenobiologist': #ff6eff,
+  // Security
+  'rawsecurity': #c75c5c,
+  'headofsecurity': #be132d,
+  'warden': #dd3944,
+  'securityofficer': #c43a3a,
+  'detective': #b45c5c,
+  'brigphysician': #b16789,
+  'secass': #cc7e7e,
+  // CentCom
+  'rawcentcom': #55b835,
+  'centcom': #419b23,
+  'ert': #0070bb,
+  'blueshield': #3333ff,
+  // MISC - job
+  'vip': #d3be62,
+  'king': #dbbc33,
+  'prisoner': #8b644b,
+  'syndicate': #6e4141,
+  'notcentcom': #6e6cc7,
+  'unassigned': #585858,
+  'unknown': #313131
+);
+
+@each $job-name, $job-color in $job-colors {
+  .job__#{$job-name} {
+    color: $job-color;
+  }
+}


### PR DESCRIPTION

## About The Pull Request

this adds ID-based chat formatting, ported from https://github.com/BeeStation/BeeStation-Hornet/pull/3165

the trim of the ID you're currently wearing decides what color your name will be in chat.

![2025-06-07 (1749281712) ~ dreamseeker](https://github.com/user-attachments/assets/914ca6af-254c-4e70-a6e6-9aaa89cbcd17)

## Why It's Good For The Game

makes reading chat easier, and adds overall flavor and color to the game

## Changelog
:cl:
qol: The color of your name in chat when speaking is now based on the trim of your current ID!
/:cl:
