### PR TITLE
Monkeys can now be gendered

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/monkeys.dm
+++ b/code/modules/mob/living/carbon/human/species_types/monkeys.dm
@@ -27,7 +27,6 @@
 	no_equip_flags = ITEM_SLOT_OCLOTHING | ITEM_SLOT_GLOVES | ITEM_SLOT_FEET | ITEM_SLOT_SUITSTORE
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | ERT_SPAWN | SLIME_EXTRACT
 	inherent_factions = list(FACTION_MONKEY)
-	sexes = FALSE
 	species_language_holder = /datum/language_holder/monkey
 
 	bodypart_overrides = list(


### PR DESCRIPTION
## About The Pull Request

Monkeys (and therefore simians) can now have gendered pronouns, and can customize it in their prefs menu.

## Why It's Good For The Game

Idk why it's like this to be honest it's not like monkeys are all gender neutral.

## Changelog

:cl:
balance: Monkeys and Simians can now be gendered.
/:cl: