### PR TITLE
Reduced slowdown from deforest heavy medical kits

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -7980,7 +7980,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/cable,
-/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
+/obj/item/storage/backpack/deforest_surgical/stocked,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "csQ" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -21241,7 +21241,7 @@
 /obj/item/storage/medkit/fire,
 /obj/item/storage/medkit/toxin,
 /obj/item/storage/medkit/brute,
-/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
+/obj/item/storage/backpack/deforest_medkit/stocked,
 /obj/item/storage/medkit/advanced,
 /obj/item/storage/medkit/civil_defense/stocked,
 /obj/item/storage/medkit/civil_defense/comfort/stocked,
@@ -28586,7 +28586,7 @@
 "qGq" = (
 /obj/machinery/light/floor/has_bulb,
 /obj/structure/table/reinforced/rglass,
-/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
+/obj/item/storage/backpack/deforest_surgical/stocked,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
@@ -29131,7 +29131,7 @@
 /area/centcom/central_command_areas/admin)
 "rGz" = (
 /obj/structure/table/reinforced/rglass,
-/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
+/obj/item/storage/backpack/deforest_surgical/stocked,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/white/small,
@@ -32926,7 +32926,7 @@
 /obj/item/reagent_containers/hypospray/medipen/gore,
 /obj/item/reagent_containers/hypospray/medipen/gore,
 /obj/item/reagent_containers/hypospray/medipen/gore,
-/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
+/obj/item/storage/backpack/deforest_medkit/stocked,
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
 	},

--- a/monkestation/code/modules/blueshift/armaments/deforest_medical.dm
+++ b/monkestation/code/modules/blueshift/armaments/deforest_medical.dm
@@ -32,11 +32,11 @@
 	cost = PAYCHECK_COMMAND * 8
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/first_responder
-	item_type = /obj/item/storage/backpack/duffelbag/deforest_surgical/stocked
+	item_type = /obj/item/storage/backpack/deforest_surgical/stocked
 	cost = PAYCHECK_COMMAND * 10
 
 /datum/armament_entry/company_import/deforest/first_aid_kit/orange_satchel
-	item_type = /obj/item/storage/backpack/duffelbag/deforest_medkit/stocked
+	item_type = /obj/item/storage/backpack/deforest_medkit/stocked
 	cost = PAYCHECK_COMMAND * 10
 
 // Basic first aid supplies like gauze, sutures, mesh, so on

--- a/monkestation/code/modules/blueshift/biogenerator/equipment.dm
+++ b/monkestation/code/modules/blueshift/biogenerator/equipment.dm
@@ -16,7 +16,7 @@
 	id = "frontier_med_belt"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 200)
-	build_path = /obj/item/storage/backpack/duffelbag/deforest_medkit
+	build_path = /obj/item/storage/backpack/deforest_medkit
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_AKHTER_EQUIPMENT,

--- a/monkestation/code/modules/blueshift/cargo/deforest.dm
+++ b/monkestation/code/modules/blueshift/cargo/deforest.dm
@@ -36,6 +36,6 @@
 	access = ACCESS_MEDICAL
 	cost = CARGO_CRATE_VALUE * 10
 	contains = list(
-		/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked,
-		/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked,
+		/obj/item/storage/backpack/deforest_medkit/stocked,
+		/obj/item/storage/backpack/deforest_surgical/stocked,
 	)

--- a/monkestation/code/modules/blueshift/items/deforest.dm
+++ b/monkestation/code/modules/blueshift/items/deforest.dm
@@ -801,8 +801,8 @@
 	)
 	generate_items_inside(items_inside,src)
 
-// Big medical kit that can be worn like a bag, holds a LOT of medical items but works like a duffelbag
-/obj/item/storage/backpack/duffelbag/deforest_medkit
+// Big medical kit that can be worn like a bag, holds a LOT of medical items but slows you down slightly
+/obj/item/storage/backpack/deforest_medkit
 	name = "satchel medical kit"
 	desc = "A large orange satchel able to hold just about any piece of small medical equipment you could think of, you can even wear it on your back or belt!"
 	icon = 'monkestation/code/modules/blueshift/icons/deforest/storage.dmi'
@@ -815,8 +815,9 @@
 	pickup_sound = 'sound/items/handling/cloth_pickup.ogg'
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_BELT
+	slowdown = 0.25
 
-/obj/item/storage/backpack/duffelbag/deforest_medkit/Initialize(mapload)
+/obj/item/storage/backpack/deforest_medkit/Initialize(mapload)
 	. = ..()
 	atom_storage.max_specific_storage = WEIGHT_CLASS_SMALL
 	atom_storage.max_slots = 21
@@ -859,9 +860,9 @@
 		/obj/item/bodybag,
 	))
 
-/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked
+/obj/item/storage/backpack/deforest_medkit/stocked
 
-/obj/item/storage/backpack/duffelbag/deforest_medkit/stocked/PopulateContents()
+/obj/item/storage/backpack/deforest_medkit/stocked/PopulateContents()
 	var/static/items_inside = list(
 		/obj/item/reagent_containers/hypospray/medipen/deforest/morpital = 1,
 		/obj/item/reagent_containers/hypospray/medipen/deforest/lepoturi = 1,
@@ -885,8 +886,8 @@
 	generate_items_inside(items_inside,src)
 
 
-// Big surgical kit that can be worn like a bag, holds 14 normal items (more than what a backpack can do!) but works like a duffelbag
-/obj/item/storage/backpack/duffelbag/deforest_surgical
+// Big surgical kit that can be worn like a bag, holds 14 normal items (more than what a backpack can do!) but slows you down slightly
+/obj/item/storage/backpack/deforest_surgical
 	name = "first responder surgical kit"
 	desc = "A large bag able to hold all the surgical tools and first response healing equipment you can think of, you can even wear it!"
 	icon = 'monkestation/code/modules/blueshift/icons/deforest/storage.dmi'
@@ -899,8 +900,9 @@
 	pickup_sound = 'sound/items/handling/cloth_pickup.ogg'
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_BELT
+	slowdown = 0.25
 
-/obj/item/storage/backpack/duffelbag/deforest_surgical/Initialize(mapload)
+/obj/item/storage/backpack/deforest_surgical/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 14
 	atom_storage.max_total_storage = 14 * WEIGHT_CLASS_NORMAL
@@ -959,9 +961,9 @@
 		/obj/item/bodybag,
 	))
 
-/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked
+/obj/item/storage/backpack/deforest_surgical/stocked
 
-/obj/item/storage/backpack/duffelbag/deforest_surgical/stocked/PopulateContents()
+/obj/item/storage/backpack/deforest_surgical/stocked/PopulateContents()
 	var/static/items_inside = list(
 		/obj/item/scalpel = 1,
 		/obj/item/hemostat = 1,

--- a/monkestation/code/modules/blueshift/opfor/equipment/medical.dm
+++ b/monkestation/code/modules/blueshift/opfor/equipment/medical.dm
@@ -34,13 +34,13 @@
 
 /datum/opposing_force_equipment/medical/satchel_medkit
 	name = "Satchel Medical Kit"
-	item_type = /obj/item/storage/backpack/duffelbag/deforest_medkit/stocked
+	item_type = /obj/item/storage/backpack/deforest_medkit/stocked
 	description = "A large orange satchel able to hold just about any piece of small medical equipment you could think of, you can even wear it on your back or belt! \
 			Keep in mind, however, that this cannot fit inside any normal bag."
 
 /datum/opposing_force_equipment/medical/super_combat_surgeon
 	name = "First Responder Surgical Kit"
-	item_type = /obj/item/storage/backpack/duffelbag/deforest_surgical/stocked
+	item_type = /obj/item/storage/backpack/deforest_surgical/stocked
 	description = "A large bag able to hold all the surgical tools and first response healing equipment you can think of, you can even wear it! \
 			Keep in mind, however, that this cannot fit inside any normal bag."
 


### PR DESCRIPTION
## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The heavy duty medical kits are borderline unusable with their duffel-bag-level slowdown. Considering you already have to sacrifice a belt or backpack slot to carry them properly, their slowdown has been reduced to a quarter of what it previously was.

## Changelog

:cl:
balance: reduced slowdown of heavy-duty medical kits by 75%
/:cl:
