### PR TITLE
Fix the ooze compressors in the deep storage ruin facing the wrong way

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -2642,7 +2642,9 @@
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "jD" = (
-/obj/machinery/plumbing/ooze_compressor,
+/obj/machinery/plumbing/ooze_compressor{
+	dir = 1
+	},
 /obj/effect/turf_decal/stripes{
 	dir = 8
 	},
@@ -2865,7 +2867,9 @@
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/pharmacy)
 "vc" = (
-/obj/machinery/plumbing/ooze_compressor,
+/obj/machinery/plumbing/ooze_compressor{
+	dir = 1
+	},
 /obj/effect/turf_decal/stripes{
 	dir = 4
 	},


### PR DESCRIPTION

## About The Pull Request

fixes https://github.com/Monkestation/Monkestation2.0/issues/6963

## Changelog
:cl:
map: The ooze compressors in the syndicate deep storage ruin are now properly connected.
/:cl:
