### PR TITLE
fix voltaic combat cyberhearts not accepting flux anomalies

### DIFF
--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -131,7 +131,7 @@
 	return owner
 
 /obj/item/organ/internal/heart/cybernetic/anomalock/attackby(obj/item/item, mob/living/user, params)
-	if(!istype(item.type, required_anomaly))
+	if(!istype(item, required_anomaly))
 		return ..()
 	if(core)
 		balloon_alert(user, "core already in!")


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/8135

lol

![2025-09-11 (1757629925)](https://github.com/user-attachments/assets/eab72ede-7df4-459e-acd9-9f85ea8ba0ed)

## Changelog
:cl:
fix: Voltaic Combat Cyberhearts now actually accept flux anomaly cores.
/:cl:
