### PR TITLE
Armor booster modules automatically activate/deactivate depending on the pressure around the user

### DIFF
--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -8,7 +8,7 @@
 		However, the additional plating cannot deploy alongside parts of the suit used for vacuum sealing, \
 		so this extra armor provides zero ability for extravehicular activity while deployed."
 	icon_state = "armor_booster"
-	module_type = MODULE_TOGGLE
+	module_type = MODULE_ACTIVE
 	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.3
 	removable = FALSE
 	incompatible_modules = list(/obj/item/mod/module/armor_booster, /obj/item/mod/module/welding)
@@ -41,6 +41,7 @@
 
 /obj/item/mod/module/armor_booster/on_suit_activation()
 	mod.helmet.flash_protect = FLASH_PROTECTION_WELDER
+	RegisterSignal(mod.wearer, COMSIG_MOVABLE_MOVED, PROC_REF(on_user_moved))
 
 /obj/item/mod/module/armor_booster/on_suit_deactivation(deleting = FALSE)
 	if(deleting)
@@ -90,6 +91,25 @@
 		overlay_icon_file = 'monkestation/icons/mob/mod.dmi' //if the user has a snout, and the module supports a snout, we'll shift to the digi/snout icon file instead
 	return ..()
 
+/obj/item/mod/module/armor_booster/proc/on_user_moved(datum/source, turf/newloc, turf/oldloc)
+	if(!istype(source, /mob/living))
+		return
+	var/mob/living/user = source
+	var/turf/T = get_turf(user)
+	if(!T)
+		return
+	var/air = T.return_analyzable_air()
+	var/list/airs = islist(T) ? T : list(T)
+	for(var/datum/gas_mixture/air as anything in airs)
+		if(airs.len > 1) //not a unary gas mixture
+			var/mix_number = airs.Find(air)
+		var/pressure = air.return_pressure()
+		if(pressure < 20)
+			if(!active)
+				on_activation()
+		else
+			if(active)
+				on_deactivation()
 ///Energy Shield - Gives you a rechargeable energy shield that nullifies attacks.
 /obj/item/mod/module/energy_shield
 	name = "MOD energy shield module"

--- a/code/modules/mod/modules/modules_antag.dm
+++ b/code/modules/mod/modules/modules_antag.dm
@@ -5,10 +5,8 @@
 	name = "MOD armor booster module"
 	desc = "A retrofitted series of retractable armor plates, allowing the suit to function as essentially power armor, \
 		giving the user incredible protection against conventional firearms, or everyday attacks in close-quarters. \
-		However, the additional plating cannot deploy alongside parts of the suit used for vacuum sealing, \
-		so this extra armor provides zero ability for extravehicular activity while deployed."
+		The additional plating automatically retracts when exposed to space and extends when the user is in a safe environment. \""
 	icon_state = "armor_booster"
-	module_type = MODULE_ACTIVE
 	active_power_cost = DEFAULT_CHARGE_DRAIN * 0.3
 	removable = FALSE
 	incompatible_modules = list(/obj/item/mod/module/armor_booster, /obj/item/mod/module/welding)
@@ -98,18 +96,16 @@
 	var/turf/T = get_turf(user)
 	if(!T)
 		return
-	var/air = T.return_analyzable_air()
-	var/list/airs = islist(T) ? T : list(T)
+	var/sair = T.return_analyzable_air()
+	var/list/airs = islist(sair) ? T : list(sair)
 	for(var/datum/gas_mixture/air as anything in airs)
-		if(airs.len > 1) //not a unary gas mixture
-			var/mix_number = airs.Find(air)
 		var/pressure = air.return_pressure()
-		if(pressure < 20)
-			if(!active)
-				on_activation()
-		else
+		if(pressure < 20 || pressure > 30)
 			if(active)
 				on_deactivation()
+		else
+			if(!active)
+				on_activation()
 ///Energy Shield - Gives you a rechargeable energy shield that nullifies attacks.
 /obj/item/mod/module/energy_shield
 	name = "MOD energy shield module"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes armor modules to be passive modules instead of toggles. 

Armor booster modules check the atmosphere around the user. If the environment is safe, it toggles. If its not, it turns off.

## Why It's Good For The Game

Armor boosters are very useful mods that are sadly underused for a few reasons. Namely, newer players don't know they exist, or they dont know to toggle them when they don't need EVA, or a knowledgeable operative gets distracted by gameplay and forgets to toggle it.

Changing the module to be an automatic toggle if the environment is safe seemed better than it being a manual toggle.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
change: Armor booster module now automatically toggles if the environment is safe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
