### PR TITLE
makes the spooky lantern small instead of normal sized

### DIFF
--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -232,6 +232,7 @@
 	inhand_icon_state = "lantern-blue-on"
 	lefthand_file = 'icons/mob/inhands/equipment/mining_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
+	w_class = WEIGHT_CLASS_SMALL
 	var/obj/effect/wisp/wisp
 
 /obj/item/wisp_lantern/attack_self(mob/user)


### PR DESCRIPTION

## About The Pull Request

exactly what the title says.

## Why It's Good For The Game

it's the same sprite as the normal lantern, which is small, with the only difference being its blue instead. so i feel like this should be consistent.

## Changelog
:cl:
qol: The spooky lantern is now small instead of normal sized.
/:cl:
