### PR TITLE
Update emergency_hugcage.dmm

### DIFF
--- a/_maps/shuttles/emergency_hugcage.dmm
+++ b/_maps/shuttles/emergency_hugcage.dmm
@@ -205,14 +205,6 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "ys" = (
-/obj/item/bedsheet/random{
-	dir = 4
-	},
-/obj/structure/bed{
-	dir = 1
-	},
-/obj/item/pillow/random,
-/obj/effect/spawner/random/entertainment/plushie_delux,
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
@@ -436,10 +428,10 @@ gc
 pY
 pY
 gc
-kB
 gc
 kB
 gc
+kB
 gc
 pY
 pY
@@ -459,8 +451,8 @@ pY
 gc
 Ag
 QX
+gg
 ys
-QX
 gg
 Ag
 gc


### PR DESCRIPTION

## About The Pull Request
Rearranges the emergency hugbox shuttle so it can actually dock with the station on all doors.
## Why It's Good For The Game
Woes, entire crew through medical
## Changelog
:cl:
mapping: Emergancy Hugbox shuttle now properly docks with the station
/:cl:
