### PR TITLE
Atom storages adjustments

### DIFF
--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -313,7 +313,7 @@
 	custom_premium_price = PAYCHECK_COMMAND * 6
 	damagetype_healed = HEAL_ALL_DAMAGE
 
-/obj/item/storage/medkit/surgery/Initialize(mapload)
+/obj/item/storage/medkit/advanced/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 8
 	atom_storage.max_total_storage = 16

--- a/code/modules/mob/living/basic/drone/drone_tools.dm
+++ b/code/modules/mob/living/basic/drone/drone_tools.dm
@@ -5,6 +5,7 @@
 	icon_state = "tool_storage"
 	item_flags = ABSTRACT
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
+	w_class = WEIGHT_CLASS_BULKY
 
 /obj/item/storage/drone_tools/Initialize(mapload)
 	. = ..()
@@ -22,7 +23,6 @@
 		/obj/item/analyzer,
 	)
 	atom_storage.max_total_storage = 80
-	atom_storage.max_specific_storage = WEIGHT_CLASS_BULKY
 	atom_storage.max_slots = 18
 	atom_storage.rustle_sound = FALSE
 	atom_storage.set_holdable(cant_hold_list = list(/obj/item/storage/backpack/satchel/flat))


### PR DESCRIPTION

## About The Pull Request

- Advanced medkits can now hold 8 items
- Surgical medkits can now hold 13 items
- Drones inbuilt tools are now actually bulk containers
## Why It's Good For The Game
Advanced medkits when pain was added were given painkillers, however their total capacity was never adjusted to actually be able to hold said items.
Similar story with the recent CMO t2 pr. Meaning as soon as you take a tool out you cant put it back in. The key difference with this and advanced medkits is CMO's surgical kit is functionally same item as the regular kit, just with different items. While advanced medkits functionally are different than regular med kits and suit the name of being advanced.

Finally back in[ Maintencedrone.exe ](https://github.com/Monkestation/Monkestation2.0/pull/6131) I thought I made the drones inbuilt tools able to carry items of larger quanitties, I did not. It was bugged. This fixes that to how the change was intended when it was admin approved.
## Changelog
:cl:
fix: Surgical kits and advanced med kits no longer start with more items than they can normally hold.
fix: Drones inbuilt tools are now properly bulky containers as intended.
/:cl:
