### PR TITLE
Revert "Silenced status effects blocks emotes too"

### DIFF
--- a/code/datums/status_effects/debuffs/silenced.dm
+++ b/code/datums/status_effects/debuffs/silenced.dm
@@ -9,14 +9,15 @@
 
 /datum/status_effect/silenced/on_apply()
 	RegisterSignal(owner, COMSIG_LIVING_DEATH, PROC_REF(clear_silence))
-	owner.add_traits(list(TRAIT_MUTE, TRAIT_EMOTEMUTE), TRAIT_STATUS_EFFECT(id))
+	ADD_TRAIT(owner, TRAIT_MUTE, TRAIT_STATUS_EFFECT(id))
 	return TRUE
 
 /datum/status_effect/silenced/on_remove()
 	UnregisterSignal(owner, COMSIG_LIVING_DEATH)
-	owner.remove_traits(list(TRAIT_MUTE, TRAIT_EMOTEMUTE), TRAIT_STATUS_EFFECT(id))
+	REMOVE_TRAIT(owner, TRAIT_MUTE, TRAIT_STATUS_EFFECT(id))
 
 /// Signal proc that clears any silence we have (self-deletes).
 /datum/status_effect/silenced/proc/clear_silence(mob/living/source)
 	SIGNAL_HANDLER
+
 	qdel(src)


### PR DESCRIPTION
Reverts Monkestation/Monkestation2.0#7486

it was an "i ded" balance pr without admin approval, and is causing extra issues, especially with social anxiety quirk