### PR TITLE
Sanguirite change take 2

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1629,12 +1629,12 @@ MONKESTATION REMOVAL END */
 
 /datum/reagent/medicine/coagulant/extreme
 	name = "Insta-Clot"
-	description = "A dark red substance that completely stops bleeding and closes wounds extremely quickly. Its clotting power does come with the drawback of it wrecking the heart of the user. An overdose will quickly kill the user"
+	description = "A dark red substance that halves bleeding and closes wounds extremely quickly. Its clotting power does come with the drawback of it wrecking the heart of the user. An overdose will quickly kill the user"
 	color = "#4b0b0be8"
 	taste_description = "dense, rotten blood"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
-	clot_rate = 0.6
-	passive_bleed_modifier = 0
+	clot_rate = 0.4
+	passive_bleed_modifier = 0.5
 	overdose_threshold = 5
 
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1531,9 +1531,9 @@ MONKESTATION REMOVAL END */
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	overdose_threshold = 20
 	/// The bloodiest wound that the patient has will have its blood_flow reduced by about half this much each second
-	var/clot_rate = 0.3
+	var/clot_rate = 0
 	/// While this reagent is in our bloodstream, we reduce all bleeding by this factor
-	var/passive_bleed_modifier = 0.7
+	var/passive_bleed_modifier = 0.2
 	/// For tracking when we tell the person we're no longer bleeding
 	var/was_working
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
@@ -1576,7 +1576,7 @@ MONKESTATION REMOVAL END */
 
 /datum/reagent/medicine/coagulant/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
 	. = ..()
-	if(!HAS_TRAIT(affected_mob, TRAIT_NOBLOOD))
+	if(HAS_TRAIT(affected_mob, TRAIT_NOBLOOD))
 		return
 
 	if(SPT_PROB(7.5, seconds_per_tick))
@@ -1626,3 +1626,27 @@ MONKESTATION REMOVAL END */
 	required_drink_type = /datum/reagent/medicine/coagulant/seraka_extract
 	name = "glass of seraka extract"
 	desc = "Deeply savoury, bitter, and makes your blood clot up in your veins. A great drink, all things considered."
+
+/datum/reagent/medicine/coagulant/extreme
+	name = "Insta-Clot"
+	desc = "A dark red substance that completely stops bleeding and closes wounds extremely quickly. Its clotting power does come with the drawback of it wrecking the heart of the user. An overdose will quickly kill the user"
+	color = "#4b0b0be8"
+	taste_description = "dense, rotten blood"
+	metabolization_rate = 0.2 * REAGENTS_METABOLISM
+	clot_rate = 0.6
+	passive_bleed_modifier = 0
+	overdose_threshold = 5
+	var/obj/item/organ/internal/heart/our_heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
+	var/obj/item/organ/internal/spleen/our_spleen = affected_mob.get_organ_slot(ORGAN_SLOT_SPLEEN)
+
+/datum/reagent/medicine/coagulant/extreme/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
+	if(HAS_TRAIT(affected_mob, TRAIT_NOBLOOD))
+		return
+	if(prob(25))
+		our_heart.apply_organ_damage(3) //Pray this kills you first
+	else
+		var/blood_addition = 10
+		affected_mob.blood_volume = blood_volume + blood_addition //Eventually will cause you to pop like a balloon at 2150 blood or about 8.3 units of the stuff over 166 cycles.
+		our_spleen.apply_organ_damage(1)
+
+

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1632,10 +1632,20 @@ MONKESTATION REMOVAL END */
 	description = "A dark red substance that completely stops bleeding and closes wounds extremely quickly. Its clotting power does come with the drawback of it wrecking the heart of the user. An overdose will quickly kill the user"
 	color = "#4b0b0be8"
 	taste_description = "dense, rotten blood"
-	metabolization_rate = 0.2 * REAGENTS_METABOLISM
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	clot_rate = 0.6
 	passive_bleed_modifier = 0
 	overdose_threshold = 5
+
+
+/datum/reagent/medicine/coagulant/extreme/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
+	. = ..()
+	var/obj/item/organ/internal/heart/our_heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
+	var/obj/item/organ/internal/spleen/our_spleen = affected_mob.get_organ_slot(ORGAN_SLOT_SPLEEN)
+	if(prob(50))
+		our_heart.apply_organ_damage(2)
+		our_spleen.apply_organ_damage(2)
+		to_chat(affected_mob, span_danger("You feel an uncomfortable squeeze on your organs!"))
 
 /datum/reagent/medicine/coagulant/extreme/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
 	var/obj/item/organ/internal/heart/our_heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
@@ -1643,10 +1653,10 @@ MONKESTATION REMOVAL END */
 	if(HAS_TRAIT(affected_mob, TRAIT_NOBLOOD))
 		return
 	if(prob(25))
-		our_heart.apply_organ_damage(3) //Pray this kills you first
+		our_heart.apply_organ_damage(6) //Pray this kills you first
 		to_chat(affected_mob, span_danger("You feel your clotted blood shredding your heart!"))
 	else
-		var/blood_addition = 10
+		var/blood_addition = 25
 		affected_mob.blood_volume = affected_mob.blood_volume + blood_addition //Eventually will cause you to pop like a balloon at 2150 blood or about 8.3 units of the stuff over 166 cycles.
 		if(prob(20))
 			to_chat(affected_mob, span_danger("Your blood feels like hot fire!"))

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1656,7 +1656,7 @@ MONKESTATION REMOVAL END */
 		our_heart.apply_organ_damage(6) //Pray this kills you first
 		to_chat(affected_mob, span_danger("You feel your clotted blood shredding your heart!"))
 	else
-		var/blood_addition = 25
+		var/blood_addition = 20
 		affected_mob.blood_volume = affected_mob.blood_volume + blood_addition //Eventually will cause you to pop like a balloon at 2150 blood or about 8.3 units of the stuff over 166 cycles.
 		if(prob(20))
 			to_chat(affected_mob, span_danger("Your blood feels like hot fire!"))

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1629,24 +1629,27 @@ MONKESTATION REMOVAL END */
 
 /datum/reagent/medicine/coagulant/extreme
 	name = "Insta-Clot"
-	desc = "A dark red substance that completely stops bleeding and closes wounds extremely quickly. Its clotting power does come with the drawback of it wrecking the heart of the user. An overdose will quickly kill the user"
+	description = "A dark red substance that completely stops bleeding and closes wounds extremely quickly. Its clotting power does come with the drawback of it wrecking the heart of the user. An overdose will quickly kill the user"
 	color = "#4b0b0be8"
 	taste_description = "dense, rotten blood"
 	metabolization_rate = 0.2 * REAGENTS_METABOLISM
 	clot_rate = 0.6
 	passive_bleed_modifier = 0
 	overdose_threshold = 5
-	var/obj/item/organ/internal/heart/our_heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
-	var/obj/item/organ/internal/spleen/our_spleen = affected_mob.get_organ_slot(ORGAN_SLOT_SPLEEN)
 
 /datum/reagent/medicine/coagulant/extreme/overdose_process(mob/living/affected_mob, seconds_per_tick, times_fired)
+	var/obj/item/organ/internal/heart/our_heart = affected_mob.get_organ_slot(ORGAN_SLOT_HEART)
+	var/obj/item/organ/internal/spleen/our_spleen = affected_mob.get_organ_slot(ORGAN_SLOT_SPLEEN)
 	if(HAS_TRAIT(affected_mob, TRAIT_NOBLOOD))
 		return
 	if(prob(25))
 		our_heart.apply_organ_damage(3) //Pray this kills you first
+		to_chat(affected_mob, span_danger("You feel your clotted blood shredding your heart!"))
 	else
 		var/blood_addition = 10
-		affected_mob.blood_volume = blood_volume + blood_addition //Eventually will cause you to pop like a balloon at 2150 blood or about 8.3 units of the stuff over 166 cycles.
+		affected_mob.blood_volume = affected_mob.blood_volume + blood_addition //Eventually will cause you to pop like a balloon at 2150 blood or about 8.3 units of the stuff over 166 cycles.
+		if(prob(20))
+			to_chat(affected_mob, span_danger("Your blood feels like hot fire!"))
 		our_spleen.apply_organ_damage(1)
 
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -281,11 +281,11 @@
 
 /obj/item/reagent_containers/hypospray/medipen/atropine
 	name = "atropine autoinjector"
-	desc = "A rapid way to save a person from a critical injury state!"
+	desc = "A rapid way to save a person from a critical injury state. Overuse is not recommended."
 	icon_state = "atropen"
 	inhand_icon_state = "atropen"
 	base_icon_state = "atropen"
-	list_reagents = list(/datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/coagulant = 2)
+	list_reagents = list(/datum/reagent/medicine/atropine = 10, /datum/reagent/medicine/coagulant/extreme = 2)
 
 /obj/item/reagent_containers/hypospray/medipen/snail
 	name = "snail shot"
@@ -328,12 +328,12 @@
 
 /obj/item/reagent_containers/hypospray/medipen/blood_loss
 	name = "hypovolemic-response autoinjector"
-	desc = "A medipen designed to stabilize and rapidly reverse severe bloodloss."
+	desc = "A medipen designed to stabilize and rapidly reverse severe bloodloss. Overuse will lead to death."
 	icon_state = "hypovolemic"
 	base_icon_state = "hypovolemic"
 	volume = 15
 	amount_per_transfer_from_this = 15
-	list_reagents = list(/datum/reagent/medicine/epinephrine = 5, /datum/reagent/medicine/coagulant = 2.5, /datum/reagent/iron = 3.5, /datum/reagent/medicine/salglu_solution = 4)
+	list_reagents = list(/datum/reagent/medicine/epinephrine = 5, /datum/reagent/medicine/coagulant/extreme = 2.5, /datum/reagent/iron = 3.5, /datum/reagent/medicine/salglu_solution = 4)
 
 /obj/item/reagent_containers/hypospray/medipen/mutadone
 	name = "mutadone autoinjector"


### PR DESCRIPTION
## About The Pull Request
Changes sanguirite to almost completely stop bleeding, but does nothing to fix it.
Adds an "extreme" coagulant to hypovolemic response pens and atropine pens that damages your heart. Overdosing with this, provided you can live without a heart does something very funny.
## Why It's Good For The Game
Pooba liked this version of it. Bleed wounds deserve to actually do something.
As for the actual reasons:

- Bleed wounds currently are the worst type of wounds due to the overtuned nature of sanguirite and its rampant availability, especially when compared to burn and blunt wounds which actually have bearing on fast paced combat with slowdowns or damage multipliers.
- Sanguirite is incredibly overtuned and can basically remove any bleeding as it is now, this PR makes it so sanguirite instead stops bleeding almost entirely but makes it so you need to find something else to actually close the wound, engaging with the system more than pressing 1 button.
- It enables you to actually use bleed wounds as a win condition in longer fights, as if you deal a weeping avulsion you can just back off for 40 seconds and wait for the sanguirite to wear off, instead of having to go in and deal another wound after the 40 seconds are up.

## Changelog
:cl:
balance: Changes sanguirite to close wounds more efficiently, but only for as long as it is in your blood.
add: Adds a new upgraded coagulant that completely blocks bloodloss and closes wounds with unparalleled speed to the atropine and hypovolemic medipens.
:cl:
