### PR TITLE
[BALANCE] Auspex/Obfuscation Nerf

### DIFF
--- a/monkestation/code/modules/bloodsuckers/powers/tremere/obfuscation.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/tremere/obfuscation.dm
@@ -51,7 +51,6 @@
 	. = list()
 	. += "When Activated, you will be hidden in a Cloak of Darkness."
 	. += "[target_range ? "Click to teleport up to [target_range] tiles away, as long as you can see it" : "You can teleport anywhere you can see"]."
-	. += "Teleporting will refill your stamina to full."
 	. += "At level [OBFUSCATION_BLEED_LEVEL] you will cause people at your end location to start bleeding."
 	. += "At level [OBFUSCATION_KNOCKDOWN_LEVEL] you will cause people at your end location to be knocked down."
 	. += "At level [OBFUSCATION_ANYWHERE_LEVEL] you will be able to teleport anywhere, even if you cannot properly see the tile."
@@ -75,7 +74,7 @@
 	..()
 	ADD_TRAIT(owner, TRAIT_UNKNOWN, REF(src))
 	owner.AddElement(/datum/element/digitalcamo)
-	animate(owner, alpha = 15, time = 2 SECONDS)
+	animate(owner, alpha = 100, time = 2 SECONDS)
 
 /datum/action/cooldown/bloodsucker/targeted/tremere/obfuscation/DeactivatePower(deactivate_flags)
 	..()
@@ -116,7 +115,7 @@
 			living_mob.Knockdown(10 SECONDS, ignore_canstun = TRUE)
 
 	do_teleport(owner, targeted_turf, no_effects = TRUE, channel = TELEPORT_CHANNEL_QUANTUM)
-	user.stamina.revitalize()
+
 	power_activated_sucessfully(cost_override = blood_cost)
 
 #undef OBFUSCATION_BLOOD_COST_PER_TILE


### PR DESCRIPTION
## About The Pull Request

"Auspex" was recently renamed to "Obfuscation" - rest of this PR description will use the new term.

Removes the stamina regen on obfuscation teleport added in https://github.com/Monkestation/Monkestation2.0/pull/7552

Nerfs obfuscation invisibility to be about on par with old slashers (i.e. before the recent changes that made them faster and more visible).

## Why It's Good For The Game

Especially that the other 2 tremere abilities have been improved now, there was just no reason to add functional stun immunity to what was already the strongest vampire clan. One of the long-time drawbacks of tremere was the lack of stun resist, let's keep it that way. Especially since space law is being changed soon to have vampires be less immediately "kill on sight", keeping them more arrestable in general is a good thing.

As for the other change: Invisibility mechanics are one of the least fun things to fight in the game, especially invis mechanics which have no way to be revealed. Ninjas or wraith module users can be hit, stealth implant users can be bumped into, but there is no way to reveal a vampire in cloak of darkness until they teleport stun you. Straining your eyes and getting stun-wounded seemingly out of nowhere every 12 seconds is just not enjoyable combat. There is just really no reason for vampires to have better invisibility than ninjas (ninja alpha is 20 out of 255, tremere invis was 15).

## Changelog

:cl:
balance: Obfuscation (previously auspex) no longer regenerates stamina damage on use.
balance: Obfuscation (previously auspex) invisibility has been reduced.
/:cl: