### PR TITLE
Touching a highly energized wire no longer dusts you

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -452,7 +452,8 @@
 		playsound(victim.loc, 'sound/magic/lightningbolt.ogg', 100, TRUE, extrarange = 30)
 		carbon_brain.forceMove(turf)
 		victim.visible_message(span_danger("[victim] turns to ash from the electrical shock!"))
-		victim.dust()
+		victim.death()
+		victim.become_husk(BURN)
 		drained_hp = PN.netexcess * 0.1
 
 	log_combat(source, victim, "electrocuted")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it where touching a high power cable no longer dusts you
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<img width="594" height="150" alt="image" src="https://github.com/user-attachments/assets/2962014e-c00a-4c18-8f13-3972809a9ed2" />

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Getting shocked with a lot of power will husk you instead of dusting you
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
