### PR TITLE
Fix the `DISABLE_STORYTELLER` config option not disabling roundstart antags

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -347,8 +347,9 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/PostSetup()
 	set waitfor = FALSE
-	SSgamemode.current_storyteller.round_started = TRUE
-	SSgamemode.current_storyteller.tick(STORYTELLER_WAIT_TIME * 0.1) // we want this asap
+	if(!CONFIG_GET(flag/disable_storyteller))
+		SSgamemode.current_storyteller.round_started = TRUE
+		SSgamemode.current_storyteller.tick(STORYTELLER_WAIT_TIME * 0.1) // we want this asap
 	mode.post_setup()
 	addtimer(CALLBACK(src, PROC_REF(fade_all_splashes)), 1 SECONDS) // extra second to make SURE all antags are setup
 


### PR DESCRIPTION
## About The Pull Request

this fixes a bug introduced by a fix in https://github.com/Monkestation/Monkestation2.0/pull/6991, which caused the storyteller to fire once at roundstart, even if the `DISABLE_STORYTELLER` config option was enabled.

## Why It's Good For The Game

makes things slightly less annoying for me when testing locally

## Changelog

no user-facing changes, only affects local testing stuff