### PR TITLE
Cleaner slimes will now target trash on dense turfs

### DIFF
--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot_ai.dm
@@ -72,6 +72,8 @@
 	action_cooldown = 3 SECONDS
 	/// Whether to also consider anything with TRAIT_TRASH_ITEM (monkestation addition)
 	var/check_trash_trait = FALSE
+	/// Minimum distance to the target before path returns. Corresponds to the "mintargetdist" arg of get_path_to.
+	var/min_target_distance = null
 
 /datum/ai_behavior/find_and_set/in_list/clean_targets/search_tactic(datum/ai_controller/controller, locate_paths, search_range)
 	var/list/found = oview(search_range, controller.pawn) // monkestation edit: don't pre-filter with typecache, so we can check for TRAIT_TRASH_ITEM
@@ -85,7 +87,7 @@
 		// monkestation end
 		if(LAZYACCESS(ignore_list, REF(found_item)))
 			continue
-		var/list/path = get_path_to(controller.pawn, found_item, max_distance = BOT_CLEAN_PATH_LIMIT, access = controller.get_access())
+		var/list/path = get_path_to(controller.pawn, found_item, max_distance = BOT_CLEAN_PATH_LIMIT, mintargetdist = min_target_distance, access = controller.get_access())
 		if(!length(path))
 			controller.set_blackboard_key_assoc_lazylist(BB_TEMPORARY_IGNORE_LIST, REF(found_item), TRUE)
 			continue

--- a/monkestation/code/modules/slimecore/mobs/ai_controller/behaviours/clean_target.dm
+++ b/monkestation/code/modules/slimecore/mobs/ai_controller/behaviours/clean_target.dm
@@ -3,3 +3,4 @@
 /datum/ai_behavior/find_and_set/in_list/clean_targets/slime
 	action_cooldown = 1.2 SECONDS
 	check_trash_trait = TRUE
+	min_target_distance = 1 // we don't have to be on top of it, just adjacent


### PR DESCRIPTION

## About The Pull Request

this makes it so cleaner slimes will now properly target things on dense turfs, when they can still path to an adjacent tile just fine.

https://github.com/user-attachments/assets/8c055289-f2f9-4838-b79a-37db7c1a265e

## Why It's Good For The Game

makes cleaner slimes less finnicky

## Changelog
:cl:
qol: Cleaner slimes will now target trash on top of "blocked" turfs (something with a dense object that it can't cross over) when they can still path right next to it just fine.
/:cl:
