### PR TITLE
Ports #74528 "Camera Obscura pictures now steal souls"

### DIFF
--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -204,6 +204,9 @@
 			if(locate(/obj/item/areaeditor/blueprints) in placeholder)
 				blueprints = TRUE
 
+	// do this before picture is taken so we can reveal revenants for the photo
+	steal_souls(mobs)
+
 	for(var/mob/mob as anything in mobs)
 		mobs_spotted += mob
 		if(mob.stat == DEAD)
@@ -225,6 +228,8 @@
 /obj/item/camera/proc/flash_end()
 	set_light_on(FALSE)
 
+/obj/item/camera/proc/steal_souls(list/victims)
+	return
 
 /obj/item/camera/proc/after_picture(mob/user, datum/picture/picture)
 	if(print_picture_on_snap)

--- a/code/modules/photography/camera/other.dm
+++ b/code/modules/photography/camera/other.dm
@@ -9,13 +9,15 @@
 			continue
 
 		// time to steal your soul
-		if(istype(target, /mob/living/simple_animal/revenant))
-			var/mob/living/simple_animal/revenant/peek_a_boo = target
-			peek_a_boo.reveal(2 SECONDS) // no hiding
-			if(!peek_a_boo.unstun_time)
-				peek_a_boo.stun(2 SECONDS)
-		target.visible_message(span_warning("[target] violently flinches!"), \
-			span_revendanger("You feel your essence draining away from having your picture taken!"))
+		if(istype(target, /mob/living/basic/revenant))
+			var/mob/living/basic/revenant/peek_a_boo = target
+			peek_a_boo.apply_status_effect(/datum/status_effect/revenant/revealed, 2 SECONDS) // no hiding
+			peek_a_boo.apply_status_effect(/datum/status_effect/incapacitating/paralyzed/revenant, 2 SECONDS)
+
+		target.visible_message(
+			span_warning("[target] violently flinches!"),
+			span_revendanger("You feel your essence draining away from having your picture taken!"),
+		)
 		target.apply_damage(rand(10, 15))
 
 /obj/item/camera/spooky/badmin

--- a/code/modules/photography/camera/other.dm
+++ b/code/modules/photography/camera/other.dm
@@ -10,9 +10,8 @@
 
 		// time to steal your soul
 		if(isrevenant(target))
-			var/mob/living/basic/revenant/peek_a_boo = target
-			peek_a_boo.apply_status_effect(/datum/status_effect/revenant/revealed, 2 SECONDS) // no hiding
-			peek_a_boo.apply_status_effect(/datum/status_effect/incapacitating/paralyzed/revenant, 2 SECONDS)
+			target.apply_status_effect(/datum/status_effect/revenant/revealed, 2 SECONDS) // no hiding
+			target.apply_status_effect(/datum/status_effect/incapacitating/paralyzed/revenant, 2 SECONDS)
 
 		target.visible_message(
 			span_warning("[target] violently flinches!"),

--- a/code/modules/photography/camera/other.dm
+++ b/code/modules/photography/camera/other.dm
@@ -9,7 +9,7 @@
 			continue
 
 		// time to steal your soul
-		if(istype(target, /mob/living/basic/revenant))
+		if(isrevenant(target))
 			var/mob/living/basic/revenant/peek_a_boo = target
 			peek_a_boo.apply_status_effect(/datum/status_effect/revenant/revealed, 2 SECONDS) // no hiding
 			peek_a_boo.apply_status_effect(/datum/status_effect/incapacitating/paralyzed/revenant, 2 SECONDS)

--- a/code/modules/photography/camera/other.dm
+++ b/code/modules/photography/camera/other.dm
@@ -3,6 +3,20 @@
 	desc = "A polaroid camera, some say it can see ghosts!"
 	see_ghosts = CAMERA_SEE_GHOSTS_BASIC
 
+/obj/item/camera/spooky/steal_souls(list/victims)
+	for(var/mob/living/target in victims)
+		if(!(target.mob_biotypes & MOB_SPIRIT))
+			continue
+
+		// time to steal your soul
+		if(istype(target, /mob/living/simple_animal/revenant))
+			var/mob/living/simple_animal/revenant/peek_a_boo = target
+			peek_a_boo.reveal(2 SECONDS) // no hiding
+			if(!peek_a_boo.unstun_time)
+				peek_a_boo.stun(2 SECONDS)
+		target.visible_message(span_warning("[target] violently flinches!"), \
+			span_revendanger("You feel your essence draining away from having your picture taken!"))
+		target.apply_damage(rand(10, 15))
 
 /obj/item/camera/spooky/badmin
 	desc = "A polaroid camera, some say it can see ghosts! It seems to have an extra magnifier on the end."


### PR DESCRIPTION

## [From the original  ](https://github.com/tgstation/tgstation/pull/74528)
## About The Pull Request
![image](https://github.com/user-attachments/assets/56cece84-48d9-4b36-883b-93171cb9b742)
But only for the `MOB_SPIRIT` biotype. This will also stun and reveal revenants briefly even if they are hidden.
## Why It's Good For The Game
It's funny and a slightly silly way to combat revenants by using paparazzi.
## Changelog
:cl:
balance: "Camera Obscura" (crafted with holy water + camera) will now steal the soul of ghostly apparitions when a picture is taken causing damage. This will also stun and reveal revenants briefly.
/:cl:
