### PR TITLE
[PORT] Your unarmed attacks are once again blocked even when you're not in combat mode

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1313,7 +1313,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		return
 	if(owner.mind)
 		attacker_style = owner.mind.martial_art
-	if((owner != target) && (owner.istate & ISTATE_HARM) && target.check_shields(owner, 0, owner.name, attack_type = UNARMED_ATTACK))
+	if((owner != target) && target.check_shields(owner, 0, owner.name, attack_type = UNARMED_ATTACK))
 		log_combat(owner, target, "attempted to touch")
 		target.visible_message(span_warning("[owner] attempts to touch [target]!"), \
 						span_danger("[owner] attempts to touch you!"), span_hear("You hear a swoosh!"), COMBAT_MESSAGE_RANGE, owner)


### PR DESCRIPTION
## About The Pull Request

ports https://github.com/tgstation/tgstation/pull/79233

>Currently, not being in combat mode when making an unarmed attack allows you to bypass ALL BLOCKING. All of it. Every single kind of shielding.

>This is now fixed.

## Why It's Good For The Game
bypassing block chance by turning combat mode off is bad
you can actually properly use block chance items now without them getting disarmed

## Changelog
:cl:
fix: (necromanceranne) Every person on the station now no longer has the Tranquility Evades the Shield Pinky Finger Shovegrab unarmed combat technique, an ancient and forbidden strike that allows anyone (literally anyone) to bypass all forms of blocking defense by simply not being in combat mode when they shove or grab their target. As a direct result, the chakra energy of the Spinward Sector has become severely misaligned. Oh well. 
/:cl:
