### PR TITLE
disables heretic void path from being selected (and it's spells)

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -109,6 +109,7 @@
 		/datum/heretic_knowledge/limited_amount/risen_corpse,
 		/datum/heretic_knowledge/mark/blade_mark,
 		/datum/heretic_knowledge/armor,
+		/datum/heretic_knowledge/void_cloak,
 	)
 	cost = 1
 	route = PATH_BLADE
@@ -251,6 +252,7 @@
 		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/rune_carver,
 		/datum/heretic_knowledge/crucible,
+		/datum/heretic_knowledge/spell/blood_siphon,
 	)
 	cost = 1
 	route = PATH_BLADE
@@ -378,6 +380,7 @@
 	adds_sidepath_points = 1
 	next_knowledge = list(
 		/datum/heretic_knowledge/summon/maid_in_mirror,
+		/datum/heretic_knowledge/spell/cleave,
 		/datum/heretic_knowledge/ultimate/blade_final,
 		/datum/heretic_knowledge/spell/rust_charge,
 	)

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -129,6 +129,7 @@
 	next_knowledge = list(
 		/datum/heretic_knowledge/mark/flesh_mark,
 		/datum/heretic_knowledge/void_cloak,
+		/datum/heretic_knowledge/limited_amount/risen_corpse,
 	)
 	required_atoms = list(
 		/mob/living/carbon/human = 1,
@@ -241,6 +242,7 @@
 		/datum/heretic_knowledge/reroll_targets,
 		/datum/heretic_knowledge/spell/blood_siphon,
 		/datum/heretic_knowledge/spell/opening_blast,
+		/datum/heretic_knowledge/rune_carver,
 	)
 	required_atoms = list(
 		/obj/item/organ/internal/eyes = 1,
@@ -281,6 +283,7 @@
 		/datum/heretic_knowledge/ultimate/flesh_final,
 		/datum/heretic_knowledge/spell/apetra_vulnera,
 		/datum/heretic_knowledge/spell/cleave,
+		/datum/heretic_knowledge/summon/maid_in_mirror,
 	)
 	required_atoms = list(
 		/obj/item/organ/external/tail = 1,

--- a/code/modules/antagonists/heretic/knowledge/side_flesh_void.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_flesh_void.dm
@@ -9,7 +9,8 @@
 	gain_text = "The Owl is the keeper of things that are not quite in practice, but in theory are. Many things are."
 	next_knowledge = list(
 		/datum/heretic_knowledge/limited_amount/flesh_ghoul,
-		/datum/heretic_knowledge/cold_snap,
+		///datum/heretic_knowledge/cold_snap,
+		/datum/heretic_knowledge/blade_dance,
 	)
 	required_atoms = list(
 		/obj/item/shard = 1,
@@ -26,8 +27,9 @@
 		Also has a chance to transfer wounds from you to the victim."
 	gain_text = "\"No matter the man, we bleed all the same.\" That's what the Marshal told me."
 	next_knowledge = list(
-		/datum/heretic_knowledge/spell/void_phase,
+		///datum/heretic_knowledge/spell/void_phase,
 		/datum/heretic_knowledge/summon/raw_prophet,
+		/datum/heretic_knowledge/duel_stance,
 	)
 	spell_to_add = /datum/action/cooldown/spell/pointed/blood_siphon
 	cost = 1
@@ -41,11 +43,13 @@
 		told me to use them regardless. Soon, he said, I would know them well."
 	next_knowledge = list(
 		/datum/heretic_knowledge/summon/stalker,
-		/datum/heretic_knowledge/spell/void_pull,
+		///datum/heretic_knowledge/spell/void_pull,
+		/datum/heretic_knowledge/spell/furious_steel,
 	)
 	spell_to_add = /datum/action/cooldown/spell/pointed/cleave
 	cost = 1
 	route = PATH_SIDE
+
 
 /datum/heretic_knowledge/spell/void_prison
 	name = "Void Prison"
@@ -56,7 +60,7 @@
 		But the only welts made are on my own beating fist. \
 		My smiling face turns to regard me, reflecting back in glassy eyes the empty path I have been lead down."
 	next_knowledge = list(
-		/datum/heretic_knowledge/spell/void_phase,
+		///datum/heretic_knowledge/spell/void_phase,
 		/datum/heretic_knowledge/summon/raw_prophet,
 	)
 	spell_to_add = /datum/action/cooldown/spell/pointed/void_prison

--- a/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
@@ -13,8 +13,9 @@
 		When it moves, it crunches like broken glass. Its hands are no longer recognizable as human - \
 		each clenched fist contains a brutal nest of sharp bone-shards instead."
 	next_knowledge = list(
-		/datum/heretic_knowledge/cold_snap,
+		///datum/heretic_knowledge/cold_snap,
 		/datum/heretic_knowledge/blade_dance,
+		/datum/heretic_knowledge/limited_amount/flesh_ghoul,
 	)
 	required_atoms = list(
 		/obj/item/clothing/suit = 1,
@@ -128,8 +129,9 @@
 	gain_text = "Etched, carved... eternal. There is power hidden in everything. I can unveil it! \
 		I can carve the monolith to reveal the chains!"
 	next_knowledge = list(
-		/datum/heretic_knowledge/spell/void_phase,
+		///datum/heretic_knowledge/spell/void_phase,
 		/datum/heretic_knowledge/duel_stance,
+		/datum/heretic_knowledge/summon/raw_prophet,
 	)
 	required_atoms = list(
 		/obj/item/knife = 1,
@@ -148,8 +150,9 @@
 	gain_text = "Within each reflection, lies a gateway into an unimaginable world of colors never seen and \
 		people never met. The ascent is glass, and the walls are knives. Each step is blood, if you do not have a guide."
 	next_knowledge = list(
-		/datum/heretic_knowledge/spell/void_pull,
+		///datum/heretic_knowledge/spell/void_pull,
 		/datum/heretic_knowledge/spell/furious_steel,
+		/datum/heretic_knowledge/summon/stalker,
 	)
 	required_atoms = list(
 		/obj/item/stack/sheet/mineral/titanium = 5,

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -26,7 +26,7 @@
  *   Maid in the Mirror
  *
  * Waltz at the End of Time
- */
+
 /datum/heretic_knowledge/limited_amount/starting/base_void
 	name = "Glimmer of Winter"
 	desc = "Opens up the Path of Void to you. \
@@ -50,7 +50,7 @@
 		return FALSE
 
 	return ..()
-
+*/
 /datum/heretic_knowledge/void_grasp
 	name = "Grasp of Void"
 	desc = "Your Mansus Grasp will temporarily mute and chill the victim."


### PR DESCRIPTION

## About The Pull Request
comments out the starter spell of void which makes it unable to be selected
yes i actually cared about the tree and blade and flesh are now sewed together
since void had 2 sideknowledges (for flesh and blade), you just get both the side knowledges upon researching the coresponding blade/flesh lore (so if you get torn champion stance, you get both blood siphon and rune carver as options, and both give you raw prophet knowledge on research)
yes void prison despite being a side knowledge also cant be acquired
## Why It's Good For The Game

top 5 reasons why i wont just apply nerfs
1. temp rework (which is main root of the issue, and void isnt the only thing it broke) cant be simply reverted thanks to pr having other 20 things
2. temp rework is way too shitcoded for me to fix it
3. commenting things out is easier than balancing
4. balancing doesnt matter because upcoming heretic rework just undoes that
5. reverting void rework doesnt matter because upcoming heretic rework just undoes that

i have seen at least like 20 people (maybe more) complain about void heretic and they cant even be simply nerfed because of the rework thats gonna get ported 
temperature rework fucked things up beyond my understanding so i just hope it pushes some smart coder to fix it
until then we shouldnt have path of instakill selectable


## Changelog


:cl:
balance: heretic void path can no longer be selected
balance:  flesh and blade path are now near eachother in the knowledge tree instead
/:cl:

