### PR TITLE
Adds MonkeTech AutoTranslators to the Sci and Medical Techfabs

### DIFF
--- a/code/modules/research/designs/autolathe/medsci_designs.dm
+++ b/code/modules/research/designs/autolathe/medsci_designs.dm
@@ -211,3 +211,15 @@
 		RND_CATEGORY_TOOLS + RND_SUBCATEGORY_TOOLS_MEDICAL,
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
+
+/datum/design/monketech_translator
+	name = "MonkeTech AutoTranslator"
+	id = "monketech_translator"
+	build_type = AUTOLATHE | PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 2.5, /datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT * 3)
+	build_path = /obj/item/clothing/mask/translator
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL,
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -213,6 +213,7 @@
 		"large_beaker",
 		"medicalbed",
 		"mmi_m",
+		"monketech_translator",
 		"operating",
 		"petri_dish",
 		"pillbottle",


### PR DESCRIPTION
## About The Pull Request

This just adds the MonkeTech AutoTranslator to Medical and Science Techfabs roundstart for 5k Iron and 3k Glass.

## Why It's Good For The Game

There's no other way to get MonkeTech AutoTranslators for simians besides already existing ones, or the 4 AutoTranslators in Box Station.

## Changelog

:cl:
add: A Science/Medical Techfab Recipe for MonkeTech AutoTranslators for 5k Iron and 3k Glass
/:cl:
