### PR TITLE
Dried gibs now merge

### DIFF
--- a/code/datums/components/cleaner.dm
+++ b/code/datums/components/cleaner.dm
@@ -121,10 +121,13 @@
 		clean_succeeded = TRUE
 		user.visible_message(span_notice("[user] finishes cleaning [target]!"), span_notice("You finish cleaning [target]."))
 		if(clean_target)
+			var/exp_gained = 0
 			for(var/obj/effect/decal/cleanable/cleanable_decal in target.contents + target) //it's important to do this before you wash all of the cleanables off
-				user.mind?.adjust_experience(/datum/skill/cleaning, round(cleanable_decal.beauty / CLEAN_SKILL_BEAUTY_ADJUSTMENT))
+				exp_gained += round(cleanable_decal.beauty / CLEAN_SKILL_BEAUTY_ADJUSTMENT, 1)
 			if(target.wash(cleaning_strength))
-				user.mind?.adjust_experience(/datum/skill/cleaning, round(CLEAN_SKILL_GENERIC_WASH_XP))
+				exp_gained += round(CLEAN_SKILL_GENERIC_WASH_XP, 1)
+			if(exp_gained)
+				user.mind?.adjust_experience(/datum/skill/cleaning, exp_gained)
 		if(isitem(target))
 			var/obj/item/item= target
 			if(length(item.viruses))

--- a/code/datums/components/cleaner.dm
+++ b/code/datums/components/cleaner.dm
@@ -121,7 +121,7 @@
 		clean_succeeded = TRUE
 		user.visible_message(span_notice("[user] finishes cleaning [target]!"), span_notice("You finish cleaning [target]."))
 		if(clean_target)
-			for(var/obj/effect/decal/cleanable/cleanable_decal in target) //it's important to do this before you wash all of the cleanables off
+			for(var/obj/effect/decal/cleanable/cleanable_decal in target.contents + target) //it's important to do this before you wash all of the cleanables off
 				user.mind?.adjust_experience(/datum/skill/cleaning, round(cleanable_decal.beauty / CLEAN_SKILL_BEAUTY_ADJUSTMENT))
 			if(target.wash(cleaning_strength))
 				user.mind?.adjust_experience(/datum/skill/cleaning, round(CLEAN_SKILL_GENERIC_WASH_XP))

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -249,6 +249,7 @@
 		if(!other_gibs.dried || other_gibs == src)
 			continue
 		other_gibs.handle_merge_decal(src)
+		beauty += other_gibs.beauty
 		var/mutable_appearance/other_appearance = copy_appearance_filter_overlays(other_gibs.appearance)
 		other_appearance.appearance_flags = KEEP_APART | RESET_COLOR | RESET_ALPHA
 		add_overlay(other_appearance)

--- a/code/game/objects/effects/decals/cleanable/humans.dm
+++ b/code/game/objects/effects/decals/cleanable/humans.dm
@@ -245,6 +245,14 @@
 	if(!.)
 		return
 	AddComponent(/datum/component/rot, 0, 5 MINUTES, 0.7)
+	for(var/obj/effect/decal/cleanable/blood/gibs/other_gibs in loc)
+		if(!other_gibs.dried || other_gibs == src)
+			continue
+		other_gibs.handle_merge_decal(src)
+		var/mutable_appearance/other_appearance = copy_appearance_filter_overlays(other_gibs.appearance)
+		other_appearance.appearance_flags = KEEP_APART | RESET_COLOR | RESET_ALPHA
+		add_overlay(other_appearance)
+		qdel(other_gibs)
 
 /obj/effect/decal/cleanable/blood/gibs/ex_act(severity, target)
 	return FALSE


### PR DESCRIPTION

## About The Pull Request

this makes it so gibs will merge when they dry, with other dried gibs on the same time

this means it'll just be one single gibs object with 4 overlays, instead of 5 gib objects stacked on one tile.
they should visually remain the same. dna and such from the gibs are also merged.

## Why It's Good For The Game

bc this can be laggy 
![image](https://github.com/user-attachments/assets/be1bbffc-a7d8-46a0-888c-613d60bc0776)


## Changelog
:cl:
code: Dried gibs now merge into one object, hopefully reducing the lag from large amounts of blood tomatoes or monkeys being gibbed.
/:cl:
