### PR TITLE
Updates the issue report message

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -96,7 +96,7 @@
 		local_template = replacetext(local_template, "## Testmerges:\n", "## Testmerges:\n[all_tms_joined]")
 
 	//Collect client info:
-	var/issue_title = input(src, "Please give the issue a title:","Issue Title") as text|null
+	var/issue_title = input(src, "Please give the issue a title, you will be given another textbox to describe it in detail.","Issue Title") as text|null
 	if(!issue_title)
 		return //Consider it aborted
 	var/user_description = input(src, "Please describe the issue you are reporting:","Issue Body") as message|null


### PR DESCRIPTION

## About The Pull Request
Adds an extra little tidbit to the issue report title section, because theres been a fair amount of issues where the entire issue is the title because people didnt realize there was a description box.

OLD:
"Please give the issue a title:"
NEW:
"Please give the issue a title, you will be given another textbox to describe it in detail."
## Why It's Good For The Game
## Changelog
:cl: Tractor Maam
spellcheck: updated the bug report title text to note the existence of the description box that appears immediately after.
/:cl:
