### PR TITLE
Reinforces metastation's singulo/tesla

### DIFF
--- a/_maps/~monkestation/RandomEngines/MetaStation/singularity.dmm
+++ b/_maps/~monkestation/RandomEngines/MetaStation/singularity.dmm
@@ -57,11 +57,6 @@
 "eg" = (
 /turf/open/floor/carpet/black,
 /area/station/engineering/supermatter/room)
-"ej" = (
-/obj/structure/grille,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "eH" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -437,11 +432,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"Fy" = (
-/obj/structure/grille/broken,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "FN" = (
 /obj/structure/particle_accelerator/end_cap{
 	dir = 4
@@ -1108,7 +1098,7 @@ je
 je
 je
 je
-An
+bM
 An
 Ki
 nM
@@ -1122,7 +1112,7 @@ Bc
 An
 An
 nM
-An
+bM
 je
 je
 je
@@ -1135,7 +1125,7 @@ je
 je
 je
 je
-Bc
+bM
 An
 ol
 An
@@ -1176,7 +1166,7 @@ nM
 An
 An
 KS
-ej
+bM
 je
 je
 je
@@ -1189,7 +1179,7 @@ je
 je
 je
 je
-An
+bM
 hW
 ol
 ol
@@ -1203,7 +1193,7 @@ Yq
 EM
 EM
 An
-Fy
+bM
 je
 je
 je
@@ -1216,7 +1206,7 @@ je
 je
 je
 je
-An
+bM
 hW
 EM
 An
@@ -1230,7 +1220,7 @@ xy
 An
 EM
 nM
-nM
+bM
 je
 je
 je
@@ -1243,7 +1233,7 @@ je
 je
 je
 je
-Bc
+bM
 hW
 EM
 wm
@@ -1257,7 +1247,7 @@ ML
 wm
 EM
 nM
-ej
+bM
 je
 je
 je
@@ -1284,7 +1274,7 @@ wm
 An
 EM
 An
-An
+bM
 je
 je
 je
@@ -1311,7 +1301,7 @@ wm
 dT
 EM
 An
-nM
+bM
 je
 je
 je
@@ -1324,7 +1314,7 @@ je
 je
 je
 je
-Bc
+bM
 hW
 EM
 NU
@@ -1338,7 +1328,7 @@ bp
 NU
 EM
 nM
-ej
+bM
 je
 je
 je
@@ -1392,7 +1382,7 @@ wm
 An
 An
 An
-nM
+bM
 je
 je
 je
@@ -1405,7 +1395,7 @@ je
 je
 je
 je
-Bc
+bM
 hW
 hW
 GG
@@ -1419,7 +1409,7 @@ ML
 EP
 An
 nM
-ej
+bM
 je
 je
 je
@@ -1432,7 +1422,7 @@ je
 je
 je
 je
-An
+bM
 hW
 An
 An
@@ -1446,7 +1436,7 @@ wm
 hW
 An
 nM
-nM
+bM
 je
 je
 je
@@ -1473,7 +1463,7 @@ hW
 hW
 An
 An
-Fy
+bM
 je
 je
 je
@@ -1487,20 +1477,20 @@ je
 je
 je
 bM
-An
 bM
-An
-Bc
-Bc
-Bc
-Bc
-Bc
-Bc
-Bc
-An
 bM
-KS
-KS
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
+bM
 je
 je
 je


### PR DESCRIPTION

## About The Pull Request

this surrounds the singulo/tesla engine on meta with r-walls, like on pretty much literally every other map.

<img width="1028" height="841" alt="2025-07-24 (1753397833) ~ strongdmm" src="https://github.com/user-attachments/assets/fe15d06e-bb0c-4cb7-bae4-3179d97e54f2" />

## Why It's Good For The Game

I AM TIRED OF HAVING FUN/CHILL ROUNDS ENDED EARLY BC HAHA FUNNY SPACE DUST CUT AN EMITTER WIRE

## Changelog
:cl:
map: MetaStation's singularity/tesla engine is now fully surrounded by reinforced walls (like every other station with a singulo/tesla), so that a single piece of stray space dust won't end the round early.
/:cl:
