### PR TITLE
[BOUNTY] Rennovates Box Station Kitchen

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -25972,7 +25972,7 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/turf/open/space/basic,
+/turf/open/floor/iron/dark/textured,
 /area/station/service/kitchen)
 "ipF" = (
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -3966,7 +3966,18 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
-/obj/item/radio/intercom/directional/south,
+/obj/structure/table,
+/obj/item/food/deadmouse{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/cigbutt{
+	pixel_y = -1
+	},
+/obj/item/cigbutt{
+	pixel_x = 8;
+	pixel_y = 11
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "bop" = (
@@ -5041,6 +5052,9 @@
 /area/station/science/breakroom)
 "bDJ" = (
 /obj/machinery/vending/barbervend,
+/obj/machinery/light_switch/directional/east{
+	pixel_y = 5
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 6
 	},
@@ -5670,6 +5684,7 @@
 	dir = 1
 	},
 /obj/structure/sign/poster/official/random/directional/south,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/port)
 "bMr" = (
@@ -6035,16 +6050,21 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "bSr" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/machinery/light/small/directional/south,
+/obj/structure/extinguisher_cabinet/directional/west,
+/obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
 	},
-/obj/machinery/newscaster/directional/south,
-/obj/structure/chair{
-	dir = 8
+/obj/item/reagent_containers/cup/glass/shaker{
+	pixel_x = -9;
+	pixel_y = 3
 	},
-/obj/effect/landmark/start/cook,
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
+/obj/item/reagent_containers/dropper{
+	pixel_y = -4
+	},
+/turf/open/floor/wood,
+/area/station/service/bar)
 "bSC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/line{
@@ -6201,9 +6221,14 @@
 /turf/open/floor/wood/tile,
 /area/station/security/prison/safe)
 "bVu" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/service)
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 1
+	},
+/obj/structure/table,
+/obj/item/plate,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "bVI" = (
 /obj/structure/lattice,
 /obj/structure/sign/warning/secure_area/directional/north,
@@ -6556,22 +6581,28 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
 "cbZ" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/service{
-	name = "Bar"
+/obj/machinery/requests_console/directional/south{
+	department = "Kitchen";
+	name = "Kitchen Requests Console"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/turf/open/floor/iron/dark/textured,
-/area/station/service/bar)
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_y = 10;
+	pixel_x = -9
+	},
+/obj/item/reagent_containers/cup/glass/bottle/beer{
+	pixel_x = 7;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/cup/glass/bottle/beer/almost_empty{
+	pixel_x = 11
+	},
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "cch" = (
 /turf/open/floor/iron/white,
 /area/station/science/explab)
@@ -8649,16 +8680,13 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
 "cMU" = (
-/obj/machinery/camera/directional/north{
-	c_tag = "Service - Hallway, 1";
-	name = "service camera"
+/obj/machinery/newscaster/directional/south,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
-/obj/machinery/light/small/directional/north,
-/obj/structure/table,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/hallway/secondary/service)
+/obj/machinery/disposal/bin,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "cNc" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/machinery/light/small/directional/east,
@@ -10009,15 +10037,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "dhZ" = (
-/obj/machinery/firealarm/directional/south{
-	pixel_x = 5
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 1
 	},
-/obj/machinery/light_switch/directional/south{
-	pixel_x = -5
-	},
-/obj/structure/closet/secure_closet/bar,
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "dia" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Engineering - Ship Breaking, Storage Room";
@@ -13357,13 +13382,12 @@
 	},
 /area/station/commons/storage/primary)
 "enB" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/green/line{
+/obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/port)
+/obj/effect/spawner/structure/window,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "enD" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/airalarm/directional/west,
@@ -14132,9 +14156,15 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "eAj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/service)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/duct,
+/turf/open/floor/wood,
+/area/station/service/bar)
 "eAp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -14910,11 +14940,12 @@
 	},
 /area/station/hallway/primary/aft)
 "eNC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/service)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "eNK" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -15087,26 +15118,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "eQw" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen_interior_shutters";
+	name = "Interior Kitchen Shutters"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/left/directional/south{
-	name = "Kitchen and Bar";
-	req_access = list("bar")
-	},
-/obj/machinery/door/window/left/directional/north{
-	name = "Kitchen and Bar";
-	req_access = list("kitchen")
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "kitchen_sec_shutters";
-	name = "Kitchen Shutters"
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/service/kitchen)
+/turf/open/floor/plating,
+/area/station/science/lab)
 "eQI" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
@@ -21418,12 +21436,21 @@
 /turf/open/floor/iron/dark,
 /area/station/security/holding_cell)
 "gQB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/service)
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/service{
+	name = "Bar Backroom"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/turf/open/floor/iron/dark/textured,
+/area/station/service/bar/backroom)
 "gQK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -22537,15 +22564,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
-"hjx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/duct,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/hallway/secondary/service)
 "hjB" = (
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
@@ -22690,6 +22708,7 @@
 /area/station/cargo/lobby)
 "hlF" = (
 /obj/machinery/firealarm/directional/west,
+/obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -23264,16 +23283,17 @@
 	dir = 1
 	},
 /obj/structure/table,
+/obj/machinery/reagentgrinder{
+	pixel_y = 8
+	},
 /obj/item/reagent_containers/condiment/peppermill{
 	pixel_x = -9;
 	pixel_y = 9
 	},
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
-	},
 /obj/item/reagent_containers/condiment/saltshaker{
 	pixel_x = -9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "hvn" = (
@@ -23428,7 +23448,10 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/south,
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/effect/landmark/start/cook,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "hxv" = (
@@ -24111,13 +24134,13 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
-/obj/structure/table,
 /obj/item/stack/package_wrap,
 /obj/item/food/mint{
 	pixel_y = 7;
 	pixel_x = -7
 	},
 /obj/item/reagent_containers/condiment/enzyme,
+/obj/structure/table,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "hHJ" = (
@@ -25648,7 +25671,7 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/north,
-/obj/machinery/griddle,
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "ikX" = (
@@ -25943,16 +25966,14 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "ipC" = (
-/obj/machinery/firealarm/directional/east{
-	pixel_y = -5
-	},
-/obj/machinery/light_switch/directional/east{
-	pixel_y = 5
-	},
-/turf/open/floor/iron/dark/side{
+/obj/machinery/door/poddoor/shutters{
+	id = "kitchen_sec_shutters";
+	name = "Kitchen Shutters";
 	dir = 4
 	},
-/area/station/hallway/secondary/service)
+/obj/structure/table/reinforced,
+/turf/open/space/basic,
+/area/station/service/kitchen)
 "ipF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -26925,13 +26946,13 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "iFL" = (
-/obj/machinery/newscaster/directional/south,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/effect/landmark/start/cook,
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 1
 	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/wood,
-/area/station/service/bar)
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "iFN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -28563,7 +28584,10 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/grill,
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe"
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "jht" = (
@@ -29024,11 +29048,13 @@
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
 "jqp" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen_interior_shutters";
+	name = "Interior Kitchen Shutters"
 	},
-/obj/machinery/oven/range,
-/turf/open/floor/iron/kitchen,
+/turf/open/floor/plating,
 /area/station/service/kitchen)
 "jqs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -30349,12 +30375,15 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "jKE" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/item/kirbyplants/random,
-/turf/open/floor/iron/dark/side{
-	dir = 5
+/obj/machinery/light/small/directional/south,
+/obj/machinery/light_switch/directional/south{
+	pixel_x = 5
 	},
-/area/station/hallway/secondary/service)
+/obj/machinery/firealarm/directional/south{
+	pixel_x = -5
+	},
+/turf/open/floor/wood,
+/area/station/service/bar)
 "jKV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
@@ -32721,21 +32750,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "kyu" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/service{
-	name = "Bar Backroom"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/service/bar,
-/turf/open/floor/iron/dark/textured,
-/area/station/service/bar/backroom)
+/obj/machinery/airalarm/directional/south,
+/obj/machinery/grill,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "kyB" = (
 /obj/structure/sign/painting/library{
 	pixel_x = -32
@@ -33440,10 +33461,7 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 6
-	},
+/obj/machinery/griddle,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "kMH" = (
@@ -37238,8 +37256,15 @@
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "lUP" = (
-/turf/open/floor/iron,
-/area/station/hallway/secondary/service)
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/stack/package_wrap,
+/obj/item/hand_labeler,
+/obj/item/holosign_creator/robot_seat/restaurant,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "lUT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38000,8 +38025,7 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
-/obj/structure/table,
-/obj/item/toy/figure/chef,
+/obj/machinery/oven/range,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "mhD" = (
@@ -38320,15 +38344,10 @@
 /turf/open/floor/wood/tile,
 /area/station/service/library/artgallery)
 "mmV" = (
-/obj/machinery/light/directional/north,
-/obj/structure/table,
-/obj/item/paper_bin,
-/obj/item/folder,
-/obj/item/pen,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/hallway/secondary/service)
+/obj/machinery/vending/wardrobe/bar_wardrobe,
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/wood,
+/area/station/service/bar/backroom)
 "mmX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/mix_output{
 	dir = 8
@@ -39198,12 +39217,16 @@
 	},
 /area/station/engineering/shipbreaker_hut)
 "mBp" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners{
-	dir = 1
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/processor,
-/turf/open/floor/iron/kitchen,
-/area/station/service/kitchen)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/firealarm/directional/south,
+/turf/open/floor/iron/dark/textured,
+/area/station/hallway/primary/port)
 "mBL" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 9
@@ -41184,9 +41207,22 @@
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
 "nmf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/secondary/service)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/service{
+	name = "Bar"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/service/bar,
+/turf/open/floor/iron/dark/textured,
+/area/station/service/bar)
 "nmm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41729,14 +41765,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "nvt" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/green/line{
+/obj/structure/table,
+/obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
-/obj/machinery/firealarm/directional/south,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/port)
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "nvx" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 9
@@ -44354,8 +44388,8 @@
 	dir = 1
 	},
 /obj/machinery/light/directional/north,
-/obj/structure/chair,
-/obj/effect/landmark/start/cook,
+/obj/machinery/oven/range,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "olT" = (
@@ -45092,17 +45126,16 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "oyo" = (
-/obj/machinery/requests_console/directional/south{
-	department = "Bar";
-	name = "Bar Requests Console"
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 1
 	},
-/obj/effect/mapping_helpers/requests_console/supplies,
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe"
+/obj/machinery/newscaster/directional/south,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_y = 6
 	},
-/turf/open/floor/wood,
-/area/station/service/bar)
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "oyp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -45148,10 +45181,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engineering/central)
 "ozj" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/vending/wardrobe/bar_wardrobe,
-/turf/open/floor/wood,
-/area/station/service/bar/backroom)
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/light/small/directional/north,
+/obj/machinery/camera/directional/north{
+	c_tag = "Service - Hallway, 1";
+	name = "service camera"
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/service)
 "oAa" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line{
 	dir = 1
@@ -45545,6 +45585,8 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/qm)
 "oHP" = (
+/obj/machinery/firealarm/directional/west,
+/obj/structure/table,
 /obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
@@ -45552,11 +45594,6 @@
 	c_tag = "Service - Kitchen, Serving Area";
 	name = "service camera"
 	},
-/obj/machinery/firealarm/directional/west,
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/landmark/start/cook,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "oIb" = (
@@ -45634,7 +45671,8 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/vending/dinnerware,
+/obj/machinery/stove,
+/obj/structure/cable,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "oII" = (
@@ -46916,9 +46954,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/patients_rooms/room_a)
 "pdr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/item/folder,
+/obj/item/pen,
+/obj/item/paper_bin,
+/obj/structure/table,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "pdz" = (
@@ -46950,14 +46991,25 @@
 /turf/open/floor/iron/dark,
 /area/station/security/processing)
 "peO" = (
-/obj/machinery/light/small/directional/south,
-/obj/machinery/light_switch/directional/south{
-	pixel_x = 5
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/firealarm/directional/south{
-	pixel_x = -5
+/obj/machinery/door/firedoor,
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/left/directional/south{
+	name = "Kitchen and Bar";
+	req_access = list("bar")
 	},
-/turf/open/floor/wood,
+/obj/machinery/door/window/left/directional/north{
+	name = "Kitchen and Bar";
+	req_access = list("kitchen")
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "kitchen_sec_shutters";
+	name = "Kitchen Shutters"
+	},
+/turf/open/floor/iron/dark/textured,
 /area/station/service/bar)
 "peS" = (
 /obj/structure/weightmachine/stacklifter,
@@ -51373,10 +51425,14 @@
 /turf/open/floor/iron/checker,
 /area/station/science/lab)
 "qBU" = (
-/turf/open/floor/iron/dark/side{
-	dir = 8
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 1
 	},
-/area/station/hallway/secondary/service)
+/obj/machinery/door/airlock/service/glass{
+	name = "Kitchen Counter"
+	},
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "qBV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -52590,6 +52646,15 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Service - Kitchen";
 	name = "service camera"
+	},
+/obj/structure/table,
+/obj/item/spatula{
+	pixel_y = 6;
+	pixel_x = 1
+	},
+/obj/item/spatula{
+	pixel_x = 5;
+	pixel_y = 2
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
@@ -56562,6 +56627,9 @@
 /area/station/command/bridge)
 "snx" = (
 /obj/structure/closet/secure_closet/barber,
+/obj/machinery/firealarm/directional/east{
+	pixel_y = -5
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -59775,7 +59843,11 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/stove,
+/obj/structure/table,
+/obj/item/toy/figure/chef,
+/obj/machinery/button/door/directional/north{
+	name = "Interior Shutters Control"
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "trz" = (
@@ -59788,11 +59860,7 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/requests_console/directional/south{
-	department = "Kitchen";
-	name = "Kitchen Requests Console"
-	},
-/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/structure/table,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "trQ" = (
@@ -65830,6 +65898,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/processor,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "vla" = (
@@ -66831,13 +66900,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "vAZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/requests_console/directional/south{
+	department = "Bar";
+	name = "Bar Requests Console"
 	},
-/obj/machinery/duct,
+/obj/effect/mapping_helpers/requests_console/supplies,
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe"
+	},
 /turf/open/floor/wood,
 /area/station/service/bar)
 "vBh" = (
@@ -67700,6 +67771,10 @@
 	name = "Kitchen Shutters Control";
 	req_access = list("kitchen")
 	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/landmark/start/cook,
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "vND" = (
@@ -68565,6 +68640,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
+"wbl" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 1
+	},
+/obj/item/radio/intercom/directional/south,
+/obj/machinery/deepfryer,
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "wbq" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -70422,21 +70505,18 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/electrical)
 "wGc" = (
-/obj/machinery/light/small/directional/south,
-/obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/tile/bar/opposingcorners{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 8
+/obj/machinery/microwave{
+	pixel_y = 6
 	},
-/obj/item/reagent_containers/cup/glass/shaker{
-	pixel_x = -9;
-	pixel_y = 3
-	},
-/obj/item/reagent_containers/dropper{
-	pixel_y = -4
-	},
-/turf/open/floor/wood,
-/area/station/service/bar)
+/turf/open/floor/iron/kitchen,
+/area/station/service/kitchen)
 "wGe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -70467,12 +70547,20 @@
 /turf/open/floor/iron/dark/side,
 /area/station/commons/fitness)
 "wGk" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/bar/opposingcorners{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
-/obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable,
+/obj/structure/table,
+/obj/item/knife/kitchen{
+	pixel_x = -2
+	},
+/obj/item/knife/kitchen{
+	pixel_x = 1
+	},
+/obj/item/knife/kitchen{
+	pixel_x = 4
+	},
 /turf/open/floor/iron/kitchen,
 /area/station/service/kitchen)
 "wGm" = (
@@ -71394,11 +71482,15 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/department/engine/atmos)
 "wWh" = (
-/obj/effect/spawner/random/vending/colavend,
-/turf/open/floor/iron/dark/side{
-	dir = 9
+/obj/machinery/firealarm/directional/south{
+	pixel_x = 5
 	},
-/area/station/hallway/secondary/service)
+/obj/machinery/light_switch/directional/south{
+	pixel_x = -5
+	},
+/obj/structure/closet/secure_closet/bar,
+/turf/open/floor/wood,
+/area/station/service/bar/backroom)
 "wWv" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -75489,6 +75581,9 @@
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
 	location = "Service"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/secondary/service)
@@ -92595,7 +92690,7 @@ jhr
 wEt
 wEt
 wEt
-kME
+puT
 pEY
 iix
 pff
@@ -92852,7 +92947,7 @@ ikU
 wEt
 gIe
 wEt
-iuG
+tnN
 xVa
 xVa
 xVa
@@ -93105,11 +93200,11 @@ vpb
 jZY
 lBN
 rRm
-jqp
+kbB
 wEt
 blE
 wEt
-iuG
+lUP
 xVa
 iJX
 toh
@@ -93364,7 +93459,7 @@ erS
 rRm
 trv
 vww
-hvk
+wEt
 iXU
 hHH
 xVa
@@ -93878,7 +93973,7 @@ erS
 rRm
 qXR
 pWG
-wEt
+bVu
 wEt
 vkX
 xVa
@@ -94131,12 +94226,12 @@ fPN
 fPN
 gIY
 jZY
-erS
+coj
 rRm
 mIK
 pWG
 wEt
-mBp
+wEt
 otK
 xVa
 tCb
@@ -94388,13 +94483,13 @@ iSa
 mNq
 dHc
 bym
-nvt
-rRm
+nZO
+jqp
 olQ
 mPm
+trF
 wEt
-rRm
-rRm
+iuG
 xVa
 xVa
 xVa
@@ -94645,20 +94740,20 @@ nZL
 nZL
 kgv
 rxt
-hWV
+mBp
 rRm
 mhA
 mPm
 bog
-rRm
+wEt
+wbl
+oLg
 xml
 eBn
 vEB
 oOl
-dhZ
-oLg
 wWh
-qBU
+oLg
 hlF
 qXb
 jiL
@@ -94902,19 +94997,19 @@ ksa
 kpr
 rWZ
 pjD
-coj
-rRm
+erS
+jqp
 oIE
 mPm
-hxu
-rRm
+wEt
+wEt
+kyu
+oLg
 aMD
 qos
 wfJ
 gaa
 gaa
-kyu
-hjx
 gQB
 gMs
 qwd
@@ -95161,20 +95256,20 @@ fZK
 pjD
 bMh
 rRm
-kbB
+kME
 mPm
 wGk
-rRm
+dhZ
+wGc
+oLg
 xhN
 nZa
 wfJ
 lIY
-ozj
-oLg
 mmV
-nmf
+oLg
+pdr
 oEc
-lUP
 cOa
 bnl
 cTK
@@ -95416,12 +95511,14 @@ ksa
 kpr
 rWZ
 pjD
-enB
-rRm
-puT
+erS
+jqp
+hvk
 mPm
 trF
-rRm
+wEt
+cbZ
+oLg
 oLg
 oLg
 oET
@@ -95429,9 +95526,7 @@ oLg
 oLg
 oLg
 bwa
-lUP
 oEc
-lUP
 szd
 bnl
 bnl
@@ -95675,20 +95770,20 @@ rWZ
 pjD
 qvY
 rRm
-tnN
+kME
 mPm
-bSr
-rRm
+wEt
+wEt
+oyo
+sHs
 rHN
 qCL
 muy
 bGl
-wGc
+bSr
 sHs
 oWj
-eAj
 hoe
-lUP
 ipL
 bnl
 uKO
@@ -95934,18 +96029,18 @@ dYc
 rRm
 rRm
 iFB
+enB
+qBU
 rRm
-rRm
+sHs
 lkq
 vLL
 wui
 ehj
-oyo
+vAZ
 sHs
 kJu
-lUP
 jMj
-lUP
 oKm
 bnl
 wji
@@ -96191,18 +96286,18 @@ erS
 lea
 vNB
 mPm
+wEt
+wEt
 oHP
-rRm
+sHs
 fTU
 tLj
 pXb
 bHn
-iFL
-sHs
 cMU
-eNC
+sHs
+ozj
 flR
-pdr
 ylS
 bnl
 gFs
@@ -96448,18 +96543,18 @@ erS
 prb
 apt
 rIX
+eNC
 sUl
-eQw
+iFL
+peO
 fZB
 fZB
 wui
 wui
-vAZ
-cbZ
-sjw
+eAj
+nmf
 xcL
 fay
-bVu
 vtc
 hCe
 rug
@@ -96703,18 +96798,18 @@ qcS
 pjD
 erS
 ocD
-wEt
+hxu
 mPm
 wEt
-rRm
+wEt
+nvt
+sHs
 kZc
 pVn
 fZB
 xsm
-peO
-sHs
 jKE
-ipC
+sHs
 nus
 snx
 bDJ
@@ -96963,6 +97058,7 @@ rRm
 cTz
 czB
 bmE
+ipC
 rRm
 uHN
 kfN
@@ -96970,8 +97066,7 @@ nJy
 sHs
 opU
 sHs
-hdj
-hdj
+sHs
 fYg
 hdj
 hdj
@@ -110587,7 +110682,7 @@ oVo
 iNT
 qBR
 oVo
-qeZ
+eQw
 kkp
 cHJ
 wxL

--- a/_maps/~monkestation/RandomBars/Box/bloody_bar.dmm
+++ b/_maps/~monkestation/RandomBars/Box/bloody_bar.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "ae" = (
-/obj/machinery/light_switch/directional/west,
 /obj/machinery/light/directional/west,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/cult,
 /area/station/commons/lounge)
 "ak" = (
@@ -214,6 +214,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/cult,
 /area/station/commons/lounge)
+"Fs" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/cult,
+/area/station/commons/lounge)
 "FK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -403,15 +410,15 @@ Gh
 Bl
 ue
 Bl
+Bl
+Bl
 DJ
-wp
+Fs
 gA
-wp
+Fs
 ae
 Bl
 wM
-Bl
-Bl
 AZ
 Bl
 Bl
@@ -424,9 +431,9 @@ ue
 ue
 ue
 ue
+ue
+ue
 Dy
-ue
-ue
 ue
 ue
 VJ

--- a/_maps/~monkestation/RandomBars/Box/clockwork_bar.dmm
+++ b/_maps/~monkestation/RandomBars/Box/clockwork_bar.dmm
@@ -73,6 +73,13 @@
 /obj/machinery/jukebox,
 /turf/open/floor/bronze,
 /area/station/commons/lounge)
+"iM" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/chair/bronze{
+	dir = 8
+	},
+/turf/open/floor/bronze,
+/area/station/commons/lounge)
 "jv" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/bronze/flat,
@@ -124,6 +131,11 @@
 "rC" = (
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light/directional/east,
+/turf/open/floor/bronze,
+/area/station/commons/lounge)
+"sh" = (
+/obj/machinery/light/directional/west,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/bronze,
 /area/station/commons/lounge)
 "si" = (
@@ -242,9 +254,10 @@
 /turf/open/floor/bronze,
 /area/station/commons/lounge)
 "Mm" = (
-/obj/machinery/light_switch/directional/west,
-/obj/machinery/light/directional/west,
 /obj/structure/fluff/clockwork/alloy_shards/small,
+/obj/structure/chair/bronze{
+	dir = 8
+	},
 /turf/open/floor/bronze,
 /area/station/commons/lounge)
 "MB" = (
@@ -381,15 +394,15 @@ OD
 TL
 qG
 TL
+TL
+TL
 LJ
-LI
-qn
-LI
+iM
 Mm
+iM
+sh
 TL
 PP
-TL
-TL
 Cz
 TL
 TL
@@ -402,9 +415,9 @@ qG
 qG
 qG
 qG
+qG
+qG
 Sf
-qG
-qG
 qG
 qG
 gg

--- a/_maps/~monkestation/RandomBars/Box/default_bar.dmm
+++ b/_maps/~monkestation/RandomBars/Box/default_bar.dmm
@@ -21,8 +21,8 @@
 /area/station/service/theater)
 "cD" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/chair/stool/bar/directional/west,
 /obj/effect/landmark/start/hangover,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "cH" = (
@@ -283,8 +283,8 @@
 /area/station/commons/lounge)
 "DZ" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/machinery/light_switch/directional/west,
-/obj/machinery/light/directional/west,
+/obj/effect/landmark/start/assistant,
+/obj/structure/chair/stool/bar/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "Ea" = (
@@ -455,8 +455,8 @@
 /area/station/commons/lounge)
 "WG" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/chair/stool/bar/directional/west,
-/obj/effect/landmark/start/assistant,
+/obj/machinery/light/directional/west,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/lounge)
 "XC" = (
@@ -477,15 +477,15 @@ Ca
 tH
 EF
 tH
+tH
+tH
 PD
 cD
-WG
-cD
 DZ
+cD
+WG
 tH
 XC
-tH
-tH
 ei
 tH
 tH
@@ -498,9 +498,9 @@ EF
 EF
 EF
 EF
+EF
+EF
 eq
-EF
-EF
 EF
 EF
 hG

--- a/_maps/~monkestation/RandomBars/Box/vietmoth_bar.dmm
+++ b/_maps/~monkestation/RandomBars/Box/vietmoth_bar.dmm
@@ -73,6 +73,10 @@
 /obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
 /area/station/commons/lounge)
+"iP" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/grass,
+/area/station/commons/lounge)
 "jB" = (
 /turf/open/misc/dirt/station,
 /area/station/service/theater)
@@ -165,9 +169,9 @@
 /turf/open/floor/grass,
 /area/station/commons/lounge)
 "po" = (
-/obj/machinery/light_switch/directional/west,
 /obj/machinery/light/directional/west,
 /obj/structure/flora/bush/jungle/b/style_random,
+/obj/machinery/light_switch/directional/west,
 /turf/open/floor/grass,
 /area/station/commons/lounge)
 "py" = (
@@ -377,6 +381,13 @@
 /obj/structure/cable,
 /turf/open/water/jungle,
 /area/station/commons/lounge)
+"NE" = (
+/obj/effect/landmark/start/hangover,
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/station/commons/lounge)
 "NP" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Service - Theater";
@@ -402,10 +413,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
 /area/station/commons/lounge)
 "OY" = (
-/obj/machinery/light/directional/west,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
@@ -455,14 +466,14 @@ nj
 jK
 nj
 OY
-nR
+nj
+iP
+NE
 Oz
-nR
+NE
 po
 nj
 YM
-ir
-nj
 OP
 gM
 CE
@@ -475,9 +486,9 @@ jK
 Bs
 jK
 jK
+jK
+jK
 nI
-jK
-jK
 jK
 jK
 HI


### PR DESCRIPTION
## About The Pull Request

Greatly increases the size of Box station's kitchen, adds visibility in, and adds new cooking facilities and *many* more tables.

Space was taken to this end from the shared service room. It's still functional, just somewhat cramped. But a place service are in only for a tiny portion of their gameplay is much less important I'd argue than the kitchen - especially on what is supposed to be a high pop map.

<img width="639" height="445" alt="Screenshot 2025-07-23 012251" src="https://github.com/user-attachments/assets/5a80dd14-6421-4464-a859-87caca32d648" />


## Why It's Good For The Game

Box station's kitchen was awful, small, barely visible, and just generally unfit for the kitchen of a high pop station. While there was some flavour gained from the unusual shape it was insufficient to make up for just how awful it is to work with.

## Changelog

:cl:
map: Box station's kitchen is now much bigger and more usable, space selflessly donated from the lathe room.
/:cl:
