### PR TITLE
Adjusts junior lone op weight/spawn timer, increases the chance lone ops gain weight

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -45,7 +45,7 @@
 		//MONKESTATION EDIT START
 		unsecured_timer = new(src)
 		unsecured_timer.start()
-		junior_lone_operative_trigger_time = (15 + rand(-5, 5)) * 60 //15 minutes + -5 to 5 minutes
+		junior_lone_operative_trigger_time = (20 + rand(-5, 5)) * 60 //35 minutes + -5 to 5 minutes
 		can_trigger_junior_operative = TRUE
 		GLOB.nuke_disk_list += src
 		//MONKESTATION EDIT STOP
@@ -79,7 +79,7 @@
 		if(istype(comfort_item, /obj/item/bedsheet) || istype(comfort_item, /obj/structure/bed))
 			disk_comfort_level++
 
-	if(last_move < world.time - 300 SECONDS && prob((world.time - 300 SECONDS - last_move)*0.0001)) //monkestation edit: weight will start increasing at 5 minutes unsecure, rather than 8.3
+	if(last_move < world.time - 300 SECONDS && prob((world.time - 300 SECONDS - last_move)*0.0005)) //monkestation edit: weight will start increasing at 5 minutes unsecure, rather than 8.3
 		var/datum/round_event_control/operative/loneopmode = locate(/datum/round_event_control/operative) in SSgamemode.control
 		if(istype(loneopmode) && loneopmode.occurrences < loneopmode.max_occurrences)
 			loneopmode.checks_antag_cap = (loneopmode.weight < 3)

--- a/code/modules/events/ghost_role/operative.dm
+++ b/code/modules/events/ghost_role/operative.dm
@@ -50,7 +50,7 @@
 
 	category = EVENT_CATEGORY_INVASION
 	description = "A junior nuclear operative infiltrates the station."
-	weight = 1
+	weight = 0
 	max_occurrences = 5
 	track = EVENT_TRACK_MAJOR
 


### PR DESCRIPTION

## About The Pull Request
Increases the weight gain chance of lone ops when the disk is unsecure by 5x (0.0001 to 0.0005), changes the weight of junior ops to 0 (doesn't affect the forced event from an unsecure disk) and changes the time for a junior op to spawn from an unsecure disk from 10-20 minutes to 15-25 minutes
## Why It's Good For The Game
Currently, lone ops rarely spawn, even if the disk is left unsecure. This is due to junior ops taking very little time from an unsecure disk to spawn, and lone ops having to compete with every other major event in order to spawn. The increased rate of weight gain will hopefully make it much more likely for a lone op to spawn if the disk is left alone for too long, while still letting junior ops spawn. Changing the weight of junior ops to 0 is so it doesn't compete with other major events, without affecting if it spawns from an unsecure disk.
## Changelog
:cl:
balance: Increased the weight gain of lone ops (not junior ops) by 5x
balance: Major events can no longer roll junior ops (unsecure disks will still spawn them)
balance: Junior ops spawn time from an unsecure disk increased from 10-20 minutes to 15-25
/:cl:
