### PR TITLE
Adds an option to hide your ckey from the roundend report

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -775,7 +775,11 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 	var/jobtext = ""
 	if(!is_unassigned_job(ply.assigned_role))
 		jobtext = " the <b>[ply.assigned_role.title]</b>"
-	var/text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext] and"
+	var/text
+	if(GLOB.roundend_hidden_ckeys[ckey(ply.key)])
+		text = "<b>[ply.name]</b>[jobtext] "
+	else
+		text = "<b>[ply.key]</b> was <b>[ply.name]</b>[jobtext] and"
 	if(ply.current)
 		if(ply.current.stat == DEAD)
 			text += " [span_redtext("died")]"

--- a/code/modules/client/preferences/hide_roundend_ckey.dm
+++ b/code/modules/client/preferences/hide_roundend_ckey.dm
@@ -1,0 +1,10 @@
+GLOBAL_DATUM_INIT(roundend_hidden_ckeys, /alist, alist())
+
+/datum/preference/toggle/hide_roundend_ckey
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "hide_roundend_ckey"
+	savefile_identifier = PREFERENCE_PLAYER
+	default_value = FALSE
+
+/datum/preference/toggle/hide_roundend_ckey/apply_to_client(client/client, value)
+	GLOB.roundend_hidden_ckeys[client.ckey] = value

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3716,6 +3716,7 @@
 #include "code\modules\client\preferences\ghost_lighting.dm"
 #include "code\modules\client\preferences\glasses.dm"
 #include "code\modules\client\preferences\heterochromatic.dm"
+#include "code\modules\client\preferences\hide_roundend_ckey.dm"
 #include "code\modules\client\preferences\hotkeys.dm"
 #include "code\modules\client\preferences\init_stats.dm"
 #include "code\modules\client\preferences\item_outlines.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/hide_roundend_ckey.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/hide_roundend_ckey.tsx
@@ -1,0 +1,11 @@
+import { multiline } from 'common/string';
+import { CheckboxInput, FeatureToggle } from '../base';
+
+export const hide_roundend_ckey: FeatureToggle = {
+  name: 'Hide ckey in roundend report',
+  category: 'GAMEPLAY',
+  description: multiline`
+    When enabled, your ckey will be hidden in the roundend report.
+  `,
+  component: CheckboxInput,
+};


### PR DESCRIPTION

## About The Pull Request

This adds a new preference, "Hide ckey in roundend report", which is... self-explanatory.

## Why It's Good For The Game

Sometimes I'd prefer the fact a character is mine not be public knowledge. Admins can still easily get that info if needed.

## Changelog
:cl:
add: Added an option to hide your ckey from the roundend report (off by default)
/:cl:
