### PR TITLE
Halves the volume of the Black Mesa Source Military VOX voice

### DIFF
--- a/code/__DEFINES/vox.dm
+++ b/code/__DEFINES/vox.dm
@@ -4,5 +4,5 @@
 #define VOX_BMS "Black Mesa Source VOX"
 /// The Half-Life 1 VOX voice.
 #define VOX_HL "Half-Life 1 VOX"
-/// The Black Mesa Source imilitary VOX voice.
+/// The Black Mesa Source military VOX voice.
 #define VOX_MIL "Black Mesa Source Military VOX"

--- a/code/modules/vox/voices/mil.dm
+++ b/code/modules/vox/voices/mil.dm
@@ -2,7 +2,7 @@
 
 /datum/vox_voice/mil
 	name = VOX_MIL
-	volume = 50
+	volume = 25
 	sounds = list(
 		"," = 'sound/announcer/vox_mil/_comma.ogg',
 		"." = 'sound/announcer/vox_mil/_period.ogg',


### PR DESCRIPTION

## About The Pull Request

this halves the base volume for the Black Mesa Source Military VOX voice from 50 to 25.

## Why It's Good For The Game

this voice is apparently INCREDIBLY loud, even with its current base volume of 50, so... let's lower that a bit more.

## Changelog
:cl:
sound: Halved the base volume of the Black Mesa Source Military VOX voice.
/:cl:
