### PR TITLE
Grab bag of fixes

### DIFF
--- a/code/datums/components/deployable.dm
+++ b/code/datums/components/deployable.dm
@@ -47,7 +47,7 @@
 	var/turf/deploy_location //Where our deployed_object gets put
 	var/new_direction //What direction do we want our deployed object in
 	if(user)
-		if(!ishuman(user))
+		if(!user.can_perform_action(source, NEED_DEXTERITY))
 			return
 
 		deploy_location = get_step(user, user.dir) //Gets spawn location for thing_to_be_deployed if there is a user

--- a/code/game/objects/structures/janitor.dm
+++ b/code/game/objects/structures/janitor.dm
@@ -33,8 +33,10 @@
 		update_appearance(UPDATE_OVERLAYS)
 		return FALSE // skip attack animation when refilling cart
 	if(istype(weapon, /obj/item/mop))
-		reagents.trans_to(src, weapon.reagents.maximum_volume, transfered_by = user)
+		weapon.reagents?.trans_to(src, weapon.reagents.maximum_volume, transfered_by = user)
 		balloon_alert(user, "wring mop")
+		update_appearance(UPDATE_OVERLAYS)
+		return FALSE
 	return ..()
 
 /obj/structure/mop_bucket/attackby_secondary(obj/item/weapon, mob/user, params)

--- a/code/modules/food_and_drinks/restaurant/_venue.dm
+++ b/code/modules/food_and_drinks/restaurant/_venue.dm
@@ -256,6 +256,7 @@
 
 /obj/item/holosign_creator/robot_seat/attack_self(mob/user)
 	return
+
 /obj/structure/holosign/robot_seat
 	density = FALSE
 	desc = "Used to indicate a place to sit for a robot tourist. I better be careful."
@@ -273,10 +274,11 @@
 /obj/structure/holosign/robot_seat/attack_holosign(mob/living/user, list/modifiers)
 	return
 
-/obj/structure/holosign/robot_seat/attacked_by(obj/item/I, mob/living/user)
-	. = ..()
-	if(I.type == projector?.type && !linked_venue.linked_seats[src])
+/obj/structure/holosign/robot_seat/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(tool.type == projector?.type && !linked_venue.linked_seats[src])
 		qdel(src)
+		return ITEM_INTERACT_SUCCESS
+	return NONE
 
 /obj/structure/holosign/robot_seat/Destroy()
 	linked_venue.linked_seats -= src

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -375,7 +375,7 @@
 				var/amount = round(min(text2num(params["sheets"]), 50, can_smelt_alloy(alloy)))
 				if(amount < 1) //no negative mats
 					return
-				materials.use_materials(alloy.materials, action = "released", name = "sheets")
+				materials.use_materials(alloy.materials, multiplier = amount, action = "released", name = "sheets")
 				var/output
 				if(ispath(alloy.build_path, /obj/item/stack/sheet))
 					output = new alloy.build_path(src, amount)

--- a/code/modules/reagents/reagent_containers/cups/glassbottle.dm
+++ b/code/modules/reagents/reagent_containers/cups/glassbottle.dm
@@ -46,7 +46,7 @@
 	custom_price = PAYCHECK_CREW * 0.9
 
 /obj/item/reagent_containers/cup/glass/bottle/smash(mob/living/target, mob/thrower, ranged = FALSE, break_top)
-	if(bartender_check(target) && ranged)
+	if(bartender_check(target) && ranged && !istype(src, /obj/item/reagent_containers/cup/glass/bottle/molotov))
 		return
 	SplashReagents(target, ranged, override_spillable = TRUE)
 	var/obj/item/broken_bottle/B = new(drop_location())

--- a/monkestation/code/modules/blueshift/items/capacitor.dm
+++ b/monkestation/code/modules/blueshift/items/capacitor.dm
@@ -1,7 +1,7 @@
 /obj/item/stock_parts/capacitor/Initialize(mapload)
 	. = ..()
 
-	RegisterSignal(src, COMSIG_ITEM_ATTACK_OBJ, PROC_REF(install_polarization_controller))
+	RegisterSignal(src, COMSIG_ITEM_ATTACK_ATOM, PROC_REF(install_polarization_controller))
 
 
 /**

--- a/monkestation/code/modules/blueshift/structures/kirbyplants.dm
+++ b/monkestation/code/modules/blueshift/structures/kirbyplants.dm
@@ -15,6 +15,8 @@
 
 	/// Can this plant be trimmed by someone with TRAIT_BONSAI
 	var/trimmable = TRUE
+	// Does the plant have an internal storage
+	var/can_hide_items_in_self = TRUE
 	/// Whether this plant is dead and requires a seed to revive
 	var/dead = FALSE
 	///If it's a special named plant, set this to true to prevent dead-name overriding.
@@ -25,7 +27,8 @@
 
 /obj/item/kirbyplants/Initialize(mapload)
 	. = ..()
-	create_storage(storage_type = /datum/storage/kirbyplants)
+	if(can_hide_items_in_self)
+		create_storage(storage_type = /datum/storage/kirbyplants)
 	AddComponent(/datum/component/tactical)
 	AddComponent(/datum/component/two_handed, require_twohands = TRUE, force_unwielded = 10, force_wielded = 10)
 	AddElement(/datum/element/beauty, 500)
@@ -153,6 +156,7 @@
 	desc = "An old botanical research sample collected on a long forgotten jungle planet."
 	icon_state = "fern"
 	trimmable = FALSE
+	can_hide_items_in_self = FALSE
 
 /obj/item/kirbyplants/fern/Initialize(mapload)
 	. = ..()

--- a/monkestation/code/modules/ranching/items.dm
+++ b/monkestation/code/modules/ranching/items.dm
@@ -232,14 +232,13 @@
 		feed_top.color = "#cacc52"
 	add_overlay(feed_top)
 
-/obj/item/chicken_feed/afterattack(atom/attacked_atom, mob/user)
-	if(!user.Adjacent(attacked_atom))
-		return
-	try_place(attacked_atom)
+/obj/item/chicken_feed/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!isopenturf(interacting_with))
+		return NONE
+	try_place(interacting_with)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/chicken_feed/proc/try_place(atom/target)
-	if(!isopenturf(target))
-		return FALSE
 	var/turf/open/targeted_turf = get_turf(target)
 	var/list/compiled_reagents = list()
 	for(var/datum/reagent/listed_reagent in reagents.reagent_list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Fixes capacitors not being able to polarize windows.
- Fixes wringing out the mop into a bucket not actually doing anything,
- Drones can now deploy flat packed machinery
- Fixes being unable to undo the restaurant seating holosign
- Fixes chicken feed interaction
- Added multiplier to alloy withdrawal https://github.com/tgstation/tgstation/pull/78404
- Molotovs thrown by bartenders now actually break
- Removed storage from the fern plant to make it swabbable

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes:
- #7819 
- #8064 
- #8063 
- #8055 
- #8038 
- #8023 
- #8003 

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: EssentialTomato
fix: Fixed capacitors not being able to polarize windows.
fix: Fixed wringing out the mop into a bucket not actually doing anything,
fix: Drone can now deploy flat packed machinery.
fix: Seating indicator can remove its holosigns again.
fix: Chicken feed can be spread on the ground again.
fix: (jlsnow301) Fixed a resource dupe in the ORM.
fix: Molotovs thrown by bartenders now actually break
fix: Neglected fern can be swabbed for samples again.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
