### PR TITLE
You can no longer enter torpor in a frenzy

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_sol.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_sol.dm
@@ -99,6 +99,9 @@
 	if(SkipChecks)
 		torpor_begin()
 		return
+	if(user.has_status_effect(/datum/status_effect/frenzy))
+		to_chat(user, span_userdanger("You are restless! Collect enough blood to end your frenzy."))
+		return
 	var/total_brute = user.getBruteLoss_nonProsthetic()
 	var/total_burn = user.getFireLoss_nonProsthetic()
 	var/total_damage = total_brute + total_burn


### PR DESCRIPTION

## About The Pull Request
fixes https://github.com/Monkestation/Monkestation2.0/issues/6638

## Why It's Good For The Game
removes a soft lock that kills you

## Changelog

:cl:
fix: you can no longer torpor in frenzy
/:cl:

