### PR TITLE
Increases price of syndicate experimental teleporter to 12tc

### DIFF
--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -83,7 +83,7 @@
 			however if that fails, you may need to be stitched back together. \
 			Comes with 4 charges, recharges randomly. Warranty null and void if exposed to an electromagnetic pulse."
 	item = /obj/item/storage/box/syndie_kit/syndicate_teleporter
-	cost = 8
+	cost = 12
 
 /datum/uplink_item/device_tools/camera_app
 	name = "SyndEye Program"


### PR DESCRIPTION
## About The Pull Request

Balance; Increases price of experimental syndicate teleporter to 12tc from 8tc

## Why It's Good For The Game

This item lets you fully bypass any access restriction and is basically a jaunt. I have played a total of 3 junior operative rounds with a simple 'meta' kit and won each of them. (The disk was secure each time and in the captains possession. It would be even easier if the disk was unsecure)

Each of the rounds went the same; buy the experimental TP and the AP 9mm rounds. 10tc total without any discounts. Wait for the captain to go into their office (or someplace alone) teleport next to them, gun them down, take the disk, teleport into the vault, then detonate the nuke. 

The sheer amount of bypass the teleporter gives you trivializes junior lone op. All you have to do is wait for the right chance and win a single fight. If you didn't have the teleporter, you would have to go through the rigamaroll of getting the captain alone, then accessing the vault BEHIND TWO REINFORCED, BOLTED VAULT DOORS. You would need the captains remote or explosives atleast to do this. Or, you can just buy the teleporter and skip all of this instantly. 

If the price is raised to 12, junior lone ops can no longer buy it without a discount. Even with the price this high, it should still stay useful for traitors and operatives.
## Changelog
:cl:
change; Experimental teleporter kit price raised from 8tc to 12tc
/:cl:
