### PR TITLE
Edible donksoft darts and toys

### DIFF
--- a/code/game/objects/items/emags.dm
+++ b/code/game/objects/items/emags.dm
@@ -46,6 +46,22 @@
 	lefthand_file = 'icons/mob/inhands/equipment/idcards_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/idcards_righthand.dmi'
 
+/obj/item/card/emagfake/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/edible, \
+		initial_reagents = list( \
+			/datum/reagent/consumable/nutriment = 1, \
+			/datum/reagent/consumable/nutriment/protein = 0.5, \
+		), \
+		food_flags = FOOD_FINGER_FOOD, \
+		tastes = list("crime" = 1), \
+		eatverbs = list("swallow" = 1), \
+		eat_time = 0, \
+		foodtypes = JUNKFOOD, \
+		bite_consumption = 99999, \
+	)
+	ADD_TRAIT(src, TRAIT_FISHING_BAIT, INNATE_TRAIT)
+
 /obj/item/card/emagfake/attack_self(mob/user) //for assistants with balls of plasteel
 	if(Adjacent(user))
 		user.visible_message(span_notice("[user] shows you: [icon2html(src, viewers(user))] [name]."), span_notice("You show [src]."))

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -671,6 +671,20 @@
 	w_class = WEIGHT_CLASS_SMALL
 	resistance_flags = FLAMMABLE
 
+/obj/item/toy/foamblade/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/edible, \
+		initial_reagents = list( \
+			/datum/reagent/consumable/nutriment = 6, \
+			/datum/reagent/consumable/nutriment/protein = 4, \
+		), \
+		food_flags = FOOD_FINGER_FOOD, \
+		tastes = list("foam" = 2, "violence" = 2, "meat" = 1), \
+		eatverbs = list("swallow" = 1), \
+		foodtypes = JUNKFOOD, \
+	)
+	ADD_TRAIT(src, TRAIT_FISHING_BAIT, INNATE_TRAIT)
+
 /obj/item/toy/windup_toolbox
 	name = "windup toolbox"
 	desc = "A replica toolbox that rumbles when you turn the key."

--- a/code/modules/projectiles/ammunition/caseless/foam.dm
+++ b/code/modules/projectiles/ammunition/caseless/foam.dm
@@ -9,6 +9,36 @@
 	custom_materials = list(/datum/material/iron = SMALL_MATERIAL_AMOUNT * 0.1125)
 	harmful = FALSE
 	var/modified = FALSE
+	var/min_choke_duration = 5 SECONDS
+	var/max_choke_duration = 12 SECONDS
+
+/obj/item/ammo_casing/caseless/foam_dart/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/edible, \
+		initial_reagents = list( \
+			/datum/reagent/consumable/nutriment = 1, \
+			/datum/reagent/consumable/nutriment/protein = 0.5, \
+		), \
+		food_flags = FOOD_FINGER_FOOD, \
+		tastes = list("foam" = 2, "action" = 2, "meat" = 1), \
+		eatverbs = list("swallow" = 1), \
+		eat_time = 0, \
+		foodtypes = JUNKFOOD, \
+		bite_consumption = 99999, \
+	)
+	ADD_TRAIT(src, TRAIT_FISHING_BAIT, INNATE_TRAIT)
+	RegisterSignal(src, COMSIG_FOOD_EATEN, PROC_REF(on_bite))
+
+/obj/item/ammo_casing/caseless/foam_dart/proc/on_bite(atom/used_in, mob/living/target, mob/living/user, bitecount, bitesize)
+	SIGNAL_HANDLER
+	if (HAS_TRAIT(target, TRAIT_CLUMSY))
+		inhale(target)
+		return DESTROY_FOOD
+
+/obj/item/ammo_casing/caseless/foam_dart/proc/inhale(mob/living/target)
+	visible_message(span_danger("[target] inhales [src]!"), \
+		span_userdanger("You inhale [src]!"))
+	target.AddComponent(/datum/status_effect/choke, new src.type, flaming = FALSE, vomit_delay = rand(min_choke_duration, max_choke_duration))
 
 /obj/item/ammo_casing/caseless/foam_dart/update_icon_state()
 	. = ..()
@@ -62,3 +92,5 @@
 	icon_state = "foamdart_riot"
 	base_icon_state = "foamdart_riot"
 	custom_materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT* 1.125)
+	min_choke_duration = 12 SECONDS
+	max_choke_duration = 20 SECONDS

--- a/code/modules/projectiles/projectile/reusable/foam_dart.dm
+++ b/code/modules/projectiles/projectile/reusable/foam_dart.dm
@@ -11,8 +11,8 @@
 	var/modified = FALSE
 	var/obj/item/pen/pen = null
 
-/obj/projectile/bullet/reusable/foam_dart/handle_drop()
-	if(dropped)
+/obj/projectile/bullet/reusable/foam_dart/handle_drop(cancel=TRUE)
+	if(dropped || cancel)
 		return
 	var/turf/T = get_turf(src)
 	dropped = 1
@@ -41,3 +41,30 @@
 	stamina = 25
 	debilitating = TRUE
 	debilitate_mult = 4
+
+/obj/projectile/bullet/reusable/foam_dart/on_hit(atom/target, blocked = 0, pierce_hit)
+	. = ..()
+	var/mob/living/carbon/ctarget = target
+	if (. != BULLET_ACT_HIT || blocked != 0 || (def_zone != BODY_ZONE_PRECISE_MOUTH && def_zone != BODY_ZONE_HEAD && def_zone != BODY_ZONE_PRECISE_EYES) || !istype(ctarget))
+		handle_drop(cancel=FALSE)
+		return
+	if(!ctarget.has_mouth() || ctarget.is_mouth_covered(ITEM_SLOT_HEAD) || ctarget.is_mouth_covered(ITEM_SLOT_MASK) || ctarget.has_status_effect(/datum/status_effect/choke))
+		handle_drop(cancel=FALSE)
+		return
+	var/inhale_prob = def_zone == BODY_ZONE_PRECISE_MOUTH ? 15 : 5
+	if(istype(src, /obj/projectile/bullet/reusable/foam_dart/riot))
+		inhale_prob *= 2
+	if((prob(inhale_prob) && hits_front(target)) || HAS_TRAIT(target, TRAIT_CURSED))
+		var/obj/item/ammo_casing/caseless/foam_dart/item = new ammo_type
+		item.inhale(target)
+
+/obj/projectile/bullet/reusable/foam_dart/proc/hits_front(mob/target)
+	if(target.flags_1 & IS_SPINNING_1 || !starting)
+		return TRUE
+
+	if(target.loc == starting)
+		return FALSE
+
+	var/target_to_starting = get_dir(target, starting)
+	var/target_dir = target.dir
+	return target_dir & target_to_starting


### PR DESCRIPTION

## About The Pull Request
### Additions
- Makes donksoft foam darts, the donkco foam arm blade and the donkco emag card edible.
- Being shot in the head (without a mask) with a donksoft dart has a chance to make the player inhale it and choke.

## Why It's Good For The Game

- Adds to the cheap fast food and toy branding of donkco.
- It's funny.
## Changelog
:cl:
add: Made donksoft foam darts, the donkco foam arm blade and the donkco emag card edible.
add: Being shot in the head (without a mask) with a donksoft dart has a chance to make the player inhale it and choke.
/:cl:
