### PR TITLE
[BALANCE] xenomorphs no longer regen while on fire

### DIFF
--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -51,6 +51,8 @@
 	actions_types = list(/datum/action/cooldown/alien/transfer)
 
 /obj/item/organ/internal/alien/plasmavessel/on_life(seconds_per_tick, times_fired)
+	if(organ_owner.on_fire)
+		return
 	var/delta_time = DELTA_WORLD_TIME(SSmobs)
 	//Instantly healing to max health in a single tick would be silly. If it takes 8 seconds to fire, then something's fucked.
 	var/delta_time_capped = min(delta_time, 8)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

see title

## Why It's Good For The Game

Why do xenos outheal fire (their one canon weakness) while on resin

## Changelog


:cl:

balance: xenomorphs no longer regen while on fire

/:cl:


