### PR TITLE
Pushbroom pulls on RMB

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_turf.dm
+++ b/code/__DEFINES/dcs/signals/signals_turf.dm
@@ -41,8 +41,6 @@
 #define COMSIG_TURF_PREPARE_STEP_SOUND "turf_prepare_step_sound"
 ///from base of datum/thrownthing/finalize(): (turf/turf, atom/movable/thrownthing) when something is thrown and lands on us
 #define COMSIG_TURF_MOVABLE_THROW_LANDED "turf_movable_throw_landed"
-///from /obj/item/pushbroom/sweep(): (broom, user, items_to_sweep)
-#define COMSIG_TURF_RECEIVE_SWEEPED_ITEMS "turf_receive_sweeped_items"
 
 ///From element/elevation/reset_elevation(): (list/values)
 #define COMSIG_TURF_RESET_ELEVATION "turf_reset_elevation"

--- a/code/game/objects/items/broom.dm
+++ b/code/game/objects/items/broom.dm
@@ -51,8 +51,15 @@
 	. = ..()
 	if(!proximity)
 		return
-	sweep(user, A)
+	sweep(user, A, towards_player = FALSE)
 	return . | AFTERATTACK_PROCESSED_ITEM
+
+/obj/item/pushbroom/afterattack_secondary(atom/target, mob/user, proximity_flag, click_parameters)
+	. = ..()
+	if(!proximity_flag)
+		return
+	sweep(user, target, towards_player = TRUE)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /**
  * Attempts to push up to BROOM_PUSH_LIMIT atoms from a given location the user's faced direction
@@ -60,14 +67,15 @@
  * Arguments:
  * * user - The user of the pushbroom
  * * A - The atom which is located at the location to push atoms from
+ * * towards_player - Boolean on whether the items will be being pushed towards the player, away if FALSE.
  */
-/obj/item/pushbroom/proc/sweep(mob/user, atom/A)
+/obj/item/pushbroom/proc/sweep(mob/user, atom/A, towards_player = FALSE)
 	SIGNAL_HANDLER
 
 	var/turf/current_item_loc = isturf(A) ? A : A.loc
 	if (!isturf(current_item_loc))
 		return
-	var/turf/new_item_loc = get_step(current_item_loc, user.dir)
+	var/turf/new_item_loc = towards_player ? get_step(current_item_loc, REVERSE_DIR(user.dir)) : get_step(current_item_loc, user.dir)
 	var/obj/machinery/disposal/bin/target_bin = locate(/obj/machinery/disposal/bin) in new_item_loc.contents
 	var/i = 1
 	for (var/obj/item/garbage in current_item_loc.contents)


### PR DESCRIPTION
## About The Pull Request

RMB with the pushbroom now pulls the items on the floor towards you rather than away.

https://github.com/user-attachments/assets/3ea4e72d-0cfc-485b-80d7-f47dc901e187

##### Code bounty - https://discord.com/channels/748354466335686736/1405818284489707663/1405818284489707663

## Why It's Good For The Game

You can use brooms in reverse to pull things towards you, helps you get trash off of tables and whatnot, and you no longer have to go angle yourself constantly in the perfect direction to push something properly.

## Changelog

:cl:
qol: The pushbroom can now pull with RMB.
/:cl: