### PR TITLE
add opendream + testing compile tasks to vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,6 +61,13 @@
 				"-trusted"
 			],
 			"preLaunchTask": "Build All (low memory mode)"
+		},
+		{
+			"type": "opendream",
+			"request": "launch",
+			"name": "Launch OpenDream (requires extension, 64 bit rustg, and an SS14 account)",
+			"preLaunchTask": "OpenDream: compile ${command:CurrentDME}",
+			"json_path": "${workspaceFolder}/${command:CurrentJson}"
 		}
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,27 @@
 		{
 			"type": "byond",
 			"request": "launch",
+			"name": "Launch DreamSeeker (testing)",
+			"preLaunchTask": "Build All (testing)",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}"
+		},
+		{
+			"type": "byond",
+			"request": "launch",
+			"name": "Launch DreamSeeker (testing + low memory mode)",
+			"preLaunchTask": "Build All (testing + low memory mode)",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}"
+		},
+		{
+			"type": "byond",
+			"request": "launch",
+			"name": "Launch DreamSeeker (map testing)",
+			"preLaunchTask": "Build All (map testing)",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}"
+		},
+		{
+			"type": "byond",
+			"request": "launch",
 			"name": "Launch DreamDaemon",
 			"preLaunchTask": "Build All",
 			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
@@ -35,6 +56,30 @@
 			"request": "launch",
 			"name": "Launch DreamDaemon (low memory mode)",
 			"preLaunchTask": "Build All (low memory mode)",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
+			"dreamDaemon": true
+		},
+		{
+			"type": "byond",
+			"request": "launch",
+			"name": "Launch DreamDaemon (testing)",
+			"preLaunchTask": "Build All (testing)",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
+			"dreamDaemon": true
+		},
+		{
+			"type": "byond",
+			"request": "launch",
+			"name": "Launch DreamDaemon (testing + low memory mode)",
+			"preLaunchTask": "Build All (testing + low memory mode)",
+			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
+			"dreamDaemon": true
+		},
+		{
+			"type": "byond",
+			"request": "launch",
+			"name": "Launch DreamDaemon (map testing)",
+			"preLaunchTask": "Build All (map testing)",
 			"dmb": "${workspaceFolder}/${command:CurrentDMB}",
 			"dreamDaemon": true
 		},

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,6 +49,78 @@
 			"label": "Build All (low memory mode)"
 		},
 		{
+			"type": "process",
+			"command": "tools/build/build",
+			"args": ["-DTESTING","-DREAGENTS_TESTING","-DTIMER_DEBUG","-DREFERENCE_DOING_IT_LIVE"],
+			"windows": {
+				"command": ".\\tools\\build\\build.bat",
+				"args": ["-DTESTING","-DREAGENTS_TESTING","-DTIMER_DEBUG","-DREFERENCE_DOING_IT_LIVE"]
+			},
+			"options": {
+				"env": {
+					"DM_EXE": "${config:dreammaker.byondPath}"
+				}
+			},
+			"problemMatcher": [
+				"$dreammaker",
+				"$tsc",
+				"$eslint-stylish"
+			],
+			"group": {
+				"kind": "build"
+			},
+			"dependsOn": "dm: reparse",
+			"label": "Build All (testing)"
+		},
+		{
+			"type": "process",
+			"command": "tools/build/build",
+			"args": ["-DLOWMEMORYMODE","-DTESTING","-DREAGENTS_TESTING","-DTIMER_DEBUG","-DREFERENCE_DOING_IT_LIVE"],
+			"windows": {
+				"command": ".\\tools\\build\\build.bat",
+				"args": ["-DLOWMEMORYMODE","-DTESTING","-DREAGENTS_TESTING","-DTIMER_DEBUG","-DREFERENCE_DOING_IT_LIVE"]
+			},
+			"options": {
+				"env": {
+					"DM_EXE": "${config:dreammaker.byondPath}"
+				}
+			},
+			"problemMatcher": [
+				"$dreammaker",
+				"$tsc",
+				"$eslint-stylish"
+			],
+			"group": {
+				"kind": "build"
+			},
+			"dependsOn": "dm: reparse",
+			"label": "Build All (testing + low memory mode)"
+		},
+		{
+			"type": "process",
+			"command": "tools/build/build",
+			"args": ["-DTESTING","-DMAP_TEST"],
+			"windows": {
+				"command": ".\\tools\\build\\build.bat",
+				"args": ["-DTESTING","-DMAP_TEST"]
+			},
+			"options": {
+				"env": {
+					"DM_EXE": "${config:dreammaker.byondPath}"
+				}
+			},
+			"problemMatcher": [
+				"$dreammaker",
+				"$tsc",
+				"$eslint-stylish"
+			],
+			"group": {
+				"kind": "build"
+			},
+			"dependsOn": "dm: reparse",
+			"label": "Build All (map testing)"
+		},
+		{
 			"type": "dreammaker",
 			"dme": "tgstation.dme",
 			"problemMatcher": [


### PR DESCRIPTION
## About The Pull Request

ports the following PRs:

https://github.com/tgstation/tgstation/pull/87393
> Adds a vscode launch option to support the new (well, it's a few months old now) OpenDream extension.

---

https://github.com/tgstation/tgstation/pull/90961
> Removes 1 knowledge check from 3 step quest of accessing some debug verbs.
> It defines: TESTING, REAGENTS_TESTING, TIMER_DEBUG, REFERENCE_DOING_IT_LIVE

## Why It's Good For The Game

less annoying testing

## Changelog

no user-facing changes, this only affects local development