### PR TITLE
Ensure Plexora cleans up HTTP requests

### DIFF
--- a/code/controllers/subsystem/plexora.dm
+++ b/code/controllers/subsystem/plexora.dm
@@ -45,6 +45,7 @@ SUBSYSTEM_DEF(plexora)
 
 	var/restart_type = PLEXORA_SHUTDOWN_NORMAL
 	var/mob/restart_requester
+	var/list/active_requests = list()
 
 /datum/controller/subsystem/plexora/Initialize()
 	if(!CONFIG_GET(flag/plexora_enabled) && !load_old_plexora_config())
@@ -76,6 +77,15 @@ SUBSYSTEM_DEF(plexora)
 
 	return SS_INIT_SUCCESS
 
+/datum/controller/subsystem/plexora/Shutdown()
+	var/end_time = REALTIMEOFDAY + (5 SECONDS)
+	while((length(active_requests) > 0) && (REALTIMEOFDAY < end_time))
+		for(var/datum/http_request/request as anything in active_requests)
+			if(request.is_complete())
+				active_requests -= request
+				qdel(request)
+	active_requests.Cut()
+
 /datum/controller/subsystem/plexora/Recover()
 	flags |= SS_NO_INIT // Make extra sure we don't initialize twice.
 	initialized = SSplexora.initialized
@@ -84,6 +94,7 @@ SUBSYSTEM_DEF(plexora)
 	enabled = SSplexora.enabled
 	tripped_bad_version = SSplexora.tripped_bad_version
 	default_headers = SSplexora.default_headers
+	active_requests = SSplexora.active_requests
 	if(initialized && !enabled)
 		flags |= SS_NO_FIRE
 
@@ -129,12 +140,18 @@ SUBSYSTEM_DEF(plexora)
 	var/datum/world_topic/status/status_handler = new()
 	var/list/status = status_handler.Run()
 
-	http_request(
+	var/datum/http_request/status_request = http_request(
 		RUSTG_HTTP_METHOD_POST,
 		"[base_url]/status",
 		json_encode(status),
 		default_headers
-	).begin_async()
+	)
+	status_request.begin_async()
+	active_requests += status_request
+	for(var/datum/http_request/request as anything in active_requests)
+		if(request.is_complete()) // rust-g will clear the job once it's complete
+			active_requests -= request
+			qdel(request)
 
 /datum/controller/subsystem/plexora/proc/notify_shutdown(restart_type_override)
 	var/static/server_restart_sent = FALSE
@@ -153,7 +170,7 @@ SUBSYSTEM_DEF(plexora)
 		"restart_type" = isnull(restart_type_override) ? restart_type : restart_type_override,
 		"requestedby" = usr?.ckey,
 		"requestedby_stealthed" = usr?.client?.holder?.fakekey,
-	))
+	), mark_active = FALSE)
 
 /datum/controller/subsystem/plexora/proc/serverstarted()
 	http_basicasync("serverupdates", list(
@@ -376,8 +393,7 @@ SUBSYSTEM_DEF(plexora)
 		"data" = data,
 	))
 
-/datum/controller/subsystem/plexora/proc/http_basicasync(path, list/body) as /datum/http_request
-	RETURN_TYPE(/datum/http_request)
+/datum/controller/subsystem/plexora/proc/http_basicasync(path, list/body, mark_active = TRUE)
 	if(!enabled) return
 
 	var/datum/http_request/request = new(
@@ -388,7 +404,8 @@ SUBSYSTEM_DEF(plexora)
 		"tmp/response.json"
 	)
 	request.begin_async()
-	return request
+	if(mark_active)
+		active_requests += request
 
 /datum/world_topic/plx_announce
 	keyword = "PLX_announce"


### PR DESCRIPTION

## About The Pull Request

Ports my SSplexora fixes from https://github.com/Monkestation/Monkestation2.0/pull/7141 / https://github.com/Monkestation/Vanderlin/pull/2379

this makes it so SSplexora keeps track of all HTTP requests it fires, and just checks `is_complete` on them every fire - querying a finished job will ensure its properly removed rust-g's internal jobs map, ensuring a bunch of un-queried jobs don't stack up and cause insane memory usage.

## Why It's Good For The Game

reduces memory leaks

## Changelog

no player-facing changes