### PR TITLE
Virus food is made through heating it now

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -175,10 +175,9 @@
 /datum/chemical_reaction/virus_food
 	results = list(/datum/reagent/consumable/virus_food = 15)
 	required_reagents = list(/datum/reagent/water = 5, /datum/reagent/consumable/milk = 5)
-	is_cold_recipe = TRUE
-	required_temp = 200
-	optimal_temp = 150
-	overheat_temp = 50
+	required_temp = 400
+	optimal_temp = 450
+	overheat_temp = 550
 
 /datum/chemical_reaction/virus_food_mutagen
 	results = list(/datum/reagent/toxin/mutagen/mutagenvirusfood = 1)


### PR DESCRIPTION

## About The Pull Request
Let me lay this out.
Originally, to make virus food, you had to cool it to 200k with water and milk mixed in equal parts.
HOWEVER. water freezes at 274k. and below that, it becomes ice.
Ice and water are not interchangable, so ice cannot be used for the virus food recipe, but virus food requires water at ice temperatures to create. Effectively making this impossible to create.
## Why It's Good For The Game
I want to make virus food and not cry in the event the pathology dispenser is inaccessible/destroyed
## Changelog
:cl: Tractor Maam
fix: Virus Food is no longer impossible to create. As a result, you have to heat it to 400k now instead of cooling it to 200k.
/:cl:
