### PR TITLE
Bumps comically larges spoons wound bonus down

### DIFF
--- a/monkestation/code/game/objects/items/comically_large_spoon.dm
+++ b/monkestation/code/game/objects/items/comically_large_spoon.dm
@@ -19,7 +19,7 @@
 	armour_penetration = -50 // Literally couldn't possibly be a worse weapon for hitting armor.
 	throwforce = 1 // It's terribly weighted, what do you expect?
 	throw_range = 1
-	wound_bonus = 30 // Bit more than a lead pipe.
+	wound_bonus = 15 // Bit less than a lead pipe.
 	demolition_mod = 0.5 // you gotta wield it to have some oomph
 	tool_behaviour = TOOL_SHOVEL
 

--- a/monkestation/code/game/objects/items/comically_large_spoon.dm
+++ b/monkestation/code/game/objects/items/comically_large_spoon.dm
@@ -19,7 +19,7 @@
 	armour_penetration = -50 // Literally couldn't possibly be a worse weapon for hitting armor.
 	throwforce = 1 // It's terribly weighted, what do you expect?
 	throw_range = 1
-	wound_bonus = 15 // Bit less than a lead pipe.
+	wound_bonus = 10 // Bit less than a lead pipe.
 	demolition_mod = 0.5 // you gotta wield it to have some oomph
 	tool_behaviour = TOOL_SHOVEL
 


### PR DESCRIPTION
## About The Pull Request
bumps down comically large spoons wound bonus from 30 to 10

## Why It's Good For The Game
The comically large spoon has been a bit of a nightmare item for a while with a absolutely insane wound bonus of 30 on 16 damage with the strongest wound type of blunt, being able to easily, reliably break anyones legs basically instantly taking them out the fight. with little crew counter to this as riot armor and mods are the only crew armors that cover legs and instantly shutting down any antags who hadn't grabbed leg armor themselves with a broken leg which can't be self surgeried or easily healed without medical who may or may not be willing to help them.(if they somehow managed to survive and escape with a broken leg)

on top of that this is a insanely common item too with a 30% chance to appear in the black market for 100-300 CR and in the common maints loot pool.

it can be easily stored on the back (and we have waist satchels only sacrificing a small amount of storage space)

and second to last it has a demo mod of 2 and a small block chance, literally being able to knock down non rwalls.

Lastly, while 10 may seem like very little this is still quite a lot, 30 was just insanely high by comparsion and it still breaks legs its just far from the near 100% chance it was before. and while the lead pipe still holds a wound chance of 20 it lacks almost all the benifits of the spoon only beating it in wound bonus and no other aspect. Also being less obtainablle in general.

## Changelog

:cl:
balance: comically large spoon's wound bonus is now 10
/:cl:

