### PR TITLE
Removes hidden limb health decrease from IPCs

### DIFF
--- a/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
+++ b/monkestation/code/modules/mob/living/carbon/human/species_type/ipc.dm
@@ -214,7 +214,7 @@
 		return
 	booting_ipc.say("Unit [booting_ipc.real_name] is fully functional. Have a nice day.")
 	if(booting_ipc.get_bodypart(BODY_ZONE_HEAD))
-		switch_to_screen(booting_ipc, "Console")
+		switch_to_screen(booting_ipc, saved_screen)
 		booting_ipc.visible_message(span_notice("[booting_ipc]'s [change_screen ? "monitor lights up" : "monitor flickers to life"]!"), span_notice("You're back online!"))
 	playsound(booting_ipc.loc, 'sound/machines/chime.ogg', 50, TRUE)
 	return

--- a/monkestation/code/modules/surgery/bodyparts/ipc_bodyparts.dm
+++ b/monkestation/code/modules/surgery/bodyparts/ipc_bodyparts.dm
@@ -14,8 +14,8 @@
 	brute_modifier = 1.2 // Monkestation Edit
 	burn_modifier = 1.2 // Monkestation Edit
 
-	body_damage_coeff = 1.1	//IPC's Head can dismember	//Monkestation Edit
-	max_damage = 40	//Keep in mind that this value is used in the //Monkestation Edit
+	body_damage_coeff = 0.75	//IPC's Head can dismember	//Monkestation Edit
+	max_damage = 70	//Keep in mind that this value is used in the //Monkestation Edit
 	dmg_overlay_type = "synth"
 
 	disabling_threshold_percentage = 1
@@ -39,7 +39,7 @@
 	bodypart_traits = list(TRAIT_LIMBATTACHMENT)
 	wing_types = list(/obj/item/organ/external/wings/functional/robotic)
 	body_damage_coeff = 1	//IPC Chest at default	///Monkestation Edit
-	max_damage = 360	//Default: 200 ///Monkestation Edit
+	max_damage = 340	//Default: 200 ///Monkestation Edit
 	brute_modifier = 1.2 // Monkestation Edit
 	burn_modifier = 1.2 // Monkestation Edit
 

--- a/monkestation/code/modules/surgery/bodyparts/ipc_bodyparts.dm
+++ b/monkestation/code/modules/surgery/bodyparts/ipc_bodyparts.dm
@@ -39,7 +39,7 @@
 	bodypart_traits = list(TRAIT_LIMBATTACHMENT)
 	wing_types = list(/obj/item/organ/external/wings/functional/robotic)
 	body_damage_coeff = 1	//IPC Chest at default	///Monkestation Edit
-	max_damage = 250	//Default: 200 ///Monkestation Edit
+	max_damage = 360	//Default: 200 ///Monkestation Edit
 	brute_modifier = 1.2 // Monkestation Edit
 	burn_modifier = 1.2 // Monkestation Edit
 

--- a/monkestation/code/modules/surgery/bodyparts/ipc_bodyparts.dm
+++ b/monkestation/code/modules/surgery/bodyparts/ipc_bodyparts.dm
@@ -66,8 +66,7 @@
 	brute_modifier = 1.2 // Monkestation Edit
 	burn_modifier = 1.2 // Monkestation Edit
 
-	body_damage_coeff = 1.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
-	max_damage = 30	//Monkestation Edit
+	hp_percent_to_dismemberable = 0.6
 
 	dmg_overlay_type = "synth"
 
@@ -92,8 +91,7 @@
 	brute_modifier = 1.2 // Monkestation Edit
 	burn_modifier = 1.2 // Monkestation Edit
 
-	body_damage_coeff = 1.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
-	max_damage = 30	//Monkestation Edit
+	hp_percent_to_dismemberable = 0.6
 
 	dmg_overlay_type = "synth"
 
@@ -142,8 +140,6 @@
 	brute_modifier = 1.2 // Monkestation Edit
 	burn_modifier = 1.2 // Monkestation Edit
 
-	body_damage_coeff = 1.1	//IPC's Limbs Should Dismember Easier	//Monkestation Edit
-	max_damage = 30	//Monkestation Edit
 
 	dmg_overlay_type = "synth"
 	step_sounds = list('sound/effects/servostep.ogg')


### PR DESCRIPTION

## About The Pull Request
1. Removes IPC limb health changes while keeping them easier to dismember
2. also fixes screen saving for when you die because it miffed me
## Why It's Good For The Game
1. IPCs are meant to be weak in combat. Fair. Reasonable. They should probably not reliably die to a single space carp.
3. We don't tell anyone about this nerf in the species section, so you read it and see the extra damage from everything and think "ok this guy is gonna be kinda weaker physically" and then instead of it being kinda weaker phyisically they're made of tinfoil.
4. Bugg fix
## Changelog
:cl:
balance: IPCs now no longer have secretly much reduced limb health and increased limb->body damage transferance. they are still easier to dismember.
fix: Screen-saving for IPCs now works when you die
/:cl:
