### PR TITLE
Makes Hiero staff use Magic channel for its dash instead of Bluespace

### DIFF
--- a/code/datums/dash_weapon.dm
+++ b/code/datums/dash_weapon.dm
@@ -23,6 +23,8 @@
 	/// What effect should we play when we phase out (at the source turf)
 	var/phaseout = /obj/effect/temp_visual/dir_setting/ninja/phase/out
 
+	var/teleport_channel = TELEPORT_CHANNEL_BLUESPACE
+
 /datum/action/innate/dash/IsAvailable(feedback = FALSE)
 	. = ..()
 	if (!.)
@@ -51,7 +53,7 @@
 		user.balloon_alert(user, "out of view!")
 		return FALSE
 
-	if(!do_teleport(user, target_turf, no_effects = TRUE))
+	if(!do_teleport(user, target_turf, no_effects = TRUE ,channel = teleport_channel))
 		user.balloon_alert(user, "dash blocked!")
 		return FALSE
 

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -15,6 +15,7 @@
 	phaseout = /obj/effect/temp_visual/hierophant/blast/visual
 	// It's a simple purple beam, works well enough for the purple hiero effects.
 	beam_effect = "plasmabeam"
+	teleport_channel = TELEPORT_CHANNEL_MAGIC
 
 /datum/action/innate/dash/hierophant/teleport(mob/user, atom/target)
 	var/dist = get_dist(user, target)


### PR DESCRIPTION

## About The Pull Request
Makes it so the Hierophant staff dash uses magic instead of bluespace, so that if your wearing a bag of holding you dont get the funny teleport interruption. Also because the recall using the beacon uses magic instead of bluespace channel, so consistency.

## Why It's Good For The Game
Consistency is good, and the fact that trying to dash with the funny obviously magical in nature purple staff will teleport you across lavaland if you wear a bag of holding is bad.

## Changelog
:cl:
balance: Hiero staff dash now counts as magic so its not disrupted by bag of holding
code: Hiero staff dash now counts as magic, just like its beacon recall does
/:cl:
