### PR TITLE
you can now click on the URL in the tgui audio player widget

### DIFF
--- a/tgui/packages/tgui-panel/audio/NowPlayingWidget.jsx
+++ b/tgui/packages/tgui-panel/audio/NowPlayingWidget.jsx
@@ -45,7 +45,7 @@ export const NowPlayingWidget = (props, context) => {
               <Section>
                 {URL !== 'Song Link Hidden' && (
                   <Flex.Item grow={1} color="label">
-                    Url: {URL}
+                    URL: <a href={URL}>{URL}</a>
                   </Flex.Item>
                 )}
                 <Flex.Item grow={1} color="label">


### PR DESCRIPTION

## About The Pull Request

<img width="454" height="129" alt="2025-07-17 (1752804636) ~ dreamseeker" src="https://github.com/user-attachments/assets/5ad96db7-c44b-41bd-bbe3-b0485872dd0d" />


## Why It's Good For The Game

much less annoying than having to copy-paste it

## Changelog
:cl:
qol: You can now click on the song URL in the music player widget in chat.
/:cl:
