### PR TITLE
Further edits to departmental bells

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -12761,9 +12761,13 @@
 /obj/machinery/door/firedoor,
 /obj/item/paper_bin,
 /obj/item/pen/blue,
-/obj/machinery/door/window/right/directional/east{
-	name = "Medbay Desk";
-	req_access = list("medical")
+/obj/machinery/door/window/right/directional/west{
+	req_access = list("medical");
+	name = "Medbay Desk"
+	},
+/obj/structure/desk_bell/departmental/medical{
+	pixel_x = 8;
+	pixel_y = -3
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
@@ -21654,7 +21658,7 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/structure/desk_bell{
+/obj/structure/desk_bell/departmental/supply{
 	pixel_x = -7;
 	pixel_y = -1
 	},
@@ -40433,6 +40437,7 @@
 /obj/machinery/door/firedoor,
 /obj/item/reagent_containers/cup/glass/mug/britcup,
 /obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "izs" = (
@@ -58719,6 +58724,10 @@
 	name = "Security Checkpoint";
 	req_access = list("security")
 	},
+/obj/structure/desk_bell/departmental/security{
+	pixel_x = -8;
+	pixel_y = -3
+	},
 /turf/open/floor/iron,
 /area/station/security/checkpoint/customs/fore)
 "pvt" = (
@@ -67840,7 +67849,7 @@
 	req_access = list("engineering")
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/desk_bell{
+/obj/structure/desk_bell/departmental/engineering{
 	pixel_x = -3;
 	pixel_y = 9
 	},
@@ -69566,10 +69575,6 @@
 /obj/machinery/door/window/left/directional/south{
 	name = "Reception Window"
 	},
-/obj/structure/desk_bell{
-	pixel_x = -7;
-	pixel_y = -1
-	},
 /obj/machinery/door/poddoor/preopen{
 	id = "hopblast";
 	name = "HoP Blast Door"
@@ -69578,6 +69583,10 @@
 /obj/machinery/door/window/brigdoor/right/directional/north{
 	name = "Head of Personnel's Desk";
 	req_access = list("hop")
+	},
+/obj/structure/desk_bell/departmental/command/hop{
+	pixel_x = -7;
+	pixel_y = -1
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hop)
@@ -76359,6 +76368,7 @@
 	},
 /obj/item/reagent_containers/syringe,
 /obj/structure/window/reinforced/spawner/directional/east,
+/obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/medical/medbay/lobby)
 "wmK" = (
@@ -80222,7 +80232,7 @@
 	name = "Research Lab Shutters"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/desk_bell{
+/obj/structure/desk_bell/departmental/science{
 	pixel_x = -7;
 	pixel_y = -1
 	},

--- a/code/modules/paperwork/department_bell.dm
+++ b/code/modules/paperwork/department_bell.dm
@@ -2,7 +2,6 @@
 	name = "department bell"
 	desc = "The cornerstone of any customer service job. Ringing it sends an announcement to the relevant radio channel."
 
-	ring_cooldown_length = 0.6 SECONDS // twice as slow
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF // Nothing stops the bell.
 	var/announce_cooldown_length = 60 SECONDS // WHAT? I CANT HEAR YOU OVER THE RADIO BEING SPAMMED.
 	/// The cooldown for announcing the bell
@@ -50,7 +49,7 @@
 	return FALSE
 
 /obj/structure/desk_bell/departmental/check_clapper(mob/living/user)
-	return //NOTHING.
+	return
 
 /obj/structure/desk_bell/departmental/MouseDrop(obj/over_object, src_location, over_location)
 	if(istype(over_object, /obj/vehicle/ridden/wheelchair))
@@ -94,3 +93,6 @@
 
 /obj/structure/desk_bell/departmental/service
 	radio_channel = FREQ_SERVICE
+
+/obj/structure/desk_bell/departmental/syndicate
+	radio_channel = FREQ_SYNDICATE

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -165,7 +165,7 @@
 	armor_type = /datum/armor/machinery_blackbox_recorder
 	///The machine's internal radio, used to broadcast alerts.
 	var/obj/item/radio/radio //i hate this fucking code
-	var/radio_channel = RADIO_CHANNEL_SYNDICATE
+	var/radio_channel = FREQ_SYNDICATE
 	var/obj/item/stored
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //meant to be breakable when box not inserted, but it might shit itself if i change resistance flags mid-operation
 

--- a/monkestation/code/modules/syndicate_ghostroles/depot.dm
+++ b/monkestation/code/modules/syndicate_ghostroles/depot.dm
@@ -165,7 +165,7 @@
 	armor_type = /datum/armor/machinery_blackbox_recorder
 	///The machine's internal radio, used to broadcast alerts.
 	var/obj/item/radio/radio //i hate this fucking code
-	var/radio_channel = FREQ_SYNDICATE
+	var/radio_channel = RADIO_CHANNEL_SYNDICATE
 	var/obj/item/stored
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF //meant to be breakable when box not inserted, but it might shit itself if i change resistance flags mid-operation
 


### PR DESCRIPTION
## About The Pull Request
Adds in a syndicate version of the departmental bell, for mapping purposes in the depot, or whatever. _i swear to god if you dont edit bell_location on this-_
Updates heliostation to have dept. bells, somehow i forgot in my original PR and noone noticed.
## Why It's Good For The Game
Might be neat for mapping, *shrug
Bug fix goob.
This threw me for a loop when i was originally coding because it was the wrong solution but still got the right answer
## Changelog
:cl: Tractor Maam
map: heliostation now has departmental bells.
map: added a syndicate variant of the departmental bell for mapping purposes.
del: Removed herobrine.
/:cl:
