### PR TITLE
Remove Troubling Names from Cyborg List

### DIFF
--- a/strings/names/ai.txt
+++ b/strings/names/ai.txt
@@ -61,6 +61,7 @@ H E R B I E
 Hadaly
 HAL 9000
 Huey
+I-Robot
 Irona
 Ironhide
 Jay-Dub
@@ -102,6 +103,7 @@ Revelation
 Ro-Man
 Robbie
 Robot Devil
+Saws-Yall
 S A M
 S H O C K
 S H R O U D


### PR DESCRIPTION

## About The Pull Request

This pull request removes "B166ER" and "Fagor" from the list of Cyborg random names from ai.txt.

## Why It's Good For The Game

Recent admin incident involved multiple people seeing "B166ER" as a troubling name due to our policy regarding bigotry. The player revealed this was a random name given to him, and was confirmed upon further code inspection. We continue to set the example we're meant to enforce.

## Changelog
:cl:
del: Removed "B166ER" from ai.txt
del: Removed "Fagor" from ai.txt
/:cl:
