### PR TITLE
Comment out

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -13,11 +13,12 @@
 	wound_falloff_tile = -5
 	embed_falloff_tile = -3
 
-	light_system = OVERLAY_LIGHT
-	light_outer_range = 1.25
-	light_power = 1
-	light_color = COLOR_VERY_SOFT_YELLOW
-	light_on = TRUE
+	//light_system = OVERLAY_LIGHT
+	//light_outer_range = 1.25
+	//light_power = 1
+	//light_color = COLOR_VERY_SOFT_YELLOW
+	//light_on = TRUE
+	//This applies to casings too, for some reason, and regardless this shouldn't apply to every bullet not every bullet should or does have a tracer.
 
 	speed = 0.4 //twice as fast
 


### PR DESCRIPTION

## About The Pull Request

Removes the light given to all bullets.

## Why It's Good For The Game

1) Not every bullet has, or should have, a tracer.
2) Because of how it is implemented, this makes all casings, and even unfired crossbow bolts glow brightly.
3) And their glow illuminates things even from the inventory because it's an overlay light.
4) This stuff should really be done bullet specific, and honestly just making the bullet sprites emissive is enough.

## Changelog

:cl:
del: Removes the light all bullets are given
fix: Bullet casings do not glow anymore
/:cl:
