### PR TITLE
fix stupid runtime that bots keep spamming when their UI is open

### DIFF
--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -70,7 +70,7 @@
 
 // Check if an item has access to this object
 /atom/movable/proc/check_access(obj/item/I)
-	return check_access_list(I ? I.GetAccess() : null)
+	return check_access_list(I?.GetAccess())
 
 /atom/movable/proc/check_access_list(list/access_list)
 	if(!length(req_access) && !length(req_one_access))

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -932,7 +932,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 	. = ..()
 	if(.)
 		return
-	if(!check_access(usr))
+	if(!allowed(usr))
 		to_chat(usr, span_warning("Access denied."))
 		return
 

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -397,7 +397,7 @@
 	if(bot_cover_flags & BOT_COVER_OPEN)
 		to_chat(user, span_warning("Please close the access panel before [bot_cover_flags & BOT_COVER_LOCKED ? "un" : ""]locking it."))
 		return
-	if(!check_access(user))
+	if(!allowed(user))
 		to_chat(user, span_warning("Access denied."))
 		return
 	bot_cover_flags ^= BOT_COVER_LOCKED
@@ -915,7 +915,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 	data["can_hack"] = (issilicon(user) || isAdminGhostAI(user))
 	data["custom_controls"] = list()
 	data["emagged"] = bot_cover_flags & BOT_COVER_EMAGGED
-	data["has_access"] = check_access(user)
+	data["has_access"] = allowed(user)
 	data["locked"] = bot_cover_flags & BOT_COVER_LOCKED
 	data["settings"] = list()
 	if(!(bot_cover_flags & BOT_COVER_LOCKED) || issilicon(user) || isAdminGhostAI(user))

--- a/code/modules/modular_computers/file_system/programs/robocontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/robocontrol.dm
@@ -35,7 +35,7 @@
 	for(var/mob/living/simple_animal/bot/simple_bot as anything in GLOB.bots_list)
 		if(!is_valid_z_level(current_turf, get_turf(simple_bot)) || !(simple_bot.bot_mode_flags & BOT_MODE_REMOTE_ENABLED)) //Only non-emagged bots on the same Z-level are detected!
 			continue
-		if(computer && !simple_bot.check_access(user)) // Only check Bots we can access)
+		if(computer && !simple_bot.allowed(user)) // Only check Bots we can access)
 			continue
 		var/list/newbot = list(
 			"name" = simple_bot.name,


### PR DESCRIPTION

## About The Pull Request

closet pr removed `/mob/living/simple_animal/bot/proc/check_access`... when there's a global proc named `check_access` that is very much not the same thing.

## Changelog

no player-facing changes