### PR TITLE
Adds silicon to job bonuses.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -75,7 +75,7 @@ SUBSYSTEM_DEF(ticker)
 	var/reboot_timer = null
 
 	///add bitflags to this that should be rewarded monkecoins, example: DEPARTMENT_BITFLAG_SECURITY
-	var/list/bitflags_to_reward = list(DEPARTMENT_BITFLAG_SECURITY,)
+	var/list/bitflags_to_reward = list(DEPARTMENT_BITFLAG_SECURITY, DEPARTMENT_BITFLAG_SILICON)
 	///add jobs to this that should get rewarded monkecoins, example: JOB_SECURITY_OFFICER
 	var/list/jobs_to_reward = list(JOB_JANITOR,)
 


### PR DESCRIPTION

## About The Pull Request
Adds department silicon to the monkecoin bonuses 
## Why It's Good For The Game
Silicons theoretically are both an important role and ongoing for the station. Several systems and antagonist spawns with counting them as enemies in mind, and the AI is the only way to be aware of probing and hackings before they happen.
In addition, silicon's lack any base way to earn monkecoins itself. They cant complete any stations objectives besides cargo budget and the BSA. They can't do bounties. Ideally, we want people to play silicon's, so give them a treat of the coins.
## Changelog
:cl:
add: Cyborgs and AI players now receive a end of our Monkecoin bonus
/:cl:
