### PR TITLE
mining bags now scoop up ores that get moved under you without you having to shuffle back and forth

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drinks/alcohol_reagents.dm
@@ -1300,8 +1300,9 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 
 /datum/reagent/consumable/ethanol/fetching_fizz/on_mob_life(mob/living/carbon/drinker, seconds_per_tick, times_fired)
-	for(var/obj/item/stack/ore/O in orange(3, drinker))
-		step_towards(O, get_turf(drinker))
+	var/turf/drinker_turf = get_turf(drinker)
+	for(var/obj/item/stack/ore/ore in orange(3, drinker))
+		step_towards(ore, drinker_turf)
 	return ..()
 
 //Another reference. Heals those in critical condition extremely quickly.


### PR DESCRIPTION

## About The Pull Request

this makes it so ores than get moved under you somehow (such as the magnet effect from fetching fizz) when u have a mining bag will get scooped into said bag, without you needed to move off and back onto the tile.

https://github.com/user-attachments/assets/2324aeee-a715-4108-99b6-92fe71330bd7

## Why It's Good For The Game

less annoying

## Changelog
:cl:
qol: Mining bags now scoop up ores that get moved under you without you having to shuffle back and forth. Rejoice, magnetization injector enjoyers.
/:cl:
