### PR TITLE
Cannibalizing/retracting limbs as an oozeling now drops any implants in that limb

### DIFF
--- a/monkestation/code/modules/surgery/organs/internal/heart.dm
+++ b/monkestation/code/modules/surgery/organs/internal/heart.dm
@@ -87,7 +87,7 @@
 	if(body.num_legs) //Legs go before arms
 		limbs_to_consume -= list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
 	consumed_limb = body.get_bodypart(pick(limbs_to_consume))
-	for(var/obj/item/organ/organ in body.get_organs_for_zone(consumed_limb.body_zone))
+	for(var/obj/item/organ/internal/organ in body.get_organs_for_zone(consumed_limb.body_zone))
 		organ.Remove(body)
 		if(!QDELETED(organ))
 			organ.forceMove(body.drop_location())
@@ -189,7 +189,7 @@
 	var/obj/item/bodypart/selected_limb = show_radial_menu(user, user, retractable_limbs)
 	if(isnull(selected_limb))
 		return
-	for(var/obj/item/organ/organ in user.get_organs_for_zone(selected_limb.body_zone))
+	for(var/obj/item/organ/internal/organ in user.get_organs_for_zone(selected_limb.body_zone))
 		organ.Remove(user)
 		if(!QDELETED(organ))
 			organ.forceMove(user.drop_location())

--- a/monkestation/code/modules/surgery/organs/internal/heart.dm
+++ b/monkestation/code/modules/surgery/organs/internal/heart.dm
@@ -87,6 +87,10 @@
 	if(body.num_legs) //Legs go before arms
 		limbs_to_consume -= list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM)
 	consumed_limb = body.get_bodypart(pick(limbs_to_consume))
+	for(var/obj/item/organ/organ in body.get_organs_for_zone(consumed_limb.body_zone))
+		organ.Remove(body)
+		if(!QDELETED(organ))
+			organ.forceMove(body.drop_location())
 	consumed_limb.drop_limb()
 	to_chat(body, span_userdanger("Your [consumed_limb] is drawn back into your body, unable to maintain its shape!"))
 	qdel(consumed_limb)
@@ -185,6 +189,10 @@
 	var/obj/item/bodypart/selected_limb = show_radial_menu(user, user, retractable_limbs)
 	if(isnull(selected_limb))
 		return
+	for(var/obj/item/organ/organ in user.get_organs_for_zone(selected_limb.body_zone))
+		organ.Remove(user)
+		if(!QDELETED(organ))
+			organ.forceMove(user.drop_location())
 	selected_limb.drop_limb()
 	qdel(selected_limb)
 	user.blood_volume += 20


### PR DESCRIPTION

## About The Pull Request

this makes it so, when an oozeling limb is retracted/cannibalized, any organs/implants in that limb will be dropped to the floor, instead of being effectively deleted.

## Why It's Good For The Game

bit annoying to have your implants just vaporized.

## Changelog
:cl:
fix: Cannibalizing/retracting limbs as an oozeling now drops any implants in that limb, instead of vaporizing it forever.
/:cl:
