### PR TITLE
[SPACE_BOX] Fixes Engineering Reception Access

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -68857,7 +68857,7 @@
 	},
 /obj/machinery/door/window/left/directional/east{
 	name = "Engineering Desk";
-	req_access = list("atmospherics","engineering")
+	req_one_access = list("atmospherics","engineering")
 	},
 /obj/machinery/door/poddoor/shutters{
 	id = "engi_office_shutters";


### PR DESCRIPTION
## About The Pull Request

I don't know who did this but

fixes engineering reception window so either those with engineer or atmos access can use it
instead of requiring both

these things should probably use the helpers for airlocks more as to help clean up clutter.
    mappers that read this don't forget pixel shifting is a thing 

## Why It's Good For The Game

self explanatory

## Changelog


:cl:
map: [SPACE_BOX] engineering reception now requires either engineering or atmos access instead of both
/:cl:


