### PR TITLE
Balance pass on Bingles

### DIFF
--- a/monkestation/code/modules/veth_misc_items/bingle/bingle_pit.dm
+++ b/monkestation/code/modules/veth_misc_items/bingle/bingle_pit.dm
@@ -24,13 +24,14 @@ GLOBAL_LIST(bingle_mobs)
 	var/list/pit_overlays = list()
 	var/last_bingle_spawn_value = 0
 	var/last_bingle_poll_value = 0
-	var/max_pit_size = 80 // Maximum size (80x80) for the pit
+	var/max_pit_size = 40 // Maximum size (40x40) for the pit
 	var/datum/component/aura_healing/aura_healing
 	var/static/datum/team/bingles/bingle_team
 	/// Typecache of things that won't be swallowed by the pit.
 	var/static/list/swallow_blacklist
 	/// Cooldown for taking bomb damage - basically a cheat solution to handle it taking damage for each tile from one bomb.
 	COOLDOWN_DECLARE(bomb_cooldown)
+	var/announcement_made = FALSE
 
 /obj/structure/bingle_hole/Initialize(mapload)
 	..()
@@ -120,12 +121,12 @@ GLOBAL_LIST(bingle_mobs)
 /obj/structure/bingle_hole/process(seconds_per_tick)
 	// Only spawn a new bingle for each 30 item value milestone, and only once per milestone
 	// Calculate how many bingles should exist based on current item value
-	var/target_bingle_count = round(item_value_consumed / 30)
-	var/current_bingle_count = round(last_bingle_spawn_value / 30)
+	var/target_bingle_count = round(item_value_consumed / 50)
+	var/current_bingle_count = round(last_bingle_spawn_value / 50)
 
 	// If we need more bingles, spawn one
 	if(target_bingle_count > current_bingle_count)
-		last_bingle_spawn_value = target_bingle_count * 30
+		last_bingle_spawn_value = target_bingle_count * 50
 		INVOKE_ASYNC(src, PROC_REF(spawn_bingle_from_ghost))
 
 	// Pit grows every 100 item value - calculate target size
@@ -362,7 +363,9 @@ GLOBAL_LIST(bingle_mobs)
 				if(iswallturf(T))
 					T.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 					item_value_consumed++
-
+				if(!announcement_made)
+					priority_announce("The blue tide has been detected upon [station_name()]. All personnel must stop the consumption of the station.", "Biohazard Alert", ANNOUNCER_OUTBREAK5)
+					announcement_made = TRUE
 	current_pit_size = new_size
 	aura_healing.range = max(round(new_size / 2, 1) + 2, 3)
 

--- a/monkestation/code/modules/veth_misc_items/bingle/mob.dm
+++ b/monkestation/code/modules/veth_misc_items/bingle/mob.dm
@@ -59,7 +59,7 @@
 		return ..()
 	var/mob/living/mob_target = target
 	mob_target.Disorient(6 SECONDS, 5, paralyze = 10 SECONDS, stack_status = FALSE)
-	mob_target.stamina.adjust(-100)
+	mob_target.stamina.adjust(-35)
 	SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK)
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Balance pass for the bingles.

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Max bingle pit size is now 40x40
balance: Bingles now stun in 6 hits (up from 2)
balance: There is now an announcement alerting the crew once the bingle pit reaches size 3.
balance: Bingles now spawn every 50 items consumed (up from 30)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
