### PR TITLE
require 30+ crew for blood brothers to get the tank

### DIFF
--- a/code/modules/antagonists/brother/gear/_gear.dm
+++ b/code/modules/antagonists/brother/gear/_gear.dm
@@ -5,6 +5,7 @@ GLOBAL_LIST_INIT_TYPED(bb_gear, /datum/bb_gear, init_bb_gear())
 	var/desc
 	var/spawn_path
 	var/preview_path
+	var/player_minimum
 	var/static/list/icon/cached_previews
 
 /datum/bb_gear/proc/summon(mob/living/summoner, datum/team/brother_team/team)
@@ -13,6 +14,11 @@ GLOBAL_LIST_INIT_TYPED(bb_gear, /datum/bb_gear, init_bb_gear())
 		"style" = STYLE_SYNDICATE,
 		"spawn" = spawn_path
 	))
+
+/datum/bb_gear/proc/is_available()
+	if(player_minimum && (player_minimum > SSgamemode.get_correct_popcount()))
+		return FALSE
+	return TRUE
 
 /datum/bb_gear/proc/preview() as /mutable_appearance
 	if(LAZYACCESS(cached_previews, type))

--- a/code/modules/antagonists/brother/gear/misc.dm
+++ b/code/modules/antagonists/brother/gear/misc.dm
@@ -12,3 +12,4 @@
 	name = "Devitt Mk3"
 	desc = "An ancient two man tank, comes with cannon and machinegun, but little ammo."
 	spawn_path = /obj/vehicle/sealed/mecha/devitt
+	player_minimum = 30


### PR DESCRIPTION

## About The Pull Request

https://github.com/Monkestation/Monkestation2.0/pull/7387 but it works

> Makes the tank choice for BBs disappear when the station is below 30 players.

## Why It's Good For The Game

> no more tanks terrorizing lowpop

## Changelog
:cl:
balance: Blood Brothers can now only get the tank if there's 30+ crew.
/:cl:
