### PR TITLE
Battlecruiser adjustment.

### DIFF
--- a/_maps/templates/battlecruiser_starfury.dmm
+++ b/_maps/templates/battlecruiser_starfury.dmm
@@ -1780,8 +1780,9 @@
 /turf/open/floor/iron/dark,
 /area/shuttle/sbc_starfury)
 "gx" = (
-/obj/effect/mob_spawn/ghost_role/human/syndicate/battlecruiser{
-	dir = 8
+/obj/effect/mob_spawn/ghost_role/human/syndicate/battlecruiser/assault{
+	dir = 8;
+	uses = 4
 	},
 /turf/open/floor/carpet/orange,
 /area/shuttle/sbc_starfury)
@@ -3310,7 +3311,8 @@
 /area/shuttle/sbc_starfury)
 "kw" = (
 /obj/effect/mob_spawn/ghost_role/human/syndicate/battlecruiser/assault{
-	dir = 8
+	dir = 8;
+	uses = 4
 	},
 /turf/open/floor/carpet,
 /area/shuttle/sbc_starfury)

--- a/monkestation/code/game/objects/items/storage/toolbox.dm
+++ b/monkestation/code/game/objects/items/storage/toolbox.dm
@@ -14,3 +14,4 @@
 	new /obj/item/analyzer(src)
 	new /obj/item/wirecutters(src)
 	new /obj/item/multitool(src)
+	new /obj/item/stack/cable_coil/industrial(src)

--- a/monkestation/code/game/objects/items/storage/toolbox.dm
+++ b/monkestation/code/game/objects/items/storage/toolbox.dm
@@ -14,4 +14,3 @@
 	new /obj/item/analyzer(src)
 	new /obj/item/wirecutters(src)
 	new /obj/item/multitool(src)
-	new /obj/item/stack/cable_coil/industrial(src)


### PR DESCRIPTION

## About The Pull Request
Removes the crew roles from the battlecruiser
## Why It's Good For The Game
The battlecruiser consists of 8 operatives, 4 crew, and the nuclear leader.
Despite the objective of the 4 crew to not directly assault the station, everyone gets giddy of "Oh battlecruiser, hell yeah". And joins in on rushing the armory and the station.
So that being said removes the 4 crew from spawning and splits the 8 operatives amongst the two dorms.
## Changelog
:cl:
balance: Removed the 4 crew spawns from the battlecruiser starfury
/:cl:
