### PR TITLE
makes cut cable pieces visible again + minor changes to ks13

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
+++ b/_maps/RandomRuins/SpaceRuins/russian_derelict.dmm
@@ -122,9 +122,11 @@
 	},
 /area/ruin/space/ks13/service/chapel)
 "aF" = (
-/obj/machinery/door/window/left/directional/east,
+/obj/machinery/door/window/left/directional/east{
+	name = "Engineering Storage";
+	req_access = list("engineering","atmospherics")
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/engine_storage)
@@ -403,7 +405,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/button/door/directional/east{
 	id = "derelict_aux1";
-	req_access = list("engineering")
+	req_access = list("engineering","atmospherics")
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/monke/engineering/aux_engine)
@@ -412,6 +414,12 @@
 /obj/item/paper/crumpled,
 /turf/open/floor/iron,
 /area/ruin/space/ks13/command/bridge)
+"do" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/structure/cable,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/monke/engineering/escape_pod_bay)
 "ds" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/cable,
@@ -515,9 +523,11 @@
 /turf/open/floor/plating,
 /area/ruin/space/ks13/command/bridge_hall)
 "eb" = (
-/obj/machinery/door/window/right/directional/south,
+/obj/machinery/door/window/right/directional/south{
+	name = "Engineering Storage";
+	req_access = list("engineering","atmospherics")
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/engine_storage)
 "ec" = (
@@ -558,6 +568,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/engine_gas_storage)
+"es" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/monke/engineering/engine_room)
 "et" = (
 /obj/effect/gibspawner/generic,
 /turf/open/floor/iron/airless,
@@ -626,9 +641,11 @@
 /turf/open/floor/iron,
 /area/ruin/space/ks13/hallway/starboard_bow)
 "eR" = (
-/obj/machinery/door/window/brigdoor/left/directional/east,
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	req_access = list("engineering","atmospherics")
+	},
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/monke/engineering/engine_hallway)
 "eV" = (
@@ -666,6 +683,9 @@
 /obj/effect/spawner/random/trash/garbage,
 /obj/machinery/light/broken/directional/west,
 /turf/open/floor/plating/airless,
+/area/ruin/space/ks13/monke/engineering/engine_hallway)
+"fj" = (
+/turf/template_noop,
 /area/ruin/space/ks13/monke/engineering/engine_hallway)
 "fm" = (
 /obj/structure/table,
@@ -916,9 +936,11 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/engineering/atmos)
 "hU" = (
-/obj/machinery/door/window/brigdoor/left/directional/east,
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	name = "Auxiliary Engine";
+	req_access = list("engineering","atmospherics")
+	},
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/aux_engine)
 "hW" = (
@@ -1000,8 +1022,10 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/repair_bay)
 "in" = (
-/obj/machinery/door/window/brigdoor/left/directional/south,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	name = "Gas Storage";
+	req_access = list("engineering","atmospherics")
+	},
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/engine_gas_storage)
@@ -1033,6 +1057,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/security/court_hall)
+"iJ" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/monke/engineering/engine_control_room)
 "iM" = (
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/cable,
@@ -1118,9 +1147,10 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/science/rnd)
 "jj" = (
-/obj/machinery/door/window/brigdoor/left/directional/east,
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	req_access = list("engineering","atmospherics")
+	},
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/engine_control_room)
@@ -1132,6 +1162,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/grav_gen)
+"jv" = (
+/obj/structure/lattice,
+/obj/item/stack/cable_coil/cut,
+/turf/template_noop,
+/area/ruin/space/ks13/monke/engineering/engine_room)
 "jO" = (
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/iron/airless,
@@ -1373,6 +1408,7 @@
 "lV" = (
 /obj/structure/lattice,
 /obj/effect/spawner/random/maintenance,
+/obj/item/stack/cable_coil/cut,
 /turf/template_noop,
 /area/space/nearstation)
 "lW" = (
@@ -1687,6 +1723,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/hallway/aft)
+"oN" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/service/jani)
 "oO" = (
 /obj/effect/mob_spawn/corpse/human/clown,
 /turf/template_noop,
@@ -1949,10 +1991,10 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/hallway/central)
 "pV" = (
-/obj/machinery/door/airlock/external/ruin{
-	name = "External Engineering"
-	},
 /obj/structure/cable,
+/obj/machinery/door/airlock/external/ruin{
+	name = "Escape Pod Bay"
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/monke/engineering/escape_pod_bay)
 "pW" = (
@@ -2619,6 +2661,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/hallway/central)
+"tk" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/monke/engineering/engine_hallway)
 "tl" = (
 /obj/structure/table_frame/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -2708,7 +2755,9 @@
 /area/ruin/space/ks13/hallway/aft)
 "tJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator"
+	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/iron/airless,
@@ -3132,6 +3181,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/service/hydro)
+"wa" = (
+/obj/item/stack/cable_coil/cut,
+/turf/template_noop,
+/area/ruin/space/ks13/monke/engineering/engine_room)
 "wb" = (
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
@@ -3578,7 +3631,9 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/monke/engineering/engine_control_room)
 "ye" = (
-/obj/machinery/door/window/left/directional/east,
+/obj/machinery/door/window/left/directional/east{
+	name = "Escape Pod Three"
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/airless,
 /area/ruin/space/ks13/monke/engineering/escape_pod_bay)
@@ -3637,9 +3692,11 @@
 /turf/closed/wall,
 /area/ruin/space/ks13/medical/morgue)
 "ys" = (
-/obj/machinery/door/window/brigdoor/left/directional/east,
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	name = "Engine Room";
+	req_access = list("engineering","atmospherics")
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/engine_room)
@@ -3732,9 +3789,10 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/engineering/aft_solars_control)
 "yJ" = (
-/obj/machinery/door/window/brigdoor/left/directional/east,
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	req_access = list("engineering","atmospherics")
+	},
 /obj/effect/mapping_helpers/broken_floor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/hallway/central)
 "yK" = (
@@ -3911,8 +3969,10 @@
 "zB" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/cable,
-/obj/machinery/door/window/brigdoor/left/directional/south,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/window/brigdoor/left/directional/south{
+	name = "Engine Room";
+	req_access = list("engineering","atmospherics")
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/monke/engineering/repair_bay)
 "zC" = (
@@ -3962,7 +4022,9 @@
 /turf/template_noop,
 /area/ruin/space/ks13/monke/engineering/engine_room)
 "zP" = (
-/obj/machinery/door/window/left/directional/east,
+/obj/machinery/door/window/left/directional/east{
+	name = "Escape Pod Bay"
+	},
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
@@ -4395,7 +4457,9 @@
 /turf/open/floor/plating,
 /area/ruin/space/ks13/command/bridge)
 "BS" = (
-/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/airlock/engineering{
+	name = "Auxiliary Engine"
+	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
@@ -4521,6 +4585,13 @@
 "Cy" = (
 /turf/closed/wall/r_wall,
 /area/ruin/space/ks13/science/rnd)
+"CA" = (
+/obj/machinery/door/window/left/directional/east{
+	name = "Escape Pod Two"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/airless,
+/area/ruin/space/ks13/monke/engineering/escape_pod_bay)
 "CC" = (
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -4535,7 +4606,7 @@
 /area/ruin/space/ks13/monke/engineering/engine_room)
 "CH" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "External Engineering"
+	name = "Escape Pod Bay"
 	},
 /obj/effect/mapping_helpers/burnt_floor,
 /obj/structure/cable,
@@ -4551,7 +4622,9 @@
 /area/ruin/space/ks13/security/sec)
 "CK" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator"
+	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -5399,6 +5472,13 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/engine_control_room)
+"GG" = (
+/obj/machinery/door/window/left/directional/east{
+	name = "Escape Pod One"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine/airless,
+/area/ruin/space/ks13/monke/engineering/escape_pod_bay)
 "GH" = (
 /obj/structure/table_frame,
 /obj/effect/decal/cleanable/dirt,
@@ -5948,8 +6028,9 @@
 /turf/closed/wall,
 /area/ruin/space/ks13/dorms)
 "Js" = (
-/turf/template_noop,
-/area/ruin/space/ks13/dorms)
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/monke/engineering/engine_hallway)
 "Jt" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -6503,7 +6584,9 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/service/bar)
 "Mw" = (
-/obj/machinery/door/window/left/directional/east,
+/obj/machinery/door/window/left/directional/east{
+	req_access = list("engineering","atmospherics")
+	},
 /obj/effect/mapping_helpers/broken_floor,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
@@ -6718,9 +6801,11 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/service/bar)
 "Nu" = (
-/obj/machinery/door/window/brigdoor/left/directional/east,
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	name = "Auxiliary Engine";
+	req_access = list("engineering","atmospherics")
+	},
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/aux_engine)
@@ -6779,7 +6864,7 @@
 /obj/machinery/light/small/directional/north,
 /obj/machinery/button/door/directional/north{
 	id = "derelict_ex";
-	req_access = list("engineering")
+	req_access = list("engineering","atmospherics")
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/engine_control_room)
@@ -6929,6 +7014,7 @@
 "Ou" = (
 /obj/machinery/light/broken/directional/north,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/science/genetics)
 "Ov" = (
@@ -6945,6 +7031,11 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/security/sec)
+"Oz" = (
+/obj/effect/mapping_helpers/broken_floor,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/iron/airless,
+/area/ruin/space/ks13/monke/engineering/engine_control_room)
 "OA" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -7216,7 +7307,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/ks13/medical/morgue)
 "PG" = (
-/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering"
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating/airless,
@@ -7338,6 +7431,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/science/ordnance_hall)
+"Qj" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/monke/engineering/engine_hallway)
 "Qm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -7647,8 +7745,9 @@
 /turf/open/floor/iron/dark,
 /area/ruin/space/ks13/medical/morgue)
 "RI" = (
-/obj/machinery/door/window/brigdoor/left/directional/east,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/window/brigdoor/left/directional/east{
+	req_access = list("engineering","atmospherics")
+	},
 /turf/open/floor/engine/airless,
 /area/ruin/space/ks13/monke/engineering/aux_engine)
 "RJ" = (
@@ -7787,9 +7886,11 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/science/rnd)
 "Sn" = (
-/obj/machinery/door/window/brigdoor/right/directional/west,
+/obj/machinery/door/window/brigdoor/right/directional/west{
+	name = "Engineering";
+	req_access = list("engineering","atmospherics")
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/escape_pod_bay)
@@ -8499,7 +8600,7 @@
 /area/ruin/space/ks13/security/sec)
 "Vo" = (
 /obj/machinery/door/airlock/external/ruin{
-	name = "External Engineering"
+	name = "Repair Bay"
 	},
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
@@ -8668,9 +8769,11 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/medical/medbay)
 "Wk" = (
-/obj/machinery/door/window/brigdoor/right/directional/east,
+/obj/machinery/door/window/brigdoor/right/directional/east{
+	name = "Tech Storage";
+	req_access = list("engineering","atmospherics")
+	},
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/engine_gas_storage)
@@ -8753,8 +8856,10 @@
 /area/ruin/space/ks13/medical/medbay)
 "WF" = (
 /obj/effect/mapping_helpers/broken_floor,
-/obj/machinery/door/window/brigdoor/left/directional/west,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/window/brigdoor/left/directional/west{
+	name = "Secure Storage";
+	req_access = list("engineering","atmospherics")
+	},
 /obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/ruin/space/ks13/monke/engineering/engine_gas_storage)
@@ -8914,7 +9019,9 @@
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/service/cafe)
 "Xt" = (
-/obj/machinery/door/window/left/directional/east,
+/obj/machinery/door/window/left/directional/east{
+	name = "Escape Pod Four"
+	},
 /obj/item/screwdriver{
 	pixel_y = 8;
 	pixel_x = -3
@@ -8941,7 +9048,9 @@
 	},
 /area/ruin/space/ks13/engineering/atmos)
 "Xx" = (
-/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering"
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
@@ -9037,9 +9146,10 @@
 /turf/open/floor/iron,
 /area/ruin/space/ks13/command/bridge)
 "Yb" = (
-/obj/machinery/door/window/left/directional/south,
+/obj/machinery/door/window/left/directional/south{
+	req_access = list("engineering","atmospherics")
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ks13/monke/engineering/engine_storage)
@@ -9077,6 +9187,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/ks13/science/ordnance)
+"Yj" = (
+/obj/structure/frame/machine,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/item/stack/cable_coil/cut,
+/turf/open/floor/plating/airless,
+/area/ruin/space/ks13/monke/engineering/engine_room)
 "Yk" = (
 /turf/open/floor/engine/airless,
 /area/ruin/space/ks13/science/ordnance)
@@ -11015,7 +11131,7 @@ wc
 Tk
 wc
 wc
-Js
+aa
 aa
 aa
 aa
@@ -12122,9 +12238,9 @@ md
 wK
 NC
 cy
-ye
+GG
 Us
-ye
+CA
 Us
 ye
 Us
@@ -12226,7 +12342,7 @@ FS
 FS
 FS
 zO
-yu
+es
 II
 qW
 zB
@@ -12238,7 +12354,7 @@ Vo
 Ch
 pi
 FV
-pi
+do
 HO
 HO
 FV
@@ -12450,7 +12566,7 @@ aa
 FS
 zO
 FS
-zO
+jv
 iV
 yu
 PK
@@ -12558,8 +12674,8 @@ rk
 aa
 rk
 lG
-aa
-aa
+fj
+fj
 FS
 FS
 GC
@@ -12672,12 +12788,12 @@ aa
 rk
 Vi
 MZ
-aa
+fj
 FS
 zO
 zO
 yu
-yu
+es
 yu
 PK
 XT
@@ -12785,8 +12901,8 @@ rk
 rk
 Vi
 lG
-aa
-FS
+fj
+wa
 zO
 yu
 yu
@@ -12902,7 +13018,7 @@ lG
 zO
 zO
 iV
-iV
+Yj
 yu
 PK
 Fy
@@ -13372,7 +13488,7 @@ df
 rT
 gD
 nr
-IY
+tk
 aa
 MG
 MG
@@ -13928,7 +14044,7 @@ gD
 hx
 rT
 lg
-lg
+Oz
 sZ
 hx
 hx
@@ -14039,7 +14155,7 @@ kI
 Fp
 gD
 hx
-rT
+iJ
 lg
 ds
 ds
@@ -14388,7 +14504,7 @@ Qg
 Qg
 fg
 IY
-lG
+Qj
 VU
 aa
 wH
@@ -14599,7 +14715,7 @@ qz
 MH
 FH
 iO
-ex
+Js
 kI
 Qg
 ij
@@ -14613,14 +14729,14 @@ ky
 MS
 lq
 Sr
-IY
+tk
 MZ
 VU
 aa
 wH
 Tq
 AR
-rF
+oN
 yb
 wH
 Hk

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -641,9 +641,6 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(/obj/structure/gri
 
 /obj/item/stack/cable_coil/cut
 	amount = null
-	icon_state = "coil2"
-	worn_icon_state = "coil"
-	base_icon_state = "coil2"
 
 /obj/item/stack/cable_coil/cut/Initialize(mapload, new_amount, merge = TRUE, list/mat_override=null, mat_amt=1)
 	if(!amount)


### PR DESCRIPTION
## About The Pull Request

makes the cut cable coils visible again
names some of ks13's airlocks
fixes the access on the windoors in ks13's engineering
adds cut cables to ks13's engineering
very minor changes to areas on ks13

## Why It's Good For The Game

invisible cables bad
mapping mistakes bad

## Changelog

:cl:
fix: Cut cable pieces on maps like KS13 (The Derelict) are no longer invisible.
map: Most airlocks in KS13's engineering are now named.
fix: Fixed access on the windoors in KS13's engineering.
map: Added cut cables to KS13's engineering.
map: Very minor change to KS13's engineering hallway area.
/:cl:
