### PR TITLE
RCD and cable map issues

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -94487,6 +94487,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/effect/turf_decal/tile/green/opposingcorners,
+/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
 "sot" = (

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -48673,7 +48673,6 @@
 /obj/machinery/airalarm/directional/north,
 /mob/living/basic/parrot/poly,
 /obj/machinery/camera/autoname/directional/east,
-/obj/item/construction/rcd/ce,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/ce)
 "ojM" = (


### PR DESCRIPTION
## About The Pull Request

- Blueshift Pathology will no longer depower
- Thesues does not start with two professional RCD's for the CE
## Why It's Good For The Game
closes: #7278
## Changelog
:cl:
map: Thesues does not start with two professional RCD's
map: Blueshift pathology will not depower
/:cl:
