### PR TITLE
Caps antimagic plants

### DIFF
--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -15,7 +15,7 @@
 	if(!.)
 		return
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
-	shield_uses = max(round(our_seed.potency / 20), 5)
+	shield_uses = round(CAPPED_POTENCY(our_seed) / 20)
 	//deliver us from evil o melon god
 	our_plant.AddComponent(/datum/component/anti_magic, \
 		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \

--- a/code/modules/hydroponics/unique_plant_genes.dm
+++ b/code/modules/hydroponics/unique_plant_genes.dm
@@ -15,7 +15,7 @@
 	if(!.)
 		return
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
-	shield_uses = round(our_seed.potency / 20)
+	shield_uses = max(round(our_seed.potency / 20), 5)
 	//deliver us from evil o melon god
 	our_plant.AddComponent(/datum/component/anti_magic, \
 		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \


### PR DESCRIPTION
## About The Pull Request
Caps the antimagic gene to a max of 5 shield uses at 100 potency
## Why It's Good For The Game
With uncapped botany and biocubes, potency is not hard to skyrocket. This adds a max cap of 5 uses before the effects wear off. Meaning if your getting spammed with spells your not near immortal.

I don't think this is the end all be all in the holy melon/magic issues but its probably a healthy step. As with how easy they are to produce, they are also easy to replace. But eith this change, it means you have to go replace it. Instead of banking on one melon for the entire shift.
## Changelog
:cl:
balance: Anti-Magic Vacuoles now caps at a total of 5 uses
/:cl:
