### PR TITLE
Color Codes Borers 

### DIFF
--- a/monkestation/code/modules/antagonists/borers/code/evolution/evolution_diveworm.dm
+++ b/monkestation/code/modules/antagonists/borers/code/evolution/evolution_diveworm.dm
@@ -51,6 +51,7 @@
 /datum/borer_evolution/diveworm/expanded_chemicals/on_evolve(mob/living/basic/cortical_borer/cortical_owner)
 	. = ..()
 	cortical_owner.potential_chemicals |= added_chemicals
+	cortical_owner.add_atom_colour(COLOR_RED, FIXED_COLOUR_PRIORITY)
 
 /datum/borer_evolution/diveworm/health_per_level/t2
 	name = "Health Increase II"

--- a/monkestation/code/modules/antagonists/borers/code/evolution/evolution_hivelord.dm
+++ b/monkestation/code/modules/antagonists/borers/code/evolution/evolution_hivelord.dm
@@ -33,6 +33,7 @@
 /datum/borer_evolution/hivelord/movespeed/on_evolve(mob/living/basic/cortical_borer/cortical_owner)
 	. = ..()
 	cortical_owner.add_movespeed_modifier(/datum/movespeed_modifier/borer_speed)
+	cortical_owner.add_atom_colour(COLOR_PURPLE, FIXED_COLOUR_PRIORITY)
 
 // T4
 /datum/borer_evolution/hivelord/stealth_mode

--- a/monkestation/code/modules/antagonists/borers/code/evolution/evolution_symbiote.dm
+++ b/monkestation/code/modules/antagonists/borers/code/evolution/evolution_symbiote.dm
@@ -49,6 +49,7 @@
 /datum/borer_evolution/symbiote/expanded_chemicals/on_evolve(mob/living/basic/cortical_borer/cortical_owner)
 	. = ..()
 	cortical_owner.potential_chemicals |= added_chemicals
+	cortical_owner.add_atom_colour(COLOR_GREEN, FIXED_COLOUR_PRIORITY)
 
 /datum/borer_evolution/symbiote/chem_per_level/t2
 	name = "Chemical Increase II"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Borers that have purchased one of the three mutually exclusive path selection evos are now colored the color of that path
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
as i see it
1. The crew hates getting jumped out of nowhere by diveworms
2. Symbiotes hate getting murdered by diveworm hating crew
3. Hivelords dont exist
this solves all of these problems except for the last one
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: oops froggy did it again
add: Borers that have taken one of the t3 mutually exclusive path upgrades are now colored based on that path. Symbiote is green, dive is red, hive(if it even exists) is purple.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
