### PR TITLE
Give roundstart / latejoin borgs their loadout hat

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -224,14 +224,17 @@
 
 /mob/living/silicon/robot/on_job_equipping(datum/job/equipping, datum/preferences/used_pref)
 	var/list/loadout_datums = loadout_list_to_datums(used_pref?.loadout_list)
-	var/atom/item_path = null
+	var/obj/item/hat_to_use = null
 
+	// We want the last hat in the list to match the behaviour of humanoid loadouts
 	for (var/datum/loadout_item/head/item in loadout_datums)
-		if (ispath(item.item_path, /obj/item/clothing/head))
-			item_path = item.item_path
+		if (ispath(item.item_path, /obj/item))
+			var/obj/item/hat = new item.item_path()
+			if (hat.slot_flags & ITEM_SLOT_HEAD)
+				hat_to_use = hat
 
-	if (item_path)
-		place_on_head(new item_path())
+	if (hat_to_use)
+		place_on_head(hat_to_use)
 
 #define VERY_LATE_ARRIVAL_TOAST_PROB 20
 

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -219,9 +219,19 @@
 /datum/job/proc/special_config_check()
 	return FALSE
 
-/mob/living/proc/on_job_equipping(datum/job/equipping)
+/mob/living/proc/on_job_equipping(datum/job/equipping, datum/preferences/used_pref)
 	return
 
+/mob/living/silicon/robot/on_job_equipping(datum/job/equipping, datum/preferences/used_pref)
+	var/list/loadout_datums = loadout_list_to_datums(used_pref?.loadout_list)
+	var/atom/item_path = null
+
+	for (var/datum/loadout_item/head/item in loadout_datums)
+		if (ispath(item.item_path, /obj/item/clothing/head))
+			item_path = item.item_path
+
+	if (item_path)
+		place_on_head(new item_path())
 
 #define VERY_LATE_ARRIVAL_TOAST_PROB 20
 


### PR DESCRIPTION

## About The Pull Request
Gives roundstart / latejoin borgs their loadout hat.
Job restrictions do not apply because goofy AA robot.

## Why It's Good For The Game

helps borgs look more distinct without having to add more sprites
## Changelog
:cl:
add: Roundstart / latejoin borgs are now given their loadout hat
/:cl:
