### PR TITLE
End of Gatekeeping to Ranching

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -1194,6 +1194,11 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
+	dir = 1
+	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "amv" = (
@@ -1921,10 +1926,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "atu" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/chicken)
 "atx" = (
@@ -8220,11 +8222,12 @@
 /turf/closed/wall,
 /area/station/engineering/shipbreaker_hut)
 "bDR" = (
-/obj/structure/railing,
-/obj/structure/railing{
+/obj/machinery/light/floor/has_bulb,
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
-/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/chicken)
 "bDS" = (
@@ -16102,9 +16105,7 @@
 /turf/open/floor/iron,
 /area/station/medical/aslyum)
 "dao" = (
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
@@ -27882,7 +27883,9 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/aslyum)
 "foV" = (
-/obj/structure/railing,
+/obj/structure/window/reinforced/tinted/spawner/directional/north{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -38744,9 +38747,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "hxV" = (
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 4
 	},
@@ -38937,7 +38938,7 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "hAp" = (
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
 /obj/structure/chair/sofa/corp{
@@ -46081,12 +46082,12 @@
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms/vacantroom)
 "iVq" = (
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
+/obj/structure/nestbox,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "iVx" = (
@@ -54819,7 +54820,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "kzk" = (
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
 /turf/open/floor/grass,
@@ -55178,7 +55179,9 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/lobby)
 "kCJ" = (
-/obj/structure/railing,
+/obj/structure/window/reinforced/tinted/spawner/directional/north{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -56730,12 +56733,10 @@
 /turf/open/floor/wood,
 /area/station/hallway/primary/central)
 "kUD" = (
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
 /obj/structure/nestbox,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken/backroom)
@@ -57846,9 +57847,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/nestbox,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken/backroom)
@@ -62680,9 +62679,7 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken/backroom)
 "mcB" = (
@@ -72888,7 +72885,7 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "oeQ" = (
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
 /obj/structure/hedge,
@@ -83999,9 +83996,9 @@
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
 "qnd" = (
-/obj/structure/nestbox,
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
 /turf/open/floor/grass,
-/area/station/service/hydroponics/chicken)
+/area/station/service/hydroponics/chicken/backroom)
 "qnf" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/door/airlock/maintenance{
@@ -88024,9 +88021,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical/central)
 "qZG" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
 /mob/living/basic/chicken/brown{
 	forced_gender = "male"
 	},
@@ -89682,9 +89677,7 @@
 /area/station/science/lab)
 "rqa" = (
 /obj/structure/sign/poster/contraband/borg_fancy_2/directional/south,
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "rqb" = (
@@ -89973,7 +89966,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "rsZ" = (
-/obj/structure/railing{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
 /turf/open/floor/grass,
@@ -90870,7 +90865,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
 /turf/open/floor/wood/parquet,
@@ -98339,6 +98334,11 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
+	dir = 1
+	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "sYK" = (
@@ -100671,7 +100671,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
 /turf/open/floor/wood/parquet,
@@ -102950,6 +102950,20 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/upper)
+"tQX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/window/reinforced/tinted/spawner/directional/north{
+	dir = 2
+	},
+/turf/open/floor/wood/large,
+/area/station/service/hydroponics/chicken)
 "tQZ" = (
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured_large,
@@ -105481,6 +105495,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "uoP" = (
@@ -110493,10 +110508,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/morgue)
 "vnJ" = (
-/obj/structure/nestbox,
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "vnK" = (
@@ -110708,7 +110723,9 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hos)
 "vpt" = (
-/obj/structure/railing{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 4
 	},
 /turf/open/floor/grass,
@@ -111109,7 +111126,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "vtN" = (
-/obj/structure/railing,
+/obj/structure/window/reinforced/tinted/spawner/directional/north{
+	dir = 2
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/flip{
@@ -112866,7 +112885,7 @@
 /area/station/maintenance/starboard/fore)
 "vIV" = (
 /obj/machinery/camera/autoname/directional/south,
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
 /obj/structure/hedge,
@@ -116260,6 +116279,8 @@
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
 	},
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
+/obj/structure/nestbox,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "wpY" = (
@@ -119430,9 +119451,7 @@
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
 "wVq" = (
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/effect/turf_decal/siding/thinplating/dark,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -120299,9 +120318,7 @@
 	},
 /area/station/engineering/atmos/hfr_room)
 "xer" = (
-/obj/structure/railing{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "xey" = (
@@ -144484,7 +144501,7 @@ xwJ
 gJL
 vdq
 xrB
-rsZ
+qnd
 sNT
 qpl
 uID
@@ -145768,7 +145785,7 @@ xHd
 eyJ
 atu
 uoN
-qnd
+tyh
 upX
 oLW
 nuT
@@ -146020,7 +146037,7 @@ lIF
 rid
 sbw
 kWu
-kCJ
+tQX
 tyh
 rlI
 bDR

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -28990,6 +28990,7 @@
 /area/station/security/interrogation)
 "fzU" = (
 /obj/structure/hedge,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/service/hydroponics/chicken/backroom)
 "fzY" = (
@@ -38938,9 +38939,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "hAp" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
 /obj/structure/chair/sofa/corp{
 	dir = 4;
 	layer = 2.8
@@ -54820,11 +54818,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
 "kzk" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
-/turf/open/floor/grass,
-/area/station/service/hydroponics/chicken/backroom)
+/obj/structure/window/reinforced/tinted/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/service/hydroponics/chicken)
 "kzn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -56733,9 +56730,6 @@
 /turf/open/floor/wood,
 /area/station/hallway/primary/central)
 "kUD" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
 /obj/structure/nestbox,
 /turf/open/floor/grass,
@@ -72885,9 +72879,6 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "oeQ" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
 /obj/structure/hedge,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/service/hydroponics/chicken)
@@ -86605,6 +86596,13 @@
 /obj/machinery/vending/medical,
 /turf/open/floor/iron,
 /area/station/medical/storage)
+"qLH" = (
+/mob/living/basic/chicken{
+	forced_gender = "male"
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/chicken)
 "qLQ" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/structure/closet/crate/hydroponics,
@@ -90865,9 +90863,6 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
 /turf/open/floor/wood/parquet,
 /area/station/service/hydroponics/chicken)
 "rCh" = (
@@ -91932,6 +91927,12 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/ordnance_maint)
+"rLx" = (
+/obj/structure/nestbox,
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/structure/window/reinforced/spawner/directional/east,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/chicken)
 "rLE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -100670,9 +100671,6 @@
 	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
-	},
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/hydroponics/chicken)
@@ -110512,6 +110510,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/tinted/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "vnK" = (
@@ -112885,9 +112884,6 @@
 /area/station/maintenance/starboard/fore)
 "vIV" = (
 /obj/machinery/camera/autoname/directional/south,
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
 /obj/structure/hedge,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/service/hydroponics/chicken)
@@ -143988,7 +143984,7 @@ mKV
 rAx
 bbr
 kUD
-kzk
+ghs
 iTQ
 iTQ
 iTQ
@@ -147066,11 +147062,11 @@ pXP
 eJY
 edQ
 kCJ
-tyh
-eyJ
-atu
+xer
+rLx
+kzk
 vnJ
-hUh
+qLH
 upX
 fPu
 dRu

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -27883,9 +27883,6 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/aslyum)
 "foV" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/north{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -27896,6 +27893,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
+/obj/structure/window/reinforced/tinted/spawner/directional/south,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/chicken)
 "foY" = (
@@ -38939,10 +38937,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
 "hAp" = (
-/obj/structure/chair/sofa/corp{
-	dir = 4;
-	layer = 2.8
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
 	},
@@ -54817,11 +54811,6 @@
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"kzk" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/north,
-/obj/structure/window/reinforced/spawner/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/service/hydroponics/chicken)
 "kzn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -55175,20 +55164,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /turf/open/floor/iron/dark,
 /area/station/cargo/lobby)
-"kCJ" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/north{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/wood/large,
-/area/station/service/hydroponics/chicken)
 "kCV" = (
 /obj/effect/spawner/random/entertainment/arcade{
 	dir = 4
@@ -90856,12 +90831,12 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "rCe" = (
-/obj/structure/chair/sofa/corp/right{
-	dir = 4;
-	layer = 2.8
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
+	},
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 4
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/hydroponics/chicken)
@@ -100665,12 +100640,12 @@
 /turf/open/floor/grass,
 /area/station/hallway/primary/central)
 "twI" = (
-/obj/structure/chair/sofa/corp/left{
-	dir = 4;
-	layer = 2.8
-	},
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
+	},
+/obj/structure/chair/comfy{
+	color = "#596479";
+	dir = 4
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/hydroponics/chicken)
@@ -102957,9 +102932,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/turf_decal/siding/wood,
-/obj/structure/window/reinforced/tinted/spawner/directional/north{
-	dir = 2
-	},
+/obj/structure/window/reinforced/tinted/spawner/directional/south,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/chicken)
 "tQZ" = (
@@ -111125,9 +111098,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "vtN" = (
-/obj/structure/window/reinforced/tinted/spawner/directional/north{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/flip{
@@ -111136,6 +111106,7 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/window/reinforced/tinted/spawner/directional/south,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/chicken)
 "vtS" = (
@@ -146290,7 +146261,7 @@ ruY
 jjm
 sbw
 kXd
-kCJ
+tQX
 xer
 wVq
 atu
@@ -146547,7 +146518,7 @@ jWg
 kiR
 fZs
 kXd
-kCJ
+tQX
 hUh
 lZw
 atu
@@ -147061,10 +147032,10 @@ dku
 pXP
 eJY
 edQ
-kCJ
+tQX
 xer
 rLx
-kzk
+atu
 vnJ
 qLH
 upX

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -22514,6 +22514,16 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
+"hjw" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/nestbox,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/chicken)
 "hjB" = (
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
@@ -40811,6 +40821,18 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/chapel/office)
+"neR" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/nestbox,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/chicken)
 "neW" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -47148,6 +47170,14 @@
 "pht" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/engineering/storage)
+"phw" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/nestbox,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/chicken)
 "pia" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -56817,7 +56847,6 @@
 /area/station/science/genetics/cloning)
 "srQ" = (
 /obj/machinery/light/directional/south,
-/obj/structure/nestbox,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "srS" = (
@@ -63984,7 +64013,6 @@
 /area/station/service/abandoned_gambling_den)
 "uGS" = (
 /obj/machinery/light/directional/north,
-/obj/structure/nestbox,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "uHc" = (
@@ -71853,6 +71881,12 @@
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/iron/dark,
 /area/station/security/execution)
+"xdu" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/nestbox,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/chicken)
 "xdw" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -90440,11 +90474,11 @@ nJa
 xqS
 pff
 aSR
-guH
+hjw
 sXx
 ohF
 vBm
-aBL
+neR
 aSR
 bnl
 wgX
@@ -90697,11 +90731,11 @@ nJa
 xqS
 pff
 knA
-pfJ
+xdu
 sXx
 ohF
 vBm
-eaL
+phw
 knA
 bnl
 epc

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -8730,7 +8730,9 @@
 /area/station/science/circuits)
 "bWL" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/railing{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 4
 	},
 /turf/open/floor/sandy_dirt,
@@ -12774,7 +12776,10 @@
 /turf/open/floor/wood,
 /area/station/security/prison/rec)
 "cVt" = (
-/obj/structure/railing,
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics")
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "cVx" = (
@@ -19656,6 +19661,9 @@
 "eGr" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/light/directional/east,
+/mob/living/basic/chicken{
+	forced_gender = "female"
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "eGs" = (
@@ -21372,9 +21380,6 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced/spawner/directional/east,
-/mob/living/basic/chicken{
-	forced_gender = "male"
-	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "fam" = (
@@ -23625,7 +23630,8 @@
 /area/station/maintenance/disposal/incinerator)
 "fzD" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "fzF" = (
@@ -36618,9 +36624,8 @@
 /area/station/medical/medbay)
 "iBc" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/nestbox,
 /mob/living/basic/chicken{
-	forced_gender = "female"
+	forced_gender = "male"
 	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
@@ -42662,6 +42667,9 @@
 "jVg" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east,
+/mob/living/basic/chicken{
+	forced_gender = "male"
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "jVj" = (
@@ -44260,9 +44268,10 @@
 /area/station/service/hydroponics)
 "kmy" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "kmE" = (
@@ -46596,7 +46605,6 @@
 /turf/open/floor/iron,
 /area/station/medical/abandoned)
 "kSi" = (
-/obj/structure/nestbox,
 /obj/machinery/light/directional/west,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
@@ -53635,11 +53643,6 @@
 	},
 /turf/open/floor/iron/edge,
 /area/station/hallway/primary/central/aft)
-"mBG" = (
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/nestbox,
-/turf/open/floor/sandy_dirt,
-/area/station/service/hydroponics/chicken)
 "mBQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera/directional/east{
@@ -79461,11 +79464,10 @@
 /area/station/service/theater)
 "sLc" = (
 /obj/structure/window/reinforced/spawner/directional/north,
-/obj/structure/railing{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 8
-	},
-/mob/living/basic/chicken{
-	forced_gender = "male"
 	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
@@ -82873,6 +82875,9 @@
 /area/station/science/robotics/lab)
 "tCH" = (
 /obj/machinery/light/directional/west,
+/mob/living/basic/chicken/brown{
+	forced_gender = "female"
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "tCI" = (
@@ -93092,12 +93097,8 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "vZQ" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/mob/living/basic/chicken/brown{
-	forced_gender = "female"
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "vZV" = (
@@ -130958,7 +130959,7 @@ qgU
 qgU
 pAd
 doY
-mBG
+kaw
 tCH
 doY
 qsn

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -44268,10 +44268,8 @@
 /area/station/service/hydroponics)
 "kmy" = (
 /obj/structure/window/reinforced/spawner/directional/south,
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
 /obj/structure/nestbox,
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "kmE" = (
@@ -131211,7 +131209,7 @@ isH
 nVF
 doY
 doY
-wFr
+wRJ
 doY
 doY
 maW

--- a/_maps/map_files/Graveyard/Graveyard.dmm
+++ b/_maps/map_files/Graveyard/Graveyard.dmm
@@ -3331,10 +3331,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "blV" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/flora/bush/flowers_br/style_random,
+/mob/living/basic/chicken{
+	forced_gender = "male"
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "bme" = (
@@ -5392,6 +5393,12 @@
 /obj/effect/landmark/start/xenobiologist,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
+"cbu" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/flora/bush/flowers_br/style_random,
+/obj/structure/nestbox,
+/turf/open/floor/sandy_dirt,
+/area/station/service/hydroponics/chicken)
 "cbz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -11086,6 +11093,11 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"enm" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/nestbox,
+/turf/open/floor/sandy_dirt,
+/area/station/service/hydroponics/chicken)
 "eno" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/siding/dark{
@@ -18061,10 +18073,9 @@
 /area/station/construction/storage_wing)
 "gZb" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "gZu" = (
@@ -20388,7 +20399,9 @@
 /turf/open/floor/iron,
 /area/graveyard/bunker/engineering)
 "hRV" = (
-/obj/structure/railing{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
 /turf/open/floor/sandy_dirt,
@@ -22407,12 +22420,12 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/warden)
 "iKl" = (
-/obj/structure/railing{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
-/mob/living/basic/chicken{
-	forced_gender = "male"
-	},
+/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "iKm" = (
@@ -28390,7 +28403,6 @@
 /turf/open/floor/iron/dark,
 /area/graveyard/bunker/security)
 "lbE" = (
-/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "lbP" = (
@@ -39171,9 +39183,7 @@
 /area/station/cargo/quartermaster)
 "pht" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /mob/living/basic/chicken/brown{
 	forced_gender = "female"
 	},
@@ -49581,6 +49591,10 @@
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"tqk" = (
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/sandy_dirt,
+/area/station/service/hydroponics/chicken)
 "tqm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54786,10 +54800,9 @@
 /turf/open/floor/iron/dark/textured,
 /area/graveyard/bunker/security)
 "vqr" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/flora/bush/sparsegrass/style_random,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "vqv" = (
@@ -58605,6 +58618,15 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/station/hallway/primary/aft)
+"wPj" = (
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
+	dir = 1
+	},
+/obj/structure/flora/bush/sparsegrass/style_random,
+/turf/open/floor/sandy_dirt,
+/area/station/service/hydroponics/chicken)
 "wPt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -175027,7 +175049,7 @@ jou
 kJg
 sJE
 kJg
-iKl
+hRV
 lbE
 cqY
 lxN
@@ -175799,7 +175821,7 @@ piW
 tiG
 kJg
 ocx
-blV
+iKl
 lbE
 cqY
 apW
@@ -176056,7 +176078,7 @@ kJg
 pYz
 kJg
 kJg
-hRV
+tqk
 fXn
 cqY
 apW
@@ -176569,7 +176591,7 @@ kqi
 kJg
 vvp
 kJg
-vqr
+wPj
 lbE
 cqY
 lxN
@@ -176826,7 +176848,7 @@ wvB
 kJg
 vvp
 kJg
-blV
+cbu
 djz
 cqY
 ulW
@@ -177340,7 +177362,7 @@ hzX
 oPS
 nsj
 gLN
-hRV
+enm
 vHb
 lil
 xQi
@@ -177854,7 +177876,7 @@ iEq
 iSH
 itz
 oPS
-hRV
+tqk
 lil
 vkh
 xQi
@@ -178111,7 +178133,7 @@ bvN
 ity
 oPS
 oPS
-hRV
+tqk
 vHb
 lil
 xQi

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -27414,9 +27414,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "doo" = (
-/obj/structure/railing/wooden_fencing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /mob/living/basic/chicken{
 	forced_gender = "female"
 	},
@@ -32748,14 +32746,8 @@
 /area/station/engineering/break_room)
 "fAO" = (
 /obj/structure/sign/warning/gas_mask/directional/north,
-/obj/structure/railing/wooden_fencing{
-	dir = 4;
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/mob/living/basic/chicken{
-	forced_gender = "female"
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "fAZ" = (
@@ -36009,7 +36001,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/virology/isolation)
 "gSt" = (
-/obj/structure/nestbox,
 /mob/living/basic/chicken{
 	forced_gender = "female"
 	},
@@ -50959,10 +50950,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "mAR" = (
-/obj/structure/railing/wooden_fencing/gate{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 8;
-	pixel_x = -4;
-	pixel_y = 0
+	pixel_x = -7
 	},
 /mob/living/basic/chicken{
 	forced_gender = "female"
@@ -51902,15 +51894,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/detectives_office)
 "mUz" = (
-/obj/structure/railing/wooden_fencing{
-	dir = 1
-	},
-/obj/structure/railing/wooden_fencing{
-	dir = 4
-	},
-/mob/living/basic/chicken{
-	forced_gender = "male"
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "mUB" = (
@@ -52790,9 +52776,7 @@
 /area/station/service/hydroponics)
 "nmH" = (
 /obj/structure/sign/warning/fire/directional/east,
-/obj/structure/railing/wooden_fencing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /mob/living/basic/chicken{
 	forced_gender = "female"
 	},
@@ -55847,9 +55831,6 @@
 	dir = 8
 	},
 /area/station/science/robotics/mechbay)
-"otr" = (
-/turf/open/floor/sandy_dirt,
-/area/station/service/hydroponics/chicken)
 "ots" = (
 /obj/structure/sink/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -63053,8 +63034,10 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "reH" = (
-/obj/structure/nestbox,
 /obj/machinery/light/directional/south,
+/mob/living/basic/chicken{
+	forced_gender = "male"
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "reR" = (
@@ -68564,9 +68547,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science)
 "tkH" = (
-/obj/structure/railing/wooden_fencing{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "tkU" = (
@@ -70010,10 +69991,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "tLZ" = (
-/obj/structure/railing/wooden_fencing/gate{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 8;
-	pixel_x = -4;
-	pixel_y = 4
+	pixel_x = -7
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -73248,10 +73230,11 @@
 /area/station/science/xenobiology)
 "vcU" = (
 /obj/machinery/light_switch/directional/south,
-/obj/structure/railing/wooden_fencing/gate{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 8;
-	pixel_x = -4;
-	pixel_y = 0
+	pixel_x = -7
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -73421,12 +73404,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/bridge)
 "vgk" = (
-/obj/structure/railing/wooden_fencing{
-	dir = 1
-	},
-/mob/living/basic/chicken{
-	forced_gender = "male"
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "vgo" = (
@@ -106064,7 +106043,7 @@ vPj
 dBL
 uGE
 fAO
-otr
+uJc
 mUz
 uJc
 uGE

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -7910,9 +7910,7 @@
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
 "cpD" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/door/window/left/directional/south{
 	name = "Chicken Pen";
 	req_access = list("hydroponics");
@@ -11230,9 +11228,7 @@
 /turf/open/floor/plating,
 /area/station/security/lockers)
 "dol" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
@@ -12749,9 +12745,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "dMR" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
@@ -13461,9 +13455,7 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
 "dZB" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /mob/living/basic/chicken/brown{
 	forced_gender = "male"
 	},
@@ -21358,6 +21350,7 @@
 	pixel_y = 3;
 	pixel_x = -27
 	},
+/obj/machinery/smartfridge/disks,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "gAR" = (
@@ -48909,6 +48902,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 6
 	},
+/obj/machinery/egg_incubator,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/chicken)
 "oVw" = (
@@ -53449,6 +53443,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 10
 	},
+/obj/machinery/egg_incubator,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/chicken)
 "qqJ" = (
@@ -60696,7 +60691,6 @@
 /turf/open/floor/carpet,
 /area/station/service/library)
 "sEp" = (
-/obj/machinery/egg_incubator,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "sEq" = (
@@ -74495,7 +74489,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
 "wUY" = (
-/obj/machinery/egg_incubator,
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -77146,9 +77139,7 @@
 /turf/closed/wall,
 /area/station/command/meeting_room)
 "xKQ" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -77367,9 +77358,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "xOI" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /mob/living/basic/chicken,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -7910,10 +7910,12 @@
 /turf/open/lava/plasma/ice_moon,
 /area/icemoon/underground/explored)
 "cpD" = (
-/obj/structure/railing/wood{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
-/obj/structure/railing/wood{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
 /obj/structure/flora/bush/flowers_br/style_random,
@@ -9581,9 +9583,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "cNg" = (
-/obj/structure/railing/wood{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "cNh" = (
@@ -11230,12 +11230,10 @@
 /turf/open/floor/plating,
 /area/station/security/lockers)
 "dol" = (
-/obj/structure/railing/wood{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
-/obj/structure/railing/wood{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "doq" = (
@@ -12751,7 +12749,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "dMR" = (
-/obj/structure/railing/wood{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -13463,10 +13461,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal)
 "dZB" = (
-/obj/structure/railing/wood{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
-/obj/structure/nestbox,
+/mob/living/basic/chicken/brown{
+	forced_gender = "male"
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "dZG" = (
@@ -28584,12 +28584,12 @@
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
 "iOC" = (
-/obj/structure/railing/wood{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
-/obj/structure/railing/wood{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "iOF" = (
@@ -29324,14 +29324,11 @@
 /turf/open/floor/iron/dark/side,
 /area/station/security/prison/workout)
 "iZp" = (
-/obj/structure/railing/wood{
-	dir = 1
-	},
-/obj/structure/railing/wood{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
+/mob/living/basic/chicken,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "iZs" = (
@@ -32295,13 +32292,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"jWh" = (
-/obj/structure/railing/wood{
-	dir = 1
-	},
-/mob/living/basic/chicken,
-/turf/open/floor/sandy_dirt,
-/area/station/service/hydroponics/chicken)
 "jWl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -39678,9 +39668,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "mkz" = (
-/obj/structure/railing/wood{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "mkA" = (
@@ -43660,14 +43648,9 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "nuA" = (
-/obj/structure/railing/wood{
-	dir = 4
-	},
-/obj/structure/railing/wood{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/nestbox,
-/mob/living/basic/chicken,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "nuH" = (
@@ -56576,7 +56559,9 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
 "rqi" = (
-/obj/structure/railing/wood{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -60135,7 +60120,8 @@
 /turf/open/floor/iron/large,
 /area/station/medical/treatment_center)
 "svr" = (
-/obj/structure/nestbox,
+/obj/structure/window/reinforced/spawner/directional/east,
+/mob/living/basic/chicken,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "svw" = (
@@ -67175,9 +67161,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "uIN" = (
-/obj/structure/railing/wood{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "uIV" = (
@@ -74511,9 +74496,6 @@
 /area/station/engineering/atmos/hfr_room)
 "wUY" = (
 /obj/machinery/egg_incubator,
-/mob/living/basic/chicken/brown{
-	forced_gender = "male"
-	},
 /obj/structure/flora/bush/flowers_pp/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -77164,12 +77146,10 @@
 /turf/closed/wall,
 /area/station/command/meeting_room)
 "xKQ" = (
-/obj/structure/railing/wood{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
-/obj/structure/railing/wood{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
@@ -77387,7 +77367,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "xOI" = (
-/obj/structure/railing/wood{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
 /mob/living/basic/chicken,
@@ -176008,7 +175988,7 @@ iZm
 xIT
 llW
 azM
-jWh
+uIN
 sLB
 sEp
 iZm
@@ -176266,7 +176246,7 @@ oHA
 ifg
 xpp
 iOC
-svr
+gUF
 nMQ
 iZm
 gjq
@@ -177552,7 +177532,7 @@ vLQ
 lfR
 nuA
 mkz
-cNg
+svr
 iZm
 iDt
 nfG

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -22396,6 +22396,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "hbf" = (
@@ -27189,17 +27190,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tcomms)
-"irz" = (
-/obj/machinery/door/window/left/directional/south{
-	name = "Chicken Pen";
-	req_access = list("hydroponics");
-	dir = 1
-	},
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
-/turf/open/floor/sandy_dirt,
-/area/station/service/hydroponics/chicken)
 "irE" = (
 /obj/machinery/teleport/station,
 /obj/machinery/status_display/evac/directional/east,
@@ -40609,7 +40599,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "mBK" = (
-/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
@@ -70639,6 +70628,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "wbG" = (
@@ -112849,7 +112841,7 @@ ehQ
 kDK
 fcR
 qDO
-irz
+doE
 bNZ
 hfR
 arl

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -2973,7 +2973,6 @@
 "aUi" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/machinery/light/directional/east,
-/mob/living/basic/chicken,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "aUv" = (
@@ -10641,7 +10640,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/ordnance)
 "doE" = (
-/obj/structure/railing{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
 /turf/open/floor/sandy_dirt,
@@ -19023,10 +19024,7 @@
 /area/station/security/prison/mess)
 "fXQ" = (
 /obj/item/radio/intercom/directional/south,
-/obj/structure/railing{
-	dir = 4;
-	layer = 4.1
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/flora/bush/sparsegrass/style_random,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -22721,7 +22719,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/storage)
 "hfR" = (
-/obj/structure/flora/bush/flowers_br/style_random,
 /mob/living/basic/chicken/brown{
 	forced_gender = "female"
 	},
@@ -27193,10 +27190,12 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage/tcomms)
 "irz" = (
-/obj/structure/railing{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
 /turf/open/floor/sandy_dirt,
@@ -27796,13 +27795,8 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "izo" = (
-/obj/structure/railing{
-	dir = 4;
-	layer = 4.1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
@@ -40615,13 +40609,12 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "mBK" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east{
 	dir = 8
 	},
 /obj/structure/sign/poster/contraband/kudzu/directional/east,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "mBS" = (
@@ -42517,9 +42510,7 @@
 	},
 /area/station/hallway/primary/central/fore)
 "ngu" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
@@ -59209,10 +59200,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "syD" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/mob/living/basic/chicken,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "syF" = (
@@ -67115,7 +67105,9 @@
 /turf/open/floor/engine,
 /area/station/engineering/storage/tech)
 "vcc" = (
-/obj/structure/nestbox,
+/mob/living/basic/chicken{
+	forced_gender = "male"
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "vcm" = (
@@ -70463,12 +70455,8 @@
 /turf/open/floor/iron/dark,
 /area/station/security/office)
 "vYu" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/mob/living/basic/chicken{
-	forced_gender = "male"
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "vYy" = (
@@ -112862,8 +112850,8 @@ kDK
 fcR
 qDO
 irz
+bNZ
 hfR
-vcc
 arl
 arl
 arl

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -2971,8 +2971,8 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "aUi" = (
-/obj/structure/flora/bush/sparsegrass/style_random,
 /obj/machinery/light/directional/east,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "aUv" = (
@@ -39988,6 +39988,7 @@
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
 "mqr" = (
+/obj/structure/flora/bush/sparsegrass/style_random,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "mqC" = (
@@ -40599,11 +40600,8 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "mBK" = (
-/obj/structure/window/reinforced/spawner/directional/east{
-	dir = 8
-	},
 /obj/structure/sign/poster/contraband/kudzu/directional/east,
-/obj/structure/nestbox,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "mBS" = (
@@ -53088,6 +53086,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "qDQ" = (
@@ -70628,9 +70627,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "wbG" = (

--- a/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
+++ b/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
@@ -230,9 +230,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "afq" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /mob/living/basic/chicken,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
@@ -10610,11 +10608,9 @@
 /area/station/security/brig/entrance)
 "fgY" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/chicken,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "fha" = (
@@ -15330,6 +15326,7 @@
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/egg_incubator,
 /turf/open/floor/stone,
 /area/station/service/hydroponics)
 "hwh" = (
@@ -29215,10 +29212,8 @@
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "nVi" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
 /obj/structure/nestbox,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "nVp" = (
@@ -33766,9 +33761,7 @@
 /area/station/security/prison/mess)
 "qkS" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
@@ -33912,10 +33905,8 @@
 /area/station/security/execution/transfer)
 "qoV" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
 /obj/structure/nestbox,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "qoW" = (

--- a/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
+++ b/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
@@ -230,7 +230,9 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "afq" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
 /mob/living/basic/chicken,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
@@ -4156,7 +4158,6 @@
 /turf/open/floor/iron/diagonal,
 /area/station/security/prison)
 "ciy" = (
-/obj/structure/nestbox,
 /obj/machinery/light/directional/west,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/chicken,
@@ -7056,7 +7057,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "dAm" = (
-/obj/structure/nestbox,
 /mob/living/basic/chicken,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
@@ -10610,7 +10610,9 @@
 /area/station/security/brig/entrance)
 "fgY" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/basic/chicken,
 /turf/open/floor/sandy_dirt,
@@ -25184,8 +25186,10 @@
 /area/station/service/bar)
 "maq" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/railing,
-/mob/living/basic/chicken,
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics")
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "maV" = (
@@ -29211,9 +29215,10 @@
 /turf/open/floor/iron/freezer,
 /area/station/security/prison/shower)
 "nVi" = (
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
 /obj/structure/nestbox,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/basic/chicken,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "nVp" = (
@@ -33761,7 +33766,10 @@
 /area/station/security/prison/mess)
 "qkS" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "qkW" = (
@@ -33904,7 +33912,10 @@
 /area/station/security/execution/transfer)
 "qoV" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "qoW" = (
@@ -41488,9 +41499,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "tPl" = (
-/obj/structure/railing{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "tPJ" = (
@@ -44528,7 +44538,6 @@
 /turf/open/floor/grass,
 /area/station/hallway/floor2/fore)
 "vnD" = (
-/obj/structure/nestbox,
 /obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/sandy_dirt,
@@ -45361,8 +45370,12 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "vLl" = (
-/obj/structure/nestbox,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
+	dir = 8;
+	pixel_x = 1
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "vLm" = (
@@ -49693,7 +49706,10 @@
 /turf/closed/wall,
 /area/station/service/hydroponics)
 "xOy" = (
-/obj/structure/railing,
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics")
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "xOQ" = (
@@ -141391,9 +141407,9 @@ rgt
 nMJ
 eDq
 pzf
-mtH
+dAm
 ciy
-xOy
+nVi
 cog
 sUD
 ilv
@@ -144733,8 +144749,8 @@ rgt
 nMJ
 pzf
 wwE
-ouH
 tPl
+vLl
 tPl
 moV
 ouH
@@ -144989,11 +145005,11 @@ gwq
 rgt
 mcx
 pzf
-vLl
+xbb
 mtH
 nQE
 xbb
-vLl
+xbb
 xbb
 pzf
 oXp
@@ -145251,7 +145267,7 @@ mtH
 vnD
 mtH
 mtH
-nVi
+nQE
 pzf
 alr
 vrs

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3427,7 +3427,9 @@
 /area/station/hallway/primary/central)
 "bel" = (
 /obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/railing{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -6498,10 +6500,8 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "cqh" = (
-/obj/effect/landmark/start/botanist,
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "cqk" = (
@@ -18072,7 +18072,7 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "gxn" = (
-/obj/structure/nestbox,
+/obj/effect/landmark/start/botanist,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "gxx" = (
@@ -23073,7 +23073,6 @@
 /area/station/hallway/primary/port)
 "igX" = (
 /obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "igZ" = (
@@ -25663,9 +25662,8 @@
 "iUQ" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "iVi" = (
@@ -26821,7 +26819,6 @@
 /area/station/engineering/main)
 "jop" = (
 /obj/machinery/light/directional/south,
-/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "joq" = (
@@ -36686,7 +36683,9 @@
 /mob/living/basic/chicken/brown{
 	forced_gender = "female"
 	},
-/obj/structure/railing{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
 /turf/open/floor/sandy_dirt,
@@ -59880,7 +59879,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/aft)
 "uAF" = (
-/obj/structure/railing{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
 /turf/open/floor/sandy_dirt,
@@ -62030,9 +62031,8 @@
 /area/station/security/prison/mess)
 "vpe" = (
 /obj/structure/sign/poster/random/directional/east,
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "vpg" = (
@@ -64266,9 +64266,7 @@
 /turf/open/floor/iron,
 /area/station/construction/storage_wing)
 "wdU" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /mob/living/basic/chicken{
 	forced_gender = "male"
 	},
@@ -106665,7 +106663,7 @@ hAr
 sve
 lXr
 cqh
-hmM
+gxn
 xpk
 tUn
 iym
@@ -107180,7 +107178,7 @@ mgG
 bZq
 dTs
 vpe
-gxn
+hmM
 unL
 eio
 ouR

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -12422,13 +12422,14 @@
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
-/obj/structure/nestbox,
+/mob/living/basic/chicken/brown{
+	forced_gender = "male"
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "aWQ" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "aWR" = (
@@ -20647,12 +20648,7 @@
 	name = "Ranch";
 	dir = 4
 	},
-/mob/living/basic/chicken/brown{
-	forced_gender = "male"
-	},
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "bIC" = (
@@ -34044,9 +34040,7 @@
 /area/station/engineering/atmos/office)
 "gWg" = (
 /obj/machinery/light/directional/west,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "gWo" = (
@@ -40556,6 +40550,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
+"mGk" = (
+/obj/machinery/egg_incubator,
+/turf/open/floor/iron,
+/area/station/service/hydroponics)
 "mGP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -52702,12 +52700,8 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "whF" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "whH" = (
@@ -81403,7 +81397,7 @@ aKT
 aNm
 mUt
 aKT
-aZW
+mGk
 aTQ
 aZW
 aRL

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -12426,7 +12426,7 @@
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "aWQ" = (
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/west{
 	dir = 4
 	},
 /turf/open/floor/sandy_dirt,
@@ -20643,13 +20643,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "bIz" = (
-/obj/structure/railing{
+/obj/machinery/door/window/right/directional/west{
+	name = "Ranch";
 	dir = 4
 	},
 /mob/living/basic/chicken/brown{
 	forced_gender = "male"
 	},
-/obj/structure/railing/corner,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
 "bIC" = (
@@ -34041,8 +34044,8 @@
 /area/station/engineering/atmos/office)
 "gWg" = (
 /obj/machinery/light/directional/west,
-/obj/structure/railing{
-	layer = 3.1
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
 	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics)
@@ -52699,10 +52702,10 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "whF" = (
-/obj/structure/railing{
-	layer = 3.1
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
 	},
-/obj/structure/railing/corner{
+/obj/structure/window/reinforced/spawner/directional/west{
 	dir = 4
 	},
 /turf/open/floor/sandy_dirt,

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -23348,10 +23348,8 @@
 /area/station/security/courtroom)
 "gUn" = (
 /obj/structure/nestbox,
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "gUJ" = (
@@ -28883,10 +28881,8 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/pumproom)
 "izE" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
 /obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "izL" = (
@@ -39208,9 +39204,7 @@
 "lsH" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "lsK" = (
@@ -45040,9 +45034,7 @@
 /turf/open/floor/iron/stairs/right,
 /area/station/service/chapel)
 "ndT" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "ndX" = (
@@ -47451,7 +47443,7 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal/incinerator)
 "nPg" = (
-/obj/effect/spawner/structure/window,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/service/hydroponics/chicken)
 "nPn" = (
@@ -57408,10 +57400,8 @@
 /area/station/medical/storage)
 "qKP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
 /obj/machinery/egg_incubator,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "qKT" = (

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -282,10 +282,7 @@
 /area/station/security/brig/entrance)
 "aev" = (
 /obj/structure/sink/directional/south,
-/obj/structure/railing{
-	dir = 8;
-	layer = 4.1
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/egg_incubator,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -5834,10 +5831,12 @@
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "bNi" = (
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/west{
 	dir = 4
 	},
-/obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "bNn" = (
@@ -11640,9 +11639,7 @@
 /turf/open/floor/iron,
 /area/station/security/courtroom)
 "dwD" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -16367,7 +16364,9 @@
 /area/station/security/execution/transfer)
 "eSU" = (
 /obj/structure/flora/bush/grassy/style_random,
-/obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
 /obj/structure/nestbox,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -20681,10 +20680,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "ggC" = (
-/obj/structure/railing{
-	dir = 8;
-	layer = 4.1
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /obj/machinery/egg_incubator,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -23364,7 +23360,7 @@
 /area/station/security/courtroom)
 "gUn" = (
 /obj/structure/nestbox,
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/west{
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -23925,11 +23921,10 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "hdr" = (
-/obj/structure/railing{
-	dir = 8;
-	layer = 4.1
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
 	},
-/obj/structure/railing,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "hdE" = (
@@ -26919,9 +26914,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "hWO" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -28902,12 +28894,10 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/pumproom)
 "izE" = (
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/west{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "izL" = (
@@ -31007,10 +30997,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "jfg" = (
-/obj/structure/railing{
-	dir = 8;
-	layer = 4.1
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /obj/item/food/grown/pumpkin{
 	pixel_y = -6;
 	pixel_x = -4
@@ -31400,9 +31387,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/morgue)
 "jkT" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
 	},
@@ -35311,13 +35296,8 @@
 /area/station/service/hydroponics/chicken)
 "krN" = (
 /obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/railing{
-	dir = 8;
-	layer = 4.1
-	},
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -37528,7 +37508,9 @@
 /area/station/hallway/primary/upper)
 "kXa" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/railing{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
 /turf/open/floor/grass,
@@ -37631,7 +37613,9 @@
 "kXV" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/machinery/egg_incubator,
-/obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "kYa" = (
@@ -38066,7 +38050,9 @@
 /area/station/science/explab)
 "lck" = (
 /obj/structure/flora/bush/sparsegrass/style_random,
-/obj/structure/railing{
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics");
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -39235,7 +39221,7 @@
 "lsH" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/structure/flora/bush/flowers_br/style_random,
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/west{
 	dir = 4
 	},
 /turf/open/floor/grass,
@@ -39715,9 +39701,7 @@
 /turf/open/floor/carpet/grimey,
 /area/station/hallway/primary/central/fore)
 "lyK" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/airalarm/directional/west,
 /turf/open/misc/dirt/station,
 /area/station/service/hydroponics/chicken)
@@ -45069,7 +45053,7 @@
 /turf/open/floor/iron/stairs/right,
 /area/station/service/chapel)
 "ndT" = (
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/west{
 	dir = 4
 	},
 /turf/open/floor/grass,
@@ -46195,9 +46179,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
 "num" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -47025,9 +47007,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "nHF" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /mob/living/basic/chicken,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -47146,10 +47126,10 @@
 /turf/open/floor/wood,
 /area/station/hallway/secondary/exit/departure_lounge)
 "nJJ" = (
-/obj/structure/railing{
-	dir = 4
+/obj/structure/flora/bush/flowers_yw/style_random,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
 	},
-/obj/structure/flora/bush/grassy/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "nJL" = (
@@ -48281,9 +48261,7 @@
 /turf/open/floor/wood,
 /area/station/commons/fitness)
 "oaX" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/misc/dirt/station,
 /area/station/service/hydroponics/chicken)
@@ -51739,12 +51717,7 @@
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
 "pdl" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/camera/autoname/directional/east,
 /obj/structure/nestbox,
 /turf/open/floor/grass,
@@ -54856,7 +54829,9 @@
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "qay" = (
-/obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "qaI" = (
@@ -55225,7 +55200,10 @@
 /area/station/medical/pharmacy)
 "qeE" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/railing,
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics")
+	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "qeL" = (
@@ -55745,9 +55723,7 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pathology/isolation)
 "qlg" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "qlo" = (
@@ -57439,7 +57415,7 @@
 /area/station/medical/storage)
 "qKP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/west{
 	dir = 4
 	},
 /obj/machinery/egg_incubator,
@@ -60523,9 +60499,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/central)
 "rDN" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 4
 	},
@@ -70282,7 +70256,10 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "usr" = (
-/obj/structure/railing,
+/obj/machinery/door/window/left/directional/south{
+	name = "Chicken Pen";
+	req_access = list("hydroponics")
+	},
 /obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -73864,9 +73841,7 @@
 /area/station/engineering/atmos)
 "vrf" = (
 /obj/structure/sink/directional/east,
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/nestbox,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -77857,9 +77832,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "wEI" = (
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
 	},
@@ -78786,10 +78759,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
 "wQr" = (
-/obj/structure/railing{
-	dir = 8;
-	layer = 4.1
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "wQv" = (
@@ -131697,7 +131667,7 @@ eFe
 nPg
 oEK
 kAJ
-qeE
+nJJ
 jUS
 cCG
 nHF
@@ -131959,7 +131929,7 @@ hDp
 uRG
 pdl
 hWO
-nJJ
+oEK
 wEI
 jSb
 cYh

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -5830,15 +5830,6 @@
 /obj/machinery/requests_console/auto_name/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"bNi" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
-/turf/open/floor/grass,
-/area/station/service/hydroponics/chicken)
 "bNn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -16364,9 +16355,6 @@
 /area/station/security/execution/transfer)
 "eSU" = (
 /obj/structure/flora/bush/grassy/style_random,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
 /obj/structure/nestbox,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -23921,11 +23909,11 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/hfr_room)
 "hdr" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
-/turf/open/floor/grass,
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/wood/large,
 /area/station/service/hydroponics/chicken)
 "hdE" = (
 /obj/effect/spawner/random/trash/food_packaging,
@@ -25678,6 +25666,7 @@
 	dir = 8;
 	color = "#4d9d4e"
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/chicken)
 "hDw" = (
@@ -33734,6 +33723,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/chicken)
 "jUZ" = (
@@ -37613,9 +37603,6 @@
 "kXV" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/machinery/egg_incubator,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "kYa" = (
@@ -47127,9 +47114,6 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "nJJ" = (
 /obj/structure/flora/bush/flowers_yw/style_random,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "nJL" = (
@@ -54829,10 +54813,18 @@
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
 "qay" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/grass,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/turf/open/floor/wood/large,
 /area/station/service/hydroponics/chicken)
 "qaI" = (
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -55202,7 +55194,8 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /obj/machinery/door/window/left/directional/south{
 	name = "Chicken Pen";
-	req_access = list("hydroponics")
+	req_access = list("hydroponics");
+	pixel_y = -7
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -60911,6 +60904,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/wood/large,
 /area/station/service/hydroponics/chicken)
 "rIK" = (
@@ -70256,11 +70250,12 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "usr" = (
+/obj/structure/flora/bush/flowers_br/style_random,
 /obj/machinery/door/window/left/directional/south{
 	name = "Chicken Pen";
-	req_access = list("hydroponics")
+	req_access = list("hydroponics");
+	pixel_y = -7
 	},
-/obj/structure/flora/bush/flowers_br/style_random,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "usE" = (
@@ -129868,8 +129863,8 @@ eFe
 lVw
 aSt
 iNN
+apV
 qay
-sep
 cCG
 qlg
 cBB
@@ -130382,8 +130377,8 @@ eFe
 lVw
 gUn
 lsH
-bNi
-sep
+ndT
+qay
 cCG
 izE
 ndT
@@ -131153,8 +131148,8 @@ eTw
 lVw
 aev
 jfg
+wQr
 hdr
-iiq
 cCG
 krN
 ggC

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -1797,6 +1797,9 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/window/reinforced/spawner/directional/north{
+	pixel_y = 1
+	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "azr" = (
@@ -43127,11 +43130,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/corrections_officer)
 "mca" = (
-/obj/machinery/door/window/right/directional/west{
-	name = "Ranch";
-	dir = 2
+/obj/structure/window/reinforced/spawner/directional/north{
+	pixel_y = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "mcu" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
@@ -45096,10 +45098,11 @@
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
 "mFR" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
+/obj/machinery/door/window/right/directional/west{
+	name = "Ranch";
+	dir = 1
 	},
-/turf/open/floor/wood,
+/turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "mGv" = (
 /obj/structure/cable,
@@ -80382,6 +80385,9 @@
 /area/station/security/detectives_office)
 "wkm" = (
 /obj/structure/nestbox,
+/obj/structure/window/reinforced/spawner/directional/north{
+	pixel_y = 1
+	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "wkK" = (
@@ -127981,7 +127987,7 @@ pzh
 jpR
 fop
 pdg
-mFR
+eKx
 azq
 eQw
 jpR
@@ -128238,8 +128244,8 @@ vRf
 jpR
 aWR
 eEo
-mFR
-fop
+eKx
+mca
 iAj
 jpR
 wtQ
@@ -128495,8 +128501,8 @@ pzh
 jpR
 lhZ
 kVo
-mca
-fop
+eKx
+mFR
 aWR
 jpR
 aqi
@@ -128752,7 +128758,7 @@ mLy
 jpR
 fop
 vuc
-mFR
+eKx
 wkm
 gSF
 jpR

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -12767,9 +12767,7 @@
 "dLi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "dLk" = (
@@ -13996,6 +13994,7 @@
 /area/station/service/chapel/funeral)
 "ebv" = (
 /obj/machinery/light/directional/south,
+/obj/machinery/egg_incubator,
 /turf/open/floor/wood,
 /area/station/service/hydroponics/chicken)
 "ebz" = (
@@ -28698,13 +28697,9 @@
 /turf/open/floor/iron/white/textured_edge,
 /area/station/medical/storage)
 "ikN" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
 /obj/structure/nestbox,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "ila" = (
@@ -48840,9 +48835,7 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/science/research/abandoned)
 "nGX" = (
-/obj/structure/window/reinforced/spawner/directional/west{
-	dir = 4
-	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "nGY" = (
@@ -65933,12 +65926,10 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/storage/eva)
 "sqd" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
 /mob/living/basic/chicken/brown{
 	forced_gender = "male"
 	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "sqo" = (

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -1796,9 +1796,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "azr" = (
@@ -12769,8 +12767,8 @@
 "dLi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable,
-/obj/structure/railing{
-	pixel_y = -5
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -16917,9 +16915,7 @@
 	},
 /area/station/engineering/power_room)
 "eQw" = (
-/obj/structure/railing{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "eQx" = (
@@ -28702,10 +28698,10 @@
 /turf/open/floor/iron/white/textured_edge,
 /area/station/medical/storage)
 "ikN" = (
-/obj/structure/railing{
-	pixel_y = -5
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
 	},
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/west{
 	dir = 4
 	},
 /obj/structure/nestbox,
@@ -38887,8 +38883,9 @@
 /turf/open/floor/iron/textured,
 /area/station/science/ordnance/storage)
 "kVo" = (
-/obj/structure/railing{
-	pixel_y = -5
+/obj/machinery/door/window/right/directional/west{
+	name = "Ranch";
+	dir = 2
 	},
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -43129,6 +43126,17 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/corrections_officer)
+"mca" = (
+/obj/machinery/door/window/right/directional/west{
+	name = "Ranch";
+	dir = 2
+	},
+/obj/machinery/door/window/right/directional/west{
+	name = "Ranch";
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/station/service/hydroponics/chicken)
 "mcu" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
@@ -45092,10 +45100,10 @@
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
 "mFR" = (
-/obj/structure/railing,
-/obj/structure/railing{
-	dir = 1
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
 	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/wood,
 /area/station/service/hydroponics/chicken)
 "mGv" = (
@@ -48832,7 +48840,7 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/science/research/abandoned)
 "nGX" = (
-/obj/structure/railing{
+/obj/structure/window/reinforced/spawner/directional/west{
 	dir = 4
 	},
 /turf/open/floor/grass,
@@ -54070,9 +54078,7 @@
 	},
 /area/station/hallway/secondary/command)
 "pdg" = (
-/obj/structure/railing{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
 /mob/living/basic/chicken{
 	forced_gender = "female"
 	},
@@ -65927,8 +65933,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/command/storage/eva)
 "sqd" = (
-/obj/structure/railing{
-	pixel_y = -5
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
 	},
 /mob/living/basic/chicken/brown{
 	forced_gender = "male"
@@ -128493,8 +128499,8 @@ pzh
 jpR
 lhZ
 fop
-mFR
-wkm
+mca
+fop
 aWR
 jpR
 aqi
@@ -128751,7 +128757,7 @@ jpR
 fop
 fop
 mFR
-fop
+wkm
 gSF
 jpR
 uKN

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -15984,6 +15984,11 @@
 	dir = 1
 	},
 /area/station/ai_monitored/security/armory)
+"eEo" = (
+/obj/structure/nestbox,
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/chicken)
 "eEp" = (
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -43126,10 +43131,6 @@
 	name = "Ranch";
 	dir = 2
 	},
-/obj/machinery/door/window/right/directional/west{
-	name = "Ranch";
-	dir = 1
-	},
 /turf/open/floor/wood,
 /area/station/service/hydroponics/chicken)
 "mcu" = (
@@ -45098,7 +45099,6 @@
 /obj/structure/window/reinforced/spawner/directional/north{
 	dir = 2
 	},
-/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/wood,
 /area/station/service/hydroponics/chicken)
 "mGv" = (
@@ -54075,6 +54075,7 @@
 /mob/living/basic/chicken{
 	forced_gender = "female"
 	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
 "pdh" = (
@@ -77476,6 +77477,10 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/medical/treatment_center)
+"vuc" = (
+/obj/structure/window/reinforced/spawner/directional/south,
+/turf/open/floor/grass,
+/area/station/service/hydroponics/chicken)
 "vud" = (
 /turf/open/floor/iron/textured,
 /area/station/maintenance/aft)
@@ -128232,7 +128237,7 @@ nuL
 vRf
 jpR
 aWR
-wkm
+eEo
 mFR
 fop
 iAj
@@ -128489,7 +128494,7 @@ hGr
 pzh
 jpR
 lhZ
-fop
+kVo
 mca
 fop
 aWR
@@ -128746,7 +128751,7 @@ pzh
 mLy
 jpR
 fop
-fop
+vuc
 mFR
 wkm
 gSF

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -15240,12 +15240,6 @@
 "dIK" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/freezerchamber)
-"dIN" = (
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
-/turf/open/floor/sandy_dirt,
-/area/station/service/hydroponics/chicken)
 "dIO" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -16414,10 +16408,8 @@
 /area/station/hallway/primary/tram/left)
 "eaX" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
 /obj/structure/nestbox,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "eaZ" = (
@@ -51252,10 +51244,8 @@
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "oXw" = (
 /obj/structure/cable,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
 /obj/structure/nestbox,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "oXz" = (
@@ -79552,9 +79542,7 @@
 /area/station/maintenance/port/aft)
 "xEE" = (
 /obj/structure/cable,
-/obj/structure/window/reinforced/spawner/directional/north{
-	dir = 2
-	},
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "xET" = (
@@ -112581,7 +112569,7 @@ aac
 aac
 kbg
 mvT
-dIN
+hUC
 eVz
 eVz
 eVz

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -15241,7 +15241,9 @@
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/freezerchamber)
 "dIN" = (
-/obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "dIO" = (
@@ -16412,7 +16414,10 @@
 /area/station/hallway/primary/tram/left)
 "eaX" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "eaZ" = (
@@ -28467,7 +28472,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/tram/mid)
 "hUC" = (
-/obj/machinery/egg_incubator,
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
@@ -39154,10 +39158,7 @@
 /area/station/maintenance/starboard/lesser)
 "ldt" = (
 /obj/structure/cable,
-/obj/structure/nestbox,
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "ldy" = (
@@ -45111,6 +45112,13 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai)
+"mZl" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/mob/living/basic/chicken/brown{
+	forced_gender = "female"
+	},
+/turf/open/floor/sandy_dirt,
+/area/station/service/hydroponics/chicken)
 "mZt" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -48935,9 +48943,8 @@
 /area/station/medical/medbay/central)
 "ojl" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/railing{
-	dir = 1
-	},
+/obj/structure/window/reinforced/spawner/directional/north,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "ojH" = (
@@ -51243,6 +51250,14 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"oXw" = (
+/obj/structure/cable,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
+/obj/structure/nestbox,
+/turf/open/floor/sandy_dirt,
+/area/station/service/hydroponics/chicken)
 "oXz" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -55176,9 +55191,8 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qfk" = (
-/obj/structure/railing{
-	dir = 8
-	},
+/obj/structure/window/reinforced/spawner/directional/west,
+/obj/structure/nestbox,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "qfv" = (
@@ -59199,11 +59213,11 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/starboard/central)
 "rpG" = (
-/obj/structure/railing,
-/obj/structure/window/reinforced/spawner/directional/east,
-/mob/living/basic/chicken/brown{
-	forced_gender = "female"
+/obj/machinery/door/window/right/directional/west{
+	name = "Ranch";
+	dir = 2
 	},
+/obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "rpJ" = (
@@ -64159,7 +64173,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/central)
 "sUm" = (
-/obj/structure/railing,
+/obj/machinery/door/window/right/directional/west{
+	name = "Ranch";
+	dir = 2
+	},
 /mob/living/basic/chicken{
 	forced_gender = "female"
 	},
@@ -67137,7 +67154,10 @@
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/greater)
 "tQj" = (
-/obj/structure/nestbox,
+/obj/machinery/door/window/right/directional/west{
+	name = "Ranch";
+	dir = 4
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "tQq" = (
@@ -74283,8 +74303,9 @@
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/central/lesser)
 "vSB" = (
-/obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/nestbox,
+/obj/machinery/door/window/right/directional/west{
+	name = "Ranch"
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "vSI" = (
@@ -75223,6 +75244,11 @@
 	},
 /turf/open/floor/stone,
 /area/station/smithing)
+"wih" = (
+/obj/structure/window/reinforced/spawner/directional/east,
+/obj/machinery/egg_incubator,
+/turf/open/floor/sandy_dirt,
+/area/station/service/hydroponics/chicken)
 "wip" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -79526,7 +79552,9 @@
 /area/station/maintenance/port/aft)
 "xEE" = (
 /obj/structure/cable,
-/obj/structure/railing,
+/obj/structure/window/reinforced/spawner/directional/north{
+	dir = 2
+	},
 /turf/open/floor/sandy_dirt,
 /area/station/service/hydroponics/chicken)
 "xET" = (
@@ -112038,9 +112066,9 @@ aac
 aac
 aac
 kbg
-tQj
+tka
 pHO
-xEE
+oXw
 ntf
 ldt
 wjX
@@ -112295,13 +112323,13 @@ aac
 aac
 aac
 kbg
-kBz
+mZl
 kBz
 rpG
 eVz
 ojl
-kBz
-kBz
+tQj
+wih
 jgl
 gtw
 xxS
@@ -113066,7 +113094,7 @@ aac
 aac
 aac
 kbg
-vSB
+kBz
 eaX
 eVz
 rCo
@@ -113838,7 +113866,7 @@ aac
 aac
 kbg
 qfk
-qfk
+vSB
 tqI
 wwg
 bzk
@@ -114351,7 +114379,7 @@ aac
 aac
 aac
 kbg
-tQj
+tka
 fDr
 kyb
 nSi


### PR DESCRIPTION
## It's time to end the Gatekeeping of Ranching _(literally)_ (and other QOL changes)

Ever since my arrival to monke at the end of the year 2024, a trauma regarding mapping has followed me everywhere i looked.

No matter how many squats, or leg presses or jumping jacks were done, simians would never be able to do one simple thing:

![mario-videogames](https://github.com/user-attachments/assets/ec30f9a0-456a-441c-b5c2-b4fc7c7e9105)

 ### _hop over ranching railings_

##  
 Since then, i haved learned, i have studied, i have trained in the art of making fences, and i have meticulously studied the fences of every ranching area of **_every_** map
 
 And thus, with inspiration from Box Station windoor and reinforced glass thin wall system, i have _changed every single ranching area_ to follow one simple rule: 
 
 ### **_No more fence jumping._**
 
 
![freedom](https://github.com/user-attachments/assets/bc835b83-0977-4daa-ba01-947010b0a2a5)

 
Not only that, but i've also changed the position of every nest box, so now, a single opening of a windoor is all you need to get your eggs. 

While i wish i had a sprite that would work like a fence but look like a thin glass wall, i currently have none, so this is the best i could do _(for now. I will learn spriting. eventually.) 
 
 ### Now, you reviewer, might be asking yourself these following questions
 
 ### _Why_?
 
Because, on the end of 2024, a tragedy had befallen my poor Monkestation. A character of mine, aptly named Mr. Socks, met the most unfortunate end of death by starvation due to the fact that botanists on MetaStation can spawn inside the nesting area of chickens, meaning Mr. Socks had forever died as a character in my eyes. 
 
 And thus, in the words of the mighty generarl Sun Tsu
 
<img width="632" height="378" alt="LYn5mz" src="https://github.com/user-attachments/assets/473ac351-b8ca-4a14-8314-9ca1e10ec1f1" />

 But now, with the support of the #EndRanchingGatekeeping and #JusticeForMrSocks communities, and of a certain... _unhinged_ mapper, i have learned how to map, and therefore, have come to make this change for my fellow 2 other ranchers out there.
 
 ### Why reinforced thin window walls?
 

https://github.com/user-attachments/assets/055836fc-83e4-49b5-989f-f1cc5a60d862

Trust me, these chickens will break shit very fast. This will at least contain their wrath for a few minutes. After that, may god be with you.
 
### Why is every PR of yours a shitpost?

Because it makes people actually want to see my PR 😭

 ### Have simians actually suffered from specism regardings the role of botanist?

 #### Have you ever seen a Simian Rancher? Nuff said. 

![monkey](https://github.com/user-attachments/assets/53b5b1df-9556-4e44-937f-273c299039cd)
(your face when you realize the consequences)
 
 ### What is ranching?


 A slower and more feathery xenobio
 

## Why It's Good For The Game

* Simians can finally do ranching thanks to the inventios of windoors.
* Ranching railings would fail to contain chickens if gravity was turned off, thin glass reinforced windows now prevent this
* Keter level dangerous Chickens now have a harder time escaping from containment
* Having nest boxes by windoors is a huge QOL addition that allows ranchers to access their eggs without having to walk to the end of each ranching area.

## Changelog

:cl:

map: Added the missing disk compartamentalizer to Icebox Botany
map: Added heated nesting boxes to some maps that did not have it before
map: Replaced all ranching railings with reinforced thin glass walls and windoors for easy access for simians
map: Chicken nest boxes are now all close to windoors for easy access to eggs

/:cl:
