### PR TITLE
Fix a hard delete with the prey of the hunt

### DIFF
--- a/code/modules/religion/hunt/prey.dm
+++ b/code/modules/religion/hunt/prey.dm
@@ -15,3 +15,7 @@
 	name = "Prey of the Hunt"
 	desc = "A hapless deer, chosen as prey for the Great Hunt"
 	butcher_results = list(/obj/item/food/meat/slab = 3, /obj/item/food/meat/religioustrophy = 1)
+
+/mob/living/basic/deer/prey/Destroy()
+	GLOB.sect_of_the_hunt_preys -= src
+	return ..()


### PR DESCRIPTION

## About The Pull Request

this ensures the deer are properly removed from `GLOB.sect_of_the_hunt_preys` after being gibbed/destroyed.

## Why It's Good For The Game

hard deletes bad

## Changelog

no player-facing changes
