### PR TITLE
[PORT] Protolathe UI QoL + fixes 

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -75,7 +75,7 @@
 
 // Defines related to the custom materials used on objects.
 ///The amount of materials you get from a sheet of mineral like iron/diamond/glass etc. 100 Units.
-#define SHEET_MATERIAL_AMOUNT 2000
+#define SHEET_MATERIAL_AMOUNT 100
 ///The amount of materials you get from half a sheet. Used in standard object quantities. 50 units.
 #define HALF_SHEET_MATERIAL_AMOUNT (SHEET_MATERIAL_AMOUNT/2)
 ///The amount of materials used in the smallest of objects, like pens and screwdrivers. 10 units.

--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movement.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movement.dm
@@ -13,6 +13,8 @@
 #define COMSIG_ATOM_INTERCEPT_Z_FALL "movable_intercept_z_impact"
 ///signal sent out by an atom upon onZImpact : (turf/impacted_turf, levels)
 #define COMSIG_ATOM_ON_Z_IMPACT "movable_on_z_impact"
+///Signal sent after an atom movable moves on shuttle.
+#define COMSIG_ATOM_AFTER_SHUTTLE_MOVE "movable_after_shuttle_move"
 ///called on a movable (NOT living) when it starts pulling (atom/movable/pulled, state, force)
 #define COMSIG_ATOM_START_PULL "movable_start_pull"
 ///called on a movable when it starts being pulled

--- a/code/datums/components/material_container.dm
+++ b/code/datums/components/material_container.dm
@@ -217,6 +217,7 @@
 		var/inserted = insert_item(target, breakdown_flags = mat_container_flags)
 		if(inserted > 0)
 			. += inserted
+			inserted /= SHEET_MATERIAL_AMOUNT // display units inserted as sheets for improved readability
 			var/message = null
 
 			//stack was either split by the container(!QDELETED(target) means the container only consumed a part of it) or by the player, put whats left back of the original stack back in players hand
@@ -231,11 +232,11 @@
 				//was this the original item in the players hand? put what's left back in the player's hand
 				if(!isnull(original_item))
 					user.put_in_active_hand(original_item)
-					message = "Only [inserted] amount of [item_name] was consumed by [parent]."
+					message = "Only [inserted] sheets of [item_name] was consumed by [parent]."
 
 			//collect all messages to print later
 			if(!message)
-				message = "[item_name] worth [inserted] material was consumed by [parent]."
+				message = "[item_name] worth [inserted] sheets was consumed by [parent]."
 			if(inserts[message])
 				inserts[message] += 1
 			else

--- a/code/datums/components/remote_materials.dm
+++ b/code/datums/components/remote_materials.dm
@@ -28,7 +28,6 @@ handles linking back and forth.
 
 	RegisterSignal(parent, COMSIG_ATOM_ATTACKBY, PROC_REF(OnAttackBy))
 	RegisterSignal(parent, COMSIG_ATOM_TOOL_ACT(TOOL_MULTITOOL), PROC_REF(OnMultitool))
-	RegisterSignal(parent, COMSIG_MOVABLE_Z_CHANGED, PROC_REF(check_z_level))
 
 	var/turf/T = get_turf(parent)
 	if (force_connect || (mapload && is_station_level(T.z)))
@@ -76,6 +75,17 @@ handles linking back and forth.
 
 	mat_container = parent.AddComponent(/datum/component/material_container, allowed_mats, local_size, mat_container_flags, allowed_items=/obj/item/stack)
 
+/datum/component/remote_materials/proc/toggle_holding(force_hold = FALSE)
+	if(isnull(silo))
+		return
+
+	if(force_hold)
+		silo.holds[src] = TRUE
+	else if(!silo.holds[src])
+		silo.holds[src] = TRUE
+	else
+		silo.holds -= src
+
 /datum/component/remote_materials/proc/set_local_size(size)
 	local_size = size
 	if (!silo && mat_container)
@@ -85,6 +95,7 @@ handles linking back and forth.
 /datum/component/remote_materials/proc/disconnect_from(obj/machinery/ore_silo/old_silo)
 	if (!old_silo || silo != old_silo)
 		return
+	silo.ore_connected_machines -= src
 	silo = null
 	mat_container = null
 	if (allow_standalone)
@@ -107,9 +118,7 @@ handles linking back and forth.
 		if (silo == M.buffer)
 			to_chat(user, span_warning("[parent] is already connected to [silo]!"))
 			return COMPONENT_BLOCK_TOOL_ATTACK
-		var/turf/silo_turf = get_turf(M.buffer)
-		var/turf/user_loc = get_turf(user)
-		if(!is_valid_z_level(silo_turf, user_loc))
+		if(!check_z_level(M.buffer))
 			to_chat(user, span_warning("[parent] is too far away to get a connection signal!"))
 			return COMPONENT_BLOCK_TOOL_ATTACK
 		if (silo)
@@ -125,17 +134,23 @@ handles linking back and forth.
 		to_chat(user, span_notice("You connect [parent] to [silo] from the multitool's buffer."))
 		return COMPONENT_BLOCK_TOOL_ATTACK
 
-/datum/component/remote_materials/proc/check_z_level(datum/source, turf/old_turf, turf/new_turf)
+/datum/component/remote_materials/proc/check_z_level(obj/silo_to_check)
 	SIGNAL_HANDLER
-	if(!silo)
-		return
+	if(!silo_to_check)
+		if(isnull(silo))
+			return FALSE
+		silo_to_check = silo
 
-	var/turf/silo_turf = get_turf(silo)
-	if(!is_valid_z_level(silo_turf, new_turf))
-		disconnect_from(silo)
+	var/turf/current_turf = get_turf(parent)
+	var/turf/silo_turf = get_turf(silo_to_check)
+	if(!is_valid_z_level(silo_turf, current_turf))
+		return FALSE
+	return TRUE
 
 /datum/component/remote_materials/proc/on_hold()
-	return silo?.holds["[get_area(parent)]/[category]"]
+	if(!check_z_level())
+		return FALSE
+	return silo.holds["[get_area(parent)]/[category]"]
 
 /datum/component/remote_materials/proc/silo_log(obj/machinery/M, action, amount, noun, list/mats)
 	if (silo)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -343,7 +343,7 @@
 	. = ..()
 	var/mat_capacity = 0
 	for(var/datum/stock_part/matter_bin/new_matter_bin in component_parts)
-		mat_capacity += new_matter_bin.tier * 75000
+		mat_capacity += new_matter_bin.tier * (37.5*SHEET_MATERIAL_AMOUNT)
 	var/datum/component/material_container/materials = GetComponent(/datum/component/material_container)
 	materials.max_amount = mat_capacity
 

--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -1,5 +1,5 @@
 /datum/export/material
-	cost = 5 // Cost per SHEET_MATERIAL_AMOUNT, which is 2000cm3 as of April 2016.
+	cost = 5 // Cost per SHEET_MATERIAL_AMOUNT, which is 100cm3 as of May 2023.
 	message = "cm3 of developer's tears. Please, report this on github"
 	amount_report_multiplier = SHEET_MATERIAL_AMOUNT
 	var/material_id = null

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -65,7 +65,7 @@
 // For base materials, see materials.dm
 
 /datum/export/stack/plasteel
-	cost = CARGO_CRATE_VALUE * 0.41 // 2000u of plasma + 2000u of iron.
+	cost = CARGO_CRATE_VALUE * 0.41 // 100u of plasma + 100u of iron.
 	message = "of plasteel"
 	export_types = list(/obj/item/stack/sheet/plasteel)
 

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -259,13 +259,15 @@
 				"icon" = text_ref(alloy_type::icon),
 				"icon_state" = alloy_type::icon_state,
 			))
-
+	data["disconnected"] = null
 	if (!mat_container)
-		data["disconnected"] = "local mineral storage is unavailable"
+		data["disconnected"] = "Local mineral storage is unavailable"
 	else if (!materials.silo)
-		data["disconnected"] = "no ore silo connection is available; storing locally"
+		data["disconnected"] = "No ore silo connection is available; storing locally"
+	else if (!materials.check_z_level())
+		data["disconnected"] = "Unable to connect to ore silo, too far away"
 	else if (materials.on_hold())
-		data["disconnected"] = "mineral withdrawal is on hold"
+		data["disconnected"] = "Mineral withdrawal is on hold"
 
 	var/obj/item/card/id/card
 	if(isliving(user))
@@ -296,6 +298,8 @@
 			if(isliving(usr))
 				var/mob/living/user = usr
 				user_id_card = user.get_idcard(TRUE)
+			if(!materials.check_z_level())
+				return TRUE
 			if(points)
 				if(user_id_card)
 					user_id_card.registered_account.mining_points += points

--- a/code/modules/mining/machine_silo.dm
+++ b/code/modules/mining/machine_silo.dm
@@ -116,9 +116,8 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 	ui += "</div><div class='statusDisplay'><h2>Connected Machines:</h2>"
 	for(var/datum/component/remote_materials/mats as anything in ore_connected_machines)
 		var/atom/parent = mats.parent
-		var/hold_key = "[get_area(parent)]/[mats.category]"
 		ui += "<a href='byond://?src=[REF(src)];remove=[REF(mats)]'>Remove</a>"
-		ui += "<a href='byond://?src=[REF(src)];hold[!holds[hold_key]]=[url_encode(hold_key)]'>[holds[hold_key] ? "Allow" : "Hold"]</a>"
+		ui += "<a href='?src=[REF(src)];hold=[REF(mats)]'>[holds[mats] ? "Allow" : "Hold"]</a>"
 		ui += " <b>[parent.name]</b> in [get_area_name(parent, TRUE)]<br>"
 	if(!ore_connected_machines.len)
 		ui += "Nothing!"
@@ -157,15 +156,11 @@ GLOBAL_LIST_EMPTY(silo_access_logs)
 		var/datum/component/remote_materials/mats = locate(href_list["remove"]) in ore_connected_machines
 		if (mats)
 			mats.disconnect_from(src)
-			ore_connected_machines -= mats
 			updateUsrDialog()
 			return TRUE
-	else if(href_list["hold1"])
-		holds[href_list["hold1"]] = TRUE
-		updateUsrDialog()
-		return TRUE
-	else if(href_list["hold0"])
-		holds -= href_list["hold0"]
+	else if(href_list["hold"])
+		var/datum/component/remote_materials/mats = locate(href_list["hold"]) in ore_connected_machines
+		mats.toggle_holding()
 		updateUsrDialog()
 		return TRUE
 	else if(href_list["ejectsheet"])

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -6,13 +6,13 @@
 For the materials datum, it assumes you need reagents unless specified otherwise. To designate a material that isn't a reagent,
 you use one of the material IDs below. These are NOT ids in the usual sense (they aren't defined in the object or part of a datum),
 they are simply references used as part of a "has materials?" type proc. They all start with a $ to denote that they aren't reagents.
-The currently supporting non-reagent materials. All material amounts are set as the define SHEET_MATERIAL_AMOUNT, which defaults to 2000
+The currently supporting non-reagent materials. All material amounts are set as the define SHEET_MATERIAL_AMOUNT, which defaults to 100
 
 Don't add new keyword/IDs if they are made from an existing one (such as rods which are made from iron). Only add raw materials.
 
 Design Guidelines
 - When adding new designs, check rdreadme.dm to see what kind of things have already been made and where new stuff is needed.
-- A single sheet of anything is 2000 units of material. Materials besides iron/glass require help from other jobs (mining for
+- A single sheet of anything is 100 units of material. Materials besides iron/glass require help from other jobs (mining for
 other types of metals and chemistry for reagents).
 - Add the AUTOLATHE tag to
 */

--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -129,7 +129,12 @@
 		ui.open()
 
 /obj/machinery/rnd/production/ui_static_data(mob/user)
-	var/list/data = list()
+	var/list/data
+	if(isnull(materials.mat_container))
+		data = list()
+	else
+		data = materials.mat_container.ui_static_data()
+
 	var/list/designs = list()
 
 	var/datum/asset/spritesheet_batched/research_designs/spritesheet = get_asset_datum(/datum/asset/spritesheet_batched/research_designs)
@@ -209,7 +214,7 @@
 		var/total_storage = 0
 
 		for(var/datum/stock_part/matter_bin/bin in component_parts)
-			total_storage += bin.tier * 75000
+			total_storage += bin.tier * (37.5*SHEET_MATERIAL_AMOUNT)
 
 		materials.set_local_size(total_storage)
 

--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -116,6 +116,7 @@ All ShuttleMove procs go here
 
 // Called on atoms after everything has been moved
 /atom/movable/proc/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
+	SEND_SIGNAL(src, COMSIG_ATOM_AFTER_SHUTTLE_MOVE)
 	if(light)
 		update_light()
 	if(rotation)
@@ -212,7 +213,7 @@ All ShuttleMove procs go here
 	. = ..()
 	if(pipe_vision_img)
 		pipe_vision_img.loc = loc
-		
+
 	var/missing_nodes = FALSE
 	for(var/i in 1 to device_type)
 		if(nodes[i])

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -92,7 +92,7 @@
 	//maximum stocking amount (default 300000, 600000 at T4)
 	for(var/datum/stock_part/matter_bin/matter_bin in component_parts)
 		T += matter_bin.tier
-	rmat.set_local_size((200000 + (T * 50000)))
+	rmat.set_local_size(((100*SHEET_MATERIAL_AMOUNT) + (T * (25*SHEET_MATERIAL_AMOUNT))))
 
 	//resources adjustment coefficient (1 -> 0.85 -> 0.7 -> 0.55)
 	T = 1.15

--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -91,7 +91,7 @@
 		var/total_storage = 0
 
 		for(var/datum/stock_part/matter_bin/bin in component_parts)
-			total_storage += bin.tier * 75000
+			total_storage += bin.tier * (37.5*SHEET_MATERIAL_AMOUNT)
 
 		materials.set_local_size(total_storage)
 
@@ -343,7 +343,7 @@
 		var/total_storage = 0
 
 		for(var/datum/stock_part/matter_bin/bin in component_parts)
-			total_storage += bin.tier * 75000
+			total_storage += bin.tier * (37.5*SHEET_MATERIAL_AMOUNT)
 
 		materials.set_local_size(total_storage)
 

--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialAccessBar.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialAccessBar.tsx
@@ -1,6 +1,6 @@
 import { sortBy } from 'common/collections';
 import { classes } from 'common/react';
-import { useLocalState } from '../../backend';
+import { useLocalState, useBackend } from '../../backend';
 import { Flex, Button, Stack, AnimatedNumber } from '../../components';
 import { formatSiUnit } from '../../format';
 import { MaterialIcon } from './MaterialIcon';
@@ -72,13 +72,15 @@ type MaterialCounterProps = {
 
 const MaterialCounter = (props: MaterialCounterProps) => {
   const { material, onEjectRequested } = props;
+  const { data } = useBackend<Material>(context);
+  const { SHEET_MATERIAL_AMOUNT } = data;
 
   const [hovering, setHovering] = useLocalState(
     `MaterialCounter__${material.name}`,
     false,
   );
 
-  const canEject = material.amount > 2_000;
+  const canEject = material.amount > SHEET_MATERIAL_AMOUNT;
 
   return (
     <div
@@ -151,6 +153,8 @@ type EjectButtonProps = {
 
 const EjectButton = (props: EjectButtonProps) => {
   const { amount, available, material, onEject } = props;
+  const { data } = useBackend<Material>(context);
+  const { SHEET_MATERIAL_AMOUNT } = data;
 
   return (
     <Button
@@ -158,7 +162,8 @@ const EjectButton = (props: EjectButtonProps) => {
       color={'transparent'}
       className={classes([
         'Fabricator__PrintAmount',
-        amount * 2_000 > available && 'Fabricator__PrintAmount--disabled',
+        amount * SHEET_MATERIAL_AMOUNT > available &&
+          'Fabricator__PrintAmount--disabled',
       ])}
       onClick={() => onEject(amount)}
     >

--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialAccessBar.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialAccessBar.tsx
@@ -1,6 +1,6 @@
 import { sortBy } from 'common/collections';
 import { classes } from 'common/react';
-import { useLocalState, useBackend } from '../../backend';
+import { useLocalState } from '../../backend';
 import { Flex, Button, Stack, AnimatedNumber } from '../../components';
 import { formatSiUnit } from '../../format';
 import { MaterialIcon } from './MaterialIcon';
@@ -72,15 +72,11 @@ type MaterialCounterProps = {
 
 const MaterialCounter = (props: MaterialCounterProps) => {
   const { material, onEjectRequested } = props;
-  const { data } = useBackend<Material>(context);
-  const { SHEET_MATERIAL_AMOUNT } = data;
 
   const [hovering, setHovering] = useLocalState(
     `MaterialCounter__${material.name}`,
     false,
   );
-
-  const canEject = material.amount > SHEET_MATERIAL_AMOUNT;
 
   return (
     <div
@@ -89,7 +85,7 @@ const MaterialCounter = (props: MaterialCounterProps) => {
       className={classes([
         'MaterialDock',
         hovering && 'MaterialDock--active',
-        !canEject && 'MaterialDock--disabled',
+        !material.removable && 'MaterialDock--disabled',
       ])}
     >
       <Stack vertial direction={'column-reverse'}>
@@ -102,11 +98,14 @@ const MaterialCounter = (props: MaterialCounterProps) => {
           <Flex.Item>
             <MaterialIcon
               materialName={material.name}
-              amount={material.amount}
+              sheets={material.sheets}
             />
           </Flex.Item>
           <Flex.Item>
-            <AnimatedNumber value={material.amount} format={LABEL_FORMAT} />
+            <AnimatedNumber
+              value={material.amount / 100}
+              format={LABEL_FORMAT}
+            />
           </Flex.Item>
         </Flex>
         {hovering && (
@@ -114,25 +113,21 @@ const MaterialCounter = (props: MaterialCounterProps) => {
             <Flex vertical direction={'column-reverse'}>
               <EjectButton
                 material={material}
-                available={material.amount}
                 amount={5}
                 onEject={onEjectRequested}
               />
               <EjectButton
                 material={material}
-                available={material.amount}
                 amount={10}
                 onEject={onEjectRequested}
               />
               <EjectButton
                 material={material}
-                available={material.amount}
                 amount={25}
                 onEject={onEjectRequested}
               />
               <EjectButton
                 material={material}
-                available={material.amount}
                 amount={50}
                 onEject={onEjectRequested}
               />
@@ -146,15 +141,13 @@ const MaterialCounter = (props: MaterialCounterProps) => {
 
 type EjectButtonProps = {
   material: Material;
-  available: number;
   amount: number;
   onEject: (quantity: number) => void;
 };
 
 const EjectButton = (props: EjectButtonProps) => {
-  const { amount, available, material, onEject } = props;
-  const { data } = useBackend<Material>(context);
-  const { SHEET_MATERIAL_AMOUNT } = data;
+  const { amount, material, onEject } = props;
+  const { sheets } = material;
 
   return (
     <Button
@@ -162,8 +155,7 @@ const EjectButton = (props: EjectButtonProps) => {
       color={'transparent'}
       className={classes([
         'Fabricator__PrintAmount',
-        amount * SHEET_MATERIAL_AMOUNT > available &&
-          'Fabricator__PrintAmount--disabled',
+        amount > sheets && 'Fabricator__PrintAmount--disabled',
       ])}
       onClick={() => onEject(amount)}
     >

--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialCostSequence.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialCostSequence.tsx
@@ -71,7 +71,7 @@ export const MaterialCostSequence = (props: MaterialCostSequenceProps) => {
             <Flex.Item>
               <MaterialIcon
                 materialName={material}
-                amount={(amount || 1) * quantity}
+                sheets={((amount || 1) * quantity) / 100}
               />
             </Flex.Item>
             <Flex.Item
@@ -86,7 +86,7 @@ export const MaterialCostSequence = (props: MaterialCostSequenceProps) => {
                 }
               }
             >
-              {formatSiUnit((amount || 1) * quantity, 0)}
+              {formatSiUnit(((amount || 1) * quantity) / 100, 0)}
             </Flex.Item>
           </Flex>
         </Flex.Item>

--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialIcon.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialIcon.tsx
@@ -1,5 +1,7 @@
 import { classes } from 'common/react';
 import { Icon } from '../../components';
+import { Material } from './Types';
+import { useBackend } from '../../backend';
 
 const MATERIAL_ICONS: Record<string, [number, string][]> = {
   iron: [
@@ -62,8 +64,8 @@ export type MaterialIconProps = {
   materialName: string;
 
   /**
-   * The amount of material. One sheet is 2,000 units. By default, the icon
-   * attempts to render a full stack (200,000 units).
+   * The amount of material. One sheet is 100 units. By default, the icon
+   * attempts to render a full stack (5,000 units).
    */
   amount?: number;
 };
@@ -75,6 +77,8 @@ export type MaterialIconProps = {
 export const MaterialIcon = (props: MaterialIconProps) => {
   const { materialName, amount } = props;
   const icons = MATERIAL_ICONS[materialName];
+  const { data } = useBackend<Material>(context);
+  const { SHEET_MATERIAL_AMOUNT } = data;
 
   if (!icons) {
     return <Icon name="question-circle" />;
@@ -84,7 +88,8 @@ export const MaterialIcon = (props: MaterialIconProps) => {
 
   while (
     icons[activeIdx + 1] &&
-    icons[activeIdx + 1][0] <= (amount ?? 200_000) / 2_000
+    icons[activeIdx + 1][0] <=
+      (amount ?? 50 * SHEET_MATERIAL_AMOUNT) / SHEET_MATERIAL_AMOUNT
   ) {
     activeIdx += 1;
   }

--- a/tgui/packages/tgui/interfaces/Fabrication/MaterialIcon.tsx
+++ b/tgui/packages/tgui/interfaces/Fabrication/MaterialIcon.tsx
@@ -1,7 +1,5 @@
 import { classes } from 'common/react';
 import { Icon } from '../../components';
-import { Material } from './Types';
-import { useBackend } from '../../backend';
 
 const MATERIAL_ICONS: Record<string, [number, string][]> = {
   iron: [
@@ -64,10 +62,9 @@ export type MaterialIconProps = {
   materialName: string;
 
   /**
-   * The amount of material. One sheet is 100 units. By default, the icon
-   * attempts to render a full stack (5,000 units).
+   * The number of sheets of the material.
    */
-  amount?: number;
+  sheets?: number;
 };
 
 /**
@@ -75,10 +72,8 @@ export type MaterialIconProps = {
  * material.
  */
 export const MaterialIcon = (props: MaterialIconProps) => {
-  const { materialName, amount } = props;
+  const { materialName, sheets = 0 } = props;
   const icons = MATERIAL_ICONS[materialName];
-  const { data } = useBackend<Material>(context);
-  const { SHEET_MATERIAL_AMOUNT } = data;
 
   if (!icons) {
     return <Icon name="question-circle" />;
@@ -86,11 +81,7 @@ export const MaterialIcon = (props: MaterialIconProps) => {
 
   let activeIdx = 0;
 
-  while (
-    icons[activeIdx + 1] &&
-    icons[activeIdx + 1][0] <=
-      (amount ?? 50 * SHEET_MATERIAL_AMOUNT) / SHEET_MATERIAL_AMOUNT
-  ) {
+  while (icons[activeIdx + 1] && icons[activeIdx + 1][0] <= sheets) {
     activeIdx += 1;
   }
 

--- a/tgui/packages/tgui/interfaces/Fabrication/Types.ts
+++ b/tgui/packages/tgui/interfaces/Fabrication/Types.ts
@@ -21,9 +21,14 @@ export type Material = {
   ref: string;
 
   /**
-   * The amount of material; 2,000 units is one sheet.
+   * The amount of material; 100 units is one sheet.
    */
   amount: number;
+
+  /**
+   * Definition of how much units 1 sheet has.
+   */
+  SHEET_MATERIAL_AMOUNT: number;
 
   /**
    * The number of sheets.

--- a/tgui/packages/tgui/interfaces/Fabrication/Types.ts
+++ b/tgui/packages/tgui/interfaces/Fabrication/Types.ts
@@ -26,11 +26,6 @@ export type Material = {
   amount: number;
 
   /**
-   * Definition of how much units 1 sheet has.
-   */
-  SHEET_MATERIAL_AMOUNT: number;
-
-  /**
    * The number of sheets.
    */
   sheets: number;

--- a/tgui/packages/tgui/interfaces/OreRedemptionMachine.jsx
+++ b/tgui/packages/tgui/interfaces/OreRedemptionMachine.jsx
@@ -18,7 +18,7 @@ import { formatSiUnit } from '../format';
 
 export const OreRedemptionMachine = (props) => {
   const { act, data } = useBackend();
-  const { unclaimedPoints, materials, user } = data;
+  const { disconnected, unclaimedPoints, materials, user } = data;
   const [tab, setTab] = useSharedState('tab', 1);
   const [searchItem, setSearchItem] = useLocalState('searchItem', '');
   const [compact, setCompact] = useSharedState('compact', false);
@@ -76,7 +76,8 @@ export const OreRedemptionMachine = (props) => {
                 <Button
                   ml={2}
                   content="Claim"
-                  disabled={unclaimedPoints === 0}
+                  disabled={unclaimedPoints === 0 || disconnected}
+                  tooltip={disconnected}
                   onClick={() => act('Claim')}
                 />
               </Box>


### PR DESCRIPTION

## About The Pull Request

Ports: 
https://github.com/tgstation/tgstation/pull/74990
https://github.com/tgstation/tgstation/pull/76870
https://github.com/tgstation/tgstation/pull/76020

## Why It's Good For The Game

Bug fixes and makes it so you don't have to count materials when using them to print stuff
Materials being in sheets is much better

## Changelog

:cl:
qol: (scriptis) techfabs now use sheets(TM) as the default unit of measurement
fix: (scriptis) mechfab icons aren't perpetually gray
balance: (JohnFulpWillard) Machines (such as ORM and Techfabs) will no longer unsync from Ore silos when it moves Z-level, instead it will prevent materials from being used, as if it was on hold.
fix: (JohnFulpWillard) Fixes whiteships with silos on them disconencting upon moving
fix: (Helg2) autolathe, protolathe, mech fabricator and component printers material capacity are now in 20 times less, as intended.
fix: (Helg2) protolathe material menu now should display material ejecting correctly.
/:cl:
