### PR TITLE
Adds a recipe for Positronic Excitement Salts

### DIFF
--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -156,3 +156,8 @@
 		var/obj/item/food/drug/saturnx/new_glob = new(location)
 		new_glob.pixel_x = rand(-6, 6)
 		new_glob.pixel_y = rand(-6, 6)
+
+/datum/chemical_reaction/positronic_excitation_salts
+	results = list(/datum/reagent/drug/methamphetamine/robo = 1)
+	required_reagents = list(/datum/reagent/drug/methamphetamine = 1, /datum/reagent/dinitrogen_plasmide = 1)
+	reaction_tags = REACTION_TAG_DRUG | REACTION_TAG_EASY


### PR DESCRIPTION

## About The Pull Request
dinitrogen plasmide + meth = as much robometh as you used meth
## Why It's Good For The Game
"J1SS13 WE NEED TO COOK J1SS13"
## Changelog
:cl:
add: Combine meth with dinitrogen plasmide to make an equivalent amount of Positronic Excitement Salts (robometh)
/:cl:
