### PR TITLE
Adjusts some round-start major threat weights

### DIFF
--- a/monkestation/code/modules/assault_ops/code/roundstart_event.dm
+++ b/monkestation/code/modules/assault_ops/code/roundstart_event.dm
@@ -37,7 +37,7 @@
 	min_players = 35
 	roundstart = TRUE
 	earliest_start = 0 SECONDS
-	weight = 4
+	weight = 3
 	max_occurrences = 1
 
 /datum/round_event/antagonist/solo/assault_operative

--- a/monkestation/code/modules/storytellers/converted_events/solo/commando_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/commando_operative.dm
@@ -42,7 +42,7 @@
 	min_players = 40
 	roundstart = TRUE
 	earliest_start = 0 SECONDS
-	weight = 5
+	weight = 4
 	max_occurrences = 1
 	event_icon_state = "nukeops"
 

--- a/monkestation/code/modules/storytellers/converted_events/solo/darkspawn.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/darkspawn.dm
@@ -38,7 +38,7 @@
 	//title_icon = "darkspawn"
 	earliest_start = 0 SECONDS
 	denominator = 25 //slightly more people for additional darkspawns
-	weight = 8
+	weight = 4
 	max_occurrences = 1
 
 /datum/round_event/antagonist/solo/darkspawn

--- a/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
@@ -41,7 +41,7 @@
 	min_players = 35
 	roundstart = TRUE
 	earliest_start = 0 SECONDS
-	weight = 4
+	weight = 3
 	max_occurrences = 3
 	event_icon_state = "nukeops"
 


### PR DESCRIPTION

## About The Pull Request
Adjusts some round-start major threat weights, specifically lowers assault operative and nuclear operative down from 4 to 3, commando from 5 to 4, and darkspawn from 8 (lol?) to 4
## Why It's Good For The Game
Operatives take up a fair amount of round-start major threats, so lowering them will hopefully let other major threats roll in their place. Darkspawn having a weight of 8 is ludicrously high, especially considering they are an antag that is encouraged to be hunted by not just sec, but the rest of the crew as well.
## Changelog
:cl:
balance: Lowered the weight of round-start nukies, ass ops, commando ops, and darkspawn to 3, 3, 4, and 4 respectively. (Down from 4, 4, 5, and 8)
/:cl:
