### PR TITLE
[PORT] Moves init time display out of chat (and make it hideable since most people don't care)

### DIFF
--- a/code/__DEFINES/MC.dm
+++ b/code/__DEFINES/MC.dm
@@ -79,6 +79,9 @@
 /// If the length() of each var is 0, it will not be queued.
 #define SS_HIBERNATE (1 << 7)
 
+/// Don't show when this has init'd
+#define SS_NO_INIT_MESSAGE (1 << 8)
+
 //! SUBSYSTEM STATES
 #define SS_IDLE 0 /// ain't doing shit.
 #define SS_QUEUED 1 /// queued to run

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -336,4 +336,4 @@
 		message = html_encode(message)
 	else
 		message = copytext(message, 2)
-	to_chat(target, custom_boxed_message("purple_box", span_purple("<span class='oocplain'><b>[source]: </b>[message]</span>")))
+	to_chat(target, custom_boxed_message("purple_box", span_purple("<b>[source]: </b>[message]")))

--- a/code/controllers/subsystem/assets.dm
+++ b/code/controllers/subsystem/assets.dm
@@ -23,10 +23,27 @@ SUBSYSTEM_DEF(assets)
 
 
 /datum/controller/subsystem/assets/Initialize()
-	for(var/type in typesof(/datum/asset))
-		var/datum/asset/A = type
-		if (type != initial(A._abstract))
-			load_asset_datum(type)
+	for(var/datum/asset/asset_type as anything in typesof(/datum/asset))
+		if (asset_type == asset_type::_abstract)
+			continue
+
+		if (asset_type::early)
+			continue
+
+		var/pre_init = REALTIMEOFDAY
+		var/list/typepath_split = splittext("[asset_type]", "/")
+		var/typepath_readable = capitalize(replacetext(typepath_split[length(typepath_split)], "_", " "))
+
+		SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='yellow'>CREATING...</font>")
+		if (load_asset_datum(asset_type))
+			var/time = (REALTIMEOFDAY - pre_init) / (1 SECONDS)
+			if(time <= 0.1)
+				SStitle.remove_init_text(asset_type)
+			else
+				SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='green'>DONE</font>", time)
+		else
+			stack_trace("Could not initialize early asset [asset_type]!")
+			SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='red'>FAILED</font>")
 
 	transport.Initialize(cache)
 

--- a/code/controllers/subsystem/early_assets.dm
+++ b/code/controllers/subsystem/early_assets.dm
@@ -16,8 +16,20 @@ SUBSYSTEM_DEF(early_assets)
 		if (!asset_type::early)
 			continue
 
-		if (!load_asset_datum(asset_type))
+		var/pre_init = REALTIMEOFDAY
+		var/list/typepath_split = splittext("[asset_type]", "/")
+		var/typepath_readable = capitalize(replacetext(typepath_split[length(typepath_split)], "_", " "))
+
+		SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='yellow'>CREATING...</font>")
+		if (load_asset_datum(asset_type))
+			var/time = (REALTIMEOFDAY - pre_init) / (1 SECONDS)
+			if(time <= 0.1)
+				SStitle.remove_init_text(asset_type)
+			else
+				SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='green'>DONE</font>", time)
+		else
 			stack_trace("Could not initialize early asset [asset_type]!")
+			SStitle.add_init_text(asset_type, "> [typepath_readable]", "<font color='red'>FAILED</font>")
 
 		CHECK_TICK
 

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -438,6 +438,7 @@ Used by the AI doomsday and the self-destruct nuke.
 
 /datum/controller/subsystem/mapping/proc/LoadStationRooms()
 	var/start_time = REALTIMEOFDAY
+	var/added_text = FALSE
 	for(var/obj/effect/spawner/room/R as() in random_room_spawners)
 		var/list/possibletemplates = list()
 		var/datum/map_template/random_room/candidate
@@ -448,7 +449,10 @@ Used by the AI doomsday and the self-destruct nuke.
 				candidate = null
 				continue
 			possibletemplates[candidate] = candidate.weight
-		if(possibletemplates.len)
+		if(length(possibletemplates))
+			if(!added_text)
+				SStitle.add_init_text("Random Rooms", "> Random Rooms", "<font color='yellow'>LOADING...</font>")
+				added_text = TRUE
 			var/datum/map_template/random_room/template = pick_weight(possibletemplates)
 			template.stock--
 			template.weight = (template.weight / 2)
@@ -459,10 +463,12 @@ Used by the AI doomsday and the self-destruct nuke.
 		SSmapping.random_room_spawners -= R
 		qdel(R)
 	random_room_spawners = null
-	INIT_ANNOUNCE("Loaded Random Rooms in [(REALTIMEOFDAY - start_time)/10]s!")
+	if(added_text)
+		SStitle.add_init_text("Random Rooms", "> Random Rooms", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
 
 /datum/controller/subsystem/mapping/proc/load_random_engines()
 	var/start_time = REALTIMEOFDAY
+	var/added_text = FALSE
 	for(var/obj/effect/spawner/random_engines/engine_spawner as() in random_engine_spawners)
 		var/list/possible_engine_templates = list()
 		var/datum/map_template/random_room/random_engines/engine_candidate
@@ -473,18 +479,23 @@ Used by the AI doomsday and the self-destruct nuke.
 				engine_candidate = null
 				continue
 			possible_engine_templates[engine_candidate] = engine_candidate.weight
-		if(possible_engine_templates.len)
+		if(length(possible_engine_templates))
+			if(!added_text)
+				SStitle.add_init_text("Random Engine", "> Random Engine", "<font color='yellow'>LOADING...</font>")
+				added_text = TRUE
 			var/datum/map_template/random_room/random_engines/template = pick_weight(possible_engine_templates)
 			log_world("Loading random engine template [template.name] ([template.type]) at [AREACOORD(engine_spawner)]")
 			template.stationinitload(get_turf(engine_spawner), centered = template.centerspawner)
 		SSmapping.random_engine_spawners -= engine_spawner
 		qdel(engine_spawner)
+	if(added_text)
+		SStitle.add_init_text("Random Engine", "> Random Engine", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
 	random_engine_spawners = null
-	INIT_ANNOUNCE("Loaded Random Engine in [(REALTIMEOFDAY - start_time)/10]s!")
 
 
 /datum/controller/subsystem/mapping/proc/load_random_bars()
 	var/start_time = REALTIMEOFDAY
+	var/added_text = FALSE
 	for(var/obj/effect/spawner/random_bar/bar_spawner as() in random_bar_spawners)
 		var/list/possible_bar_templates = list()
 		var/datum/map_template/random_room/random_bar/bar_candidate
@@ -495,19 +506,24 @@ Used by the AI doomsday and the self-destruct nuke.
 				bar_candidate = null
 				continue
 			possible_bar_templates[bar_candidate] = bar_candidate.weight
-		if(possible_bar_templates.len)
+		if(length(possible_bar_templates))
+			if(!added_text)
+				SStitle.add_init_text("Random Bar", "> Random Bar", "<font color='yellow'>LOADING...</font>")
+				added_text = TRUE
 			var/datum/map_template/random_room/random_bar/template = pick_weight(possible_bar_templates)
 			log_world("Loading random bar template [template.name] ([template.type]) at [AREACOORD(bar_spawner)]")
 			template.stationinitload(get_turf(bar_spawner), centered = template.centerspawner)
 		SSmapping.random_bar_spawners -= bar_spawner
 		qdel(bar_spawner)
+	if(added_text)
+		SStitle.add_init_text("Random Bar", "> Random Bar", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
 	random_bar_spawners = null
-	INIT_ANNOUNCE("Loaded Random Bars in [(REALTIMEOFDAY - start_time)/10]s!")
 
 /datum/controller/subsystem/mapping/proc/load_random_arena()
 	var/start_time = REALTIMEOFDAY
+	SStitle.add_init_text("Random Arena", "> Random Arena", "<font color='yellow'>LOADING...</font>")
 	GLOB.ghost_arena.spawn_random_arena(init = TRUE)
-	INIT_ANNOUNCE("Loaded Random Arenas in [(REALTIMEOFDAY - start_time) / 10]s!")
+	SStitle.add_init_text("Random Arena", "> Random Arena", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
 /// New Random Bars and Engines Spawning - MonkeStation Edit End
 
 /datum/controller/subsystem/mapping/proc/loadWorld()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -200,6 +200,7 @@ SUBSYSTEM_DEF(ticker)
 			send2chat(new /datum/tgs_message_content("New round starting on [SSmapping.current_map.map_name]!"), CONFIG_GET(string/channel_announce_new_game))
 			current_state = GAME_STATE_PREGAME
 			SEND_SIGNAL(src, COMSIG_TICKER_ENTER_PREGAME)
+			SStitle.update_init_text()
 			// MONKESTATION EDIT START - lobby notices
 			if (length(config.lobby_notices))
 				config.ShowLobbyNotices(world)
@@ -229,6 +230,7 @@ SUBSYSTEM_DEF(ticker)
 			if(timeLeft <= 300 && !tipped)
 				send_tip_of_the_round(world, selected_tip)
 				tipped = TRUE
+				SStitle.update_init_text()
 
 			if(timeLeft <= 0)
 				SEND_SIGNAL(src, COMSIG_TICKER_ENTER_SETTING_UP)

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -3,11 +3,23 @@ SUBSYSTEM_DEF(title)
 	flags = SS_NO_FIRE
 	init_order = INIT_ORDER_TITLE
 	init_stage = INITSTAGE_EARLY
-
+	/// The path to the title screen image
 	var/file_path
+	/// The icon to use for the title screen
 	var/icon/icon
+	/// The previous title screen icon (from the last round)
 	var/icon/previous_icon
+	/// Reference to the turf in the lobby, which is where we hold the title screen
 	var/turf/closed/indestructible/splashscreen/splash_turf
+	/// A holder for maptext that displays initialization information on the title screen
+	var/obj/effect/abstract/init_order_holder/maptext_holder
+
+	/// A list of initialization information
+	var/list/init_infos = list()
+	/// Tracks the number of dots to display
+	var/num_dots = 1
+	/// The total time taken to initialize the game
+	var/total_init_time = -1
 
 /datum/controller/subsystem/title/Initialize()
 	if(file_path && icon)
@@ -25,7 +37,7 @@ SUBSYSTEM_DEF(title)
 
 	for(var/S in provisional_title_screens)
 		var/list/L = splittext(S,"+")
-		if((L.len == 1 && (L[1] != "exclude" && L[1] != "blank.png")) || (L.len > 1 && ((use_rare_screens && lowertext(L[1]) == "rare") || (lowertext(L[1]) == lowertext(SSmapping.current_map.map_name)))))
+		if((length(L) == 1 && (L[1] != "exclude" && L[1] != "blank.png")) || (L.len > 1 && ((use_rare_screens && lowertext(L[1]) == "rare") || (lowertext(L[1]) == lowertext(SSmapping.current_map.map_name)))))
 			title_screens += S
 
 	if(length(title_screens))
@@ -60,7 +72,7 @@ SUBSYSTEM_DEF(title)
 	for(var/thing in GLOB.clients)
 		if(!thing)
 			continue
-		var/atom/movable/screen/splash/S = new(null, null, thing, FALSE)
+		var/atom/movable/screen/splash/S = new(thing, FALSE)
 		S.Fade(FALSE,FALSE)
 
 /datum/controller/subsystem/title/Recover()
@@ -68,3 +80,114 @@ SUBSYSTEM_DEF(title)
 	splash_turf = SStitle.splash_turf
 	file_path = SStitle.file_path
 	previous_icon = SStitle.previous_icon
+	init_infos = SStitle.init_infos
+
+#define MAX_INIT_TEXT 40
+
+/**
+ * Adds an entry to the initialization information list
+ *
+ * * init_category: The category of the initialization information - this must be a unique key, such as a typepath.
+ * Tt's not displayed to the player, so don't worry about making it pretty.
+ * * name: The name of the initialization information. This is displayed to the player.
+ * * stage: The "stage" of the initialization information, such as "loading" / "complete" / "failed".
+ * * seconds: The number of seconds this initialization information took. Optional.
+ * * override: If TRUE, this will overwrite any existing entry with the same init_category.
+ * Othewise, it will try to update the existing entry's state and time.
+ * * major_update: Indicates this init text is a major update, which will update a "dot" animation.
+ */
+/datum/controller/subsystem/title/proc/add_init_text(init_category, name, stage, seconds, override = FALSE, major_update = FALSE)
+	if(override || !init_infos[init_category])
+		init_infos[init_category] = list(name, stage, seconds)
+	else
+		init_infos[init_category][2] = stage
+		init_infos[init_category][3] += seconds
+	if(major_update)
+		num_dots = (num_dots % 6 + 1)
+	if(length(init_infos) > MAX_INIT_TEXT)
+		init_infos.Cut(1, length(init_infos) - MAX_INIT_TEXT + 1)
+	update_init_text()
+
+#undef MAX_INIT_TEXT
+
+/// Removes the passed category from the initialization information list
+/datum/controller/subsystem/title/proc/remove_init_text(init_category)
+	init_infos -= init_category
+	update_init_text()
+
+/// Updates the displayed initialization text according to all initialization information
+/datum/controller/subsystem/title/proc/update_init_text()
+	if(!maptext_holder)
+		if(!splash_turf)
+			return
+		maptext_holder = new(splash_turf)
+
+	maptext_holder.maptext = "<span class='maptext'>"
+	maptext_holder.maptext += "<span class='big'>"
+	if(SSticker?.current_state == GAME_STATE_PREGAME)
+		var/total_time_formatted = "[total_init_time]s"
+		switch(total_init_time)
+			if(0 to 60)
+				total_time_formatted = "<font color='green'>[total_init_time]s</font>"
+			if(60 to 120)
+				total_time_formatted = "<font color='yellow'>[total_init_time]s</font>"
+			if(120 to INFINITY)
+				total_time_formatted = "<font color='red'>[total_init_time]s</font>"
+
+		maptext_holder.maptext += "Game Ready! ([total_time_formatted])"
+	else
+		maptext_holder.maptext += "Initializing game"
+		for(var/i in 1 to num_dots)
+			maptext_holder.maptext += "."
+	maptext_holder.maptext += "</span><br>"
+	for(var/sstype in init_infos)
+		var/list/init_data = init_infos[sstype]
+		var/init_name = init_data[1]
+		var/init_stage = init_data[2]
+		var/init_time = isnum(init_data[3]) ? "([init_data[3]]s)" : ""
+		maptext_holder.maptext += "<br>[init_name] [init_stage] [init_time]"
+	maptext_holder.maptext += "<br></span>"
+
+/// Simply fades out the initialization text
+/datum/controller/subsystem/title/proc/fade_init_text()
+	update_init_text()
+	animate(maptext_holder, alpha = 0, time = 8 SECONDS)
+
+/// Abstract holder for maptext on the lobby screen
+/obj/effect/abstract/init_order_holder
+	icon = null
+	icon_state = null
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	maptext_height = 500
+	maptext_width = 200
+	maptext_x = 12
+	maptext_y = 12
+	plane = SPLASHSCREEN_PLANE
+	pixel_x = -64
+	/// Conceals the holder from clients who don't want to see it
+	var/image/hide_me
+
+/obj/effect/abstract/init_order_holder/Initialize(mapload)
+	. = ..()
+	for(var/mob/dead/new_player/lobby_goer as anything in GLOB.new_player_list)
+		check_client(lobby_goer.client)
+
+/// Check if the client should see or should not see the initialization information. Updates accordingly.
+/obj/effect/abstract/init_order_holder/proc/check_client(client/seer)
+	if(isnull(seer))
+		return
+	if(!seer.prefs.read_preference(/datum/preference/toggle/show_init_stats))
+		hide_from_client(seer)
+		return
+	show_to_client(seer)
+
+/// Hides the initialization information from the client
+/obj/effect/abstract/init_order_holder/proc/hide_from_client(client/seer)
+	if(isnull(hide_me))
+		hide_me = image(loc = src)
+		hide_me.override = TRUE
+	seer?.images |= hide_me
+
+/// Shows the initialization information to the client (if already hidden, otherwise nothing happens)
+/obj/effect/abstract/init_order_holder/proc/show_to_client(client/seer)
+	seer?.images -= hide_me

--- a/code/datums/mapgen/CaveGenerator.dm
+++ b/code/datums/mapgen/CaveGenerator.dm
@@ -111,6 +111,7 @@
 		return generate_terrain_with_biomes(turfs, generate_in)
 
 	var/start_time = REALTIMEOFDAY
+	SStitle.add_init_text("[type]gen", "> [name]: Generation", "<font color='yellow'>LOADING</font>")
 	string_gen = rustg_cnoise_generate("[initial_closed_chance]", "[smoothing_iterations]", "[birth_limit]", "[death_limit]", "[world.maxx]", "[world.maxy]") //Generate the raw CA data
 
 	for(var/turf/gen_turf as anything in turfs) //Go through all the turfs and generate them
@@ -125,9 +126,8 @@
 		if(gen_turf.turf_flags & NO_RUINS)
 			new_turf.turf_flags |= NO_RUINS
 
-	var/message = "[name] terrain generation finished in [(REALTIMEOFDAY - start_time)/10]s!"
-	to_chat(world, span_boldannounce("[message]"))
-	log_world(message)
+	SStitle.add_init_text("[type]gen", "> [name]: Generation", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
+	log_world("[name] terrain generation finished in [(REALTIMEOFDAY - start_time)/10]s!")
 
 
 /**
@@ -217,6 +217,7 @@
 	var/mobs_allowed = (generate_in.area_flags & MOB_SPAWN_ALLOWED) && length(mob_spawn_list)
 	var/megas_allowed = (generate_in.area_flags & MEGAFAUNA_SPAWN_ALLOWED) && length(megafauna_spawn_list)
 
+	SStitle.add_init_text("[type]fill", "> [name]: Population", "<font color='yellow'>LOADING</font>")
 	var/start_time = REALTIMEOFDAY
 	SSore_generation.ore_vent_minerals = (SSore_generation.ore_vent_minerals_default).Copy()
 
@@ -296,9 +297,8 @@
 				spawned_something = TRUE
 		CHECK_TICK
 
-	var/message = "[name] terrain population finished in [(REALTIMEOFDAY - start_time)/10]s!"
-	to_chat(world, span_boldannounce("[message]"))
-	log_world(message)
+	SStitle.add_init_text("[type]fill", "> [name]: Population", "<font color='green'>DONE</font>", (REALTIMEOFDAY - start_time) / (1 SECONDS))
+	log_world("[name] terrain population finished in [(REALTIMEOFDAY - start_time)/10]s!")
 
 
 /**

--- a/code/modules/client/preferences/init_stats.dm
+++ b/code/modules/client/preferences/init_stats.dm
@@ -1,0 +1,9 @@
+/datum/preference/toggle/show_init_stats
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "show_init_stats"
+	savefile_identifier = PREFERENCE_PLAYER
+	default_value = TRUE
+
+/datum/preference/toggle/show_init_stats/apply_to_client_updated(client/client, value)
+	if(isnewplayer(client.mob))
+		SStitle?.maptext_holder?.check_client(client)

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -71,6 +71,7 @@
 		return FALSE
 
 	if(SSticker.current_state < GAME_STATE_SETTING_UP)
+		SStitle?.maptext_holder?.check_client(client)
 		var/tl = SSticker.GetTimeLeft()
 		to_chat(src, "Please set up your character and select \"Ready\". The game will start [tl > 0 ? "in about [DisplayTimeText(tl)]" : "soon"].")
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3651,6 +3651,7 @@
 #include "code\modules\client\preferences\glasses.dm"
 #include "code\modules\client\preferences\heterochromatic.dm"
 #include "code\modules\client\preferences\hotkeys.dm"
+#include "code\modules\client\preferences\init_stats.dm"
 #include "code\modules\client\preferences\item_outlines.dm"
 #include "code\modules\client\preferences\jobless_role.dm"
 #include "code\modules\client\preferences\language.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/init_stats.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/init_stats.tsx
@@ -1,0 +1,9 @@
+import { CheckboxInput, FeatureToggle } from '../base';
+
+export const show_init_stats: FeatureToggle = {
+  name: 'Enable Lobby Game Stats',
+  category: 'UI',
+  description:
+    'When enabled, the lobby screen will report how long game set up is taking.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/MrMelbert/MapleStationCode/pull/656

> Init time is displayed on text that scrolls on the left side of the lobby screen
> 
> The text will fade out 30 seconds to roundstart
> 
> There is also a preference to hide it entirely, so you can enjoy the lobby art.


<img width="1708" height="1349" alt="2025-07-25 (1753494465) ~ dreamseeker" src="https://github.com/user-attachments/assets/9befd453-18d3-457e-9858-86a657f877b9" />

<img width="501" height="697" alt="2025-07-25 (1753494521) ~ dreamseeker" src="https://github.com/user-attachments/assets/b9255cef-209b-43e9-add6-44a6e1288ece" />

## Why It's Good For The Game

it looks nice

## Changelog