### PR TITLE
stopping the Devitt from terrorizing low pop

### DIFF
--- a/code/modules/antagonists/brother/gear/_gear.dm
+++ b/code/modules/antagonists/brother/gear/_gear.dm
@@ -5,6 +5,7 @@ GLOBAL_LIST_INIT_TYPED(bb_gear, /datum/bb_gear, init_bb_gear())
 	var/desc
 	var/spawn_path
 	var/preview_path
+	var/pop_lock = 0
 	var/static/list/icon/cached_previews
 
 /datum/bb_gear/proc/summon(mob/living/summoner, datum/team/brother_team/team)
@@ -30,6 +31,8 @@ GLOBAL_LIST_INIT_TYPED(bb_gear, /datum/bb_gear, init_bb_gear())
 /proc/init_bb_gear()
 	. = list()
 	for(var/datum/bb_gear/gear as anything in subtypesof(/datum/bb_gear))
+		if(SSgamemode.get_correct_popcount() < gear.pop_lock)
+			return
 		var/name = gear::name
 		if(istext(name))
 			.[name] = new gear

--- a/code/modules/antagonists/brother/gear/misc.dm
+++ b/code/modules/antagonists/brother/gear/misc.dm
@@ -8,7 +8,9 @@
 	desc = "Contains a disk containing designs to make subpar, but accessible guns.."
 	spawn_path = /obj/item/disk/design_disk/fss
 
+
 /datum/bb_gear/devitt
 	name = "Devitt Mk3"
+	pop_lock = 30
 	desc = "An ancient two man tank, comes with cannon and machinegun, but little ammo."
 	spawn_path = /obj/vehicle/sealed/mecha/devitt


### PR DESCRIPTION

## About The Pull Request

Makes the tank choice for BBs disappear when the station is below 30 players.
## Why It's Good For The Game

no more tanks terrorizing lowpop
## Changelog
:cl:
add: lowpop restriction to Devitt from BB
/:cl:
