### PR TITLE
Fixes some CI failures with space ruins

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -2257,6 +2257,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage)
+"gp" = (
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron/white/textured,
+/area/ruin/space/has_grav/deepstorage/xenobiology)
 "gq" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -3024,6 +3028,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/has_grav/deepstorage/dorm)
+"zv" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/machinery/light/floor/has_bulb,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/deepstorage)
 "Ad" = (
 /obj/machinery/slime_market_pad,
 /obj/machinery/light/directional/north,
@@ -3082,7 +3091,6 @@
 /obj/item/storage/box/beakers/bluespace,
 /obj/item/storage/box/syringes,
 /obj/item/storage/box/syringes,
-/obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/white/textured,
 /area/ruin/space/has_grav/deepstorage/xenobiology)
 "Cf" = (
@@ -3386,12 +3394,6 @@
 /obj/effect/mapping_helpers/airalarm/syndicate_access,
 /turf/open/floor/iron,
 /area/ruin/space/has_grav/deepstorage/dorm)
-"QH" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/table/wood,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/deepstorage)
 "Re" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -4299,7 +4301,7 @@ KZ
 CQ
 sy
 sy
-sy
+gp
 KO
 An
 VY
@@ -4403,7 +4405,7 @@ KZ
 NE
 sy
 sy
-sy
+gp
 UO
 sx
 ml
@@ -4621,8 +4623,8 @@ yQ
 yQ
 tH
 cl
-QH
-cT
+cI
+zv
 fT
 dF
 dV

--- a/_maps/RandomRuins/SpaceRuins/interdyne.dmm
+++ b/_maps/RandomRuins/SpaceRuins/interdyne.dmm
@@ -358,6 +358,7 @@
 "me" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical/old,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/ruin/space/has_grav/interdyne)
 "mf" = (
@@ -915,6 +916,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
+"Jy" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/ruin/space/has_grav/interdyne)
 "JC" = (
 /obj/machinery/door/airlock/hatch,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
@@ -1334,11 +1340,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/interdyne)
-"XD" = (
-/obj/structure/cable,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/iron/smooth,
-/area/ruin/space/has_grav/interdyne)
 "XS" = (
 /obj/machinery/vending/cigarette/syndicate,
 /turf/open/floor/mineral/plastitanium/red,
@@ -1380,6 +1381,7 @@
 /obj/structure/rack,
 /obj/structure/rack,
 /obj/item/storage/medkit/regular,
+/obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/ruin/space/has_grav/interdyne)
 "Zi" = (
@@ -1835,9 +1837,9 @@ nw
 Zi
 dU
 Vp
-EM
+wE
 YB
-oJ
+Jy
 me
 dU
 Zi
@@ -1871,8 +1873,8 @@ Zi
 dU
 Fe
 wE
-XD
-wE
+Ye
+EM
 wE
 li
 fu
@@ -1905,7 +1907,7 @@ qj
 Zi
 dU
 rQ
-EM
+wE
 OW
 iN
 EM

--- a/_maps/shuttles/ruin_pirate_cutter.dmm
+++ b/_maps/shuttles/ruin_pirate_cutter.dmm
@@ -236,12 +236,6 @@
 /obj/item/stack/spacecash/c200,
 /turf/open/floor/iron/dark,
 /area/shuttle/ruin/caravan/pirate)
-"se" = (
-/obj/machinery/light/small/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/shuttle/ruin/caravan/pirate)
 "sR" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -914,7 +908,7 @@ wg
 pR
 xq
 iM
-se
+wg
 ZU
 ti
 Kc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

fixes these test failures:

```
FAILURE #1: The floor light (/obj/machinery/light/floor/has_bulb) obscured by the wooden table (/obj/structure/table/wood) at Deep Storage (169,180,4) at code/modules/unit_tests/floor_lights.dm:21
```
```
FAILURE #1: SMES at Pirate Cutter (75,61,4) has identical input and output powernets at code/modules/unit_tests/smes_connections.dm:12
FAILURE #2: SMES at Interdyne Research Base (213,158,4) has identical input and output powernets at code/modules/unit_tests/smes_connections.dm:12
```

## Why It's Good For The Game

fixes some unit tests

## Changelog

:cl:
map: Fixed some SMES loops in a couple of space ruins.
map: The Deep Storage ruin's xenobiology no longer has a floor light hidden under a table.
/:cl: