### PR TITLE
automatically remove nametag keybindings from prefs

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 // You do not need to raise this if you are adding new values that have sane defaults.
 // Only raise this value when changing the meaning/format/name/layout of an existing value
 // where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX 43
+#define SAVEFILE_VERSION_MAX 44
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -90,6 +90,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	if (current_version < 41)
 		migrate_preferences_to_tgui_prefs_menu()
+
+	if (current_version < 44)
+		key_bindings -= "show_names"
 
 /datum/preferences/proc/update_character(current_version, list/save_data)
 	if (current_version < 41)


### PR DESCRIPTION

## About The Pull Request

for some reason, a lot of people's keybindings still have `show_names` in them, when that was removed by https://github.com/Monkestation/Monkestation2.0/pull/7009, so this just does a savefile migration to remove the now non-existent keybind from prefs

## Why It's Good For The Game

less runtime spam

## Changelog

no player-facing changes