### PR TITLE
Prosthetics and Qaud Amputtee blacklist oozelings

### DIFF
--- a/code/datums/quirks/negative_quirks/prosthetic_limb.dm
+++ b/code/datums/quirks/negative_quirks/prosthetic_limb.dm
@@ -10,6 +10,7 @@
 	var/slot_string = "limb"
 	/// The slot to replace, in GLOB.limb_zones (both arms and both legs)
 	var/limb_zone
+	species_blacklist = list(SPECIES_OOZELING)
 
 /datum/quirk/prosthetic_limb/add_unique(client/client_source)
 	var/obj/item/bodypart/limb_type = GLOB.limb_choice[client_source?.prefs?.read_preference(/datum/preference/choiced/prosthetic)]

--- a/code/datums/quirks/negative_quirks/quadruple_amputee.dm
+++ b/code/datums/quirks/negative_quirks/quadruple_amputee.dm
@@ -7,6 +7,7 @@
 	hardcore_value = 6
 	quirk_flags = QUIRK_HUMAN_ONLY | QUIRK_CHANGES_APPEARANCE | QUIRK_DONT_CLONE // monkestation edit: QUIRK_DONT_CLONE
 	mail_goodies = list(/obj/item/weldingtool/mini, /obj/item/stack/cable_coil/five)
+	species_blacklist = list(SPECIES_OOZELING)
 
 /datum/quirk/quadruple_amputee/add_unique(client/client_source)
 	var/mob/living/carbon/human/human_holder = quirk_holder


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Blacklists Oozelings from taking spare limbs as a quirk, as they have to abilities roundstart to lose a limb, then immediately regrow it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Simple balance, if a race has a ability that nullifies the downsides of a quirk. Then they shouldnt be able to take it. Florans and IPCs can also can techically replace their limbs quickly, but they still need to find/harvest and detach their previous limb. A at least process for getting limbs and tools to do so.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Oozelings are blacklisted from Prosthetics  and Qaud Amputtee quirks
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
