### PR TITLE
Renames the patho splicer's "Target stage" function

### DIFF
--- a/monkestation/code/modules/virology/machines/splicer.dm
+++ b/monkestation/code/modules/virology/machines/splicer.dm
@@ -19,7 +19,7 @@
 	var/scanning = 0 // Time in process ticks until scan is over
 	var/spliced = FALSE // If at least one effect has been spliced into the current dish this is TRUE
 
-	///the stage we are set to grab from
+	///the slot we are set to grab from
 	var/target_slot = 1
 	idle_power_usage = 100
 	active_power_usage = 600

--- a/monkestation/code/modules/virology/machines/splicer.dm
+++ b/monkestation/code/modules/virology/machines/splicer.dm
@@ -20,7 +20,7 @@
 	var/spliced = FALSE // If at least one effect has been spliced into the current dish this is TRUE
 
 	///the stage we are set to grab from
-	var/target_stage = 1
+	var/target_slot = 1
 	idle_power_usage = 100
 	active_power_usage = 600
 
@@ -65,7 +65,7 @@
 		"splicing" = splicing,
 		"scanning" = scanning,
 		"burning" = burning,
-		"target_stage" = target_stage,
+		"target_slot" = target_slot,
 	)
 
 	if(dish)
@@ -167,7 +167,7 @@
 
 	var/list/effects = dish.contained_virus.symptoms
 	for(var/x = 1 to length(effects))
-		if(x == target_stage)
+		if(x == target_slot)
 			var/datum/symptom/e = effects[x]
 			effects[x] = memorybank.Copy(dish.contained_virus)
 			dish.contained_virus.log += "<br />[ROUND_TIME()] [memorybank.name] spliced in by [key_name(usr)] (replaces [e.name])"
@@ -177,7 +177,7 @@
 	spliced = TRUE
 	update_icon()
 
-/obj/machinery/computer/diseasesplicer/proc/dish2buffer(target_stage)
+/obj/machinery/computer/diseasesplicer/proc/dish2buffer(target_slot)
 	if(!dish?.contained_virus)
 		return
 	if(dish.growth < 50)
@@ -185,7 +185,7 @@
 	var/list/effects = dish.contained_virus.symptoms
 	for(var/x = 1 to effects.len)
 		var/datum/symptom/e = effects[x]
-		if(e.stage == target_stage)
+		if(e.stage == target_slot)
 			memorybank = e
 			break
 	scanning = DISEASE_SPLICER_SCANNING_TICKS
@@ -239,7 +239,7 @@
 			update_appearance()
 			return TRUE
 		if("dish_effect_to_buffer")
-			dish2buffer(target_stage)
+			dish2buffer(target_slot)
 			return TRUE
 		if("splice_buffer_to_dish")
 			buffer2dish()
@@ -247,8 +247,8 @@
 		if("burn_buffer_to_disk")
 			burning = DISEASE_SPLICER_BURNING_TICKS
 			return TRUE
-		if("target_stage")
-			target_stage = params["stage"]
+		if("target_slot")
+			target_slot = params["stage"]
 	return FALSE
 
 #undef DISEASE_SPLICER_BURNING_TICKS

--- a/tgui/packages/tgui/interfaces/DiseaseSplicer.jsx
+++ b/tgui/packages/tgui/interfaces/DiseaseSplicer.jsx
@@ -19,7 +19,7 @@ export const DiseaseSplicer = (props) => {
     dish_name,
     memorybank,
     dish_error,
-    target_stage,
+    target_slot,
   } = data;
   return (
     <Window width={475} height={300}>
@@ -79,18 +79,18 @@ export const DiseaseSplicer = (props) => {
                 />
               </LabeledList.Item>
             )}
-            <LabeledList.Item label={'Targeted Stage'}>
+            <LabeledList.Item label={'Targeted Slot'}>
               <Slider
                 width="70%"
                 minValue={1}
                 maxValue={4}
                 step={1}
                 stepPixelSize={50}
-                value={target_stage}
-                onDrag={(e, stage) => act('target_stage', { stage })}
-                onChange={(e, stage) => act('target_stage', { stage })}
+                value={target_slot}
+                onDrag={(e, stage) => act('target_slot', { stage })}
+                onChange={(e, stage) => act('target_slot', { stage })}
               >
-                {target_stage}
+                {target_slot}
               </Slider>
               <Button
                 color="green"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Renames "target stage" in the disease splicer to "target slot"
<img width="475" height="300" alt="Summer City 8 7_28_2025 4_59_28 PM" src="https://github.com/user-attachments/assets/125891b7-9f26-44ef-99cd-a2921ca8e34b" />

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The current name suggest that you are targeting symptoms with the selected stage, when you are actually choosing which symptom slot to modify. Renaming it will make it much clearer, making patho easier for newer players.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
spellcheck: Renamed "Target stage" in the disease splicer to "Target slot".
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
