### PR TITLE
Fix some species damage modifiers not working

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -100,11 +100,14 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	///List of external organs to generate like horns, frills, wings, etc. list(typepath of organ = "Round Beautiful BDSM Snout"). Still WIP
 	var/list/external_organs = list()
 
-	///Percentage modifier for overall defense of the race, or less defense, if it's negative.
+	/// Percentage modifier for overall defense of the race, or less defense, if it's negative.
+	/// Please use bodypart damage modifiers instead of this.
 	var/armor = 0
-	///multiplier for brute damage
+	/// Multiplier for brute damage.
+	/// Please use bodypart damage modifiers instead of this.
 	var/brutemod = 1
-	///multiplier for burn damage
+	/// Multiplier for burn damage.
+	/// Please use bodypart damage modifiers instead of this.
 	var/burnmod = 1
 	//Used for metabolizing reagents. We're going to assume you're a meatbag unless you say otherwise.
 	var/reagent_tag = PROCESS_ORGANIC

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -25,9 +25,7 @@
 	mutantbutt = /obj/item/organ/internal/butt/plasma
 	mutantappendix = null
 	mutantheart = null
-	burnmod = 1.5
 	heatmod = 1.5
-	brutemod = 1.5
 	payday_modifier = 0.75
 	breathid = "plas"
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -476,6 +476,11 @@
 			return FALSE
 
 	var/dmg_multi = CONFIG_GET(number/damage_multiplier) * hit_percent
+	var/datum/species/owner_species = owner.dna?.species
+	if(owner_species)
+		dmg_multi *= (100 - owner_species.armor) / 100 // species.armor is a 0-100 percentage of damage reduction, so we have to convert that to a 0-1 multiplier
+		brute *= owner_species.brutemod
+		burn *= owner_species.burnmod
 	brute = round(max(brute * dmg_multi * brute_modifier, 0), DAMAGE_PRECISION)
 	burn = round(max(burn * dmg_multi * burn_modifier, 0), DAMAGE_PRECISION)
 

--- a/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/ethereal_bodyparts.dm
@@ -8,6 +8,7 @@
 	unarmed_miss_sound = 'sound/weapons/etherealmiss.ogg'
 	palette = /datum/color_palette/generic_colors
 	palette_key = "ethereal_color"
+	brute_modifier = 1.25
 
 /obj/item/bodypart/head/ethereal/update_limb(dropping_limb, is_creating)
 	. = ..()
@@ -24,6 +25,7 @@
 	dmg_overlay_type = null
 	palette = /datum/color_palette/generic_colors
 	palette_key = "ethereal_color"
+	brute_modifier = 1.25
 
 /obj/item/bodypart/chest/ethereal/update_limb(dropping_limb, is_creating)
 	. = ..()
@@ -42,6 +44,7 @@
 	unarmed_miss_sound = 'sound/weapons/etherealmiss.ogg'
 	palette = /datum/color_palette/generic_colors
 	palette_key = "ethereal_color"
+	brute_modifier = 1.25
 
 /obj/item/bodypart/arm/left/ethereal/update_limb(dropping_limb, is_creating)
 	. = ..()
@@ -60,6 +63,7 @@
 	unarmed_miss_sound = 'sound/weapons/etherealmiss.ogg'
 	palette = /datum/color_palette/generic_colors
 	palette_key = "ethereal_color"
+	brute_modifier = 1.25
 
 /obj/item/bodypart/arm/right/ethereal/update_limb(dropping_limb, is_creating)
 	. = ..()
@@ -78,6 +82,7 @@
 	unarmed_miss_sound = 'sound/weapons/etherealmiss.ogg'
 	palette = /datum/color_palette/generic_colors
 	palette_key = "ethereal_color"
+	brute_modifier = 1.25
 
 /obj/item/bodypart/leg/left/ethereal/update_limb(dropping_limb, is_creating)
 	. = ..()
@@ -95,6 +100,7 @@
 	unarmed_miss_sound = 'sound/weapons/etherealmiss.ogg'
 	palette = /datum/color_palette/generic_colors
 	palette_key = "ethereal_color"
+	brute_modifier = 1.25
 
 /obj/item/bodypart/leg/right/ethereal/update_limb(dropping_limb, is_creating)
 	. = ..()

--- a/monkestation/code/modules/mob/living/carbon/human/species_type/ethereal.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/ethereal.dm
@@ -20,7 +20,6 @@
 	temperature_normalization_speed = 3
 
 	siemens_coeff = 0.5 //They thrive on energy
-	brutemod = 1.25 //They're weak to punches
 	payday_modifier = 1
 	inherent_traits = list(
 		TRAIT_MUTANT_COLORS,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this makes it so the species `armor`, `brutemod`, and `burnmod` values properly work again, for species that haven't been subject to the species nuking yet. too lazy to properly nuke remaining species rn, so this will do.

i also species nuked ethereals (moved their brute resistance to their bodyparts) and fixed plasmamen taking 2.25x brute/burn instead of 1.5x.

## Why It's Good For The Game

bug fix good

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Golem species now have their proper damage resistances again.
fix: Ethereals properly take 25% more brute damage again.
fix: Plasmamen now take 50% more brute and burn damage instead of 125%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
