### PR TITLE
Allow wizard/witch robes to have oxygen tanks in suit storage

### DIFF
--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -9,7 +9,7 @@
 		/obj/item/tank/internals/plasmaman,
 		/obj/item/tank/jetpack/oxygen/captain,
 		/obj/item/storage/belt/holster,
-		)
+	)
 	armor_type = /datum/armor/none
 	drop_sound = 'sound/items/handling/cloth_drop.ogg'
 	pickup_sound = 'sound/items/handling/cloth_pickup.ogg'

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -107,11 +107,8 @@
 	allowed = list(
 		/obj/item/teleportation_scroll,
 		/obj/item/highfrequencyblade/wizard,
-		// parent type allowed items
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/tank/internals/plasmaman,
-		/obj/item/tank/jetpack/oxygen/captain,
-		/obj/item/storage/belt/holster,
 	)
 	flags_inv = HIDEJUMPSUIT
 	strip_delay = 50

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -104,7 +104,15 @@
 	inhand_icon_state = "wizrobe"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	armor_type = /datum/armor/suit_wizrobe
-	allowed = list(/obj/item/teleportation_scroll, /obj/item/highfrequencyblade/wizard)
+	allowed = list(
+		/obj/item/teleportation_scroll,
+		/obj/item/highfrequencyblade/wizard,
+		// parent type allowed items
+		/obj/item/tank/internals/emergency_oxygen,
+		/obj/item/tank/internals/plasmaman,
+		/obj/item/tank/jetpack/oxygen/captain,
+		/obj/item/storage/belt/holster,
+	)
 	flags_inv = HIDEJUMPSUIT
 	strip_delay = 50
 	equip_delay_other = 50


### PR DESCRIPTION
## About The Pull Request

this makes it so the wizard/witch robes also has the same allowed suit storage items as the parent `/obj/item/clothing/suit` type, meaning they can now have emergency oxygen tanks and plasmaman tanks.

## Why It's Good For The Game

i want my witch drip without compromising on a pocket slot for internals :(

## Changelog
:cl:
qol: Wizard/witch robes can now also hold emergency oxygen tanks and plasmaman tanks their suit storage.
/:cl:
