### PR TITLE
Budgeted meteor satellite crate

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -50686,6 +50686,7 @@
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
+/obj/structure/closet/crate/engineering/fundedsatellites,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "jPa" = (
@@ -103218,6 +103219,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/structure/closet/crate/engineering/fundedsatellites,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
 "tUW" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -33890,6 +33890,10 @@
 /obj/structure/sign/departments/engineering/directional/west,
 /turf/open/space/basic,
 /area/space/nearstation)
+"kTO" = (
+/obj/structure/closet/crate/engineering/fundedsatellites,
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "kUa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -100316,7 +100320,7 @@ uEU
 fxk
 hGH
 jvA
-rFn
+kTO
 rFn
 rFn
 mwn

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -37256,6 +37256,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/west,
 /obj/effect/turf_decal/bot,
+/obj/structure/closet/crate/engineering/fundedsatellites,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "iMV" = (

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -52286,6 +52286,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/structure/closet/crate/engineering/fundedsatellites,
 /turf/open/floor/iron/smooth_corner{
 	dir = 1
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -6486,6 +6486,12 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/toilet/restrooms)
+"cbt" = (
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/effect/turf_decal/tile/red,
+/obj/structure/closet/crate/engineering/fundedsatellites,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "cbC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -114559,7 +114565,7 @@ rja
 fvC
 xCr
 btQ
-xyg
+cbt
 lIU
 bGY
 wTe

--- a/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
+++ b/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
@@ -4588,6 +4588,10 @@
 /obj/effect/turf_decal/trimline/yellow/warning,
 /turf/open/floor/iron/shuttle/arrivals/airless,
 /area/space/nearstation)
+"csT" = (
+/obj/structure/closet/crate/engineering/fundedsatellites,
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "csU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/liquids_spawner/acid_waist,
@@ -65808,7 +65812,7 @@ xlc
 ghy
 rfU
 kom
-dnj
+csT
 ghy
 oni
 uwb

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -7170,6 +7170,10 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"cCE" = (
+/obj/structure/closet/crate/engineering/fundedsatellites,
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "cCN" = (
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
@@ -109696,7 +109700,7 @@ rBe
 uXd
 dVc
 bYp
-gXu
+cCE
 oaC
 uXd
 hps

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -45764,6 +45764,10 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/department/engine)
+"rhY" = (
+/obj/structure/closet/crate/engineering/fundedsatellites,
+/turf/open/floor/plating,
+/area/station/engineering/storage_shared)
 "rie" = (
 /obj/structure/chair/wood{
 	dir = 8
@@ -82156,7 +82160,7 @@ xiw
 cdI
 cri
 eVW
-nqa
+rhY
 tkr
 ceq
 ceq

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -73529,6 +73529,7 @@
 "vpS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/closet/crate/engineering/fundedsatellites,
 /turf/open/floor/plating,
 /area/station/engineering/storage)
 "vpU" = (

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -42513,6 +42513,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/genetics)
+"lTK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/closet/crate/engineering/fundedsatellites,
+/turf/open/floor/engine,
+/area/station/engineering/main)
 "lTS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -117779,7 +117786,7 @@ vZF
 mAy
 mAy
 mym
-vRH
+lTK
 luV
 cNe
 qcq

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -52615,6 +52615,7 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 8
 	},
+/obj/structure/closet/crate/engineering/fundedsatellites,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "pxM" = (
@@ -74339,6 +74340,7 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_ccw{
 	dir = 4
 	},
+/obj/structure/closet/crate/engineering/fundedsatellites,
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "wbf" = (

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -290,6 +290,33 @@
 	name = "engineering crate"
 	icon_state = "engi_crate"
 
+/obj/structure/closet/crate/engineering/fundedsatellites
+	name = "budgeted meteor satellites"
+	desc = "The lock seems to respond to Centcom's station goal announcements."
+	secure = TRUE
+	locked = TRUE
+
+/obj/structure/closet/crate/engineering/fundedsatellites/PopulateContents()
+	. = ..()
+	if(GLOB.station_goals.len)
+		for(var/datum/station_goal/station_goal as anything in GLOB.station_goals)
+			if(istype(station_goal, /datum/station_goal/station_shield))
+				new /obj/item/paper/crumpled/wehavenomoneyhaha(src)
+				return
+		for(var/i in 1 to 20)
+			new /obj/item/meteor_shield_capsule(src)
+	else
+		new /mob/living/basic/spider/giant(src)
+
+/obj/structure/closet/crate/engineering/fundedsatellites/allowed(user)
+	if(GLOB.station_goals.len)
+		return TRUE
+	return FALSE
+
+/obj/item/paper/crumpled/wehavenomoneyhaha
+	name = "note from Centcom's accounting department"
+	default_raw_text = "We ran out of budget."
+
 /obj/structure/closet/crate/engineering/electrical
 	icon_state = "engi_e_crate"
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -292,7 +292,7 @@
 
 /obj/structure/closet/crate/engineering/fundedsatellites
 	name = "budgeted meteor satellites"
-	desc = "The lock seems to respond to Centcom's station goal announcements."
+	desc = "The lock seems to respond to Centcom's station goal announcements. CAUTION: Do not attempt to break the lock."
 	secure = TRUE
 	locked = TRUE
 


### PR DESCRIPTION

## About The Pull Request
Added a new crate to the engineering department that only spawns meteor satellites if they are not a current station goal.
## Why It's Good For The Game
Engineers can now protect the station more reliably without getting a freebie goal completion.
## Changelog
:cl: EssentialTomato
add: Added a roundstart crate that only contains meteor satellites if they are not a current station goal.
/:cl:
