### PR TITLE
Fixes a ratvarian grammatical error in the spelling of the Rat'vander cocktail

### DIFF
--- a/monkestation/code/modules/reagents/chemistry/reagents/drinks/glass_styles/mixed_alcohol.dm
+++ b/monkestation/code/modules/reagents/chemistry/reagents/drinks/glass_styles/mixed_alcohol.dm
@@ -1,6 +1,6 @@
 /datum/glass_style/drinking_glass/ratvander
 	required_drink_type = /datum/reagent/consumable/ethanol/ratvander
-	name = "Rat'vander Cocktail"
+	name = "Ratvander Cocktail"
 	desc = "A new cocktail originally mixed by TRNE Corp. Said to be embued with eldritch magic."
 	icon = 'monkestation/icons/obj/drinks/mixed_drinks.dmi'
 	icon_state = "ratvander"


### PR DESCRIPTION
So according to the offical ratvarian language pastebin this spelling of The Great Engine's name is incorrect, see here https://pastebin.com/ngFMZHNV there should be no grave and i assume this incorrect spelling is a carryover from Nar'sour where there should be a grave
## About The Pull Request
So the and-splicing rule doesn't apply inside of words and Ratvar is a proper noun spelled R A T V A R anyhow so there shouldn't be a grave or an apostrophe and someone probably just carried it over from nar'sour which has an apostrophe and should have one because nar'sie has one in it but ratvar doesnt because the great engine is a proper noun you fools
## Why It's Good For The Game
We should be remaining internally consistant with the grammar and spellings of our own fictional languages see the offical ratvarian document here https://pastebin.com/ngFMZHNV
## Changelog
:cl:
spellcheck: TRNE Corp. has hired a Ratvarian-fluent spellchecker and has subsequently renamed the Rat'vander cocktail to Ratvander.
/:cl:
