### PR TITLE
Removes "brotherly connections" on examine

### DIFF
--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -65,12 +65,6 @@
 		flashed.balloon_alert(source, "[flashed.p_their()] mind is vacant!")
 		return
 
-	// monkestation edit: dont try to convert banned people
-	if(is_banned_from(flashed.ckey, list(ROLE_BROTHER, ROLE_SYNDICATE)))
-		flashed.balloon_alert(source, "cannot become brother!")
-		return
-	// monkestation end
-
 	for(var/datum/objective/brother_objective as anything in source.mind.get_all_objectives())
 		// If the objective has a target, are we flashing them?
 		if(flashed == brother_objective.target?.current)

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -65,6 +65,12 @@
 		flashed.balloon_alert(source, "[flashed.p_their()] mind is vacant!")
 		return
 
+	// monkestation edit: dont try to convert banned people
+	if(is_banned_from(flashed.ckey, list(ROLE_BROTHER, ROLE_SYNDICATE)))
+		flashed.balloon_alert(source, "cannot become brother!")
+		return
+	// monkestation end
+
 	for(var/datum/objective/brother_objective as anything in source.mind.get_all_objectives())
 		// If the objective has a target, are we flashing them?
 		if(flashed == brother_objective.target?.current)

--- a/monkestation/code/modules/blueshift/items/soul_catcher.dm
+++ b/monkestation/code/modules/blueshift/items/soul_catcher.dm
@@ -111,11 +111,6 @@
 					composed_message += special_desc
 					. += composed_message
 
-/mob/living/carbon/human/examine_more(mob/user)
-	. = ..()
-	if(user.mind?.has_antag_datum(/datum/antagonist/brother) && !(ROLE_BROTHER in client?.prefs?.be_special))
-		. += span_userdanger("[p_They()] do[p_es()] not seem to be too fond of brotherly connections.")
-
 /obj/item/disk/nifsoft_uploader/soulcatcher
 	name = "Soulcatcher"
 	loaded_nifsoft = /datum/nifsoft/soulcatcher


### PR DESCRIPTION

## About The Pull Request
Removes the "does not seem to be fond of brotherly connections" pop up on inspecting as a blood brother

## Why It's Good For The Game
Blood brothers dont work off flash anymore, its just kinda a annoying pop up that means nothing

## Changelog

:cl:
del: Removed brotherly connections pop up on inspecting
/:cl:

