### PR TITLE
Fix slime market and pen UIs being cut off at the bottom

### DIFF
--- a/tgui/packages/tgui/interfaces/SlimePenController.jsx
+++ b/tgui/packages/tgui/interfaces/SlimePenController.jsx
@@ -19,28 +19,34 @@ export const SlimePenController = (_) => {
   return (
     <Window width={450} height={(tabIndex === 1 && 412) || 600}>
       <Window.Content>
-        <Tabs style={{ 'border-radius': '5px' }}>
-          <Tabs.Tab
-            key={1}
-            selected={tabIndex === 1}
-            icon="flask"
-            onClick={() => setTabIndex(1)}
-          >
-            Slime Data
-          </Tabs.Tab>
-          <Tabs.Tab
-            key={2}
-            selected={tabIndex === 2}
-            icon="flask"
-            onClick={() => setTabIndex(2)}
-          >
-            Corral Data
-          </Tabs.Tab>
-        </Tabs>
-        <Section fill scrollable>
-          {tabIndex === 1 && <SlimeData />}
-          {tabIndex === 2 && <StoreViewer />}
-        </Section>
+        <Stack vertical fill>
+          <Stack.Item>
+            <Tabs style={{ 'border-radius': '5px' }}>
+              <Tabs.Tab
+                key={1}
+                selected={tabIndex === 1}
+                icon="flask"
+                onClick={() => setTabIndex(1)}
+              >
+                Slime Data
+              </Tabs.Tab>
+              <Tabs.Tab
+                key={2}
+                selected={tabIndex === 2}
+                icon="flask"
+                onClick={() => setTabIndex(2)}
+              >
+                Corral Data
+              </Tabs.Tab>
+            </Tabs>
+          </Stack.Item>
+          <Stack.Item grow>
+            <Section fill scrollable height="100%">
+              {tabIndex === 1 && <SlimeData />}
+              {tabIndex === 2 && <StoreViewer />}
+            </Section>
+          </Stack.Item>
+        </Stack>
       </Window.Content>
     </Window>
   );

--- a/tgui/packages/tgui/interfaces/XenobioMarket.jsx
+++ b/tgui/packages/tgui/interfaces/XenobioMarket.jsx
@@ -12,40 +12,46 @@ export const XenobioMarket = (_) => {
   return (
     <Window width={900} height={(tabIndex === 1 && 412) || 600}>
       <Window.Content>
-        <Tabs style={{ 'border-radius': '5px' }}>
-          <Tabs.Tab
-            key={1}
-            selected={tabIndex === 1}
-            icon="flask"
-            onClick={() => setTabIndex(1)}
-          >
-            Slime Market
-          </Tabs.Tab>
-          <Tabs.Tab
-            key={2}
-            selected={tabIndex === 2}
-            icon="flask"
-            onClick={() => setTabIndex(2)}
-          >
-            Active Requests
-          </Tabs.Tab>
-          <Tabs.Tab
-            key={3}
-            selected={tabIndex === 3}
-            icon="sack-dollar"
-            onClick={() => setTabIndex(3)}
-          >
-            View Shop
-          </Tabs.Tab>
-          <Button icon={'sack-dollar'} color="green">
-            {points}
-          </Button>
-        </Tabs>
-        <Section fill scrollable>
-          {tabIndex === 1 && <SlimeMarket />}
-          {tabIndex === 2 && <RequestViewer />}
-          {tabIndex === 3 && <StoreViewer />}
-        </Section>
+        <Stack vertical fill>
+          <Stack.Item>
+            <Tabs style={{ 'border-radius': '5px' }}>
+              <Tabs.Tab
+                key={1}
+                selected={tabIndex === 1}
+                icon="flask"
+                onClick={() => setTabIndex(1)}
+              >
+                Slime Market
+              </Tabs.Tab>
+              <Tabs.Tab
+                key={2}
+                selected={tabIndex === 2}
+                icon="flask"
+                onClick={() => setTabIndex(2)}
+              >
+                Active Requests
+              </Tabs.Tab>
+              <Tabs.Tab
+                key={3}
+                selected={tabIndex === 3}
+                icon="sack-dollar"
+                onClick={() => setTabIndex(3)}
+              >
+                View Shop
+              </Tabs.Tab>
+              <Button icon={'sack-dollar'} color="green">
+                {points || '0'}
+              </Button>
+            </Tabs>
+          </Stack.Item>
+          <Stack.Item grow>
+            <Section fill scrollable height="100%">
+              {tabIndex === 1 && <SlimeMarket />}
+              {tabIndex === 2 && <RequestViewer />}
+              {tabIndex === 3 && <StoreViewer />}
+            </Section>
+          </Stack.Item>
+        </Stack>
       </Window.Content>
     </Window>
   );
@@ -70,6 +76,9 @@ const SlimeMarket = (_) => {
                           'xenobio_market32x32',
                           slime_price.icon,
                         ])}
+                        style={{
+                          'image-rendering': 'pixelated',
+                        }}
                       />
                     </Stack.Item>
                     <Stack.Item mt="10px">
@@ -99,6 +108,7 @@ const RequestViewer = (_) => {
               <Box
                 style={{
                   transform: 'scale(2)',
+                  'image-rendering': 'pixelated',
                 }}
                 className={classes(['xenobio_market32x32', request.icon])}
               />
@@ -132,6 +142,7 @@ const StoreViewer = (_) => {
               <Box
                 style={{
                   transform: 'scale(2)',
+                  'image-rendering': 'pixelated',
                 }}
                 className={classes(['xenobio_market32x32', item.icon_state])}
               />


### PR DESCRIPTION

## About The Pull Request

this fixes the UIs for the slime market and pen controller consoles no longer extend past the bottom sometimes, cutting stuff off from the UI.

these UIs need a rewrite/massive cleanup, as does a lot of xenobio-related code tbh.

thanks to Kashargul on the coderbus discord for helping me fix this.

<details>
<summary><h3>Before</h3></summary>

![2025-06-26 (1750984597)](https://github.com/user-attachments/assets/a7da70bf-02a4-4f04-8d84-e19db925aa13)

</details>

<details>
<summary><h3>After</h3></summary>

![2025-06-26 (1750984917)](https://github.com/user-attachments/assets/7bf68f87-4414-4214-a939-2b13cec01b38)
![2025-06-26 (1750984922)](https://github.com/user-attachments/assets/e730a165-bbd9-4101-be5a-8859f3fb59c6)

</details>


## Why It's Good For The Game

bgugfix

## Changelog
:cl:
fix: Fixed the UIs for the xenobio market and slime pen controller being cut off at the bottom.
/:cl:
