### PR TITLE
Attempt to make ICARUS Sunbeam a little bit more deadly

### DIFF
--- a/monkestation/code/modules/assault_ops/code/sunbeam.dm
+++ b/monkestation/code/modules/assault_ops/code/sunbeam.dm
@@ -116,8 +116,10 @@
 
 			if(isliving(atom_to_obliterate))
 				var/mob/living/mob_to_obliterate = atom_to_obliterate
+				mob_to_obliterate.visible_message(span_danger("[mob_to_obliterate] gets absolutely obliterated by \the [src]! Holy fuck!"), \
+					span_userdanger("A blinding flash of light sears into your eyes as you're consumed by \the [src]!"))
 				mob_to_obliterate.apply_damage(200, BURN)
-				mob_to_obliterate.dust()
+				mob_to_obliterate.dust(TRUE)
 				continue
 
 	COOLDOWN_START(src, oblirerate_cooldown, obliteration_cooldown)


### PR DESCRIPTION

## About The Pull Request

Instead of following rod-like movement, Sunbeam will now pick a random turf in the station area and path directly towards it, destroying everything on the way
Once it reaches the said turf, it picks a new one and repeats
This makes the whole "evil piss laser destroys the station" a little bit more accurate

Another big change is that getting blasted with the sunbeam dusts you

Since sunbeam uses turfs as targets, admin verb "Summon Sunbeam"  uses /targeted subtype that paths towards any atom and deletes itself once it destroys it (or the target gets deleted). Just a code change

Because of how code works sunbeams that are spawned in centcomm/other zlevels may tweak out a little bit but it's not like its a big deal (and shoudn't be possible in the first place)

## Why It's Good For The Game

Assault op victory fucking sucks for how hard it is, it basically just summons a rod event but it's on fire and larger
...and sometimes the beam just misses the station
This makes the beam ACTUALLY destroy the station (or at least try to because of how much it lags sometimes)

## Changelog

:cl:
add: ICARUS Sunbeam will now pick a random turf on the station to path to and pick another upon reaching it, instead of following rod-like movement.
/:cl:
