### PR TITLE
Not-so-Wee acarp buff

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -186,7 +186,7 @@
 		)
 	to_chat(attacker, span_danger("You [atk_verb] [defender]!"), type = MESSAGE_TYPE_COMBAT)
 
-	defender.apply_damage(rand(10,15), attacker.get_attack_type(), affecting, wound_bonus = CANT_WOUND, blocked = def_check)
+	defender.apply_damage(15, attacker.get_attack_type(), affecting, wound_bonus = CANT_WOUND, blocked = def_check)
 	playsound(defender, 'sound/weapons/punch1.ogg', 25, TRUE, -1)
 	log_combat(attacker, defender, "punched ([log_name]])") //monke edit
 	return MARTIAL_ATTACK_SUCCESS
@@ -347,7 +347,7 @@
 						span_userdanger("[user] [pick(fluffmessages)]s you with [src]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), null, user)
 		to_chat(user, span_danger("You [pick(fluffmessages)] [H] with [src]!"))
 		playsound(get_turf(user), 'sound/effects/woodhit.ogg', 75, TRUE, -1)
-		H.stamina.adjust(-rand(13,20))
+		H.stamina.adjust(-20)
 		if(prob(10))
 			H.visible_message(span_warning("[H] collapses!"), \
 							span_userdanger("Your legs give out!"))

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -131,6 +131,7 @@
 	return
 
 /datum/martial_art/the_sleeping_carp/grab_act(mob/living/attacker, mob/living/defender)
+	var/old_grab_state = attacker.grab_state
 	if(!can_deflect(attacker)) //allows for deniability
 		return ..()
 
@@ -147,8 +148,13 @@
 		)
 		grab_log_description = "grabbed and nerve pinched"
 		defender.Unconscious(10 SECONDS)
-		if(attacker.grab_state == GRAB_PASSIVE && instant_grab == TRUE)
-			attacker.grab_state = GRAB_NECK
+		if(old_grab_state == GRAB_PASSIVE || old_grab_state == GRAB_AGGRESSIVE && instant_grab == TRUE)
+			attacker.setGrabState(GRAB_NECK)
+			defender.grabbedby(attacker, 1)
+			log_combat(attacker, defender, "grabbed", addition="by the neck")
+			defender.visible_message(span_warning("[attacker] violently grabs [defender]!"), \
+			span_userdanger("You're grabbed violently by [attacker]!"), span_hear("You hear sounds of aggressive fondling!"), COMBAT_MESSAGE_RANGE, attacker)
+			to_chat(attacker, span_danger("You violently grab [defender]!"))
 	defender.stamina.adjust(-50)
 	log_combat(attacker, defender, "[grab_log_description] (Sleeping Carp)")
 	return ..()

--- a/monkestation/code/modules/martial_arts/awakened_dragon.dm
+++ b/monkestation/code/modules/martial_arts/awakened_dragon.dm
@@ -55,7 +55,7 @@
 
 /datum/martial_art/the_sleeping_carp/awakened_dragon/remove(mob/living/carbon/human/target)
 	. = ..()
-	target.physiology.stamina_mod = 1
+	target.physiology.stamina_mod /= 0.7
 	target.fully_replace_character_name(titled_name, original_name)
 
 /datum/martial_art/the_sleeping_carp/awakened_dragon/strongPunch(mob/living/attacker, mob/living/defender, set_damage)

--- a/monkestation/code/modules/martial_arts/awakened_dragon.dm
+++ b/monkestation/code/modules/martial_arts/awakened_dragon.dm
@@ -22,6 +22,9 @@
 	var/original_name
 	var/titled_name
 	var/list/datum/weakref/all_bodies = list()
+	instant_grab = TRUE
+	snap_grab_state = GRAB_NECK //you can kill people a little faster
+	damage_sharpness = TRUE
 
 /datum/martial_art/the_sleeping_carp/awakened_dragon/can_deflect(mob/living/carp_user, check_intent = TRUE)
 	//if(!COOLDOWN_FINISHED(src, block_cooldown)) //monke edit
@@ -60,7 +63,7 @@
 
 /datum/martial_art/the_sleeping_carp/awakened_dragon/strongPunch(mob/living/attacker, mob/living/defender, set_damage)
 	damage = 55
-	. = ..(attacker, defender, set_damage = FALSE)
+	. = ..(attacker, defender)
 	attacker.say("Crushing Maw!!", forced = /datum/martial_art/the_sleeping_carp/awakened_dragon, ignore_spam = TRUE)
 
 /datum/martial_art/the_sleeping_carp/awakened_dragon/launchKick(mob/living/attacker, mob/living/defender, set_damage)

--- a/monkestation/code/modules/martial_arts/awakened_dragon.dm
+++ b/monkestation/code/modules/martial_arts/awakened_dragon.dm
@@ -3,7 +3,7 @@
 	id = MARTIALART_AWAKENEDDRAGON
 	help_verb = /mob/living/proc/awakened_dragon_help
 	//deflect_cooldown = 0
-	deflect_stamcost = 10
+	deflect_stamcost = 0
 	log_name = "Awakened Dragon"
 	scarp_traits = list(TRAIT_NOGUNS, TRAIT_NEVER_WOUNDED, TRAIT_NODISMEMBER, TRAIT_LIGHT_SLEEPER, TRAIT_THROW_GUNS)
 	counter = TRUE
@@ -43,6 +43,7 @@
 
 /datum/martial_art/the_sleeping_carp/awakened_dragon/teach(mob/living/carbon/human/target, make_temporary)
 	. = ..()
+	target.physiology.stamina_mod = 0.7
 	original_name = target.real_name
 	if(original_body == null)
 		original_body = target
@@ -54,6 +55,7 @@
 
 /datum/martial_art/the_sleeping_carp/awakened_dragon/remove(mob/living/carbon/human/target)
 	. = ..()
+	target.physiology.stamina_mod = 1
 	target.fully_replace_character_name(titled_name, original_name)
 
 /datum/martial_art/the_sleeping_carp/awakened_dragon/strongPunch(mob/living/attacker, mob/living/defender, set_damage)

--- a/monkestation/code/modules/martial_arts/awakened_dragon.dm
+++ b/monkestation/code/modules/martial_arts/awakened_dragon.dm
@@ -43,7 +43,7 @@
 
 /datum/martial_art/the_sleeping_carp/awakened_dragon/teach(mob/living/carbon/human/target, make_temporary)
 	. = ..()
-	target.physiology.stamina_mod = 0.7
+	target.physiology.stamina_mod *= 0.7
 	original_name = target.real_name
 	if(original_body == null)
 		original_body = target


### PR DESCRIPTION
## About The Pull Request
Gives acarp back SOME stam resist but not nearly as much as what they used to do. 30% reduction on all stamina damage.
Decided to ball a little and give them a necksnap combo with their nerve pinch. Not too strong its still 4 actions to crit/kill, just gives them a bit more of a chance in a 2v1 fight.
## Why It's Good For The Game
Acarp is currently beat out by 2 guys with batons which is... meh? They're supposed to be a much bigger threat. Also this should add a bit into the player fantasy that comes with acarp.
## Changelog
:cl:
balance: Gives awakened dragon a 30% reduction to all stamina damage. Go wild.
balance: Makes the neck snap threshold on awakened dragon neck grab instead of strangle grab.
balance: Gives awakened dragon an instant neck grab on vulcan pinch, which can be comboed with their neck snap.
:cl:
