### PR TITLE
Changes assault operative's sunbeam alert level

### DIFF
--- a/monkestation/code/modules/assault_ops/code/sunbeam.dm
+++ b/monkestation/code/modules/assault_ops/code/sunbeam.dm
@@ -164,13 +164,13 @@ ADMIN_VERB(spawn_sunbeam, R_FUN, FALSE, "Spawn Sunbeam", "Spawns an ICARUS sunbe
 	var/turf/end_turf = get_edge_target_turf(get_safe_random_station_turf_equal_weight(), turn(startside, 180))
 	var/turf/start_turf = spaceDebrisStartLoc(startside, end_turf.z)
 	new /obj/effect/sunbeam(start_turf, end_turf)
-	SSsecurity_level.set_level(SEC_LEVEL_GAMMA)
+	SSsecurity_level.set_level(SEC_LEVEL_DELTA)
 	SSshuttle.admin_emergency_no_recall = TRUE
 	if(SSshuttle.emergency?.mode == SHUTTLE_DISABLED || EMERGENCY_PAST_POINT_OF_NO_RETURN)
 		return
 	if(EMERGENCY_IDLE_OR_RECALLED)
 		SSshuttle.emergency.request(
-			red_alert = (SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_GAMMA)
+			red_alert = (SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_DELTA)
 		)
 
 #undef SUNBEAM_OBLITERATION_RANGE_FIRE


### PR DESCRIPTION

## About The Pull Request
Changes the alert level that is set when assault operatives get all of their disks from gamma to delta
## Why It's Good For The Game
Gamma is meant to be an "event level" that admins set whenever they wanna run some kind of event. Using it for assault operatives is not only odd, considering it's supposed to "station destroying threat", but the alert actively tells crew to stay in their departments (as if it was just red). This also makes it consistent with other antags that destroy the station, like nukies and blob.
## Changelog
:cl:
balance: Assault Operatives sunbeam will now set the alert level to Delta
/:cl:
