### PR TITLE
Stargazers can now slime link basic/simplemobs

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/oozeling/stargazers.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozeling/stargazers.dm
@@ -152,7 +152,7 @@
 
 /datum/action/innate/link_minds/proc/try_link()
 	var/mob/living/living_target = owner.pulling
-	if(!isliving(living_target) || (iscarbon(living_target) && owner.grab_state < GRAB_AGGRESSIVE && (living_target.status_flags & CANPUSH) && !HAS_TRAIT(living_target, TRAIT_PUSHIMMUNE)))
+	if(!isliving(living_target) || issilicon(living_target) || (iscarbon(living_target) && owner.grab_state < GRAB_AGGRESSIVE && (living_target.status_flags & CANPUSH) && !HAS_TRAIT(living_target, TRAIT_PUSHIMMUNE)))
 		to_chat(owner, span_warning("You need to aggressively grab someone to link minds!"))
 		return
 


### PR DESCRIPTION

## About The Pull Request

https://github.com/Monkestation/Monkestation2.0/pull/6809 was meant to allow this but it didn't work.

this makes it so simple/basic mobs, which can't be aggressively grabbed, can be slime linked with a normal grab.
the aggro grab requirement only applies to carbons now.

## Why It's Good For The Game

i wanna slime link more people dammit

## Changelog
:cl:
qol: Stargazers can now slime link basic/simple mobs using a normal grab.
/:cl:
