### PR TITLE
Makes the proto-kinetic railgun bulky instead of huge

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -668,7 +668,7 @@
 	icon = 'icons/obj/weapons/guns/energy.dmi'
 	icon_state = "kineticrailgun"
 	base_icon_state = "kineticrailgun"
-	w_class = WEIGHT_CLASS_HUGE
+	w_class = WEIGHT_CLASS_BULKY
 	pin = /obj/item/firing_pin/wastes
 	recharge_time = 3 SECONDS
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic/railgun)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this downgrades the pk railgun's size from huge to bulky, allowing it to fit in the suit storage of things that allow for pkas in the suit storage

## Why It's Good For The Game

the railgun being huge feels awkwardly arbitrary

the mining guns - which are far more powerful when used correctly - are _normal sized_, and fit in a backpack along with their ammo, and as far as I know, the railgun the only of the miner weapons that cannot fit in suit storage of drake armor or whatever.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The proto-kinetic railgun is now bulky instead of huge, allowing it to fit in the suit storage of certain mining suits/armors.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
