### PR TITLE
[PORT] Ninja energy net now a projectile

### DIFF
--- a/code/modules/antagonists/ninja/energy_net_nets.dm
+++ b/code/modules/antagonists/ninja/energy_net_nets.dm
@@ -12,7 +12,6 @@
 	desc = "It's a net made of green energy."
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "energynet"
-
 	density = TRUE//Can't pass through.
 	opacity = FALSE //Can see through.
 	mouse_opacity = MOUSE_OPACITY_ICON//So you can hit it with stuff.
@@ -23,23 +22,20 @@
 	can_buckle = 1
 	buckle_lying = 0
 	buckle_prevents_pull = TRUE
-	///The creature currently caught in the net
-	var/mob/living/affected_mob
 
 /obj/structure/energy_net/play_attack_sound(damage, damage_type = BRUTE, damage_flag = 0)
 	if(damage_type == BRUTE || damage_type == BURN)
 		playsound(src, 'sound/weapons/slash.ogg', 80, TRUE)
 
-/obj/structure/energy_net/Destroy()
-	if(!QDELETED(affected_mob))
-		affected_mob.visible_message(span_notice("[affected_mob.name] is recovered from the energy net!"), span_notice("You are recovered from the energy net!"), span_hear("You hear a grunt."))
-	affected_mob = null
+/obj/structure/energy_net/atom_destruction(damage_flag)
+	for(var/mob/recovered_mob as anything in buckled_mobs)
+		recovered_mob.visible_message(span_notice("[recovered_mob] is recovered from the energy net!"), span_notice("You are recovered from the energy net!"), span_hear("You hear a grunt."))
 	return ..()
 
 /obj/structure/energy_net/attack_paw(mob/user, list/modifiers)
 	return attack_hand(user, modifiers)
 
-/obj/structure/energy_net/user_buckle_mob(mob/living/M, mob/user, check_loc = TRUE)
+/obj/structure/energy_net/user_buckle_mob(mob/living/buckled_mob, mob/user, check_loc = TRUE)
 	return//We only want our target to be buckled
 
 /obj/structure/energy_net/user_unbuckle_mob(mob/living/buckled_mob, mob/living/user)

--- a/code/modules/mod/modules/modules_engineering.dm
+++ b/code/modules/mod/modules/modules_engineering.dm
@@ -124,7 +124,7 @@
 /obj/projectile/tether/fire(setAngle)
 	if(firer)
 		line = firer.Beam(src, "line", 'icons/obj/clothing/modsuit/mod_modules.dmi', emissive = FALSE)
-	..()
+	return ..()
 
 /obj/projectile/tether/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Ports: https://github.com/tgstation/tgstation/pull/77423
## Why It's Good For The Game
Getting instantly snared with no counterplay isn't exactly fun.
## Changelog
:cl: EssentialTomato
balance: (Fikou) Space Ninja's energy net uses a projectile to catch people now.
/:cl:
