### PR TITLE
Fixes oozeling burn resistance being applied twice.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
@@ -29,7 +29,6 @@
 	meat = /obj/item/food/meat/slab/human/mutant/slime
 	exotic_bloodtype = /datum/blood_type/slime
 	inert_mutation = /datum/mutation/acid_touch
-	burnmod = 0.6 // = 3/5x generic burn damage
 	coldmod = 6   // = 3x cold damage
 	heatmod = 0.5 // = 1/4x heat damage
 	inherent_factions = list(FACTION_SLIME) //an oozeling wont be eaten by their brethren


### PR DESCRIPTION

## About The Pull Request
Oozeling burn modifier was applied twice, once in their species datum, and another time in their limbs.

## Why It's Good For The Game
Having your burn resistance applied twice is quite overpowered.
## Changelog
:cl:
fix: Fixes oozelings having their burn modifier applied twice.
/:cl:
