### PR TITLE
[QOL] [FIX] Adds a preference toggle for spinning and flipping making stacks of hats come off. Adds another way to disassemble hat stacks. Fixes some minor description bugs with stacks of hats.

### DIFF
--- a/code/modules/client/preferences/spin_flip_hats.dm
+++ b/code/modules/client/preferences/spin_flip_hats.dm
@@ -1,0 +1,6 @@
+/// When toggled, spinning and flipping will cause you to lose all stacked hats.
+/datum/preference/toggle/spin_flip_hats
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	default_value = TRUE
+	savefile_key = "spin_flip_hats"
+	savefile_identifier = PREFERENCE_PLAYER

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -94,7 +94,7 @@
 			var/mob/living/carbon/hat_loser = user
 			if(hat_loser.head)
 				var/obj/item/clothing/head/worn_headwear = hat_loser.head
-				if(worn_headwear.contents.len)
+				if(worn_headwear.contents.len && L.client?.prefs?.read_preference(/datum/preference/toggle/spin_flip_hats))
 					worn_headwear.throw_hats(rand(2,3), get_turf(hat_loser), hat_loser)
 
 /datum/emote/flip/check_cooldown(mob/user, intentional)
@@ -136,7 +136,7 @@
 				var/mob/living/carbon/hat_loser = user
 				if(hat_loser.head)
 					var/obj/item/clothing/head/worn_headwear = hat_loser.head
-					if(worn_headwear.contents.len)
+					if(worn_headwear.contents.len && L.client?.prefs?.read_preference(/datum/preference/toggle/spin_flip_hats))
 						worn_headwear.throw_hats(rand(1,2), get_turf(hat_loser), hat_loser)
 
 /datum/emote/spin/check_cooldown(mob/living/carbon/user, intentional)

--- a/monkestation/code/modules/clothing/head/misc.dm
+++ b/monkestation/code/modules/clothing/head/misc.dm
@@ -24,6 +24,15 @@
 	else
 		. = ..()
 
+/obj/item/clothing/head/attack_self(mob/user, modifiers)
+	if(length(contents) > 0)
+		for (var/obj/item/clothing/head/hat in contents)
+			hat.forceMove(get_turf(user))
+			hat.restore_initial()
+
+		to_chat(user, span_warning("You take apart the pile of hats."))
+		update_hats(NONE, user)
+
 
 /obj/item/clothing/head/verb/detach_stacked_hat()
 	set name = "Remove Stacked Hat"
@@ -45,6 +54,7 @@
 			break
 		throwing_hat.forceMove(wearer_location)
 		throwing_hat.throw_at(destination, rand(1, 4), 10)
+		throwing_hat.restore_initial()
 		hat_count--
 	update_hats(NONE, user)
 	if(user)
@@ -59,7 +69,38 @@
 
 	cut_overlays()
 
-	if(length(contents))
+	switch(length(contents)) //Section for naming/description
+		if(0)
+			restore_initial()
+			remove_verb(user, /obj/item/clothing/head/verb/detach_stacked_hat)
+		if (1,2)
+			name = "Pile of Hats"
+			desc = "A meagre pile of hats"
+		if (3)
+			name = "Stack of Hats"
+			desc = "A decent stack of hats"
+		if(5,6)
+			name = "Towering Pillar of Hats"
+			desc = "A magnificent display of pride and wealth"
+		if(7,8)
+			name = "A Dangerous Amount of Hats"
+			desc = "A truly grand tower of hats"
+		if(9,10)
+			name = "A Lesser Hatularity"
+			desc = "A tower approaching unstable levels of hats"
+		if(11,12,13,14,15)
+			name = "A Hatularity"
+			desc = "A tower that has grown far too powerful"
+		if(16,17,18,19)
+			name = "A Greater Hatularity"
+			desc = "A monument to the madness of man"
+		if(20)
+			name = "The True Hat Tower"
+			desc = "<span class='narsiesmall'>AFTER NINE YEARS IN DEVELOPMENT, HOPEFULLY IT WILL HAVE BEEN WORTH THE WAIT</span>"
+
+	if(length(contents) > 0)
+		desc += "<BR>You can use it in hand to separate all the hats."
+
 		//This section prepares the in-hand and on-ground icon states for the hats.
 		var/current_hat = 1
 		for(var/obj/item/clothing/head/selected_hat in contents)
@@ -75,39 +116,8 @@
 
 		add_verb(user, /obj/item/clothing/head/verb/detach_stacked_hat) //Verb for removing hats.
 
-		switch(length(contents)) //Section for naming/description
-			if(0)
-				name = initial(name)
-				desc = initial(desc)
-				remove_verb(user, /obj/item/clothing/head/verb/detach_stacked_hat)
-			if (1,2)
-				name = "Pile of Hats"
-				desc = "A meagre pile of hats"
-			if (3)
-				name = "Stack of Hats"
-				desc = "A decent stack of hats"
-			if(5,6)
-				name = "Towering Pillar of Hats"
-				desc = "A magnificent display of pride and wealth"
-			if(7,8)
-				name = "A Dangerous Amount of Hats"
-				desc = "A truly grand tower of hats"
-			if(9,10)
-				name = "A Lesser Hatularity"
-				desc = "A tower approaching unstable levels of hats"
-			if(11,12,13,14,15)
-				name = "A Hatularity"
-				desc = "A tower that has grown far too powerful"
-			if(16,17,18,19)
-				name = "A Greater Hatularity"
-				desc = "A monument to the madness of man"
-			if(20)
-				name = "The True Hat Tower"
-				desc = "<span class='narsiesmall'>AFTER NINE YEARS IN DEVELOPMENT, HOPEFULLY IT WILL HAVE BEEN WORTH THE WAIT</span>"
-
 	worn_overlays() //This is where the actual worn icon is generated
 	user.update_worn_head() //Regenerate the wearer's head appearance so that they have real-time hat updates.
-
 
 #undef HAT_CAP
 #undef ADD_HAT

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3765,6 +3765,7 @@
 #include "code\modules\client\preferences\skin_tone.dm"
 #include "code\modules\client\preferences\sounds.dm"
 #include "code\modules\client\preferences\species.dm"
+#include "code\modules\client\preferences\spin_flip_hats.dm"
 #include "code\modules\client\preferences\statpanel.dm"
 #include "code\modules\client\preferences\tgui.dm"
 #include "code\modules\client\preferences\tooltips.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/spin_flip_hats.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/spin_flip_hats.tsx
@@ -1,0 +1,12 @@
+import { multiline } from 'common/string';
+import { CheckboxInput, FeatureToggle } from '../base';
+
+export const spin_flip_hats: FeatureToggle = {
+  name: 'Lose hat stacks when spinning or flipping',
+  category: 'GAMEPLAY',
+  description: multiline`
+    When on, you will lose any stacked hats when you use the *spin or *flip emotes.
+    When off, disables this behavior.
+  `,
+  component: CheckboxInput,
+};


### PR DESCRIPTION
## About The Pull Request

Adds a preference toggle for whether or not spinning and flipping should make stacked hats come off. Default is ON, like on live. 

Adds the ability to disassemble a stack of hats by using them in hand with Z. (Also adds it to the description of stacks of hats- this is a lot more intuitive than having to use the secret shift+right-click verb, or spin/flipping).

Fixes some bugs with hats not updating their name and description correctly when removed from a stack of hats.

## Why It's Good For The Game

As a chronic lover of spinning and flipping, I am very frequently annoyed by my beautiful stacks of hats coming off. Especially when I overslot my modsuit over my hat and have to MAKE AN ACTIVE EFFORT TO RESTRAIN MYSELF from hitting my beloved spin and flip keybinds, lest my hat be lost to space forever. For too long have us spin-flip-clappers been oppressed. Now we can enjoy our love of spin flipping with our beautiful stacks of hats in peace. 

Also bug fixes are good.

## Changelog

:cl:
qol: Adds a pref toggle for spinning & flipping making stacks of hats come off. Default is on.
qol: Adds the ability to disassemble stacks of hats by using them in hand with Z.
fix: Fixes some bugs with hats not updating their name and description correctly when removed from a stack of hats.
/:cl: