### PR TITLE
Fixes slimes not running away from people with fire extinguishers

### DIFF
--- a/monkestation/code/modules/slimecore/components/basic_scared_of_item.dm
+++ b/monkestation/code/modules/slimecore/components/basic_scared_of_item.dm
@@ -3,7 +3,7 @@
 	var/was_scared = FALSE
 	var/mob/last_scared_by
 
-/datum/component/scared_of_item/Initialize(item_path, range)
+/datum/component/scared_of_item/Initialize(range)
 	src.range = range
 	START_PROCESSING(SSobj, src)
 
@@ -19,20 +19,19 @@
 		if(living.stat == DEAD)
 			return
 
-	main_loop:
-		for(var/mob/living/carbon/human/human in oview(range, basic_mob))
-			for(var/obj/item/item as anything in human.held_items)
-				if(QDELETED(item))
-					continue
-				if(item.type != basic_mob.ai_controller?.blackboard[BB_BASIC_MOB_SCARED_ITEM])
-					continue
-				basic_mob.ai_controller?.set_blackboard_key(BB_BASIC_MOB_STOP_FLEEING, FALSE)
+	for(var/mob/living/carbon/human/human in oview(range, basic_mob))
+		for(var/obj/item/item as anything in human.held_items)
+			if(QDELETED(item))
+				continue
+			if(!istype(item, basic_mob.ai_controller?.blackboard[BB_BASIC_MOB_SCARED_ITEM]))
+				continue
+			basic_mob.ai_controller?.set_blackboard_key(BB_BASIC_MOB_STOP_FLEEING, FALSE)
 
-				if(!was_scared)
-					SEND_SIGNAL(basic_mob, COMSIG_EMOTION_STORE, human, EMOTION_SCARED, "chased me with an extinguisher.")
-					last_scared_by = human
-					was_scared = TRUE
-				break main_loop
+			if(!was_scared)
+				SEND_SIGNAL(basic_mob, COMSIG_EMOTION_STORE, human, EMOTION_SCARED, "chased me with an extinguisher.")
+				last_scared_by = human
+				was_scared = TRUE
+			return
 	basic_mob.ai_controller?.set_blackboard_key(BB_BASIC_MOB_STOP_FLEEING, TRUE)
 	if(was_scared)
 		SEND_SIGNAL(basic_mob, COMSIG_EMOTION_STORE, last_scared_by, EMOTION_HAPPY, "stopped chasing me with an extinguisher.", 0)

--- a/monkestation/code/modules/slimecore/mobs/ai_controller/behaviours/flee_from_item.dm
+++ b/monkestation/code/modules/slimecore/mobs/ai_controller/behaviours/flee_from_item.dm
@@ -41,9 +41,9 @@
 
 			var/mob/living/carbon/human/human = pot_target
 			for(var/obj/item/item as anything in human.held_items)
-				if(!item)
+				if(QDELETED(item))
 					continue
-				if(item.type != scared_item_path)
+				if(!istype(item, scared_item_path))
 					continue
 				filtered_targets += pot_target
 				break


### PR DESCRIPTION

## About The Pull Request
The component that was ment to cause slimes to be scared of fire extinguishers did not return early which caused it to stop the slime from fleeing just as it caused them to flee.

Also removed the item_path argument since it was never used and it caused an issue in _base_slime.dm which looks like it assumes the range argument is the first one, causing the actual range var to be null.

It now also works with subtypes, a bit silly it only worked with extinguishers that did not spawn empty.
## Why It's Good For The Game
Makes a thing that did not work, work.
## Changelog
:cl:
fix: Slimes now flee from people with extinguishers again.
/:cl:
