### PR TITLE
Making baton drain less insane.

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -462,7 +462,7 @@
 	if(!active || !cell)
 		return PROCESS_KILL
 
-	if(!cell.use((cell.maxcharge * 0.01) * seconds_per_tick) || cell.charge < cell_hit_cost) //reduces the charge by 1% no matter what the max is, so botany super cells cant be used to bypass your baton drain.
+	if(!cell.use((75 - (cell.maxcharge * 0.0025)) * seconds_per_tick) || cell.charge < cell_hit_cost) // This formula causes a exponential decay at 400 seconds. 6.66 minutes of baton time. Bluespace cells give 228 seconds, or 3.75 minutes
 		visible_message(span_warning("The baton fizzles and slowly dims as the charge runs out!"))
 		src.attack_self()
 


### PR DESCRIPTION
## About The Pull Request
Updates the formula of baton charge drain so upgrading it feels like a upgrade.
Roundstart batons drain in 100 seconds as per usual.
Super are 160 seconds
Hyper are 200
Bluespace cells drain in 228 seconds
Your artifact/potatoe infinite battery will drain in 400 seconds tops. No matter what
## Why It's Good For The Game
Adding a passive charge drain I can agree makes sense and is functional, however what I have a strong disagreement is making a baton somehow consume power equally at all levels. The reasoning given was to not make giga botany batteries give an infinite turn on period for the baton. Besides balancing a function around the most extreme edge case being not the greatest idea. As no other item is balanced for this factor, modsuits, durand mechs shield walls, the list goes on. And poses the more of a issue being on botany being able to make these cells, rather than with the baton.

It also makes the security staple nonlethal weapon weaker overall without much consideration for how to improve it and the flat rate causes issues. As upgrading it so the actual charge usage % per swing doesn't matter as much past a certain upgrade threshold as the drain will always outperform it mathematically. And makes upgrading it past a certain power capacity objectively makes the item worse. As while the charge drain is flat. **_The recharge rate isnt_**. Meaning for having to spend 100 seconds using it. You could have to sit the entire round recharging it for your hubris if using one of these cells.

But if putting a theoretical cap is important for some reason theres still better ways to do that.

# So lets use math to do that.

Formula is:

## C - ((f-(C*R)x) = 0 
Solve for x to find maxium turn on time.

C is maxium charge capacity.
f is flat charge rate. This is so the weakest cells matter
R is rate, the % drain we want. This determines our maximum charge time. 
x serves as time.

This formula means as the numbers say up top.
Basic tier 1 cell is unaffected. 
Bluespace t4 cell despite being four times the capacity is only twice as long.
And a nearing infinite capacity cells only ever always shy's of four times as long.

TDLR. Makes upgrading a baton, a nonlethal weapon. Actually matter.
## Changelog
:cl:
balance: Makes it so upgrading a baton actually increases the theoretical maximum baton uptime. See PR for numbers.
/:cl:
