### PR TITLE
Mirror Bugfix

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -87,7 +87,7 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/mirror, 28)
 	. = ..()
 	if(broken) // breaking a mirror truly gets you bad luck!
 		to_chat(user, span_warning("A chill runs down your spine as [src] shatters..."))
-		user.AddComponent(/datum/component/, incidents_left = 7)
+		user.AddComponent(/datum/component/omen, incidents_left = 7)
 
 /obj/structure/mirror/bullet_act(obj/projectile/P)
 	if(broken || !isliving(P.firer) || !P.damage)


### PR DESCRIPTION
## About The Pull Request

I noticed while working on another PR of mine and so here I am fixing it

attacking a mirror gives you /datum/component/ instead of /datum/component/omen

## Why It's Good For The Game

Bugfix

## Changelog
:cl:
fix: fixed attacking a mirror giving you /datum/component/ instead of /datum/component/omen
/:cl: