### PR TITLE
Makes the Analgesia quirk -4 instead of -2

### DIFF
--- a/code/datums/quirks/negative_quirks/numb.dm
+++ b/code/datums/quirks/negative_quirks/numb.dm
@@ -2,7 +2,7 @@
 	name = "Analgesia"
 	desc = "You can't feel pain at all."
 	icon = FA_ICON_STAR_OF_LIFE
-	value = -2
+	value = -4
 	gain_text = "You feel your body becoming numb."
 	lose_text = "The numbness subsides."
 	medical_record_text = "The patient exhibits congenital hypoesthesia, making them insensitive to pain stimuli."


### PR DESCRIPTION

## About The Pull Request

this makes the Analgesia (numb) quirk -4 points (like it is on tg) instead of -2.

## Why It's Good For The Game

in the original PR, it was lowered from -4 to -2 due to concerns about it being immune to pain

turns out, pain immunity is nothing when you literally can't tell that you're one hit from crit mid-fight.

## Changelog
:cl:
balance: The Analgesia quirk is now -4 points instead of -2.
/:cl:
