### PR TITLE
Xenobio slime vac QOL

### DIFF
--- a/monkestation/code/modules/slimecore/items/vacuum_pack.dm
+++ b/monkestation/code/modules/slimecore/items/vacuum_pack.dm
@@ -36,24 +36,36 @@
 	max_integrity = 200
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
+	/// The nozzle that is attached to our vacuum pack
 	var/obj/item/vacuum_nozzle/nozzle
+	/// Type of nozzle that is created on initialize
 	var/nozzle_type = /obj/item/vacuum_nozzle
+	/// List of mobs that are stores inside the vacuum
 	var/list/stored = list()
+	/// How many mobs can be stored inside the vacuum
 	var/capacity = NORMAL_VACUUM_PACK_CAPACITY
+	/// How far away the vacuum can pick up mobs
 	var/range = NORMAL_VACUUM_PACK_RANGE
+	/// How fast the vacuum picks up mobs
 	var/speed = NORMAL_VACUUM_PACK_SPEED
+	/// Boolean, if the vacuum is illegal
 	var/illegal = FALSE
+	/// List of upgrades installed
 	var/list/upgrades = list()
+	/// The biomass recycler we are linked to
 	var/obj/machinery/biomass_recycler/linked
-	var/give_choice = TRUE //If set to true the pack will give the owner a radial selection to choose which object they want to shoot
-	var/check_backpack = TRUE //If it can only be used while worn on the back
-	var/static/list/storable_objects = typecacheof(list(/mob/living/basic/slime,
-														/mob/living/basic/cockroach/rockroach,
-														))
-	var/modified = FALSE //If the gun is modified to fight with revenants
-	var/mob/living/basic/revenant/ghost_busting //Stores the revenant we're currently sucking in
-	var/mob/living/ghost_buster //Stores the user
-	var/busting_beam //Stores visual effects
+	/// If set to true the pack will give the owner a radial selection to choose which object they want to shoot on left click
+	var/give_choice = TRUE
+	/// If it can only be used while worn on the back
+	var/check_backpack = TRUE
+	/// If the gun is modified to fight with revenants
+	var/modified = FALSE
+	/// Stores the revenant we're currently sucking in
+	var/mob/living/basic/revenant/ghost_busting
+	/// Stores the user
+	var/mob/living/ghost_buster
+	/// Stores visual effects
+	var/busting_beam
 	COOLDOWN_DECLARE(busting_throw_cooldown)
 
 /obj/item/vacuum_pack/Initialize(mapload)
@@ -61,6 +73,7 @@
 	nozzle = new nozzle_type(src)
 
 /obj/item/vacuum_pack/Destroy()
+	linked = null
 	QDEL_NULL(nozzle)
 	if(VACUUM_PACK_UPGRADE_HEALING in upgrades)
 		STOP_PROCESSING(SSobj, src)
@@ -85,6 +98,9 @@
 	if(LAZYLEN(upgrades))
 		for(var/upgrade in upgrades)
 			. += span_notice("It has \a [upgrade] upgrade installed.")
+	if(!linked)
+		return
+	. += span_info("It has [linked.stored_matter] unit\s of biomass.")
 
 /obj/item/vacuum_pack/attackby(obj/item/item, mob/living/user, params)
 	if(item == nozzle)
@@ -182,9 +198,28 @@
 	item_flags = NOBLUDGEON | ABSTRACT
 	slot_flags = NONE
 
+	/// The vacuum pack this nozzle is from
 	var/obj/item/vacuum_pack/pack
+	/// Boolean, if enabled it shows a radial wheel of what to shoot on left click
 	var/is_selecting = FALSE
-
+	/// The mob we have selected with attack_self_alternate
+	var/selected_creature = /mob/living/carbon/human/species/monkey // Shoot monkeys by default until something else is chosen
+	/// Conversion list of type to name for the examine of the nozzle
+	var/static/list/name_of_mobs = list(
+		/mob/living/carbon/human/species/monkey = "monkey",
+		/mob/living/basic/cockroach/rockroach = "rock roache",
+		/mob/living/basic/cockroach/iceroach = "ice roache",
+		/mob/living/basic/xenofauna/meatbeast = "meat beast",
+		/mob/living/basic/xenofauna/diyaab = "diyaab",
+		/mob/living/basic/xenofauna/thinbug = "thin bug",
+		/mob/living/basic/cockroach/recursive = "recursive roach",
+		/mob/living/basic/xenofauna/thoom = "thoom",
+		/mob/living/basic/xenofauna/greeblefly = "greeblefly",
+		/mob/living/basic/xenofauna/lavadog = "lava dog",
+		/mob/living/basic/xenofauna/voxslug = "strange slug",
+		/mob/living/basic/xenofauna/possum = "possum",
+		/mob/living/basic/xenofauna/dron = "semi-organic bug",
+	)
 /obj/item/vacuum_nozzle/Initialize(mapload)
 	. = ..()
 	pack = loc
@@ -197,6 +232,11 @@
 		. += span_notice("Activate to change firing modes. Currently set to [pack.give_choice ? "selective" : "indiscriminate"].")
 	else
 		. += span_notice("It's selection mechanism is hotwired to fire indiscriminately.")
+	if(!pack.linked)
+		return
+	. += span_notice("Right click in hand to select the type of creature to spawn.")
+	. += span_info("It is currently set to spawn a [name_of_mobs[selected_creature]]")
+	. += span_info("It has [pack.linked.stored_matter] unit\s of biomass.")
 
 /obj/item/vacuum_nozzle/equipped(mob/user, slot, initial)
 	. = ..()
@@ -226,6 +266,39 @@
 			span_hear("You hear a click.")
 		)
 
+/obj/item/vacuum_nozzle/attack_self_secondary(mob/user, modifiers)
+	. = ..()
+	var/choosing_creature = select_spawned_mob(user)
+	if(!choosing_creature)
+		return
+	selected_creature = choosing_creature
+
+/obj/item/vacuum_nozzle/proc/select_spawned_mob(mob/user)
+	var/list/items = list()
+	var/list/item_names = list()
+
+	for(var/printable_type in GLOB.biomass_unlocks)
+		pack.linked.vacuum_printable_types |= printable_type
+		pack.linked.vacuum_printable_types[printable_type] = GLOB.biomass_unlocks[printable_type]
+
+	for(var/printable_type in pack.linked.vacuum_printable_types)
+		var/atom/movable/printable = printable_type
+		var/image/printable_image = image(icon = initial(printable.icon), icon_state = initial(printable.icon_state))
+		items += list(initial(printable.name) = printable_image)
+		item_names[initial(printable.name)] = printable_type
+
+	var/pick = show_radial_menu(user, src, items, custom_check = FALSE, require_near = TRUE, tooltips = TRUE)
+
+	if(!pick)
+		return FALSE
+
+	var/spawn_type = item_names[pick]
+	if(pack.linked.stored_matter < pack.linked.vacuum_printable_types[spawn_type])
+		to_chat(user, span_warning("[pack.linked] does not have enough stored biomass for that! It currently has [pack.linked.stored_matter] out of [pack.linked.vacuum_printable_types[spawn_type]] unit\s required."))
+		return FALSE
+
+	return spawn_type
+
 /obj/item/vacuum_nozzle/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
 	. = ..()
 
@@ -242,34 +315,20 @@
 		to_chat(user, span_warning("[pack] is not linked to a biomass recycler!"))
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
-	var/list/items = list()
-	var/list/item_names = list()
+	if(!selected_creature)
+		var/choosing_creature = select_spawned_mob(user)
+		if(!choosing_creature)
+			return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+		selected_creature = choosing_creature
 
-	for(var/printable_type in GLOB.biomass_unlocks)
-		pack.linked.vacuum_printable_types |= printable_type
-		pack.linked.vacuum_printable_types[printable_type] = GLOB.biomass_unlocks[printable_type]
+	if(pack.linked.stored_matter < pack.linked.vacuum_printable_types[selected_creature])
+		to_chat(user, span_warning("[pack.linked] does not have enough stored biomass for that! It currently has [pack.linked.stored_matter] out of [pack.linked.vacuum_printable_types[selected_creature]] unit\s required."))
+		return FALSE
 
-	for(var/printable_type in pack.linked.vacuum_printable_types)
-		var/atom/movable/printable = printable_type
-		var/image/printable_image = image(icon = initial(printable.icon), icon_state = initial(printable.icon_state))
-		items += list(initial(printable.name) = printable_image)
-		item_names[initial(printable.name)] = printable_type
-
-
-	var/pick = show_radial_menu(user, src, items, custom_check = FALSE, require_near = TRUE, tooltips = TRUE)
-
-	if(!pick)
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-	var/spawn_type = item_names[pick]
-	if(pack.linked.stored_matter < pack.linked.vacuum_printable_types[spawn_type])
-		to_chat(user, span_warning("[pack.linked] does not have enough stored biomass for that! It currently has [pack.linked.stored_matter] out of [pack.linked.vacuum_printable_types[spawn_type]] unit\s required."))
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
-
-	var/atom/movable/spawned = new spawn_type(user.loc)
+	var/atom/movable/spawned = new selected_creature(user.loc)
 	spawned.AddComponent(/datum/component/vac_tagged, user)
 
-	pack.linked.stored_matter -= pack.linked.vacuum_printable_types[spawn_type]
+	pack.linked.stored_matter -= pack.linked.vacuum_printable_types[selected_creature]
 	playsound(user, 'sound/misc/moist_impact.ogg', 50, TRUE)
 	spawned.transform = matrix().Scale(0.5)
 	spawned.alpha = 0
@@ -285,6 +344,14 @@
 
 /obj/item/vacuum_nozzle/afterattack(atom/movable/target, mob/user, proximity, click_parameters)
 	. = ..()
+	if(istype(target, /obj/machinery/biomass_recycler) && target.Adjacent(user))
+		if(!(VACUUM_PACK_UPGRADE_BIOMASS in pack.upgrades))
+			to_chat(user, span_warning("[pack] does not posess a required upgrade!"))
+			return
+		pack.linked = target
+		to_chat(user, span_notice("You link [pack] to [target]."))
+		return
+
 	do_suck(target, user)
 
 /obj/item/vacuum_nozzle/proc/do_suck(atom/movable/target, mob/user)
@@ -295,94 +362,72 @@
 		start_busting(target, user)
 		return
 
-	if(istype(target, /obj/machinery/biomass_recycler) && target.Adjacent(user))
-		if(!(VACUUM_PACK_UPGRADE_BIOMASS in pack.upgrades))
-			to_chat(user, span_warning("[pack] does not posess a required upgrade!"))
-			return
-		pack.linked = target
-		to_chat(user, span_notice("You link [pack] to [target]."))
+	if(!isliving(target))
+		spew_contents(target, user)
 		return
+	var/mob/living/living_target = target
 
-	if(pack.linked)
-		var/can_recycle
-		for(var/recycable_type in pack.linked.recyclable_types)
-			if(istype(target, recycable_type))
-				can_recycle = recycable_type
-				break
-
-		var/target_stat = FALSE
-		if(isliving(target))
-			var/mob/living/living_target = target
-			target_stat = living_target.stat
-
-		if(can_recycle && (!is_type_in_typecache(target, pack.storable_objects) || target_stat != CONSCIOUS))
-			if(!(VACUUM_PACK_UPGRADE_BIOMASS in pack.upgrades))
-				to_chat(user, span_warning("[pack] does not posess a required upgrade!"))
-				return
-
-			if(!pack.linked)
-				to_chat(user, span_warning("[pack] is not linked to a biomass recycler!"))
-				return
-
-			if(target_stat == CONSCIOUS)
-				to_chat(user, span_warning("[target] is struggling far too much for you to suck it in!"))
-				return
-
-			if(isliving(target))
-				var/mob/living/living = target
-				if(living.buckled)
-					living.buckled.unbuckle_mob(target, force = TRUE)
-			target.unbuckle_all_mobs(force = TRUE)
-
-			if(!do_after(user, pack.speed, target, timed_action_flags = IGNORE_TARGET_LOC_CHANGE))
-				return
-
-			playsound(src, 'sound/effects/refill.ogg', 50, TRUE)
-			var/matrix/animation_matrix = matrix()
-			animation_matrix.Scale(0.5)
-			animation_matrix.Translate((user.x - target.x) * 32, (user.y - target.y) * 32)
-			animate(target, alpha = 0, time = 8, easing = QUAD_EASING|EASE_IN, transform = animation_matrix, flags = ANIMATION_PARALLEL)
-			sleep(0.8 SECONDS)
-			user.visible_message(span_warning("[user] sucks [target] into their [pack]!"), span_notice("You successfully suck [target] into your [src] and recycle it."))
-			qdel(target)
-			playsound(user, 'sound/machines/juicer.ogg', 50, TRUE)
-			pack.linked.use_power(500)
-			pack.linked.stored_matter += pack.linked.cube_production * pack.linked.recyclable_types[can_recycle]
+	if(isslime(living_target))
+		if(get_dist(user, living_target) > pack.range)
+			to_chat(user, span_warning("[living_target] is too far away!"))
 			return
-
-	if(is_type_in_typecache(target, pack.storable_objects))
-		if(get_dist(user, target) > pack.range)
-			to_chat(user, span_warning("[target] is too far away!"))
+		if(!(living_target in view(user, pack.range)))
+			to_chat(user, span_warning("You can't reach [living_target]!"))
 			return
-
-		if(!(target in view(user, pack.range)))
-			to_chat(user, span_warning("You can't reach [target]!"))
+		if(living_target.anchored || living_target.move_resist > MOVE_FORCE_STRONG)
+			to_chat(user, span_warning("You can't manage to suck [living_target] in!"))
 			return
-
-		if(target.anchored || target.move_resist > MOVE_FORCE_STRONG)
-			to_chat(user, span_warning("You can't manage to suck [target] in!"))
+		if(HAS_TRAIT(living_target, TRAIT_SLIME_RABID) && !pack.illegal && !(VACUUM_PACK_UPGRADE_PACIFY in pack.upgrades))
+			to_chat(user, span_warning("[living_target] is wiggling far too much for you to suck it in!"))
 			return
-
-		if(isslime(target))
-			var/mob/living/basic/slime/slime = target
-			if(HAS_TRAIT(slime, TRAIT_SLIME_RABID) && !pack.illegal && !(VACUUM_PACK_UPGRADE_PACIFY in pack.upgrades))
-				to_chat(user, span_warning("[slime] is wiggling far too much for you to suck it in!"))
-				return
-
 		if(LAZYLEN(pack.stored) >= pack.capacity)
 			to_chat(user, span_warning("[pack] is already filled to the brim!"))
 			return
-
-		if(!do_after(user, pack.speed, target, timed_action_flags = IGNORE_TARGET_LOC_CHANGE|IGNORE_USER_LOC_CHANGE, extra_checks = CALLBACK(src, .proc/suck_checks, target, user)))
+		if(!do_after(user, pack.speed, living_target, timed_action_flags = IGNORE_TARGET_LOC_CHANGE|IGNORE_USER_LOC_CHANGE, extra_checks = CALLBACK(src, PROC_REF(suck_checks), living_target, user)))
 			return
-
-		if(SEND_SIGNAL(target, COMSIG_LIVING_VACUUM_PRESUCK, src, user) & COMPONENT_LIVING_VACUUM_CANCEL_SUCK)
+		if(LAZYLEN(pack.stored) >= pack.capacity) // This is checked again after the do_after because otherwise you can bypass the cap by clicking fast enough
 			return
-
-		suck_victim(target, user)
+		if(SEND_SIGNAL(living_target, COMSIG_LIVING_VACUUM_PRESUCK, src, user) & COMPONENT_LIVING_VACUUM_CANCEL_SUCK)
+			return
+		suck_victim(living_target, user)
 		return
 
-	if(LAZYLEN(pack.stored) == 0)
+	if(pack.linked && (living_target.type in pack.linked.recyclable_types))
+		if(get_dist(user, living_target) > pack.range)
+			to_chat(user, span_warning("[living_target] is too far away!"))
+			return
+		if(!(living_target in view(user, pack.range)))
+			to_chat(user, span_warning("You can't reach [living_target]!"))
+			return
+		if(living_target.anchored || living_target.move_resist > MOVE_FORCE_STRONG)
+			to_chat(user, span_warning("You can't manage to suck [living_target] in!"))
+			return
+		if(ismonkey(living_target)) // Snowflake that blocks recycling healthy monkeys
+			var/mob/living/carbon/human/species/monkey/target_monkey = living_target
+			if(target_monkey.stat == CONSCIOUS)
+				to_chat(user, span_warning("[target_monkey] is struggling far too much for you to suck it in!"))
+				return
+
+		living_target.buckled?.unbuckle_mob(living_target, force = TRUE)
+		living_target.unbuckle_all_mobs(force = TRUE)
+		if(!do_after(user, pack.speed, living_target, timed_action_flags = IGNORE_TARGET_LOC_CHANGE))
+			return
+		playsound(src, 'sound/effects/refill.ogg', 50, TRUE)
+		var/matrix/animation_matrix = matrix()
+		animation_matrix.Scale(0.5)
+		animation_matrix.Translate((user.x - living_target.x) * 32, (user.y - living_target.y) * 32)
+		animate(living_target, alpha = 0, time = 8, easing = QUAD_EASING|EASE_IN, transform = animation_matrix, flags = ANIMATION_PARALLEL)
+		sleep(0.8 SECONDS)
+		user.visible_message(span_warning("[user] sucks [living_target] into their [pack]!"), span_notice("You successfully suck [living_target] into your [src] and recycle it."))
+		qdel(living_target)
+		playsound(user, 'sound/machines/juicer.ogg', 50, TRUE)
+		pack.linked.use_power(500)
+		pack.linked.stored_matter += pack.linked.cube_production * pack.linked.recyclable_types[living_target.type]
+		return
+
+/// Shoots out whatever is stored inside the vacuum
+/obj/item/vacuum_nozzle/proc/spew_contents(atom/movable/target, mob/user)
+	if(LAZYLEN(pack.stored) <= 0)
 		to_chat(user, span_warning("[pack] is empty!"))
 		return
 
@@ -396,9 +441,7 @@
 			stored_image.color = stored_obj.color
 			items += list(stored_obj.name = stored_image)
 			items_stored[stored_obj.name] = stored_obj
-
 		var/pick = show_radial_menu(user, src, items, custom_check = FALSE, require_near = TRUE, tooltips = TRUE)
-
 		if(!pick)
 			return
 		spewed = items_stored[pick]
@@ -418,7 +461,7 @@
 		if(prob(99) && spewed.stat != DEAD)
 			playsound(spewed, 'sound/misc/woohoo.ogg', 50, TRUE)
 
-	if(istype(spewed, /mob/living/basic/slime))
+	if(isslime(spewed))
 		var/mob/living/basic/slime/slime = spewed
 		slime.slime_flags &= ~STORED_SLIME
 		slime.ai_controller?.reset_ai_status()
@@ -426,14 +469,10 @@
 			REMOVE_TRAIT(slime, TRAIT_SLIME_STASIS, "vacuum_pack_stasis")
 
 		if(pack.illegal)
-
 			ADD_TRAIT(slime, TRAIT_SLIME_RABID, "syndicate_slimepack")
-
 			user.changeNext_move(CLICK_CD_RAPID) //Like a machine gun
-
 		else if(VACUUM_PACK_UPGRADE_PACIFY in pack.upgrades)
 			REMOVE_TRAIT(slime, TRAIT_SLIME_RABID, null)
-
 
 	pack.stored -= spewed
 	user.visible_message(span_warning("[user] shoots [spewed] out their [src]!"), span_notice("You shoot [spewed] out of your [src]."))
@@ -474,14 +513,17 @@
 	target.unbuckle_all_mobs(force = TRUE)
 	target.forceMove(pack)
 	pack.stored += target
-	if((VACUUM_PACK_UPGRADE_STASIS in pack.upgrades) && isslime(target))
-		var/mob/living/basic/slime/slime = target
-		ADD_TRAIT(slime, TRAIT_SLIME_STASIS, "vacuum_pack_stasis")
+
 	SEND_SIGNAL(target, COMSIG_ATOM_SUCKED)
 	if(!silent)
 		user.visible_message(span_warning("[user] sucks [target] into their [pack]!"), span_notice("You successfully suck [target] into your [src]."))
+
+	if(!isslime(target))
+		return
 	var/mob/living/basic/slime/slime = target
 	slime.slime_flags |= STORED_SLIME
+	if((VACUUM_PACK_UPGRADE_STASIS in pack.upgrades))
+		ADD_TRAIT(slime, TRAIT_SLIME_STASIS, "vacuum_pack_stasis")
 
 /obj/item/vacuum_nozzle/proc/start_busting(mob/living/basic/revenant/revenant, mob/living/user)
 	revenant.visible_message(span_warning("[user] starts sucking [revenant] into their [src]!"), span_userdanger("You are being sucked into [user]'s [src]!"))
@@ -492,14 +534,14 @@
 
 /obj/item/vacuum_nozzle/proc/bust_the_ghost()
 	while(check_busting())
-		if(!do_after(pack.ghost_buster, 0.5 SECONDS, target = pack.ghost_busting, extra_checks = CALLBACK(src, .proc/check_busting), timed_action_flags = IGNORE_TARGET_LOC_CHANGE|IGNORE_USER_LOC_CHANGE))
+		if(!do_after(pack.ghost_buster, 0.5 SECONDS, target = pack.ghost_busting, extra_checks = CALLBACK(src, PROC_REF(check_busting), timed_action_flags = IGNORE_TARGET_LOC_CHANGE|IGNORE_USER_LOC_CHANGE)))
 			pack.ghost_busting = null
 			pack.ghost_buster = null
 			QDEL_NULL(pack.busting_beam)
 			return
 
-		//pack.ghost_busting.adjustHealth(5)
-		//pack.ghost_busting.reveal(0.5 SECONDS, TRUE)
+		pack.ghost_busting.adjustHealth(5)
+		pack.ghost_busting.reveal(0.5 SECONDS, TRUE)
 
 /obj/item/vacuum_nozzle/proc/check_busting()
 	if(isnull(pack.ghost_busting?.loc) || QDELING(pack.ghost_busting))
@@ -511,7 +553,7 @@
 	if(loc != pack.ghost_buster)
 		return FALSE
 
-	if(get_dist(pack.ghost_buster, pack.ghost_busting) > 3)
+	if(get_dist(pack.ghost_buster, pack.ghost_busting) > pack.range)
 		return FALSE
 
 	if(pack.ghost_busting.essence <= 0) //Means that the revenant is dead
@@ -541,7 +583,7 @@
 		return
 	var/list/options = list()
 	for(var/atom/movable/thing as anything in target_turf)
-		if(!is_type_in_typecache(thing, pack.storable_objects) && !is_type_in_list(thing, pack.linked?.recyclable_types))
+		if(!isslime(thing) && !(thing.type in pack.linked?.recyclable_types))
 			continue
 		var/mutable_appearance/copied_appearance = copy_appearance_filter_overlays(thing.appearance)
 		copied_appearance.dir = SOUTH

--- a/monkestation/code/modules/slimecore/items/vacuum_pack.dm
+++ b/monkestation/code/modules/slimecore/items/vacuum_pack.dm
@@ -207,8 +207,8 @@
 	/// Conversion list of type to name for the examine of the nozzle
 	var/static/list/name_of_mobs = list(
 		/mob/living/carbon/human/species/monkey = "monkey",
-		/mob/living/basic/cockroach/rockroach = "rock roache",
-		/mob/living/basic/cockroach/iceroach = "ice roache",
+		/mob/living/basic/cockroach/rockroach = "rock roach",
+		/mob/living/basic/cockroach/iceroach = "ice roach",
 		/mob/living/basic/xenofauna/meatbeast = "meat beast",
 		/mob/living/basic/xenofauna/diyaab = "diyaab",
 		/mob/living/basic/xenofauna/thinbug = "thin bug",
@@ -534,14 +534,14 @@
 
 /obj/item/vacuum_nozzle/proc/bust_the_ghost()
 	while(check_busting())
-		if(!do_after(pack.ghost_buster, 0.5 SECONDS, target = pack.ghost_busting, extra_checks = CALLBACK(src, PROC_REF(check_busting), timed_action_flags = IGNORE_TARGET_LOC_CHANGE|IGNORE_USER_LOC_CHANGE)))
+		if(!do_after(pack.ghost_buster, 0.5 SECONDS, target = pack.ghost_busting, extra_checks = CALLBACK(src, PROC_REF(check_busting)), timed_action_flags = IGNORE_TARGET_LOC_CHANGE|IGNORE_USER_LOC_CHANGE))
 			pack.ghost_busting = null
 			pack.ghost_buster = null
 			QDEL_NULL(pack.busting_beam)
 			return
 
-		pack.ghost_busting.adjustHealth(5)
-		pack.ghost_busting.reveal(0.5 SECONDS, TRUE)
+		pack.ghost_busting.adjust_health(5)
+		pack.ghost_busting.apply_status_effect(/datum/status_effect/revenant/revealed, 0.5 SECONDS)
 
 /obj/item/vacuum_nozzle/proc/check_busting()
 	if(isnull(pack.ghost_busting?.loc) || QDELING(pack.ghost_busting))

--- a/monkestation/code/modules/slimecore/machines/biomass_recycler.dm
+++ b/monkestation/code/modules/slimecore/machines/biomass_recycler.dm
@@ -8,11 +8,30 @@ GLOBAL_LIST_INIT(biomass_unlocks, list())
 	layer = BELOW_OBJ_LAYER
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/biomass_recycler
-	var/stored_matter = 0
-	var/cube_production = 0.2
 
-	var/static/list/recyclable_types = list(/mob/living/carbon/human/species/monkey = 1)
+	/// How much biomass is currently stores in the recycler
+	var/stored_matter = 0
+	/// Multiplier that affects how much biomass is gained when recycling
+	var/cube_production = 0.2
+	/// List of all creatures that the biomass recycler can grind down for biomass
+	var/static/list/recyclable_types = list(
+		/mob/living/carbon/human/species/monkey = 1,
+		/mob/living/basic/cockroach/rockroach = 1,
+		/mob/living/basic/cockroach/iceroach = 1,
+		/mob/living/basic/xenofauna/meatbeast = 2,
+		/mob/living/basic/xenofauna/diyaab = 1,
+		/mob/living/basic/xenofauna/thinbug = 1,
+		/mob/living/basic/cockroach/recursive = 1,
+		/mob/living/basic/xenofauna/thoom = 2,
+		/mob/living/basic/xenofauna/greeblefly = 2,
+		/mob/living/basic/xenofauna/lavadog = 1,
+		/mob/living/basic/xenofauna/voxslug = 1,
+		/mob/living/basic/xenofauna/possum = 1,
+		/mob/living/basic/xenofauna/dron = 1,
+	)
+	/// List of things you can print at the biomass recycler
 	var/list/printable_types = list(/obj/item/stack/biomass = 1, /obj/item/food/monkeycube = 1)
+	/// List of things you can generate with the right click of a linked vacuum
 	var/list/vacuum_printable_types = list(/mob/living/carbon/human/species/monkey = 1)
 
 /obj/machinery/biomass_recycler/RefreshParts() //Ranges from 0.2 to 0.8 per monkey recycled
@@ -27,6 +46,7 @@ GLOBAL_LIST_INIT(biomass_unlocks, list())
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Recycles <b>[cube_production]</b> biomass units per unit inserted.")
+		. += span_info("It currently has [stored_matter] unit\s of biomass.")
 
 /obj/machinery/biomass_recycler/wrench_act(mob/living/user, obj/item/tool)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Improves the code for the xenobio slime vac, and adds in some QOL including being able to recycle the xenofauna and being able to right click to spawn mobs without having to go through the radial every time.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nice QOL + Some annoyances I fixed
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Xenobio slime vacuum can recycle the fauna that it spawns (instead of having to kill them)
qol: Select the creature you want to spawn by right clicking the nozzle, then dispense it with right clicking
fix: Slime vac can damage revenants when it's in ghost buster mode
fix: Slime vac no longer has infinite range when recycling monkeys
qol: Slime vac, Nozzle, and recycler now display their biomass on examine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
