### PR TITLE
use `load_ext` for dreamluau

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -84,6 +84,10 @@ GLOBAL_VAR(restart_counter)
 	Profile(PROFILE_RESTART)
 	Profile(PROFILE_RESTART, type = "sendmaps")
 
+#ifndef DISABLE_DREAMLUAU
+	dreamluau_load()
+#endif
+
 	// Write everything to this log file until we get to SetupLogs() later
 	_initialize_log_files("data/logs/config_error.[GUID()].log")
 	GLOB.demo_log = "[GLOB.log_directory]/demo.txt" //Guh //Monkestation Edit: REPLAYS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this makes it so all dreamluau calls use `load_ext` for improved performance

hopefully this might speed up `/atom/Destroy()`, as that _always_ does 4 dreamluau calls.

## Why It's Good For The Game

performance :3

## Changelog

no user-facing changes