### PR TITLE
Zoinks Captain, let's get out of here

### DIFF
--- a/monkestation/code/modules/assault_ops/code/sunbeam.dm
+++ b/monkestation/code/modules/assault_ops/code/sunbeam.dm
@@ -170,7 +170,7 @@ ADMIN_VERB(spawn_sunbeam, R_FUN, FALSE, "Spawn Sunbeam", "Spawns an ICARUS sunbe
 		return
 	if(EMERGENCY_IDLE_OR_RECALLED)
 		SSshuttle.emergency.request(
-d			red_alert = (SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_GAMMA)
+			red_alert = (SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_GAMMA)
 		)
 
 #undef SUNBEAM_OBLITERATION_RANGE_FIRE

--- a/monkestation/code/modules/assault_ops/code/sunbeam.dm
+++ b/monkestation/code/modules/assault_ops/code/sunbeam.dm
@@ -164,6 +164,14 @@ ADMIN_VERB(spawn_sunbeam, R_FUN, FALSE, "Spawn Sunbeam", "Spawns an ICARUS sunbe
 	var/turf/end_turf = get_edge_target_turf(get_safe_random_station_turf_equal_weight(), turn(startside, 180))
 	var/turf/start_turf = spaceDebrisStartLoc(startside, end_turf.z)
 	new /obj/effect/sunbeam(start_turf, end_turf)
+	SSsecurity_level.set_level(SEC_LEVEL_GAMMA)
+	SSshuttle.admin_emergency_no_recall = TRUE
+	if(SSshuttle.emergency?.mode == SHUTTLE_DISABLED || EMERGENCY_PAST_POINT_OF_NO_RETURN)
+		return
+	if(EMERGENCY_IDLE_OR_RECALLED)
+		SSshuttle.emergency.request(
+d			red_alert = (SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_GAMMA)
+		)
 
 #undef SUNBEAM_OBLITERATION_RANGE_FIRE
 #undef SUNBEAM_OBLITERATION_RANGE_FLATTEN


### PR DESCRIPTION

## About The Pull Request
Forces a unrecallable shuttle and Gamma event alert level whever the ICARUS Weapons System Ignition is activated
<img width="596" height="650" alt="image" src="https://github.com/user-attachments/assets/25fbb590-91d7-4f10-b0c5-ee51df577911" />
## Why It's Good For The Game
 Once the ICARUS Weapons System Ignition is activated, the operatives have already won for all intents and purposes. And the station is in an unrecoverable state. Theres no further reasons to stall out the round. GAMMA alert is forced so Operatives AI ect cant stall the round out further and a shuttle is forced.
## Changelog
:cl:
add: ICARUS Weapons System Ignition Now triggers a unrecallable shuttle.
add: ICARUS Weapons System Ignition now auto elevates to Gamma alert.
/:cl:
