### PR TITLE
Free Miner frontier surplus crate is no longer locked

### DIFF
--- a/_maps/shuttles/ruin_freeminer.dmm
+++ b/_maps/shuttles/ruin_freeminer.dmm
@@ -618,14 +618,12 @@
 "pQ" = (
 /obj/effect/turf_decal/delivery/white,
 /obj/item/flatpacked_machine,
-/obj/structure/closet/crate/secure{
-	req_access = list("qm");
-	name = "old crate";
-	desc = "An old, dinged-up crate. The lock's been in place for years.";
-	max_integrity = 600
-	},
 /obj/item/flatpacked_machine/organics_ration_printer,
 /obj/item/flatpacked_machine/recycler,
+/obj/structure/closet/crate/engineering{
+	name = "frontier surplus cate";
+	desc = "A rusty steel crate."
+	},
 /turf/open/floor/iron/shuttle/exploration/flat,
 /area/shuttle/ruin/free_miner)
 "pR" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

unlocks that crate

## Why It's Good For The Game

crates ash their contents sometimes if forced now so this makes sure free miners dont lose their cool frontier stuff

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Frontier surplus crates on Sheffield-class free mining vessels have had their security locks removed by Johnson & Co. (free miners no longer lose frontier surplus to dusting)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
