### PR TITLE
emote mute status effect

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -160,6 +160,11 @@
 #define set_silence(duration) set_timed_status_effect(duration, /datum/status_effect/silenced)
 #define set_silence_if_lower(duration) set_timed_status_effect(duration, /datum/status_effect/silenced, TRUE)
 
+#define adjust_emote_mute(duration) adjust_timed_status_effect(duration, /datum/status_effect/emote_mute)
+#define adjust_emote_mute_up_to(duration, up_to) adjust_timed_status_effect(duration, /datum/status_effect/emote_mute, up_to)
+#define set_emote_mute(duration) set_timed_status_effect(duration, /datum/status_effect/emote_mute)
+#define set_emote_mute_if_lower(duration) set_timed_status_effect(duration, /datum/status_effect/emote_mute, TRUE)
+
 #define adjust_hallucinations(duration) adjust_timed_status_effect(duration, /datum/status_effect/hallucination)
 #define adjust_hallucinations_up_to(duration, up_to) adjust_timed_status_effect(duration, /datum/status_effect/hallucination, up_to)
 #define set_hallucinations(duration) set_timed_status_effect(duration, /datum/status_effect/hallucination)

--- a/code/datums/status_effects/debuffs/emote_mute.dm
+++ b/code/datums/status_effects/debuffs/emote_mute.dm
@@ -1,0 +1,23 @@
+/datum/status_effect/emote_mute
+	id = "emote_muted"
+	alert_type = null
+	remove_on_fullheal = TRUE
+
+/datum/status_effect/emote_mute/on_creation(mob/living/new_owner, duration = 10 SECONDS)
+	src.duration = duration
+	return ..()
+
+/datum/status_effect/emote_mute/on_apply()
+	RegisterSignal(owner, COMSIG_LIVING_DEATH, PROC_REF(clear_effect))
+	ADD_TRAIT(owner, TRAIT_EMOTEMUTE, TRAIT_STATUS_EFFECT(id))
+	return TRUE
+
+/datum/status_effect/emote_mute/on_remove()
+	UnregisterSignal(owner, COMSIG_LIVING_DEATH)
+	REMOVE_TRAIT(owner, TRAIT_EMOTEMUTE, TRAIT_STATUS_EFFECT(id))
+
+/// Signal proc that self-deletes
+/datum/status_effect/emote_mute/proc/clear_effect(mob/living/source)
+	SIGNAL_HANDLER
+
+	qdel(src)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -518,6 +518,7 @@
 				C.set_handcuffed(new /obj/item/restraints/handcuffs/energy/cult/used(C))
 				C.update_handcuffed()
 				C.adjust_silence(10 SECONDS)
+				C.adjust_emote_mute(10 SECONDS)
 				to_chat(user, span_notice("You shackle [C]."))
 				log_combat(user, C, "shackled")
 				uses--

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -74,6 +74,7 @@
 
 	var/mob/living/carbon/carbon_target = target
 	carbon_target.adjust_silence(10 SECONDS)
+	carbon_target.adjust_emote_mute(10 SECONDS)
 	carbon_target.apply_status_effect(/datum/status_effect/void_chill, 2)
 
 /datum/heretic_knowledge/cold_snap
@@ -265,6 +266,7 @@
 			if(close_carbon.can_block_magic())
 				continue
 			close_carbon.adjust_silence_up_to(2 SECONDS, 20 SECONDS)
+			close_carbon.adjust_emote_mute_up_to(2 SECONDS, 20 SECONDS)
 			close_carbon.apply_status_effect(/datum/status_effect/void_chill, 1)
 			close_carbon.adjust_eye_blur(rand(0 SECONDS, 2 SECONDS))
 			if(close_carbon.has_reagent(/datum/reagent/water/holywater))

--- a/code/modules/antagonists/heretic/magic/moon_smile.dm
+++ b/code/modules/antagonists/heretic/magic/moon_smile.dm
@@ -43,6 +43,7 @@
 	ears?.adjustEarDamage(0, moon_smile_duration + 2 SECONDS)
 
 	cast_on.adjust_silence(moon_smile_duration + 5 SECONDS)
+	cast_on.adjust_emote_mute(moon_smile_duration + 5 SECONDS)
 	cast_on.AdjustKnockdown(2 SECONDS)
 	cast_on.add_mood_event("moon_smile", /datum/mood_event/moon_smile)
 	//Lowers sanity

--- a/code/modules/antagonists/heretic/status_effects/mark_effects.dm
+++ b/code/modules/antagonists/heretic/status_effects/mark_effects.dm
@@ -134,6 +134,7 @@ monkestation end */
 /datum/status_effect/eldritch/void/on_effect(mob/living/activator) // monkestation edit: add "activator" arg to /datum/status_effect/eldritch/proc/on_effect()
 	owner.apply_status_effect(/datum/status_effect/void_chill, 2)
 	owner.adjust_silence(10 SECONDS)
+	owner.adjust_emote_mute(10 SECONDS)
 	return ..()
 
 // MARK OF BLADES

--- a/code/modules/antagonists/heretic/structures/carving_knife.dm
+++ b/code/modules/antagonists/heretic/structures/carving_knife.dm
@@ -240,6 +240,7 @@
 	var/mob/living/carbon/carbon_victim = victim
 	carbon_victim.stamina.adjust(-80)
 	carbon_victim.adjust_silence(20 SECONDS)
+	carbon_victim.adjust_emote_mute(20 SECONDS)
 	carbon_victim.adjust_stutter(1 MINUTES)
 	carbon_victim.adjust_confusion(5 SECONDS)
 	carbon_victim.set_jitter_if_lower(20 SECONDS)

--- a/code/modules/antagonists/revolution/revolution.dm
+++ b/code/modules/antagonists/revolution/revolution.dm
@@ -302,6 +302,7 @@
 
 	if(mute)
 		rev_mind.current.set_silence_if_lower(10 SECONDS)
+		rev_mind.current.set_emote_mute_if_lower(10 SECONDS)
 	if(stun)
 		rev_mind.current.flash_act(1, 1)
 		rev_mind.current.Stun(10 SECONDS)

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -322,6 +322,7 @@
 /mob/living/silicon/pai/on_saboteur(datum/source, disrupt_duration)
 	. = ..()
 	set_silence_if_lower(disrupt_duration)
+	set_emote_mute_if_lower(disrupt_duration)
 	balloon_alert(src, "muted!")
 	return TRUE
 

--- a/monkestation/code/modules/antagonists/clock_cult/scriptures/servitude/kindle.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/scriptures/servitude/kindle.dm
@@ -91,6 +91,7 @@
 		carbon_hit.adjust_timed_status_effect(26 SECONDS, /datum/status_effect/speech/slurring/clock)
 
 		carbon_hit.adjust_silence(EFFECT_TIME * 2) //enough time to cuff and remove their radio, or just go back to reebe where their comms wont work
+		carbon_hit.adjust_emote_mute(EFFECT_TIME * 2)
 		carbon_hit.AdjustKnockdown(EFFECT_TIME * (has_mindshield ? 1 : 1.5))
 		//pretty much 0 stun if your on reebe, still good for knockdown though, also only a 1 second stun on mindshielded people
 		carbon_hit.Stun((has_mindshield ? 1 SECONDS : EFFECT_TIME) * ((on_reebe(carbon_hit) && GLOB.clock_ark?.current_state) ? 0.1 : 1))

--- a/monkestation/code/modules/antagonists/clock_cult/structures/anchor_crystal.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/structures/anchor_crystal.dm
@@ -95,6 +95,7 @@ GLOBAL_LIST_EMPTY(anchoring_crystals) //list of all anchoring crystals
 			affected_mob.stamina.adjust(7.5 * seconds_per_tick, TRUE)
 			continue
 		affected_mob.adjust_silence_up_to(5 SECONDS * seconds_per_tick, 2 MINUTES)
+		affected_mob.adjust_emote_mute_up_to(5 SECONDS * seconds_per_tick, 2 MINUTES)
 
 	if(charge_state == FULLY_CHARGED) //if fully charged then add the power and return
 		GLOB.clock_power = min(GLOB.clock_power + (10 * seconds_per_tick), GLOB.max_clock_power)

--- a/monkestation/code/modules/antagonists/contractor/items/baton.dm
+++ b/monkestation/code/modules/antagonists/contractor/items/baton.dm
@@ -49,6 +49,7 @@
 	var/mob/living/carbon/carbon_target = target
 	if(upgrade_flags & BATON_MUTE_UPGRADE)
 		carbon_target.adjust_silence_up_to(MUTE_APPLIED, MUTE_MAX)
+		carbon_target.adjust_emote_mute_up_to(MUTE_APPLIED, MUTE_MAX)
 
 	if(upgrade_flags & BATON_FOCUS_UPGRADE)
 		var/datum/antagonist/traitor/traitor_datum = IS_TRAITOR(user)

--- a/monkestation/code/modules/antagonists/cult/blood_magic.dm
+++ b/monkestation/code/modules/antagonists/cult/blood_magic.dm
@@ -45,6 +45,7 @@
 	to_chat(target, span_cultboldtalic("Eldritch horrors try to flood your thoughts, before being drowned out by an intense alcoholic haze!"), type = MESSAGE_TYPE_COMBAT) // yeah nobody's gonna be able to understand you through the slurring but it's funny anyways
 	target.say("MUCKLE DAMRED CULT! 'AIR EH NAMBLIES BE KEEPIN' ME WEE MEN!?!!", forced = "drunk cult stun")
 	target.adjust_silence(15 SECONDS)
+	target.adjust_emote_mute(15 SECONDS)
 	target.adjust_confusion(15 SECONDS)
 	target.set_jitter_if_lower(15 SECONDS)
 
@@ -57,6 +58,7 @@
 	target.stamina.adjust(-80)
 	target.adjust_timed_status_effect(12 SECONDS, /datum/status_effect/speech/slurring/cult)
 	target.adjust_silence(8 SECONDS)
+	target.adjust_emote_mute(8 SECONDS)
 	target.adjust_stutter(20 SECONDS)
 	target.set_jitter_if_lower(20 SECONDS)
 
@@ -70,6 +72,7 @@
 	else if(iscarbon(target))
 		var/mob/living/carbon/carbon_target = target
 		carbon_target.adjust_silence(12 SECONDS)
+		carbon_target.adjust_emote_mute(12 SECONDS)
 		carbon_target.adjust_stutter(30 SECONDS)
 		carbon_target.adjust_timed_status_effect(30 SECONDS, /datum/status_effect/speech/slurring/cult)
 		carbon_target.set_jitter_if_lower(30 SECONDS)

--- a/monkestation/code/modules/bloodsuckers/powers/targeted/mesmerize.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/targeted/mesmerize.dm
@@ -122,6 +122,7 @@
 			ADD_TRAIT(mesmerized_target, TRAIT_MUTE, MESMERIZED_TRAIT)
 		mesmerized_target.Immobilize(power_time)
 		mesmerized_target.adjust_silence(power_time)
+		mesmerized_target.adjust_emote_mute(power_time)
 		//mesmerized_target.silent += power_time / 10 // Silent isn't based on ticks.
 		COOLDOWN_START(mesmerized_target, next_move, power_time) // <--- Use direct change instead. We want an unmodified delay to their next move // mesmerized_target.changeNext_move(power_time) // check click.dm
 		ADD_TRAIT(mesmerized_target, TRAIT_NO_TRANSFORM, MESMERIZED_TRAIT)// <--- Fuck it. We tried using next_move, but they could STILL resist. We're just doing a hard freeze.

--- a/monkestation/code/modules/martial_arts/tribal_claw.dm
+++ b/monkestation/code/modules/martial_arts/tribal_claw.dm
@@ -132,6 +132,7 @@ If the target is T3 grabbed or sleeping, instead deal 60 damage with a weeping a
 	defender.Knockdown(5) //Without knockdown defender still stands up while T3 grabbed.
 	attacker.setGrabState(GRAB_NECK)
 	defender.adjust_silence_up_to(10 SECONDS, 10 SECONDS)
+	defender.adjust_emote_mute_up_to(10 SECONDS, 10 SECONDS)
 
 /datum/martial_art/tribal_claw/harm_act(mob/living/carbon/human/attacker, mob/living/carbon/human/defender)
 	add_to_streak("H",defender)

--- a/monkestation/code/modules/virology/disease/symtoms/restricted/stage1.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/restricted/stage1.dm
@@ -192,4 +192,5 @@
 			if(prob(12))
 				to_chat(mob, span_danger("You try to scream, but nothing comes out!"))
 				mob.set_silence_if_lower(5 SECONDS)
+				mob.set_emote_mute_if_lower(5 SECONDS)
 	multiplier_tweak(0.1)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1827,6 +1827,7 @@
 #include "code\datums\status_effects\debuffs\drowsiness.dm"
 #include "code\datums\status_effects\debuffs\drugginess.dm"
 #include "code\datums\status_effects\debuffs\drunk.dm"
+#include "code\datums\status_effects\debuffs\emote_mute.dm"
 #include "code\datums\status_effects\debuffs\fire_stacks.dm"
 #include "code\datums\status_effects\debuffs\genetic_damage.dm"
 #include "code\datums\status_effects\debuffs\hallucination.dm"


### PR DESCRIPTION

## About The Pull Request
Adds emote mute status effects
## Why It's Good For The Game
Better solution than https://github.com/Monkestation/Monkestation2.0/pull/7486
If you magically make someone unable to talk, they should not be able to bypass that using /me to do a loud emote or use sign language to ignore it entirely.
## Changelog
:cl:
code: adds emote_mute status effect and helper procs
balance: adds emote mute to some silencing effects
/:cl:
