### PR TITLE
Rapid PK Pistol Fix

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -645,7 +645,7 @@
 	icon = 'icons/obj/weapons/guns/energy.dmi'
 	icon_state = "kineticpistol"
 	base_icon_state = "kineticpistol"
-	recharge_time = 2 SECONDS
+	recharge_time = 4 SECONDS
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/glock)
 	can_bayonet = FALSE
 	max_mod_capacity = 300 //experimental, if people find too many wack ass combos on the pistol im dropping it back to 200


### PR DESCRIPTION

## About The Pull Request
In my previous PR I buffed the mod capacity of the proto kinetic pistol to a whopping 300% instead of 200%, well turns out I didn't account for one small error, that being now you could get the cooldown into the negatives (which then errors and defaults to 0.5)

This nerfs pistol by making the recharge time now 4 seconds meaning even with 10 cooldown mods it wont go into the negative.

## Why It's Good For The Game
Errors bad, me stupid.

## Changelog
:cl:
balance: PK Pistol cooldown upped to 4 seconds
fix: You can no longer cause an error by giving the PK Pistol 10 cooldown mods
/:cl:
