### PR TITLE
Fix store not giving you the right lizard plushie

### DIFF
--- a/monkestation/code/modules/store/store_items/plushies.dm
+++ b/monkestation/code/modules/store/store_items/plushies.dm
@@ -16,7 +16,7 @@ GLOBAL_LIST_INIT(store_plushies, generate_store_items(/datum/store_item/plushies
 /datum/store_item/plushies/lizard_greyscale
 	item_cost = 7500
 	name = "Lizard Plushie"
-	item_path = /obj/item/toy/plush/lizard_plushie
+	item_path = /obj/item/toy/plush/lizard_plushie/greyscale
 
 /datum/store_item/plushies/moth
 	item_cost = 7500


### PR DESCRIPTION
## About The Pull Request

Fixes the store not giving you the right lizard plushie. As it is currently, if you buy the lizard plushie in the shop you get nothing. Unfortunately it does nothing if you already bought it, as it gave the wrong path. The plushie that the store currently gives you is non-recolorable.

## Why It's Good For The Game

Getting what you pay for is good.

## Changelog

:cl:
fix: Fix store not giving you the right lizard plushie
/:cl: