### PR TITLE
Allows weapons with the Wastes firing pin to be used on centcom (to an extent)

### DIFF
--- a/code/game/machinery/computer/orders/order_items/mining/order_pka.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_pka.dm
@@ -8,11 +8,11 @@
 /datum/orderable_item/accelerator/gun/repeater //monke edit
 	item_path = /obj/item/gun/energy/recharge/kinetic_accelerator/repeater
 	cost_per_order = 1250
-
-/datum/orderable_item/accelerator/gun/shotgun //monke edit
+/*
+/datum/orderable_item/accelerator/gun/shotgun //monke edit WILL BE REPLACED WITH THE REWORK
 	item_path = /obj/item/gun/energy/recharge/kinetic_accelerator/shotgun
 	cost_per_order = 1250
-
+*/
 /datum/orderable_item/accelerator/gun/shockwave //monke edit
 	item_path = /obj/item/gun/energy/recharge/kinetic_accelerator/shockwave
 	cost_per_order = 1250

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -180,6 +180,7 @@
 	var/pressure_decrease_active = FALSE
 	var/pressure_decrease = 0.25
 	var/obj/item/gun/energy/recharge/kinetic_accelerator/kinetic_gun
+	var/Skillbasedweapon = TRUE //monkestation edit that allows you to toggle off the quicker reload chance on hitting minerals
 
 /obj/projectile/kinetic/Destroy()
 	kinetic_gun = null
@@ -225,7 +226,8 @@
 			// If there is a mind, check for skill modifier to allow them to reload faster.
 			if(carbon_firer.mind)
 				skill_modifier = carbon_firer.mind.get_skill_modifier(/datum/skill/mining, SKILL_SPEED_MODIFIER)
-			kinetic_gun.attempt_reload(kinetic_gun.recharge_time * skill_modifier) //If you hit a mineral, you might get a quicker reload. epic gamer style.
+			if(Skillbasedweapon) //monkestation edit that allows this feature to be toggled off, for special weapons like the PKSMG
+				kinetic_gun.attempt_reload(kinetic_gun.recharge_time * skill_modifier) //If you hit a mineral, you might get a quicker reload. epic gamer style.
 	var/obj/effect/temp_visual/kinetic_blast/K = new /obj/effect/temp_visual/kinetic_blast(target_turf)
 	K.color = color
 

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -570,14 +570,13 @@
 	var/chassis_icon = "kineticgun_u"
 	var/chassis_name = "super-kinetic accelerator"
 
-/obj/item/borg/upgrade/modkit/chassis_mod/install(obj/item/gun/energy/recharge/kinetic_accelerator/KA, mob/user)
+/obj/item/borg/upgrade/modkit/chassis_mod/install(obj/item/gun/energy/recharge/kinetic_accelerator/KA, mob/user) //NEED TO RE-ADD THE SHOTGUN TO THIS BLACKLIST WHEN ITS REWORKED
 //monkestation edit start
 	if(is_type_in_list(KA, list(/obj/item/gun/energy/recharge/kinetic_accelerator/glock,
 								/obj/item/gun/energy/recharge/kinetic_accelerator/meme,
 								/obj/item/gun/energy/recharge/kinetic_accelerator/railgun,
 								/obj/item/gun/energy/recharge/kinetic_accelerator/repeater,
-								/obj/item/gun/energy/recharge/kinetic_accelerator/shockwave,
-								/obj/item/gun/energy/recharge/kinetic_accelerator/shotgun)))
+								/obj/item/gun/energy/recharge/kinetic_accelerator/shockwave,)))
 		to_chat(user, span_warning("[src] is not compatible with [KA]."))
 		return FALSE
 //monkestation edit end

--- a/monkestation/code/modules/mining/accelerators/_wastes_pin.dm
+++ b/monkestation/code/modules/mining/accelerators/_wastes_pin.dm
@@ -16,6 +16,9 @@
 		/area/ocean/generated_above,
 
 		/area/ruin,
+
+		/area/centcom/central_command_areas/evacuation, //END OF ROUND GRIEFING AVAILABLE NOW!!!
+		/area/centcom/central_command_areas/firing_range, //can be used in the centcom firing range if you get a waste pin there
 	)
 
 /obj/item/firing_pin/wastes/pin_auth(mob/living/user)

--- a/monkestation/code/modules/mining/accelerators/shotgun.dm
+++ b/monkestation/code/modules/mining/accelerators/shotgun.dm
@@ -2,7 +2,7 @@
 /// Caliber used by Ballistic Kinetic weapons for miners (More specifically the proto shotgun)
 #define MINER_SHOTGUN "kinetic shotgun"
 
-/obj/item/gun/ballistic/shotgun/doublebarrel/kinetic
+/obj/item/gun/ballistic/shotgun/doublebarrel/kinetic //FIX ALL THE DESCRIPTIONS BEFORE YOU PUT THIS UP AT ALL RAHHHGGGGG
 	name = "Kinetic Boomstick"
 	desc = "A true classic with a miner twist."
 	icon_state = "dshotgun"
@@ -33,7 +33,7 @@
 	caliber = MINER_SHOTGUN
 	pellets = 5
 	variance = 40
-	projectile_type = /obj/projectile/kinetic/shotgun
+	projectile_type = /obj/projectile/plasma/kineticshotgun
 
 /obj/item/ammo_casing/shotgun/kinetic/sniperslug
 	name = "Kinetic .50 BMG"
@@ -41,25 +41,75 @@
 	icon_state = "stunshell"
 	pellets = 1
 	variance = 5
-	projectile_type = /obj/projectile/kinetic/shotgun/sniperslug
+	projectile_type = /obj/projectile/plasma/kineticshotgun/sniperslug
 
-/obj/projectile/kinetic/shotgun //NEEDS SKILLBASEDWEAPON = FALSE WHEN THE SMG GETS ADDED
+/obj/projectile/kinetic/shotgun
 	name = "magnum kinetic projectile"
-	damage = 30
+	damage = 35
 	range = 7
 	icon_state = "cryoshot"
-	projectile_piercing = list(PASSMOB)
+	projectile_piercing = PASSMOB
+	Skillbasedweapon = FALSE
 
-/obj/projectile/kinetic/shotgun/on_hit(atom/target, blocked = 0, pierce_hit)
-	. = ..()
-	if(ismineralturf(target))
-		var/turf/closed/mineral/M = target
-		M.gets_drilled(firer, FALSE)
+/obj/projectile/plasma/kineticshotgun //subtype of plasma instead of kinetic so it can mine walls. Cant be used off of lavaland or off the wastes of icemoon anyways so...
+	name = "magnum kinetic projectile"
+	icon_state = "cryoshot"
+	damage_type = BRUTE
+	armor_flag = BOMB
+	damage = 35  //totals 175 damage letting them kill watchers instantly and penetrates targets for crowd controla
+	range = 7
+	dismemberment = 0
+	projectile_piercing = PASSMOB
+	impact_effect_type = /obj/effect/temp_visual/kinetic_blast
+	mine_range = 1
+	tracer_type = ""
+	muzzle_type = ""
+	impact_type = ""
 
-/obj/projectile/kinetic/shotgun/sniperslug //ALSO NEEDS SKILLBASEDWEAPON = FALSE WHEN THE SMG GETS ADDED
+/obj/projectile/plasma/kineticshotgun/sniperslug // long range but cant hit the oneshot breakpoint of a watcher and does not penetrate targets
 	name = ".50 BMG Kinetic"
 	speed = 0.4
 	damage = 150
 	range = 10
 	icon_state = "gaussstrong"
 	projectile_piercing = NONE
+
+/obj/item/storage/box/kinetic/shotgun
+	name = "box of kinetic shells"
+	desc = "A box full of kinetic projectile magazines, specifically for the proto-kinetic SMG.\
+	It is specially designed to only hold proto-kinetic magazines, and also fit inside of explorer webbing."
+	icon_state = "rubbershot_box"
+	illustration = "rubbershot_box"
+
+/obj/item/storage/box/kinetic/shotgun/Initialize(mapload)
+	. = ..()
+	atom_storage.max_slots = 10
+	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
+	atom_storage.max_total_storage = 20
+	atom_storage.set_holdable(list(
+		/obj/item/ammo_casing/shotgun/kinetic,
+	))
+
+/obj/item/storage/box/kinetic/shotgun/PopulateContents()
+	for(var/i in 1 to 10)
+		new /obj/item/ammo_casing/shotgun/kinetic(src)
+
+/obj/item/storage/box/kinetic/shotgun/sniperslug
+	name = "box of .50 BMG Kinetic"
+	desc = "A box full of kinetic projectile magazines, specifically for the proto-kinetic SMG.\
+	It is specially designed to only hold proto-kinetic magazines, and also fit inside of explorer webbing."
+	icon_state = "rubbershot_box"
+	illustration = "rubbershot_box"
+
+/obj/item/storage/box/kinetic/shotgun/shotgun/sniperslug/Initialize(mapload)
+	. = ..()
+	atom_storage.max_slots = 10
+	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
+	atom_storage.max_total_storage = 20
+	atom_storage.set_holdable(list(
+		/obj/item/ammo_casing/shotgun/kinetic/shotgun/sniperslug,
+	))
+
+/obj/item/storage/box/kinetic/shotgun/PopulateContents()
+	for(var/i in 1 to 10)
+		new /obj/item/ammo_casing/shotgun/kinetic/shotgun/sniperslug(src)

--- a/monkestation/code/modules/mining/accelerators/shotgun.dm
+++ b/monkestation/code/modules/mining/accelerators/shotgun.dm
@@ -1,21 +1,65 @@
-/obj/item/gun/energy/recharge/kinetic_accelerator/shotgun
-	name = "proto-kinetic shotgun"
-	desc = "During the crusher design pizza party, one member of the Mining Research and Development team brought out a real riot shotgun, and killed three \
-	other research members with one blast. The MR&D Director immedietly thought of a genuis idea, creating the proto-kinetic shotgun moments later, which he \
-	immedietly used to execute the research member who brought the real shotgun. The proto-kinetic shotgun trades off some mod capacity and cooldown in favor \
-	of firing three shots at once with reduce range and power. The total damage of all three shots is higher than a regular PKA but the individual shots are weaker."
-	icon = 'monkestation/icons/obj/guns/guns.dmi'
-	icon_state = "kineticshotgun"
-	base_icon_state = "kineticshotgun"
-	recharge_time = 2 SECONDS
-	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/shotgun)
-	max_mod_capacity = 60
 
-/obj/item/ammo_casing/energy/kinetic/shotgun
+/// Caliber used by Ballistic Kinetic weapons for miners (More specifically the proto shotgun)
+#define MINER_SHOTGUN "kinetic shotgun"
+
+/obj/item/gun/ballistic/shotgun/doublebarrel/kinetic
+	name = "Kinetic Boomstick"
+	desc = "A true classic with a miner twist."
+	icon_state = "dshotgun"
+	inhand_icon_state = "shotgun_db"
+	worn_icon_state = ""
+	recoil = 4
+	pin = /obj/item/firing_pin/wastes //yes this is required, do NOT remove it
+	w_class = WEIGHT_CLASS_NORMAL
+	weapon_weight = WEAPON_HEAVY
+	slot_flags = ITEM_SLOT_BELT
+	fire_sound = 'monkestation/code/modules/blueshift/sounds/shotgun_heavy.ogg'
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/dual/kinetic
+	unique_reskin = list()
+	can_be_sawn_off = FALSE
+
+/obj/item/ammo_box/magazine/internal/shot/dual/kinetic
+	name = "kinetic double barrel shotgun internal magazine"
+	desc = "how did you break my gun like this, please report whatever you did then feel bad!!!"
+	ammo_type = /obj/item/ammo_casing/shotgun/kinetic
+	caliber = MINER_SHOTGUN
+	max_ammo = 2
+
+/obj/item/ammo_casing/shotgun/kinetic
+	name = "Kinetic Shell"
+	desc = "A 12 gauge Shell loaded with kinetic projectiles."
+	icon_state = "heshell"
+	worn_icon_state = ""
+	caliber = MINER_SHOTGUN
+	pellets = 5
+	variance = 40
 	projectile_type = /obj/projectile/kinetic/shotgun
-	pellets = 3
-	variance = 50
 
-/obj/projectile/kinetic/shotgun
-	name = "split kinetic force"
-	damage = 20
+/obj/item/ammo_casing/shotgun/kinetic/sniperslug
+	name = "Kinetic .50 BMG"
+	desc = "If god did not want us to put 50 BMG in a 12 gauge, he would not have given them similar diameter!"
+	icon_state = "stunshell"
+	pellets = 1
+	variance = 5
+	projectile_type = /obj/projectile/kinetic/shotgun/sniperslug
+
+/obj/projectile/kinetic/shotgun //NEEDS SKILLBASEDWEAPON = FALSE WHEN THE SMG GETS ADDED
+	name = "magnum kinetic projectile"
+	damage = 30
+	range = 7
+	icon_state = "cryoshot"
+	projectile_piercing = list(PASSMOB)
+
+/obj/projectile/kinetic/shotgun/on_hit(atom/target, blocked = 0, pierce_hit)
+	. = ..()
+	if(ismineralturf(target))
+		var/turf/closed/mineral/M = target
+		M.gets_drilled(firer, FALSE)
+
+/obj/projectile/kinetic/shotgun/sniperslug //ALSO NEEDS SKILLBASEDWEAPON = FALSE WHEN THE SMG GETS ADDED
+	name = ".50 BMG Kinetic"
+	speed = 2
+	damage = 150
+	range = 10
+	icon_state = "gaussstrong"
+	projectile_piercing = NONE

--- a/monkestation/code/modules/mining/accelerators/shotgun.dm
+++ b/monkestation/code/modules/mining/accelerators/shotgun.dm
@@ -58,7 +58,7 @@
 
 /obj/projectile/kinetic/shotgun/sniperslug //ALSO NEEDS SKILLBASEDWEAPON = FALSE WHEN THE SMG GETS ADDED
 	name = ".50 BMG Kinetic"
-	speed = 2
+	speed = 0.4
 	damage = 150
 	range = 10
 	icon_state = "gaussstrong"

--- a/monkestation/code/modules/mining/accelerators/shotgun.dm
+++ b/monkestation/code/modules/mining/accelerators/shotgun.dm
@@ -9,14 +9,21 @@
 	inhand_icon_state = "shotgun_db"
 	worn_icon_state = ""
 	recoil = 4
+	force = 20
+	armour_penetration = 5
 	pin = /obj/item/firing_pin/wastes //yes this is required, do NOT remove it
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
-	slot_flags = ITEM_SLOT_BELT
+	slot_flags = ITEM_SLOT_BACK
 	fire_sound = 'monkestation/code/modules/blueshift/sounds/shotgun_heavy.ogg'
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/dual/kinetic
 	unique_reskin = list()
 	can_be_sawn_off = FALSE
+	sharpness = SHARP_EDGED
+	hitsound = 'sound/weapons/bladeslice.ogg'
+	attack_verb_continuous = list("slashes", "cuts", "cleaves", "chops", "swipes")
+	attack_verb_simple = list("cleave", "chop", "cut", "swipe", "slash")
+	pb_knockback = 0 // :3
 
 /obj/item/ammo_box/magazine/internal/shot/dual/kinetic
 	name = "kinetic double barrel shotgun internal magazine"
@@ -107,9 +114,9 @@
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
 	atom_storage.max_total_storage = 20
 	atom_storage.set_holdable(list(
-		/obj/item/ammo_casing/shotgun/kinetic/shotgun/sniperslug,
+		/obj/item/ammo_casing/shotgun/kinetic/sniperslug,
 	))
 
 /obj/item/storage/box/kinetic/shotgun/PopulateContents()
 	for(var/i in 1 to 10)
-		new /obj/item/ammo_casing/shotgun/kinetic/shotgun/sniperslug(src)
+		new /obj/item/ammo_casing/shotgun/kinetic/sniperslug(src)

--- a/monkestation/code/modules/mining/accelerators/shotgun.dm
+++ b/monkestation/code/modules/mining/accelerators/shotgun.dm
@@ -8,7 +8,7 @@
 	icon_state = "dshotgun"
 	inhand_icon_state = "shotgun_db"
 	worn_icon_state = ""
-	recoil = 4
+	recoil = 3
 	force = 20
 	armour_penetration = 5
 	pin = /obj/item/firing_pin/wastes //yes this is required, do NOT remove it
@@ -23,7 +23,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb_continuous = list("slashes", "cuts", "cleaves", "chops", "swipes")
 	attack_verb_simple = list("cleave", "chop", "cut", "swipe", "slash")
-	pb_knockback = 0 // :3
+	pb_knockback = 0 //you may have your point blank, but you dont get a fling
 
 /obj/item/ammo_box/magazine/internal/shot/dual/kinetic
 	name = "kinetic double barrel shotgun internal magazine"
@@ -32,17 +32,28 @@
 	caliber = MINER_SHOTGUN
 	max_ammo = 2
 
-/obj/item/ammo_casing/shotgun/kinetic
-	name = "Kinetic Shell"
+//You cant just pry these shells out with your fingers, youll have to eject them by breaking open the shotgun
+/obj/item/ammo_box/magazine/internal/shot/dual/kinetic/give_round(obj/item/ammo_casing/R)
+	if(!R || !(caliber ? (caliber == R.caliber) : (ammo_type == R.type)))
+		return FALSE
+
+	else if (stored_ammo.len < max_ammo)
+		stored_ammo += R
+		R.forceMove(src)
+		return TRUE
+	return FALSE
+
+/obj/item/ammo_casing/shotgun/kinetic //for slaying, works on crowds
+	name = "Kinetic Magnum Buckshot Shell"
 	desc = "A 12 gauge Shell loaded with kinetic projectiles."
 	icon_state = "heshell"
 	worn_icon_state = ""
 	caliber = MINER_SHOTGUN
 	pellets = 5
-	variance = 40
+	variance = 30
 	projectile_type = /obj/projectile/plasma/kineticshotgun
 
-/obj/item/ammo_casing/shotgun/kinetic/sniperslug
+/obj/item/ammo_casing/shotgun/kinetic/sniperslug //slugs essentially
 	name = "Kinetic .50 BMG"
 	desc = "If god did not want us to put 50 BMG in a 12 gauge, he would not have given them similar diameter!"
 	icon_state = "stunshell"
@@ -50,15 +61,18 @@
 	variance = 5
 	projectile_type = /obj/projectile/plasma/kineticshotgun/sniperslug
 
-/obj/projectile/kinetic/shotgun
-	name = "magnum kinetic projectile"
-	damage = 35
-	range = 7
-	icon_state = "cryoshot"
-	projectile_piercing = PASSMOB
-	Skillbasedweapon = FALSE
 
-/obj/projectile/plasma/kineticshotgun //subtype of plasma instead of kinetic so it can mine walls. Cant be used off of lavaland or off the wastes of icemoon anyways so...
+/obj/item/ammo_casing/shotgun/kinetic/rockbreaker //for digging!
+	name = "Kinetic Rockbreaker Shell"
+	desc = "A 12 gauge Shell loaded with dozens of special tiny kinetic rockbreaker pellets, perfect for clearing masses of rocks but no good for killing fauna."
+	icon_state = "bountyshell"
+	worn_icon_state = ""
+	caliber = MINER_SHOTGUN
+	pellets = 10
+	variance = 120
+	projectile_type = /obj/projectile/plasma/kineticshotgun/rockbreaker
+
+/obj/projectile/plasma/kineticshotgun //subtype of plasma instead of kinetic so it can punch through mineable turf. Cant be used off of lavaland or off the wastes of icemoon anyways so...
 	name = "magnum kinetic projectile"
 	icon_state = "cryoshot"
 	damage_type = BRUTE
@@ -74,21 +88,28 @@
 	impact_type = ""
 
 /obj/projectile/plasma/kineticshotgun/sniperslug // long range but cant hit the oneshot breakpoint of a watcher and does not penetrate targets
-	name = ".50 BMG Kinetic"
+	name = ".50 BMG kinetic"
 	speed = 0.4
 	damage = 150
 	range = 10
 	icon_state = "gaussstrong"
 	projectile_piercing = NONE
 
-/obj/item/storage/box/kinetic/shotgun
+/obj/projectile/plasma/kineticshotgun/rockbreaker // for breaking rocks
+	name = "kinetic rockbreaker"
+	speed = 1 //slower than average
+	damage = 2
+	range = 13
+	icon_state = "guardian"
+	projectile_piercing = NONE
+
+/obj/item/storage/box/kinetic/shotgun //box
 	name = "box of kinetic shells"
-	desc = "A box full of kinetic projectile magazines, specifically for the proto-kinetic SMG.\
-	It is specially designed to only hold proto-kinetic magazines, and also fit inside of explorer webbing."
+	desc = ""
 	icon_state = "rubbershot_box"
 	illustration = "rubbershot_box"
 
-/obj/item/storage/box/kinetic/shotgun/Initialize(mapload)
+/obj/item/storage/box/kinetic/shotgun/Initialize(mapload) //initialize
 	. = ..()
 	atom_storage.max_slots = 10
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
@@ -97,18 +118,17 @@
 		/obj/item/ammo_casing/shotgun/kinetic,
 	))
 
-/obj/item/storage/box/kinetic/shotgun/PopulateContents()
+/obj/item/storage/box/kinetic/shotgun/PopulateContents() //populate
 	for(var/i in 1 to 10)
 		new /obj/item/ammo_casing/shotgun/kinetic(src)
 
-/obj/item/storage/box/kinetic/shotgun/sniperslug
+/obj/item/storage/box/kinetic/shotgun/sniperslug //box
 	name = "box of .50 BMG Kinetic"
-	desc = "A box full of kinetic projectile magazines, specifically for the proto-kinetic SMG.\
-	It is specially designed to only hold proto-kinetic magazines, and also fit inside of explorer webbing."
+	desc = ""
 	icon_state = "rubbershot_box"
 	illustration = "rubbershot_box"
 
-/obj/item/storage/box/kinetic/shotgun/shotgun/sniperslug/Initialize(mapload)
+/obj/item/storage/box/kinetic/shotgun/sniperslug/Initialize(mapload) //initialize
 	. = ..()
 	atom_storage.max_slots = 10
 	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
@@ -117,6 +137,25 @@
 		/obj/item/ammo_casing/shotgun/kinetic/sniperslug,
 	))
 
-/obj/item/storage/box/kinetic/shotgun/PopulateContents()
+/obj/item/storage/box/kinetic/shotgun/sniperslug/PopulateContents() //populate
 	for(var/i in 1 to 10)
 		new /obj/item/ammo_casing/shotgun/kinetic/sniperslug(src)
+
+/obj/item/storage/box/kinetic/shotgun/rockbreaker //box
+	name = "box of kinetic rock breaker"
+	desc = ""
+	icon_state = "rubbershot_box"
+	illustration = "rubbershot_box"
+
+/obj/item/storage/box/kinetic/shotgun/rockbreaker/Initialize(mapload) //initialize
+	. = ..()
+	atom_storage.max_slots = 20
+	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL
+	atom_storage.max_total_storage = 20
+	atom_storage.set_holdable(list(
+		/obj/item/ammo_casing/shotgun/kinetic/rockbreaker,
+	))
+
+/obj/item/storage/box/kinetic/shotgun/rockbreaker/PopulateContents() //populate
+	for(var/i in 1 to 20)
+		new /obj/item/ammo_casing/shotgun/kinetic/rockbreaker(src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Guns that have the wastes firing pin (locking them to icemoon and lavaland outside the station becuase they are way too strong)
can now be fired on centcom in the room where people kill each other after they step off the shuttle, and in the firing range.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

The waste pin locked weapons are really strong, and im sure plenty of people want to use them to end of round death match. so here you go.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: waste pin weapons can now be used on centcom for end of round deathmatch, go nuts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
