### PR TITLE
prevent becoming your own master through weird xenobio golem mind transfer shenaniganry

### DIFF
--- a/code/datums/mind/antag.dm
+++ b/code/datums/mind/antag.dm
@@ -200,7 +200,7 @@
 /// Link a new mobs mind to the creator of said mob. They will join any team they are currently on, and will only switch teams when their creator does.
 /datum/mind/proc/enslave_mind_to_creator(mob/living/creator)
 	// you ain't bladewolf, bud
-	if(owner == creator || astype(owner, /mob/living/carbon)?.last_mind == src)
+	if(current == creator || astype(current, /mob/living/carbon)?.last_mind == src)
 		return
 
 	if(IS_CULTIST(creator))

--- a/code/datums/mind/antag.dm
+++ b/code/datums/mind/antag.dm
@@ -199,6 +199,10 @@
 
 /// Link a new mobs mind to the creator of said mob. They will join any team they are currently on, and will only switch teams when their creator does.
 /datum/mind/proc/enslave_mind_to_creator(mob/living/creator)
+	// you ain't bladewolf, bud
+	if(owner == creator || astype(owner, /mob/living/carbon)?.last_mind == src)
+		return
+
 	if(IS_CULTIST(creator))
 		add_antag_datum(/datum/antagonist/cult)
 


### PR DESCRIPTION
## About The Pull Request

this adds a check to `/datum/mind/proc/enslave_mind_to_creator`, so that if you yourself are the creator, or the creator's last mind is yourself, it'll just return early and do nothing.

## Why It's Good For The Game

bugfix

## Changelog
:cl:
fix: Fixed xenobio golem mind transfer stuff resulting in you being marked as your own master.
/:cl:
