### PR TITLE
Icebox Service distro fix

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -1344,13 +1344,6 @@
 /obj/effect/landmark/start/bridge_assistant,
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"avU" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/fore)
 "awa" = (
 /turf/open/openspace,
 /area/station/science/ordnance)
@@ -12702,11 +12695,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "dMq" = (
+/obj/machinery/airalarm/directional/north,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark/textured_edge{
-	dir = 4
-	},
-/area/station/security/brig/entrance)
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "dMu" = (
 /obj/machinery/door/airlock/research{
 	name = "Communications Server"
@@ -60764,6 +60757,13 @@
 	},
 /turf/open/floor/stone,
 /area/station/smithing)
+"sEN" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/fore)
 "sEU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
@@ -61919,12 +61919,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/mining,
 /turf/open/floor/iron/smooth,
 /area/mine/eva/lower)
-"tad" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/hallway/primary/starboard)
 "tae" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72222,6 +72216,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
+"wnD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/textured_edge{
+	dir = 4
+	},
+/area/station/security/brig/entrance)
 "wnG" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -77321,8 +77321,6 @@
 /area/station/science/xenobiology)
 "xNk" = (
 /obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
@@ -238422,8 +238420,8 @@ qml
 qml
 qml
 iiH
-dMq
-dMq
+wnD
+wnD
 teP
 fEC
 gMK
@@ -252058,7 +252056,7 @@ kKL
 dCA
 xFj
 xFj
-avU
+sEN
 sEE
 xWM
 hUD
@@ -252326,7 +252324,7 @@ dtb
 pgi
 dtb
 hUD
-tad
+dMq
 rvZ
 lso
 lso


### PR DESCRIPTION
## About The Pull Request

- Northeast station is now connected to the distro
- Removed some doubling cable and pipes into security
closes: #7901
## Why It's Good For The Game
Pipes were unconnected meaning they were nonfunctional, and security seems to have a gimic of being able to sneak a gas specifically into their air supply. However this means it would loop all the way around into the entire station. 

I really ought to change every maps distro so power and pipes run through maintenance primarily than the main halls, but for another time.
## Changelog
:cl:
fix: Icebox Northeast maintence is now connected to distro
fix: Flooding icebox security wont do that to the rest of the station.
/:cl:
