### PR TITLE
[S] fixes a fuckup that lets ghosts access station comms from centcom

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -23232,6 +23232,7 @@
 /obj/machinery/telecomms/relay/preset/ruskie{
 	banned_frequencies = list(1213,1215,1221,1219,1217);
 	id = "CentCom Offices Relay"
+	on = "0"
 	},
 /turf/open/floor/circuit/green/anim,
 /area/centcom/central_command_areas/adminroom)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

oopsies. turns off that relay. (this is a webedit but it SHOULD work)

## Why It's Good For The Game
bug bad

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: is your telecomms relay running? (the one on centcom isn't anymore)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
