### PR TITLE
removes anime trait confusion from getting sprayed with water

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -272,7 +272,6 @@
 	var/mob/living/victim = exposed_mob
 	if((methods & (TOUCH|VAPOR)) && !victim.is_pepper_proof() && !HAS_TRAIT(victim, TRAIT_FEARLESS))
 		victim.set_eye_blur_if_lower(3 SECONDS)
-		victim.set_confusion_if_lower(5 SECONDS)
 		if(ishuman(victim))
 			victim.add_mood_event("watersprayed", /datum/mood_event/watersprayed/cat)
 		victim.update_damage_hud()


### PR DESCRIPTION

## About The Pull Request

title

## Why It's Good For The Game

0 cost quirk should NOT have a chance to get you killed

## Changelog
:cl:
del: anime quirk users no longer get confusion from getting sprayed with water
/:cl:

