### PR TITLE
Golem stupidity reduction

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golem/cardboard_golem.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golem/cardboard_golem.dm
@@ -21,7 +21,7 @@
 		TRAIT_RESISTLOWPRESSURE,
 		TRAIT_NOBLOOD,
 	)
-	mutanttongue = null
+	//mutanttongue = null
 	fixed_mut_color = null
 	armor = 25
 	burnmod = 1.25
@@ -40,7 +40,7 @@
 /datum/species/golem/cardboard/spec_attacked_by(obj/item/I, mob/living/user, obj/item/bodypart/affecting, mob/living/carbon/human/H)
 	. = ..()
 	if(user != H)
-		return FALSE //forced reproduction is rape.
+		return FALSE
 	if(istype(I, /obj/item/stack/sheet/cardboard))
 		var/obj/item/stack/sheet/cardboard/C = I
 		if(last_creation + brother_creation_cooldown > world.time) //no cheesing dork

--- a/code/modules/mob/living/carbon/human/species_types/golem/cardboard_golem.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golem/cardboard_golem.dm
@@ -3,8 +3,7 @@
 	id = SPECIES_GOLEM_CARDBOARD
 	prefix = "Cardboard"
 	special_names = list("Box")
-	info_text = "As a <span class='danger'>Cardboard Golem</span>, you aren't very strong, but you are a bit quicker and can easily create more brethren by using cardboard on yourself. Cardboard makes a poor building material for tongues, so you'll have difficulty speaking."
-	inherent_traits = list(
+	info_text = "As a <span class='danger'>Cardboard Golem</span>, you aren't very strong, but you are a bit quicker and can easily create more brethren by using cardboard on yourself."
 		TRAIT_MUTANT_COLORS,
 		TRAIT_NO_UNDERWEAR,
 		TRAIT_ADVANCEDTOOLUSER,

--- a/code/modules/mob/living/carbon/human/species_types/golem/cardboard_golem.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golem/cardboard_golem.dm
@@ -4,6 +4,7 @@
 	prefix = "Cardboard"
 	special_names = list("Box")
 	info_text = "As a <span class='danger'>Cardboard Golem</span>, you aren't very strong, but you are a bit quicker and can easily create more brethren by using cardboard on yourself."
+	inherent_traits = list(
 		TRAIT_MUTANT_COLORS,
 		TRAIT_NO_UNDERWEAR,
 		TRAIT_ADVANCEDTOOLUSER,

--- a/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/species_parts/misc_bodyparts.dm
@@ -486,28 +486,24 @@
 	limb_id = SPECIES_GOLEM_CLOTH
 	should_draw_greyscale = FALSE
 	unarmed_damage_low = 7
-	unarmed_stun_threshold = 7
-	unarmed_damage_high = 8
+	unarmed_damage_high = 7
 
 /obj/item/bodypart/arm/right/golem/cloth
 	limb_id = SPECIES_GOLEM_CLOTH
 	should_draw_greyscale = FALSE
 	unarmed_damage_low = 7
-	unarmed_stun_threshold = 7
-	unarmed_damage_high = 8
+	unarmed_damage_high = 7
 
 /obj/item/bodypart/leg/left/golem/cloth
 	limb_id = SPECIES_GOLEM_CLOTH
 	should_draw_greyscale = FALSE
-	unarmed_damage_low = 7
-	unarmed_stun_threshold = 7
+	unarmed_damage_low = 12
 	unarmed_damage_high = 12
 
 /obj/item/bodypart/leg/right/golem/cloth
 	limb_id = SPECIES_GOLEM_CLOTH
 	should_draw_greyscale = FALSE
-	unarmed_damage_low = 7
-	unarmed_stun_threshold = 7
+	unarmed_damage_low = 12
 	unarmed_damage_high = 12
 
 ///CARDBOARD GOLEM
@@ -528,8 +524,7 @@
 	unarmed_attack_verb = "whip"
 	unarmed_attack_sound = 'sound/weapons/whip.ogg'
 	unarmed_miss_sound = 'sound/weapons/etherealmiss.ogg'
-	unarmed_damage_low = 7
-	unarmed_stun_threshold = 7
+	unarmed_damage_low = 8
 	unarmed_damage_high = 8
 
 /obj/item/bodypart/arm/right/golem/cardboard
@@ -538,8 +533,7 @@
 	unarmed_attack_verb = "whip"
 	unarmed_attack_sound = 'sound/weapons/whip.ogg'
 	unarmed_miss_sound = 'sound/weapons/etherealmiss.ogg'
-	unarmed_damage_low = 7
-	unarmed_stun_threshold = 7
+	unarmed_damage_low = 8
 	unarmed_damage_high = 8
 
 /obj/item/bodypart/leg/left/golem/cardboard
@@ -547,8 +541,7 @@
 	should_draw_greyscale = FALSE
 	unarmed_attack_sound = 'sound/weapons/whip.ogg'
 	unarmed_miss_sound = 'sound/weapons/etherealmiss.ogg'
-	unarmed_damage_low = 7
-	unarmed_stun_threshold = 7
+	unarmed_damage_low = 12
 	unarmed_damage_high = 12
 
 /obj/item/bodypart/leg/right/golem/cardboard
@@ -556,8 +549,7 @@
 	should_draw_greyscale = FALSE
 	unarmed_attack_sound = 'sound/weapons/whip.ogg'
 	unarmed_miss_sound = 'sound/weapons/etherealmiss.ogg'
-	unarmed_damage_low = 7
-	unarmed_stun_threshold = 7
+	unarmed_damage_low = 12
 	unarmed_damage_high = 12
 
 ///DURATHREAD GOLEM
@@ -655,31 +647,27 @@
 	attack_type = BURN
 	unarmed_attack_verb = "burn"
 	unarmed_attack_sound = 'sound/weapons/sear.ogg'
-	unarmed_damage_low = 1
+	unarmed_damage_low = 10
 	unarmed_damage_high = 10
-	unarmed_stun_threshold = 9
 
 /obj/item/bodypart/arm/right/golem/uranium
 	attack_type = BURN
 	unarmed_attack_verb = "burn"
 	unarmed_attack_sound = 'sound/weapons/sear.ogg'
-	unarmed_damage_low = 1
+	unarmed_damage_low = 10
 	unarmed_damage_high = 10
-	unarmed_stun_threshold = 9
 
 /obj/item/bodypart/leg/left/golem/uranium
 	attack_type = BURN
 	unarmed_attack_sound = 'sound/weapons/sear.ogg'
-	unarmed_damage_low = 2
+	unarmed_damage_low = 15
 	unarmed_damage_high = 15
-	unarmed_stun_threshold = 9
 
 /obj/item/bodypart/leg/right/golem/uranium
 	attack_type = BURN
 	unarmed_attack_sound = 'sound/weapons/sear.ogg'
-	unarmed_damage_low = 2
+	unarmed_damage_low = 15
 	unarmed_damage_high = 15
-	unarmed_stun_threshold = 9
 
 ///PLASTEEL GOLEM
 /obj/item/bodypart/arm/left/golem/plasteel
@@ -709,8 +697,8 @@
 /obj/item/bodypart/leg/right/golem/plasteel
 	unarmed_attack_effect = ATTACK_EFFECT_SMASH
 	unarmed_attack_sound = 'sound/effects/meteorimpact.ogg'
-	unarmed_damage_low = 18
-	unarmed_damage_high = 32
+	unarmed_damage_low = 22
+	unarmed_damage_high = 22
 	unarmed_stun_threshold = 18
 
 ///BANANIUM GOLEM
@@ -718,28 +706,24 @@
 	unarmed_attack_verb = "honk"
 	unarmed_attack_sound = 'sound/items/airhorn2.ogg'
 	unarmed_damage_low = 0
-	unarmed_damage_high = 1
-	unarmed_stun_threshold = 2 //Harmless and can't stun
+	unarmed_damage_high = 1 //Harmless and can't stun
 
 /obj/item/bodypart/arm/right/golem/bananium
 	unarmed_attack_verb = "honk"
 	unarmed_attack_sound = 'sound/items/airhorn2.ogg'
 	unarmed_damage_low = 0
 	unarmed_damage_high = 1
-	unarmed_stun_threshold = 2
 
 /obj/item/bodypart/leg/right/golem/bananium
 	unarmed_attack_verb = "honk"
 	unarmed_attack_sound = 'sound/items/airhorn2.ogg'
 	unarmed_damage_low = 0
 	unarmed_damage_high = 1
-	unarmed_stun_threshold = 2
 
 /obj/item/bodypart/leg/left/golem/bananium
 	unarmed_attack_verb = "honk"
 	unarmed_attack_sound = 'sound/items/airhorn2.ogg'
 	unarmed_damage_low = 0
 	unarmed_damage_high = 1
-	unarmed_stun_threshold = 2
 
 //


### PR DESCRIPTION

## About The Pull Request

Gives cardboard golems their tongues back (Golemtide is chaos enough when they can actually talk), nukes damage rng from golem limbs, and stops golems with on purpose weak punches from knocking down on every hit.

## Why It's Good For The Game

Should help reduce cardboard golem rp degradation a TON, also makes it so that weak golems don't have krav maga tier melee.

## Changelog

:cl:
balance: cardboard golems have tongues now
balance: weak punching golems no longer get 1 hit knockdowns
fix: fixes golem numbers that might have made sense at one point maybe
/:cl:
