### PR TITLE
the Mystic storyteller now actually prefers mystical antags

### DIFF
--- a/code/__DEFINES/~monkestation/storytellers.dm
+++ b/code/__DEFINES/~monkestation/storytellers.dm
@@ -30,6 +30,8 @@
 #define TAG_ALIEN "alien"
 /// When the event is magical in nature
 #define TAG_MAGICAL "magical"
+/// When the event is mundane in nature (complete opposite of the above)
+#define TAG_MUNDANE "mundane"
 
 #define EVENT_TRACK_MUNDANE "Mundane"
 #define EVENT_TRACK_MODERATE "Moderate"

--- a/code/modules/antagonists/pirate/pirate_event.dm
+++ b/code/modules/antagonists/pirate/pirate_event.dm
@@ -15,7 +15,7 @@
 	map_flags = EVENT_SPACE_ONLY
 //monkestation edit start
 	track = EVENT_TRACK_MAJOR
-	tags = list(TAG_COMBAT, TAG_COMMUNAL, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
+	tags = list(TAG_COMBAT, TAG_COMMUNAL, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG, TAG_MUNDANE)
 	checks_antag_cap = TRUE
 	dont_spawn_near_roundend = TRUE
 	repeated_mode_adjust = TRUE

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -141,8 +141,13 @@
 /datum/round_event_control/proc/can_spawn_event(players_amt, allow_magic = FALSE, fake_check = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
 // monkestation start: event groups and storyteller stuff
-	if(SSgamemode.current_storyteller?.disable_distribution || SSgamemode.halted_storyteller)
+	if(SSgamemode.halted_storyteller)
 		return FALSE
+	if(SSgamemode.current_storyteller)
+		if(SSgamemode.current_storyteller.disable_distribution)
+			return FALSE
+		if(!SSgamemode.current_storyteller.can_run_event(src))
+			return FALSE
 	if(dont_spawn_near_roundend && EMERGENCY_PAST_POINT_OF_NO_RETURN)
 		return FALSE
 	if(event_group && !GLOB.event_groups[event_group].can_run())

--- a/monkestation/code/modules/assault_ops/code/midround_event.dm
+++ b/monkestation/code/modules/assault_ops/code/midround_event.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/antagonist/solo/from_ghosts/assault_operative
 	name = "Operative Assault"
-	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
+	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG, TAG_MUNDANE)
 	antag_flag = ROLE_ASSAULT_OPERATIVE
 	antag_datum = /datum/antagonist/assault_operative
 	typepath = /datum/round_event/antagonist/solo/ghost/assault_operative

--- a/monkestation/code/modules/assault_ops/code/roundstart_event.dm
+++ b/monkestation/code/modules/assault_ops/code/roundstart_event.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/antagonist/solo/assault_operative
 	name = "Roundstart Assault Operatives"
-	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
+	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG, TAG_MUNDANE)
 	antag_flag = ROLE_ASSAULT_OPERATIVE
 	antag_datum = /datum/antagonist/assault_operative
 	typepath = /datum/round_event/antagonist/solo/assault_operative

--- a/monkestation/code/modules/storytellers/converted_events/event_overrides.dm
+++ b/monkestation/code/modules/storytellers/converted_events/event_overrides.dm
@@ -12,7 +12,7 @@
 
 /datum/round_event_control/alien_infestation
 	track = EVENT_TRACK_ROLESET
-	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_EXTERNAL, TAG_ALIEN, TAG_OUTSIDER_ANTAG)
+	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_EXTERNAL, TAG_ALIEN, TAG_OUTSIDER_ANTAG, TAG_MUNDANE)
 	checks_antag_cap = TRUE
 	dont_spawn_near_roundend = TRUE
 
@@ -85,7 +85,7 @@
 
 /datum/round_event_control/fugitives
 	track = EVENT_TRACK_MAJOR
-	tags = list(TAG_COMBAT, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
+	tags = list(TAG_COMBAT, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG, TAG_MUNDANE)
 	dont_spawn_near_roundend = TRUE
 
 /datum/round_event_control/gravity_generator_blackout
@@ -228,7 +228,7 @@
 
 /datum/round_event_control/space_ninja
 	track = EVENT_TRACK_ROLESET
-	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
+	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG, TAG_MUNDANE)
 	checks_antag_cap = TRUE
 	dont_spawn_near_roundend = TRUE
 	repeated_mode_adjust = TRUE
@@ -241,7 +241,7 @@
 
 /datum/round_event_control/spider_infestation
 	track = EVENT_TRACK_ROLESET
-	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_EXTERNAL, TAG_ALIEN, TAG_OUTSIDER_ANTAG)
+	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_EXTERNAL, TAG_ALIEN, TAG_OUTSIDER_ANTAG, TAG_MUNDANE)
 	checks_antag_cap = TRUE
 	dont_spawn_near_roundend = TRUE
 
@@ -281,7 +281,7 @@
 	tags = list(TAG_COMMUNAL)
 
 /datum/round_event_control/antagonist/solo/from_ghosts/alien_infestation
-	tags = list(TAG_COMBAT, TAG_ALIEN, TAG_DESTRUCTIVE, TAG_TEAM_ANTAG)
+	tags = list(TAG_COMBAT, TAG_ALIEN, TAG_DESTRUCTIVE, TAG_TEAM_ANTAG, TAG_MUNDANE)
 	repeated_mode_adjust = TRUE
 
 /datum/round_event_control/dark_matteor

--- a/monkestation/code/modules/storytellers/converted_events/solo/brother.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/brother.dm
@@ -3,7 +3,7 @@
 	antag_flag = ROLE_BROTHER
 	antag_datum = /datum/antagonist/brother
 	typepath = /datum/round_event/antagonist/solo/brother
-	tags = list(TAG_COMBAT, TAG_TEAM_ANTAG, TAG_CREW_ANTAG)
+	tags = list(TAG_COMBAT, TAG_TEAM_ANTAG, TAG_CREW_ANTAG, TAG_MUNDANE)
 	cost = 0.45 // so it doesn't eat up threat for a relatively low-threat antag
 	weight = 10
 	required_enemies = 1

--- a/monkestation/code/modules/storytellers/converted_events/solo/clown_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/clown_operative.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/antagonist/solo/nuclear_operative/clown
 	name = "Roundstart Clown Operative"
-	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
+	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG, TAG_MUNDANE)
 	antag_flag = ROLE_CLOWN_OPERATIVE
 	antag_datum = /datum/antagonist/nukeop/clownop
 	typepath = /datum/round_event/antagonist/solo/nuclear_operative/clown

--- a/monkestation/code/modules/storytellers/converted_events/solo/commando_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/commando_operative.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/antagonist/solo/commando_operative
 	name = "Roundstart Commando Operative"
-	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
+	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG, TAG_MUNDANE)
 	antag_flag = ROLE_COMMANDO_OPERATIVE
 	antag_datum = /datum/antagonist/nukeop/commando
 	typepath = /datum/round_event/antagonist/solo/commando_operative

--- a/monkestation/code/modules/storytellers/converted_events/solo/ghosts/nuclear_operative_ghost.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/ghosts/nuclear_operative_ghost.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/antagonist/solo/from_ghosts/nuclear_operative
 	name = "Nuclear Assault"
-	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
+	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG, TAG_MUNDANE)
 	antag_flag = ROLE_OPERATIVE_MIDROUND
 	antag_datum = /datum/antagonist/nukeop
 	typepath = /datum/round_event/antagonist/solo/ghost/nuclear_operative

--- a/monkestation/code/modules/storytellers/converted_events/solo/malf.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/malf.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/antagonist/solo/malf
 	antag_datum = /datum/antagonist/malf_ai
-	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_ALIEN, TAG_CREW_ANTAG) //not exactly alien but close enough / Not actually crew but is part of the initial staff
+	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_ALIEN, TAG_CREW_ANTAG, TAG_MUNDANE) //not exactly alien but close enough / Not actually crew but is part of the initial staff
 	antag_flag = ROLE_MALF
 	enemy_roles = list(
 		JOB_CHEMIST,

--- a/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/nuclear_operative.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/antagonist/solo/nuclear_operative
 	name = "Roundstart Nuclear Operative"
-	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG)
+	tags = list(TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_EXTERNAL, TAG_OUTSIDER_ANTAG, TAG_MUNDANE)
 	antag_flag = ROLE_OPERATIVE
 	antag_datum = /datum/antagonist/nukeop
 	typepath = /datum/round_event/antagonist/solo/nuclear_operative

--- a/monkestation/code/modules/storytellers/converted_events/solo/obsessed.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/obsessed.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/antagonist/solo/obsessed
 	antag_flag = ROLE_OBSESSED
-	tags = list(TAG_COMBAT, TAG_TARGETED, TAG_CREW_ANTAG)
+	tags = list(TAG_COMBAT, TAG_TARGETED, TAG_CREW_ANTAG, TAG_MUNDANE)
 	antag_datum = /datum/antagonist/obsessed
 	typepath = /datum/round_event/antagonist/solo/obsessed
 	restricted_roles = list(

--- a/monkestation/code/modules/storytellers/converted_events/solo/revolutionary.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/revolutionary.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/antagonist/solo/revolutionary
 	name = "Roundstart Revolution"
-	tags = list(TAG_COMMUNAL, TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_CREW_ANTAG)
+	tags = list(TAG_COMMUNAL, TAG_DESTRUCTIVE, TAG_COMBAT, TAG_TEAM_ANTAG, TAG_CREW_ANTAG, TAG_MUNDANE)
 	antag_flag = ROLE_REV_HEAD
 	antag_datum = /datum/antagonist/rev/head/event_trigger
 	typepath = /datum/round_event/antagonist/solo/revolutionary

--- a/monkestation/code/modules/storytellers/converted_events/solo/traitor.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/traitor.dm
@@ -1,6 +1,6 @@
 /datum/round_event_control/antagonist/solo/traitor
 	antag_flag = ROLE_SYNDICATE_INFILTRATOR
-	tags = list(TAG_COMBAT, TAG_CREW_ANTAG)
+	tags = list(TAG_COMBAT, TAG_CREW_ANTAG, TAG_MUNDANE)
 	antag_datum = /datum/antagonist/traitor/infiltrator
 	protected_roles = list(
 		JOB_CAPTAIN,

--- a/monkestation/code/modules/storytellers/storytellers/_storyteller.dm
+++ b/monkestation/code/modules/storytellers/storytellers/_storyteller.dm
@@ -205,6 +205,10 @@
 		/// Write it
 		event.calculated_weight = weight_total
 
+/// Extra storyteller-specific checks for if an event can run or not.
+/datum/storyteller/proc/can_run_event(datum/round_event_control/event)
+	return TRUE
+
 /datum/storyteller/guide
 	name = "The Guide"
 	desc = "The Guide will provide a balanced and varied experience. Consider this the default experience."

--- a/monkestation/code/modules/storytellers/storytellers/mystic.dm
+++ b/monkestation/code/modules/storytellers/storytellers/mystic.dm
@@ -1,6 +1,12 @@
 /datum/storyteller/mystic
 	name = "The Mystic"
 	desc = "The Mystic gives events from beyond the veil, some of which may even be magic in nature."
-	tag_multipliers = list(TAG_SPOOKY = 1.2, TAG_MAGICAL = 1.5, TAG_SPACE = 1.1)
+	tag_multipliers = list(TAG_SPOOKY = 1.2, TAG_MAGICAL = 1.5, TAG_SPACE = 1.1, TAG_MUNDANE = 0.4)
 	weight = 2
 	population_min = 40 //all current magic antags are very murder and/or pop-based (eg: cult, wizard, heretic) change if we get less murdery magic antags
+
+// do NOT run any mundane antags roundstart at all.
+/datum/storyteller/mystic/can_run_event(datum/round_event_control/event)
+	if(event.roundstart && (TAG_MUNDANE in event.tags))
+		return FALSE
+	return TRUE

--- a/monkestation/code/modules/virology/disease/plague_rat/event.dm
+++ b/monkestation/code/modules/virology/disease/plague_rat/event.dm
@@ -11,7 +11,7 @@
 	description = "Spawns a horde of plague rats."
 	min_wizard_trigger_potency = 6
 	max_wizard_trigger_potency = 7
-	tags = list(TAG_OUTSIDER_ANTAG, TAG_COMMUNAL, TAG_COMBAT, TAG_ALIEN)
+	tags = list(TAG_OUTSIDER_ANTAG, TAG_COMMUNAL, TAG_COMBAT, TAG_ALIEN, TAG_MUNDANE)
 	dont_spawn_near_roundend = TRUE
 
 /datum/round_event/ghost_role/plague_rat


### PR DESCRIPTION

## About The Pull Request

this makes some changes to the Mystic storyteller, and laying some code groundwork for some more storyteller stuff:
- `TAG_MUNDANE` added for mundane antags (traitors, BBs, nukies, etc), Mystic now has a 0.4x multiplier for those
- the Mystic will NEVER run any roundstart event that has `TAG_MUNDANE`
  - the fact it has a min pop of 40 should ensure at least one eligible event always has enough pop to run
- added support for storytellers to have additional checks for if an event can run, used for the above

## Why It's Good For The Game

because it's stupid seeing "Storyteller: The Mystic" and then there's just like 5 traitors lmao

## Changelog
:cl:
balance: The Mystic storyteller now actually prefers mystical antags - it will NEVER spawn "mundane" antags roundstart, and is heavily weighted against them for midrounds.
/:cl:
