### PR TITLE
fix broken tgui passthrough + keybindings

### DIFF
--- a/tgui/packages/tgui/hotkeys.ts
+++ b/tgui/packages/tgui/hotkeys.ts
@@ -188,6 +188,12 @@ export const setupHotKeys = () => {
   globalEvents.on('input-focus', () => {
     releaseHeldKeys();
   });
+  globalEvents.on('key', (key: KeyEvent) => {
+    for (const keyListener of keyListeners) {
+      keyListener(key);
+    }
+    handlePassthrough(key);
+  });
 };
 
 /**


### PR DESCRIPTION

## About The Pull Request

i accidentally broke keybindings when porting https://github.com/Monkestation/Monkestation2.0/pull/6862, and also fucked up key passthru in general, both due to a skill issue on my part.

## Why It's Good For The Game

bugfix

## Changelog
:cl:
fix: Fixed not being able to set keybindings.
fix: Fixed keys not properly passing through tgui windows.
/:cl:
