### PR TITLE
Nerfs sanguirite

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1559,13 +1559,16 @@ MONKESTATION REMOVAL END */
 		return
 
 	var/datum/wound/bloodiest_wound
-
+	var/datum/wound/slash/flesh/slash_wound
 	for(var/i in affected_mob.all_wounds)
 		var/datum/wound/iter_wound = i
 		if(iter_wound.blood_flow)
 			if(iter_wound.blood_flow > bloodiest_wound?.blood_flow)
 				bloodiest_wound = iter_wound
-
+		if(istype(iter_wound, /datum/wound/slash/flesh)) //not inclusive of internal or pierce as that would take a refactor of the wounds themselves
+			slash_wound = iter_wound
+		if(slash_wound.clot_rate < 0)
+			slash_wound.clot_rate = 0
 	if(bloodiest_wound && affected_mob.health <= affected_mob.crit_threshold) //only works in crit
 		if(!was_working)
 			to_chat(affected_mob, span_green("You can feel your flowing blood start thickening!"))

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1530,10 +1530,10 @@ MONKESTATION REMOVAL END */
 	color = "#bb2424"
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	overdose_threshold = 20
-	/// The bloodiest wound that the patient has will have its blood_flow reduced by about half this much each second
+	/// The bloodiest wound that the patient has will have its blood_flow reduced by about half this much each second whilst in crit
 	var/clot_rate = 0.3
 	/// While this reagent is in our bloodstream, we reduce all bleeding by this factor
-	var/passive_bleed_modifier = 0.7
+	var/passive_bleed_modifier = 0.85
 	/// For tracking when we tell the person we're no longer bleeding
 	var/was_working
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
@@ -1566,7 +1566,7 @@ MONKESTATION REMOVAL END */
 			if(iter_wound.blood_flow > bloodiest_wound?.blood_flow)
 				bloodiest_wound = iter_wound
 
-	if(bloodiest_wound)
+	if(bloodiest_wound && affected_mob.health <= affected_mob.crit_threshold) //only works in crit
 		if(!was_working)
 			to_chat(affected_mob, span_green("You can feel your flowing blood start thickening!"))
 			was_working = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so sanguirite only closes your wounds if you are in crit, and reduces its bloodflow reduction.
Using it on someone in crit still closes wounds fast enough to stop them from dying to bloodloss.

Tldr: hold your wounds or die.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Bleed wounds being actually effective and not trivialized by pressing z on a single item you spawn with is good. Moves the epi pen into something more of a last-ditch effort to not bleed out/something to use on crit players rather than yourself.

This also works well with longer fights as it lets bleed be an actual win condition rather than just an occasional fuck you if you forgot your epi. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog
🆑 
balance: Makes sanguirite only clot wounds if you are in crit and nerfs its bloodflow reduction. Also makes weeping avulsions not get worse while you are affected by sanguirite.
:cl:
<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
