### PR TITLE
Queue starlight updates in a subsystem

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -184,8 +184,9 @@
 #define INIT_ORDER_XKEYSCORE -10
 #define INIT_ORDER_STICKY_BAN -10
 #define INIT_ORDER_LIGHTING -20
-#define INIT_ORDER_OUTDOOR_EFFECTS -21 //monkestation addition
-#define INIT_ORDER_SHUTTLE -22 //monkestation edit -21 > -22
+#define INIT_ORDER_STARLIGHT -21
+#define INIT_ORDER_OUTDOOR_EFFECTS -22 //monkestation addition
+#define INIT_ORDER_SHUTTLE -23 //monkestation edit -21 > -22
 #define INIT_ORDER_MINOR_MAPPING -40
 #define INIT_ORDER_PATH -50
 #define INIT_ORDER_EXPLOSIONS -69

--- a/code/controllers/subsystem/starlight.dm
+++ b/code/controllers/subsystem/starlight.dm
@@ -1,0 +1,68 @@
+#define STARLIGHT_RUN_TYPE_UPDATE 1
+#define STARLIGHT_RUN_TYPE_ENABLE 2
+
+SUBSYSTEM_DEF(starlight)
+	name = "Starlight"
+	init_order = INIT_ORDER_STARLIGHT
+	flags = SS_BACKGROUND | SS_KEEP_TIMING | SS_NO_INIT | SS_HIBERNATE
+	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT // running in the lobby allows us to handle the queue during pre-game
+
+	var/list/turfs_to_update = list()
+	var/list/turfs_to_enable = list()
+	var/list/currentrun_update
+	var/list/currentrun_enable
+	var/run_type = STARLIGHT_RUN_TYPE_UPDATE
+
+/datum/controller/subsystem/starlight/PreInit()
+	. = ..()
+	hibernate_checks = list(
+		NAMEOF(src, turfs_to_update),
+		NAMEOF(src, turfs_to_enable),
+		NAMEOF(src, currentrun_update),
+		NAMEOF(src, currentrun_enable),
+	)
+
+/datum/controller/subsystem/starlight/Recover()
+	turfs_to_update = SSstarlight.turfs_to_update
+	turfs_to_enable = SSstarlight.turfs_to_enable
+
+/datum/controller/subsystem/starlight/stat_entry(msg)
+	msg = "U:[length(turfs_to_update)]|E:[length(turfs_to_enable)]"
+	return ..()
+
+/datum/controller/subsystem/starlight/fire(resumed)
+	if(!resumed)
+		run_type = STARLIGHT_RUN_TYPE_UPDATE
+		currentrun_update = turfs_to_update.Copy()
+		currentrun_enable = turfs_to_enable.Copy()
+
+	var/list/current_run
+	var/list/current_queue
+	if(run_type == STARLIGHT_RUN_TYPE_UPDATE)
+		current_run = currentrun_update
+		current_queue = turfs_to_update
+		while(length(current_run))
+			var/turf/open/space/turf = current_run[length(current_run)]
+			current_run.len--
+			if(isspaceturf(turf))
+				turf.immediate_update_starlight()
+			current_queue -= turf
+			if(MC_TICK_CHECK)
+				return
+		run_type = STARLIGHT_RUN_TYPE_ENABLE
+
+	if(run_type == STARLIGHT_RUN_TYPE_ENABLE)
+		current_run = currentrun_enable
+		current_queue = turfs_to_enable
+		while(length(current_run))
+			var/turf/open/space/turf = current_run[length(current_run)]
+			current_run.len--
+			if(isspaceturf(turf))
+				turf.immediate_enable_starlight()
+			current_queue -= turf
+			if(MC_TICK_CHECK)
+				return
+		run_type = STARLIGHT_RUN_TYPE_UPDATE
+
+#undef STARLIGHT_RUN_TYPE_ENABLE
+#undef STARLIGHT_RUN_TYPE_UPDATE

--- a/code/game/turfs/open/space/space.dm
+++ b/code/game/turfs/open/space/space.dm
@@ -107,9 +107,12 @@ GLOBAL_VAR_INIT(starlight_color, pick(COLOR_TEAL, COLOR_GREEN, COLOR_CYAN, COLOR
 /turf/open/space/remove_air(amount)
 	return null
 
+/turf/open/space/proc/update_starlight()
+	SSstarlight.turfs_to_update |= src
+
 /// Updates starlight. Called when we're unsure of a turf's starlight state
 /// Returns TRUE if we succeed, FALSE otherwise
-/turf/open/space/proc/update_starlight()
+/turf/open/space/proc/immediate_update_starlight()
 	for(var/t in RANGE_TURFS(1,src)) //RANGE_TURFS is in code\__HELPERS\game.dm
 		// I've got a lot of cordons near spaceturfs, be good kids
 		if(isspaceturf(t) || istype(t, /turf/cordon))
@@ -120,8 +123,11 @@ GLOBAL_VAR_INIT(starlight_color, pick(COLOR_TEAL, COLOR_GREEN, COLOR_CYAN, COLOR
 	set_light(l_on = FALSE)
 	return FALSE
 
-/// Turns on the stars, if they aren't already
 /turf/open/space/proc/enable_starlight()
+	SSstarlight.turfs_to_enable |= src
+
+/// Turns on the stars, if they aren't already
+/turf/open/space/proc/immediate_enable_starlight()
 	if(space_lit)
 		set_light(l_color = GLOB.starlight_color, l_on = TRUE)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -796,6 +796,7 @@
 #include "code\controllers\subsystem\spatial_gridmap.dm"
 #include "code\controllers\subsystem\speech_controller.dm"
 #include "code\controllers\subsystem\stamina.dm"
+#include "code\controllers\subsystem\starlight.dm"
 #include "code\controllers\subsystem\statpanel.dm"
 #include "code\controllers\subsystem\stickyban.dm"
 #include "code\controllers\subsystem\sun.dm"


### PR DESCRIPTION
## About The Pull Request

This adds a new subsystem, `SSstarlight`.

`/turf/proc/update_starlight` and `/turf/proc/enable_starlight` now queue updates into that subsystem, instead of doing the update immediately.

If you _need_ to immediately update it, the `immediate_update_starlight` and `immediate_enable_starlight` procs have the same exact behavior as before.

## Why It's Good For The Game

Improved performance, _especially_ during turf reservations and map loading.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: Improved the performance of how starlight is enabled/updated.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
