### PR TITLE
fulton in cargo teleporter

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -403,7 +403,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(isitem(parent))
 		var/obj/item/item_parent = parent
 		var/datum/storage/smaller_fish = to_insert.atom_storage
-		if(smaller_fish && !allow_big_nesting && to_insert.w_class >= item_parent.w_class)
+		if(!is_type_in_typecache(to_insert, exception_hold) && smaller_fish && !allow_big_nesting && to_insert.w_class >= item_parent.w_class)
 			if(messages && user)
 				user.balloon_alert(user, "too big!")
 			return FALSE

--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -360,6 +360,11 @@
 	desc = "May or may not contain traces of lead."
 	grind_results = list(/datum/reagent/lead = 10)
 
+/obj/item/storage/medkit/tactical/premium/Initialize(mapload)
+	. = ..()
+	atom_storage.max_slots = 21
+	atom_storage.set_holdable(exception_hold_list = list(/obj/item/storage/box/evilmeds, /obj/item/autosurgeon/syndicate/emaggedsurgerytoolset))
+
 /obj/item/storage/medkit/tactical/premium/PopulateContents()
 	if(empty)
 		return

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -423,26 +423,26 @@
 	return obscured
 
 
-/obj/item/proc/equip_to_best_slot(mob/M)
-	if(M.equip_to_appropriate_slot(src))
-		M.update_held_items()
+/obj/item/proc/equip_to_best_slot(mob/equipper)
+	if(equipper.active_storage?.attempt_insert(src, equipper)) // Prioritize our open storage before trying to decide anything else
+		return TRUE
+
+	if(equipper.equip_to_appropriate_slot(src))
+		equipper.update_held_items()
 		return TRUE
 	else
 		if(equip_delay_self)
 			return
 
-	if(M.active_storage?.attempt_insert(src, M))
-		return TRUE
-
-	var/list/obj/item/possible = list(M.get_inactive_held_item(), M.get_item_by_slot(ITEM_SLOT_BELT), M.get_item_by_slot(ITEM_SLOT_DEX_STORAGE), M.get_item_by_slot(ITEM_SLOT_BACK))
+	var/list/obj/item/possible = list(equipper.get_inactive_held_item(), equipper.get_item_by_slot(ITEM_SLOT_BELT), equipper.get_item_by_slot(ITEM_SLOT_DEX_STORAGE), equipper.get_item_by_slot(ITEM_SLOT_BACK))
 	for(var/i in possible)
 		if(!i)
 			continue
 		var/obj/item/I = i
-		if(I.atom_storage?.attempt_insert(src, M))
+		if(I.atom_storage?.attempt_insert(src, equipper))
 			return TRUE
 
-	to_chat(M, span_warning("You are unable to equip that!"))
+	to_chat(equipper, span_warning("You are unable to equip that!"))
 	return FALSE
 
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -81,6 +81,37 @@
 	ignore_flags = 1 // So they can heal their comrades.
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 30, /datum/reagent/medicine/omnizine = 30, /datum/reagent/medicine/leporazine = 15, /datum/reagent/medicine/atropine = 15)
 
+/obj/item/reagent_containers/hypospray/combat/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
+	. = ..()
+	if(!proximity_flag)
+		return
+	if(!target.reagents)
+		return
+
+	. |= SECONDARY_ATTACK_CONTINUE_CHAIN
+	if(reagents.total_volume >= reagents.maximum_volume)
+		to_chat(user, span_notice("[src] is full."))
+		return
+
+	if(reagents.total_volume >= reagents.maximum_volume)
+		to_chat(user, span_notice("[src] is full."))
+		return
+
+	if(isliving(target)) // Combat hypo can only draw chems
+		return
+
+	if(!target.reagents.total_volume)
+		to_chat(user, span_warning("[target] is empty!"))
+		return
+
+	if(!target.is_drawable(user))
+		to_chat(user, span_warning("You cannot directly remove reagents from [target]!"))
+		return
+
+	var/trans = target.reagents.trans_to(src, amount_per_transfer_from_this, transfered_by = user) // transfer from, transfer to - who cares?
+	to_chat(user, span_notice("You fill [src] with [trans] units of the solution. It now contains [reagents.total_volume] units."))
+	target.update_appearance()
+
 /obj/item/reagent_containers/hypospray/combat/empty
 	list_reagents = null
 

--- a/monkestation/code/modules/jobs/job_types/explorer.dm
+++ b/monkestation/code/modules/jobs/job_types/explorer.dm
@@ -81,3 +81,4 @@
 /obj/item/storage/box/emergency_eva/explorer/Initialize(mapload)
 	. = ..()
 	atom_storage.set_holdable(exception_hold_list = list(/obj/item/tank/jetpack/mining, /obj/item/clothing/suit/space/hardsuit/mining))
+	atom_storage.max_specific_storage = WEIGHT_CLASS_NORMAL


### PR DESCRIPTION
combat hypos can draw reagent
premium medkit made bigger
quick equip prioritizes open inventory
explorer EVA box can hold bigger items (big box)
## About The Pull Request
Tweaks a bit of space exploration content:
- Cargo teleporter can hold fultons, and consumes their charge with right click
- Combat Hyposprays can draw reagents with right click
- Premium tactical medkit is allowed to hold more of the stuff it spawns with
- Explorer EVA box can hold 3 weight items

Also makes it where if you have an active storage open, quick equip will prioritize that over equipping to a slot (putting things in pockets for example)
## Why It's Good For The Game
Just a few things that were still bothering me.
Taking items out of a medkit and not being able to put them back feels awful.
Having to carry the EVA box to put your suit back in it feels bad when it only has 3 slots that can only hold small items.
Having an open inventory and pressing E to put something away is annoying when it would get sent to your pocket instead.
## Changelog
:cl:
add: Cargo teleporter can hold fulton charges. Load it up with a fulton, and right click to use it
qol: Quick equipping something while you have an open storage will prioritize that storage
balance: Explorer EVA box can hold medium sized items
fix: Premium Tactical Medkit can hold more of the items it spawns with
add: Combat hyposprays can draw reagents with right click
/:cl:
