### PR TITLE
Clothes that would hide ears/tails now properly hide anime implants too

### DIFF
--- a/monkestation/code/modules/surgery/organs/external/anime.dm
+++ b/monkestation/code/modules/surgery/organs/external/anime.dm
@@ -21,6 +21,11 @@
 /datum/bodypart_overlay/mutant/anime_head/get_base_icon_state()
 	return sprite_datum.icon_state
 
+/datum/bodypart_overlay/mutant/anime_head/can_draw_on_bodypart(mob/living/carbon/human/human)
+	if(human.head?.flags_inv & HIDEEARS)
+		return FALSE
+	return ..()
+
 /obj/item/organ/external/anime_middle
 	name = "anime implants"
 	desc = "An anime implant fitted for a persons chest."
@@ -44,6 +49,11 @@
 /datum/bodypart_overlay/mutant/anime_middle/get_base_icon_state()
 	return sprite_datum.icon_state
 
+/datum/bodypart_overlay/mutant/anime_middle/can_draw_on_bodypart(mob/living/carbon/human/human)
+	if(human.wear_suit?.flags_inv & HIDEJUMPSUIT)
+		return FALSE
+	return ..()
+
 /obj/item/organ/external/anime_bottom
 	name = "anime implants"
 	desc = "An anime implant fitted for a persons lower half."
@@ -66,3 +76,8 @@
 
 /datum/bodypart_overlay/mutant/anime_bottom/get_base_icon_state()
 	return sprite_datum.icon_state
+
+/datum/bodypart_overlay/mutant/anime_bottom/can_draw_on_bodypart(mob/living/carbon/human/human)
+	if(human.wear_suit?.flags_inv & HIDEJUMPSUIT)
+		return FALSE
+	return ..()


### PR DESCRIPTION
## About The Pull Request

this makes it so clothes properly hide anime implants - head anime implants will be hidden by helmets that'd hide normal cat ears, etc etc etc.

https://github.com/user-attachments/assets/4c05dce4-5b73-4ab5-9fd0-d7afa87918b1

## Why It's Good For The Game

makes things consistent and allows for actual disguises.

## Changelog
:cl:
fix: Clothes that would hide ears/tails now properly hide anime implants too.
/:cl:
