### PR TITLE
minor nitpick about stealth mode

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -570,10 +570,11 @@ GLOBAL_PROTECT(admin_verbs_poll)
 	ADD_TRAIT(mob, TRAIT_ORBITING_FORBIDDEN, STEALTH_MODE_TRAIT)
 	QDEL_NULL(mob.orbiters)
 
-	log_admin("[key_name(usr)] has turned stealth mode ON")
-	message_admins("[key_name_admin(usr)] has turned stealth mode ON")
+	log_admin("[key_name(usr)] has turned stealth mode ON (with key '[new_key]')")
+	message_admins("[key_name_admin(usr)] has turned stealth mode ON (with key '[new_key]')")
 
 /client/proc/disable_stealth_mode()
+	var/previous_fakekey = holder.fakekey
 	holder.fakekey = null
 	if(isobserver(mob))
 		mob.remove_alt_appearance("stealthmin")
@@ -590,8 +591,8 @@ GLOBAL_PROTECT(admin_verbs_poll)
 
 	REMOVE_TRAIT(mob, TRAIT_ORBITING_FORBIDDEN, STEALTH_MODE_TRAIT)
 
-	log_admin("[key_name(usr)] has turned stealth mode OFF")
-	message_admins("[key_name_admin(usr)] has turned stealth mode OFF")
+	log_admin("[key_name(usr)] has turned stealth mode OFF (with previous key '[previous_fakekey]')")
+	message_admins("[key_name_admin(usr)] has turned stealth mode OFF (with previous key '[previous_fakekey]')")
 
 #undef STEALTH_MODE_TRAIT
 


### PR DESCRIPTION

## About The Pull Request

Admin stealthmode doesnt say the ckey the admin stealthed under, now it should

## Why It's Good For The Game
## Changelog
:cl:
admin: stealthed admin logs now show the key they are/were under
/:cl:
