### PR TITLE
Silver-forged weapons now deal extra damage against bloodsuckers and the werewolf+vampire species

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -101,6 +101,7 @@ GLOBAL_LIST_INIT(turfs_openspace, typecacheof(list(
 #define ismoth(A) (is_species(A, /datum/species/moth))
 #define isethereal(A) (is_species(A, /datum/species/ethereal))
 #define isvampire(A) (is_species(A,/datum/species/vampire))
+#define iswerewolf(A) (is_species(A,/datum/species/werewolf))
 #define isdullahan(A) (is_species(A, /datum/species/dullahan))
 #define ismonkey(A) (is_species(A, /datum/species/monkey))
 #define isandroid(A) (is_species(A, /datum/species/android))

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -42,9 +42,10 @@
 		damage_amount *= ((100 - blocked) / 100)
 		damage_amount *= get_incoming_damage_modifier(damage_amount, damagetype, def_zone, sharpness, attack_direction, attacking_item)
 		if(attacking_item)
-			if(!SEND_SIGNAL(attacking_item, COMSIG_ITEM_DAMAGE_MULTIPLIER, src, def_zone))
-				attacking_item.last_multi = 1
-			damage_amount *= attacking_item.last_multi
+			var/damage_multiplier = 1
+			SEND_SIGNAL(attacking_item, COMSIG_ITEM_DAMAGE_MULTIPLIER, &damage_multiplier, src, def_zone)
+			if(damage_multiplier != 1)
+				damage_amount = round(damage_amount * damage_multiplier, 1)
 
 	if(damage_amount <= 0)
 		return 0

--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/slasher_datum.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/slasher_datum.dm
@@ -383,13 +383,9 @@
 	SIGNAL_HANDLER
 	UnregisterSignal(source, COMSIG_ITEM_DAMAGE_MULTIPLIER)
 
-/obj/item/var/last_multi = 1
-
-/datum/antagonist/slasher/proc/damage_multiplier(obj/item/source, mob/living/attacked, def_zone)
+/datum/antagonist/slasher/proc/damage_multiplier(obj/item/source, damage_multiplier_ptr, mob/living/attacked, def_zone)
 	//keeping this just in case we use it later, but the damage changing has been turned off
-	source.last_multi = 1
-
-	return TRUE
+	// *damage_multiplier_ptr = 1
 
 /datum/antagonist/slasher/proc/increase_fear(atom/movable/target, amount)
 	var/datum/weakref/weak = WEAKREF(target)

--- a/monkestation/code/modules/smithing/anvil/anvil.dm
+++ b/monkestation/code/modules/smithing/anvil/anvil.dm
@@ -16,6 +16,9 @@
 	var/list/recipes = list()
 	var/list/name_to_type = list()
 
+	///for debugging purposes: this will always be perfect
+	var/always_perfect = FALSE
+
 /obj/structure/anvil/Initialize(mapload)
 	. = ..()
 	for(var/datum/anvil_recipe/recipe as anything in subtypesof(/datum/anvil_recipe))

--- a/monkestation/code/modules/smithing/material_changes/material_traits/holy.dm
+++ b/monkestation/code/modules/smithing/material_changes/material_traits/holy.dm
@@ -1,0 +1,42 @@
+/datum/material_trait/holy
+	name = "Holy"
+	desc = "This item does extra damage against unholy beings."
+	trait_flags = MT_NO_STACK_ADD
+	value_bonus = 25
+
+/datum/material_trait/holy/post_parent_init(obj/item/parent)
+	if(!isitem(parent))
+		return
+	// DO NOT DOUBLE APPLY THIS!!!
+	if(locate(/datum/material_trait/holy) in parent.material_stats?.material_traits - src)
+		return
+	RegisterSignal(parent, COMSIG_ITEM_DAMAGE_MULTIPLIER, PROC_REF(damage_multiplier))
+
+/datum/material_trait/holy/proc/damage_multiplier(obj/item/source, damage_multiplier_ptr, mob/living/victim, def_zone)
+	SIGNAL_HANDLER
+	if(IS_BLOODSUCKER(victim))
+		// negate the damage reduction from fortitude
+		if(HAS_TRAIT_FROM(victim, TRAIT_PIERCEIMMUNE, FORTITUDE_TRAIT) && source.damtype == BRUTE)
+			var/datum/physiology/physiology = astype(victim, /mob/living/carbon/human)?.physiology
+			if(physiology)
+				*damage_multiplier_ptr /= physiology.brute_mod
+
+		// extra damage during sol
+		if(victim.has_status_effect(/datum/status_effect/bloodsucker_sol))
+			*damage_multiplier_ptr *= 2
+		else
+			*damage_multiplier_ptr *= 1.5
+
+	// werewolves have insane damage resistance, so 3x damage
+	if(iswerewolf(victim))
+		*damage_multiplier_ptr *= 3
+	else if(isvampire(victim))
+		*damage_multiplier_ptr *= 1.5
+
+
+/datum/material_trait/holy/proc/is_unholy_target(mob/living/victim)
+	if(isvampire(victim) || iswerewolf(victim))
+		return TRUE
+	if(IS_BLOODSUCKER(victim))
+		return TRUE
+	return FALSE

--- a/monkestation/code/modules/smithing/material_changes/materials.dm
+++ b/monkestation/code/modules/smithing/material_changes/materials.dm
@@ -56,7 +56,7 @@
 	hardness = 60
 	density = 40
 	conductivity = 30
-	material_traits = list(/datum/material_trait/shiny)
+	material_traits = list(/datum/material_trait/shiny, /datum/material_trait/holy)
 
 /datum/material/bluespace
 	density = 60

--- a/monkestation/code/modules/smithing/minigame/anvil_minigame.dm
+++ b/monkestation/code/modules/smithing/minigame/anvil_minigame.dm
@@ -170,6 +170,10 @@
 	//Success == quality, takes highest of Smithing level * 5 || 100 minus a number based on how 'accurate' you were plus (smithlevel *5)-15.
 	//So missing nothing, a level 3 smith will make a qual 100 item.
 	var/smithlevel = user.mind.get_skill_level(/datum/skill/smithing)
+	if(host_anvil.always_perfect)
+		failed_notes = 0
+		off_time = 0
+		success = 100
 	success = max(smithlevel * 5, round(success - ((100 * (failed_notes / total_notes)) + 1 * (off_time * 2)) +((smithlevel * 5) - 15)))
 	UnregisterSignal(user.client, COMSIG_CLIENT_CLICK_DIRTY)
 	STOP_PROCESSING(SSfishing, src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -8431,6 +8431,7 @@
 #include "monkestation\code\modules\smithing\material_changes\new_materials.dm"
 #include "monkestation\code\modules\smithing\material_changes\material_traits\_base_trait.dm"
 #include "monkestation\code\modules\smithing\material_changes\material_traits\chemical_injector.dm"
+#include "monkestation\code\modules\smithing\material_changes\material_traits\holy.dm"
 #include "monkestation\code\modules\smithing\material_changes\material_traits\honk.dm"
 #include "monkestation\code\modules\smithing\material_changes\material_traits\magical.dm"
 #include "monkestation\code\modules\smithing\material_changes\material_traits\radioactive.dm"


### PR DESCRIPTION
## About The Pull Request

This makes it so silver-forged weapons deal extra damage against bloodsuckers, werewolves, and vampires (the species)

- Bloodsuckers take 1.5x damage (2x during Sol), and any damage resistance from fortitude is negated.
- Werewolves take 3x damage (they have insane innate damage resistance, so a higher multiplier should negate that)
- Vampires (the species) take 1.5x damage.

These stack, so a werewolf vampire will take 6x damage during Sol, for example.

draft+dnm bc i still need to properly test this

## Why It's Good For The Game

It's fitting, and gives forging another use, as a counter against otherwise powerful beings that are traditionally weak to silver.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Silver forged weapons now deal bonus damage against bloodsuckers, werewolves, and the vampire species.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
