### PR TITLE
Lets people censor their ckey off credits

### DIFF
--- a/code/modules/client/preferences/credits.dm
+++ b/code/modules/client/preferences/credits.dm
@@ -1,0 +1,4 @@
+/datum/preference/toggle/feature_key_credits
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "feature_key_credits"
+	savefile_identifier = PREFERENCE_PLAYER

--- a/monkestation/code/modules/and_roll_credits/credits_subsystem.dm
+++ b/monkestation/code/modules/and_roll_credits/credits_subsystem.dm
@@ -171,14 +171,16 @@ SUBSYSTEM_DEF(credits)
 	for(var/mob/living/carbon/human/H in GLOB.player_list)
 		if(!H.ckey && !(H.stat == DEAD))
 			continue
+		var/player_key = H.client?.prefs?.read_preference(/datum/preference/toggle/feature_key_credits) ? "<td class= 'actorname'>[uppertext(H.mind.key)]</td><td class='actorsegue'> as </td>" : null
 		var/assignment = H.get_assignment(if_no_id = "", if_no_job = "")
-		cast_string += "<center><tr><td class= 'actorname'>[uppertext(H.mind.key)]</td><td class='actorsegue'> as </td><td class='actorrole'>[H.real_name][assignment == "" ? "" : ", [assignment]"]</td></tr></center>"
+		cast_string += "<center><tr>[player_key]<td class='actorrole'>[H.real_name][assignment == "" ? "" : ", [assignment]"]</td></tr></center>"
 		cast_num++
 
 	for(var/mob/living/silicon/S in GLOB.silicon_mobs)
 		if(!S.ckey)
 			continue
-		cast_string += "<center>[uppertext(S.mind.key)] as [S.name]</center>"
+		var/player_key = S.client?.prefs?.read_preference(/datum/preference/toggle/feature_key_credits) ? "[uppertext(S.mind.key)] as " : null
+		cast_string += "<center>[player_key][S.name]</center>"
 		cast_num++
 
 	if(!cast_num)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3641,6 +3641,7 @@
 #include "code\modules\client\preferences\body_type.dm"
 #include "code\modules\client\preferences\broadcast_login_logout.dm"
 #include "code\modules\client\preferences\clothing.dm"
+#include "code\modules\client\preferences\credits.dm"
 #include "code\modules\client\preferences\darkened_flash.dm"
 #include "code\modules\client\preferences\food_allergy.dm"
 #include "code\modules\client\preferences\fov_darkness.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/credits.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/credits.tsx
@@ -1,0 +1,11 @@
+import { multiline } from 'common/string';
+import { CheckboxInput, FeatureToggle } from '../base';
+
+export const feature_key_credits: FeatureToggle = {
+  name: 'Feature ckey in credits',
+  category: 'GAMEPLAY',
+  description: multiline`
+    When enabled, will display your ckey as 'you' in the credits.
+  `,
+  component: CheckboxInput,
+};


### PR DESCRIPTION
## About The Pull Request

Some people like playing a character without the player behind it being doxxed at the end of the round, so this adds a preference that would remove your ckey from the credits, on by default for everyone so has to be manually opted out of.

## Why It's Good For The Game

Explained in the about section.

## Changelog

:cl:
add: You can opt out of having your character's ckey revealed at the credits.
/:cl: