### PR TITLE
Fixes hardlight spear implant pad data

### DIFF
--- a/code/game/objects/items/implants/hardlight.dm
+++ b/code/game/objects/items/implants/hardlight.dm
@@ -89,7 +89,7 @@
 	spell_type = /datum/action/cooldown/spell/conjure_item/hardlight_spear/max
 	allow_multiple = FALSE
 
-/obj/item/implant/hard_spear/get_data()
+/obj/item/implant/hard_spear/max/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
 				<b>Name:</b> Aetherofusion Experimental Resonance System<BR>
 				<b>Life:</b>  8 millennia in a dead host.<BR>


### PR DESCRIPTION

## About The Pull Request
Hey did you know you can put a implant case into a doodad to read information about it? did you know that the hardlight spear has different text for its regular and commanding implant variants? you didnt for that last one? thats because it didnt work. the text for the max version wasnt put under ..spear/max/get_data(), but instead ..spear/get_data() again. Which made the max hardlight spear implant replace the regular hardlight spear implants data text.
## Why It's Good For The Game
Text Good, Accuracy Good.
## Changelog
:cl: Tractor Maam
spellcheck: the regular Hardlight Spear Implant will not use the Commanding Hardlight Spear Implant's information when inside a implant pad.
/:cl:
