### PR TITLE
adds some more SDQL2/Lua wrappers

### DIFF
--- a/code/__HELPERS/generators.dm
+++ b/code/__HELPERS/generators.dm
@@ -9,3 +9,13 @@
 	string_repr = copytext(string_repr, 11, length(string_repr)) // strips extraneous data
 	string_repr = replacetext(string_repr, "\"", "") // removes the " around the type
 	return splittext(string_repr, ", ")
+
+/generator/proc/RandList()
+	var/possible_vector = Rand()
+	var/vector_length = length(possible_vector)
+	if(vector_length == 0)
+		return possible_vector
+	. = list()
+	for(var/i in 1 to vector_length)
+		. += possible_vector[i]
+	return .

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -86,6 +86,9 @@
 /proc/_log(X, Y)
 	return log(X, Y)
 
+/proc/_uppertext(T)
+	return uppertext(T)
+
 /proc/_lowertext(T)
 	return lowertext(T)
 
@@ -305,3 +308,26 @@
 
 /proc/_is_type_in_typecache(thing_to_check, typecache)
 	return is_type_in_typecache(thing_to_check, typecache)
+
+/proc/_floor(a)
+	return floor(a)
+
+/proc/_ceil(a)
+	return ceil(a)
+
+/proc/_typesof(a, subtypes_only = FALSE)
+	. = typesof(a)
+	if(subtypes_only)
+		. -= a
+
+/proc/_html_encode(text)
+	return html_encode(text)
+
+/proc/_html_decode(text)
+	return html_decode(text)
+
+/proc/_url_encode(text)
+	return url_encode(text)
+
+/proc/_url_decode(text)
+	return url_decode(text)

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -292,6 +292,9 @@
 /proc/_viewers(Dist, Center = usr)
 	return viewers(Dist, Center)
 
+/proc/_generator(type = "num", A = 0, B = 1, rand = UNIFORM_RAND)
+	return generator(type, A, B, rand)
+
 /// Auxtools REALLY doesn't know how to handle filters as values;
 /// when passed as arguments to auxtools-called procs, they aren't simply treated as nulls -
 /// they don't even count towards the length of args.

--- a/html/changelogs/AutoChangeLog-pr-91950.yml
+++ b/html/changelogs/AutoChangeLog-pr-91950.yml
@@ -1,0 +1,4 @@
+author: "Absolucy"
+delete-after: True
+changes:
+  - admin: "Added some more Lua/SDQL2 wrappers: _floor(), _ceil(), _typesof(), _uppertext(), _html_encode(), _html_decode(), _url_encode(), and _url_decode()"

--- a/html/changelogs/AutoChangeLog-pr-91954.yml
+++ b/html/changelogs/AutoChangeLog-pr-91954.yml
@@ -1,0 +1,4 @@
+author: "Fikou"
+delete-after: True
+changes:
+  - admin: "_generator wrapper for sdql, RandList proc for generators"

--- a/lua/SS13_base.lua
+++ b/lua/SS13_base.lua
@@ -51,6 +51,10 @@ function SS13.is_type_in_typecache(thing, typecache)
 	return dm.global_procs._is_type_in_typecache(thing, typecache) == 1
 end
 
+function SS13.typesof(type, subtypes_only)
+	return dm.global_procs._typesof(SS13.type(type), subtypes_only)
+end
+
 function SS13.get_turf(thing)
 	return dm.global_procs._get_step(thing, 0)
 end

--- a/monkestation/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/monkestation/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -1,5 +1,0 @@
-/proc/_floor(a)
-	return floor(a)
-
-/proc/_ceil(a)
-	return ceil(a)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6493,7 +6493,6 @@
 #include "monkestation\code\modules\admin\verbs\ticketpanel.dm"
 #include "monkestation\code\modules\admin\verbs\tracy.dm"
 #include "monkestation\code\modules\admin\verbs\traits.dm"
-#include "monkestation\code\modules\admin\verbs\SDQL2\SDQL_2_wrappers.dm"
 #include "monkestation\code\modules\aesthetics\airlock\airlock.dm"
 #include "monkestation\code\modules\aesthetics\items\clothing.dm"
 #include "monkestation\code\modules\aesthetics\mapping\tilecoloring.dm"


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/91950

> This adds ~~3~~ 8 wrappers for SDQL2/Lua: `_floor(x)`, `_ceil(x)` (we already had `_round(a, b = 1)`), and `_typesof(a, subtypes_only)`
> 
> `_typesof` has a second argument, `subtypes_only` (default false), which makes it act like `subtypesof` instead, to save from having to manually remove the base type (especially since removing by value is kind of annoying in Lua)
> 
> the Lua SS13 library has had a `SS13.typesof` function added, which does exactly what it says on the tin (also with the second `subtypes_only` argument)
> 
> also added `_uppertext`, `_html_encode`, `_html_decode`, `_url_encode`, and `_url_decode`. these should all be selfexplanatory

----

Ports https://github.com/tgstation/tgstation/pull/91954


> adds sdql wrapper for making a generator
> adds a RandList proc for generators which makes them return a list instead of vector
> this means u can work with generators in lua scripts or sdql (or any other reason you would rather handle a list than a vector)
> see here
> ![image](https://github.com/user-attachments/assets/3e73dd6f-4c7c-44d9-981b-f80c1bf14897)

---

i also demodularized the `floor` and `ceil` wrappers

## Why It's Good For The Game

more versatility for lua scripts

## Changelog

i directly cherry-picked the auto-changelog commits from upstream, so no need for an auto-generated changelog in this PR body (and the about section here should sufficiently explain everything)
