### PR TITLE
Fix delay_round_end

### DIFF
--- a/code/modules/admin/verbs/server.dm
+++ b/code/modules/admin/verbs/server.dm
@@ -79,7 +79,7 @@ ADMIN_VERB(cancel_reboot, R_SERVER, FALSE, "Cancel Reboot", "Cancels a pending w
 	SSplexora.restart_requester = null // monkestation edit: Plexora
 	log_admin("[key_name(user)] cancelled the pending world reboot.")
 	message_admins("[key_name_admin(user)] cancelled the pending world reboot.")
-	BLACKBOX_LOG_ADMIN_VERB("Cancel Reboot") //MONKE EDIT added just in case?
+	BLACKBOX_LOG_ADMIN_VERB("Cancel Reboot")
 
 ADMIN_VERB(end_round, R_SERVER, FALSE, "End Round", "Forcibly ends the round and allows the server to restart normally.", ADMIN_CATEGORY_SERVER)
 	var/confirm = tgui_alert(user, "End the round and  restart the game world?", "End Round", list("Yes", "Cancel"))
@@ -143,6 +143,8 @@ ADMIN_VERB(delay_round_end, R_SERVER, FALSE, "Delay Round End", "Prevent the ser
 
 	SSticker.delay_end = TRUE
 	SSticker.admin_delay_notice = delay_reason
+	if(SSticker.reboot_timer)
+		SSticker.cancel_reboot(user)
 
 	log_admin("[key_name(user)] delayed the round end for reason: [SSticker.admin_delay_notice]")
 	message_admins("[key_name_admin(user)] delayed the round end for reason: [SSticker.admin_delay_notice]")


### PR DESCRIPTION

## About The Pull Request

Fixes a bug caused by https://github.com/Monkestation/Monkestation2.0/pull/5944 where the server would reboot despite delay if the delay was called after the timer was started.

## Why It's Good For The Game

Fixing a bug I caused. Sorry.

## Changelog
:cl:Siro
fix: Delay round end will once again delay the round end reboot properly. 
/:cl:
