### PR TITLE
Adds Fauna Modifier for projectiles

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -172,6 +172,7 @@
 	var/decayedRange //stores original range
 	var/reflect_range_decrease = 5 //amount of original range that falls off when reflecting, so it doesn't go forever
 	var/reflectable = NONE // Can it be reflected or not?
+	var/fauna_mod = 1 // What is the multiplier vs lavaland fauna and megafauna?
 
 	// Status effects applied on hit
 	var/stun = 0 SECONDS
@@ -347,6 +348,8 @@
 
 	if(blocked != 100) // not completely blocked
 		var/obj/item/bodypart/hit_bodypart = living_target.get_bodypart(def_zone)
+		if(faction_check(living_target.faction, FACTION_MINING || FACTION_BOSS))
+			damage *= fauna_mod
 		if (damage)
 			if (living_target.blood_volume && damage_type == BRUTE && (isnull(hit_bodypart) || hit_bodypart.can_bleed()))
 				var/splatter_dir = dir


### PR DESCRIPTION
## About The Pull Request

Adds a fauna damage modifier to projectiles, so you can make fauna killing guns without having them delete everything else.

## Why It's Good For The Game

Relying on waste firing pins has MANY issues that I have detailed elsewhere. This allows for a far more reliable and total solution.

## Changelog
:cl:
code: Adds a fauna_mod variable, that can be used to add a damage multiplier against lavaland fauna to any projectile.
/:cl:
