### PR TITLE
very minor service borg update

### DIFF
--- a/code/game/objects/items/robot/items/storage.dm
+++ b/code/game/objects/items/robot/items/storage.dm
@@ -163,8 +163,11 @@
 	name = "beverage storage apparatus"
 	desc = "A special apparatus for carrying drinks without spilling the contents. Will resynthesize any drinks you pour out!"
 	icon_state = "borg_beaker_apparatus"
-	storable = list(/obj/item/reagent_containers/cup/glass,
-					/obj/item/reagent_containers/condiment)
+	storable = list(/obj/item/reagent_containers/cup/beaker,
+					/obj/item/reagent_containers/cup/bottle,
+					/obj/item/reagent_containers/cup/glass,
+					/obj/item/reagent_containers/condiment,
+					/obj/item/reagent_containers/cup/coffeepot)
 
 /obj/item/borg/apparatus/beaker/service/add_glass()
 	stored = new /obj/item/reagent_containers/cup/glass/drinkingglass(src)

--- a/monkestation/code/game/objects/items/robot/items/borg_cooking.dm
+++ b/monkestation/code/game/objects/items/robot/items/borg_cooking.dm
@@ -18,7 +18,7 @@
 	update_appearance()
 	return ..()
 
-/obj/item/borg/apparatus/cooking/pre_attack(atom/atom, mob/living/user, params)
+/obj/item/borg/apparatus/cooking/proc/on_attack(atom/atom, mob/living/user, params, mode)
 	if(!stored)
 		var/itemcheck = FALSE
 		for(var/storable_type in storable)
@@ -33,11 +33,21 @@
 			update_appearance()
 			return TRUE
 		else
-			return ..()
+			return FALSE
 	else
-		stored.pre_attack(atom, user, params) //this might be a terrible idea
-		atom.attackby(stored, user, params)
+		if(mode)
+			stored.pre_attack(atom, user, params)
+			atom.attackby(stored, user, params)
+		else
+			stored.pre_attack_secondary(atom, user, params)
+			atom.attackby_secondary(stored, user, params)
 		return TRUE
+
+/obj/item/borg/apparatus/cooking/pre_attack(atom/atom, mob/living/user, params)
+	return on_attack(atom, user, params, TRUE) || ..()
+
+/obj/item/borg/apparatus/cooking/pre_attack_secondary(atom/atom, mob/living/user, params)
+	return on_attack(atom, user, params, FALSE) || ..()
 
 /obj/item/borg/apparatus/cooking/examine()
 	. = ..()

--- a/monkestation/code/game/objects/items/robot/items/borg_cooking.dm
+++ b/monkestation/code/game/objects/items/robot/items/borg_cooking.dm
@@ -18,7 +18,7 @@
 	update_appearance()
 	return ..()
 
-/obj/item/borg/apparatus/cooking/proc/on_attack(atom/atom, mob/living/user, params, mode)
+/obj/item/borg/apparatus/cooking/pre_attack(atom/atom, mob/living/user, params)
 	if(!stored)
 		var/itemcheck = FALSE
 		for(var/storable_type in storable)
@@ -33,21 +33,10 @@
 			update_appearance()
 			return TRUE
 		else
-			return FALSE
+			return ..()
 	else
-		if(mode)
-			stored.pre_attack(atom, user, params)
-			atom.attackby(stored, user, params)
-		else
-			stored.pre_attack_secondary(atom, user, params)
-			atom.attackby_secondary(stored, user, params)
+		stored.melee_attack_chain(user, atom, params)
 		return TRUE
-
-/obj/item/borg/apparatus/cooking/pre_attack(atom/atom, mob/living/user, params)
-	return on_attack(atom, user, params, TRUE) || ..()
-
-/obj/item/borg/apparatus/cooking/pre_attack_secondary(atom/atom, mob/living/user, params)
-	return on_attack(atom, user, params, FALSE) || ..()
 
 /obj/item/borg/apparatus/cooking/examine()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

very minor service borg update
service borgs can now hold beakers, bottles, and coffeepots
fixed bug that was preventing service borgs from cooking eggs

## Why It's Good For The Game

not being able to use beakers and bottles is just kinda annoying
added coffeepots to the mix because i felt like it fight me
egg

## Changelog

:cl:
qol: Service borgs can now hold beakers, bottles, and coffeepots.
fix: Service borgs are now capable of cooking eggs on griddles, let's get cracking!
/:cl:
