### PR TITLE
Allows waste pin locked weapons to be used for end of round MURDER

### DIFF
--- a/monkestation/code/modules/mining/accelerators/_wastes_pin.dm
+++ b/monkestation/code/modules/mining/accelerators/_wastes_pin.dm
@@ -16,6 +16,9 @@
 		/area/ocean/generated_above,
 
 		/area/ruin,
+
+		/area/centcom/central_command_areas/evacuation, //END OF ROUND GRIEFING AVAILABLE NOW!!!
+		/area/centcom/central_command_areas/firing_range, //can be used in the centcom firing range if you get a waste pin there
 	)
 
 /obj/item/firing_pin/wastes/pin_auth(mob/living/user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The silly super strong mining weapons and stuff locked with the wastes pin (restricted to lavaland and icemoon wastes) can now be used on centcom after you step off the shuttle. Go nuts. Also works in the firing range on centcom.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

People can now use the silly strong mining guns and other stuff locked with the waste pin to KILL people after the round is over on centcom, if they evac of course.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Wastes pin locked weapons now work on centcom after you step off the shuttle, go nuts. Also work in the centcom firing range.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
