### PR TITLE
Fixes cyberimp toolset multitool retraction issue when using APC scanner feature

### DIFF
--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -45,9 +45,7 @@
 	return !isitem(storage_holder) || !(user?.istate & (ISTATE_HARM | ISTATE_SECONDARY))
 
 /obj/item/multitool/attack_self(mob/user, list/modifiers)
-	. = ..()
-
-	if(. || !apc_scanner)
+	if(!apc_scanner)
 		return
 
 	if(!COOLDOWN_FINISHED(src, next_apc_scan))

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -20,8 +20,7 @@
 	var/view_check = TRUE
 	var/forensicPrintCount = 0
 
-/obj/item/detective_scanner/interact(mob/user)
-	. = ..()
+/obj/item/detective_scanner/attack_self(mob/user)
 	if(user.stat != CONSCIOUS || !user.can_read(src) || user.is_blind())
 		return
 	ui_interact(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Previously, the attack calls triggered a retraction of the implant multitool when the APC scanner was used (attackself with multitool in hand). Now the multitool only retracts with attackself SECONDARY (since it has a primary use already), which is the intended behaviour for tool arm implants in general. That way, no retraction is called when using the APC scanner, and the implant multitool stays in your hand.

## Why It's Good For The Game
Bug fix, closes secondary issue in #7989.

An additional minor (non game-breaking) issue was discovered during testing, that when the tools are used on an autolathe or protolathe the arm tool apparently attempts to get placed into the autolathe/protolathe, but for the protolathe as the item cannot be dropped (?) the tool disappears, and you can retract and extend the tool again. But for the autolathe the default behaviour is to  "feed the item into the autolathe" (for normal tools, this INSERTS the item back into the autolathe to be recycled). Thankfully, this is not the case for the implant tools, but it does PLACE the implant tool from your hand ONTO the lathe, separating it from your arm. Other hands or mobs, should be able to pick your (cyborg) tool up... But when retraction is called the item disappears so it should hopefully not result in any lasting effects as long as retraction is called. Tldr the minor bugs can be resolved once the user retracts the tool arm as it does not need to be in hand for retraction to occur; the deletion signal gets sent to the tool anyway.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Lawlolawl
fix: Fixed toolset cybernetic implant multitool retraction issue when using APC scanner feature. Hint: use in hand for APC scanning, right-click on the item in hand to retract! (Or use the UI button.)
/:cl:

