### PR TITLE
Adds random critical hits to entrenching tools

### DIFF
--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -195,6 +195,10 @@
 	attack_verb_continuous = list("bashes", "bludgeons", "thrashes", "whacks")
 	attack_verb_simple = list("bash", "bludgeon", "thrash", "whack")
 	wound_bonus = 10
+	/// Percent chance for a critical hit.
+	var/crit_chance = 3
+	/// How much the force is multiplied by during a critical hit.
+	var/crit_multiplier = 3
 
 /obj/item/trench_tool/get_all_tool_behaviours()
 	return list(TOOL_MINING, TOOL_SHOVEL, TOOL_WRENCH)
@@ -207,7 +211,10 @@
 	. = ..()
 	. += span_notice("Use in hand to switch configuration.")
 	. += span_notice("It functions as a [tool_behaviour] tool.")
-	. += span_danger("<i>This weapon has no random critical hits.</i>")
+	if(crit_chance > 0)
+		. += span_danger("<i>This weapon has random critical hits!</i>")
+	else
+		. += span_danger("<i>This weapon has no random critical hits.</i>")
 
 /obj/item/trench_tool/update_icon_state()
 	. = ..()
@@ -218,6 +225,14 @@
 			icon_state = inhand_icon_state = "[initial(icon_state)]_shovel"
 		if(TOOL_MINING)
 			icon_state = inhand_icon_state = "[initial(icon_state)]_pick"
+
+/obj/item/trench_tool/attack(mob/living/target_mob, mob/living/user, list/modifiers, list/attack_modifiers)
+	var/old_force = force
+	if(isliving(target_mob) && target_mob.stat < DEAD && prob(crit_chance))
+		force *= crit_multiplier
+		target_mob.balloon_alert(user, "critical hit!")
+	. = ..()
+	force = old_force
 
 /obj/item/trench_tool/attack_self(mob/user, modifiers)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this makes it so the entrenching tool has a % chance to do extra damage each time it hits a living mob.

currently, it's a 3% chance per hit for 3x. numbers can be easily tweaked.

## Why It's Good For The Game

why would the examine say "_This weapon has no random critical hits._" if they didn't want coders to add random critical hits?

space fortress two

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: The entrenching tool now actually does random critical hits. Enjoy.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
