### PR TITLE
Fix brains/cores being labeled as "unknown" if they died without an ID.

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -126,7 +126,7 @@
 	brain_owner.clear_mood_event("brain_damage")
 
 /obj/item/organ/internal/brain/proc/transfer_identity(mob/living/L)
-	name = "[L.name]'s [initial(name)]"
+	name = "[L.real_name]'s [initial(name)]"
 	if(brainmob || decoy_override)
 		return
 	if(!L.mind)

--- a/monkestation/code/modules/surgery/organs/internal/brain.dm
+++ b/monkestation/code/modules/surgery/organs/internal/brain.dm
@@ -238,7 +238,7 @@ GLOBAL_LIST_EMPTY_TYPED(dead_oozeling_cores, /obj/item/organ/internal/brain/slim
 	playsound(victim, 'sound/effects/blobattack.ogg', 80, TRUE)
 
 	if(gps_active) // adding the gps signal if they have activated the ability
-		AddComponent(/datum/component/gps/no_bsa, "[victim]'s Core")
+		AddComponent(/datum/component/gps/no_bsa, "[victim.real_name]'s Core")
 
 	if(brainmob)
 		membrane_mur.Grant(brainmob)


### PR DESCRIPTION

## About The Pull Request

just changing it to use `real_name`

## Changelog
:cl:
fix: Fixed brains/cores being labeled as "unknown" if they died without an ID.
/:cl:
