### PR TITLE
Frenzy martial art is now TRAIT_STRONG_GRABBER, some auspex fixes

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
@@ -48,8 +48,6 @@
 
 	///ALL Powers currently owned
 	var/list/datum/action/cooldown/bloodsucker/powers = list()
-	///Frenzy Grab Martial art given to Bloodsuckers in a Frenzy
-	var/datum/martial_art/frenzygrab/frenzygrab = new
 
 	///Vassals under my control. Periodically remove the dead ones.
 	var/list/datum/antagonist/vassal/vassals = list()

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_frenzy.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_frenzy.dm
@@ -1,20 +1,4 @@
 /**
- * # FrenzyGrab
- *
- * The martial art given to Bloodsuckers so they can instantly aggressively grab people.
- */
-/datum/martial_art/frenzygrab
-	name = "Frenzy Grab"
-	id = MARTIALART_FRENZYGRAB
-
-/datum/martial_art/frenzygrab/grab_act(mob/living/user, mob/living/target)
-	if(user != target)
-		target.grabbedby(user)
-		target.grippedby(user, instant = TRUE)
-		return TRUE
-	return ..()
-
-/**
  * # Status effect
  *
  * This is the status effect given to Bloodsuckers in a Frenzy
@@ -46,6 +30,7 @@
 		TRAIT_PUSHIMMUNE,
 		TRAIT_SLEEPIMMUNE,
 		TRAIT_STUNIMMUNE,
+		TRAIT_STRONG_GRABBER,
 	)
 
 /datum/status_effect/frenzy/get_examine_text()
@@ -72,7 +57,6 @@
 	// Give the other Frenzy effects
 	owner.add_traits(frenzy_traits, TRAIT_STATUS_EFFECT(id))
 	owner.add_movespeed_modifier(/datum/movespeed_modifier/bloodsucker_frenzy)
-	bloodsuckerdatum.frenzygrab.teach(user, TRUE)
 	owner.add_client_colour(/datum/client_colour/cursed_heart_blood)
 	user.uncuff()
 	bloodsuckerdatum.frenzied = TRUE
@@ -80,11 +64,9 @@
 
 /datum/status_effect/frenzy/on_remove()
 	if(bloodsuckerdatum?.frenzied)
-		var/mob/living/carbon/human/user = owner
 		owner.balloon_alert(owner, "you come back to your senses.")
 		owner.remove_traits(frenzy_traits, TRAIT_STATUS_EFFECT(id))
 		owner.remove_movespeed_modifier(/datum/movespeed_modifier/bloodsucker_frenzy)
-		bloodsuckerdatum.frenzygrab.remove(user)
 		owner.remove_client_colour(/datum/client_colour/cursed_heart_blood)
 
 		SEND_SIGNAL(bloodsuckerdatum, COMSIG_BLOODSUCKER_EXITS_FRENZY)

--- a/monkestation/code/modules/bloodsuckers/powers/tremere/auspex.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/tremere/auspex.dm
@@ -70,7 +70,7 @@
 	name = "Level 5: Auspex"
 	upgraded_power = null
 	level_current = 5
-	desc = "Hide yourself within a Cloak of Darkness, click on an area to teleport, leaving nearby people bleeding and asleep."
+	desc = "Hide yourself within a Cloak of Darkness, click on an area to teleport, knocking anyone nearby down and causing them to bleed."
 	power_explanation = "Level 5: Auspex:\n\
 		When Activated, you will be hidden in a Cloak of Darkness.\n\
 		Click any area up to teleport there, ending the Power and causing people at your end location to fall over in pain."
@@ -113,10 +113,11 @@
 			continue
 		if(level_current >= 4)
 			var/obj/item/bodypart/bodypart = pick(living_mob.bodyparts)
-			living_mob.cause_wound_of_type_and_severity(WOUND_SLASH, bodypart, WOUND_SEVERITY_MODERATE, WOUND_SEVERITY_CRITICAL)
+			var/severity = pick(WOUND_SEVERITY_MODERATE, WOUND_SEVERITY_CRITICAL)
+			living_mob.cause_wound_of_type_and_severity(WOUND_SLASH, bodypart, severity, wound_source = "auspex")
 			living_mob.adjustBruteLoss(15)
-		if(level_current >= 5)
-			living_mob.Knockdown(10 SECONDS, ignore_canstun = TRUE)
+			if(level_current >= 5)
+				living_mob.Knockdown(10 SECONDS, ignore_canstun = TRUE)
 
 	do_teleport(owner, targeted_turf, no_effects = TRUE, channel = TELEPORT_CHANNEL_QUANTUM)
 	power_activated_sucessfully()


### PR DESCRIPTION

## About The Pull Request
Deletes frenzy martial art, giving frenzied vamps TRAIT_STRONG_GRABBER instead (works exactly the same but less martial arts edge cases/issues and cleaner code)

Fixes auspex description saying it left nearby asleep (it knocks down)
Auspex now properly wounds

fixes https://github.com/Monkestation/Monkestation2.0/issues/1637

## Why It's Good For The Game
Cleans up code and fixes a bug and misleading description

## Changelog

:cl:
fix: auspex now properly wounds
fix: auspex description now accurate
code: frenzy now uses strong grab trait rather than martial arts
/:cl:

