### PR TITLE
Adds reminders to ghostroles to behave

### DIFF
--- a/code/modules/antagonists/pirate/pirate_roles.dm
+++ b/code/modules/antagonists/pirate/pirate_roles.dm
@@ -15,6 +15,7 @@
 	flavour_text = "The station refused to pay for your protection, protect the ship, siphon the credits from the station and raid it for even more loot."
 	spawner_job_path = /datum/job/space_pirate
 	random_appearance = TRUE
+	dont_be_a_shit = FALSE //explicitly an antag
 	///Rank of the pirate on the ship, it's used in generating pirate names!
 	var/rank = "Deserter"
 	///Path of the structure we spawn after creating a pirate.

--- a/code/modules/mob_spawn/ghost_roles/space_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/space_roles.dm
@@ -98,6 +98,7 @@
 	outfit = /datum/outfit/syndicate_empty/battlecruiser
 	spawner_job_path = /datum/job/battlecruiser_crew
 	uses = 4
+	dont_be_a_shit = FALSE //explicitly an antag
 
 	/// The antag team to apply the player to
 	var/datum/team/antag_team

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -136,6 +136,9 @@
 	///This is critical non-policy information about the ghost role. Shown in the spawner menu and after spawning last.
 	var/important_text = ""
 
+	///Trigger "don't be a shit" reminder? ONLY DISABLE FOR GHOSTROLES THAT ARE OPEN ANTAGONISTS (PIRATES AND BATTLECRUISER) AND NO EXCEPTIONS
+	var/dont_be_a_shit = TRUE
+
 	///Show these on spawn? Usually used for hardcoded special flavor
 	var/show_flavor = TRUE
 
@@ -303,6 +306,8 @@
 			output_message += "\n<span class='infoplain'><b>[flavour_text]</b></span>"
 		if(important_text != "")
 			output_message += "\n[span_userdanger("[important_text]")]"
+		if(dont_be_a_shit = TRUE)
+			output_message += "\n[span_adminhelp("DO NOT DIRECTLY INTERFERE WITH OR SABOTAGE THE ROUND ON THE MAIN STATION IN ANY WAY WITHOUT PROVOCATION OR DIRECT ADMIN APPROVAL OR YOU WILL BE BANNED.")]"
 		to_chat(spawned_mob, output_message)
 
 /// Checks if the spawner has zero uses left, if so, delete yourself... NOW!

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -136,7 +136,7 @@
 	///This is critical non-policy information about the ghost role. Shown in the spawner menu and after spawning last.
 	var/important_text = ""
 
-	///Trigger "don't be a shit" reminder? ONLY DISABLE FOR GHOSTROLES THAT ARE OPEN ANTAGONISTS (PIRATES AND BATTLECRUISER) AND NO EXCEPTIONS
+	///Trigger "don't be a shit" reminder - should only be disabled for ghostroles that are antagonists.
 	var/dont_be_a_shit = TRUE
 
 	///Show these on spawn? Usually used for hardcoded special flavor

--- a/code/modules/mob_spawn/mob_spawn.dm
+++ b/code/modules/mob_spawn/mob_spawn.dm
@@ -306,7 +306,7 @@
 			output_message += "\n<span class='infoplain'><b>[flavour_text]</b></span>"
 		if(important_text != "")
 			output_message += "\n[span_userdanger("[important_text]")]"
-		if(dont_be_a_shit = TRUE)
+		if(dont_be_a_shit != FALSE)
 			output_message += "\n[span_adminhelp("DO NOT DIRECTLY INTERFERE WITH OR SABOTAGE THE ROUND ON THE MAIN STATION IN ANY WAY WITHOUT PROVOCATION OR DIRECT ADMIN APPROVAL OR YOU WILL BE BANNED.")]"
 		to_chat(spawned_mob, output_message)
 


### PR DESCRIPTION

## About The Pull Request
![image](https://github.com/user-attachments/assets/7b22b5c1-1b49-44e3-be07-96d044843548)
This reminder now appears with every **non-antagonist** ghostrole. Pirates and battlecruiser operatives do not recieve this warning.

## Why It's Good For The Game

Admins (specifically Faustbyte) have noted that ghostroles have repeatedly contemplated fucking with the station even though that isn't allowed. If being subtle with IC command orders doesn't solve the problem, then a little sprinking of span_ahelp should.

## Changelog
:cl:
add: To further discourage poor behaviour from ghostroles, a warning has been added that will appear on spawn. I will make this even more in-your-face if you don't listen.
/:cl:
