### PR TITLE
fire breath now requires your mouth to be uncovered

### DIFF
--- a/code/datums/actions/mobs/fire_breath.dm
+++ b/code/datums/actions/mobs/fire_breath.dm
@@ -19,10 +19,27 @@
 	/// How much damage to mechs take when engulfed?
 	var/mech_damage = 45
 
+/datum/action/cooldown/mob_cooldown/fire_breath/Grant(mob/granted_to)
+	. = ..()
+	RegisterSignals(granted_to, list(COMSIG_MOB_EQUIPPED_ITEM, COMSIG_ITEM_POST_UNEQUIP), PROC_REF(update_status_on_signal))
+
+/datum/action/cooldown/mob_cooldown/fire_breath/Remove(mob/removed_from)
+	UnregisterSignal(removed_from, list(COMSIG_MOB_EQUIPPED_ITEM, COMSIG_ITEM_POST_UNEQUIP))
+	return ..()
+
 /datum/action/cooldown/mob_cooldown/fire_breath/Activate(atom/target_atom)
 	attack_sequence(target_atom)
 	StartCooldown()
 	return TRUE
+
+/datum/action/cooldown/mob_cooldown/fire_breath/IsAvailable(feedback = FALSE)
+	. = ..()
+	if(!.)
+		return
+	if(astype(owner, /mob/living)?.is_mouth_covered())
+		if(feedback)
+			owner.balloon_alert(owner, "mouth covered!")
+		return FALSE
 
 /// Apply our specific fire breathing shape, in proc form so we can override it in subtypes
 /datum/action/cooldown/mob_cooldown/fire_breath/proc/attack_sequence(atom/target)


### PR DESCRIPTION

## About The Pull Request

This makes it so you need your mouth to be uncovered to use fire breath, simple as that.

https://github.com/user-attachments/assets/7323aba8-288d-4533-89ac-591c966e51eb

## Why It's Good For The Game

balances onis a bit more (slap a mask or whatever on them and they can't breathe fire on you)

## Changelog
:cl:
balance: Fire breath now requires your mouth to be uncovered, so a muzzle/mask/etc will stop onis from setting you on fire.
/:cl:
