### PR TITLE
Viewer defines

### DIFF
--- a/code/__HELPERS/view.dm
+++ b/code/__HELPERS/view.dm
@@ -20,16 +20,23 @@
 	view_info[2] *= world.icon_size
 	return view_info
 
-// monkestation edit: make this proc actually work as seemingly intended
-/proc/in_view_range(mob/user, atom/A, require_same_z = FALSE)
-	var/list/view_range = getviewsize(user.client?.view || world.view)
-	var/turf/source = get_turf(user)
-	var/turf/target = get_turf(A)
-	if(QDELETED(source) || QDELETED(target))
-		return FALSE
-	var/x_range = ceil(view_range[1] * 0.5)
-	var/y_range = ceil(view_range[2] * 0.5)
-	if(require_same_z && source.z != target.z)
-		return FALSE
-	return ISINRANGE(target.x, source.x - x_range, source.x + x_range) && ISINRANGE(target.y, source.y - y_range, source.y + y_range)
-// monkestation end
+/**
+* Frustrated with bugs in can_see(), this instead uses viewers for a much more effective approach.
+* ### Things to note:
+* - Src/source must be a mob. `viewers()` returns mobs.
+* - Adjacent objects are always considered visible.
+*/
+
+/// The default tile-distance between two atoms for one to consider the other as visible.
+#define DEFAULT_SIGHT_DISTANCE 7
+
+/// Basic check to see if the src object can see the target object.
+#define CAN_I_SEE(target) ((src in viewers(DEFAULT_SIGHT_DISTANCE, target)) || in_range(target, src))
+
+
+/// Checks the visibility between two other objects.
+#define CAN_THEY_SEE(target, source) ((source in viewers(DEFAULT_SIGHT_DISTANCE, target)) || in_range(target, source))
+
+
+/// Further checks distance between source and target.
+#define CAN_SEE_RANGED(target, source, dist) ((source in viewers(dist, target)) || in_range(target, source))

--- a/code/datums/components/fullauto.dm
+++ b/code/datums/components/fullauto.dm
@@ -249,7 +249,7 @@
 	if(get_dist(shooter, target) <= 0)
 		target = get_step(shooter, shooter.dir) //Shoot in the direction faced if the mouse is on the same tile as we are.
 		target_loc = target
-	else if(!in_view_range(shooter, target))
+	else if(!CAN_THEY_SEE(target, shooter))
 		stop_autofiring() //Elvis has left the building.
 		return FALSE
 	shooter.face_atom(target)

--- a/code/datums/components/ranged_mob_full_auto.dm
+++ b/code/datums/components/ranged_mob_full_auto.dm
@@ -56,7 +56,7 @@
 	if (get_dist(living_parent, target) <= 0)
 		set_target(get_step(living_parent, living_parent.dir)) // Shoot in the direction faced if the mouse is on the same tile as we are.
 		target_loc = target
-	else if (!in_view_range(living_parent, target))
+	else if (!CAN_THEY_SEE(target, living_parent))
 		stop_firing()
 		return FALSE // Can't see shit
 

--- a/code/modules/antagonists/monster_hunters/monsters/monster_effects/white_rabbit.dm
+++ b/code/modules/antagonists/monster_hunters/monsters/monster_effects/white_rabbit.dm
@@ -99,7 +99,7 @@
 
 /// Janky workaround to avoid the 512x512 sprite always occuping the user's right click menu
 /obj/effect/bnnuy/proc/update_mouse_opacity(mob/living/user)
-	if(in_view_range(user, src, TRUE) && can_see(user, src))
+	if(CAN_THEY_SEE(user, src) && can_see(user, src))
 		mouse_opacity = MOUSE_OPACITY_ICON
 	else
 		mouse_opacity = MOUSE_OPACITY_TRANSPARENT

--- a/code/modules/mob/dead/observer/observer_say.dm
+++ b/code/modules/mob/dead/observer/observer_say.dm
@@ -64,7 +64,7 @@
 		create_chat_message(speaker, message_language, raw_message, spans)
 	// monkestation start: bold messages for ghosts when they're nearby
 	var/list/our_spans = spans
-	if((client?.prefs.chat_toggles & CHAT_GHOSTEARS) && in_view_range(src, to_follow, TRUE))
+	if((client?.prefs.chat_toggles & CHAT_GHOSTEARS) && CAN_THEY_SEE(src, to_follow))
 		our_spans = spans.Copy()
 		our_spans |= SPAN_BOLD
 	// monkestation end

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -425,8 +425,8 @@
 /obj/item/gun/energy/marksman_revolver/try_fire_gun(atom/target, mob/living/user, params)
 	if(!LAZYACCESS(params2list(params), RIGHT_CLICK))
 		return ..()
-	if(!can_see(user, get_turf(target), length = 9))
-		return ITEM_INTERACT_BLOCKING
+	if(!CAN_THEY_SEE(target, user))
+		return ..()
 
 	if(max_coins && coin_count <= 0)
 		to_chat(user, span_warning("You don't have any coins right now!"))

--- a/monkestation/code/modules/bloodsuckers/powers/targeted/lunge.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/targeted/lunge.dm
@@ -114,7 +114,7 @@
 	var/turf/targeted_turf = get_turf(hit_atom)
 
 	var/dist = get_dist(owner, targeted_turf)
-	if(target_range ? (dist <= target_range) : in_view_range(owner, targeted_turf, TRUE))
+	if(target_range ? (dist <= target_range) : CAN_THEY_SEE(owner, targeted_turf))
 		var/safety = dist * 3 + 1
 		var/consequetive_failures = 0
 		while(--safety && !hit_atom.Adjacent(owner))

--- a/monkestation/code/modules/slimecore/items/vacuum_pack.dm
+++ b/monkestation/code/modules/slimecore/items/vacuum_pack.dm
@@ -606,7 +606,7 @@
 		do_suck(chosen, user)
 
 /obj/item/vacuum_nozzle/proc/extra_selection_checks(mob/living/user, turf/target_turf)
-	return user.get_active_held_item() == src && !user.incapacitated() && in_view_range(user, target_turf, require_same_z = TRUE)
+	return user.get_active_held_item() == src && !user.incapacitated() && CAN_THEY_SEE(user, target_turf)
 
 /obj/item/disk/vacuum_upgrade
 	name = "vacuum pack upgrade disk"


### PR DESCRIPTION
## About The Pull Request
PORTS: https://github.com/tgstation/tgstation/pull/82767

According to the can_see() code, this user cannot see the clown (and that's sad!)
<img width="526" height="257" alt="323866047-108137e8-dbbf-459f-a223-af34b35e5dc9" src="https://github.com/user-attachments/assets/fa418ac7-92db-484e-bfaf-d7d4c75fd9c1" />
## Why It's Good For The Game
Makes an easier to comprehend define that checks the visibility of a thing
## Changelog
:cl: jlsnow301
fix: Fixed the targeting capability of mobs with full auto
fix: You can now fire the marksman revolver at things you can see
/:cl:
