### PR TITLE
[PORT] Make a global list of items that any suit storage can hold, also make suit storage able to hold any "tiny" item

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -182,6 +182,34 @@ DEFINE_BITFIELD(no_equip_flags, list(
 /// The index of the entry in 'afk_thefts' with the time it happened
 #define AFK_THEFT_TIME 3
 
+/// A list of things that any suit storage can hold
+/// Should consist of ubiquitous, non-specialized items
+/// or items that are meant to be "suit storage agnostic" as
+/// a benefit, which of the time of this commit only applies
+/// to the captain's jetpack, here
+GLOBAL_LIST_INIT(any_suit_storage, typecacheof(list(
+	/obj/item/clipboard,
+	/obj/item/flashlight,
+	/obj/item/tank/internals/emergency_oxygen,
+	/obj/item/tank/internals/plasmaman,
+	/obj/item/lighter,
+	/obj/item/pen,
+	/obj/item/modular_computer/pda,
+	/obj/item/toy,
+	/obj/item/radio,
+	/obj/item/storage/bag/books,
+	/obj/item/storage/fancy/cigarettes,
+	/obj/item/tank/jetpack/oxygen/captain,
+	/obj/item/stack/spacecash,
+	/obj/item/storage/wallet,
+	/obj/item/folder,
+	/obj/item/storage/box/matches,
+	/obj/item/cigarette,
+	/obj/item/gun/energy/laser/bluetag,
+	/obj/item/gun/energy/laser/redtag,
+	/obj/item/storage/belt/holster
+)))
+
 //Allowed equipment lists for security vests.
 
 GLOBAL_LIST_INIT(detective_vest_allowed, list(

--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -204,7 +204,7 @@ GLOBAL_LIST_INIT(any_suit_storage, typecacheof(list(
 	/obj/item/storage/wallet,
 	/obj/item/folder,
 	/obj/item/storage/box/matches,
-	/obj/item/cigarette,
+	/obj/item/clothing/mask/cigarette,
 	/obj/item/gun/energy/laser/bluetag,
 	/obj/item/gun/energy/laser/redtag,
 	/obj/item/storage/belt/holster

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1024,15 +1024,14 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				if(!disable_warning)
 					to_chat(H, span_warning("You need a suit before you can attach this [I.name]!"))
 				return FALSE
-			if(!H.wear_suit.allowed)
-				if(!disable_warning)
-					to_chat(H, span_warning("You somehow have a suit with no defined allowed items for suit storage, stop that."))
-				return FALSE
+			var/any_suit_storage = (is_type_in_typecache(I, GLOB.any_suit_storage) || I.w_class == WEIGHT_CLASS_TINY)
+			if(any_suit_storage)
+				return TRUE
 			if(I.w_class > WEIGHT_CLASS_BULKY)
 				if(!disable_warning)
 					to_chat(H, span_warning("The [I.name] is too big to attach!")) //should be src?
 				return FALSE
-			if( istype(I, /obj/item/modular_computer/pda) || istype(I, /obj/item/pen) || is_type_in_list(I, H.wear_suit.allowed) )
+			if( is_type_in_list(I, H.wear_suit.allowed) )
 				return TRUE
 			return FALSE
 		if(ITEM_SLOT_HANDCUFFED)


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/92406

> This is a much smaller change to make a list of items that any suit storage can hold. They're all, mostly, ubiquitous, low-impact items such as emergency oxygen tanks, lighters, and wallets. The full list:
> 
> -	/obj/item/clipboard,
> -	/obj/item/flashlight,
> -	/obj/item/tank/internals/emergency_oxygen,
> -	/obj/item/tank/internals/plasmaman,
> -	/obj/item/lighter,
> -	/obj/item/pen,
> -	/obj/item/modular_computer/pda,
> -	/obj/item/toy,
> -	/obj/item/radio,
> -	/obj/item/storage/bag/books,
> -	/obj/item/storage/fancy/cigarettes,
> -	/obj/item/tank/jetpack/oxygen/captain,
> -	/obj/item/stack/spacecash,
> -	/obj/item/storage/wallet,
> -	/obj/item/folder,
> -	/obj/item/storage/box/matches,
> -	/obj/item/cigarette,
> -	/obj/item/storage/belt/holster
> 
> Of note from the rest are the captain's jetpack and holsters. During my slog through the codebase for the various .allowed defines and redefines, the holster and jetpack have been the subject of multiple PRs that tried and either failed or were supplanted by other PRs that undid their work. By the intent of these multiple PRs, the captain's jetpack and the holster are meant to be "universal" high-utiliity suit storage items but until this PR, we lacked any implementation for "universal" suit storage items. The other items are of varying utility but are still something nice to carry.
> 
> Elsewise, suit storage has been refiiggered to hold any item of size "tiny". This is in consideration that almost any item of significant use is of size "small" or larger. If there's some game-breakingly OP "tiny" item I would say we should probably make that item bigger.

## Why It's Good For The Game
> Suit storage's per-type snowflake implementation makes it confusing to use and quite often nonsensical (why can I not hold a lighter in my jacket pocket). This adds a global universal list of useful and ubiquitous items, as well as a couple of items that are meant to be powerful in their sense of being able to fit on any suit storage. It also makes sense for anything that's "tiny" would reasonably be able to just be tucked or clipped on whatever you're wearing.

## Changelog
:cl: Absolucy, Bisar
balance: Added a list of "universal" items that can fit on any suit storage. Mostly low-impact but high-utility items, but of special note: holsters and the captain's jetpack can be worn on any suit storage.
balance: Any item of size "tiny" can now also be worn in suit storage.
qol: The suit storage change gives some small amount of sanity to wearing things on suit storage, such as emergency oxygen tanks or a pack of smokes.
/:cl:
