### PR TITLE
Clientless mobs no longer log their emotes

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -145,7 +145,7 @@
 				to_chat(viewer, msg)
 
 	SEND_SIGNAL(user, COMSIG_MOB_EMOTED(key))
-	SSblackbox.record_feedback("tally", "emote_used", 1, name)
+	// SSblackbox.record_feedback("tally", "emote_used", 1, name)
 
 /**
  * For handling emote cooldown, return true to allow the emote to happen.


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/92803

> Prevents mobs without a client from logging their (automated) emotes.

## Why It's Good For The Game

> This spams logs pretty badly, and is most likely undesired assuming from internal discussions.
>
> I don't think that we have player-controlled clientless emotes which cannot be tracked down via TGUI interactions.

## Changelog
:cl: Absolucy, SmArtKar
admin: Clientless mobs no longer log their emotes.
/:cl:
