### PR TITLE
Gun interaction fixes (plus protokinetic dagger nerf)

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -837,8 +837,8 @@
 	name = "set of proto kinetic knives"
 	desc = "With a touch of bluespace, the crusher has been made into a more practical form for throwing. \
 	This set of throwing knives allows you to utilize the features of a crusher while maintaining more than a safe \
-	distance from whatever fauna stands between you and your ore. Unfortunetly, while they are the perfect shape for throwing, the awkward grip \
-	and blade make it pretty much impossible to stab with... at least it can still utilize trophies."
+	distance from whatever fauna stands between you and your ore, though the small weapon limits damage... \
+	at least it can still utilize trophies."
 	fire_sound = 'sound/weapons/fwoosh.ogg'
 	pinless = TRUE
 	force = 10
@@ -867,8 +867,8 @@
 	var/list/trophies = list() //yes these are new variables because this isnt a crusher subtype
 	var/charged = TRUE
 	var/charge_time = 5
-	var/detonation_damage = 60 //these are the same as the thrown projectile so the description is correct on the damage.
-	var/backstab_bonus = 10
+	var/detonation_damage = 30 //these are the same as the thrown projectile so the description is correct on the damage.
+	var/backstab_bonus = 20
 	//so a quick note, you can technically land crusher melee stabs... however thats if point blanking it removed, from this... which i admittedly cant get removed from here so... im just redacting any mention of stabbing... sorry :(
 
 
@@ -972,13 +972,10 @@
 			SEND_SIGNAL(user, COMSIG_LIVING_CRUSHER_DETONATE, L, src, backstabbed)
 			L.apply_damage(combined_damage, BRUTE, blocked = def_check)
 
-/obj/item/gun/magic/crusherknives/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
-	if(interacting_with == user)
-		balloon_alert(user, "can't aim at yourself!")
-		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+/obj/item/gun/magic/crusherknives/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	fire_kinetic_blast(interacting_with, user, modifiers)
 	user.changeNext_move(CLICK_CD_MELEE)
-	return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
+	return
 
 /obj/item/gun/magic/crusherknives/proc/fire_kinetic_blast(atom/target, mob/living/user, list/modifiers)
 	if(!charged)
@@ -1039,8 +1036,8 @@
 	antimagic_flags = NONE
 	antimagic_charge_cost = 0
 	var/obj/item/gun/magic/crusherknives/hammer_synced
-	var/detonation_damage = 60
-	var/backstab_bonus = 10
+	var/detonation_damage = 30
+	var/backstab_bonus = 20
 
 //we have more copy pasted crusher code here because the damage from a projectile is different from a melee strike
 /obj/projectile/magic/knives/on_hit(atom/target, Firer, blocked = 0, pierce_hit)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -291,14 +291,14 @@
 /obj/item/gun/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(try_fire_gun(interacting_with, user, list2params(modifiers)))
 		return ITEM_INTERACT_SUCCESS
-	return NONE
+	return ITEM_INTERACT_BLOCKING
 
 /obj/item/gun/interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
 	if((user.istate & ISTATE_HARM) && isliving(interacting_with))
 		return ITEM_INTERACT_SKIP_TO_ATTACK // Gun bash / bayonet attack
 
-	if(!can_hold_up || !isliving(interacting_with))
-		return interact_with_atom(interacting_with, user, modifiers)
+	if(!isliving(interacting_with))
+		return ITEM_INTERACT_SKIP_TO_ATTACK
 
 	var/datum/component/gunpoint/gunpoint_component = user.GetComponent(/datum/component/gunpoint)
 	if (gunpoint_component)
@@ -318,9 +318,8 @@
 	return ITEM_INTERACT_BLOCKING
 
 /obj/item/gun/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
-	if(IN_GIVEN_RANGE(user, interacting_with, GUNPOINT_SHOOTER_STRAY_RANGE))
-		return interact_with_atom_secondary(interacting_with, user, modifiers)
-	return ..()
+	return ITEM_INTERACT_BLOCKING
+//Just exists to stop it running ranged interact primary, and for other stuff to work based off of it
 
 /obj/item/gun/proc/try_fire_gun(atom/target, mob/living/user, params)
 	return fire_gun(target, user, user.Adjacent(target), params)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -228,10 +228,13 @@
 	underbarrel = new /obj/item/gun/ballistic/revolver/grenadelauncher/unrestricted(src)
 	update_appearance()
 
-/obj/item/gun/ballistic/automatic/m90/try_fire_gun(atom/target, mob/living/user, params)
-	if(LAZYACCESS(params2list(params), RIGHT_CLICK))
-		return underbarrel.try_fire_gun(target, user, params)
-	return ..()
+///obj/item/gun/ballistic/automatic/m90/try_fire_gun(atom/target, mob/living/user, params)
+	//if(LAZYACCESS(params2list(params), RIGHT_CLICK))
+	//	return underbarrel.try_fire_gun(target, user, params)
+	//return ..()
+
+/obj/item/gun/ballistic/automatic/m90/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
+	return underbarrel.try_fire_gun(interacting_with, user, list2params(modifiers))
 
 /obj/item/gun/ballistic/automatic/m90/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(isammocasing(tool))


### PR DESCRIPTION

## About The Pull Request

Fixes various issues guns were having with the recent item interaction refactor.
Including : meleeing with medbeams
meleeing when pbing with an empty weapon
the m90gl firing when you fire a grenade
not being able to melee objects

In addition, nerfs the protokinetic daggers so they don't totally eclipse every other crusher in the game.

I hoped to fix scoping too but I'm at a loss for why it's broken.

## Why It's Good For The Game

Good balance change, and a big ol slew of bugfixes

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: You will now no longer melee when you pb someone with a medbeam
fix: You will now no longer melee when you pb someone with an empty gun
fix: The m90gl will not fire a burst when it fires a grenade
fix: the protokinetic daggers function
balance: the protokinetic daggers no longer totally eclipse normal crushers
/:cl:
