### PR TITLE
[PORT] [QOL] Allows pointblank shots in combat mode.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -229,6 +229,8 @@
 /obj/item/gun/afterattack_secondary(mob/living/victim, mob/living/user, params)
 	if(!isliving(victim) || !IN_GIVEN_RANGE(user, victim, GUNPOINT_SHOOTER_STRAY_RANGE))
 		return ..() //if they're out of range, just shootem.
+	if (user.istate & ISTATE_HARM)
+		return SECONDARY_ATTACK_CALL_NORMAL //continue attack chain for melee attack, we dont want to hold up
 	if(!can_hold_up)
 		return ..()
 	var/datum/component/gunpoint/gunpoint_component = user.GetComponent(/datum/component/gunpoint)
@@ -262,7 +264,7 @@
 	if(flag) //It's adjacent, is the user, or is on the user's person
 		if(target in user.contents) //can't shoot stuff inside us.
 			return
-		if(!ismob(target) || (user.istate & ISTATE_HARM)) //melee attack
+		if(!ismob(target) || (user.istate & ISTATE_HARM && user.istate & ISTATE_SECONDARY)) //melee attack
 			return
 		if(target == user && user.zone_selected != BODY_ZONE_PRECISE_MOUTH) //so we can't shoot ourselves (unless mouth selected)
 			return
@@ -462,7 +464,7 @@
 	semicd = FALSE
 
 /obj/item/gun/attack(mob/M, mob/living/user)
-	if((user.istate & ISTATE_HARM)) //Flogging
+	if((user.istate & ISTATE_HARM && user.istate & ISTATE_SECONDARY)) //Flogging
 		if(bayonet)
 			M.attackby(bayonet, user)
 			return
@@ -471,7 +473,7 @@
 	return
 
 /obj/item/gun/attack_atom(obj/O, mob/living/user, params)
-	if((user.istate & ISTATE_HARM))
+	if((user.istate & ISTATE_HARM && user.istate & ISTATE_SECONDARY))
 		if(bayonet)
 			O.attackby(bayonet, user)
 			return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -264,7 +264,7 @@
 	if(flag) //It's adjacent, is the user, or is on the user's person
 		if(target in user.contents) //can't shoot stuff inside us.
 			return
-		if(!ismob(target) || (user.istate & ISTATE_HARM && user.istate & ISTATE_SECONDARY)) //melee attack
+		if(!ismob(target) || (user.istate & (ISTATE_HARM | ISTATE_SECONDARY))) //melee attack
 			return
 		if(target == user && user.zone_selected != BODY_ZONE_PRECISE_MOUTH) //so we can't shoot ourselves (unless mouth selected)
 			return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -473,7 +473,7 @@
 	return
 
 /obj/item/gun/attack_atom(obj/O, mob/living/user, params)
-	if((user.istate & ISTATE_HARM && user.istate & ISTATE_SECONDARY))
+	if((user.istate & (ISTATE_HARM | ISTATE_SECONDARY)))
 		if(bayonet)
 			O.attackby(bayonet, user)
 			return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -464,7 +464,7 @@
 	semicd = FALSE
 
 /obj/item/gun/attack(mob/M, mob/living/user)
-	if((user.istate & ISTATE_HARM && user.istate & ISTATE_SECONDARY)) //Flogging
+	if((user.istate & (ISTATE_HARM | ISTATE_SECONDARY))) //Flogging
 		if(bayonet)
 			M.attackby(bayonet, user)
 			return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -264,7 +264,7 @@
 	if(flag) //It's adjacent, is the user, or is on the user's person
 		if(target in user.contents) //can't shoot stuff inside us.
 			return
-		if(!ismob(target) || (user.istate & (ISTATE_HARM | ISTATE_SECONDARY))) //melee attack
+		if(!ismob(target) || (user.istate & ISTATE_HARM && user.istate & ISTATE_SECONDARY)) //melee attack
 			return
 		if(target == user && user.zone_selected != BODY_ZONE_PRECISE_MOUTH) //so we can't shoot ourselves (unless mouth selected)
 			return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -473,7 +473,7 @@
 	return
 
 /obj/item/gun/attack_atom(obj/O, mob/living/user, params)
-	if((user.istate & (ISTATE_HARM | ISTATE_SECONDARY)))
+	if((user.istate & ISTATE_HARM && user.istate & ISTATE_SECONDARY))
 		if(bayonet)
 			O.attackby(bayonet, user)
 			return

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -464,7 +464,7 @@
 	semicd = FALSE
 
 /obj/item/gun/attack(mob/M, mob/living/user)
-	if((user.istate & (ISTATE_HARM | ISTATE_SECONDARY))) //Flogging
+	if((user.istate & ISTATE_HARM && user.istate & ISTATE_SECONDARY)) //Flogging
 		if(bayonet)
 			M.attackby(bayonet, user)
 			return


### PR DESCRIPTION
## About The Pull Request

Port of (https://github.com/tgstation/tgstation/pull/89799) from tgstation.

Note that my implementation is a bit different as the attack chain seems to work differently here, but I have thoroughly tested it on localhost and the result is the same as live on tg.

## Why It's Good For The Game

Combat mode should be for combat- it's very unintuitive to bash someone when you are obviously trying to shoot them. You can still pistol whip people with RMB, and you can still do hold-ups by using RMB in non-combat mode.

## Changelog

:cl:
qol: You can now shoot people pointblank in combat mode. Use right click if you want to pistol whip them instead.
/:cl:
