### PR TITLE
DeForest Wallmed slight tweaks

### DIFF
--- a/monkestation/code/modules/blueshift/items/deforest.dm
+++ b/monkestation/code/modules/blueshift/items/deforest.dm
@@ -1123,11 +1123,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/biogenerator/medstation, 29)
 
 /obj/item/wallframe/frontier_medstation/Initialize(mapload, biomass)
 	. = ..()
+	if(isnull(biomass))
+		return
 	stored_biomass = biomass // Preserves stored biomass when deconstructed
 
 /obj/item/wallframe/frontier_medstation/after_attach(obj/attached_to)
 	. = ..()
 	var/obj/machinery/biogenerator/medstation/wall_vendor = attached_to
-	if(!istype(wall_vendor))
+	if(!istype(wall_vendor) || isnull(stored_biomass))
 		return
 	wall_vendor.biomass = stored_biomass


### PR DESCRIPTION

## About The Pull Request
Adjusts the deforest wallmed:
- Fixes being unable to deconstruct it (You can now pick it up with a wrench)
- Deconstructing the wallmed will preserve any stored biomass
- Because of this, I've made it bulky so you can't just have 200 bruise packs in a single normal slot in a backpack
## Why It's Good For The Game
bugfix + slight qol/rebalance
## Changelog
:cl:
fix: You can now deconstruct a deforest wallmed with a wrench
qol: deforest wallmed will preserve biomass when deconstructed
balance: deforest wallmed is now a bulky item
/:cl:
