### PR TITLE
makes pubby's nt rep office not shit

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6702,14 +6702,9 @@
 /turf/open/floor/iron/stairs,
 /area/station/hallway/secondary/command)
 "ayi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/kitchen/small,
-/area/station/command/heads_quarters/nt_rep)
+/obj/item/shard,
+/turf/open/floor/plating/airless,
+/area/station/service/abandoned_gambling_den)
 "ayj" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet,
@@ -8744,18 +8739,12 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "aFD" = (
-/obj/machinery/door/airlock/corporate{
-	name = "Representative's Quarters"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/command/nt_rep,
-/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/kitchen/small,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/nt_rep)
 "aFF" = (
 /obj/item/storage/box/lights/mixed,
@@ -29711,14 +29700,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
-"dqW" = (
-/obj/structure/table/wood,
-/obj/item/newspaper{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/nt_rep)
 "dqY" = (
 /obj/structure/table,
 /obj/machinery/conveyor_switch/oneway{
@@ -32909,6 +32890,23 @@
 /obj/machinery/netpod,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/bitden)
+"fZT" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/table/wood,
+/obj/item/phone{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/stamp{
+	pixel_x = -1;
+	pixel_y = 17
+	},
+/obj/item/stamp/denied{
+	pixel_x = -9;
+	pixel_y = 12
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/nt_rep)
 "fZV" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/tile/blue,
@@ -33189,8 +33187,15 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gna" = (
-/turf/open/floor/iron/stairs/medium,
-/area/station/service/abandoned_gambling_den)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/kitchen/small,
+/area/station/command/heads_quarters/nt_rep)
 "gne" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -33825,7 +33830,7 @@
 /area/station/security/prison/workout)
 "gNv" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
-/turf/open/floor/iron/stairs/right,
+/turf/closed/wall,
 /area/station/service/abandoned_gambling_den)
 "gNA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -35958,14 +35963,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"iLt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/green,
-/area/station/command/heads_quarters/nt_rep)
 "iLF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36226,17 +36223,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
-"jbQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/griddle,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/iron/kitchen/small,
-/area/station/command/heads_quarters/nt_rep)
 "jcc" = (
 /obj/machinery/chem_mass_spec,
 /turf/open/floor/iron/white,
@@ -37567,22 +37553,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "klV" = (
-/obj/machinery/airalarm/directional/east,
-/obj/structure/table/wood,
-/obj/item/phone{
-	pixel_x = -5;
-	pixel_y = -2
-	},
-/obj/item/stamp{
-	pixel_x = -1;
-	pixel_y = 17
-	},
-/obj/item/stamp/denied{
-	pixel_x = -9;
-	pixel_y = 12
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/nt_rep)
+/obj/structure/holosign/barrier/engineering,
+/turf/open/floor/iron/dark/airless,
+/area/station/service/abandoned_gambling_den)
 "kmn" = (
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
@@ -38745,14 +38718,60 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "lkm" = (
-/obj/structure/bed/double{
-	dir = 4
+/obj/item/plate,
+/obj/item/plate{
+	pixel_y = 2
 	},
-/obj/item/bedsheet/centcom/double{
-	dir = 1
+/obj/item/plate{
+	pixel_y = 4
 	},
-/obj/machinery/light_switch/directional/north,
-/turf/open/floor/carpet/green,
+/obj/item/plate{
+	pixel_y = 6
+	},
+/obj/item/kitchen/fork{
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/kitchen/fork{
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/kitchen/fork{
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/kitchen/fork{
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/kitchen/spoon{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/kitchen/spoon{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/kitchen/spoon{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/kitchen/spoon{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/kitchen/spoon{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/knife{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/kitchen/rollingpin,
+/obj/structure/table/reinforced,
+/obj/structure/sign/flag/nanotrasen/directional/north,
+/turf/open/floor/iron/kitchen,
 /area/station/command/heads_quarters/nt_rep)
 "lkA" = (
 /obj/structure/table/glass,
@@ -39744,6 +39763,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/griddle,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/kitchen/small,
 /area/station/command/heads_quarters/nt_rep)
@@ -40380,60 +40400,11 @@
 /turf/open/space,
 /area/space/nearstation)
 "mDp" = (
-/obj/item/plate,
-/obj/item/plate{
-	pixel_y = 2
+/obj/effect/landmark/start/nanotrasen_representative,
+/obj/machinery/button/door/directional/north{
+	id = "ntrep_bedroom_windows"
 	},
-/obj/item/plate{
-	pixel_y = 4
-	},
-/obj/item/plate{
-	pixel_y = 6
-	},
-/obj/item/kitchen/fork{
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/item/kitchen/fork{
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/item/kitchen/fork{
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/item/kitchen/fork{
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/item/kitchen/spoon{
-	pixel_x = 10;
-	pixel_y = 2
-	},
-/obj/item/kitchen/spoon{
-	pixel_x = 10;
-	pixel_y = 2
-	},
-/obj/item/kitchen/spoon{
-	pixel_x = 10;
-	pixel_y = 2
-	},
-/obj/item/kitchen/spoon{
-	pixel_x = 10;
-	pixel_y = 2
-	},
-/obj/item/kitchen/spoon{
-	pixel_x = 10;
-	pixel_y = 2
-	},
-/obj/item/knife{
-	pixel_x = 6;
-	pixel_y = 7
-	},
-/obj/item/kitchen/rollingpin,
-/obj/structure/table/reinforced,
-/obj/structure/sign/flag/nanotrasen/directional/north,
-/turf/open/floor/iron/kitchen,
+/turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/nt_rep)
 "mDN" = (
 /obj/item/reagent_containers/cup/bottle/epinephrine,
@@ -41171,11 +41142,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "nnh" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/item/stack/spacecash/c10,
-/turf/open/floor/iron/dark,
+/obj/item/chair,
+/turf/open/floor/iron/dark/airless,
 /area/station/service/abandoned_gambling_den)
 "nnl" = (
 /obj/structure/table,
@@ -42958,8 +42926,10 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "oMN" = (
-/turf/open/floor/iron/stairs/left,
-/area/station/service/abandoned_gambling_den)
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/green,
+/area/station/command/heads_quarters/nt_rep)
 "oMV" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "armory";
@@ -44472,13 +44442,6 @@
 "qaQ" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/service)
-"qbq" = (
-/obj/effect/landmark/start/nanotrasen_representative,
-/obj/machinery/button/door/directional/north{
-	id = "ntrep_bedroom_windows"
-	},
-/turf/open/floor/carpet/green,
-/area/station/command/heads_quarters/nt_rep)
 "qbv" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 4
@@ -46009,6 +45972,14 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"rmc" = (
+/obj/structure/table/wood,
+/obj/item/newspaper{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/nt_rep)
 "rmP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -46726,6 +46697,15 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"rLL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/command/heads_quarters/nt_rep)
 "rLQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -47373,11 +47353,14 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "sqh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "ntrep_bedroom_windows"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/landmark/start/nanotrasen_representative,
+/turf/open/floor/iron/kitchen/small,
 /area/station/command/heads_quarters/nt_rep)
 "sqi" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
@@ -48929,10 +48912,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "tvj" = (
-/obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/carpet/green,
-/area/station/command/heads_quarters/nt_rep)
+/obj/structure/girder/displaced,
+/turf/open/floor/plating/airless,
+/area/station/service/abandoned_gambling_den)
 "tvq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
@@ -49995,6 +49977,13 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/chapel)
+"ulp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ntrep_bedroom_windows"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/nt_rep)
 "ulq" = (
 /obj/item/paper_bin{
 	pixel_x = -2;
@@ -51297,6 +51286,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
+"viu" = (
+/obj/item/shard,
+/turf/open/space/basic,
+/area/space)
 "viB" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/sign/warning/deathsposal/directional/west,
@@ -51309,14 +51302,13 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "vlF" = (
-/obj/item/coin/silver,
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor5"
 	},
 /obj/structure/light_construct/small{
 	dir = 8
 	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/airless,
 /area/station/service/abandoned_gambling_den)
 "vmo" = (
 /obj/machinery/camera/directional/west{
@@ -52218,6 +52210,20 @@
 	dir = 1
 	},
 /area/station/security/prison)
+"vXI" = (
+/obj/machinery/door/airlock/corporate{
+	name = "Representative's Quarters"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/command/nt_rep,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/command/heads_quarters/nt_rep)
 "vXW" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -53784,7 +53790,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "xbJ" = (
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/dark/airless,
 /area/station/service/abandoned_gambling_den)
 "xbX" = (
 /obj/machinery/conveyor{
@@ -54886,6 +54892,16 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"xNT" = (
+/obj/structure/bed/double{
+	dir = 4
+	},
+/obj/item/bedsheet/centcom/double{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/carpet/green,
+/area/station/command/heads_quarters/nt_rep)
 "xOm" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 4;
@@ -91469,10 +91485,10 @@ ljT
 aJc
 ljT
 aJc
-ljT
 aJc
 aJc
-aaa
+ayi
+abI
 lcZ
 bcK
 apq
@@ -91484,7 +91500,7 @@ auh
 avb
 awl
 gii
-lkm
+xNT
 nPR
 gii
 gii
@@ -91726,10 +91742,10 @@ akf
 gxe
 akf
 eqD
-oMN
+aJc
 vlF
-ljT
-aaa
+tvj
+abI
 cBU
 lcZ
 lcZ
@@ -91741,12 +91757,12 @@ aui
 avc
 pFQ
 gii
-qbq
+mDp
 ldp
 gii
 cvH
 lWa
-jbQ
+mcF
 paZ
 urU
 qko
@@ -91983,10 +91999,10 @@ ngp
 cBr
 cBs
 qRW
-gna
+ljT
+klV
 xbJ
-aJc
-aaa
+abI
 aaa
 aaa
 aaa
@@ -91999,13 +92015,13 @@ cBU
 xDl
 gii
 jSF
-iLt
 aFD
-ayi
-ayi
-mcF
+vXI
+rLL
+sqh
+gna
 fHa
-dqW
+rmc
 uBl
 oHS
 hFy
@@ -92242,27 +92258,27 @@ cBv
 dQr
 gNv
 nnh
-ljT
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aht
-aaa
-aht
-aaa
-sqh
-gbT
+fNg
 tvj
+viu
+aaa
+aaa
+aaa
+aaa
+aaa
+aht
+aaa
+aht
+aaa
+ulp
+gbT
+oMN
 gii
-mDp
+lkm
 eql
 cor
 rKH
-klV
+fZT
 doW
 awe
 hFy

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6165,7 +6165,9 @@
 	name = "Consultant's Fax Machine";
 	pixel_y = 3
 	},
-/obj/machinery/light/directional/east,
+/obj/effect/mapping_helpers/requests_console/information,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/machinery/requests_console/auto_name/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
 "awg" = (
@@ -6326,6 +6328,7 @@
 "awJ" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/siding/wood/corner,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "awL" = (
@@ -6699,13 +6702,14 @@
 /turf/open/floor/iron/stairs,
 /area/station/hallway/secondary/command)
 "ayi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Dorm2Shutters";
-	name = "Dorm Shutters"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/commons/dorms)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen/small,
+/area/station/command/heads_quarters/nt_rep)
 "ayj" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet,
@@ -7350,6 +7354,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "aAM" = (
+/obj/machinery/light_switch/directional/south,
+/obj/structure/filingcabinet/employment,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
 "aAN" = (
@@ -8738,11 +8744,18 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "aFD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "NTREP"
+/obj/machinery/door/airlock/corporate{
+	name = "Representative's Quarters"
 	},
-/turf/open/floor/iron,
+/obj/effect/mapping_helpers/airlock/access/any/command/nt_rep,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/kitchen/small,
 /area/station/command/heads_quarters/nt_rep)
 "aFF" = (
 /obj/item/storage/box/lights/mixed,
@@ -26970,8 +26983,10 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "cor" = (
-/obj/structure/dresser,
-/turf/open/floor/carpet/green,
+/obj/structure/sign/flag/nanotrasen/directional/east,
+/obj/machinery/oven/range,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/kitchen/small,
 /area/station/command/heads_quarters/nt_rep)
 "cot" = (
 /obj/machinery/light/small/directional/east,
@@ -28125,13 +28140,9 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/storage)
 "cvH" = (
-/obj/structure/bed/double{
-	dir = 4
-	},
-/obj/item/bedsheet/centcom/double{
-	dir = 1
-	},
-/turf/open/floor/carpet/green,
+/obj/machinery/vending/boozeomat/all_access,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/kitchen/small,
 /area/station/command/heads_quarters/nt_rep)
 "cvI" = (
 /obj/machinery/light/small/directional/south,
@@ -29606,7 +29617,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "doW" = (
-/obj/structure/table/wood,
+/obj/machinery/light/directional/east,
 /obj/item/paper_bin/carbon{
 	pixel_x = 7;
 	pixel_y = 2
@@ -29615,17 +29626,14 @@
 	pixel_x = 8;
 	pixel_y = 2
 	},
-/obj/item/stamp/denied{
-	pixel_x = -9;
-	pixel_y = 12
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -6;
+	pixel_y = 2
 	},
-/obj/item/stamp{
-	pixel_x = -1;
-	pixel_y = 17
-	},
-/obj/item/phone{
+/obj/item/pen{
 	pixel_x = -5;
-	pixel_y = -2
+	pixel_y = 4
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
@@ -29703,6 +29711,14 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit/departure_lounge)
+"dqW" = (
+/obj/structure/table/wood,
+/obj/item/newspaper{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/nt_rep)
 "dqY" = (
 /obj/structure/table,
 /obj/machinery/conveyor_switch/oneway{
@@ -30867,8 +30883,13 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "eql" = (
-/obj/effect/landmark/start/nanotrasen_representative,
-/turf/open/floor/carpet/green,
+/obj/machinery/microwave{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/machinery/light/small/directional/east,
+/obj/structure/table/reinforced,
+/turf/open/floor/iron/kitchen/small,
 /area/station/command/heads_quarters/nt_rep)
 "eqD" = (
 /obj/structure/sign/poster/contraband/random/directional/west,
@@ -32514,9 +32535,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "fHa" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -35115,6 +35133,7 @@
 	name = "Walter";
 	real_name = "Walter"
 	},
+/obj/structure/sign/flag/nanotrasen/directional/north,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/blueshield)
 "icy" = (
@@ -35939,6 +35958,14 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/library)
+"iLt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/green,
+/area/station/command/heads_quarters/nt_rep)
 "iLF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36199,6 +36226,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/miningdock)
+"jbQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/griddle,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/kitchen/small,
+/area/station/command/heads_quarters/nt_rep)
 "jcc" = (
 /obj/machinery/chem_mass_spec,
 /turf/open/floor/iron/white,
@@ -37068,8 +37106,22 @@
 /turf/closed/wall,
 /area/station/maintenance/department/medical)
 "jSF" = (
-/turf/closed/wall/r_wall,
-/area/station/hallway/secondary/command)
+/obj/structure/table/wood/fancy/green,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 5;
+	pixel_y = 16
+	},
+/obj/item/reagent_containers/cup/glass/bottle/whiskey{
+	pixel_x = 10;
+	pixel_y = 13
+	},
+/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/structure/sign/flag/nanotrasen/directional/north,
+/turf/open/floor/carpet/green,
+/area/station/command/heads_quarters/nt_rep)
 "jSP" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -37515,9 +37567,22 @@
 /turf/open/floor/iron/dark,
 /area/station/science/lab)
 "klV" = (
-/obj/item/clothing/under/rank/civilian/clown/sexy,
-/turf/open/floor/iron/dark,
-/area/station/service/abandoned_gambling_den)
+/obj/machinery/airalarm/directional/east,
+/obj/structure/table/wood,
+/obj/item/phone{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/stamp{
+	pixel_x = -1;
+	pixel_y = 17
+	},
+/obj/item/stamp/denied{
+	pixel_x = -9;
+	pixel_y = 12
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/nt_rep)
 "kmn" = (
 /turf/open/floor/iron/white,
 /area/station/science/ordnance)
@@ -38533,8 +38598,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "ldp" = (
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/green,
+/area/station/command/heads_quarters/nt_rep)
 "lem" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38676,8 +38745,14 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/aft)
 "lkm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/bed/double{
+	dir = 4
+	},
+/obj/item/bedsheet/centcom/double{
+	dir = 1
+	},
+/obj/machinery/light_switch/directional/north,
+/turf/open/floor/carpet/green,
 /area/station/command/heads_quarters/nt_rep)
 "lkA" = (
 /obj/structure/table/glass,
@@ -39457,20 +39532,38 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/dock)
 "lWa" = (
-/obj/structure/table/wood/fancy/green,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 5;
-	pixel_y = 16
+/obj/structure/closet/secure_closet/freezer/fridge/all_access,
+/obj/item/storage/box/ingredients/vegetarian,
+/obj/item/storage/box/ingredients/italian,
+/obj/item/storage/box/ingredients/fruity,
+/obj/item/storage/box/ingredients/fiesta,
+/obj/item/storage/box/ingredients/american,
+/obj/item/reagent_containers/condiment/flour{
+	list_reagents = list(/datum/reagent/consumable/flour=600);
+	name = "Premium All-Purpose Flour (16KG)";
+	volume = 600
 	},
-/obj/item/reagent_containers/cup/glass/bottle/whiskey{
-	pixel_x = 10;
-	pixel_y = 13
+/obj/item/reagent_containers/condiment/milk,
+/obj/item/reagent_containers/condiment/enzyme{
+	list_reagents = list(/datum/reagent/consumable/enzyme=500);
+	name = "universe-sized universal enyzyme";
+	volume = 500
 	},
-/obj/item/reagent_containers/cup/glass/drinkingglass/shotglass{
-	pixel_x = -1;
-	pixel_y = 5
+/obj/item/reagent_containers/condiment/rice{
+	list_reagents = list(/datum/reagent/consumable/rice=150);
+	name = "Basmati Rice Sack (4KG)";
+	volume = 150
 	},
-/turf/open/floor/carpet/green,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/slab,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/rawbacon,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/obj/item/food/meat/slab/chicken,
+/turf/open/floor/iron/kitchen/small,
 /area/station/command/heads_quarters/nt_rep)
 "lWe" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/hidden/layer4{
@@ -39645,7 +39738,14 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "mcF" = (
-/turf/open/floor/carpet/green,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/iron/kitchen/small,
 /area/station/command/heads_quarters/nt_rep)
 "mcL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -40280,7 +40380,60 @@
 /turf/open/space,
 /area/space/nearstation)
 "mDp" = (
-/turf/closed/wall,
+/obj/item/plate,
+/obj/item/plate{
+	pixel_y = 2
+	},
+/obj/item/plate{
+	pixel_y = 4
+	},
+/obj/item/plate{
+	pixel_y = 6
+	},
+/obj/item/kitchen/fork{
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/kitchen/fork{
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/kitchen/fork{
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/kitchen/fork{
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/obj/item/kitchen/spoon{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/kitchen/spoon{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/kitchen/spoon{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/kitchen/spoon{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/kitchen/spoon{
+	pixel_x = 10;
+	pixel_y = 2
+	},
+/obj/item/knife{
+	pixel_x = 6;
+	pixel_y = 7
+	},
+/obj/item/kitchen/rollingpin,
+/obj/structure/table/reinforced,
+/obj/structure/sign/flag/nanotrasen/directional/north,
+/turf/open/floor/iron/kitchen,
 /area/station/command/heads_quarters/nt_rep)
 "mDN" = (
 /obj/item/reagent_containers/cup/bottle/epinephrine,
@@ -41622,8 +41775,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/security/brig)
 "nPR" = (
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/dresser,
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/carpet/green,
+/area/station/command/heads_quarters/nt_rep)
 "nQc" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -42742,9 +42897,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "oHS" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
+/obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
 "oJj" = (
@@ -43159,9 +43312,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "paZ" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -44322,6 +44472,13 @@
 "qaQ" = (
 /turf/closed/wall,
 /area/station/hallway/secondary/service)
+"qbq" = (
+/obj/effect/landmark/start/nanotrasen_representative,
+/obj/machinery/button/door/directional/north{
+	id = "ntrep_bedroom_windows"
+	},
+/turf/open/floor/carpet/green,
+/area/station/command/heads_quarters/nt_rep)
 "qbv" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2{
 	dir = 4
@@ -44874,6 +45031,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
@@ -46197,6 +46357,9 @@
 "ryd" = (
 /obj/machinery/newscaster/directional/east,
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "ryC" = (
@@ -46538,9 +46701,6 @@
 /area/station/maintenance/solars/port)
 "rKH" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
@@ -47213,15 +47373,12 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "sqh" = (
-/obj/structure/chair{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "ntrep_bedroom_windows"
 	},
-/obj/structure/sign/poster/contraband/random/directional/east,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/abandoned_gambling_den)
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/nt_rep)
 "sqi" = (
 /obj/machinery/atmospherics/components/trinary/filter/critical{
 	dir = 8
@@ -48772,12 +48929,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "tvj" = (
-/obj/structure/festivus{
-	anchored = 1;
-	name = "pole"
-	},
-/turf/open/floor/iron/dark,
-/area/station/service/abandoned_gambling_den)
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet/green,
+/area/station/command/heads_quarters/nt_rep)
 "tvq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
@@ -49997,7 +50152,9 @@
 /area/station/science/lab)
 "urU" = (
 /obj/machinery/button/door/directional/west{
-	id = "NTREP"
+	id = "NTREP";
+	req_access = list("nt_rep");
+	name = "Office Window Shutters"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -50295,7 +50452,10 @@
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
 "uBl" = (
-/obj/machinery/modular_computer/preset/command,
+/obj/effect/landmark/start/nanotrasen_representative,
+/obj/structure/chair/comfy/carp{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
 "uBs" = (
@@ -52001,6 +52161,7 @@
 	id_tag = "Repdoor";
 	name = "Representative's Office"
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/nt_rep)
 "vWe" = (
@@ -90541,10 +90702,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
 cBU
 lcZ
 lcZ
+cBU
 apT
 apT
 apT
@@ -90798,7 +90959,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 lcZ
 aoA
 apq
@@ -90808,6 +90968,7 @@ arX
 ata
 auf
 ava
+jeG
 jeG
 ayh
 ayh
@@ -91055,7 +91216,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 cBU
 aoB
 apr
@@ -91066,9 +91226,10 @@ dda
 aug
 cBU
 pfw
-xDl
-xDl
-xDl
+gii
+gii
+gii
+gii
 nro
 gCW
 awJ
@@ -91310,7 +91471,6 @@ ljT
 aJc
 ljT
 aJc
-ljT
 aJc
 aaa
 lcZ
@@ -91323,17 +91483,18 @@ atc
 auh
 avb
 awl
-xDl
+gii
+lkm
 nPR
 gii
 gii
-aFD
+hFy
 gii
 vVv
 gii
-aFD
-aFD
-mDp
+hFy
+hFy
+gii
 nIt
 ame
 nQH
@@ -91567,7 +91728,6 @@ akf
 eqD
 oMN
 vlF
-tvj
 ljT
 aaa
 cBU
@@ -91580,17 +91740,18 @@ atd
 aui
 avc
 pFQ
-xDl
+gii
+qbq
 ldp
-hFy
+gii
 cvH
 lWa
-mcF
+jbQ
 paZ
 urU
 qko
 aAM
-mDp
+gii
 aIg
 aKb
 bLA
@@ -91823,7 +91984,6 @@ cBr
 cBs
 qRW
 gna
-klV
 xbJ
 aJc
 aaa
@@ -91837,17 +91997,18 @@ cBU
 cBU
 cBU
 xDl
+gii
 jSF
-aaa
-hFy
-mcF
-mcF
+iLt
+aFD
+ayi
+ayi
 mcF
 fHa
-aAM
+dqW
 uBl
 oHS
-lkm
+hFy
 nFT
 ame
 riB
@@ -92081,7 +92242,6 @@ cBv
 dQr
 gNv
 nnh
-sqh
 ljT
 aaa
 aaa
@@ -92089,22 +92249,23 @@ aaa
 aaa
 aaa
 aaa
-aht
 aaa
 aht
 aaa
-aaa
 aht
 aaa
-hFy
+sqh
 gbT
+tvj
+gii
+mDp
 eql
 cor
 rKH
-aAM
+klV
 doW
 awe
-lkm
+hFy
 nFT
 ame
 riB
@@ -92350,9 +92511,9 @@ aiS
 aiS
 aiS
 avd
-avd
-apX
-ayi
+aBL
+aBL
+aBL
 aBL
 aBL
 aBL


### PR DESCRIPTION
# BEHOLD THE PALACE OF GREED 

<img width="385" height="726" alt="image" src="https://github.com/user-attachments/assets/84a856a0-67e5-4f05-9e04-ec0eaafa8bf0" />

brings the nt rep office on-par with other station offices (nt rep gets private quarters and a kitchen now, as well as proper paperwork gear)

## Why It's Good For The Game

make the paperwork dudes able to A, do their job, B, remind people who owns their soul (their boss), C, photocopy, and D, feed the entire command staff if they're bored

## Changelog
:cl:
map: A Johnson & Co engineering team has completely redone the office of the Nanotrasen Representative assigned to Pubby Station, pending more serious works at the site
/:cl:
