### PR TITLE
[BOUNTY] Space Dragons No Longer Die If They Don't Place a Rift

### DIFF
--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -37,7 +37,6 @@
 		return
 	var/obj/structure/carp_rift/new_rift = new(get_turf(owner))
 	playsound(owner.loc, 'sound/vehicles/rocketlaunch.ogg', 100, TRUE)
-	dragon.riftTimer = -1
 	new_rift.dragon = dragon
 	dragon.rift_list += new_rift
 	to_chat(owner, span_boldwarning("The rift has been summoned. Prevent the crew from destroying it at all costs!"))
@@ -216,7 +215,6 @@
 		if(dragon.rifts_charged != 3 && !dragon.objective_complete)
 			dragon.rift_ability = new()
 			dragon.rift_ability.Grant(dragon.owner.current)
-			dragon.riftTimer = 0
 			dragon.rift_empower()
 		// Early return, nothing to do after this point.
 		return

--- a/code/modules/antagonists/space_dragon/space_dragon.dm
+++ b/code/modules/antagonists/space_dragon/space_dragon.dm
@@ -11,10 +11,6 @@
 	var/list/datum/mind/carp = list()
 	/// The innate ability to summon rifts
 	var/datum/action/innate/summon_rift/rift_ability
-	/// Current time since the the last rift was activated.  If set to -1, does not increment.
-	var/riftTimer = 0
-	/// Maximum amount of time which can pass without a rift before Space Dragon despawns.
-	var/maxRiftTimer = 300
 	/// A list of all of the rifts created by Space Dragon.  Used for setting them all to infinite carp spawn when Space Dragon wins, and removing them when Space Dragon dies.
 	var/list/obj/structure/carp_rift/rift_list = list()
 	/// How many rifts have been successfully charged
@@ -36,7 +32,6 @@
 					It is an empty void, of which our kind was the apex predator, and there was little to rival our claim to this title.\n\
 					But now, we find intruders spread out amongst our claim, willing to fight our teeth with magics unimaginable, their dens like lights flickering in the depths of space.\n\
 					Today, we will snuff out one of those lights.</b>")
-	to_chat(owner, span_boldwarning("You have five minutes to find a safe location to place down the first rift.  If you take longer than five minutes to place a rift, you will be returned from whence you came."))
 	owner.announce_objectives()
 
 /datum/antagonist/space_dragon/forge_objectives()
@@ -132,19 +127,6 @@
 /datum/antagonist/space_dragon/proc/rift_checks()
 	if((rifts_charged == 3 || (SSshuttle.emergency.mode == SHUTTLE_DOCKED && rifts_charged > 0)) && !objective_complete)
 		victory()
-		return
-	if(riftTimer == -1)
-		return
-	riftTimer = min(riftTimer + 1, maxRiftTimer + 1)
-	if(riftTimer == (maxRiftTimer - 60))
-		to_chat(owner.current, span_boldwarning("You have a minute left to summon the rift! Get to it!"))
-		return
-	if(riftTimer >= maxRiftTimer)
-		to_chat(owner.current, span_boldwarning("You've failed to summon the rift in a timely manner! You're being pulled back from whence you came!"))
-		destroy_rifts()
-		SEND_SOUND(owner.current, sound('sound/magic/demon_dies.ogg'))
-		owner.current.death(/* gibbed = */ TRUE)
-		QDEL_NULL(owner.current)
 
 /**
  * Destroys all of Space Dragon's current rifts.
@@ -159,7 +141,6 @@
 	rifts_charged = 0
 	ADD_TRAIT(owner.current, TRAIT_RIFT_FAILURE, REF(src))
 	owner.current.add_movespeed_modifier(/datum/movespeed_modifier/dragon_depression)
-	riftTimer = -1
 	SEND_SOUND(owner.current, sound('sound/vehicles/rocketlaunch.ogg'))
 	for(var/obj/structure/carp_rift/rift as anything in rift_list)
 		rift.dragon = null

--- a/code/modules/unit_tests/dragon_expiration.dm
+++ b/code/modules/unit_tests/dragon_expiration.dm
@@ -11,21 +11,3 @@
 	TEST_ASSERT_EQUAL(to_be_consumed.loc, dragon_time, "The dummy's location, after being successfuly consumed, was not within the space dragon's contents!")
 	dragon_time.death()
 	TEST_ASSERT(isturf(to_be_consumed.loc), "After dying, the space dragon did not eject the consumed dummy content barfer element.")
-
-/// Unit tests that the space dragon - when its rift expires and it gets qdel'd - doesn't delete all the mobs it has eaten
-/datum/unit_test/space_dragon_expiration
-
-/datum/unit_test/space_dragon_expiration/Run()
-	var/mob/living/basic/space_dragon/dragon_time = allocate(/mob/living/basic/space_dragon)
-	var/mob/living/carbon/human/to_be_consumed = allocate(/mob/living/carbon/human/consistent)
-
-	dragon_time.mind_initialize()
-	var/datum/antagonist/space_dragon/dragon_antag_datum = dragon_time.mind.add_antag_datum(/datum/antagonist/space_dragon)
-	dragon_time.eat(to_be_consumed)
-
-	dragon_antag_datum.riftTimer = dragon_antag_datum.maxRiftTimer + 1
-	dragon_antag_datum.rift_checks()
-
-	TEST_ASSERT(QDELETED(dragon_time), "The space dragon wasn't deleted after having its rift timer exceeded!")
-	TEST_ASSERT(!QDELETED(to_be_consumed), "After having its rift timer exceeded, the dragon deleted the dummy instead! The dragon should be dead prior to being deleted!")
-	TEST_ASSERT(isturf(to_be_consumed.loc), "After having its rift timer exceeded, the dragon did not eject the dummy! (Dummy's loc: [to_be_consumed.loc])")

--- a/tools/pull_request_hooks/tests/flakyTestPayloads/invalid_timer.txt
+++ b/tools/pull_request_hooks/tests/flakyTestPayloads/invalid_timer.txt
@@ -1123,9 +1123,6 @@
 2023-11-12T09:04:04.1659906Z ##[group]/datum/unit_test/contents_barfer
 2023-11-12T09:04:04.1881762Z [1;32mPASS[0m /datum/unit_test/contents_barfer 0s
 2023-11-12T09:04:04.1884275Z ##[endgroup]
-2023-11-12T09:04:04.2328534Z ##[group]/datum/unit_test/space_dragon_expiration
-2023-11-12T09:04:04.2672064Z [1;32mPASS[0m /datum/unit_test/space_dragon_expiration 0s
-2023-11-12T09:04:04.2674522Z ##[endgroup]
 2023-11-12T09:04:04.3282341Z ##[group]/datum/unit_test/glass_style_icons
 2023-11-12T09:04:04.3517947Z [1;32mPASS[0m /datum/unit_test/glass_style_icons 0s
 2023-11-12T09:04:04.3520368Z ##[endgroup]


### PR DESCRIPTION
## About The Pull Request

Requested by: LeaveTheCapsuleIfYouDare

Space Dragons No Longer have a 5 minute requirement in order to place a rift.

## Why It's Good For The Game

Gives space dragons the chance to RP or do Gimmicks without constantly having to worry about dying due to their rift timer expiring. Also gives inexperienced players more leniency if they can't find a location due to being in a new or unfamiliar map.

## Changelog

:cl:
del: Space Dragons No Longer Die If They Don't Place a Rift in a 5 Minute Timer
/:cl: