### PR TITLE
Allow Stargazers to manually disconnect someone from their Slime Link

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/oozeling/stargazers.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozeling/stargazers.dm
@@ -61,19 +61,25 @@
 
 /datum/action/innate/link_minds
 	name = "Link Minds"
-	desc = "Link someone's mind to your Slime Link, allowing them to communicate telepathically with other linked minds."
+	desc = "Link someone's mind to your Slime Link, allowing them to communicate telepathically with other linked minds.\n\nRight click this button in order to unlink someone from your Slime Link instead."
 	button_icon_state = "mindlink"
 	button_icon = 'icons/mob/actions/actions_slime.dmi'
 	background_icon_state = "bg_alien"
 	overlay_icon_state = "bg_alien_border"
 	/// The species required to use this ability. Typepath.
 	var/req_species = /datum/species/oozeling/stargazer
+	/// Cached appearances of linked mobs, for unlink radial menu.
+	var/list/linked_appearances = list()
 
 /datum/action/innate/link_minds/New(Target)
 	. = ..()
 	if(!istype(Target, /datum/component/mind_linker))
 		stack_trace("[name] ([type]) was instantiated on a non-mind_linker target, this doesn't work.")
 		qdel(src)
+
+/datum/action/innate/link_minds/Destroy()
+	linked_appearances.Cut()
+	return ..()
 
 /datum/action/innate/link_minds/IsAvailable(feedback = FALSE)
 	. = ..()
@@ -86,7 +92,65 @@
 
 	return TRUE
 
-/datum/action/innate/link_minds/Activate()
+/datum/action/innate/link_minds/Trigger(trigger_flags)
+	. = ..()
+	if(!.)
+		return FALSE
+	if(trigger_flags & TRIGGER_SECONDARY_ACTION)
+		unlink_prompt()
+	else
+		try_link()
+
+/datum/action/innate/link_minds/proc/get_link_preview(mob/target, force = FALSE)
+	var/mob_ref = REF(target)
+	if(!mob_ref)
+		return
+	if(!force && (mob_ref in linked_appearances))
+		return linked_appearances[mob_ref]
+	var/mutable_appearance/linked_appearance = copy_appearance_filter_overlays(target.appearance)
+	var/mob/living/carbon/carbon_target = astype(target)
+	if(carbon_target)
+		for(var/layer in list(HANDS_LAYER, HANDCUFF_LAYER, LEGCUFF_LAYER))
+			linked_appearance.overlays -= carbon_target.overlays_standing[layer]
+	linked_appearance.appearance_flags = KEEP_TOGETHER
+	linked_appearance.dir = SOUTH
+	linked_appearance.pixel_x = target.base_pixel_x
+	linked_appearance.pixel_y = target.base_pixel_y
+	linked_appearance.pixel_z = 0 /* target.base_pixel_z */
+	linked_appearance.transform = matrix()
+	linked_appearances[mob_ref] = linked_appearance
+	return linked_appearance
+
+/datum/action/innate/link_minds/proc/unlink_prompt()
+	var/datum/component/mind_linker/linker = target
+	if(!length(linker.linked_mobs))
+		to_chat(owner, span_warning("There is nobody on your [linker.network_name] to unlink!"))
+		return
+	var/list/linked_options = list()
+	var/list/linked_mobs = list()
+	var/list/used_names = list()
+	for(var/mob/living/linked_mob in linker.linked_mobs)
+		var/linked_name = avoid_assoc_duplicate_keys(trimtext(linked_mob.mind?.name || linked_mob.real_name || linked_mob.name), used_names)
+		linked_options[linked_name] = get_link_preview(linked_mob)
+		linked_mobs[linked_name] = linked_mob
+
+	var/to_unlink = show_radial_menu(
+		owner,
+		owner,
+		linked_options,
+		radius = 40,
+		tooltips = TRUE,
+		autopick_single_option = FALSE,
+	)
+	if(!to_unlink)
+		return
+	var/mob/mob_to_unlink = linked_mobs[to_unlink]
+	if(tgui_alert(owner, "Are you sure you would like to remove [mob_to_unlink] from your [linker.network_name]?", "[linker.network_name]", list("Yes", "No")) != "Yes")
+		return
+	to_chat(owner, span_notice("You disconnect [to_unlink] from your [linker.network_name]."))
+	linker.unlink_mob(mob_to_unlink)
+
+/datum/action/innate/link_minds/proc/try_link()
 	var/mob/living/living_target = owner.pulling
 	if(!isliving(living_target) || (owner.grab_state < GRAB_AGGRESSIVE && (living_target.status_flags & CANPUSH) && !HAS_TRAIT(living_target, TRAIT_PUSHIMMUNE)))
 		to_chat(owner, span_warning("You need to aggressively grab someone to link minds!"))
@@ -111,7 +175,8 @@
 	if(!linker.link_mob(living_target))
 		to_chat(owner, span_warning("You can't seem to link [living_target]'s mind."))
 		to_chat(living_target, span_warning("The foreign presence leaves your mind."))
-
+	else
+		get_link_preview(living_target, force = TRUE) // refresh cached appearance if they're being re-linked
 
 /// Callback ran during the do_after of Activate() to see if we can keep linking with someone.
 /datum/action/innate/link_minds/proc/while_link_callback(mob/living/linkee)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so stargazers can right click the "Link Minds" action to instead bring up a menu to select someone to remove from their link. Pretty simple.

It uses a radial menu (however it doesn't update and show their current appearance, it uses the appearance from whenever you first linked them)

![2025-06-11 (1749620324)](https://github.com/user-attachments/assets/7567db97-1c54-4240-b146-63fcfbf42598)

## Why It's Good For The Game

Its _your_ slime link, why shouldn't you be able to kick someone from your own group chat?

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Stargazers (the species) can now manually disconnect someone from their Slime Link, by right clicking the "Link Minds" action.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
