### PR TITLE
(hopefully) fix lathe UIs scrolling back to the beginning when printing shit

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -318,7 +318,6 @@
 	var/time_coefficient = design.lathe_time_factor * efficiency_coeff
 	addtimer(CALLBACK(src, PROC_REF(reset_busy)), (30 * time_coefficient * print_quantity) ** 0.5)
 	addtimer(CALLBACK(src, PROC_REF(do_print), design.build_path, print_quantity), (32 * time_coefficient * print_quantity) ** 0.8)
-	update_static_data_for_all_viewers()
 
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request

partial port of https://github.com/tgstation/tgstation/pull/81244

## Changelog
:cl:
fix: (Hopefully) fixed lathe/techfab UIs scrolling back to the beginning when printing shit.
/:cl:
