### PR TITLE
prevent making the annoying flashy text over comms with the pocket watch

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -73,7 +73,8 @@
 #define SPAN_TAPE_RECORDER "tape_recorder"
 #define SPAN_HELIUM "small"
 #define SPAN_SOAPBOX "soapbox"
-#define SPAN_BOLD "bold" // monkestation addition
+#define SPAN_BOLD "bold"
+#define SPAN_HYPNOPHRASE "hypnophrase"
 
 //bitflag #defines for return value of the radio() proc.
 #define ITALICS (1<<0)

--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -60,7 +60,8 @@
 	var/list/levels
 	/// Blacklisted spans we don't want being put into comms by anything, ever - a place to put any new spans we want to make without letting them annoy people on comms
 	var/list/blacklisted_spans = list(
-		SPAN_SOAPBOX
+		SPAN_SOAPBOX,
+		SPAN_HYPNOPHRASE,
 	)
 
 /datum/signal/subspace/New(data)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this makes it so that the styling of the pocket watch text (`hypnophrase` span) will no longer be transmitted over the radio

## Why It's Good For The Game

the flashy text is an eyesore when spammed

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: You can no longer use the pocket watch to broadcast annoying flashy text over the radio.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
