### PR TITLE
fix double-encoded messages in ticket viewer

### DIFF
--- a/tgui/packages/tgui/interfaces/TicketPanel.jsx
+++ b/tgui/packages/tgui/interfaces/TicketPanel.jsx
@@ -2,6 +2,7 @@ import { useBackend, useLocalState } from '../backend';
 import { Section, Button, Box, Flex, TextArea } from '../components';
 import { Window } from '../layouts';
 import { KEY_ENTER } from 'common/keycodes';
+import { decodeHtmlEntities } from 'common/string';
 
 export const TicketPanel = (props) => {
   const { act, data } = useBackend();
@@ -182,7 +183,7 @@ export const TicketMessages = (props) => {
         (entry) =>
           (
             <Box key={entry.time} m="2px">
-              {entry.time} - <b>{entry.ckey}</b> - {entry.text}
+              {entry.time} - <b>{entry.ckey}</b> - {decodeHtmlEntities(entry.text)}
             </Box>
           ) || '',
       )}


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

i just threw a `decodeHtmlEntities` in the ticketviewer tgui, to hopefully make it so `I've` stops appearing as `I&#39;ve` instead.

## Why It's Good For The Game

makes ticket messages easier to read

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed messages in the ticket viewer sometimes having messed up apostrophes and similar symbols.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
