### PR TITLE
fixes all misspellings of "oozeling"

### DIFF
--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -656,7 +656,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	desc = "A picture of a blood-soaked medical cyborg flashes on the screen. The mediborg has a speech bubble that says, \"Put your hand in the machine if you aren't a <b>coward!</b>\""
 	icon_state = "arcade"
 	circuit = /obj/item/circuitboard/computer/arcade/amputation
-	/// does this machine work with slime people and oozlings
+	/// does this machine work with slime people and oozelings
 	var/works_with_slimes = TRUE
 
 /obj/machinery/computer/arcade/amputation/attack_tk(mob/user)

--- a/code/game/machinery/computer/orders/order_items/mining/order_survival.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_survival.dm
@@ -9,8 +9,8 @@
 	item_path = /obj/item/reagent_containers/hypospray/medipen/survival/luxury
 	cost_per_order = 1000
 
-/datum/orderable_item/survival/luxury_pen/oozling //monkestation edit
-	item_path = /obj/item/reagent_containers/hypospray/medipen/survival/luxury/oozling
+/datum/orderable_item/survival/luxury_pen/oozeling //monkestation edit
+	item_path = /obj/item/reagent_containers/hypospray/medipen/survival/luxury/oozeling
 	cost_per_order = 1000
 
 /datum/orderable_item/survival/survival_pen/synthcare //monkestation edit CHEAPER THAN SURVIVAL PEN BECAUSE IT DOES NOT HEAL NEARLY AS MUCH AS A SURVIVAL PEN

--- a/code/modules/mob/living/basic/lavaland/legion/legion.dm
+++ b/code/modules/mob/living/basic/lavaland/legion/legion.dm
@@ -59,7 +59,7 @@
 
 /mob/living/basic/mining/legion/death(gibbed)
 	if (isnull(stored_mob))
-		for(var/obj/item/organ/internal/brain/slime in contents) // If oozling brain in contents eject instead of corpse.
+		for(var/obj/item/organ/internal/brain/slime in contents) // If oozeling brain in contents eject instead of corpse.
 			slime.forceMove(get_turf(slime))
 			return ..()
 		new corpse_type(loc)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -427,9 +427,9 @@
 	volume = 20
 	list_reagents = list(/datum/reagent/consumable/ethanol/fetching_fizz = 20)
 
-/obj/item/reagent_containers/hypospray/medipen/survival/luxury/oozling //oozling safe version of the luxury pen!
-	name = "luxury oozling medipen"
-	desc = "Even more cutting edge bluespace technology allowed Nanotrasen to compact 90u of volume into a single medipen. Contains rare and powerful chemicals that are also oozling safe! Used to aid in exploration of very harsh enviroments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE. <b> EXTRA WARNING : UNSAFE FOR NON OOZLING LIFE </b>"
+/obj/item/reagent_containers/hypospray/medipen/survival/luxury/oozeling //oozeling safe version of the luxury pen!
+	name = "luxury oozeling medipen"
+	desc = "Even more cutting edge bluespace technology allowed Nanotrasen to compact 90u of volume into a single medipen. Contains rare and powerful chemicals that are also oozeling safe! Used to aid in exploration of very harsh enviroments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE. <b> EXTRA WARNING : UNSAFE FOR NON OOZELING LIFE </b>"
 	icon_state = "luxpen"
 	inhand_icon_state = "atropen"
 	base_icon_state = "luxpen"

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -152,12 +152,12 @@
 				for(var/obj/item/organ/lmbimplant in limborgans)
 					lmbimplant.forceMove(drop_loc)
 					if(istype(lmbimplant, /obj/item/organ/internal/eyes)) // The eye slot is going to be some type of eyes right?
-						if(lmbimplant.type == /obj/item/organ/internal/eyes) // but we don't want to to drop oozlings natural eyes. Do the proper species check for eyes.
+						if(lmbimplant.type == /obj/item/organ/internal/eyes) // but we don't want to to drop oozelings natural eyes. Do the proper species check for eyes.
 							qdel(lmbimplant)
 							continue
 						var/obj/item/bodypart/head/oozeling/oozhead = src
 						oozhead.eyes = null // Need this otherwise qdel on head deletes the eyes.
-					if(istype(lmbimplant, /obj/item/organ/internal/brain)) // Go figure rare interactions give humans oozling heads. This stops rr's for head dismemeberment.
+					if(istype(lmbimplant, /obj/item/organ/internal/brain)) // Go figure rare interactions give humans oozeling heads. This stops rr's for head dismemeberment.
 						var/obj/item/bodypart/head/oozeling/oozhead = src
 						oozhead.brain = null // Similar to eyes
 					to_chat(phantom_owner, span_notice("Something small falls out the [src]."))

--- a/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
+++ b/monkestation/code/modules/antagonists/heretic/knowledge/sacrifice_knowledge/sacrifice_knowledge.dm
@@ -205,7 +205,7 @@
 
 	if(sacrifice.mind)
 		sac_department_flag |= sacrifice.mind.assigned_role?.departments_bitflags
-	if(istype(sacrifice, /mob/living/carbon/human) && sacrifice.last_mind) // If mob even has a last mind. Oozling issue.
+	if(istype(sacrifice, /mob/living/carbon/human) && sacrifice.last_mind) // If mob even has a last mind. Oozeling issue.
 		sac_department_flag |= sacrifice.last_mind.assigned_role?.departments_bitflags
 
 	if(sac_department_flag & DEPARTMENT_BITFLAG_COMMAND)

--- a/monkestation/code/modules/surgery/organs/internal/brain.dm
+++ b/monkestation/code/modules/surgery/organs/internal/brain.dm
@@ -47,7 +47,7 @@ GLOBAL_LIST_EMPTY_TYPED(dead_oozeling_cores, /obj/item/organ/internal/brain/slim
 	var/static/list/allowed_implants = typecacheof(list(
 		//obj/item/implant
 	))
-	//Extraneous organs not of oozling origin. Usually cyber implants.
+	//Extraneous organs not of oozeling origin. Usually cyber implants.
 	var/static/list/allowed_organ_types = typecacheof(list(
 		/obj/item/organ/internal/cyberimp,
 		/obj/item/organ/external/wings,
@@ -446,10 +446,10 @@ GLOBAL_LIST_EMPTY_TYPED(dead_oozeling_cores, /obj/item/organ/internal/brain/slim
 					var/obj/item/organ/internal/eyes/eyes = new_body.get_organ_slot(ORGAN_SLOT_EYES)
 					eyes.Remove(new_body)
 					qdel(eyes)
-			bodypart.drop_limb() // Drop limb should delete the limb for oozlings unless someone changes it.
+			bodypart.drop_limb() // Drop limb should delete the limb for oozelings unless someone changes it.
 		new_body.visible_message(span_warning("[new_body]'s torso \"forms\" from [new_body.p_their()] core, yet to form the rest."))
 		to_chat(owner, span_purple("Your torso fully forms out of your core, yet to form the rest."))
-		//Make oozlings revive similar to other species.
+		//Make oozelings revive similar to other species.
 		new_body.set_jitter_if_lower(200 SECONDS)
 		new_body.emote("scream")
 	else

--- a/tools/ci/check_grep.sh
+++ b/tools/ci/check_grep.sh
@@ -206,6 +206,11 @@ if $grep -ni "rat'var" $code_files; then
     echo -e "${RED}ERROR: Misspelling(s) of Ratvar detected in code, please remove the apostrophe(s).${NC}"
     st=1
 fi;
+if $grep -ni "oozling" $code_files; then
+	echo
+    echo -e "${RED}ERROR: Misspelling(s) of Oozeling detected in code, please ensure there is an e before 'ling'.${NC}"
+    st=1
+fi;
 part "map json naming"
 if ls _maps/*.json | $grep "[A-Z]"; then
 	echo


### PR DESCRIPTION

## About The Pull Request

this fixes all instances of "oozeling" being spelled "oozling", and adds a grep to detect similar mistakes in the future.

## Why It's Good For The Game

as an oozeling main this annoys me quite a bit.

## Changelog
:cl:
spellcheck: Fixed all instances of "oozeling" being mispelled as "oozling".
/:cl:
