### PR TITLE
some boxing changes

### DIFF
--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -8,8 +8,11 @@
 	return TRUE
 
 /datum/martial_art/boxing/grab_act(mob/living/attacker, mob/living/defender)
-	to_chat(attacker, span_warning("Can't grab while boxing!"))
-	return TRUE
+	if(defender.body_position == LYING_DOWN)
+		return
+	else
+		to_chat(attacker, span_warning("They need to be down first!"))
+		return TRUE
 
 /datum/martial_art/boxing/harm_act(mob/living/attacker, mob/living/defender)
 
@@ -41,7 +44,7 @@
 
 	defender.apply_damage(damage, STAMINA, affecting, armor_block)
 	log_combat(attacker_human, defender, "punched (boxing) ")
-	if(defender.stamina.loss > 230 && istype(defender.mind?.martial_art, /datum/martial_art/boxing))
+	if(defender.stamina.loss > 235 && istype(defender.mind?.martial_art, /datum/martial_art/boxing))
 		var/knockout_prob = 10 // 10% chance to win by knockout when they are around one hit from stam crit anyways
 		if((defender.stat != DEAD) && prob(knockout_prob))
 			defender.visible_message(span_danger("[attacker_human] knocks [defender] out with a haymaker!"), \

--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -20,7 +20,7 @@
 
 	var/atk_verb = pick("left hook","right hook","straight punch")
 
-	var/damage = rand(10, 16) + (active_arm.unarmed_damage_low * 2)
+	var/damage = 25
 	if(!damage)
 		playsound(defender.loc, active_arm.unarmed_miss_sound, 25, TRUE, -1)
 		defender.visible_message(span_warning("[attacker]'s [atk_verb] misses [defender]!"), \
@@ -41,8 +41,8 @@
 
 	defender.apply_damage(damage, STAMINA, affecting, armor_block)
 	log_combat(attacker_human, defender, "punched (boxing) ")
-	if(defender.stamina.loss > 50 && istype(defender.mind?.martial_art, /datum/martial_art/boxing))
-		var/knockout_prob = defender.stamina.loss_as_percent + rand(-15,15)
+	if(defender.stamina.loss > 230 && istype(defender.mind?.martial_art, /datum/martial_art/boxing))
+		var/knockout_prob = 10 // 10% chance to win by knockout when they are around one hit from stam crit anyways
 		if((defender.stat != DEAD) && prob(knockout_prob))
 			defender.visible_message(span_danger("[attacker_human] knocks [defender] out with a haymaker!"), \
 							span_userdanger("You're knocked unconscious by [attacker_human]!"), span_hear("You hear a sickening sound of flesh hitting flesh!"), COMBAT_MESSAGE_RANGE, attacker_human)


### PR DESCRIPTION

## About The Pull Request
Done primarly for the boxing event soon, but overall just to de-rngify and improve boxing some overall

boxing gloves do flat 25 stam damage a punch rather than being dependent on your arm strength + random number 10-16

Boxing gloves have a 10% chance to knockout at over 235 stam loss rather than its original loss as percent + random number between -15through15 when over 50 stamina loss. (can only knock out other people with boxing gloves as before)

You can grab people who are laying down with boxing gloves

## Why It's Good For The Game
RNG is pretty terrible, with good vs bad RNG you can knock out other people boxing in as little as 3 hits or over 10 hits. You can also stam crit people way way faster than they can you which just leaves boxing feeling inconsistent and discourging.
The 10% knockout chance allows people to have a low chance to win the fight they already would've most likely won by knockout rather than just stam crit rather than just being a chance to instantly end the fight early with a knockout.

so I mistook boxing for wrestling where you have to hold the other guy down for 10 seconds but in boxing they just have to be down for 10 seconds for you to win, however doesn't really work in ss13 they are always gonna get back up so this kinda mimics that.

## Changelog

:cl:
balance: boxing no longer uses rng
balance: boxers can now grab people who are laying down
/:cl:

