### PR TITLE
Adds a new alternate job title for xenobiologist

### DIFF
--- a/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
+++ b/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
@@ -404,4 +404,5 @@
 		"Xenobiologist",
 		"Cytologist",
 		"Cryptozoologist",
+		"Slime Mage",
 	)

--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -316,6 +316,7 @@ const ALTTITLES = {
   // Xenobiologist -
   Cytologist: BASEICONS['Xenobiologist'],
   Cryptozoologist: BASEICONS['Xenobiologist'],
+  'Slime Mage': BASEICONS['Xenobiologist'],
 } as const;
 
 // Combine the Base icons and ALt titles


### PR DESCRIPTION

## About The Pull Request

this simply adds a new alternate job title for xenobiologist, "Slime Mage"

pooba seemed to think it was good so I'm PRing it

## Why It's Good For The Game

xenobiology is just NT-approved magic masquerading as science and I will die on that hill.

## Changelog
:cl:
add: Added a new alternate job title for xenobiologist: "Slime Mage"
/:cl:
