### PR TITLE
Optical sensors update.

### DIFF
--- a/monkestation/code/modules/surgery/organs/internal/eyes.dm
+++ b/monkestation/code/modules/surgery/organs/internal/eyes.dm
@@ -68,7 +68,7 @@
 	icon_state = "cybernetic_eyeballs"
 	desc = "A very sensitive set of optical sensors, with functionality to toggle a protective film against lights."
 	maxHealth = 1 * STANDARD_ORGAN_THRESHOLD
-	flash_protect = FLASH_PROTECTION_HYPER_SENSITIVE
+	flash_protect = FLASH_PROTECTION_SENSITIVE
 	organ_flags = ORGAN_ROBOTIC | ORGAN_SYNTHETIC_FROM_SPECIES
 	actions_types = list(/datum/action/item_action/organ_action/toggle)
 	var/shielding = FALSE
@@ -103,7 +103,7 @@
  */
 /obj/item/organ/internal/eyes/synth/proc/deactivate(mob/living/carbon/eye_owner = owner)
 	shielding = FALSE
-	flash_protect = FLASH_PROTECTION_HYPER_SENSITIVE
+	flash_protect = FLASH_PROTECTION_SENSITIVE
 	tint = 0
 	to_chat(eye_owner, "The protective film over your optical sensors recedes.")
 


### PR DESCRIPTION
## About The Pull Request

- Optical sensors are flash sensitive, but have a functionality akin to akin to welding goggles, giving a tint and immunity.
- Closes: #8527

- Optical sensors no longer use the snowflake check for conversion.
## Why It's Good For The Game
Optical sensors are almost equivalent to shielded eyes, a cybernetic that needs to be researched, with the only key difference being the EMP effect and having the snowflake protection against flash conversion. Which only exists for a conversion type that no longer exists in blood brothers, and a disabled antagonist, revolutionaries. And better than t2 eyes having said welding protection. All while being printable for both medical and robotics roundstart, and without any research like t2 or shielding eyes.

And instead of a outright replacement of optical sensors for shielded eyes, I thought that was a overall boring choice, when we can add more of a tradeoff to getting optical sensors to shielding eyes by adding what is historically synthetics weakness right next to emp's. Flashes.

Functionally they passively have sensitive eyes. However, they can be toggled to become welding immune, the opposite side of the flash protection spectrum, at the cost of having a tinted vision. Thus being a mechanical tradeoff, and being a option to blind a user if you get the jump on them.

This may be a horrible idea I will admit, but I thought about it in a car ride, and thought it was a neat way to merge what is supposedly silicon's weakness while still granting them the ability to weld themselves to fix wounds.  And to balance a roundstart cybernetic with later researchable options.
## Changelog
:cl:
balance: Optical sensors are now flash sensitive,
balance: Optical sensors now have a toggle gain to welding protection and a tint on their vision.
balance: Optical sensors no longer snowflake checks conversions.
/:cl:
