### PR TITLE
Synthetic borring chem updates

### DIFF
--- a/monkestation/code/modules/antagonists/borers/code/evolution/evolution_general.dm
+++ b/monkestation/code/modules/antagonists/borers/code/evolution/evolution_general.dm
@@ -56,6 +56,7 @@
 		/datum/reagent/fuel,
 		/datum/reagent/medicine/nanite_slurry,
 		/datum/reagent/medicine/painkiller/robopiates,
+		/datum/reagent/drug/methamphetamine/robo,
 	)
 
 /datum/borer_evolution/synthetic_chems_positive/on_evolve(mob/living/basic/cortical_borer/cortical_owner)

--- a/monkestation/code/modules/antagonists/borers/code/evolution/evolution_general.dm
+++ b/monkestation/code/modules/antagonists/borers/code/evolution/evolution_general.dm
@@ -54,6 +54,8 @@
 		/datum/reagent/medicine/liquid_solder,
 		/datum/reagent/fuel/oil,
 		/datum/reagent/fuel,
+		/datum/reagent/medicine/nanite_slurry,
+		/datum/reagent/medicine/painkiller/robopiates,
 	)
 
 /datum/borer_evolution/synthetic_chems_positive/on_evolve(mob/living/basic/cortical_borer/cortical_owner)
@@ -71,6 +73,7 @@
 		/datum/reagent/thermite,
 		/datum/reagent/pyrosium,
 		/datum/reagent/oxygen,
+		/datum/reagent/medicine/painkiller/robopiates
 	)
 
 /datum/borer_evolution/synthetic_chems_negative/on_evolve(mob/living/basic/cortical_borer/cortical_owner)


### PR DESCRIPTION
## About The Pull Request
Added to synth chems +:
Positronic Neural Dampener
Nanite Slurry
Positronic Excitation Salts

added to synth chems -:
positronic neural dampener
## Why It's Good For The Game
synth boring was basically useless for the symbiote and also the robot being bored
## Changelog
:cl: that one particular vaguely frog adjacent goober
add: the positive synth chems upgrade on borrers now has Positronic Neural Dampener and Nanite Slurry and Positronic Excitation Salts
add: the negative synth chems upgrade on borrers now has Positronic Neural Dampener
/:cl:
