### PR TITLE
Forced storyteller fix

### DIFF
--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -1070,6 +1070,8 @@ SUBSYSTEM_DEF(gamemode)
 					message_admins("[key_name_admin(usr)] has chosen [new_storyteller_name] as the new Storyteller.")
 					var/new_storyteller_type = name_list[new_storyteller_name]
 					set_storyteller(new_storyteller_type)
+					if (SSticker.HasRoundStarted())
+						current_storyteller.round_started = TRUE
 				if("halt_storyteller")
 					halted_storyteller = !halted_storyteller
 					message_admins("[key_name_admin(usr)] has [halted_storyteller ? "HALTED" : "un-halted"] the Storyteller.")

--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -135,7 +135,7 @@ SUBSYSTEM_DEF(gamemode)
 	/// Whether the storyteller has been halted
 	var/halted_storyteller = FALSE
 
-	// Used for ssticker to determine if an admin chosed a storyteller, so it doesnt pick one randomly
+	// Used to determine if an admin chosed a storyteller, so it doesnt pick one randomly
 	var/admin_picked_storyteller = FALSE
 
 	/// Ready players for roundstart events.

--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -135,6 +135,9 @@ SUBSYSTEM_DEF(gamemode)
 	/// Whether the storyteller has been halted
 	var/halted_storyteller = FALSE
 
+	// Used for ssticker to determine if an admin chosed a storyteller, so it doesnt pick one randomly
+	var/admin_picked_storyteller = FALSE
+
 	/// Ready players for roundstart events.
 	var/ready_players = 0
 	var/active_players = 0
@@ -827,6 +830,9 @@ SUBSYSTEM_DEF(gamemode)
 	return valid_storytellers
 
 /datum/controller/subsystem/gamemode/proc/init_storyteller()
+	// Don't allow the storyteller to be set if an admin set the storyteller
+	if (admin_picked_storyteller)
+		return
 	set_storyteller(selected_storyteller)
 
 /datum/controller/subsystem/gamemode/proc/set_storyteller(passed_type)
@@ -1070,8 +1076,8 @@ SUBSYSTEM_DEF(gamemode)
 					message_admins("[key_name_admin(usr)] has chosen [new_storyteller_name] as the new Storyteller.")
 					var/new_storyteller_type = name_list[new_storyteller_name]
 					set_storyteller(new_storyteller_type)
-					if (SSticker.HasRoundStarted())
-						current_storyteller.round_started = TRUE
+					current_storyteller.round_started = SSticker.HasRoundStarted()
+					admin_picked_storyteller = TRUE
 				if("halt_storyteller")
 					halted_storyteller = !halted_storyteller
 					message_admins("[key_name_admin(usr)] has [halted_storyteller ? "HALTED" : "un-halted"] the Storyteller.")


### PR DESCRIPTION

## About The Pull Request

This PR fixes storytellers being forcibly set and not running events when they should.
So, previously if an admin set the storyteller before the round started, the gamemode subsystem wouldn't give a fuck and set the planned storyteller regardless.

Now, when an admin sets the storyteller, any subsequent calls to init the storyteller get ignored if an admin overrided the storyteller. 

Also, previously when setting the storyteller after the round had started, the storyteller's "round_started" variable was never changed, so the new storyteller you chose would never run events.

## Why It's Good For The Game

uhh, meow? mrrp mrrp~
## Changelog
:cl:
fix: Setting storytellers should now actually set, before the round starts
fix: Storytellers changed after roundstart will now tick instead of doing nothing
/:cl:
