### PR TITLE
Regeneration Coma and No healing

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/helpful/coma.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/helpful/coma.dm
@@ -35,6 +35,8 @@
 /datum/symptom/coma/proc/CanHeal(mob/living/victim)
 	if(!iscarbon(victim))
 		return FALSE
+	if(HAS_TRAIT(victem, TRAIT_NO_HEALS))
+		return FALSE
 	if(HAS_TRAIT(victim, TRAIT_DEATHCOMA))
 		return multiplier
 	if(victim.IsSleeping())

--- a/monkestation/code/modules/virology/disease/symtoms/helpful/coma.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/helpful/coma.dm
@@ -35,7 +35,7 @@
 /datum/symptom/coma/proc/CanHeal(mob/living/victim)
 	if(!iscarbon(victim))
 		return FALSE
-	if(HAS_TRAIT(victem, TRAIT_NO_HEALS))
+	if(HAS_TRAIT(victim, TRAIT_NO_HEALS))
 		return FALSE
 	if(HAS_TRAIT(victim, TRAIT_DEATHCOMA))
 		return multiplier


### PR DESCRIPTION

## About The Pull Request
Adds a check to regeneration Coma and No heal trait to prevent actual comas.
## Why It's Good For The Game
Oh gods actual softlocks
## Changelog
:cl:
fix: Regeneration Coma will no longer Put No healings into a death coma.
/:cl:
