### PR TITLE
remove knockback on security shotguns

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -48,8 +48,12 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
 	can_be_sawn_off = TRUE
+	pb_knockback = 0
 
 // Automatic Shotguns//
+
+/obj/item/gun/ballistic/shotgun/automatic
+	pb_knockback = 0
 
 /obj/item/gun/ballistic/shotgun/automatic/shoot_live_shot(mob/living/user)
 	..()
@@ -63,7 +67,6 @@
 	fire_delay = 8
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
-	pbk_gentle = TRUE
 
 /obj/item/gun/ballistic/shotgun/automatic/combat/compact
 	name = "compact shotgun"
@@ -167,6 +170,7 @@
 	tac_reloads = TRUE
 	projectile_damage_multiplier = 1.2
 	casing_ejector = TRUE
+	pb_knockback = 2
 	///the type of secondary magazine for the bulldog
 	var/secondary_magazine_type
 	///the secondary magazine


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this makes it so most of the crew shotguns (riot shotguns and such) have no knockback.

double-barreled shotguns and bulldog shotguns still have their own knockback values, and are unchanged.

## Why It's Good For The Game

because the stunlock with almost zero counterplay is bullshit

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Removed knockback from riot shotguns and such. Bulldog and double-barrelled shotguns still have knockback, tho.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
