### PR TITLE
Dont worries guys I found a splint for the greys

### DIFF
--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -378,7 +378,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 			SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK)
 			target.Paralyze(knockdown_time * (HAS_TRAIT(target, TRAIT_BATON_RESISTANCE) ? 0.1 : 1))
 			ADD_TRAIT(target, TRAIT_SOFTSPOKEN, type)
-			addtimer(TRAIT_CALLBACK_REMOVE(target, TRAIT_SOFTSPOKEN, type), 15 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+			addtimer(TRAIT_CALLBACK_REMOVE(target, TRAIT_SOFTSPOKEN, type), 14 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		if(BATON_SLEEP)
 			SleepAttack(target,user)
 		if(BATON_CUFF)

--- a/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
+++ b/code/modules/antagonists/abductor/equipment/gear/abductor_items.dm
@@ -131,12 +131,11 @@
 		radio_off_mob(human_target)
 
 /obj/item/abductor/silencer/proc/radio_off_mob(mob/living/carbon/human/target)
-	var/list/all_items = target.get_all_contents()
-
-	for(var/obj/item/radio/radio in all_items)
-		radio.set_listening(FALSE)
-		if(!istype(radio, /obj/item/radio/headset))
-			radio.set_broadcasting(FALSE) //goddamned headset hacks
+	var/list/target_contents = target.get_all_contents() + target
+	for (var/obj/item/radio/radio in target_contents)
+		radio.set_broadcasting(FALSE)
+	for (var/obj/item/bodycam_upgrade/bodycamera in target_contents)
+		bodycamera.turn_off()
 
 /obj/item/abductor/mind_device
 	name = "mental interface device"
@@ -378,6 +377,8 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 			target.set_stutter_if_lower(16 SECONDS)
 			SEND_SIGNAL(target, COMSIG_LIVING_MINOR_SHOCK)
 			target.Paralyze(knockdown_time * (HAS_TRAIT(target, TRAIT_BATON_RESISTANCE) ? 0.1 : 1))
+			ADD_TRAIT(target, TRAIT_SOFTSPOKEN, type)
+			addtimer(TRAIT_CALLBACK_REMOVE(target, TRAIT_SOFTSPOKEN, type), 15 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		if(BATON_SLEEP)
 			SleepAttack(target,user)
 		if(BATON_CUFF)
@@ -406,7 +407,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 			return
 		target.visible_message(span_danger("[user] paralyzes [target] with [src]!"), \
 		span_userdanger("You suddenly feel very drowsy!"))
-		target.Paralyze(sleep_time)
+		target.SetParalyzed(sleep_time)
 		log_combat(user, target, "paralyzed")
 	else
 		if(target.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))


### PR DESCRIPTION

## About The Pull Request

- Abductor Stun mode now applies a corresponding duration of TRAIT_SOFTSPOKEN. To help get the patient initially settled.
- Abductor alien silencers now turn broadcasting off of radios, and disable body cameras, because they didn't before.
- Abductor Paralyze mode now properly establishes the paralyze duration
## Why It's Good For The Game
Screaming for help at max volume can be an issue, so letting them hush the patient for a time while moving or prepping the extraction area can be benifical.
I honestly, thought it would do this but there was a specific check to ignore radio headsets, for... some reason. Anywho all radios are now jammed, and body cameras are disabled also to keep it in line with disruptor waves.
Paralyze now uses set paralyze instead of paralyze to ignore the issues of diminshing stuns, which made the mode almost useless. My bad.
## Changelog
:cl:
add: Abductor Baton sleep mode applies 14 seconds of softspoken, this does not prevent radios.
balance: Abductor Silencers no longer turn off listening on radios, but now will jam all headsets/radios microphones and disable body cameras akin to a disruptor wave.
fix: Abductor Paralyze mode is no longer effected by diminishing returns and instead resets the timer to 60 seconds.
/:cl:
