### PR TITLE
Smokes produce light when lit

### DIFF
--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -138,6 +138,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	body_parts_covered = null
 	grind_results = list()
 	heat = 1000
+	light_outer_range = 1
+	light_color = LIGHT_COLOR_FIRE
+	light_system = OVERLAY_LIGHT
+	light_on = FALSE
 	supports_variations_flags = CLOTHING_SNOUTED_VARIATION
 	throw_verb = "flick"
 	/// Whether this cigarette has been lit.
@@ -315,6 +319,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	lit = TRUE
 	make_cig_smoke()
+	set_light_on(TRUE)
 	if(!(flags_1 & INITIALIZED_1))
 		update_appearance(UPDATE_ICON)
 		return
@@ -368,6 +373,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	reagents.flags |= NO_REACT
 	lit = FALSE
 	update_appearance(UPDATE_ICON)
+	set_light_on(FALSE)
 	if(ismob(loc))
 		to_chat(loc, span_notice("Your [name] goes out."))
 	QDEL_NULL(cig_smoke)
@@ -751,6 +757,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			to_chat(user, span_notice("Your [name] goes out."))
 		packeditem = null
 	update_appearance(UPDATE_ICON)
+	set_light_on(FALSE)
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(cig_smoke)
 
@@ -1123,6 +1130,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	inhand_icon_state = null
 	w_class = WEIGHT_CLASS_TINY
 	flags_1 = IS_PLAYER_COLORABLE_1
+	light_outer_range = 1
+	light_color = LIGHT_COLOR_HALOGEN
+	light_system = OVERLAY_LIGHT
+	light_on = FALSE
 
 	/// The capacity of the vape.
 	var/chem_volume = 100
@@ -1219,12 +1230,14 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	to_chat(user, span_notice("You start puffing on the vape."))
 	reagents.flags &= ~(NO_REACT)
 	START_PROCESSING(SSobj, src)
+	set_light_on(TRUE)
 
 /obj/item/clothing/mask/vape/dropped(mob/user)
 	. = ..()
 	if(user.get_item_by_slot(ITEM_SLOT_MASK) == src)
 		reagents.flags |= NO_REACT
 		STOP_PROCESSING(SSobj, src)
+		set_light_on(FALSE)
 
 /obj/item/clothing/mask/vape/proc/handle_reagents()
 	if(!reagents.total_volume)


### PR DESCRIPTION
Lit cigarettes and some other types of smokes now produce light when lit

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Code directly taken from a [/tg/ PR](https://github.com/tgstation/tgstation/pull/91648). Credit goes to [kittysmooch](https://github.com/kittysmooch) for the code, not me.

Cigarettes, cigars, and other smokable items now produce very faint amounts of light when lit up.

## Why It's Good For The Game

As in the words of [kittysmooch](https://github.com/kittysmooch),

"its cute! its flavor! you can farm aura by sparking a dart in a dark maint tunnel! tactical dudes can talk about 'light discipline' and go oorah! there's something for everyone here really"

It further adds to player immersion and is just another tiny but nice feature to have.

~Also Pooba told me to do it~

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Cigarettes, cigars, and other smokable items now produce faint amounts of light when lit up.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
