### PR TITLE
Custom objectives now alert admins audibly. Cassettes now ask you twice to confirm

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -574,6 +574,10 @@ GLOBAL_LIST_EMPTY(cached_antag_previews)
 
 	log_game("[key_name(owner_mob)] [retain_existing ? "" : "opted out of their original objectives and "]chose a custom objective: [custom_objective_text]")
 	message_admins("[ADMIN_LOOKUPFLW(owner_mob)] has chosen a custom antagonist objective: [span_syndradio("[custom_objective_text]")] | [ADMIN_SMITE(owner_mob)] | [ADMIN_SYNDICATE_REPLY(owner_mob)]")
+	for(var/client/staff as anything in GLOB.admins)
+		if(staff?.prefs?.toggles & SOUND_ADMINHELP)
+			SEND_SOUND(staff, sound('sound/effects/adminhelp.ogg'))
+		window_flash(staff, ignorepref = TRUE)
 
 	var/datum/objective/custom/custom_objective = new()
 	custom_objective.owner = owner

--- a/monkestation/code/modules/cassettes/machines/postbox.dm
+++ b/monkestation/code/modules/cassettes/machines/postbox.dm
@@ -49,8 +49,8 @@
 		return
 
 	// are you sure
-	var/choice = tgui_alert(user, "Please make sure to Adminhelp and check for any available admins that can review your cassette before submitting, you will not be refunded if it is denied. If an admin does not review your cassette, and you are connected at the end of the round, you may be refunded.", "Mailbox", list("Acknowledge", "Cancel"))
-	if(choice != "Acknowledge")
+	var/secondchoice = tgui_alert(user, "Please make sure to Adminhelp and check for any available admins that can review your cassette before submitting, you will not be refunded if it is denied. If an admin does not review your cassette, and you are connected at the end of the round, you may be refunded.", "Mailbox", list("Acknowledge", "Cancel"))
+	if(secondchoice != "Acknowledge")
 		return
 	///these two parts here should be commented out for local testing without a db
 	if(user.client.prefs.metacoins < 5000)

--- a/monkestation/code/modules/cassettes/machines/postbox.dm
+++ b/monkestation/code/modules/cassettes/machines/postbox.dm
@@ -49,7 +49,7 @@
 		return
 
 	// are you sure
-	var/choice = tgui_alert(user, "Please make sure to Adminhelp and check for any available admins that can review your cassette before submitting, you will not be refunded if it is denied.", "Mailbox", list("Acknowledge", "Cancel"))
+	var/choice = tgui_alert(user, "Please make sure to Adminhelp and check for any available admins that can review your cassette before submitting, you will not be refunded if it is denied. If an admin does not review your cassette, and you are connected at the end of the round, you may be refunded.", "Mailbox", list("Acknowledge", "Cancel"))
 	if(choice != "Acknowledge")
 		return
 	///these two parts here should be commented out for local testing without a db

--- a/monkestation/code/modules/cassettes/machines/postbox.dm
+++ b/monkestation/code/modules/cassettes/machines/postbox.dm
@@ -47,6 +47,11 @@
 	var/choice = tgui_alert(user, "Are you sure? This costs 5k Monkecoins", "Mailbox", list("Yes", "No"))
 	if(choice != "Yes")
 		return
+
+	// are you sure
+	var/choice = tgui_alert(user, "Please make sure to Adminhelp and check for any available admins that can review your cassette before submitting, you will not be refunded if it is denied.", "Mailbox", list("Acknowledge", "Cancel"))
+	if(choice != "Acknowledge")
+		return
 	///these two parts here should be commented out for local testing without a db
 	if(user.client.prefs.metacoins < 5000)
 		to_chat(user, span_notice("Sorry, you don't have enough Monkecoins to submit a cassette for review."))


### PR DESCRIPTION
## About The Pull Request
Talked about in recent admin meetings.
## Why It's Good For The Game
Chaos all over. Someone makes a shitty custom, admins couldnt notice it in the flood of logs. Explosions everywhere.
Wheres my monkecoin?!! -poor sod who didnt get reviewed due to 15 explosions and 3 shitters on the server at the same time of their cassette.
## Changelog
:cl: Tractor Maam
admin: Antagonist Custom Objectives now play a bwoink sound when created.
admin: The Space Postbox will now ask you again before submitting a cassette, reminding you adminhelp to make sure someone CAN review.
/:cl:
