### PR TITLE
Gives the CMO access to advanced surgeries roundstart

### DIFF
--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -221,7 +221,7 @@
 		/datum/job/chaplain = /obj/item/organ/internal/cyberimp/brain/anti_drop,
 		/datum/job/chemist = /obj/item/organ/internal/liver/cybernetic/tier3,
 		/datum/job/chief_engineer = /obj/item/organ/internal/cyberimp/chest/thrusters,
-		/datum/job/chief_medical_officer = /obj/item/organ/internal/cyberimp/brain/linked_surgery/perfect/nt,
+		/datum/job/chief_medical_officer = /obj/item/organ/internal/cyberimp/arm/item_set/surgery,
 		/datum/job/clown = /obj/item/organ/internal/cyberimp/chest/knockout,
 		/datum/job/cook = /obj/item/organ/internal/cyberimp/arm/item_set/cook,
 		/datum/job/curator = /obj/item/organ/internal/eyes/robotic/glow,

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -83,6 +83,7 @@
 	new /obj/item/defibrillator/compact/loaded(src)
 	new /obj/item/assembly/flash/handheld(src)
 	new /obj/item/autosurgeon/medical_hud(src)
+	new /obj/item/autosurgeon/perfect_serverlink(src) // MONKE EDIT: Adds serverlink implanter
 	new /obj/item/door_remote/chief_medical_officer(src)
 	new /obj/item/clothing/neck/petcollar(src)
 	new /obj/item/pet_carrier(src)

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -134,6 +134,12 @@
 	uses = 1
 	starting_organ = /obj/item/organ/internal/cyberimp/eyes/hud/medical
 
+/obj/item/autosurgeon/perfect_serverlink
+	name = "autosurgeon"
+	desc = "A single use autosurgeon that contains an advanced serverlink augment. A screwdriver can be used to remove it, but implants can't be placed back in."
+	uses = 1
+	starting_organ = /obj/item/organ/internal/cyberimp/brain/linked_surgery/perfect/nt
+
 // monkestation edit start
 /obj/item/autosurgeon/security_hud
 	name = "autosurgeon"


### PR DESCRIPTION

## About The Pull Request
Adds an autosurgeon to the CMO locker which teaches him all the (non blacklisted) surgeries
## Why It's Good For The Game
The CMO is the big boss of doctoring, he should have access to the better surgeries.
## Changelog
:cl:
add: CMO starts with an advanced serverlink in his locker
/:cl:
