### PR TITLE
Adds Griddle Toast to the monkestore

### DIFF
--- a/monkestation/code/modules/loadouts/items/masks.dm
+++ b/monkestation/code/modules/loadouts/items/masks.dm
@@ -82,6 +82,11 @@ GLOBAL_LIST_INIT(loadout_masks, generate_loadout_items(/datum/loadout_item/mask)
 /*
 *	MISC
 */
+
+/datum/loadout_item/mask/griddle_toast
+	name = "Griddle Toast"
+	item_path = /obj/item/food/griddle_toast
+
 /datum/loadout_item/mask/fake_mustache
 	name = "Fake Moustache"
 	item_path = /obj/item/clothing/mask/fakemoustache
@@ -133,6 +138,7 @@ GLOBAL_LIST_INIT(loadout_masks, generate_loadout_items(/datum/loadout_item/mask)
 /datum/loadout_item/mask/manhunt
 	name = "Smiley Mask"
 	item_path = /obj/item/clothing/mask/joy/manhunt
+
 /*
 *	DONATOR
 */

--- a/monkestation/code/modules/store/store_items/masks.dm
+++ b/monkestation/code/modules/store/store_items/masks.dm
@@ -64,6 +64,12 @@ GLOBAL_LIST_INIT(store_masks, generate_store_items(/datum/store_item/mask))
 /*
 *	MISC
 */
+
+/datum/store_item/mask/griddle_toast
+	name = "Griddle Toast"
+	item_path = /obj/item/food/griddle_toast
+	item_cost = 2500
+
 /datum/store_item/mask/fake_mustache
 	name = "Fake Moustache"
 	item_path = /obj/item/clothing/mask/fakemoustache


### PR DESCRIPTION

## About The Pull Request
Adds griddle toast to the monkestore for 2500 coins in the mask section
Because you can wear it in your mask slot to carry it around like your late for work and cant eat breakfast at home.

## Why It's Good For The Game
Toast, it would be nice to round start with toast to keep in your mouth for the entire shift.

## Changelog
:cl:
add: Griddle Toast in monkestore for 2500, its a mask slot item.
/:cl:
