### PR TITLE
Gives CE an industrial welder

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -93,7 +93,7 @@
 /obj/item/storage/belt/utility/chief/full/PopulateContents()
 	SSwardrobe.provide_type(/obj/item/screwdriver, src)
 	SSwardrobe.provide_type(/obj/item/wrench, src)
-	SSwardrobe.provide_type(/obj/item/weldingtool, src)
+	SSwardrobe.provide_type(/obj/item/weldingtool/largetank, src)
 	SSwardrobe.provide_type(/obj/item/crowbar, src)
 	SSwardrobe.provide_type(/obj/item/wirecutters, src)
 	SSwardrobe.provide_type(/obj/item/multitool, src)


### PR DESCRIPTION

## About The Pull Request
Gives the CE an industrial welder, instead of a normal one
## Why It's Good For The Game
Heads should at least have equipment that isn't worse than their subdepartments
## Changelog
:cl:
balance: Replaced CE's welder with an industrial version
/:cl:
