### PR TITLE
hopefully prevent storyteller from running roundstart high threat antags back-to-back

### DIFF
--- a/monkestation/code/modules/storytellers/converted_events/_base_event.dm
+++ b/monkestation/code/modules/storytellers/converted_events/_base_event.dm
@@ -160,6 +160,14 @@
 	. = ..()
 	if(!.)
 		return
+	if(shared_occurence_type == SHARED_HIGH_THREAT)
+		if(name in SSgamemode.last_round_events)
+			return FALSE
+		for(var/datum/round_event_control/antagonist/solo/event as anything in subtypesof(/datum/round_event_control/antagonist/solo))
+			if(event::shared_occurence_type != SHARED_HIGH_THREAT || !event::name)
+				continue
+			if(event::name in SSgamemode.last_round_events)
+				return FALSE
 	var/antag_amt = get_antag_amount()
 	var/list/candidates = get_candidates()
 	if(length(candidates) < antag_amt)

--- a/monkestation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/monkestation/code/modules/storytellers/gamemode_subsystem.dm
@@ -1161,11 +1161,7 @@ SUBSYSTEM_DEF(gamemode)
 
 
 /datum/controller/subsystem/gamemode/proc/store_roundend_data()
-	var/congealed_string = ""
-	for(var/event_name as anything in triggered_round_events)
-		congealed_string += event_name
-		congealed_string += ","
-	text2file(congealed_string, "data/last_round_events.txt")
+	rustg_file_write(jointext(triggered_round_events, ","), "data/last_round_events.txt")
 
 /datum/controller/subsystem/gamemode/proc/load_roundstart_data()
 	var/massive_string = trim(file2text("data/last_round_events.txt"))


### PR DESCRIPTION
## About The Pull Request
## Why It's Good For The Game
## Changelog
:cl:
qol: The storyteller should no longer roll high-threat roundstart antags two rounds in a row.
/:cl:
