### PR TITLE
Deletes dupe items in blueshield locker on blueshift and delta

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -11017,7 +11017,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/item/clothing/neck/mantle/bsmantle,
 /obj/machinery/duct,
 /obj/structure/closet/secure_closet/blueshield,
 /turf/open/floor/carpet/executive,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -33565,10 +33565,6 @@
 /area/station/service/kitchen/abandoned)
 "hSv" = (
 /obj/structure/closet/secure_closet/blueshield,
-/obj/item/storage/bag/garment/blueshield,
-/obj/item/storage/backpack/satchel/blueshield,
-/obj/item/storage/backpack/duffelbag/blueshield,
-/obj/item/storage/backpack/blueshield,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},


### PR DESCRIPTION

## About The Pull Request
Deletes dupe items in blueshield locker on blueshift and delta
## Why It's Good For The Game
These were just randomly mapped in duplicates, despite them already spawning in the locker.
## Changelog
:cl:
fix: fixed delta and blueshift maps giving the blueshield duplicate items
/:cl:
