### PR TITLE
Remove the random color syringe from the slime market

### DIFF
--- a/monkestation/code/modules/slimecore/machines/slime_store/mutators.dm
+++ b/monkestation/code/modules/slimecore/machines/slime_store/mutators.dm
@@ -34,12 +34,6 @@
 	item_path = /obj/item/slime_mutation_syringe/never_ooze
 	cost = 2500
 
-/datum/slime_store_item/random_color_mutator
-	name = "Random Color Mutation Syringe"
-	desc = "Mutates a single slime into a possible mutation."
-	item_path = /obj/item/slime_mutation_syringe/random_color
-	cost = 3000
-
 /datum/slime_store_item/soda_slime
 	name = "Soda Slime Mutation Syringe"
 	desc = "Adds the soda slime mutation to a single slime."


### PR DESCRIPTION
## About The Pull Request
Title, keeps the syringe in the game in-case
## Why It's Good For The Game
Being able to rng a high tier slime early into the shift seems incredibly unbalanced, and bypasses the slime mutation system we have in place. Removing it means xenobiologist will have to actually get the things needed for the slime to mutate, rather than getting a T3 and popping a syringe on them (or just spamming syringes).
## Changelog
:cl:
del: Removed the random color syringe from the slime market
/:cl:
