### PR TITLE
Makes the lava staff useful for terraforming lavaland

### DIFF
--- a/code/__DEFINES/do_afters.dm
+++ b/code/__DEFINES/do_afters.dm
@@ -10,3 +10,4 @@
 #define DOAFTER_SOURCE_SEED_MESH "doafter_seed_mesh"
 /* #define DOAFTER_SOURCE_ATM "doafter_atm" */
 #define DOAFTER_SOURCE_EXTINGUISHING_HUG "doafter_extinguishing_hug"
+#define DOAFTER_SOURCE_LAVA_STAFF "doafter_lava_staff"

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -797,7 +797,8 @@
 	var/create_cooldown = 10 SECONDS
 	var/create_delay = 3 SECONDS
 	var/reset_cooldown = 5 SECONDS
-	var/timer = 0
+	/// Cooldown for when this can be used again.
+	COOLDOWN_DECLARE(next_use)
 	var/static/list/banned_turfs = typecacheof(list(/turf/open/space/transit, /turf/closed))
 
 /obj/item/lava_staff/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
@@ -806,43 +807,56 @@
 	return ranged_interact_with_atom(interacting_with, user, modifiers)
 
 /obj/item/lava_staff/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
-	if(timer > world.time)
+	if(!COOLDOWN_FINISHED(src, next_use))
+		to_chat(user, span_warning("Wait [DisplayTimeText(COOLDOWN_TIMELEFT(src, next_use))] before using \the [src] again!"))
 		return NONE
-	if(is_type_in_typecache(interacting_with, banned_turfs))
+	if(DOING_INTERACTION(user, DOAFTER_SOURCE_LAVA_STAFF))
+		to_chat(user, span_warning("You're already using \the [src]!"))
 		return NONE
-	if(!(interacting_with in view(user.client.view, get_turf(user))))
+	var/turf/target_turf = get_turf(interacting_with)
+	if(!isopenturf(target_turf) || is_type_in_typecache(target_turf, banned_turfs))
 		return NONE
-	var/turf/open/T = get_turf(interacting_with)
-	if(!istype(T))
+	if(!(target_turf in view(user.client.view, get_turf(user))))
 		return NONE
-	if(!islava(T))
-		var/obj/effect/temp_visual/lavastaff/L = new /obj/effect/temp_visual/lavastaff(T)
-		L.alpha = 0
-		animate(L, alpha = 255, time = create_delay)
-		user.visible_message(span_danger("[user] points [src] at [T]!"))
-		timer = world.time + create_delay + 1
-		if(do_after(user, create_delay, target = T))
-			var/old_name = T.name
-			if(T.TerraformTurf(turf_type, flags = CHANGETURF_INHERIT_AIR))
-				user.visible_message(span_danger("[user] turns \the [old_name] into [transform_string]!"))
-				message_admins("[ADMIN_LOOKUPFLW(user)] fired the lava staff at [ADMIN_VERBOSEJMP(T)]")
-				user.log_message("fired the lava staff at [AREACOORD(T)].", LOG_ATTACK)
-				timer = world.time + create_cooldown
-				playsound(T,'sound/magic/fireball.ogg', 200, TRUE)
-		else
-			timer = world.time
-		qdel(L)
+	if(islava(target_turf))
+		remove_lava(user, target_turf)
 	else
-		var/old_name = T.name
-		if(T.TerraformTurf(reset_turf_type, flags = CHANGETURF_INHERIT_AIR))
-			user.visible_message(span_danger("[user] turns \the [old_name] into [reset_string]!"))
-			timer = world.time + reset_cooldown
-			playsound(T,'sound/magic/fireball.ogg', 200, TRUE)
+		create_lava(user, target_turf)
 	return ITEM_INTERACT_SUCCESS
+
+/obj/item/lava_staff/proc/create_lava(mob/living/user, turf/open/target)
+	var/obj/effect/temp_visual/lavastaff/lava_visual = new(target)
+	animate(lava_visual, alpha = 255, time = create_delay)
+	user.visible_message(span_danger("[user] points [src] at [target]!"))
+	if(do_after(user, create_delay, target, interaction_key = DOAFTER_SOURCE_LAVA_STAFF))
+		var/old_name = target.name
+		if(target.TerraformTurf(turf_type, flags = CHANGETURF_INHERIT_AIR))
+			// 2x faster on lavaland
+			var/cooldown = create_cooldown
+			if(is_mining_level(target.z))
+				cooldown *= 0.5
+			COOLDOWN_START(src, next_use, cooldown)
+			user.visible_message(span_danger("[user] turns \the [old_name] into [transform_string]!"))
+			message_admins("[ADMIN_LOOKUPFLW(user)] fired the lava staff at [ADMIN_VERBOSEJMP(target)]")
+			user.log_message("fired the lava staff at [AREACOORD(target)].", LOG_ATTACK)
+			playsound(target, 'sound/magic/fireball.ogg', vol = 200, vary = TRUE)
+	qdel(lava_visual)
+
+/obj/item/lava_staff/proc/remove_lava(mob/living/user, turf/open/lava/target)
+	var/old_name = target.name
+	if(target.TerraformTurf(reset_turf_type, flags = CHANGETURF_INHERIT_AIR))
+		// reset cooldown is 10x faster on lavaland!
+		var/cooldown = reset_cooldown
+		if(is_mining_level(target.z))
+			cooldown *= 0.1
+		COOLDOWN_START(src, next_use, cooldown)
+		user.visible_message(span_danger("[user] turns \the [old_name] into [reset_string]!"))
+		playsound(target, 'sound/magic/fireball.ogg', vol = 200, vary = TRUE)
 
 /obj/effect/temp_visual/lavastaff
 	icon_state = "lavastaff_warn"
-	duration = 50
+	duration = 5 SECONDS
+	alpha = 0 // animated upon creation
 
 /turf/open/lava/smooth/weak
 	lava_damage = 10


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this makes it so that the lava staff's cooldowns are reduced on lavaland: 10 -> 5 seconds to create lava, 5 -> 0.5 seconds to remove lava.

cooldowns outside of lavaland are unaffected.

also cleaned up the code a bit.

## Why It's Good For The Game

usually the lava staff is really only used to like, put lava underneath doors and such, so this gives it more of a proper _utility_ use too.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: The cooldowns for using the lava staff are now heavily reduce on lavaland, making it far more viable to use the staff to terraform lavaland with it.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
