### PR TITLE
Nerfs void chill

### DIFF
--- a/code/modules/antagonists/heretic/status_effects/void_chill.dm
+++ b/code/modules/antagonists/heretic/status_effects/void_chill.dm
@@ -51,7 +51,7 @@
 		to_chat(owner, span_notice("You feel holy water warming you up."))
 		adjust_stacks(-1)
 	else
-		owner.adjust_bodytemperature(-12 KELVIN * stacks * seconds_between_ticks)
+		owner.adjust_bodytemperature(-5 KELVIN * stacks * seconds_between_ticks)
 	if (stacks == 0)
 		owner.remove_status_effect(/datum/status_effect/void_chill)
 


### PR DESCRIPTION

## About The Pull Request
Reduces void chill's temperature drain from -12 per stack each tick, to -5 per stack each tick.
## Why It's Good For The Game
Void heretic is heavily overtuned right now, specifically with how quickly they can drain players temperatures to such drastic degrees that they rapidly die to the cold. Lowering these numbers will hopefully make it more in line with other paths.
## Changelog
:cl:
balance: rReduced heretic's void chill temperature loss from -12 kelvin per tick, to -5 kelvin per tick
/:cl:
