### PR TITLE
Hiding latejoins from options

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -44,6 +44,7 @@
 	M.mind.add_antag_datum(antag_datum)
 	return TRUE
 
+/*
 //////////////////////////////////////////////
 //                                          //
 //           SYNDICATE TRAITORS             //
@@ -234,3 +235,4 @@
 	new_heretic.knowledge_points = min(new_heretic.knowledge_points, 5)
 
 	return TRUE
+*/

--- a/config/dynamic.json
+++ b/config/dynamic.json
@@ -121,17 +121,4 @@
 		}
 	},
 
-	"Latejoin": {
-		"Syndicate Infiltrator": {
-			"weight": 0
-		},
-
-		"Provocateur": {
-			"weight": 0
-		},
-
-		"Heretic Smuggler": {
-			"weight": 0
-		}
-	}
 }

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/bloodsuckerbreakout.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/bloodsuckerbreakout.ts
@@ -1,3 +1,4 @@
+/*
 import { Antagonist, Category } from '../base';
 import { multiline } from 'common/string';
 
@@ -15,3 +16,4 @@ const BloodsuckerBreakout: Antagonist = {
 };
 
 export default BloodsuckerBreakout;
+*/

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/hereticsmuggler.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/hereticsmuggler.ts
@@ -1,3 +1,4 @@
+/*
 import { Antagonist, Category } from '../base';
 import { HERETIC_MECHANICAL_DESCRIPTION } from './heretic';
 
@@ -12,3 +13,4 @@ const HereticSmuggler: Antagonist = {
 };
 
 export default HereticSmuggler;
+*/

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/syndicateinfiltrator.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/antagonists/antagonists/syndicateinfiltrator.ts
@@ -1,3 +1,4 @@
+/*
 import { Antagonist, Category } from '../base';
 import { TRAITOR_MECHANICAL_DESCRIPTION } from './traitor';
 
@@ -13,3 +14,4 @@ const SyndicateInfiltrator: Antagonist = {
 };
 
 export default SyndicateInfiltrator;
+*/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Latejoins are nonexistant storyteller wise, move them out of perception to create less confusion about mechanics.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Smugglers and infiltrators are real, dont be silly.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed latejoin antag preferences from being chosen
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
