### PR TITLE
Disabling unique AI station trait.

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -26,7 +26,7 @@
 /datum/station_trait/unique_ai
 	name = "Unique AI"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 5
+	weight = 0
 	show_in_report = TRUE
 	report_message = "For experimental purposes, this station AI might show divergence from default lawset. Do not meddle with this experiment, we've removed \
 		access to your set of alternative upload modules because we know you're already thinking about meddling with this experiment."


### PR DESCRIPTION

## About The Pull Request
Turns the unique AI station trait to 0.
## Why It's Good For The Game
Unique AI station trait does the following. 

- Gives AI's a unique lawset.

- Deletes all lawboards from the upload.

- Triples the price ai laws (Which is broken looking at the code.)

The second and the third are theres prevent people from messing with the first. the fact that the ai has a unique quirky lawset. The issue is? 
_We dont have unique lawsets._

The short of the history is ai went from a default lawset to a random lawset, which shared alot of laws with the unique ai list. I [made a config suggestion back in May](https://discord.com/channels/748354466335686736/1350082619190022234/1350082623283662909) to separate the lists. The result in the end was swapping the lawsets from the random list to the weighted list. Which the unique station AI trait uses making the issue even worse going from sharing some laws to sharing all of the laws. 

Meaning the whole point of this station trait is nonexistant as 1/3 of the station trait actually matters/works. Which is denying a roundstart law change. Which currently is beyond rare and against the rules as you can't change the lawset roundstart because you don't like the law set.

So I see no real reason to keep the weight active than keeping the revolution antag preference clickable.
## Changelog
:cl:
del: Disables the unique AI station trait
/:cl:
