### PR TITLE
make icons in the crafting menu not blurry

### DIFF
--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -591,6 +591,7 @@ const MaterialContent = (props) => {
             mode ? 'cooking32x32' : 'crafting32x32',
             'a' + atom_id,
           ])}
+          style={{ 'image-rendering': 'pixelated' }}
         />
       </Stack.Item>
       <Stack.Item
@@ -697,6 +698,7 @@ const RecipeContentCompact = ({ item, craftable, busy, mode }) => {
               mode ? 'cooking32x32' : 'crafting32x32',
               'a' + item.result,
             ])}
+            style={{ 'image-rendering': 'pixelated' }}
           />
         </Stack.Item>
         <Stack.Item grow>
@@ -947,6 +949,7 @@ const RecipeContent = ({ item, craftable, busy, mode, diet }) => {
               height={'32px'}
               style={{
                 transform: 'scale(2)',
+                'image-rendering': 'pixelated',
               }}
               m={'16px'}
               className={classes([
@@ -1093,6 +1096,7 @@ const AtomContent = ({ atom_id, amount }) => {
           mode ? 'cooking32x32' : 'crafting32x32',
           'a' + atom_id,
         ])}
+        style={{ 'image-rendering': 'pixelated' }}
       />
       <Box inline verticalAlign="middle">
         {name}
@@ -1111,6 +1115,7 @@ const ToolContent = ({ tool }) => {
         my={-1}
         mr={0.5}
         className={classes(['crafting32x32', tool])}
+        style={{ 'image-rendering': 'pixelated' }}
       />
       <Box inline verticalAlign="middle">
         {tool}


### PR DESCRIPTION

## About The Pull Request

this applies pixelated scaling to all icons in the crafting menu, so they scale cleanly, instead of being blurry

before (left) vs after (right)
(you may need to open the whole image to properly see it at full resolution)

<img width="1400" height="720" alt="2025-09-20 (1758405249)" src="https://github.com/user-attachments/assets/8a85cca7-2911-437a-9a44-32b4439aa6e4" />


## Why It's Good For The Game

blurry icons look like ass

## Changelog
:cl:
fix: Icons in the personal crafting menu are no longer blurry.
/:cl:
