### PR TITLE
[PORT] Fixed false anomaly announcements

### DIFF
--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -28,6 +28,7 @@
 
 //monkestation edit note: this list was out dated due to TG not using it so I put all the pirate types in it
 /datum/round_event/pirates
+	fakeable = FALSE
 	///admin chosen pirate team
 	var/list/datum/pirate_gang/gang_list
 

--- a/code/modules/events/anomaly/_anomaly.dm
+++ b/code/modules/events/anomaly/_anomaly.dm
@@ -27,6 +27,8 @@
 	setup = TRUE //MONKESTATION ADDITION
 
 /datum/round_event/anomaly/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Energetic flux wave detected on [ANOMALY_ANNOUNCE_DANGEROUS_TEXT] [impact_area.name].", "Anomaly Alert")
 
 /datum/round_event/anomaly/start()

--- a/code/modules/events/anomaly/anomaly_bioscrambler.dm
+++ b/code/modules/events/anomaly/anomaly_bioscrambler.dm
@@ -15,4 +15,6 @@
 	anomaly_path = /obj/effect/anomaly/bioscrambler
 
 /datum/round_event/anomaly/anomaly_bioscrambler/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Biologic limb swapping agent detected on [ANOMALY_ANNOUNCE_MEDIUM_TEXT] [impact_area.name]. Wear biosuits or other protective gear to counter the effects.", "Anomaly Alert") // monke edit: bioscrambler is no longer immortal

--- a/code/modules/events/anomaly/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly/anomaly_bluespace.dm
@@ -14,4 +14,6 @@
 	anomaly_path = /obj/effect/anomaly/bluespace
 
 /datum/round_event/anomaly/anomaly_bluespace/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Bluespace instability detected on [ANOMALY_ANNOUNCE_MEDIUM_TEXT] [impact_area.name].", "Anomaly Alert")

--- a/code/modules/events/anomaly/anomaly_dimensional.dm
+++ b/code/modules/events/anomaly/anomaly_dimensional.dm
@@ -23,6 +23,8 @@
 	new_anomaly.prepare_area(new_theme_path = anomaly_theme)
 
 /datum/round_event/anomaly/anomaly_dimensional/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Dimensional instability detected on [ANOMALY_ANNOUNCE_MEDIUM_TEXT] [impact_area.name].", "Anomaly Alert")
 
 /datum/event_admin_setup/listed_options/anomaly_dimensional

--- a/code/modules/events/anomaly/anomaly_ectoplasm.dm
+++ b/code/modules/events/anomaly/anomaly_ectoplasm.dm
@@ -39,6 +39,8 @@
 		announce_to_ghosts(newAnomaly)
 
 /datum/round_event/anomaly/anomaly_ectoplasm/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Paranormal ectoplasmic outburst detected on [ANOMALY_ANNOUNCE_HARMFUL_TEXT] [impact_area.name].", "Anomaly Alert")
 
 /datum/event_admin_setup/anomaly_ectoplasm

--- a/code/modules/events/anomaly/anomaly_flux.dm
+++ b/code/modules/events/anomaly/anomaly_flux.dm
@@ -16,4 +16,6 @@
 	oshan_blocked = TRUE
 
 /datum/round_event/anomaly/anomaly_flux/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Hyper-energetic flux wave detected on [ANOMALY_ANNOUNCE_DANGEROUS_TEXT]. [impact_area.name].", "Anomaly Alert")

--- a/code/modules/events/anomaly/anomaly_grav.dm
+++ b/code/modules/events/anomaly/anomaly_grav.dm
@@ -27,4 +27,6 @@
 	anomaly_path = /obj/effect/anomaly/grav/high
 
 /datum/round_event/anomaly/anomaly_grav/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Gravitational anomaly detected on [ANOMALY_ANNOUNCE_HARMFUL_TEXT] [impact_area.name].", "Anomaly Alert" , ANNOUNCER_GRANOMALIES)

--- a/code/modules/events/anomaly/anomaly_hallucination.dm
+++ b/code/modules/events/anomaly/anomaly_hallucination.dm
@@ -15,4 +15,6 @@
 	anomaly_path = /obj/effect/anomaly/hallucination
 
 /datum/round_event/anomaly/anomaly_hallucination/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Hallucinatory event [ANOMALY_ANNOUNCE_MEDIUM_TEXT] [impact_area.name].", "Anomaly Alert")

--- a/code/modules/events/anomaly/anomaly_pyro.dm
+++ b/code/modules/events/anomaly/anomaly_pyro.dm
@@ -14,4 +14,6 @@
 	anomaly_path = /obj/effect/anomaly/pyro
 
 /datum/round_event/anomaly/anomaly_pyro/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Pyroclastic anomaly detected on [ANOMALY_ANNOUNCE_HARMFUL_TEXT] [impact_area.name].", "Anomaly Alert")

--- a/code/modules/events/anomaly/anomaly_vortex.dm
+++ b/code/modules/events/anomaly/anomaly_vortex.dm
@@ -16,4 +16,6 @@
 	oshan_blocked = TRUE
 
 /datum/round_event/anomaly/anomaly_vortex/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Localized high-intensity vortex anomaly detected on [ANOMALY_ANNOUNCE_DANGEROUS_TEXT] [impact_area.name]", "Anomaly Alert")

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -98,6 +98,19 @@
 	var/list/afflicted = list()
 
 /datum/round_event/disease_outbreak/announce(fake)
+	if(!illness_type)
+		var/list/virus_candidates = list(
+			/datum/disease/cold,
+			/datum/disease/cold9,
+			/datum/disease/brainrot,
+			/datum/disease/flu,
+			/datum/disease/fluspanish,
+			/// And here are some that will never roll for real, just to mess around.
+			/datum/disease/gastrolosis,
+			/datum/disease/gbs,
+		)
+		var/datum/disease/fake_virus = pick(virus_candidates)
+		illness_type = initial(fake_virus.name)
 	priority_announce("Confirmed outbreak of level 7 viral biohazard aboard [station_name()]. All personnel must contain the outbreak.", "[illness_type] Alert", ANNOUNCER_OUTBREAK7)
 
 /datum/round_event/disease_outbreak/setup()

--- a/code/modules/events/grey_tide.dm
+++ b/code/modules/events/grey_tide.dm
@@ -35,6 +35,8 @@
 		grey_tide_areas += pick_n_take(potential_areas)
 
 /datum/round_event/grey_tide/announce(fake)
+	if(fake)
+		severity = rand(1,3)
 	priority_announce("Gr3y.T1d3 virus detected in [station_name()] secure locking encryption subroutines. Severity level of [severity]. Recommend station AI involvement.", "Security Alert")
 
 /datum/round_event/grey_tide/start()

--- a/code/modules/events/scrubber_clog.dm
+++ b/code/modules/events/scrubber_clog.dm
@@ -25,8 +25,9 @@
 	///Used for tracking if the clog signal should be sent.
 	var/clogged = TRUE
 
-/datum/round_event/scrubber_clog/announce()
-	priority_announce("Minor biological obstruction detected in the ventilation network. Blockage is believed to be in the [get_area_name(scrubber)].", "Custodial Notification")
+/datum/round_event/scrubber_clog/announce(fake)
+	var/area/event_area = fake ? pick(GLOB.teleportlocs) : get_area_name(scrubber)
+	priority_announce("Minor biological obstruction detected in the ventilation network. Blockage is believed to be in the [event_area].", "Custodial Notification")
 
 /datum/round_event/scrubber_clog/setup()
 	scrubber = get_scrubber()
@@ -156,8 +157,9 @@
 	)
 	return pick(mob_list)
 
-/datum/round_event/scrubber_clog/major/announce()
-	priority_announce("Major biological obstruction detected in the ventilation network. Blockage is believed to be in the [get_area_name(scrubber)] area.", "Infestation Alert")
+/datum/round_event/scrubber_clog/major/announce(fake)
+	var/area/event_area = fake ? pick(GLOB.teleportlocs) : get_area_name(scrubber)
+	priority_announce("Major biological obstruction detected in the ventilation network. Blockage is believed to be in the [event_area] area.", "Infestation Alert")
 
 /datum/round_event_control/scrubber_clog/critical
 	name = "Scrubber Clog: Critical"
@@ -177,8 +179,9 @@
 	. = ..()
 	spawn_delay = rand(15,25)
 
-/datum/round_event/scrubber_clog/critical/announce()
-	priority_announce("Potentially hazardous lifesigns detected in the [get_area_name(scrubber)] ventilation network.", "Security Alert")
+/datum/round_event/scrubber_clog/critical/announce(fake)
+	var/area/event_area = fake ? pick(GLOB.teleportlocs) : get_area_name(scrubber)
+	priority_announce("Potentially hazardous lifesigns detected in the [event_area] ventilation network.", "Security Alert")
 
 /datum/round_event/scrubber_clog/critical/get_mob()
 	var/static/list/mob_list = list(
@@ -206,8 +209,9 @@
 	end_when = rand(600, 720)
 	spawn_delay = rand(6, 25) //Wide range, for maximum utility/comedy
 
-/datum/round_event/scrubber_clog/strange/announce()
-	priority_announce("Unusual lifesign readings detected in the [get_area_name(scrubber)] ventilation network.", "Lifesign Alert", ANNOUNCER_ALIENS)
+/datum/round_event/scrubber_clog/strange/announce(fake)
+	var/area/event_area = fake ? pick(GLOB.teleportlocs) : get_area_name(scrubber)
+	priority_announce("Unusual lifesign readings detected in the [event_area] ventilation network.", "Lifesign Alert", ANNOUNCER_ALIENS)
 
 /datum/round_event/scrubber_clog/strange/get_mob()
 	var/static/list/mob_list = list(

--- a/code/modules/events/shuttle_loan/shuttle_loan_event.dm
+++ b/code/modules/events/shuttle_loan/shuttle_loan_event.dm
@@ -40,6 +40,13 @@
 	setup = TRUE
 
 /datum/round_event/shuttle_loan/announce(fake)
+	if(fake)
+		var/datum/shuttle_loan_situation/fake_situation = pick(subtypesof(/datum/shuttle_loan_situation))
+		situation = new fake_situation
+		priority_announce("Cargo: [situation.announcement_text]", situation.sender)
+		qdel(situation)
+		return
+
 	priority_announce("Cargo: [situation.announcement_text]", situation.sender)
 	SSshuttle.shuttle_loan = src
 

--- a/monkestation/code/modules/events/anomaly/anomaly_clown.dm
+++ b/monkestation/code/modules/events/anomaly/anomaly_clown.dm
@@ -17,4 +17,6 @@
 	anomaly_path = /obj/effect/anomaly/clown
 
 /datum/round_event/anomaly/anomaly_clown/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("There should be clowns. Where are the clowns? [impact_area.name]. Send in the clowns.", "Anomaly Alert", SSstation.announcer.get_rand_alert_sound())

--- a/monkestation/code/modules/events/anomaly/anomaly_fluid.dm
+++ b/monkestation/code/modules/events/anomaly/anomaly_fluid.dm
@@ -15,4 +15,6 @@
 	anomaly_path = /obj/effect/anomaly/fluid
 
 /datum/round_event/anomaly/anomaly_fluid/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Fluidic anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", SSstation.announcer.get_rand_alert_sound())

--- a/monkestation/code/modules/events/anomaly/anomaly_frost.dm
+++ b/monkestation/code/modules/events/anomaly/anomaly_frost.dm
@@ -18,4 +18,6 @@
 	anomaly_path = /obj/effect/anomaly/frost
 
 /datum/round_event/anomaly/anomaly_frost/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Frost Anomaly detected in: [impact_area.name]. Brace for the cold.", "Anomaly Alert", 'monkestation/sound/misc/frost_horn.ogg')

--- a/monkestation/code/modules/events/anomaly/anomaly_lifebringer.dm
+++ b/monkestation/code/modules/events/anomaly/anomaly_lifebringer.dm
@@ -1,5 +1,5 @@
 /datum/round_event_control/anomaly/anomaly_lifebringer
-	name = "Anomaly: lifebringer"
+	name = "Anomaly: Lifebringer"
 	description = "Meow"
 	typepath = /datum/round_event/anomaly/anomaly_lifebringer
 
@@ -12,4 +12,6 @@
 	anomaly_path = /obj/effect/anomaly/lifebringer
 
 /datum/round_event/anomaly/anomaly_lifebringer/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Lifebringer anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", SSstation.announcer.get_rand_alert_sound())

--- a/monkestation/code/modules/events/anomaly/anomaly_monkey.dm
+++ b/monkestation/code/modules/events/anomaly/anomaly_monkey.dm
@@ -12,4 +12,6 @@
 	anomaly_path = /obj/effect/anomaly/monkey
 
 /datum/round_event/anomaly/anomaly_monkey/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Random Chimp Event detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", SSstation.announcer.get_rand_alert_sound())

--- a/monkestation/code/modules/events/anomaly/anomaly_radiation.dm
+++ b/monkestation/code/modules/events/anomaly/anomaly_radiation.dm
@@ -17,4 +17,6 @@
 	anomaly_path = /obj/effect/anomaly/radioactive
 
 /datum/round_event/anomaly/anomaly_radiation/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Radioactive anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", SSstation.announcer.get_rand_alert_sound())

--- a/monkestation/code/modules/events/anomaly/anomaly_storm.dm
+++ b/monkestation/code/modules/events/anomaly/anomaly_storm.dm
@@ -17,4 +17,6 @@
 	anomaly_path = /obj/effect/anomaly/storm
 
 /datum/round_event/anomaly/anomaly_storm/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("Powerful Storm anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", SSstation.announcer.get_rand_alert_sound())

--- a/monkestation/code/modules/events/anomaly/anomaly_walterverse.dm
+++ b/monkestation/code/modules/events/anomaly/anomaly_walterverse.dm
@@ -11,4 +11,6 @@
 	anomaly_path = /obj/effect/anomaly/walterverse
 
 /datum/round_event/anomaly/anomaly_walterverse/announce(fake)
+	if(isnull(impact_area))
+		impact_area = placer.findValidArea()
 	priority_announce("The Walterverse has been opened. Expected location: [impact_area.name].", "Anomaly Alert", SSstation.announcer.get_rand_alert_sound())


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/80137
Also prevents false alarm from rolling pirates, because it doesn't do anything (missing `announce` proc).

## Why It's Good For The Game

>Just some quick runtime error I've seen in the runtime viewer.
## Changelog
:cl: leaKsi, Ghommie
fix: False anomaly alarms now work.
/:cl:
