### PR TITLE
I finally figured out what was up with my strongdmm at least

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -32759,7 +32759,9 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
-/obj/machinery/door/airlock/hydroponics,
+/obj/machinery/door/airlock/hydroponics{
+	name = "Ranching"
+	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics/chicken)
 "hHQ" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -32758,10 +32758,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Ranching"
-	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
+/obj/machinery/door/airlock/hydroponics,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/chicken)
 "hHQ" = (
@@ -100612,6 +100610,9 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/vacant_room)
 "xLV" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -62242,9 +62242,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/iron,
 /area/station/service/hydroponics/chicken)
@@ -91411,6 +91408,9 @@
 	dir = 8
 	},
 /obj/effect/mapping_helpers/airlock/access/any/service/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/port/fore)
 "vCq" = (

--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -69,6 +69,8 @@
 	canSmoothWith = SMOOTH_GROUP_FLOOR_SNOWED
 	planetary_atmos = TRUE
 
+/turf/open/floor/plating/snowed/smoothed/arena
+	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
 /turf/open/floor/plating/snowed/temperatre
 	temperature = 255.37
 

--- a/monkestation/code/game/objects/items/storage/garment.dm
+++ b/monkestation/code/game/objects/items/storage/garment.dm
@@ -27,8 +27,3 @@
 	new /obj/item/clothing/suit/armor/vest/blueshield/jacket(src)
 	new /obj/item/clothing/neck/mantle/bsmantle(src)
 
-/obj/item/storage/belt/security/blueshield/PopulateContents()
-		new /obj/item/grenade/flashbang(src)
-		new /obj/item/assembly/flash/handheld(src)
-		new /obj/item/reagent_containers/spray/pepper(src)
-		new /obj/item/restraints/handcuffs(src)

--- a/monkestation/code/modules/ghost_players/arena/maps/jungle.dmm
+++ b/monkestation/code/modules/ghost_players/arena/maps/jungle.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/open/water,
+/turf/open/water/arena,
 /area/centcom/tdome/arena/actual)
 "b" = (
 /obj/structure/flora/bush/flowers_br/style_3,
@@ -12,7 +12,7 @@
 /area/centcom/tdome/arena/actual)
 "k" = (
 /obj/structure/flora/bush/reed/style_random,
-/turf/open/water,
+/turf/open/water/arena,
 /area/centcom/tdome/arena/actual)
 "l" = (
 /obj/structure/flora/bush/flowers_yw/style_3,
@@ -65,7 +65,7 @@
 /obj/machinery/camera/motion/thunderdome{
 	pixel_x = 10
 	},
-/turf/open/water,
+/turf/open/water/arena,
 /area/centcom/tdome/arena/actual)
 "O" = (
 /obj/structure/flora/tree/jungle/small/style_6,
@@ -77,7 +77,7 @@
 /area/centcom/tdome/arena/actual)
 "T" = (
 /obj/structure/punji_sticks,
-/turf/open/water,
+/turf/open/water/arena,
 /area/centcom/tdome/arena/actual)
 "U" = (
 /obj/machinery/light/floor/has_bulb,

--- a/monkestation/code/modules/ghost_players/arena/maps/snow.dmm
+++ b/monkestation/code/modules/ghost_players/arena/maps/snow.dmm
@@ -3,7 +3,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 8
 	},
-/turf/open/floor/plating/snowed/smoothed,
+/turf/open/floor/plating/snowed/smoothed/arena,
 /area/centcom/tdome/arena/actual)
 "cc" = (
 /obj/structure/fermenting_barrel{
@@ -104,7 +104,7 @@
 /turf/open/floor/wood/large,
 /area/centcom/tdome/arena/actual)
 "pD" = (
-/turf/open/floor/plating/snowed/smoothed,
+/turf/open/floor/plating/snowed/smoothed/arena,
 /area/centcom/tdome/arena/actual)
 "pQ" = (
 /obj/structure/chair/wood{
@@ -191,7 +191,7 @@
 /obj/effect/turf_decal/weather/snow/corner{
 	dir = 4
 	},
-/turf/open/floor/plating/snowed/smoothed,
+/turf/open/floor/plating/snowed/smoothed/arena,
 /area/centcom/tdome/arena/actual)
 "ET" = (
 /obj/structure/flora/tree/stump{
@@ -275,7 +275,7 @@
 /area/centcom/tdome/arena/actual)
 "Tr" = (
 /obj/machinery/light/floor/has_bulb,
-/turf/open/floor/plating/snowed/smoothed,
+/turf/open/floor/plating/snowed/smoothed/arena,
 /area/centcom/tdome/arena/actual)
 "Ty" = (
 /obj/item/wallframe/picture{

--- a/monkestation/code/modules/ghost_players/arena/maps/two_forts.dmm
+++ b/monkestation/code/modules/ghost_players/arena/maps/two_forts.dmm
@@ -140,9 +140,6 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/misc/sandy_dirt,
 /area/centcom/tdome/arena/actual)
-"PS" = (
-/turf/open/water,
-/area/centcom/tdome/arena/actual)
 "TW" = (
 /obj/machinery/light/small/blacklight/directional/east,
 /turf/open/floor/stone,
@@ -318,9 +315,9 @@ MZ
 Yq
 Lu
 MZ
-PS
-PS
-PS
+VF
+VF
+VF
 "}
 (13,1,1) = {"
 Pg

--- a/tgui/packages/tgui/interfaces/AutomatedAnnouncement.tsx
+++ b/tgui/packages/tgui/interfaces/AutomatedAnnouncement.tsx
@@ -33,7 +33,7 @@ export const AutomatedAnnouncement = (props) => {
     node_message,
   } = data;
   return (
-    <Window title="Automated Announcement System" width={500} height={225}>
+    <Window title="Automated Announcement System" width={500} height={255}>
       <Window.Content>
         <Section
           title="Arrival Announcement"


### PR DESCRIPTION
## About The Pull Request
I finally figured up whats with strongddm.
So

- Snow two fort and jungle arenas now have consistent atmosphere turfing

- Deltastation Chicken coop maints now has its unrestricted access helpers flipped so you can actually leave.

- Increased the TGUI height of Automated announcement panel to include the new research portion properly.

- Deleted unused code/subtype of blueshield security belt. Blueshields uses assault belts.

## Why It's Good For The Game
## Changelog
:cl:
map: Jungle, Two fort, and Arena arenas now have consistent atmospherics.
map: Deltastation Chicken Coop botany now has more escapable. unrestricted access helpers
fix: Automated announcement TUGI height has been increased to 255 to include the research section
code: Deleted unused blueshield security belt from code.
/:cl:
