### PR TITLE
Bloodsuckers now properly exit Frenzy if given enough blood while dead

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_frenzy.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_frenzy.dm
@@ -75,10 +75,10 @@
 	return ..()
 
 /datum/status_effect/frenzy/tick()
-	var/mob/living/carbon/human/user = owner
-	if(!bloodsuckerdatum?.frenzied)
+	if(!bloodsuckerdatum?.frenzied || bloodsuckerdatum.bloodsucker_blood_volume >= FRENZY_THRESHOLD_EXIT)
+		qdel(src)
 		return
-	user.adjustFireLoss(1.5 + (bloodsuckerdatum.humanity_lost / 10))
+	owner.take_overall_damage(burn = 1.5 + (bloodsuckerdatum.humanity_lost / 10))
 
 /datum/movespeed_modifier/bloodsucker_frenzy
 	multiplicative_slowdown = -0.4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Normally, the frenzy status effect is removed during `handle_starving()`, however this won't really run if they're dead, due to it being linked to `COMSIG_HUMAN_ON_HANDLE_BLOOD`.

This makes it so that the frenzy status effect clear itself if the blood volume goes over the frenzy threshold when it ticks.

## Why It's Good For The Game

bug fix.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Bloodsuckers now properly exit Frenzy if given enough blood while dead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
