### PR TITLE
Gives NT reps a good assistant points puncher

### DIFF
--- a/monkestation/code/modules/blueshift/machines/good_assistant.dm
+++ b/monkestation/code/modules/blueshift/machines/good_assistant.dm
@@ -156,6 +156,12 @@
 		/obj/item/gbp_puncher = 1,
 	)
 
+/datum/outfit/job/nanotrasen_representative/pre_equip(mob/living/carbon/human/human, visualsOnly)
+	. = ..()
+	backpack_contents += list(
+		/obj/item/gbp_puncher = 1,
+	)
+
 /datum/outfit/job/quartermaster/pre_equip(mob/living/carbon/human/human, visualsOnly)
 	. = ..()
 	backpack_contents += list(


### PR DESCRIPTION

## About The Pull Request

Gives the NT rep the ability to reward assistants with the silly little corporate punchcard.

## Why It's Good For The Game

It makes sense from a flavour standpoint, it's corporate as hell and the NT rep is the representative of the corporation. Hell, NT are the ones regularly sending waves of interns at problems.

## Changelog


:cl:
add: Gives NT representatives a good assistant points punchcard.
/:cl:

