### PR TITLE
Removes the bad nodnod so mine works

### DIFF
--- a/monkestation/code/modules/emotes/code/emote.dm
+++ b/monkestation/code/modules/emotes/code/emote.dm
@@ -315,12 +315,6 @@
 	message = "squints."
 	message_param = "squints at %t."
 
-/datum/emote/living/nodnod
-	key = "nodnod"
-	key_third_person = "nodnods"
-	message = "nodnods."
-	message_param = "nodnods at %t."
-
 //The code from 'Start' to 'End' was ported from Russ-station, with permission.
 //All credit to 'bitch fish'
 //Start


### PR DESCRIPTION
## About The Pull Request

because of COURSE there was a nodnod hidden in modularisation

## Why It's Good For The Game

nodnods at sounds like ass. nods twice is descriptive and better fits the action, as fitting of an emote.

## Changelog


:cl:
fix: fixes the nodnod/nod2 emote.
del: removes the inferior version that was overwriting
/:cl:
