### PR TITLE
Fairly balances the Bingle threat

### DIFF
--- a/monkestation/code/modules/veth_misc_items/bingle/ghost_role.dm
+++ b/monkestation/code/modules/veth_misc_items/bingle/ghost_role.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/bingle
 	name = "Spawn Bingle"
 	typepath = /datum/round_event/ghost_role/bingle
-	weight = 5
+	weight = 8
 	max_occurrences = 1
 	track = EVENT_TRACK_MODERATE
 	description = "Spawns a pesky little blue fella."

--- a/monkestation/code/modules/veth_misc_items/bingle/mob.dm
+++ b/monkestation/code/modules/veth_misc_items/bingle/mob.dm
@@ -75,7 +75,7 @@
 		return ..()
 	var/mob/living/mob_target = target
 	mob_target.Disorient(6 SECONDS, 5, paralyze = 10 SECONDS, stack_status = FALSE)
-	mob_target.stamina.adjust(-35)
+	mob_target.stamina.adjust(-50)
 	SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK)
 	return ..()
 


### PR DESCRIPTION
About The Pull Request

Increases the stamina attack to negative 50, which is 4 hits to stun (I think)
Slightly increases the weight to 8, which is still lower than the pre nerf

 Why It's Good For The Game

Look, a lot of people actually love this antag and the nerfs just don't make sense to me. It feels like someone doesn't like this antag or got salty and over did the nerfs.  I don't think the game needs to revolve around heavy handed nerfs and sometimes the solution is literally get better.

The original nerf made it to be 6 hits to stamina crit which is way to much.  It's hard to obtain that in combat and you'll just likely end up dying. 4 is a decent number since you still need to put effort in to down crew and the crew can still run away... unless they made a bad play and get punished. In fact, I think I've seen people get killed more than actually get stamina crit from these things.

I also increased the rate a bit to make them pop up more, but not as much as before.

After the original nerf [https://github.com/Monkestation/Monkestation2.0/pull/7599](url) bingles have been struggling to get anywhere. They are often very short lived and easy to deal with. Give them some bite back or remove them from the game entirely.

