### PR TITLE
Britarnya's No More Vore PR

### DIFF
--- a/code/modules/industrial_lift/industrial_lift.dm
+++ b/code/modules/industrial_lift/industrial_lift.dm
@@ -249,7 +249,7 @@ GLOBAL_LIST_INIT(all_radial_directions, list(
 
 			overlays += other_lift
 
-	//now we vore all the other lifts connected to us on our z level
+	//now we devour all the other lifts connected to us on our z level
 	for(var/obj/structure/industrial_lift/other_lift in lift_master_datum.lift_platforms)
 		if(other_lift == src || other_lift.z != z)
 			continue

--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -197,7 +197,7 @@
 	button_icon_state = "consume"
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_IMMOBILE|AB_CHECK_INCAPACITATED
 	///The mob thats being consumed by this creature
-	var/mob/living/vored_mob
+	var/mob/living/devoured_mob
 
 ///Register for owner death
 /datum/action/consume/New(Target)
@@ -207,7 +207,7 @@
 
 /datum/action/consume/proc/handle_mob_deletion()
 	SIGNAL_HANDLER
-	stop_consuming() //Shit out the vored mob before u go go
+	stop_consuming() //Shit out the devoured mob before u go go
 
 ///Try to consume the pulled mob
 /datum/action/consume/Trigger(trigger_flags)
@@ -218,7 +218,7 @@
 	if(!isliving(ooze.pulling))
 		to_chat(src, span_warning("You need to be pulling a creature for this to work!"))
 		return FALSE
-	if(vored_mob)
+	if(devoured_mob)
 		to_chat(src, span_warning("You are already consuming another creature!"))
 		return FALSE
 	owner.visible_message(span_warning("[ooze] starts attempting to devour [target]!"), span_notice("You start attempting to devour [target]."))
@@ -233,9 +233,9 @@
 
 ///Start allowing this datum to process to handle the damage done to  this mob.
 /datum/action/consume/proc/start_consuming(mob/living/target)
-	vored_mob = target
-	vored_mob.forceMove(owner) ///AAAAAAAAAAAAAAAAAAAAAAHHH!!!
-	RegisterSignal(vored_mob, COMSIG_QDELETING, PROC_REF(handle_mob_deletion))
+	devoured_mob = target
+	devoured_mob.forceMove(owner) ///AAAAAAAAAAAAAAAAAAAAAAHHH!!!
+	RegisterSignal(devoured_mob, COMSIG_QDELETING, PROC_REF(handle_mob_deletion))
 	playsound(owner,'sound/items/eatfood.ogg', rand(30,50), TRUE)
 	owner.visible_message(span_warning("[src] devours [target]!"), span_notice("You devour [target]."))
 	START_PROCESSING(SSprocessing, src)
@@ -243,24 +243,24 @@
 ///Stop consuming the mob; dump them on the floor
 /datum/action/consume/proc/stop_consuming()
 	STOP_PROCESSING(SSprocessing, src)
-	vored_mob.forceMove(get_turf(owner))
+	devoured_mob.forceMove(get_turf(owner))
 	playsound(get_turf(owner), 'sound/effects/splat.ogg', 50, TRUE)
-	owner.visible_message(span_warning("[owner] pukes out [vored_mob]!"), span_notice("You puke out [vored_mob]."))
-	UnregisterSignal(vored_mob, COMSIG_QDELETING)
-	vored_mob = null
+	owner.visible_message(span_warning("[owner] pukes out [devoured_mob]!"), span_notice("You puke out [devoured_mob]."))
+	UnregisterSignal(devoured_mob, COMSIG_QDELETING)
+	devoured_mob = null
 
 ///Gain health for the consumption and dump some clone loss on the target.
 /datum/action/consume/process()
 	var/mob/living/simple_animal/hostile/ooze/gelatinous/ooze = owner
-	vored_mob.adjustBruteLoss(5)
+	devoured_mob.adjustBruteLoss(5)
 	ooze.heal_ordered_damage((ooze.maxHealth * 0.03), list(BRUTE, BURN, OXY)) ///Heal 6% of these specific damage types each process
 	ooze.adjust_ooze_nutrition(3)
 
 	///Dump em at 200 cloneloss.
-	if(vored_mob.getBruteLoss() >= 200)
+	if(devoured_mob.getBruteLoss() >= 200)
 		stop_consuming()
 
-///On owner death dump the current vored mob
+///On owner death dump the current devoured mob
 /datum/action/consume/proc/on_owner_death()
 	SIGNAL_HANDLER
 	stop_consuming()

--- a/code/modules/vehicles/cars/clowncar.dm
+++ b/code/modules/vehicles/cars/clowncar.dm
@@ -76,8 +76,8 @@
 /obj/vehicle/sealed/car/clowncar/after_add_occupant(mob/M, control_flags)
 	. = ..()
 	if(return_controllers_with_flag(VEHICLE_CONTROL_KIDNAPPED).len >= 30)
-		for(var/mob/voreman as anything in return_drivers())
-			voreman.client.give_award(/datum/award/achievement/misc/round_and_full, voreman)
+		for(var/mob/victim as anything in return_drivers())
+			victim.client.give_award(/datum/award/achievement/misc/round_and_full, victim)
 
 /obj/vehicle/sealed/car/clowncar/attack_animal(mob/living/simple_animal/user, list/modifiers)
 	if((user.loc != src) || user.environment_smash >= ENVIRONMENT_SMASH_WALLS)

--- a/html/changelogs/archive/2019-05.yml
+++ b/html/changelogs/archive/2019-05.yml
@@ -335,8 +335,8 @@
   nemvar:
   - bugfix: Podcloning now lets you keep your quirks.
   vuonojenmustaturska:
-  - rscdel: Removed the ability of fat people to vore monkeys, and the ability of
-      aliens to vore humans.
+  - rscdel: Removed the ability of fat people to devour monkeys, and the ability of
+      aliens to devour humans.
   - code_imp: Removed stubbed out would-be functionality related to stomach contents
   - rscadd: Nuclear Operative reinforcements now get uplinks with 0 TC and a real
       name.

--- a/html/changelogs/archive/2021-05.yml
+++ b/html/changelogs/archive/2021-05.yml
@@ -471,7 +471,7 @@
   - bugfix: Cryopods can no longer be used to round remove other SSD players.
   - bugfix: Cryopods no longer delete traitor objectives under certain edge cases,
       and can no longer be used to metagame the existence of traitors with steal objectives.
-  - balance: Cryopods now vomit out all the items of players who get vored by them,
+  - balance: Cryopods now vomit out all the items of players who get devoured by them,
       like beautiful loot pinatas.
   itseasytosee:
   - bugfix: changeling spacesuits no longer come with a battery hud
@@ -479,7 +479,7 @@
   Kylerace:
   - bugfix: i dont have the energy for a witty in-universe changelog so airhorns can
       honk again
-  - bugfix: Recyclers dont vore themselves the moment the world is created anymore.
+  - bugfix: Recyclers dont devour themselves the moment the world is created anymore.
   Mothblocks:
   - refactor: tgui tooltips have been moved to a new system that keeps them within
       bounds of the screen.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR removes all instances of the term "vore" in the code and replaces them appropriately.

## Why It's Good For The Game

We are a zero-tolerance on sexual content in the server, and our code should reflect the same.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: ooze.dm; all instances of var/mob/living/vored_mob -> var/mob/living/devoured_mob, as well as comments referencing the same.
spellcheck: clowncar.dm; all instance of voreman -> victim (thank you Shion for the recommendation!)
spellcheck: industrial_lift.dm; comment - vore -> devour 
spellcheck: archived changelogs; two instances - changed vore -> devour 
/:cl: