### PR TITLE
Oozelings can now extinguish people on fire by hugging them!

### DIFF
--- a/code/__DEFINES/do_afters.dm
+++ b/code/__DEFINES/do_afters.dm
@@ -9,3 +9,4 @@
 #define DOAFTER_SOURCE_CHARGE_GUNCRANK "doafter_charge_guncrank"
 #define DOAFTER_SOURCE_SEED_MESH "doafter_seed_mesh"
 /* #define DOAFTER_SOURCE_ATM "doafter_atm" */
+#define DOAFTER_SOURCE_EXTINGUISHING_HUG "doafter_extinguishing_hug"

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -430,7 +430,32 @@
 
 /mob/living/carbon/proc/help_shake_act(mob/living/carbon/helper)
 	if(on_fire)
-		to_chat(helper, span_warning("You can't put [p_them()] out with just your bare hands!"))
+		if(!HAS_TRAIT(helper, TRAIT_NOFIRE) || helper == src)
+			to_chat(helper, span_warning("You can't put [p_them()] out with just your bare hands!"))
+			return
+		if(DOING_INTERACTION(helper, DOAFTER_SOURCE_EXTINGUISHING_HUG))
+			to_chat(helper, span_warning("You are already extinguishing someone!"))
+			return
+		visible_message(
+			span_notice("[helper] begins to closely hug [src], beginning to smother the fire consuming [p_their()] body!"),
+			span_boldnotice("[helper] holds you closely in a tight hug, beginning to smother the fire consuming your body!"),
+		)
+		while(on_fire && fire_stacks > 0)
+			if(!do_after(helper, 1 SECONDS, src, IGNORE_HELD_ITEM, interaction_key = DOAFTER_SOURCE_EXTINGUISHING_HUG))
+				visible_message(span_notice("[src] wriggles out of [helper]'s close hug!"), span_notice("You wriggle out of [src]'s close hug."))
+				return
+			visible_message(
+				span_notice("[helper] closely hugs [src], smothering the flames consuming [p_their()] body!"),
+				span_boldnotice("[helper] closely hugs you, smothering the flames consuming your body!"),
+				span_italics("You hear a fire sizzle out."),
+			)
+			var/stacks_to_extinguish = 2
+			if(pulledby == helper)
+				if(helper.grab_state > GRAB_PASSIVE)
+					stacks_to_extinguish = 5
+				else
+					stacks_to_extinguish = 3
+			adjust_fire_stacks(-stacks_to_extinguish)
 		return
 
 	if(SEND_SIGNAL(src, COMSIG_CARBON_PRE_MISC_HELP, helper) & COMPONENT_BLOCK_MISC_HELP)


### PR DESCRIPTION

## About The Pull Request

Same idea as https://github.com/BeeStation/BeeStation-Hornet/pull/8880, albeit not really a port due to not really using the same code.

this makes it so oozelings (or anyone with `TRAIT_NOFIRE`, but in practice that's usually only oozelings) will attempt to smother flames with a close hug if they try to hug a flaming person.

Just to prevent an oozeling from spam clicking a bunch of people to constantly put fires out, there's a 1 second do_after when hugging someone on fire as an ooze, and you can only do one person at a time.

Grabbing someone extinguishes slightly more fire stacks, and aggro grab (or higher) extinguishes even morefire  stacks.

## Why It's Good For The Game

it makes since that a being immune to fire could smother flames with their body.

## Changelog
:cl:
add: Oozelings can now hug flaming people to extinguish them! Grabbing someone will extinguish them slightly more, and aggressively grabbing them far more!
/:cl:
