### PR TITLE
Nutshots are prevented by armor

### DIFF
--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1264,7 +1264,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			target.apply_damage(damage * 1.5, attack_type, affecting, armor_block, attack_direction = attack_direction)
 			if(zone == BODY_ZONE_CHEST && user.zone_selected == BODY_ZONE_PRECISE_GROIN && ishuman(target))
 				for(var/obj/item/clothing/iter_clothing in target.get_clothing_on_part(affecting))
-					if(iter_clothing.clothing_flags & THICKMATERIAL)
+					if(iter_clothing.clothing_flags & THICKMATERIAL || iter_clothing.get_armor_rating(MELEE) >= 15)
 						if(iter_clothing.body_parts_covered && BODY_ZONE_PRECISE_GROIN)
 							return TRUE
 				target.sharp_pain(BODY_ZONE_CHEST, 25, BRUTE, 30 SECONDS)


### PR DESCRIPTION

## About The Pull Request
Nutshots are now prevented if the chest has at least 15 melee armor (armor ratting of II)
## Why It's Good For The Game
Doesn't really make sense that nutshots ignore armor, especially considering some decent melee armor (Like sec vests) can block bullets, but not a bare hand.
## Changelog
:cl:
balance: Clothing that covers the chest with an armor rating of at least II now block nut shots
/:cl:
