### PR TITLE
make it obvious when someone can't be decapitated

### DIFF
--- a/code/datums/wounds/cranial_fissure.dm
+++ b/code/datums/wounds/cranial_fissure.dm
@@ -147,6 +147,10 @@
 	var/mob/living/victim = src.victim
 	var/limb_name = limb.plaintext_zone
 
+	if((limb.bodypart_flags & BODYPART_UNREMOVABLE) || HAS_TRAIT(victim, TRAIT_GODMODE) | HAS_TRAIT(victim, TRAIT_NODISMEMBER))
+		victim.balloon_alert(user, "cannot decapitate!")
+		return
+
 	var/decap_time
 	switch(item.force)
 		if(15 to 24)
@@ -178,7 +182,7 @@
 		if(time_since >= decap_time)
 			break
 	progress.end_progress()
-	if(!limb.dismember(dam_type = item.damtype, sound = FALSE))
+	if(!limb.dismember(dam_type = item.damtype))
 		user.visible_message(span_danger("[user] fails to slice through [victim]'s [limb_name] with \the [item]!"), span_boldnotice("You fail to slice through [victim]'s [limb_name] with \the [item]!"))
 		return TRUE
 	log_combat(user, victim, "beheaded", item)


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: It's now obvious whenever someone can't be decapitated, instead of just wasting time swinging at their head without any feedback.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
