### PR TITLE
fix bloodsuckers being able to spam blood thickening prompts

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_misc_procs.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_misc_procs.dm
@@ -143,13 +143,20 @@
 // The maximum blood that counts towards this
 /datum/antagonist/bloodsucker/proc/blood_level_gain()
 	var/level_cost = get_level_cost()
-	if(blood_level_gain >= level_cost && bloodsucker_blood_volume >= level_cost) // Checks if we have drunk enough blood from the living to allow us to gain a level up as well as checking if we have enough blood to actually use on the level up
-		switch(tgui_alert(owner.current, "You have drunk enough blood from the living to thicken your blood, this will cost you [level_cost] blood and give you another level",  "Thicken your blood?.", list("Yes", "No"))) //asks user if they want to spend their blood on a level
-			if("Yes")
-				RankUp() // gives level
-				blood_level_gain -= level_cost // Subtracts the cost from the pool of drunk blood
-				AddBloodVolume(-level_cost) // Subtracts the cost from the bloodsucker's actual blood
-				blood_level_gain_amount += 1 // Increments the variable that makes future levels more expensive
+	// Checks if we have drunk enough blood from the living to allow us to gain a level up as well as checking if we have enough blood to actually use on the level up
+	if(blood_level_gain < level_cost || bloodsucker_blood_volume < level_cost)
+		return
+	if(tgui_alert(owner.current, "You have drunk enough blood from the living to thicken your blood, this will cost you [level_cost] blood and give you another level", "Thicken your blood?", list("Yes", "No")) != "Yes") //asks user if they want to spend their blood on a level
+		return
+	// check again to make sure nothing weird has happened in between
+	level_cost = get_level_cost()
+	if(blood_level_gain < level_cost || bloodsucker_blood_volume < level_cost)
+		to_chat(owner.current, span_warning("You no longer have enough living blood to thicken!"))
+		return
+	RankUp() // gives level
+	blood_level_gain -= level_cost // Subtracts the cost from the pool of drunk blood
+	AddBloodVolume(-level_cost) // Subtracts the cost from the bloodsucker's actual blood
+	blood_level_gain_amount += 1 // Increments the variable that makes future levels more expensive
 
 /datum/antagonist/bloodsucker/proc/get_level_cost()
 	var/level_cost = (0.3 + (0.05 * blood_level_gain_amount))


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/6820

## Changelog
:cl:
fix: Fixed bloodsuckers being able to spam their coffin to open a bunch of blood thickening prompts to rank up when they really shouldn't be able to.
/:cl:
