### PR TITLE
Ranching fixes

### DIFF
--- a/monkestation/code/modules/ranching/items.dm
+++ b/monkestation/code/modules/ranching/items.dm
@@ -56,6 +56,13 @@
 					reagents += "[initial(listed_reagent.name)]"
 				var/reagent_string = reagents.Join(" , ")
 				combined_msg += "\t<span class='info'>Required Reagents: [reagent_string]</span>"
+			if(held_mutation.nearby_items.len)
+				var/list/items = list()
+				for(var/item in held_mutation.nearby_items)
+					var/obj/item/listed_item = item
+					items += "[initial(listed_item.name)]"
+				var/item_string = items.Join(" , ")
+				combined_msg += "\t<span class='info'>Required items: [item_string]</span>"
 			if(held_mutation.needed_turfs.len)
 				var/list/turfs = list()
 				for(var/tile in held_mutation.needed_turfs)

--- a/monkestation/code/modules/ranching/mutations/tier2.dm
+++ b/monkestation/code/modules/ranching/mutations/tier2.dm
@@ -36,7 +36,7 @@
 	chicken_type = /mob/living/basic/chicken/pigeon
 	egg_type = /obj/item/food/egg/pigeon
 	happiness = 30
-	nearby_items = list(/obj/item/radio)
+	nearby_items = list(/obj/item/radio/off)
 	food_requirements = list(/obj/item/food/grown/corn)
 
 	can_come_from_string = "Silkie"


### PR DESCRIPTION

## About The Pull Request
Fixes some ranching things. Namely the mutation scan list not showing needed items and pigeons mutation item not being able to be gotten.

## Why It's Good For The Game
Pigeons needed a very specific type of radio to mutate. One that basically only existed on map spawn and was not guaranteed.
![image](https://github.com/user-attachments/assets/6f478817-df68-4168-aece-d1531440f5fb)
![image](https://github.com/user-attachments/assets/6881f09d-66cb-4709-a70d-714890731b9f)
 Also adds the required item listings to the possible mutation scan, this was missing previously.
![image](https://github.com/user-attachments/assets/1919ed8f-c1cd-459a-ade3-0a90e6fcf243)



## Changelog
:cl: QueenReduviidae
fix: Chickens possible mutation scan now includes required items.
fix: Pigeons are no longer basically impossible to get.
/:cl:
