### PR TITLE
Silences Fireplaces

### DIFF
--- a/code/game/objects/structures/fireplace.dm
+++ b/code/game/objects/structures/fireplace.dm
@@ -111,7 +111,6 @@
 		put_out()
 		return
 
-	playsound(src, 'sound/effects/comfyfire.ogg',50,FALSE, FALSE, TRUE)
 	var/turf/T = get_turf(src)
 	T.hotspot_expose(700, 2.5 * seconds_per_tick)
 	update_appearance()


### PR DESCRIPTION

## About The Pull Request

Removes the horrible sound from the fireplace. Inspired by Shion's tweaks to other sounds, except the fireplace can't even be mitigated by walls despite ignoring walls being false so I'm just removing it.

## Why It's Good For The Game

It gives me a very bad headache, and is legitimately one of the worst sounds I have ever had the displeasure of hearing. Plus the bonfire is just fine without sfx so why does the fireplace need it.

## Changelog

:cl:
del: The fireplace no longer makes sound
/:cl:
