### PR TITLE
Revenge Vassals now also resist mindshields

### DIFF
--- a/monkestation/code/modules/bloodsuckers/vassals/types/revenge.dm
+++ b/monkestation/code/modules/bloodsuckers/vassals/types/revenge.dm
@@ -54,7 +54,7 @@
 
 	return data + ..()
 
-/datum/antagonist/vassal/favorite/pre_mindshield(mob/implanter, mob/living/mob_override)
+/datum/antagonist/vassal/revenge/pre_mindshield(mob/implanter, mob/living/mob_override)
 	return COMPONENT_MINDSHIELD_RESISTED
 
 /datum/antagonist/vassal/revenge/proc/on_master_death(datum/antagonist/bloodsucker/bloodsuckerdatum, mob/living/carbon/master)

--- a/monkestation/code/modules/bloodsuckers/vassals/types/revenge.dm
+++ b/monkestation/code/modules/bloodsuckers/vassals/types/revenge.dm
@@ -54,6 +54,9 @@
 
 	return data + ..()
 
+/datum/antagonist/vassal/favorite/pre_mindshield(mob/implanter, mob/living/mob_override)
+	return COMPONENT_MINDSHIELD_RESISTED
+
 /datum/antagonist/vassal/revenge/proc/on_master_death(datum/antagonist/bloodsucker/bloodsuckerdatum, mob/living/carbon/master)
 	SIGNAL_HANDLER
 

--- a/monkestation/code/modules/bloodsuckers/vassals/vassal_misc_procs.dm
+++ b/monkestation/code/modules/bloodsuckers/vassals/vassal_misc_procs.dm
@@ -67,6 +67,6 @@
 	vassaldatum.silent = FALSE
 
 	//send alerts of completion
-	to_chat(master, span_danger("You have turned [vassal_owner.current] into your [vassaldatum.name]! They will no longer be deconverted upon Mindshielding!"))
-	to_chat(vassal_owner, span_notice("As Blood drips over your body, you feel closer to your Master... You are now the Favorite Vassal!"))
+	to_chat(master, span_danger("You have turned [vassal_owner.current] into your [vassaldatum.name]! [vassal_owner.current.p_They()] will no longer be deconverted upon Mindshielding!"))
+	to_chat(vassal_owner, span_notice("As Blood drips over your body, you feel closer to your Master... You are now the [vassaldatum.name]!"))
 	vassal_owner.current.playsound_local(null, 'sound/magic/mutate.ogg', vol = 75, vary = FALSE, pressure_affected = FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

`/datum/antagonist/vassal/proc/make_special(datum/antagonist/vassal/vassal_type)`, which is used for both favorite and revenge vassals, says "They will no longer be deconverted upon Mindshielding"... so let's make it that way.

## Why It's Good For The Game

consistency's sake + kind of makes sense, since they're also a special vassal, just with a different "purpose"

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Revenge Vassals now also resist mindshields, just like Favorite Vassals.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
