### PR TITLE
adds a monkecoin bonus for mentors who play head of staff

### DIFF
--- a/code/__HELPERS/~monkestation-helpers/roundend.dm
+++ b/code/__HELPERS/~monkestation-helpers/roundend.dm
@@ -51,7 +51,10 @@
 	if(special_bonus)
 		queue[ckey] += list(list(special_bonus, "Special Bonus"))
 	if(client?.is_mentor())
-		queue[ckey] += list(list(500, "Mentor Bonus"))
+		if(details?.mob?.mind?.assigned_role?.departments_bitflags & DEPARTMENT_BITFLAG_COMMAND)
+			queue[ckey] += list(list(800, "Mentor Head of Staff Bonus"))
+		else
+			queue[ckey] += list(list(500, "Mentor Bonus"))
 
 	var/list/applied_challenges = details?.applied_challenges
 	if(LAZYLEN(applied_challenges))


### PR DESCRIPTION

## About The Pull Request

mentors now get an extra 300 monkecoins at roundend if they were a head of staff, in addition to the existing base mentor bonus (500 normally, 800 as command)

pooba requested this

## Changelog
:cl:
add: Mentors now get an extra 500 monkecoins at roundend if they were a head of staff.
/:cl:
