### PR TITLE
[BALANCE] [PORT] Nerfs ninja hardstun + minor fix

### DIFF
--- a/code/modules/antagonists/ninja/ninjaDrainAct.dm
+++ b/code/modules/antagonists/ninja/ninjaDrainAct.dm
@@ -319,7 +319,11 @@
 		//Got that electric touch
 		var/datum/effect_system/spark_spread/spark_system = new /datum/effect_system/spark_spread()
 		spark_system.set_up(5, 0, loc)
-		playsound(src, SFX_SPARKS, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
+		spark_system.start()
 		visible_message(span_danger("[ninja] electrocutes [src] with [ninja.p_their()] touch!"), span_userdanger("[ninja] electrocutes you with [ninja.p_their()] touch!"))
-		Knockdown(3 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(ninja_knockdown)), 0.3 SECONDS)
 	return NONE
+
+/mob/living/carbon/proc/ninja_knockdown()
+	Knockdown(3 SECONDS)
+	set_jitter_if_lower(3 SECONDS)


### PR DESCRIPTION
## About The Pull Request

Partial port of https://github.com/tgstation/tgstation/pull/77810 

Ninja gloves now no longer hardstun on first hit, instead applying a 3 second knockdown after a 0.3s delay. Since old shovestuns are still a thing here, the ninja can still shove someone again for the 3s paralyze.

Also fixes ninja shoves not causing sparks.

## Why It's Good For The Game

One hit hardstuns are ass to play against. This puts the stun about on par with a contractor baton, which is still pretty rough but at least you have SOME chance at counterplay after getting clicked once. 

## Changelog

:cl:
balance: ninja shoves are now knockdowns instead of immediate hardstuns
fix: fixes ninja shoves not causing sparks
/:cl: