### PR TITLE
Ensures all maps have a XenoDrobe in xenobiology

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -40323,6 +40323,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/north,
+/obj/machinery/vending/wardrobe/xeno_wardrobe,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "ivS" = (

--- a/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
+++ b/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
@@ -31725,10 +31725,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
-"pjh" = (
-/obj/item/ammo_casing/rocket,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "pjx" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -31759,6 +31755,15 @@
 /obj/structure/cable,
 /turf/open/floor/eighties/red,
 /area/station/service/theater)
+"pkL" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/machinery/vending/wardrobe/xeno_wardrobe,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/station/science/xenobiology)
 "pkS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38558,10 +38563,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/diagonal,
 /area/station/ai_monitored/command/storage/eva)
-"suv" = (
-/obj/effect/landmark/start/scientist,
-/turf/open/floor/iron/dark/corner,
-/area/station/science/xenobiology)
 "suC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -41802,6 +41803,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
+/obj/effect/landmark/start/xenobiologist,
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
@@ -46695,6 +46697,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
+/obj/effect/landmark/start/xenobiologist,
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -48114,11 +48117,6 @@
 /obj/item/toy/mecha/darkhonk,
 /turf/open/floor/plating,
 /area/station/maintenance/port/central)
-"xbF" = (
-/obj/effect/mapping_helpers/broken_floor,
-/obj/item/ammo_casing/rocket,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "xbG" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -63298,7 +63296,7 @@ ghX
 ghX
 ghX
 tLF
-pjh
+tLF
 mnv
 xdv
 tLF
@@ -64328,7 +64326,7 @@ tLF
 bmn
 tLF
 tLF
-xbF
+gue
 mYY
 xdv
 tLF
@@ -65527,7 +65525,7 @@ mfE
 pAk
 fDl
 pUe
-suv
+sxH
 pAk
 sEt
 dZA
@@ -65783,7 +65781,7 @@ lnF
 cyG
 hIj
 kta
-ait
+pkL
 mfE
 pAk
 sEt
@@ -68358,7 +68356,7 @@ xMr
 pAk
 uVv
 tbs
-suv
+sxH
 pAk
 fDl
 php

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -33470,6 +33470,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/vending/wardrobe/xeno_wardrobe,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "gzf" = (

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -36530,6 +36530,9 @@
 	pixel_y = -3;
 	pixel_x = 3
 	},
+/obj/item/wrench{
+	pixel_x = 2
+	},
 /turf/open/floor/iron/dark/side,
 /area/station/science/xenobiology/hallway)
 "kKY" = (
@@ -64786,15 +64789,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 6
-	},
-/obj/item/wrench{
-	pixel_y = 4;
-	pixel_x = -5
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/vending/wardrobe/xeno_wardrobe,
 /turf/open/floor/iron/dark/corner,
 /area/station/science/xenobiology/hallway)
 "sVT" = (


### PR DESCRIPTION

## About The Pull Request

this maps a xenodrobe vendor into the several stations that were missing one: helio, lead poisoning, pubby, and theseus.

see mapdiffbot for where they're at.

## Changelog
:cl:
map: HelioStation, Lead Poisoning Station, PubbyStation, and Theseus now all properly have XenoDrobe vendors mapped into xenobiology.
map: Lead Poisoning Station now has proper Xenobiologist spawn points.
/:cl:
