### PR TITLE
[Port] Bridge Assistant Axe Delusions

### DIFF
--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -584,7 +584,6 @@ monkestation end */
 /datum/brain_trauma/special/axedoration/on_gain()
 	RegisterSignal(owner, COMSIG_MOB_EQUIPPED_ITEM, PROC_REF(on_equip))
 	RegisterSignal(owner, COMSIG_MOB_UNEQUIPPED_ITEM, PROC_REF(on_unequip))
-	RegisterSignal(owner, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	if(!GLOB.bridge_axe)
 		axe_gone()
 		return ..()
@@ -654,15 +653,6 @@ monkestation end */
 		return
 	to_chat(owner, span_warning("Should I really leave it here?"))
 	owner.add_mood_event("fireaxe", /datum/mood_event/axe_neutral)
-
-/datum/brain_trauma/special/axedoration/proc/on_examine(mob/source, atom/target, list/examine_strings)
-	SIGNAL_HANDLER
-	if(!istype(target, /obj/item/fireaxe))
-		return
-	if(target == GLOB.bridge_axe)
-		examine_strings += span_notice("It's the axe I've sworn to protect.")
-	else
-		examine_strings += span_warning("It's a simulacra, a fake axe made to fool the masses.")
 
 /datum/brain_trauma/special/axedoration/proc/on_axe_attack(obj/item/axe, atom/target, mob/user, click_parameters)
 	SIGNAL_HANDLER

--- a/code/datums/brain_damage/special.dm
+++ b/code/datums/brain_damage/special.dm
@@ -504,3 +504,179 @@ monkestation end */
 		color = "orange",
 	)
 	//MONKESTATION ADDITION END
+
+/datum/brain_trauma/special/axedoration
+	name = "Axe Delusions"
+	desc = "Patient feels an immense sense of duty towards protecting an axe and has hallucinations regarding it."
+	scan_desc = "object attachment"
+	gain_text = span_notice("You feel like protecting the fire axe is one of your greatest duties.")
+	lose_text = span_warning("You feel like you lost your sense of duty.")
+	resilience = TRAUMA_RESILIENCE_ABSOLUTE
+	random_gain = FALSE
+	var/static/list/talk_lines = list(
+		"I'm proud of you.",
+		"I believe in you!",
+		"Do I bother you?",
+		"Praise me!",
+		"Fires burn.",
+		"We made it!",
+		"Mother, my body disgusts me.",
+		"There's a gap where we meet, where I end and you begin.",
+		"Humble yourself.",
+	)
+	var/static/list/hurt_lines = list(
+		"Ow!",
+		"Ouch!",
+		"Ack!",
+		"It burns!",
+		"Stop!",
+		"Arghh!",
+		"Please!",
+		"End it!",
+		"Cease!",
+		"Ah!",
+	)
+
+/datum/brain_trauma/special/axedoration/on_life(seconds_per_tick, times_fired)
+	if(owner.stat != CONSCIOUS)
+		return
+
+	if(!GLOB.bridge_axe)
+		if(SPT_PROB(0.5, seconds_per_tick))
+			to_chat(owner, span_warning("I've failed my duty..."))
+			owner.set_jitter_if_lower(5 SECONDS)
+			owner.set_stutter_if_lower(5 SECONDS)
+			if(SPT_PROB(20, seconds_per_tick))
+				owner.vomit()
+		return
+
+	var/atom/axe_location = get_axe_location()
+	if(!SPT_PROB(1.5, seconds_per_tick))
+		return
+	if(isliving(axe_location))
+		var/mob/living/axe_holder = axe_location
+		if(axe_holder == owner)
+			talk_tuah(pick(talk_lines))
+			return
+		var/datum/job/holder_job = axe_holder.mind?.assigned_role
+		if(holder_job && (/datum/job_department/command in holder_job.departments_list))
+			to_chat(owner, span_notice("I hope the axe is in good hands..."))
+			owner.add_mood_event("fireaxe", /datum/mood_event/axe_neutral)
+			return
+		to_chat(owner, span_warning("You start having a bad feeling..."))
+		owner.add_mood_event("fireaxe", /datum/mood_event/axe_missing)
+		return
+
+	if(!isarea(axe_location))
+		owner.add_mood_event("fireaxe", /datum/mood_event/axe_gone)
+		return
+
+	if(istype(axe_location, /area/station/command))
+		to_chat(owner, span_notice("You feel a sense of relief..."))
+		if(istype(GLOB.bridge_axe.loc, /obj/structure/fireaxecabinet))
+			return
+		owner.add_mood_event("fireaxe", /datum/mood_event/axe_neutral)
+		return
+
+	to_chat(owner, span_warning("You start having a bad feeling..."))
+	owner.add_mood_event("fireaxe", /datum/mood_event/axe_missing)
+
+/datum/brain_trauma/special/axedoration/on_gain()
+	RegisterSignal(owner, COMSIG_MOB_EQUIPPED_ITEM, PROC_REF(on_equip))
+	RegisterSignal(owner, COMSIG_MOB_UNEQUIPPED_ITEM, PROC_REF(on_unequip))
+	RegisterSignal(owner, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+	if(!GLOB.bridge_axe)
+		axe_gone()
+		return ..()
+	RegisterSignal(GLOB.bridge_axe, COMSIG_QDELETING, PROC_REF(axe_gone))
+	if(istype(get_axe_location(), /area/station/command) && istype(GLOB.bridge_axe.loc, /obj/structure/fireaxecabinet))
+		owner.add_mood_event("fireaxe", /datum/mood_event/axe_cabinet)
+	else if(owner.is_holding(GLOB.bridge_axe))
+		on_equip(owner, GLOB.bridge_axe)
+	else
+		owner.add_mood_event("fireaxe", /datum/mood_event/axe_neutral)
+	RegisterSignal(GLOB.bridge_axe, COMSIG_ITEM_AFTERATTACK, PROC_REF(on_axe_attack))
+	return ..()
+
+
+/datum/brain_trauma/special/axedoration/on_lose()
+	owner.clear_mood_event("fireaxe")
+	UnregisterSignal(owner, list(COMSIG_MOB_EQUIPPED_ITEM, COMSIG_MOB_UNEQUIPPED_ITEM, COMSIG_ATOM_EXAMINE))
+	if(GLOB.bridge_axe)
+		UnregisterSignal(GLOB.bridge_axe, COMSIG_ITEM_AFTERATTACK)
+	return ..()
+
+/datum/brain_trauma/special/axedoration/proc/axe_gone(source)
+	SIGNAL_HANDLER
+	to_chat(owner, span_danger("You feel a great disturbance in the force."))
+	owner.add_mood_event("fireaxe", /datum/mood_event/axe_gone)
+	owner.set_jitter_if_lower(15 SECONDS)
+	owner.set_stutter_if_lower(15 SECONDS)
+
+/datum/brain_trauma/special/axedoration/proc/on_equip(source, obj/item/picked_up, slot)
+	SIGNAL_HANDLER
+	if(!istype(picked_up, /obj/item/fireaxe))
+		return
+	owner.set_jitter_if_lower(3 SECONDS)
+	if(picked_up == GLOB.bridge_axe)
+		to_chat(owner, span_hypnophrase("I have it. It's time to put it back."))
+		owner.add_mood_event("fireaxe", /datum/mood_event/axe_held)
+		return
+	ADD_TRAIT(picked_up, TRAIT_NODROP, type)
+	to_chat(owner, span_warning("...This is not the one I'm looking after."))
+	owner.Immobilize(2 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(throw_faker), picked_up), 2 SECONDS)
+
+/datum/brain_trauma/special/axedoration/proc/throw_faker(obj/item/faker)
+	REMOVE_TRAIT(faker, TRAIT_NODROP, type)
+	var/held_index = owner.get_held_index_of_item(faker)
+	if(!held_index)
+		return
+	to_chat(owner, span_warning("Be gone with you."))
+	owner.swap_hand(held_index)
+	var/turf/target_turf = get_ranged_target_turf(owner, owner.dir, faker.throw_range)
+	owner.throw_item(target_turf)
+
+/datum/brain_trauma/special/axedoration/proc/on_unequip(datum/source, obj/item/dropped_item, force, new_location)
+	SIGNAL_HANDLER
+	if(dropped_item != GLOB.bridge_axe)
+		return
+	if(get_axe_location() == owner)
+		return
+	if(istype(new_location, /obj/structure/fireaxecabinet))
+		if(istype(get_area(new_location), /area/station/command))
+			to_chat(owner, span_nicegreen("Ah! Back where it belongs!"))
+			owner.add_mood_event("fireaxe", /datum/mood_event/axe_cabinet)
+			INVOKE_ASYNC(owner, TYPE_PROC_REF(/mob, emote), "smile")
+			return
+		to_chat(owner, span_warning("Leaving it outside of command? Am I sure about that?"))
+		owner.add_mood_event("fireaxe", /datum/mood_event/axe_neutral)
+		return
+	to_chat(owner, span_warning("Should I really leave it here?"))
+	owner.add_mood_event("fireaxe", /datum/mood_event/axe_neutral)
+
+/datum/brain_trauma/special/axedoration/proc/on_examine(mob/source, atom/target, list/examine_strings)
+	SIGNAL_HANDLER
+	if(!istype(target, /obj/item/fireaxe))
+		return
+	if(target == GLOB.bridge_axe)
+		examine_strings += span_notice("It's the axe I've sworn to protect.")
+	else
+		examine_strings += span_warning("It's a simulacra, a fake axe made to fool the masses.")
+
+/datum/brain_trauma/special/axedoration/proc/on_axe_attack(obj/item/axe, atom/target, mob/user, click_parameters)
+	SIGNAL_HANDLER
+	if(user != owner)
+		return
+	talk_tuah(pick(hurt_lines))
+
+/datum/brain_trauma/special/axedoration/proc/talk_tuah(sent_message = "Hello World.")
+	owner.Hear(null, GLOB.bridge_axe, owner.get_selected_language(), sent_message)
+
+/datum/brain_trauma/special/axedoration/proc/get_axe_location()
+	if(!GLOB.bridge_axe)
+		return
+	var/atom/axe_loc = GLOB.bridge_axe.loc
+	while(!ismob(axe_loc) && !isarea(axe_loc) && !isnull(axe_loc))
+		axe_loc = axe_loc.loc
+	return axe_loc

--- a/code/datums/mood_events/axe_events.dm
+++ b/code/datums/mood_events/axe_events.dm
@@ -1,0 +1,20 @@
+
+/datum/mood_event/axe_gone
+	description = "What happened to the axe... Where is it? It can't be..."
+	mood_change = -15
+
+/datum/mood_event/axe_neutral
+	description = "I'm sure the axe is okay."
+	mood_change = 1
+
+/datum/mood_event/axe_cabinet
+	description = "The axe is where it belongs."
+	mood_change = 5
+
+/datum/mood_event/axe_missing
+	description = "The axe, there's something wrong..."
+	mood_change = -5
+
+/datum/mood_event/axe_held
+	description = "I'm not worthy of you, axe. I need to put you back."
+	mood_change = -10

--- a/code/datums/mood_events/axe_events.dm
+++ b/code/datums/mood_events/axe_events.dm
@@ -1,7 +1,7 @@
 
 /datum/mood_event/axe_gone
 	description = "What happened to the axe... Where is it? It can't be..."
-	mood_change = -10
+	mood_change = -4
 
 /datum/mood_event/axe_neutral
 	description = "I'm sure the axe is okay."
@@ -13,8 +13,8 @@
 
 /datum/mood_event/axe_missing
 	description = "The axe, there's something wrong..."
-	mood_change = -5
+	mood_change = -3
 
 /datum/mood_event/axe_held
 	description = "I'm not worthy of you, axe. I need to put you back."
-	mood_change = -5
+	mood_change = -3

--- a/code/datums/mood_events/axe_events.dm
+++ b/code/datums/mood_events/axe_events.dm
@@ -1,7 +1,7 @@
 
 /datum/mood_event/axe_gone
 	description = "What happened to the axe... Where is it? It can't be..."
-	mood_change = -15
+	mood_change = -10
 
 /datum/mood_event/axe_neutral
 	description = "I'm sure the axe is okay."
@@ -9,7 +9,7 @@
 
 /datum/mood_event/axe_cabinet
 	description = "The axe is where it belongs."
-	mood_change = 5
+	mood_change = 3
 
 /datum/mood_event/axe_missing
 	description = "The axe, there's something wrong..."
@@ -17,4 +17,4 @@
 
 /datum/mood_event/axe_held
 	description = "I'm not worthy of you, axe. I need to put you back."
-	mood_change = -10
+	mood_change = -5

--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -1,3 +1,5 @@
+GLOBAL_DATUM(bridge_axe, /obj/item/fireaxe)
+
 /*
  * Fireaxe
  */
@@ -34,6 +36,9 @@
 
 /obj/item/fireaxe/Initialize(mapload)
 	. = ..()
+	if(!GLOB.bridge_axe && istype(get_area(src), /area/station/command))
+		GLOB.bridge_axe = src
+
 	AddComponent(/datum/component/butchering, \
 		speed = 10 SECONDS, \
 		effectiveness = 80, \
@@ -45,6 +50,11 @@
 
 /obj/item/fireaxe/update_icon_state()
 	icon_state = "[base_icon_state]0"
+	return ..()
+
+/obj/item/fireaxe/Destroy()
+	if(GLOB.bridge_axe == src)
+		GLOB.bridge_axe = null
 	return ..()
 
 /obj/item/fireaxe/suicide_act(mob/living/user)

--- a/code/modules/jobs/job_types/bridgeassistant.dm
+++ b/code/modules/jobs/job_types/bridgeassistant.dm
@@ -30,6 +30,12 @@ Bridge Assistant
 
 	family_heirlooms = list(/obj/item/banner/command/mundane, /obj/item/pen/fountain, /obj/item/stamp/granted, /obj/item/reagent_containers/cup/glass/mug/nanotrasen, /obj/item/reagent_containers/cup/coffeepot/bluespace/synthesiser)
 
+/datum/job/bridge_assistant/after_spawn(mob/living/spawned, client/player_client)
+	. = ..()
+	var/mob/living/carbon/bridgie = spawned
+	if(istype(bridgie))
+		bridgie.gain_trauma(/datum/brain_trauma/special/axedoration)
+
 	mail_goodies = list(
 		/obj/item/storage/fancy/cigarettes = 1,
 		/obj/item/pen/fountain = 1,

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1626,6 +1626,7 @@
 #include "code\datums\mocking\client.dm"
 #include "code\datums\mood_events\_mood_event.dm"
 #include "code\datums\mood_events\area_events.dm"
+#include "code\datums\mood_events\axe_events.dm"
 #include "code\datums\mood_events\beauty_events.dm"
 #include "code\datums\mood_events\dna_infuser_events.dm"
 #include "code\datums\mood_events\drink_events.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/87513 (explained best in that PR but small run down below)

gives bridge assistants a fire axe related trauma that gives them a mood debuff when holding the bridge axe, when its out of its case and not held by a member of command, and a much bigger one if it is destroyed.

but a small mood buff when its in its case.

The axe also whispers to them when they use it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This is for three main reasons. Basically the same as the reason it was added on TG. 

To DISCOURAGE bridge assistants from constantly using/grabbing the fire axe. but not stop entirely for a number of reasons

I also think this brings some interesting RP over the axe and the bridge assistant and a little more weight to the tot destroy axe objective (assuming they go after the bridge axe and not atmos one) just overall more things to RP with. Some axe fanatic bridge assistant turned crazed axe murderer after a event and opfor later or such.

Lastly I think its pretty funny. 
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Shod, Fikou
add: The Bridge Assistant now has a duty-sworn axe protection brain trauma.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
