### PR TITLE
Update SpacemanDMM suite to 1.11 (#92811)

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -14,7 +14,7 @@ export RUST_G_VERSION=4.0.0
 export NODE_VERSION_LTS=22.11.0
 
 # SpacemanDMM git tag
-export SPACEMAN_DMM_VERSION=suite-1.10
+export SPACEMAN_DMM_VERSION=suite-1.11
 
 # Python version for mapmerge and other tools
 export PYTHON_VERSION=3.9.0


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/92811

Updates `SPACEMAN_DMM_VERSION` to `suite-1.11` in `dependencies.sh`, for the new https://github.com/SpaceManiac/SpacemanDMM/releases/tag/suite-1.11 release

## Why It's Good For The Game

finally... `load_ext`, `for(k,v)`, and `callee.proc.type` support

## Changelog

No user-facing changes.