### PR TITLE
Circuits can only understand roundstart languages, and properly html decode messages

### DIFF
--- a/code/modules/wiremod/components/atom/hear.dm
+++ b/code/modules/wiremod/components/atom/hear.dm
@@ -43,9 +43,16 @@
 	if(speaker == parent?.shell)
 		return
 
-	message_port.set_output(raw_message)
+	var/output_message = html_decode(raw_message)
 	if(message_language)
-		language_port.set_output(initial(message_language.name))
+		var/language_output = message_language::name
+		if(!(message_language in GLOB.roundstart_languages))
+			var/datum/language/dialect = GLOB.language_datum_instances[message_language]
+			output_message = dialect.scramble(output_message)
+			if(dialect.flags & LANGUAGE_HIDE_ICON_IF_NOT_UNDERSTOOD)
+				language_output = "Unknown Language"
+		language_port.set_output(language_output)
+	message_port.set_output(output_message)
 	speaker_port.set_output(speaker)
 	speaker_name.set_output(speaker.GetVoice())
 	trigger_port.set_output(COMPONENT_SIGNAL)


### PR DESCRIPTION
## About The Pull Request

![image](https://github.com/user-attachments/assets/e98fc078-17a2-46bf-8496-8618f7156ac2)

The language name output will simply be "Unknown Language" if it's a language with the `LANGUAGE_HIDE_ICON_IF_NOT_UNDERSTOOD` flag (currently that consists of blah-tongue, codespeak, and gibbering)

## Why It's Good For The Game

Prevents a circuit you can slap together in a minute from invalidating part of the job of curator / pAI / miner with a book of babel, while still leaving them kind of useful. _For now_.

## Changelog
:cl:
fix: Voice Activator circuit components now properly decode messages, meaning apostrophes and such no longer make the message look weird.
balance: Voice Activator circuit components can now only understand roundstart languages - languages such as codespeak, xenomorph, blah-tongue, shadowtongue, etc will not be translated.
/:cl:
