### PR TITLE
[PORT] fixes the tgui blacksquare issue

### DIFF
--- a/code/__DEFINES/tgui.dm
+++ b/code/__DEFINES/tgui.dm
@@ -24,6 +24,16 @@
 /// Window is free and ready to receive data
 #define TGUI_WINDOW_READY 2
 
+/// Though not the maximum renderable ByondUis within tgui, this is the maximum that the server will manage per-UI
+#define TGUI_MANAGED_BYONDUI_LIMIT 10
+
+// These are defines instead of being inline, as they're being sent over
+// from tgui-core, so can't be easily played with
+#define TGUI_MANAGED_BYONDUI_TYPE_RENDER "renderByondUi"
+#define TGUI_MANAGED_BYONDUI_TYPE_UNMOUNT "unmountByondUi"
+
+#define TGUI_MANAGED_BYONDUI_PAYLOAD_ID "renderByondUi"
+
 /// Get a window id based on the provided pool index
 #define TGUI_WINDOW_ID(index) "tgui-window-[index]"
 /// Get a pool index of the provided window id

--- a/code/modules/tgui/tgui.dm
+++ b/code/modules/tgui/tgui.dm
@@ -40,6 +40,9 @@
 	/// Are byond mouse events beyond the window passed in to the ui
 	var/mouse_hooked = FALSE
 
+	/// The id of any ByondUi elements that we have opened
+	var/list/open_byondui_elements
+
 /**
  * public
  *
@@ -146,8 +149,25 @@
 		window.close(can_be_suspended)
 		src_object.ui_close(user)
 		SStgui.on_close(src)
+
+		if(user.client)
+			terminate_byondui_elements()
+
 	state = null
 	qdel(src)
+
+/**
+ * public
+ *
+ * Closes all ByondUI elements, left dangling by a forceful TGUI exit,
+ * such as via Alt+F4, closing in non-fancy mode, or terminating the process
+ *
+ */
+/datum/tgui/proc/terminate_byondui_elements()
+	set waitfor = FALSE
+
+	for(var/byondui_element in open_byondui_elements)
+		winset(user.client, byondui_element, list("parent" = ""))
 
 /**
  * public
@@ -356,6 +376,18 @@
 			LAZYINITLIST(src_object.tgui_shared_states)
 			src_object.tgui_shared_states[href_list["key"]] = href_list["value"]
 			SStgui.update_uis(src_object)
+		if(TGUI_MANAGED_BYONDUI_TYPE_RENDER)
+			var/byond_ui_id = payload[TGUI_MANAGED_BYONDUI_PAYLOAD_ID]
+			if(!byond_ui_id || LAZYLEN(open_byondui_elements) > TGUI_MANAGED_BYONDUI_LIMIT)
+				return
+
+			LAZYOR(open_byondui_elements, byond_ui_id)
+		if(TGUI_MANAGED_BYONDUI_TYPE_UNMOUNT)
+			var/byond_ui_id = payload[TGUI_MANAGED_BYONDUI_PAYLOAD_ID]
+			if(!byond_ui_id)
+				return
+
+			LAZYREMOVE(open_byondui_elements, byond_ui_id)
 
 /// Wrapper for behavior to potentially wait until the next tick if the server is overloaded
 /datum/tgui/proc/on_act_message(act_type, payload, state)

--- a/tgui/packages/tgui/components/ByondUi.jsx
+++ b/tgui/packages/tgui/components/ByondUi.jsx
@@ -15,7 +15,7 @@ const logger = createLogger('ByondUi');
 // Stack of currently allocated BYOND UI element ids.
 const byondUiStack = [];
 
-const createByondUiElement = (elementId) => {
+const createByondUiElement = (elementId, phonehome = true) => {
   // Reserve an index in the stack
   const index = byondUiStack.length;
   byondUiStack.push(null);
@@ -26,11 +26,13 @@ const createByondUiElement = (elementId) => {
   return {
     render: (params) => {
       logger.log(`rendering '${id}'`);
+      if (phonehome) Byond.sendMessage('renderByondUi', { renderByondUi: id });
       byondUiStack[index] = id;
       Byond.winset(id, params);
     },
     unmount: () => {
       logger.log(`unmounting '${id}'`);
+      if (phonehome) Byond.sendMessage('unmountByondUi', { renderByondUi: id });
       byondUiStack[index] = null;
       Byond.winset(id, {
         parent: '',
@@ -76,7 +78,10 @@ export class ByondUi extends Component {
   constructor(props) {
     super(props);
     this.containerRef = createRef();
-    this.byondUiElement = createByondUiElement(props.params?.id);
+    this.byondUiElement = createByondUiElement(
+      props.params?.id,
+      props.phonehome,
+    );
     this.handleResize = debounce(() => {
       this.forceUpdate();
     }, 100);


### PR DESCRIPTION
## About The Pull Request

ports https://github.com/tgstation/tgstation/pull/91389

> the black squares appear when the byondui process is exited without time to 
> 1) unmount the component
> 2) hit the "blur" event
> 3) hit the "beforeunload" event
> 
> this occurs when being killed by windows, such as alt+f4, the close window button (in non-fancy mode), or any other way of killing the window

## Why It's Good For The Game

> ominous black square bad

## Changelog

:cl: Absolucy, hry-gh
fix: fixes the ominous black squares appearing over tgui windows, sometimes
/:cl:

