### PR TITLE
Void chill restores your body temp when it expires

### DIFF
--- a/code/modules/antagonists/heretic/status_effects/void_chill.dm
+++ b/code/modules/antagonists/heretic/status_effects/void_chill.dm
@@ -38,6 +38,7 @@
 /datum/status_effect/void_chill/on_remove()
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/void_chill)
 	REMOVE_TRAIT(owner, TRAIT_HYPOTHERMIC, TRAIT_STATUS_EFFECT(id))
+	owner.bodytemperature = BODYTEMP_NORMAL
 	UnregisterSignal(owner, COMSIG_ATOM_UPDATE_OVERLAYS)
 	owner.update_icon(UPDATE_OVERLAYS)
 


### PR DESCRIPTION

## About The Pull Request
When void chill expires it sets you to normal bodytemp.
## Why It's Good For The Game
This was never intended to outright kill people. on TG temperature is actually reasonable, whereas getting cold just kills you on Monke. This rebalances the debuff to be more reasonable.
## Changelog
:cl:
balance: Void chill fixes your bodytemp when it expires
/:cl:
