### PR TITLE
add a maximum lifetime to hotspots from certain sources

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -681,7 +681,8 @@ ADMIN_VERB(check_bomb_impacts, R_DEBUG, FALSE, "Check Bomb Impact", "See what th
 		for(var/thing in flame_turf)
 			if(thing)
 				var/turf/T = thing
-				new /obj/effect/hotspot(T) //Mostly for ambience!
+				var/obj/effect/hotspot/hotspot = new(T) //Mostly for ambience!
+				QDEL_IN(hotspot, rand(1 SECONDS, 2 SECONDS))
 		cost_flameturf = MC_AVERAGE(cost_flameturf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 
 		/*

--- a/code/datums/actions/mobs/fire_breath.dm
+++ b/code/datums/actions/mobs/fire_breath.dm
@@ -83,6 +83,7 @@
 		hit_list |= robotron
 		robotron.take_damage(mech_damage, BURN, FIRE)
 
+	QDEL_IN(fire_hotspot, 2.5 SECONDS)
 	return fire_hotspot
 
 /// Do something unpleasant to someone we set on fire

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -296,8 +296,9 @@
 		var/turf/closed/mineral/M = T
 		M.gets_drilled()
 	playsound(T, SFX_EXPLOSION, 80, TRUE)
-	new /obj/effect/hotspot(T)
+	var/obj/effect/hotspot/hotspot = new(T)
 	T.hotspot_expose(DRAKE_FIRE_TEMP, DRAKE_FIRE_EXPOSURE, 1)
+	QDEL_IN(hotspot, 1 SECONDS)
 	for(var/mob/living/L in T.contents)
 		if(istype(L, /mob/living/simple_animal/hostile/megafauna/dragon))
 			continue


### PR DESCRIPTION

## About The Pull Request

this makes it so hotspots from explosions, ash drakes, and fire breath will get `QDEL_IN`'d, ensuring they only have a maximum lifetime of a couple of seconds, regardless of atmos subsystem lag.

## Why It's Good For The Game

> i cant stand the secret ash drake varient with its domain expansion, time dilation abuse
- @Salted-Zen 

## Changelog
:cl:
fix: Hotspots/fire from ash drakes, explosions, and fire breath should no longer last more than a couple of seconds.
/:cl:
