### PR TITLE
fixes infinite recursion with surgery gas masks

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -910,7 +910,6 @@
 		if (breath_mask != tool)
 			breath_mask = tool
 			RegisterSignal(breath_mask, COMSIG_MOVABLE_MOVED, PROC_REF(on_mask_moved))
-			RegisterSignal(breath_mask, COMSIG_ITEM_DROPPED, PROC_REF(check_mask_range))
 
 		balloon_alert(user, "mask attached")
 		playsound(src, 'sound/machines/click.ogg', 50, TRUE)


### PR DESCRIPTION
## About The Pull Request
there was an infinite recursion with masks being dropped over and over again so the 'move' signal wasnt being unregistered from the mob holding the mask. i figured the unequip signal wasnt needed anyway since we're already registering a moved signal on the mask, which already handles clearing signals from the holding mob upon being removed from their inventory.

Ports https://github.com/tgstation/tgstation/pull/91608
## Why It's Good For The Game
bugfix

## Changelog
:cl: Ben10Omintrix
fix: moving away from the surgery table with its mask no longer causes lag
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
