### PR TITLE
Adding the Dealmaker to the loadout

### DIFF
--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -666,7 +666,7 @@
 	inhand_icon_state = null
 
 /obj/item/clothing/glasses/salesman
-	name = "colored glasses"
+	name = "Dealmaker"
 	desc = "A pair of glasses with uniquely colored lenses. The frame is inscribed with 'Best Salesman 1997'."
 	icon_state = "salesman"
 	inhand_icon_state = "salesman"

--- a/monkestation/code/modules/loadouts/items/glasses.dm
+++ b/monkestation/code/modules/loadouts/items/glasses.dm
@@ -87,6 +87,10 @@ GLOBAL_LIST_INIT(loadout_glasses, generate_loadout_items(/datum/loadout_item/gla
 	name = "Red Glasses"
 	item_path = /obj/item/clothing/glasses/red
 
+/datum/loadout_item/glasses/salesman
+	name = "Dealmaker"
+	item_path = /obj/item/clothing/glasses/salesman
+
 /*
 *	MISC
 */

--- a/monkestation/code/modules/store/store_items/glasses.dm
+++ b/monkestation/code/modules/store/store_items/glasses.dm
@@ -56,6 +56,11 @@ GLOBAL_LIST_INIT(store_glasses, generate_store_items(/datum/store_item/glasses))
 	name = "Red Glasses"
 	item_path = /obj/item/clothing/glasses/red
 
+/datum/store_item/glasses/salesman
+	name = "Dealmaker"
+	item_path = /obj/item/clothing/glasses/salesman
+	item_cost = 10000
+
 /*
 *	MISC
 */


### PR DESCRIPTION

## About The Pull Request

Renames the "colored glasses" into the Dealmaker (to solidify the reference). Also, adds the Dealmaker to the store as a 10000 Monkecoin item.

PR created by request.
## Why It's Good For The Game

Making the Dealmaker easier to obtain yet still locked behind a paywall allows for people to enhance their roleplay WITHOUT relying on maints luck (it is still in the maints loot pool).

Also, who WOULDN'T want the Number 1 rated salesman's glasses available at will? They just look cool.

## Changelog
:cl:
config: Renamed "colored glasses" to "Dealmaker". The Dealmaker can now be purchased for 10000 Monkecoins in the loadout store.
/:cl: