### PR TITLE
minor CI improvements

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -32,7 +32,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install pyyaml
-          sudo apt-get install  dos2unix
 
       - name: "Checkout"
         if: steps.value_holder.outputs.ACTIONS_ENABLED

--- a/.github/workflows/run_integration_tests.yml
+++ b/.github/workflows/run_integration_tests.yml
@@ -41,12 +41,15 @@ jobs:
           name: build-artifact-${{ inputs.major || env.BYOND_MAJOR }}-${{ inputs.minor || env.BYOND_MINOR}}
           path: ./
       - name: Setup database
+        env:
+          MYSQL_CONFIG_FILE: tools/ci/mysql_config.cnf
         run: |
           sudo systemctl start mysql
-          mysql -u root -proot -e 'CREATE DATABASE tg_ci;'
-          mysql -u root -proot tg_ci < SQL/tgstation_schema.sql
-          mysql -u root -proot -e 'CREATE DATABASE tg_ci_prefixed;'
-          mysql -u root -proot tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql
+          mysql --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }} -e 'CREATE DATABASE tg_ci;'
+          mysql --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }} tg_ci < SQL/tgstation_schema.sql
+          mysql --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }} -e 'CREATE DATABASE tg_ci_prefixed;'
+          mysql --defaults-extra-file=${{ env.MYSQL_CONFIG_FILE }} tg_ci_prefixed < SQL/tgstation_schema_prefixed.sql
+          echo "Sucessful MySQL Database Setup"
       - name: Install rust-g
         run: |
           bash tools/ci/install_rust_g.sh

--- a/tools/ci/mysql_config.cnf
+++ b/tools/ci/mysql_config.cnf
@@ -1,0 +1,3 @@
+[client]
+user = "root"
+password = "root"


### PR DESCRIPTION
## About The Pull Request

Ports the following PRs:

https://github.com/tgstation/tgstation/pull/91739
> This warning thing has been annoying me for a while when I scour CI logs looking for oranges/reds, let's remove this needless emission by confabulating a `.cfg` file and using that to run any necessary commands. This worked on my local repository and should pass CI without any issues on this repo as well.

https://github.com/tgstation/tgstation/pull/91903
> Remove `sudo apt-get install dos2unix` from compile changelogs workflow

## Why It's Good For The Game

> In case we really wanna start cracking down on failing due to warnings in CI it's helpful to ensure that the standard case is normal. Also just cleaner in general.

---
> The step using it was deleted in https://github.com/tgstation/tgstation/commit/e378552368c538c47d8718d9e230e7ae7d663f04 but the dependency install step remains

## Changelog

no user-facing or even DM changes whatsoever