### PR TITLE
[PORT] Buffs godslayer armor values

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -297,8 +297,8 @@
 
 /datum/armor/cloak_godslayer
 	melee = 70
-	bullet = 50
-	laser = 30
+	bullet = 25
+	laser = 25
 	energy = 40
 	bomb = 50
 	bio = 50


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/92368

## Why It's Good For The Game

> Why the fuck is an armor that you have to fight 2 megafauna (one being the hardest in the game imo) worse than an armor that you have to butcher 3 ice drakes to make. it was straight up just not worth the effort you had to put in to make it, AND it was a downgrade from the standard armor you should have (considering everyone gets drake armor on icebox as a miner)

## Changelog
:cl: Absolucy, kuricityy
balance: Buffs godslayer armor values to be worth the effort you have to put in to getting it.
/:cl:
