### PR TITLE
Tweaks kitsune mask clothing flags

### DIFF
--- a/code/modules/clothing/masks/costume.dm
+++ b/code/modules/clothing/masks/costume.dm
@@ -51,9 +51,8 @@
 	w_class = WEIGHT_CLASS_SMALL
 	adjusted_flags = ITEM_SLOT_HEAD
 	flags_inv = HIDEFACE|HIDEFACIALHAIR
-	flags_cover = MASKCOVERSMOUTH
-	visor_flags_inv = HIDEFACE|HIDEFACIALHAIR
-	visor_flags_cover = MASKCOVERSMOUTH
+
+	visor_flags_inv = HIDEFACIALHAIR
 	custom_price = PAYCHECK_CREW
 	greyscale_colors = "#EEEEEE#AA0000"
 	greyscale_config = /datum/greyscale_config/kitsune


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the MASKCOVERSFACE flags from both the visor version and the mask version. Also removes the HIDES_IDENTITY flag from the visor version because you can very clearly see someone through the visor

## Why It's Good For The Game

Poor kitsune mask users  having to take off their mask every time to sip or eat something, even though the mask has a mouth hole (I think??) but even then, the visor version was clearly out of the way of your face, shouldnt have covered mouth and shouldnt have concealed your identity.

## Changelog


:cl:
qol: Kitsune masks no longer block you from drinking or eating, and do not hide your identity when used in the hat slot.
/:cl:


