### PR TITLE
Oozeling slime washing tweaks

### DIFF
--- a/monkestation/code/modules/smithing/oozelings/actions.dm
+++ b/monkestation/code/modules/smithing/oozelings/actions.dm
@@ -43,14 +43,14 @@
 /datum/status_effect/slime_washing/tick(seconds_between_ticks, seconds_per_tick)
 	var/mob/living/carbon/human/slime = owner
 	slime.wash(CLEAN_WASH)
-	if((slime.wear_suit?.body_parts_covered | slime.w_uniform?.body_parts_covered | slime.shoes?.body_parts_covered) & FEET)
+	if(slime.body_position != LYING_DOWN && ((slime.wear_suit?.body_parts_covered | slime.w_uniform?.body_parts_covered | slime.shoes?.body_parts_covered) & FEET))
 		return
 	var/turf/open/open_turf = get_turf(slime)
-	if(istype(open_turf))
-		open_turf.wash(CLEAN_WASH)
-		return TRUE
-	if(SPT_PROB(5, seconds_per_tick))
-		slime.adjust_nutrition(rand(5,25))
+	if(!istype(open_turf))
+		return
+	if(open_turf.wash(CLEAN_WASH) && slime.nutrition <= NUTRITION_LEVEL_FED)
+		slime.adjust_nutrition(rand(5, 25))
+	return TRUE
 
 /datum/status_effect/slime_washing/get_examine_text()
 	return span_notice("[owner.p_Their()] outer layer is pulling in grime, filth sinking inside of their body and vanishing.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

pretty simple, this makes it so you can lie down to use slime washing on the floor without taking off your shoes, and also makes it so it actually gives nutrition without you needing to be inside of a wall

for balance reasons, it will only feed you up to the "fed" level, tho.

## Why It's Good For The Game

i want to crawl around on the floor and lick blood and grime up without having to toss off my shoes each time

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Slime Washing now works if the oozeling is lying down, even if they have shoes on.
fix: Slime Washing now actually feeds the oozeling when they clean up grime, as intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
