### PR TITLE
Fix sacrificing oozeling cores rendering them brainless yet fully functional

### DIFF
--- a/monkestation/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/monkestation/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -16,6 +16,8 @@
 		if(QDELETED(living_target))
 			continue
 		var/sac_name = trimtext(target_mind.name || living_target.real_name || living_target.name)
+		if(isbrain(living_target))
+			living_target = living_target.loc
 		living_targets[sac_name] = living_target
 		var/mutable_appearance/target_appearance = new(living_target)
 		target_appearance.appearance_flags = KEEP_TOGETHER

--- a/monkestation/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/monkestation/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -16,10 +16,8 @@
 		if(QDELETED(living_target))
 			continue
 		var/sac_name = trimtext(target_mind.name || living_target.real_name || living_target.name)
-		if(isbrain(living_target))
-			living_target = living_target.loc
 		living_targets[sac_name] = living_target
-		var/mutable_appearance/target_appearance = new(living_target)
+		var/mutable_appearance/target_appearance = new(isbrain(living_target) ? living_target.loc : living_target)
 		target_appearance.appearance_flags = KEEP_TOGETHER
 		target_appearance.layer = FLOAT_LAYER
 		target_appearance.plane = FLOAT_PLANE

--- a/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -187,10 +187,10 @@
 		else if(istype(sacrifice_candidate, /obj/item/organ/internal/brain/slime))
 			var/obj/item/organ/internal/brain/slime/core = sacrifice_candidate
 			sacrifice = core.rebuild_body(nugget = FALSE)
-			if(!sacrifice && core.brainmob)
-				sacrifice = core.brainmob
-				selected_atoms -= core
-				break
+			// ELSE THE CORE GETS DELETED AND WEIRD SHIT HAPPENS
+			selected_atoms -= core
+			selected_atoms += sacrifice
+			break
 	if(!sacrifice)
 		CRASH("[type] sacrifice_process didn't have a human in the atoms list. How'd it make it so far?")
 	if(!heretic_datum.can_sacrifice(sacrifice))
@@ -217,20 +217,10 @@
 	heretic_datum.total_sacrifices++
 	heretic_datum.knowledge_points += 2
 
-	if(!istype(sacrifice, /mob/living/carbon/human))
-		notify_ghosts(	// Sorry for copy paste. Trying to keep consistency
-			"[heretic_mind.name] has sacrificed [sacrifice] to the Mansus!",
-			source = sacrifice,
-			action = NOTIFY_ORBIT,
-			notify_flags = NOTIFY_CATEGORY_NOFLASH,
-			header = "Oozling core Sacrificed to Mansus.",
-			)
-		log_combat(heretic_mind.current, sacrifice, "sacrificed")
-	else
-		sacrifice.apply_status_effect(/datum/status_effect/heretic_curse, user)
+	sacrifice.apply_status_effect(/datum/status_effect/heretic_curse, user)
 
-		if(!begin_sacrifice(sacrifice))
-			disembowel_target(sacrifice)
+	if(!begin_sacrifice(sacrifice))
+		disembowel_target(sacrifice)
 
 /**
  * This proc is called from [proc/sacrifice_process] after the heretic successfully sacrifices [sac_target].)


### PR DESCRIPTION
## About The Pull Request

whoopsie, so it turns out that sacrificing an oozeling core would *delete the core* during cleanup, rendering the victim brainless (yet still alive, with the player in control). so uh, this just removes the core from `selected_atoms` (but adds the newly recreated body, for consistency's sake)

also removed some unused code regarding oozeling sacs, and made it so brains/cores will properly render in the living heart selection.

## Changelog
:cl:
fix: Oozelings will no longer literally lose their brain upon being sacrificed by a heretic.
fix: Tracking a target who's beheaded or an oozeling core using your living heart as a heretic will now actually show the brain/core sprite, instead of nothing at all.
/:cl:
