### PR TITLE
Replaces plague rats door passthrough with a do-after

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -187,10 +187,10 @@
 		var/mob/B = AM
 		if((isdrone(B) || iscyborg(B)) && B.stat)
 			return
-		if(istype(b, /mob/living/basic/mouse/plague))
-			if(!do_after(movable_atom, 3 SECONDS, src))
-			movable_atom.forceMove(drop_location())
-			to_chat(movable_atom, span_notice("You squeeze through [src]."))
+		if(istype(B, /mob/living/basic/mouse/plague))
+			if(!do_after(B, 3 SECONDS, src))
+			B.forceMove(drop_location())
+			to_chat(B, span_notice("You squeeze through [src]."))
 			return
 		if(isliving(AM))
 			var/mob/living/M = AM

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -189,9 +189,9 @@
 			return
 		if(istype(B, /mob/living/basic/mouse/plague))
 			if(!do_after(B, 3 SECONDS, src))
-			B.forceMove(drop_location())
-			to_chat(B, span_notice("You squeeze through [src]."))
-			return
+				B.forceMove(drop_location())
+				to_chat(B, span_notice("You squeeze through [src]."))
+				return
 		if(isliving(AM))
 			var/mob/living/M = AM
 			//Can bump-open maybe 3 airlocks per second. This is to prevent weird mass door openings

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -187,6 +187,11 @@
 		var/mob/B = AM
 		if((isdrone(B) || iscyborg(B)) && B.stat)
 			return
+		if(istype(b, /mob/living/basic/mouse/plague))
+			if(!do_after(movable_atom, 3 SECONDS, src))
+			movable_atom.forceMove(drop_location())
+			to_chat(movable_atom, span_notice("You squeeze through [src]."))
+			return
 		if(isliving(AM))
 			var/mob/living/M = AM
 			//Can bump-open maybe 3 airlocks per second. This is to prevent weird mass door openings

--- a/monkestation/code/modules/virology/disease/plague_rat/plague_rat.dm
+++ b/monkestation/code/modules/virology/disease/plague_rat/plague_rat.dm
@@ -12,7 +12,7 @@
 	melee_damage_lower = 4
 	melee_damage_upper = 7
 	chooses_bodycolor = FALSE
-	pass_flags = PASSTABLE|PASSGRILLE|PASSMOB|PASSDOORS
+	pass_flags = PASSTABLE|PASSGRILLE|PASSMOB
 	hungry = TRUE
 
 /mob/living/basic/mouse/plague/Initialize(mapload, tame, new_body_color)

--- a/monkestation/code/modules/virology/disease/plague_rat/plague_rat.dm
+++ b/monkestation/code/modules/virology/disease/plague_rat/plague_rat.dm
@@ -6,8 +6,8 @@
 	icon_living = "mouse_plague"
 	icon_dead = "mouse_plague_dead"
 
-	maxHealth = 30
-	health = 30
+	maxHealth = 50
+	health = 50
 
 	melee_damage_lower = 4
 	melee_damage_upper = 7


### PR DESCRIPTION

## About The Pull Request
- Plague rats no longer gain DOORPASSTHROUGH
- Plague rats now have to crawl through doors, which takes three seconds.
- Plague rats in compensation has recieved a small hp buff to 50 hp. (was thirty)
## Why It's Good For The Game
The whole strategy behind plague rat is that you run out, try to bite someone. Fail is likley, then run back to a airlock you know they dont have access to.
This is stinky and unengaging as the rat knows they have a safe option.
Instead move the plague to a door bump like borers, and then since they are bound to take a few more hits, just increase hp so they can tank said extra hit 
## Changelog
:cl:
add: Plague rats can bump into doors to crawl through them.
del: Plague rats no longer get door passthrough
balance: Plague rats now have 50 hp, from 30
/:cl:
