### PR TITLE
Make surgical processor accessible in belt

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -263,6 +263,7 @@
 		/obj/item/storage/fancy/cigarettes,
 		/obj/item/storage/pill_bottle,
 		/obj/item/surgical_drapes, //for true paramedics
+		/obj/item/surgical_processor,
 		/obj/item/surgicaldrill,
 		/obj/item/tank/internals/emergency_oxygen,
 		/obj/item/wrench/medical,


### PR DESCRIPTION

## About The Pull Request
Im writing this quickly but I forgot to make it placeable in belts, was in medkits but doctors like belts too. Because noone really reads these send help I am being forced to play fighting games there is so much power creep I am scared my blocks do nothing.
## Why It's Good For The Game
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
## Changelog
:cl:
qol:  Surgical processor is stored in belts also now
/:cl:
