### PR TITLE
Pr Improving specific clothing stuff I like because it bugs me

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -570,6 +570,7 @@
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 	action_slots = ALL
+	clothing_traits = list(TRAIT_CAN_SIGN_ON_COMMS, TRAIT_FAST_CUFFING)
 
 /datum/armor/gloves_chameleon
 	melee = 10
@@ -579,8 +580,6 @@
 	acid = 50
 
 // MONKESTATION ADDITION START
-/obj/item/clothing/gloves/chameleon
-	clothing_traits = list(TRAIT_CAN_SIGN_ON_COMMS, TRAIT_FAST_CUFFING)
 
 /obj/item/clothing/gloves/chameleon/attackby(obj/item/W, mob/user, params)
 	if(W.tool_behaviour != TOOL_MULTITOOL)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -355,6 +355,9 @@
 	if(TRAIT_FAST_CUFFING in clothing_traits)
 		. += "[src] increase the speed that you handcuff others."
 
+	if(TRAIT_CAN_SIGN_ON_COMMS in clothing_traits)
+		. += "[src] allows you talk on radios through sign language."
+	
 	switch (max_heat_protection_temperature)
 		if (400 to 1000)
 			. += "[src] offers the wearer limited protection from fire."

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -197,6 +197,11 @@
 	icon_state = (icon_state == base_icon_state) ? "[base_icon_state]_flipped" : base_icon_state
 	user.update_worn_glasses()
 
+/obj/item/clothing/glasses/eyepatch/AltClick(mob/user)
+	. = ..()
+	icon_state = (icon_state == base_icon_state) ? "[base_icon_state]_flipped" : base_icon_state
+	user.update_worn_glasses()
+
 /obj/item/clothing/glasses/eyepatch/medical
 	name = "medical eyepatch"
 	desc = "Used by space weeaboos to pretend their eye isn't there, and crewmembers who actually lost their eye to pretend their eye is there."

--- a/code/modules/clothing/gloves/special.dm
+++ b/code/modules/clothing/gloves/special.dm
@@ -88,7 +88,7 @@
 	strip_delay = 60
 	armor_type = /datum/armor/captain_gloves
 	resistance_flags = NONE
-	clothing_traits = list(TRAIT_FAST_CUFFING)
+	clothing_traits = list(TRAIT_FAST_CUFFING, TRAIT_CAN_SIGN_ON_COMMS)
 
 /datum/armor/captain_gloves
 	bio = 90

--- a/code/modules/clothing/masks/costume.dm
+++ b/code/modules/clothing/masks/costume.dm
@@ -49,6 +49,9 @@
 	w_class = WEIGHT_CLASS_SMALL
 	adjusted_flags = ITEM_SLOT_HEAD
 	flags_inv = HIDEFACE|HIDEFACIALHAIR
+	flags_cover = MASKCOVERSMOUTH
+	visor_flags_inv = HIDEFACE|HIDEFACIALHAIR
+	visor_flags_cover = MASKCOVERSMOUTH
 	custom_price = PAYCHECK_CREW
 	greyscale_colors = "#EEEEEE#AA0000"
 	greyscale_config = /datum/greyscale_config/kitsune
@@ -66,6 +69,12 @@
 /obj/item/clothing/mask/kitsune/attack_self(mob/user)
 	weldingvisortoggle(user)
 	alternate_worn_layer = up ? ABOVE_BODY_FRONT_HEAD_LAYER : null
+
+/obj/item/clothing/mask/kitsune/AltClick(mob/user)
+	. = ..()
+	weldingvisortoggle(user)
+	alternate_worn_layer = up ? ABOVE_BODY_FRONT_HEAD_LAYER : null
+	return TRUE
 
 /obj/item/clothing/mask/joy/manhunt
 	name = "smiley mask"

--- a/code/modules/clothing/masks/costume.dm
+++ b/code/modules/clothing/masks/costume.dm
@@ -73,7 +73,6 @@
 /obj/item/clothing/mask/kitsune/AltClick(mob/user)
 	. = ..()
 	weldingvisortoggle(user)
-	alternate_worn_layer = up ? ABOVE_BODY_FRONT_HEAD_LAYER : null
 	return TRUE
 
 /obj/item/clothing/mask/joy/manhunt

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -428,7 +428,10 @@
 	name = "gothic coat"
 	desc = "Perfect for those who want to stalk around a corner of a bar."
 	icon_state = "gothcoat"
+	body_parts_covered = ARMS|HANDS|CHEST|GROIN //the model has a glove on it so protect the hands.
 	inhand_icon_state = null
+	slot_flags = ITEM_SLOT_OCLOTHING|ITEM_SLOT_NECK
+	armor_type = /datum/armor/colonist_clothing
 
 /obj/item/clothing/suit/costume/xenos
 	name = "xenos suit"

--- a/code/modules/clothing/suits/costume.dm
+++ b/code/modules/clothing/suits/costume.dm
@@ -431,7 +431,7 @@
 	body_parts_covered = ARMS|HANDS|CHEST|GROIN //the model has a glove on it so protect the hands.
 	inhand_icon_state = null
 	slot_flags = ITEM_SLOT_OCLOTHING|ITEM_SLOT_NECK
-	armor_type = /datum/armor/colonist_clothing
+	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 
 /obj/item/clothing/suit/costume/xenos
 	name = "xenos suit"


### PR DESCRIPTION
## About The Pull Request
Improving various clothing items with no correlation to eachother.

- Greyscale kitsune mask can now be adjusted via alt clicking the icon.
- Greyscale kitsune mask now properly respect mouth covered.
- Greyscale Kitsune mask when adjusted now properly show beard and face when mask it put up.
- Eyepatches can toggled with alt click
- Gothic coats now cover the chest groin arms and hands.
- Gothic coats can now be equipped on the neck and has minimum cold protect like jackets
- Clothing that can transmit sign language on radio will now have a short mention of being able to do such on inspect.
- Captains gloves can now transmit sign language.
## Why It's Good For The Game
I like them.
bwah.
## Changelog
:cl:
add: gothic coat can be equipped on the neck slot.
add: gothic coat now actually covers various parts of the body
add: Captains gloves can now transmit sign language
add: Gloves that can transmit sign language on radio now have a description mentioning it on inspect.
qol: Eyepatches can be adjusted with alt click.
qol: Greyscale Kitsune mask can be adjusted by alt clicking the icon.
fix: Greyscale kitsune mask now shows beards/faces when in the up postion and hides while put down
fix: You can no longer eat through plastic on the greyscale kitsune mask.
/:cl:
