### PR TITLE
[FIX] Improves tackles

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -74,7 +74,7 @@
 	if(!modifiers[RIGHT_CLICK] || modifiers[ALT_CLICK] || modifiers[SHIFT_CLICK] || modifiers[CTRL_CLICK] || modifiers[MIDDLE_CLICK])
 		return
 
-	if(!user.throw_mode || user.get_active_held_item() || user.pulling || user.buckled || user.incapacitated())
+	if(!user.throw_mode || user.get_active_held_item() || user.buckled || user.incapacitated())
 		return
 
 	if(!clicked_atom || !(isturf(clicked_atom) || isturf(clicked_atom.loc)))
@@ -100,9 +100,13 @@
 		to_chat(user, span_warning("You're too off balance to tackle!"))
 		return
 
+	if (user.pulling)
+		user.stop_pulling()
+
 	user.face_atom(clicked_atom)
 
 	tackling = TRUE
+	user.toggle_throw_mode()
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(checkObstacle))
 	playsound(user, 'sound/weapons/thudswoosh.ogg', 40, TRUE, -1)
 
@@ -148,7 +152,6 @@
 		tackle = null
 		return
 
-	user.toggle_throw_mode()
 	if(!iscarbon(hit))
 		if(hit.density)
 			INVOKE_ASYNC(src, PROC_REF(splat), user, hit)


### PR DESCRIPTION
## About The Pull Request

Fixes being unable to tackle while pulling something (it now just automatically breaks the pull).

Disables throw mode the moment you launch the tackle instead of when you land, which fixes some issues I have experienced on live where throw mode wouldn't toggle correctly and you would end up with it on at the end of the tackle. I did test and if you are HOLDING throw mode with the keybind instead, it will still keep it on through the tackle.

## Why It's Good For The Game

Fixes good. Tackles fun.

## Changelog

:cl:
fix: You can now tackle while pulling something (it will automatically break the pull, however.)
fix: If you are using toggle throw mode, tackles should now always disable throw mode correctly after being used.
/:cl
