### PR TITLE
Giving some hecks to the ghost roles

### DIFF
--- a/code/modules/mob/living/basic/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/basic/drone/extra_drone_types.dm
@@ -46,6 +46,7 @@
 	flavour_text = "In a prior life, you maintained a Nanotrasen Research Station. Abducted from your home, you were given some upgrades... and now serve an enemy of your former masters."
 	important_text = ""
 	spawner_job_path = /datum/job/ghost_role
+	dont_be_a_shit = FALSE //I feel this goes without question. If were using this its a bus.
 
 /// A version of the syndrone that gets a nuclear uplink, a firearms implant, and 30 TC.
 /mob/living/basic/drone/syndrone/badass

--- a/code/modules/mob_spawn/ghost_roles/fugitive_hunter_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/fugitive_hunter_roles.dm
@@ -7,6 +7,7 @@
 	show_flavor = FALSE
 	var/back_story = "error"
 	loadout_enabled = FALSE
+	dont_be_a_shit = FALSE
 
 /obj/effect/mob_spawn/ghost_role/human/fugitive/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob_spawn/ghost_roles/spider_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/spider_roles.dm
@@ -86,6 +86,7 @@
 	)
 	/// Do we flash the byond window when this particular egg type is available?
 	var/flash_window = FALSE
+	dont_be_a_shit = FALSE
 
 /obj/effect/mob_spawn/ghost_role/spider/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
+++ b/code/modules/mob_spawn/ghost_roles/venus_human_trap.dm
@@ -15,6 +15,7 @@
 	var/obj/structure/alien/resin/flower_bud/flower_bud
 	/// Used to determine when to notify ghosts
 	var/ready = FALSE
+	dont_be_a_shit = FALSE
 
 /obj/effect/mob_spawn/ghost_role/venus_human_trap/Destroy()
 	if(flower_bud) // anti harddel checks

--- a/monkestation/code/modules/antagonists/borers/code/items/egg.dm
+++ b/monkestation/code/modules/antagonists/borers/code/items/egg.dm
@@ -32,6 +32,7 @@
 	var/generation = 0
 	///the egg that is attached to this mob spawn
 	var/obj/item/borer_egg/host_egg = /obj/item/borer_egg
+	dont_be_a_shit = FALSE
 
 /obj/effect/mob_spawn/ghost_role/borer_egg/Destroy()
 	host_egg = null


### PR DESCRIPTION

## About The Pull Request
We have this flavor text when you join in as a ghost role thats suppose to act as a admin warning. However theres quite a few that probably shouldn't have it.
Closes: #7170
Ive removed the warning from spiders, borers, venus fly traps, syndicate drones, and fugitive hunters
## Why It's Good For The Game
They are evil, let them be evil.
## Changelog
:cl:
fix: Spiders, borers, syndicate drones, venus human traps, and fugitive hunters have their warning about interfering with station events removed
/:cl:
