### PR TITLE
enables `repeated_mode_adjust` for a couple more antags

### DIFF
--- a/monkestation/code/modules/storytellers/converted_events/solo/bloodling.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/bloodling.dm
@@ -5,6 +5,7 @@
 	antag_datum = /datum/antagonist/bloodling
 	typepath = /datum/round_event/antagonist/solo/bloodling
 	shared_occurence_type = SHARED_HIGH_THREAT
+	repeated_mode_adjust = TRUE
 	protected_roles = list(
 		JOB_CAPTAIN,
 		JOB_HEAD_OF_PERSONNEL,

--- a/monkestation/code/modules/storytellers/converted_events/solo/darkspawn.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/darkspawn.dm
@@ -5,6 +5,7 @@
 	antag_datum = /datum/antagonist/darkspawn
 	typepath = /datum/round_event/antagonist/solo/darkspawn
 	shared_occurence_type = SHARED_HIGH_THREAT
+	repeated_mode_adjust = TRUE
 	restricted_roles = list(
 		JOB_AI,
 		JOB_CAPTAIN,

--- a/monkestation/code/modules/storytellers/converted_events/solo/ghosts/wizard.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/ghosts/wizard.dm
@@ -2,6 +2,8 @@
 	name = "Ghost Wizard"
 	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_EXTERNAL, TAG_MAGICAL, TAG_OUTSIDER_ANTAG)
 	typepath = /datum/round_event/antagonist/solo/ghost/wizard
+	shared_occurence_type = SHARED_HIGH_THREAT
+	repeated_mode_adjust = TRUE
 	antag_flag = ROLE_WIZARD
 	antag_datum = /datum/antagonist/wizard
 	restricted_roles = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this makes it so bloodlings, darkspawn, and ghost wizards all have `repeated_mode_adjust = TRUE`, meaning they can't be chained into

## Why It's Good For The Game

consistency. idk too tired to explain this

## Changelog

purely numbers adjustments