### PR TITLE
Spiders now see their current directive in the status panel (+ spider type check fix)

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -199,7 +199,7 @@ GLOBAL_LIST_INIT(cat_typecache, typecacheof(list(
 
 #define isclown(A) (istype(A, /mob/living/basic/clown))
 
-#define isspider(A) (istype(A, /mob/living/basic/spider/giant))
+#define isspider(A) (istype(A, /mob/living/basic/spider))
 
 #define isbingle(A) (istype(A, /mob/living/basic/bingle))
 

--- a/code/game/objects/effects/spiderwebs.dm
+++ b/code/game/objects/effects/spiderwebs.dm
@@ -174,11 +174,11 @@
 
 /obj/structure/spider/sticky/CanAllowThrough(atom/movable/mover, border_dir)
 	. = ..()
-	if(isspider(mover))
+	if(HAS_TRAIT(mover, TRAIT_WEB_SURFER))
 		return TRUE
 	if(!isliving(mover))
 		return
-	if(!isnull(mover.pulledby) && isspider(mover.pulledby))
+	if(mover.pulledby && HAS_TRAIT(mover.pulledby, TRAIT_WEB_SURFER))
 		return TRUE
 	loc.balloon_alert(mover, "stuck in web!")
 	return FALSE

--- a/code/modules/mob/living/basic/space_fauna/spider/spider.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider.dm
@@ -87,6 +87,11 @@
 	for(var/datum/reagent/toxin/pestkiller/current_reagent in reagents)
 		apply_damage(50 * volume_modifier, STAMINA, BODY_ZONE_CHEST)
 
+/mob/living/basic/spider/get_status_tab_items()
+	. = ..()
+	if(directive)
+		. += "Directive: [html_decode(directive)]"
+
 /// Spider which turns into another spider over time
 /mob/living/basic/spider/growing
 	/// The mob type we will grow into.

--- a/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/hivemind.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/hivemind.dm
@@ -64,11 +64,13 @@
 /datum/action/cooldown/mob_cooldown/command_spiders/proc/spider_command(mob/living/user, message)
 	var/my_message = format_message(user,message)
 	for(var/mob/living/basic/spider as anything in GLOB.spidermobs)
-		to_chat(spider, my_message)
-		spider.balloon_alert(spider, "new command!")
+		var/is_own_message = spider == user
+		to_chat(spider, my_message, type = MESSAGE_TYPE_RADIO, avoid_highlighting = is_own_message)
+		if(!is_own_message)
+			spider.balloon_alert(spider, "new command!")
 	for(var/ghost in GLOB.dead_mob_list)
 		var/link = FOLLOW_LINK(ghost, user)
-		to_chat(ghost, "[link] [my_message]")
+		to_chat(ghost, "[link] [my_message]", type = MESSAGE_TYPE_RADIO)
 	user.log_talk(message, LOG_SAY, tag = "spider command")
 
 /**

--- a/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/hivemind.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/spider_abilities/hivemind.dm
@@ -25,6 +25,9 @@
 	current_directive = new_directive
 	message_admins("[ADMIN_LOOKUPFLW(owner)] set its directive to: '[current_directive]'.")
 	owner.log_message("set its directive to: '[current_directive]'.", LOG_GAME)
+	if(isspider(owner))
+		var/mob/living/basic/spider/spider_owner = owner
+		spider_owner.directive = new_directive
 	StartCooldown()
 
 /**
@@ -62,6 +65,7 @@
 	var/my_message = format_message(user,message)
 	for(var/mob/living/basic/spider as anything in GLOB.spidermobs)
 		to_chat(spider, my_message)
+		spider.balloon_alert(spider, "new command!")
 	for(var/ghost in GLOB.dead_mob_list)
 		var/link = FOLLOW_LINK(ghost, user)
 		to_chat(ghost, "[link] [my_message]")


### PR DESCRIPTION
## About The Pull Request

this makes it so spiders will always see their directive in their top right status panel:
<img width="449" height="242" alt="2025-07-30 (1753889652) ~ dreamseeker" src="https://github.com/user-attachments/assets/952f2cc9-bb32-4f81-9459-23c77a2afebd" />

also, setting a directive also sets it for yourself, and commands broadcasted by the broodmother will show a "new command!" balloon alert to all spiders that hear it.

Also ports https://github.com/tgstation/tgstation/pull/78817

## Why It's Good For The Game

makes it harder to "forget" or not notice your directive or commands.

## Changelog
:cl:
qol: Spiders will now see their directive (if they have one) in their Status panel.
qol: Setting a directive as a broodmother spider also sets the directive for yourself.
qol: Spiders will now get a balloon alert notifying them of any commands from the broodmother.
fix: (Comxy) Spider types get properly checked again.
/:cl:
