### PR TITLE
Removes Rng From ARoboparts

### DIFF
--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -505,8 +505,8 @@
 	desc = "An advanced cybernetic arm, capable of greater feats of strength and durability."
 	icon_static = 'icons/mob/augmentation/advanced_augments.dmi'
 	icon = 'icons/mob/augmentation/advanced_augments.dmi'
-	unarmed_damage_low = 12
-	unarmed_damage_high = 12
+	unarmed_damage_low = 11
+	unarmed_damage_high = 11
 	unarmed_stun_threshold = 15
 	max_damage = 75
 	brute_modifier = 0.5
@@ -518,8 +518,8 @@
 	desc = "An advanced cybernetic arm, capable of greater feats of strength and durability."
 	icon_static = 'icons/mob/augmentation/advanced_augments.dmi'
 	icon = 'icons/mob/augmentation/advanced_augments.dmi'
-	unarmed_damage_low = 12
-	unarmed_damage_high = 12
+	unarmed_damage_low = 11
+	unarmed_damage_high = 11
 	unarmed_stun_threshold = 15
 	max_damage = 75
 	brute_modifier = 0.5


### PR DESCRIPTION
 ##About The Pull Request
Advanced Robo arms now have a consistent damage spread

## Why It's Good For The Game
We removed rng from base punches, it stood to reason they should be gone from these limbs too. It was also silly you could roll a one tap knockdown if blessed by rngesus, so that's no longer possible... unless you raise unarmed damage by some other means... *wink wink*
## Changelog


:cl:
balance: advanced robot limbs no longer have rng damage or knockdown.
/:cl:
