### PR TITLE
evaporates progtot (secondary traitor objectives) from orbit (contractors still exist dw)

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -20,7 +20,7 @@
 	stinger_sound = 'sound/ambience/antag/tatoralert.ogg'
 	var/give_objectives = TRUE
 	/// Whether to give secondary objectives to the traitor, which aren't necessary but can be completed for a progression and TC boost.
-	var/give_secondary_objectives = TRUE
+	var/give_secondary_objectives = FALSE
 	var/should_give_codewords = TRUE
 	///give this traitor an uplink?
 	var/give_uplink = TRUE
@@ -54,7 +54,6 @@
 	// Progression elements are best left to the roundstart antagonists
 	// There will still be a timelock on uplink items
 	name = "\improper Infiltrator"
-	give_secondary_objectives = TRUE // Changed from FALSE to TRUE - MONKEYSTATION EDIT CHANGE
 
 /datum/antagonist/traitor/infiltrator/sleeper_agent
 	name = "\improper Syndicate Sleeper Agent"

--- a/monkestation/code/modules/antagonists/contractor/datums/contractor_datum.dm
+++ b/monkestation/code/modules/antagonists/contractor/datums/contractor_datum.dm
@@ -36,6 +36,7 @@
 	show_to_ghosts = TRUE
 	give_uplink = FALSE
 	suicide_cry = "FOR THE CONTRACTS!!"
+	give_secondary_objectives = TRUE
 	/// The outfit the contractor is equipped with
 	var/contractor_outfit = /datum/outfit/contractor
 


### PR DESCRIPTION
## About The Pull Request

this removes secondary objectives from traitors (except contractors). simple as that.

## Why It's Good For The Game

progtot is bolted on top of an antag that was not intended to be progressive. it sucks for balancing, it sucks for gameplay, it sucks in every aspect. good riddance

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Traitors can no longer get secondary objectives. 20 TC, take it or leave it (unless you team up with steal from other traitors, I guess). Contractors are unchanged, tho.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
