### PR TITLE
Fixes up lobby screen fading out + roundstart storyteller

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -826,12 +826,12 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/splash)
 	if(QDELETED(src))
 		return
 	if(out)
-		animate(src, alpha = 0, time = 30)
+		animate(src, alpha = 0, time = 3 SECONDS)
 	else
 		alpha = 0
-		animate(src, alpha = 255, time = 30)
+		animate(src, alpha = 255, time = 3 SECONDS)
 	if(qdel_after)
-		QDEL_IN(src, 30)
+		QDEL_IN(src, 3 SECONDS)
 
 /atom/movable/screen/splash/Destroy()
 	if(holder)

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -60,7 +60,7 @@ SUBSYSTEM_DEF(title)
 	for(var/thing in GLOB.clients)
 		if(!thing)
 			continue
-		var/atom/movable/screen/splash/S = new(null, thing, FALSE)
+		var/atom/movable/screen/splash/S = new(null, null, thing, FALSE)
 		S.Fade(FALSE,FALSE)
 
 /datum/controller/subsystem/title/Recover()

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -119,7 +119,7 @@
 
 /area/shuttle/arrival/on_joining_game(mob/living/boarder)
 	if(SSshuttle.arrivals?.mode == SHUTTLE_CALL)
-		var/atom/movable/screen/splash/Spl = new(null, boarder.client, TRUE)
+		var/atom/movable/screen/splash/Spl = new(null, null, boarder.client, TRUE)
 		Spl.Fade(TRUE)
 		boarder.playsound_local(get_turf(boarder), 'monkestation/sound/ai/duke/welcome/welcome2.ogg', 50) //MONKESTATION EDIT
 	boarder.update_parallax_teleport()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -20,7 +20,7 @@
 
 /mob/dead/new_player/Initialize(mapload)
 	if(client && SSticker.state == GAME_STATE_STARTUP)
-		var/atom/movable/screen/splash/S = new(null, client, TRUE, TRUE)
+		var/atom/movable/screen/splash/S = new(null, null, client, TRUE, TRUE)
 		S.Fade(TRUE)
 
 	if(length(GLOB.newplayer_start))

--- a/monkestation/code/modules/storytellers/storytellers/_storyteller.dm
+++ b/monkestation/code/modules/storytellers/storytellers/_storyteller.dm
@@ -60,6 +60,10 @@
 	var/weight = 0
 
 /datum/storyteller/process(seconds_per_tick)
+	tick(seconds_per_tick)
+
+// process() has waitfor = FALSE, so use this if you want to wait til it's done doing its thing
+/datum/storyteller/proc/tick(seconds_per_tick)
 	if(!round_started || disable_distribution) // we are differing roundstarted ones until base roundstart so we can get cooler stuff
 		return
 


### PR DESCRIPTION
## About The Pull Request

this is just some fixes split off from https://github.com/Monkestation/Monkestation2.0/pull/6967

This fixes lobby screen fadeout not properly working (client needs to be the third argument, not second, due to https://github.com/Monkestation/Monkestation2.0/pull/5830, as it ported https://github.com/tgstation/tgstation/pull/76772), and also properly runs a storyteller process at roundstart.

This did _nothing_:
```dm
SSgamemode.current_storyteller.process(STORYTELLER_WAIT_TIME * 0.1) // we want this asap
SSgamemode.current_storyteller.round_started = TRUE
```
because it set `round_started` to true _after_ process... so the process would just immediately exit:
```dm
/datum/storyteller/process(seconds_per_tick)
	if(!round_started || disable_distribution) // we are differing roundstarted ones until base roundstart so we can get cooler stuff
		return
```

In addition, I've moved the storyteller process code to a new proc, `/datum/storyteller/proc/tick(seconds_per_tick)`
This is _solely_ because `process()` sets waitfor = FALSE:
```dm
/datum/proc/process(seconds_per_tick)
	set waitfor = FALSE
```
and thus any sleep would result in roundstart continuing before the storyteller setup finishes.

I also made the lobby screen fadeout _after_ storyteller setup finished (+ 1 extra second), to hopefully reduce or eliminate the "someone sees their coworker who got chosen for nukie just disappear into thin air" thing.

## Why It's Good For The Game

Fixes bugs, and hopefully reduces jank relating to roundstart antags being slightly delayed.

## Changelog
:cl:
fix: The lobby screen now properly fades out during roundstart/latejoin/
fix: Roundstart setup now properly immediately triggers the storyteller to process.
/:cl:
