### PR TITLE
Reduces meteor sat deploy time to half a second

### DIFF
--- a/monkestation/code/modules/meteor_shield/meteor_shield.dm
+++ b/monkestation/code/modules/meteor_shield/meteor_shield.dm
@@ -19,7 +19,7 @@ GLOBAL_VAR_INIT(total_meteors_zapped, 0)
 
 /obj/machinery/satellite/meteor_shield/Initialize(mapload)
 	. = ..()
-	AddElement(/datum/element/repackable, /obj/item/flatpacked_machine/generic, 5 SECONDS, TRUE, TRUE)
+	AddElement(/datum/element/repackable, /obj/item/flatpacked_machine/generic, 2 SECONDS, TRUE, TRUE)
 
 	GLOB.meteor_shield_sats += src
 	RegisterSignal(src, COMSIG_MOVABLE_SPACEMOVE, PROC_REF(on_space_move)) // so these fuckers don't drift off into space when you're trying to position them

--- a/monkestation/code/modules/meteor_shield/meteor_shield_capsule.dm
+++ b/monkestation/code/modules/meteor_shield/meteor_shield_capsule.dm
@@ -7,4 +7,4 @@
 
 /obj/item/meteor_shield_capsule/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/deployable, 1.5 SECONDS, /obj/machinery/satellite/meteor_shield, delete_on_use = TRUE)
+	AddComponent(/datum/component/deployable, 0.5 SECONDS, /obj/machinery/satellite/meteor_shield, delete_on_use = TRUE)

--- a/monkestation/code/modules/meteor_shield/meteor_shield_capsule.dm
+++ b/monkestation/code/modules/meteor_shield/meteor_shield_capsule.dm
@@ -7,4 +7,4 @@
 
 /obj/item/meteor_shield_capsule/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/deployable, 5 SECONDS, /obj/machinery/satellite/meteor_shield, delete_on_use = TRUE)
+	AddComponent(/datum/component/deployable, 1.5 SECONDS, /obj/machinery/satellite/meteor_shield, delete_on_use = TRUE)


### PR DESCRIPTION
## About The Pull Request

this makes it so it takes 0.5 secs instead of 5 seconds to deploy meteor sats from a capsule.

repacking it takes 2 seconds instead of 5.

## Why It's Good For The Game

makes setting up meteor sats less of a slog.

## Changelog
:cl:
qol: Reduced the meteor sat deploy time to half a second, from 5 seconds.
/:cl:
