### PR TITLE
Allows the construction bag to hold more contruction-related stuff

### DIFF
--- a/code/datums/storage/subtypes/bags.dm
+++ b/code/datums/storage/subtypes/bags.dm
@@ -1,3 +1,25 @@
+///Construction bag
+/datum/storage/bag/construction
+	max_total_storage = 100
+	max_slots = 50
+	max_specific_storage = WEIGHT_CLASS_SMALL
+
+/datum/storage/bag/construction/New(atom/parent, max_slots, max_specific_storage, max_total_storage)
+	. = ..()
+	set_holdable(list(
+		/obj/item/assembly,
+		/obj/item/circuitboard,
+		/obj/item/electronics,
+		/obj/item/reagent_containers/cup/beaker,
+		/obj/item/stack/cable_coil,
+		/obj/item/stack/ore/bluespace_crystal,
+		/obj/item/stock_parts,
+		/obj/item/wallframe/camera,
+		/obj/item/stack/sheet,
+		/obj/item/rcd_ammo,
+		/obj/item/stack/rods,
+	))
+
 ///Rebar quiver bag
 /datum/storage/bag/rebar_quiver
 	max_specific_storage = WEIGHT_CLASS_TINY

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -524,10 +524,6 @@
 		/obj/item/stack/biomass // monke: make science bags able to hold biomass cubes
 		))
 
-/*
- *  Construction bag (for engineering, holds stock parts and electronics)
- */
-
 /obj/item/storage/bag/construction
 	name = "construction bag"
 	icon = 'icons/obj/tools.dmi'
@@ -535,22 +531,7 @@
 	worn_icon_state = "construction_bag"
 	desc = "A bag for storing small construction components."
 	resistance_flags = FLAMMABLE
-
-/obj/item/storage/bag/construction/Initialize(mapload)
-	. = ..()
-	atom_storage.max_total_storage = 100
-	atom_storage.max_slots = 50
-	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
-	atom_storage.set_holdable(list(
-		/obj/item/assembly,
-		/obj/item/circuitboard,
-		/obj/item/electronics,
-		/obj/item/reagent_containers/cup/beaker,
-		/obj/item/stack/cable_coil,
-		/obj/item/stack/ore/bluespace_crystal,
-		/obj/item/stock_parts,
-		/obj/item/wallframe/camera,
-		))
+	storage_type = /datum/storage/bag/construction
 
 /obj/item/storage/bag/harpoon_quiver
 	name = "harpoon quiver"


### PR DESCRIPTION

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/90947
## Why It's Good For The Game
Makes the construction bag more enticing by allowing it to hold more things related to construction.
## Changelog
:cl: Bisar Xander3359
balance: Construction bags can now carry stacks of material up to size 'small', and can now also carry RCD ammo.
/:cl:
