### PR TITLE
evil drones don't get passthrough

### DIFF
--- a/code/modules/mob/living/basic/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/basic/drone/extra_drone_types.dm
@@ -25,6 +25,7 @@
 	can_unhack = FALSE
 	shy = FALSE
 	flavortext = null
+	pass_flags = PASSTABLE | PASSMOB
 
 	/// The number of telecrystals to put in the drone's uplink
 	var/telecrystal_count = 10

--- a/monkestation/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/mobs/cogscarab.dm
@@ -29,6 +29,7 @@ GLOBAL_LIST_EMPTY(cogscarabs)
 	shy = FALSE
 	///var for in case admins want a cogsarab to stay off reebe for some reason
 	var/stay_on_reebe = TRUE
+	pass_flags = PASSTABLE | PASSMOB
 
 //No you can't go wielding guns like that.
 /mob/living/basic/drone/cogscarab/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request
Removes the ability for evil drones (syndiedrones and clockwork scarabs) to walk through doors. Uninterrupted.
## Why It's Good For The Game
The passthrough was to stop maintenance drones from letting people into areas they really didnt belong as the drone went about its duties. These drone subtypes are actually playing the game and not a colony simulator so they should have to interact with the rest of the game.

Otherwise they can use doors as bullet shields, and weave within cover without consequences.
## Changelog
:cl:
qol: Evil subtypes of drones no longer have door passthrough, and will have to open the door like anyone normal.
/:cl:
