### PR TITLE
[Code Bounty] Gives CMO advanced tools

### DIFF
--- a/monkestation/code/game/objects/items/storage/medkit.dm
+++ b/monkestation/code/game/objects/items/storage/medkit.dm
@@ -8,8 +8,10 @@
 		/obj/item/stack/medical/mesh = 2,
 		/obj/item/reagent_containers/hypospray/medipen = 1,
 		/obj/item/surgical_drapes = 1,
-		/obj/item/scalpel = 1,
-		/obj/item/hemostat = 1,
-		/obj/item/cautery = 1,
+		/obj/item/scalpel/advanced = 1,
+		/obj/item/retractor/advanced = 1,
+		/obj/item/cautery/advanced = 1,
+		/obj/item/bonesetter = 1,
+		/obj/item/blood_filter = 1,
 	)
 	generate_items_inside(items_inside,src)


### PR DESCRIPTION

## About The Pull Request
Adds advanced surgery tools, bonesetter, and blood filter to CMOs medkit

## Why It's Good For The Game
> If the CE gets free tools without having to research them then I want em too. CMO also has the killing potential of a thousand chemists but only the healing potential of a normal ass medical doctor, since the hypospray is significantly better with poisons than anything.

quoting bounty maker

## Changelog

:cl:
add: CMO's medkit now starts with advanced surgery tools
/:cl:

