### PR TITLE
searching in the loot panel now properly updates as you type

### DIFF
--- a/tgui/packages/tgui/interfaces/LootPanel/index.tsx
+++ b/tgui/packages/tgui/interfaces/LootPanel/index.tsx
@@ -86,7 +86,7 @@ export class LootPanel extends Component<{}, LootPanelState> {
         buttons={
           <Stack align="center">
             <Input
-              onChange={(_, value) => this.setState({ searchText: value })}
+              onInput={(_, value) => this.setState({ searchText: value })}
               placeholder="Search items..."
               value={this.state.searchText}
             />


### PR DESCRIPTION

## About The Pull Request

pretty simple, this makes it so the search properly updates in the lootpanel as you type.

![2025-08-08 (1754691294)](https://github.com/user-attachments/assets/3929177d-b9e8-400d-ae35-97776663942f)

## Why It's Good For The Game

makes searching slightly less annoying, and im pretty sure this is how its intended to work anyways

## Changelog
:cl:
fix: Searching in the alt-click loot panel now properly updates as yout ype.
/:cl:
