### PR TITLE
Names Brig Physician's Toolbox, well, Brig Physician's Toolbox (typo fix)

### DIFF
--- a/monkestation/code/game/objects/items/storage/toolbox.dm
+++ b/monkestation/code/game/objects/items/storage/toolbox.dm
@@ -1,5 +1,5 @@
 /obj/item/storage/toolbox/brig_physician
-	name = "Brig Phyiscan's Toolbox"
+	name = "Brig Physician's Toolbox"
 	desc = "Capable of robusting and repairing any troublesome robots after the fact."
 	icon_state = "toolbox-brigphys"
 	inhand_icon_state = "toolbox-brigphys"


### PR DESCRIPTION
## About The Pull Request


<img width="418" height="79" alt="image" src="https://github.com/user-attachments/assets/c5622de2-52ce-41bb-951c-d5e5c5bb963c" />


## Why It's Good For The Game
It causes pain when not fixed, proper grammar causes less pain


## Changelog
:cl:
spellcheck: fixed a SINGLE typo in the brigphys' toolbox's name
/:cl:
