### PR TITLE
Item Interaction Fixes (Touch Spells, Holosigns, Chemical Patches, Cigarette Packs)

### DIFF
--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -45,6 +45,9 @@
 	var/obj/structure/holosign/target_holosign = locate(holosign_type) in target_turf
 
 	if(target_holosign)
+		if(target_holosign.projector == src)
+			target_holosign.attackby(src, user, modifiers)
+			return ITEM_INTERACT_SUCCESS
 		return ITEM_INTERACT_BLOCKING
 	if(target_turf.is_blocked_turf(TRUE, ignore_atoms = projectable_through, type_list = TRUE)) //can't put holograms on a tile that has dense stuff
 		return ITEM_INTERACT_BLOCKING

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -227,8 +227,10 @@
 	register_context()
 
 /obj/item/storage/fancy/cigarettes/attack_hand_secondary(mob/user, list/modifiers)
-	. = ..()
+	if(..() == SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN)
+		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 	quick_remove_item(/obj/item/clothing/mask/cigarette, user)
+	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/storage/fancy/cigarettes/AltClick(mob/user)
 	. = ..()

--- a/code/modules/spells/spell_types/touch/_touch.dm
+++ b/code/modules/spells/spell_types/touch/_touch.dm
@@ -129,6 +129,8 @@
 	SHOULD_CALL_PARENT(TRUE)
 
 	RegisterSignal(attached_hand, COMSIG_ITEM_AFTERATTACK, PROC_REF(on_hand_hit))
+	RegisterSignal(attached_hand, COMSIG_ITEM_INTERACTING_WITH_ATOM, PROC_REF(on_hand_interact))
+	RegisterSignal(attached_hand, COMSIG_ITEM_INTERACTING_WITH_ATOM_SECONDARY, PROC_REF(on_hand_interact_secondary))
 	RegisterSignal(attached_hand, COMSIG_ITEM_DROPPED, PROC_REF(on_hand_dropped))
 	RegisterSignal(attached_hand, COMSIG_QDELETING, PROC_REF(on_hand_deleted))
 
@@ -142,6 +144,8 @@
 
 	UnregisterSignal(attached_hand, list(
 		COMSIG_ITEM_AFTERATTACK,
+		COMSIG_ITEM_INTERACTING_WITH_ATOM,
+		COMSIG_ITEM_INTERACTING_WITH_ATOM_SECONDARY,
 		COMSIG_ITEM_DROPPED,
 		COMSIG_QDELETING,
 		COMSIG_ITEM_OFFER_TAKEN,
@@ -175,6 +179,26 @@
 		INVOKE_ASYNC(src, PROC_REF(do_secondary_hand_hit), source, victim, caster)
 	else
 		INVOKE_ASYNC(src, PROC_REF(do_hand_hit), source, victim, caster)
+
+/**
+ * Signal proc for [COMSIG_ITEM_INTERACTING_WITH_ATOM] from our attached hand.
+ *
+ * Handles left-click interactions through the item interaction system.
+ */
+/datum/action/cooldown/spell/touch/proc/on_hand_interact(obj/item/melee/touch_attack/source, mob/living/user, atom/target, list/modifiers)
+		SIGNAL_HANDLER
+
+		return source.interact_with_atom(target, user, modifiers)
+
+/**
+ * Signal proc for [COMSIG_ITEM_INTERACTING_WITH_ATOM_SECONDARY] from our attached hand.
+ *
+ * Handles right-click interactions through the item interaction system.
+ */
+/datum/action/cooldown/spell/touch/proc/on_hand_interact_secondary(obj/item/melee/touch_attack/source, mob/living/user, atom/target, list/modifiers)
+		SIGNAL_HANDLER
+
+		return source.interact_with_atom_secondary(target, user, modifiers)
 
 /// Checks if the passed victim can be cast on by the caster.
 /datum/action/cooldown/spell/touch/proc/can_hit_with_hand(atom/victim, mob/caster)
@@ -337,6 +361,26 @@
 		user.balloon_alert(user, "can't reach out!")
 		return TRUE
 	return ..()
+
+/obj/item/melee/touch_attack/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	var/datum/action/cooldown/spell/touch/hand_spell = spell_which_made_us?.resolve()
+	if(!hand_spell || !hand_spell.can_hit_with_hand(interacting_with, user))
+		return NONE
+
+	hand_spell.do_hand_hit(src, interacting_with, user)
+	if(QDELETED(src))
+		return ITEM_INTERACT_SUCCESS
+	return NONE
+
+/obj/item/melee/touch_attack/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
+	var/datum/action/cooldown/spell/touch/hand_spell = spell_which_made_us?.resolve()
+	if(!hand_spell || !hand_spell.can_hit_with_hand(interacting_with, user))
+		return NONE
+
+	hand_spell.do_secondary_hand_hit(src, interacting_with, user)
+	if(QDELETED(src))
+		return ITEM_INTERACT_SUCCESS
+	return NONE
 
 /**
  * When the hand component of a touch spell is qdel'd, (the hand is dropped or otherwise lost),

--- a/code/modules/spells/spell_types/touch/_touch.dm
+++ b/code/modules/spells/spell_types/touch/_touch.dm
@@ -131,6 +131,10 @@
 	RegisterSignal(attached_hand, COMSIG_ITEM_AFTERATTACK, PROC_REF(on_hand_hit))
 	RegisterSignal(attached_hand, COMSIG_ITEM_INTERACTING_WITH_ATOM, PROC_REF(on_hand_interact))
 	RegisterSignal(attached_hand, COMSIG_ITEM_INTERACTING_WITH_ATOM_SECONDARY, PROC_REF(on_hand_interact_secondary))
+
+	RegisterSignal(attached_hand, COMSIG_RANGED_ITEM_INTERACTING_WITH_ATOM, PROC_REF(on_hand_ranged_interact))
+	RegisterSignal(attached_hand, COMSIG_RANGED_ITEM_INTERACTING_WITH_ATOM_SECONDARY, PROC_REF(on_hand_ranged_interact_secondary))
+
 	RegisterSignal(attached_hand, COMSIG_ITEM_DROPPED, PROC_REF(on_hand_dropped))
 	RegisterSignal(attached_hand, COMSIG_QDELETING, PROC_REF(on_hand_deleted))
 
@@ -146,6 +150,8 @@
 		COMSIG_ITEM_AFTERATTACK,
 		COMSIG_ITEM_INTERACTING_WITH_ATOM,
 		COMSIG_ITEM_INTERACTING_WITH_ATOM_SECONDARY,
+		COMSIG_RANGED_ITEM_INTERACTING_WITH_ATOM,
+		COMSIG_RANGED_ITEM_INTERACTING_WITH_ATOM_SECONDARY,
 		COMSIG_ITEM_DROPPED,
 		COMSIG_QDELETING,
 		COMSIG_ITEM_OFFER_TAKEN,
@@ -199,6 +205,26 @@
 		SIGNAL_HANDLER
 
 		return source.interact_with_atom_secondary(target, user, modifiers)
+
+/**
+ * Signal proc for [COMSIG_RANGED_ITEM_INTERACTING_WITH_ATOM] from our attached hand.
+ *
+ * Handles left-click ranged interactions through the item interaction system.
+ */
+/datum/action/cooldown/spell/touch/proc/on_hand_ranged_interact(obj/item/melee/touch_attack/source, mob/living/user, atom/target, list/modifiers)
+	SIGNAL_HANDLER
+
+	return source.ranged_interact_with_atom(target, user, modifiers)
+
+/**
+ * Signal proc for [COMSIG_RANGED_ITEM_INTERACTING_WITH_ATOM_SECONDARY] from our attached hand.
+ *
+ * Handles right-click ranged interactions through the item interaction system.
+ */
+/datum/action/cooldown/spell/touch/proc/on_hand_ranged_interact_secondary(obj/item/melee/touch_attack/source, mob/living/user, atom/target, list/modifiers)
+	SIGNAL_HANDLER
+
+	return source.ranged_interact_with_atom_secondary(target, user, modifiers)
 
 /// Checks if the passed victim can be cast on by the caster.
 /datum/action/cooldown/spell/touch/proc/can_hit_with_hand(atom/victim, mob/caster)
@@ -380,6 +406,12 @@
 	hand_spell.do_secondary_hand_hit(src, interacting_with, user)
 	if(QDELETED(src))
 		return ITEM_INTERACT_SUCCESS
+	return NONE
+
+/obj/item/melee/touch_attack/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	return NONE
+
+/obj/item/melee/touch_attack/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	return NONE
 
 /**

--- a/monkestation/code/datums/mutations/touch.dm
+++ b/monkestation/code/datums/mutations/touch.dm
@@ -34,11 +34,45 @@
 
 /obj/item/melee/touch_attack/shock/far
 
-/obj/item/melee/touch_attack/shock/far/afterattack(atom/target, mob/living/carbon/user, proximity, click_parameters)
-	if(!can_see(user, target, 5) || get_dist(target, user) > 5)
+/obj/item/melee/touch_attack/shock/far/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!can_see(user, interacting_with, 5) || get_dist(interacting_with, user) > 5)
 		user.visible_message(span_notice("[user]'s hand reaches out but nothing happens."))
-		return
-	return ..(target, user, TRUE, click_parameters) //call the parent, forcing proximity = TRUE so even distant things are considered nearby
+		return NONE
+	return ..()
+
+/obj/item/melee/touch_attack/shock/far/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!can_see(user, interacting_with, 5) || get_dist(interacting_with, user) > 5)
+		user.visible_message(span_notice("[user]'s hand reaches out but nothing happens."))
+		return NONE
+	return ..()
+
+/obj/item/melee/touch_attack/shock/far/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	var/datum/action/cooldown/spell/touch/hand_spell = spell_which_made_us?.resolve()
+	if(!hand_spell || !hand_spell.can_hit_with_hand(interacting_with, user))
+		return NONE
+
+	if(!can_see(user, interacting_with, 5) || get_dist(interacting_with, user) > 5)
+		user.visible_message(span_notice("[user]'s hand reaches out but nothing happens."))
+		return NONE
+
+	hand_spell.do_hand_hit(src, interacting_with, user)
+	if(QDELETED(src))
+		return ITEM_INTERACT_SUCCESS
+	return NONE
+
+/obj/item/melee/touch_attack/shock/far/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
+	var/datum/action/cooldown/spell/touch/hand_spell = spell_which_made_us?.resolve()
+	if(!hand_spell || !hand_spell.can_hit_with_hand(interacting_with, user))
+		return NONE
+
+	if(!can_see(user, interacting_with, 5) || get_dist(interacting_with, user) > 5)
+		user.visible_message(span_notice("[user]'s hand reaches out but nothing happens."))
+		return NONE
+
+	hand_spell.do_secondary_hand_hit(src, interacting_with, user)
+	if(QDELETED(src))
+		return ITEM_INTERACT_SUCCESS
+	return NONE
 
 /datum/mutation/lay_on_hands
 	conflicts = list(/datum/mutation/lay_on_hands/syndicate)

--- a/monkestation/code/modules/patches_if_they_were_cool/_base_patch_changes.dm
+++ b/monkestation/code/modules/patches_if_they_were_cool/_base_patch_changes.dm
@@ -12,7 +12,7 @@
 
 /obj/item/reagent_containers/pill/patch/interact_with_atom(atom/target, mob/living/user, list/modifiers)
 	if(!isliving(target))
-		return ITEM_INTERACT_BLOCKING
+		return ..()
 
 	if(target != user && !do_after(user, CHEM_INTERACT_DELAY(3 SECONDS, user), target))
 		return ITEM_INTERACT_BLOCKING


### PR DESCRIPTION
## About The Pull Request

Fixes some of the **aftermath** of the **afterattack** PR. 

- Touch spells now correctly use the new interaction signals (`COMSIG_ITEM_INTERACTING_WITH_ATOM`, `COMSIG_ITEM_INTERACTING_WITH_ATOM_SECONDARY`, `COMSIG_ITEM_RANGED_INTERACTING_WITH_ATOM`, `COMSIG_ITEM_RANGED_INTERACTING_WITH_ATOM_SECONDARY`).  
  - Fixes **Knock Heretic's Mansus Grasp** opening airlocks again.  
  - Fixes **Extended Shock Touch** actually shocking targets at range as intended.  
- **Holosign Projectors** can now delete their own signs again.  
- **Chemical Patches** can be inserted into chemical reagent grinders again.  
- **Cigarette Packs** no longer fall to the floor if you open them while they’re inside a backpack.  


## Why It's Good For The Game

It fixes stuff :D

## Changelog

:cl:  
fix: Touch spells now use the new interaction/ranged interaction signals, fixing Knock Mansus Grasp and Extended Shock Touch at range.  
fix: Holosign Projectors can again delete holosigns they created.  
fix: Chemical patches can now be placed into chemical grinders.  
fix: Cigarette packs no longer drop to the ground when opened from inside a backpack.  
/:cl: