### PR TITLE
Automated CC Firing range cleanup + Bullet drive bugfix

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -24959,6 +24959,10 @@
 /obj/item/restraints/handcuffs/cable/white,
 /turf/open/floor/carpet/neon/simple/blue/nodots,
 /area/centcom/central_command_areas/prison)
+"jVH" = (
+/mob/living/basic/bot/cleanbot/firing_range,
+/turf/open/indestructible/dark,
+/area/centcom/central_command_areas/firing_range)
 "jWH" = (
 /obj/effect/turf_decal/sand/plating,
 /turf/closed/indestructible/wood,
@@ -27534,6 +27538,11 @@
 /obj/effect/mapping_helpers/airlock/access/any/admin/general,
 /turf/open/floor/plating,
 /area/centcom/central_command_areas/admin)
+"oKo" = (
+/obj/structure/table/reinforced,
+/obj/machinery/dish_drive/firing_range,
+/turf/open/indestructible/dark,
+/area/centcom/central_command_areas/firing_range)
 "oKS" = (
 /obj/structure/sign{
 	name = "wall";
@@ -74016,7 +74025,7 @@ aRy
 asC
 aRy
 asC
-aRy
+oKo
 asC
 aRy
 asC
@@ -75045,7 +75054,7 @@ aBo
 aUR
 aBo
 aUR
-aBo
+jVH
 aUR
 aBo
 aUR

--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -177,3 +177,16 @@
 			visible_message(span_notice("There are no disposable items in [src]!"))
 		return
 	COOLDOWN_START(src, time_since_dishes, 1 MINUTES)
+
+/obj/machinery/dish_drive/firing_range
+	resistance_flags = INDESTRUCTIBLE
+	icon_state = null
+	icon = null  // These three are just so it pratically doesnt exist.
+	collectable_items = list(/obj/item/ammo_casing,
+		/obj/item/bodypart,
+		/obj/item/organ,)
+
+/obj/machinery/dish_drive/firing_range/Initialize(mapload)
+	. = ..()
+	RefreshParts()
+	suck_distance = 8 

--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -37,6 +37,7 @@
 	var/list/dish_drive_contents
 	/// Distance this is capable of sucking dishes up over. (2 + servo tier)
 	var/suck_distance = 0
+	var/suck_distance_bonus = 8
 	var/binrange = 7
 
 	COOLDOWN_DECLARE(time_since_dishes)
@@ -126,7 +127,7 @@
 	if(!suction_enabled)
 		return
 
-	for(var/obj/item/dish in view(2 + suck_distance, src))
+	for(var/obj/item/dish in view(2 + suck_distance + suck_distance_bonus, src))
 		if(is_type_in_list(dish, collectable_items) && dish.loc != src && (!dish.reagents || !dish.reagents.total_volume) && (dish.contents.len < 1))
 			if(dish.Adjacent(src))
 				LAZYADD(dish_drive_contents, dish)
@@ -182,11 +183,7 @@
 	resistance_flags = INDESTRUCTIBLE
 	icon_state = null
 	icon = null  // These three are just so it pratically doesnt exist.
+	suck_distance_bonus = 8
 	collectable_items = list(/obj/item/ammo_casing,
 		/obj/item/bodypart,
 		/obj/item/organ,)
-
-/obj/machinery/dish_drive/firing_range/Initialize(mapload)
-	. = ..()
-	RefreshParts()
-	suck_distance = 8 

--- a/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
+++ b/code/modules/mob/living/basic/bots/cleanbot/cleanbot.dm
@@ -366,3 +366,14 @@
 	name = "Scrubs, MD"
 	maints_access_required = list(ACCESS_ROBOTICS, ACCESS_JANITOR, ACCESS_MEDICAL)
 	bot_mode_flags = ~(BOT_MODE_ON | BOT_MODE_REMOTE_ENABLED)
+
+/mob/living/basic/bot/cleanbot/firing_range //An invicible cleanbot to clean the firing range of blood.
+	name = "M-O"
+	desc = "A little cleaning robot, he looks like he's taken a beating."
+	bot_mode_flags = (BOT_MODE_ON)
+	health = 24
+
+/mob/living/basic/bot/cleanbot/firing_range/Initialize(mapload)
+	. = ..()
+	//Area based godmode to clean the firing range, just incase it somehow escapes onto station. Somehow....
+	AddComponentFrom(ROUNDSTART_TRAIT, /datum/component/area_based_godmode, area_type = /area/centcom, allow_area_subtypes = TRUE)

--- a/monkestation/code/modules/blueshift/machines/bullet_drive.dm
+++ b/monkestation/code/modules/blueshift/machines/bullet_drive.dm
@@ -6,7 +6,7 @@
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/dish_drive/bullet
 	collectable_items = list(/obj/item/ammo_casing)
-	suck_distance = 8
+	suck_distance_bonus = 8
 	binrange = 10
 
 /obj/item/circuitboard/machine/dish_drive/bullet

--- a/monkestation/code/modules/ghost_players/job_helpers/firing_range_helper.dm
+++ b/monkestation/code/modules/ghost_players/job_helpers/firing_range_helper.dm
@@ -71,7 +71,7 @@
 		/obj/item/gun/chem,
 		/obj/item/gun/grenadelauncher,
 		/obj/structure/training_machine,
-		/mob/living/carbon/human) + typesof(/obj/item/gun/syringe, /obj/item/target)
+		/mob/living/carbon/human/ghost) + typesof(/obj/item/gun/syringe, /obj/item/target)
 	. = ..()
 
 //blocks passage if you have a gun


### PR DESCRIPTION
## About The Pull Request
Adds an invincible cleanbot and invisible dish drive to clean up CC firing ranges. And weapon spawners spawn human/ghost subtypes that delete themselves on death. Cleans most messes with the exception of gun spam, but still less messes!

And bullet drives had a extended range variable but it got refreshed upon initialisation, meaning it was never properly kept. This refactors it into a separate variable thats added later.
## Why It's Good For The Game
Helps clean one of the most messy rooms I've seen when properly used without additional added systems.

And bullet drive broke. Will fix.
## Changelog
:cl:
add: CC Firing range will automate its cleaning better.
fix: Bullet drives will now properly clean dishes at further ranges.
/:cl:
