### PR TITLE
More BM Guns and Goodie Items

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -431,6 +431,7 @@
 		/obj/item/wirecutters,
 		/obj/item/wrench,
 		/obj/item/wormhole_jaunter,
+		/obj/item/trench_tool, //monkestation edit
 		/obj/item/cargo_teleporter, //monkestation edit
 		/obj/item/storage/box/kinetic, //monkestation edit
 		/obj/item/ammo_box/magazine/pksmgmag, //monkestation edit
@@ -440,6 +441,8 @@
 		/obj/item/storage/box/kinetic/shotgun, //monkestation edit
 		/obj/item/storage/box/kinetic/shotgun/rockbreaker, //monkestation edit
 		/obj/item/storage/box/kinetic/shotgun/sniperslug, //monkestation edit
+		/obj/item/ammo_box/advanced/s12gauge/hunter, //monkestation edit
+		/obj/item/ammo_casing/shotgun/hunter, //monkestation edit
 	))
 
 

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -45,6 +45,26 @@
 	cost = PAYCHECK_COMMAND * 1.75
 	contains = list(/obj/item/knife/combat/survival)
 
+/datum/supply_pack/goody/hunterslugs
+	name = "12 Gauge Hunter Slugs"
+	desc = "12 Gauge shells designed to put down most lavaland xenofauna in a single shot. Make sure to take a combative stance before firing."
+	cost = PAYCHECK_CREW * 2
+	contains = list(/obj/item/ammo_box/advanced/s12gauge/hunter)
+
+/datum/supply_pack/goody/barkeep_single
+	name = "Double Barrel Single-Pack"
+	desc = "Lost your lupara in a brawl fight? Drunken haze? Simply want a dedicated 'shot'gun? We got you, as long as you pay the fee."
+	cost = PAYCHECK_COMMAND * 12
+	access_view = ACCESS_WEAPONS
+	contains = list(/obj/item/gun/ballistic/shotgun/doublebarrel, /obj/item/storage/belt/bandolier)
+
+/datum/supply_pack/goody/pump_single
+	name = "Pump Shotgun Single-Pack"
+	desc = "A respectable pump action shotgun, to restock armoury supplies. Comes with a bandolier."
+	cost = PAYCHECK_COMMAND * 15
+	access_view = ACCESS_ARMORY
+	contains = list(/obj/item/gun/ballistic/shotgun/riot, /obj/item/storage/belt/bandolier)
+
 /datum/supply_pack/goody/ballistic_single
 	name = "Combat Shotgun Single-Pack"
 	desc = "For when the enemy absolutely needs to be replaced with lead. Contains one Aussec-designed Combat Shotgun, and one Shotgun Bandolier."

--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -60,7 +60,7 @@
 	name = "Insulated Gloves Crate"
 	desc = "The backbone of modern society. Barely ever ordered for actual engineering. \
 		Contains three insulated gloves."
-	cost = CARGO_CRATE_VALUE * 8 //Made of pure-grade bullshittinium
+	cost = CARGO_CRATE_VALUE * 5 //Made of pure-grade bullshittinium
 	contains = list(/obj/item/clothing/gloves/color/yellow = 3)
 	crate_name = "insulated gloves crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -9,9 +9,9 @@
 		of rubbershot shotgun shells, two boxes of buckshot, and one of each special .38 speedloaders."
 	cost = CARGO_CRATE_VALUE * 8
 	access_view = ACCESS_ARMORY
-	contains = list(/obj/item/storage/box/beanbag = 2,
-					/obj/item/storage/box/rubbershot = 2,
-					/obj/item/storage/box/lethalshot = 2,
+	contains = list(/obj/item/ammo_box/advanced/s12gauge/bean = 2,
+					/obj/item/ammo_box/advanced/s12gauge/rubber = 2,
+					/obj/item/ammo_box/advanced/s12gauge/buckshot = 2,
 					/obj/item/ammo_box/c38/trac,
 					/obj/item/ammo_box/c38/hotshot,
 					/obj/item/ammo_box/c38/iceblox,

--- a/monkestation/code/modules/blueshift/items/company_guns.dm
+++ b/monkestation/code/modules/blueshift/items/company_guns.dm
@@ -169,6 +169,9 @@
 /obj/item/gun/ballistic/automatic/sol_rifle/evil/no_mag
 	spawnwithmagazine = FALSE
 
+/obj/item/gun/ballistic/automatic/sol_rifle/evil/unrestricted
+	pin = /obj/item/firing_pin
+
 // SolFed shotgun (this was gonna be in a proprietary shotgun shell type outside of 12ga at some point, wild right?)
 
 /obj/item/gun/ballistic/shotgun/riot/sol
@@ -238,6 +241,8 @@
 	projectile_wound_bonus = 15
 	pin = /obj/item/firing_pin/implant/pindicate
 
+/obj/item/gun/ballistic/shotgun/riot/sol/evil/unrestricted
+	pin = /obj/item/firing_pin
 // Low caliber grenade launcher (fun & games)
 
 /obj/item/gun/ballistic/automatic/sol_grenade_launcher
@@ -339,6 +344,9 @@
 
 /obj/item/gun/ballistic/automatic/sol_grenade_launcher/evil/no_mag
 	spawnwithmagazine = FALSE
+
+/obj/item/gun/ballistic/automatic/sol_grenade_launcher/evil/unrestricted
+	pin = /obj/item/firing_pin
 
 /*
 *	QM Sporter Rifle
@@ -608,6 +616,9 @@
 
 /obj/item/gun/ballistic/automatic/pistol/sol/evil/no_mag
 	spawnwithmagazine = FALSE
+
+/obj/item/gun/ballistic/automatic/pistol/sol/evil/unrestricted
+	pin = /obj/item/firing_pin
 
 // Trappiste high caliber pistol in .585
 
@@ -1067,6 +1078,9 @@
 
 /obj/item/gun/ballistic/automatic/sol_smg/evil/no_mag
 	spawnwithmagazine = FALSE
+
+/obj/item/gun/ballistic/automatic/sol_smg/evil/unrestricted
+	pin = /obj/item/firing_pin
 
 /// File location for the long gun's speech
 #define LONG_MOD_LASER_SPEECH "nova/long_modular_laser.json"

--- a/monkestation/code/modules/modular_guns/blackmarket/auction_items/gun_parts.dm
+++ b/monkestation/code/modules/modular_guns/blackmarket/auction_items/gun_parts.dm
@@ -12,6 +12,7 @@
 
 	price_min = CARGO_CRATE_VALUE * 2.5
 	price_max = CARGO_CRATE_VALUE * 5
+	auction_weight = 2
 
 /datum/market_item/auction/gun_part/cirno
 	name = "MK 58 Cirno keychain"
@@ -20,7 +21,7 @@
 
 	price_min = CARGO_CRATE_VALUE * 2
 	price_max = CARGO_CRATE_VALUE * 3
-	auction_weight = 3
+	auction_weight = 2
 
 /datum/market_item/auction/gun_part/mk58_suppressor
 	name = "MK 58 Suppressor"
@@ -29,4 +30,49 @@
 
 	price_min = CARGO_CRATE_VALUE * 2.5
 	price_max = CARGO_CRATE_VALUE * 7
-	auction_weight = 3
+	auction_weight = 2
+
+/datum/market_item/auction/gun_part/evil_wespe //Funny guns that fit the shoddy gun bidding market.
+	name = "Modified Wespe"
+	desc = "Super Illegal."
+	item = /obj/item/gun/ballistic/automatic/pistol/sol/evil/unrestricted
+
+	price_min = CARGO_CRATE_VALUE * 6
+	price_max = CARGO_CRATE_VALUE * 8
+	auction_weight = 4
+
+/datum/market_item/auction/gun_part/evil_eland
+	name = "Eland Revolver"
+	desc = "Super Illegal... and weak."
+	item = /obj/item/gun/ballistic/revolver/sol
+
+	price_min = CARGO_CRATE_VALUE * 4
+	price_max = CARGO_CRATE_VALUE * 6.25
+	auction_weight = 4
+
+/datum/market_item/auction/gun_part/evil_skild
+	name = "Skild Pistol"
+	desc = "Super Illegal, favoured by frontiermen."
+	item = /obj/item/gun/ballistic/automatic/pistol/trappiste
+
+	price_min = CARGO_CRATE_VALUE * 6
+	price_max = CARGO_CRATE_VALUE * 8
+	auction_weight = 4
+
+/datum/market_item/auction/gun_part/evil_sindano
+	name = "Modified Sindano"
+	desc = "Super Duper Illegal, goodluck getting it to fire!"
+	item = /obj/item/gun/ballistic/automatic/sol_smg/evil
+
+	price_min = CARGO_CRATE_VALUE * 8
+	price_max = CARGO_CRATE_VALUE * 12
+	auction_weight = 4
+
+/datum/market_item/auction/gun_part/evil_cawil
+	name = "Modified Carwo-Cawil"
+	desc = "We found these in the wreckage of the GRV Brutus, no one'll care if they aren't found. No lowballing, we know what we got!"
+	item = /obj/item/gun/ballistic/automatic/sol_rifle/evil
+
+	price_min = CARGO_CRATE_VALUE * 15
+	price_max = CARGO_CRATE_VALUE * 20
+	auction_weight = 4

--- a/monkestation/code/modules/modular_guns/blackmarket/auction_items/restock_gun_parts.dm
+++ b/monkestation/code/modules/modular_guns/blackmarket/auction_items/restock_gun_parts.dm
@@ -47,3 +47,33 @@
 	price_max = CARGO_CRATE_VALUE * 4
 	stock_max = 3
 	availability_prob = 90
+
+/datum/market_item/ammo/m45
+	name = ".45 APC Mag"
+	desc = "Fits into standard 1911s."
+	item = /obj/item/ammo_box/magazine/m45
+
+	price_min = CARGO_CRATE_VALUE * 3.4
+	price_max = CARGO_CRATE_VALUE * 4
+	stock_max = 1
+	availability_prob = 90
+
+/datum/market_item/ammo/c35sol
+	name = ".35 Short Box"
+	desc = "A box of .35 Short."
+	item = /obj/item/ammo_box/c35sol
+
+	price_min = CARGO_CRATE_VALUE * 1.5
+	price_max = CARGO_CRATE_VALUE * 2.75
+	stock_max = 3
+	availability_prob = 70
+
+/datum/market_item/ammo/c585trappiste
+	name = ".585 Trappiste Box"
+	desc = "A box of .585 Trappiste"
+	item = /obj/item/ammo_box/c585trappiste
+
+	price_min = CARGO_CRATE_VALUE * 1.5
+	price_max = CARGO_CRATE_VALUE * 2.75
+	stock_max = 3
+	availability_prob = 70


### PR DESCRIPTION

## About The Pull Request
Some more flavour for the cargo goodie sections, intended for barkeeps and a way to replenish the wooden riot shotguns,
along inserting some of the seldom used solfed weapons into the black market; shoddy, exotic guns, at a price.
Insul crates now cost 1000 credits, down from 1600; quite odd that you were extra for bulk.
You may now buy hunter slugs from cargo, itself along trench tools now fit inside explorer webbing.

## Why It's Good For The Game

Gives the currently semi-unused solfed pistols and long arms a purpose. Shoddy, weak, exotic, super illegal, still serviceable, yet even more expensive contraband weapons. Distinctly (mostly) evil overt weapons for crime enthusiasts to use. The longarms are still syndicate pinned, requiring you to ally with cargo, or (forcefully) convince them to help you make your purchases usable.

Hunter slugs are a classic, they fit a gimmick and do it well. Moreso, further adding compatibility with explorer webbing to merge it with the lavaland hunter playstyle. Easily accessible from cargo now, shouldn't have any PvP issues due to its incredibly weak damage to humans.

Also, riot shotguns from goodies, basically a sidegrade from the combat shotgun that you can already buy. Locked to armoury access.
Along with double barrels, slightly less expensive than their big boy cousins, still relatively expensive, these are designer!

Plus unrestricted variants of the evil solfeds, we probably needed those at some point.

Now theres a way to get more advanced ammo boxes, they shall no longer be finite items that only the warden and certain armouries have.

1911 mags, these are REALLY rare, sometimes a magazineless, therefore unusable 1911 ends up taking up space in cargo's floor; an opportunist CT or tider can now get these off the BM.

Cool stuff in general.
## Changelog
:cl:
add: Various pallets of SolFed weapons have dissapeared off their local warehouses. Unrelated, theres now new offerings available in the black market!
add: Hunter slugs, double barrel and pump action shotguns are now available in the goodie section of cargo.
add: Unrestricted variants for every SolFed evil reskin
qol: Hunter slugs and trench tools now fit in explorer webbing.
qol: Seccie ammo crates from cargo no longer contain their old shotgun ammo boxes, having the advanced shotgun ammo boxes instead. 
balance: Lowered the price of the insul gloves crate to 1000 credits, you aren't paying for an ethereal fourth pair of gloves anymore!
/:cl:
