### PR TITLE
Fixes announcement device.

### DIFF
--- a/monkestation/code/modules/blueshift/items/syndicate.dm
+++ b/monkestation/code/modules/blueshift/items/syndicate.dm
@@ -258,12 +258,9 @@
 		balloon_alert(user, "bad text!")
 		return
 
-	//treat voice
-	var/list/message_data = user.treat_message(input)
-
 	//send
 	priority_announce(
-		text = message_data["message"],
+		text = input,
 		title = title,
 		sound = audio_key,
 		sender_override = origin,


### PR DESCRIPTION

## About The Pull Request
Fixes the announcement device from reading a bad index.
## Why It's Good For The Game
Not sure why the extra step was there for the body of the text, but its gone now. You can announce spam to your hearts content
<img width="648" height="229" alt="image" src="https://github.com/user-attachments/assets/9ae7f40d-1899-4198-b645-f0a6b644e895" />
## Changelog
:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: The 'odd announcement' device, found in opfors, now properly announce instead of runtiming.
/:cl:
