### PR TITLE
Crutches now reduce the chance of falling with the weak motor nerve signal brain trauma

### DIFF
--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -134,9 +134,8 @@
 	var/fall_chance = 1
 	if(owner.m_intent == MOVE_INTENT_RUN)
 		fall_chance += 2
-	for(var/obj/item/held_item as anything in owner.held_items) // crutches will lessen the chance of you falling.
-		if(istype(held_item, /obj/item/cane)) //crutches are cane subtypes, why not let the cane work too
-			fall_chance /= 2
+	for(var/obj/item/cane/cane in owner.held_items) // crutches will lessen the chance of you falling.
+		fall_chance /= 2
 	if(SPT_PROB(0.5 * fall_chance, seconds_per_tick) && owner.body_position == STANDING_UP)
 		to_chat(owner, span_warning("Your leg gives out!"))
 		owner.Paralyze(35)

--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -134,6 +134,9 @@
 	var/fall_chance = 1
 	if(owner.m_intent == MOVE_INTENT_RUN)
 		fall_chance += 2
+	for(var/obj/item/held_item as anything in owner.held_items) // crutches will lessen the chance of you falling.
+		if(istype(held_item, /obj/item/cane)) //crutches are cane subtypes, why not let the cane work too
+			fall_chance /= 2
 	if(SPT_PROB(0.5 * fall_chance, seconds_per_tick) && owner.body_position == STANDING_UP)
 		to_chat(owner, span_warning("Your leg gives out!"))
 		owner.Paralyze(35)


### PR DESCRIPTION

## About The Pull Request
fixes #6291 
adds a function to the brain trauma that halves the fall chance if you are holding a cane, this can happen twice if you decide to hold 2 canes.
## Why It's Good For The Game
falling down and getting paralyzed kinda sucks, and you would really expect a crutch to help against your leg failing, it helps against it not existing at all!
## Changelog
:cl: Tractor Maam
add: Holding a crutch halves the chance of your leg giving out with the "weak motor nerve signal" brain trauma, did you know you can switch to walk to cut the fall chance in third?
/:cl:
