### PR TITLE
Resource dupe and storage apparatus fix

### DIFF
--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -57,6 +57,8 @@
 
 /obj/item/borg/apparatus/pre_attack(atom/atom, mob/living/user, params)
 	if(!stored)
+		if(istype(atom.loc, /mob/living/silicon/robot) || istype(atom.loc, /obj/item/robot_model) || HAS_TRAIT(atom, TRAIT_NODROP))
+			return ..() // Borgs should not be grabbing their own modules
 		var/itemcheck = FALSE
 		for(var/storable_type in storable)
 			if(istype(atom, storable_type))

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -89,6 +89,8 @@ GLOBAL_LIST_INIT(rod_recipes, list ( \
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/rods/welder_act_secondary(mob/living/user, obj/item/tool)
+	if(get_amount() < 1)
+		return
 	if(tool.use_tool(src, user, delay = 0, volume = 40))
 		var/obj/item/stack/tile/iron/two/new_item = new(user.loc)
 		user.visible_message(

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -207,6 +207,8 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	return BRUTELOSS
 
 /obj/item/stack/sheet/iron/welder_act(mob/living/user, obj/item/tool)
+	if(get_amount() < 1)
+		return
 	if(tool.use_tool(src, user, delay = 0, volume = 40))
 		var/obj/item/stack/rods/two/new_item = new(user.loc)
 		user.visible_message(
@@ -220,6 +222,8 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 		return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/item/stack/sheet/iron/welder_act_secondary(mob/living/user, obj/item/tool)
+	if(get_amount() < 1)
+		return
 	if(tool.use_tool(src, user, delay = 0, volume = 40))
 		var/obj/item/stack/tile/iron/four/new_item = new(user.loc)
 		user.visible_message(

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -47,6 +47,6 @@
 	user.do_attack_animation(src, ATTACK_EFFECT_BOOP)
 	playsound(src, SFX_SHATTER, 70, TRUE)
 	use(1)
-	user.visible_message(span_notice("[user] shatters the sheet of [name] on the floor, leaving behind [english_list(shards)]."), \
-		span_notice("You shatter the sheet of [name] on the floor, leaving behind [english_list(shards)]."))
+	user.visible_message(span_notice("[user] shatters the sheet of [name] on the floor, leaving [english_list(shards)]."), \
+		span_notice("You shatter the sheet of [name] on the floor, leaving [english_list(shards)]."))
 	return TRUE

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -33,9 +33,8 @@
  * * params: paramas passed in from attackby
  */
 /obj/item/stack/sheet/proc/on_attack_floor(mob/user, params)
-	if(is_cyborg)
-		if(source.energy<cost)
-			return FALSE
+	if(get_amount() < 1)
+		return FALSE
 	var/list/shards = list()
 	for(var/datum/material/mat in custom_materials)
 		if(mat.shard_type)

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -33,6 +33,9 @@
  * * params: paramas passed in from attackby
  */
 /obj/item/stack/sheet/proc/on_attack_floor(mob/user, params)
+	if(is_cyborg)
+		if(source.energy<cost)
+			return FALSE
 	var/list/shards = list()
 	for(var/datum/material/mat in custom_materials)
 		if(mat.shard_type)
@@ -44,6 +47,6 @@
 	user.do_attack_animation(src, ATTACK_EFFECT_BOOP)
 	playsound(src, SFX_SHATTER, 70, TRUE)
 	use(1)
-	user.visible_message(span_notice("[user] shatters the sheet of [name] on the floor, leaving [english_list(shards)]."), \
-		span_notice("You shatter the sheet of [name] on the floor, leaving [english_list(shards)]."))
+	user.visible_message(span_notice("[user] shatters the sheet of [name] on the floor, leaving behind [english_list(shards)]."), \
+		span_notice("You shatter the sheet of [name] on the floor, leaving behind [english_list(shards)]."))
 	return TRUE


### PR DESCRIPTION

## About The Pull Request
Adds quantity checks to stack modules and a no drop check to the storage apparatus
## Why It's Good For The Game
Fixes #6167 and #6881. Borgs will no longer accidentally brick their modules by pulling them out.
## Changelog
:cl: EssentialTomato
fix: Fixed engineering cyborg resource dupe glitch.
fix: Fixed cyborgs accidentally ripping out their modules.
/:cl:
