### PR TITLE
More interaction fixes

### DIFF
--- a/code/game/objects/items/tools/painter/decal_painter.dm
+++ b/code/game/objects/items/tools/painter/decal_painter.dm
@@ -23,12 +23,10 @@
 	. = ..()
 	set_category(GLOB.paintable_decals[1])
 
-/obj/item/airlock_painter/decal/afterattack(atom/interacting_with, mob/living/user, list/modifiers)
-	if(get_dist(user, interacting_with) > 1)
-		return NONE
+/obj/item/airlock_painter/decal/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(isfloorturf(interacting_with) && use_paint(user))
 		paint_floor(interacting_with)
-		return TRUE
+		return ITEM_INTERACT_SUCCESS
 	return NONE
 
 /**

--- a/code/game/objects/structures/janitor.dm
+++ b/code/game/objects/structures/janitor.dm
@@ -33,8 +33,10 @@
 		update_appearance(UPDATE_OVERLAYS)
 		return FALSE // skip attack animation when refilling cart
 	if(istype(weapon, /obj/item/mop))
-		reagents.trans_to(src, weapon.reagents.maximum_volume, transfered_by = user)
+		var/obj/item/mop/attacking_mop = weapon
+		attacking_mop.reagents?.trans_to(src, weapon.reagents.maximum_volume, transfered_by = user)
 		balloon_alert(user, "wring mop")
+		return FALSE
 	return ..()
 
 /obj/structure/mop_bucket/attackby_secondary(obj/item/weapon, mob/user, params)

--- a/code/game/objects/structures/janitor.dm
+++ b/code/game/objects/structures/janitor.dm
@@ -33,8 +33,7 @@
 		update_appearance(UPDATE_OVERLAYS)
 		return FALSE // skip attack animation when refilling cart
 	if(istype(weapon, /obj/item/mop))
-		var/obj/item/mop/attacking_mop = weapon
-		attacking_mop.reagents?.trans_to(src, weapon.reagents.maximum_volume, transfered_by = user)
+		weapon.reagents?.trans_to(src, weapon.reagents.maximum_volume, transfered_by = user)
 		balloon_alert(user, "wring mop")
 		update_appearance(UPDATE_OVERLAYS)
 		return FALSE

--- a/code/game/objects/structures/janitor.dm
+++ b/code/game/objects/structures/janitor.dm
@@ -36,6 +36,7 @@
 		var/obj/item/mop/attacking_mop = weapon
 		attacking_mop.reagents?.trans_to(src, weapon.reagents.maximum_volume, transfered_by = user)
 		balloon_alert(user, "wring mop")
+		update_appearance(UPDATE_OVERLAYS)
 		return FALSE
 	return ..()
 

--- a/monkestation/code/modules/blueshift/items/capacitor.dm
+++ b/monkestation/code/modules/blueshift/items/capacitor.dm
@@ -1,7 +1,7 @@
 /obj/item/stock_parts/capacitor/Initialize(mapload)
 	. = ..()
 
-	RegisterSignal(src, COMSIG_ITEM_ATTACK_OBJ, PROC_REF(install_polarization_controller))
+	RegisterSignal(src, COMSIG_ITEM_ATTACK_ATOM, PROC_REF(install_polarization_controller))
 
 
 /**

--- a/monkestation/code/modules/liquids/liquid_interaction.dm
+++ b/monkestation/code/modules/liquids/liquid_interaction.dm
@@ -16,17 +16,18 @@
 	return ..()
 
 /datum/component/liquids_interaction/RegisterWithParent()
-	RegisterSignal(parent, COMSIG_ITEM_AFTERATTACK, PROC_REF(AfterAttack)) //The only signal allowing item -> turf interaction
+	RegisterSignal(parent, COMSIG_ITEM_INTERACTING_WITH_ATOM, PROC_REF(item_turf_interact))
 
 /datum/component/liquids_interaction/UnregisterFromParent()
-	UnregisterSignal(parent, COMSIG_ITEM_AFTERATTACK)
+	UnregisterSignal(parent, COMSIG_ITEM_INTERACTING_WITH_ATOM)
 
-/datum/component/liquids_interaction/proc/AfterAttack(datum/source, atom/victim, mob/caster, proximity_flag, click_parameters)
+/datum/component/liquids_interaction/proc/item_turf_interact(datum/source, mob/living/user, atom/target, list/modifiers)
 	SIGNAL_HANDLER
-	var/turf/turf_target = victim
+	var/turf/turf_target = target
 
 	if(!isturf(turf_target) || !turf_target.liquids)
 		return NONE
 
-	if(interaction_callback.Invoke(parent, victim, caster, turf_target.liquids))
-		return COMPONENT_CANCEL_ATTACK_CHAIN
+	if(interaction_callback.Invoke(parent, target, user, turf_target.liquids))
+		return ITEM_INTERACT_SUCCESS
+	return NONE


### PR DESCRIPTION

## About The Pull Request

- Fixes decal painter not being able to spray on floors.
- Fixes capacitors not being able to polarize windows.
- Fixes beakers and mops not being able to scoop up liquids off floors.
- Fixes wringing out the mop into a bucket not actually doing anything,
## Why It's Good For The Game
Fixes #7819 and other stuff
## Changelog
:cl: EssentialTomato
fix: Fixed decal painter not being able to spray on floors.
fix: Fixed capacitors not being able to polarize windows.
fix: Fixed beakers and mops not being able to scoop up liquids off floors.
fix: Fixed wringing out the mop into a bucket not actually doing anything,
/:cl:
