### PR TITLE
[PORT] Caps the eyeblur caused through apply_effects()

### DIFF
--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -275,7 +275,7 @@
 	if(drowsy)
 		adjust_drowsiness(drowsy)
 	if(eyeblur)
-		adjust_eye_blur(eyeblur)
+		adjust_eye_blur_up_to(eyeblur, eyeblur)
 	if(jitter && !check_stun_immunity(CANSTUN))
 		adjust_jitter(jitter)
 	if(slur)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -275,7 +275,7 @@
 	if(drowsy)
 		adjust_drowsiness(drowsy)
 	if(eyeblur)
-		adjust_eye_blur_up_to(eyeblur, eyeblur)
+		set_eye_blur_if_lower(eyeblur)
 	if(jitter && !check_stun_immunity(CANSTUN))
 		adjust_jitter(jitter)
 	if(slur)


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/90982

> `apply_effects()` cannot have its eyeblur exceed its applied timer.

## Why It's Good For The Game

> This can scale near infinitely and cause _problems_ depending on what source is using `apply_effect()`. That happens to be pretty much only projectiles so this basically keeps some projectiles from blinding you due to how spammy they are.

also some of the comments on the original PR sum it up pretty well:
> finally the shotgun disabler will no longer blind me for half the shift

> gone are the days of being blind for 15 minutes because security thinks it's funny to spam disabler shots at the assistant. (it is still funny though)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Absolucy, necromanceranne
fix: Caps how much eyeblur can be caused by things like projectiles.
/:cl:
