### PR TITLE
Buffs darkspawn tankiness

### DIFF
--- a/code/modules/antagonists/darkspawn/darkspawn_upgrades/passive_upgrades.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_upgrades/passive_upgrades.dm
@@ -61,12 +61,13 @@
 
 /datum/psi_web/stamina_res
 	name = "Vigor Sigils"
-	desc = "Unlocking this sigil halves stamina damage taken."
+	desc = "Unlocking this sigil reduces stamina damage taken by 50%, stacks diminishingly."
 	lore_description = "The Kalak sigils, representing eternity, are etched onto the legs."
 	icon_state = "vigor"
 	willpower_cost = 2
 	menu_tab = STORE_PASSIVE
 	shadow_flags = DARKSPAWN_SCOUT | DARKSPAWN_FIGHTER
+	infinite = TRUE
 
 /datum/psi_web/stamina_res/on_gain()
 	darkspawn.stam_mod *= 0.5
@@ -159,51 +160,51 @@
 //Halves lightburn damage.
 /datum/psi_web/light_resistance
 	name = "Shadowskin Sigil"
-	desc = "Unlocking this sigil reduces light damage taken."
+	desc = "Unlocking this sigil reduces light damage taken by 40%, stacks diminishingly."
 	lore_description = "The Xlynsh sigil, representing refraction, is etched onto the abdomen."
 	icon_state = "shadow_skin"
-	willpower_cost = 2
+	willpower_cost = 3
 	menu_tab = STORE_PASSIVE
 	shadow_flags = DARKSPAWN_FIGHTER
 	infinite = TRUE
 
 /datum/psi_web/light_resistance/on_gain()
-	darkspawn.light_burning *= 0.8
+	darkspawn.light_burning *= 0.6
 
 /datum/psi_web/light_resistance/on_loss()
-	darkspawn.light_burning /= 0.8
+	darkspawn.light_burning /= 0.6
 
 /datum/psi_web/brute_res
 	name = "Callous Sigil"
-	desc = "Unlocking this sigil reduces brute damage taken."
+	desc = "Unlocking this sigil reduces brute damage taken by 40%, stacks diminishingly."
 	lore_description = "The Hh'sha sigil, representing perserverance, is etched onto the abdomen."
 	icon_state = "callous"
-	willpower_cost = 2
+	willpower_cost = 3
 	menu_tab = STORE_PASSIVE
 	shadow_flags = DARKSPAWN_FIGHTER
 	infinite = TRUE
 
 /datum/psi_web/brute_res/on_gain()
-	darkspawn.brute_mod *= 0.8
+	darkspawn.brute_mod *= 0.6
 
 /datum/psi_web/brute_res/on_loss()
-	darkspawn.brute_mod /= 0.8
+	darkspawn.brute_mod /= 0.6
 
 /datum/psi_web/burn_res
 	name = "Stifle Sigil"
-	desc = "Unlocking this sigil reduces burn damage taken."
+	desc = "Unlocking this sigil reduces burn damage taken by 40%, stacks diminishingly."
 	lore_description = "The Khophg sigil, representing suffocation, is etched onto the abdomen."
 	icon_state = "stifle"
-	willpower_cost = 2
+	willpower_cost = 3
 	menu_tab = STORE_PASSIVE
 	shadow_flags = DARKSPAWN_FIGHTER
 	infinite = TRUE
 
 /datum/psi_web/burn_res/on_gain()
-	darkspawn.burn_mod *= 0.85
+	darkspawn.burn_mod *= 0.6
 
 /datum/psi_web/burn_res/on_loss()
-	darkspawn.burn_mod /= 0.85
+	darkspawn.burn_mod /= 0.6
 
 /datum/psi_web/undying
 	name = "Undying Sigils"

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -215,7 +215,8 @@
 	changesource_flags = MIRROR_BADMIN //never put this in the pride pool because they look super valid and can never be changed off of
 	siemens_coeff = 0
 	armor = 10
-	burnmod = 1.2
+	brutemod = 0.8
+	burnmod = 1
 	heatmod = 1.5
 	no_equip_flags = ITEM_SLOT_MASK | ITEM_SLOT_OCLOTHING | ITEM_SLOT_GLOVES | ITEM_SLOT_FEET | ITEM_SLOT_ICLOTHING | ITEM_SLOT_SUITSTORE | ITEM_SLOT_EYES
 	inherent_traits = list(


### PR DESCRIPTION

## About The Pull Request
Apparently yall on monke have some CRAZY 25 damage laser weapons just being tossed around between security members.
Darkspawns on yogs weren't designed with this sort of incoming damage in mind.
makes a couple minor tweaks to ensure time to kill is slightly longer, and hopefully makes the defensive upgrades on fighter actually worth buying
changes some numbers to hopefully make darkspawns live slightly longer when in direct combat

## Why It's Good For The Game
For a big antag like this, time to kill should ideally be at least longer than an average assistant
for the damage reduction passives, i wanted to make them more impactful, but more expensive
so it feels like a more deliberate decision for those that want the survivability

## Changelog

Changed darkspawn species damage mods
-brute 1 -> 0.8
-burn 1.2 -> 1

Changed darkspawn passive upgrades
Stamina reduction
-can now be purchased infinitely
Light damage reduction
-amount 15% -> 40%
-cost 2 -> 3
Burn damage reduction
-amount 15% -> 40%
-cost 2 -> 3
Brute damage reduction
-amount 20% -> 40%
-cost 2 -> 3

also updates the description to properly display the effect of the passives

:cl: Molti
balance: made darkspawns innately slightly tankier
balance: buffed darkspawn damage reduction upgrades
/:cl:

