### PR TITLE
[PORT] Fixes hardcore random never paying out as non-antag

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -213,7 +213,7 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 				if(!objective_datum.check_completion())
 					return FALSE
 		player_client.give_award(/datum/award/score/hardcore_random, human_mob, round(human_mob.hardcore_survival_score * 2))
-	else if(considered_escaped(human_mob))
+	else if(considered_escaped(human_mob.mind))
 		player_client.give_award(/datum/award/score/hardcore_random, human_mob, round(human_mob.hardcore_survival_score))
 
 /datum/controller/subsystem/ticker/proc/declare_completion(was_forced = END_ROUND_AS_NORMAL)


### PR DESCRIPTION

## About The Pull Request

Fixes #6597
Port of https://github.com/tgstation/tgstation/pull/75725

## Changelog
:cl: leaKsi, Time-Green
fix: Hardcore random pays your score again as non-antag.
/:cl:
