### PR TITLE
Stops lockers ashing items when broken

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -31,6 +31,8 @@ GLOBAL_LIST_EMPTY_TYPED(closets, /obj/structure/closet)
 	var/door_hinge_x = -6.5
 	/// Amount of time it takes for the door animation to play
 	var/door_anim_time = 1.5 // set to 0 to make the door not animate at all
+	/// Chance for an item inside to get ashed upon the destruction of the lock
+	var/ash_chance = 0
 
 	/// Controls whether a door overlay should be applied using the icon_door value as the icon state
 	var/enable_door_overlay = TRUE
@@ -713,7 +715,7 @@ GLOBAL_LIST_EMPTY_TYPED(closets, /obj/structure/closet)
 	broken = TRUE //applies to secure lockers only
 	for(var/obj/item/broken as anything in src.contents)
 		if(!istype(broken, /mob))
-			if(prob(33))
+			if(prob(ash_chance))
 				QDEL_NULL(broken)
 				new /obj/effect/decal/cleanable/ash(src.loc)
 				if(istype(broken, /obj/item/ammo_box))

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -9,6 +9,8 @@
 	allow_objects = TRUE
 	allow_dense = TRUE
 	dense_when_open = TRUE
+	//One third chance of ashing things inside
+	ash_chance = 33
 	delivery_icon = "deliverycrate"
 	open_sound = 'sound/machines/crate_open.ogg'
 	close_sound = 'sound/machines/crate_close.ogg'


### PR DESCRIPTION

## About The Pull Request
Makes it so that only crates can ash items inside when their lock is broken, and adds a new variable allowing people to customise what ash chance they want for any specific crate or locker
## Why It's Good For The Game

While this has been a good change for discouraging certain types of degenerate cargo gameplay, encouraging them to do things the proper way rather than just resorting to smashing every crate, it doesn't really make much sense as a mechanic for lockers, and in fact, pretty heavily contradicts the idea of breaking in and stealing stuff from lockers despite it very much being SUPPOSED to be a part of the antag loop. Plus, while it would make sense for a crate to have a destructive anti tamper system, the same makes a lot less sense for a locker designed to keep people's things safe and not just out of other's hands.

## Changelog



:cl:
balance: closets no longer ash things inside when broken - crates are unaffected
code: Adds a new "ash_chance" variable for crates and lockers that let you set the chance to be ashed
/:cl:
