### PR TITLE
Untest commando operatives weight

### DIFF
--- a/monkestation/code/modules/storytellers/converted_events/solo/commando_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/commando_operative.dm
@@ -42,7 +42,7 @@
 	min_players = 40
 	roundstart = TRUE
 	earliest_start = 0 SECONDS
-	weight = 8
+	weight = 5
 	max_occurrences = 1
 	event_icon_state = "nukeops"
 


### PR DESCRIPTION

## About The Pull Request
Nerfs commando operatives from 8 weight to their intended 5 weight, closer to other operatives
## Why It's Good For The Game
Talking to the creator, they were at a higher weight for testing purposes and were never lowered by accident.
## Changelog
:cl:
balance: Lowered commando operatives to their intended weight. (8 -> 5)
/:cl:
