### PR TITLE
Reduces lone op starting/minimum weight

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_authentication_disk.dm
@@ -56,7 +56,7 @@
 	var/turf/new_turf = get_turf(src)
 	var/datum/round_event_control/operative/loneopmode = locate(/datum/round_event_control/operative) in SSgamemode.control
 	if(istype(loneopmode) && loneopmode.occurrences < loneopmode.max_occurrences && prob(loneopmode.get_weight()))
-		loneopmode.weight = max(loneopmode.weight - 1, 1) //monkestation edit: increased minimum to 1
+		loneopmode.weight = max(loneopmode.weight - 1, 0)
 		loneopmode.checks_antag_cap = (loneopmode.get_weight() < 3)
 		if(loneopmode.weight % 5 == 0 && SSticker.totalPlayers > 1)
 			message_admins("[src] is secured (currently in [ADMIN_VERBOSEJMP(new_turf)]). The weight of Lone Operative is now [loneopmode.get_weight()] (base [loneopmode.weight]).")

--- a/code/modules/events/ghost_role/operative.dm
+++ b/code/modules/events/ghost_role/operative.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/operative
 	name = "Lone Operative"
 	typepath = /datum/round_event/ghost_role/operative
-	weight = 1 //its weight is relative to how much stationary and neglected the nuke disk is. See nuclearbomb.dm. Shouldn't be dynamic hijackable. //monkestation edit: changed to 1 to allow it to always have a slim chance to roll
+	weight = 0 //its weight is relative to how much stationary and neglected the nuke disk is. See nuclearbomb.dm. Shouldn't be dynamic hijackable.
 	max_occurrences = 1
 	category = EVENT_CATEGORY_INVASION
 	description = "A single nuclear operative assaults the station."


### PR DESCRIPTION

## About The Pull Request
Reduces the lone op's starting and minimum weight to 0, down from 1
## Why It's Good For The Game
A lone op spawning on low pop is incredibly difficult to deal with, and the original reason the minimum was increased to 1 was as a band-aid fix  to the antag not spawning. Now that their spawning has been fixed, this band-aid solution is no longer needed, and low pop can rest easy (unless they don't get the disk).
## Changelog
:cl:
balance: Lone Op's minimum/starting weight decreased to 0
/:cl:
