### PR TITLE
fix the ashen duelist, rockspider, and trench jockey pack still having full slowdown

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -23,7 +23,7 @@
 	resistance_flags = NONE
 	max_integrity = 300
 	var/shoulder_carry = FALSE
-	var/satchel_movespeed_modifier = /datum/movespeed_modifier/belt_satchel //added this variable so that you can change the movespeed penalty a backpack gives if paired with a satchel
+	var/satchel_movespeed_modifier = 2
 
 /obj/item/storage/backpack/Initialize(mapload)
 	. = ..()
@@ -41,13 +41,13 @@
 /obj/item/storage/backpack/proc/check_belt_satchel(mob/user)
 	if(QDELETED(user))
 		return
-	var/back_item = user.get_item_by_slot(ITEM_SLOT_BACK)
-	var/belt_item = user.get_item_by_slot(ITEM_SLOT_BELT)
-	if(istype(back_item, /obj/item/storage/backpack) && istype(belt_item, /obj/item/storage/backpack/satchel))
-		user.add_movespeed_modifier(satchel_movespeed_modifier)
+	user.remove_movespeed_modifier(/datum/movespeed_modifier/belt_satchel, update = FALSE)
+	var/obj/item/storage/backpack/back_item = user.get_item_by_slot(ITEM_SLOT_BACK)
+	var/obj/item/storage/backpack/belt_item = user.get_item_by_slot(ITEM_SLOT_BELT)
+	if(istype(back_item) && istype(belt_item))
+		user.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/belt_satchel, min(back_item.satchel_movespeed_modifier, belt_item.satchel_movespeed_modifier))
 	else
-		user.remove_movespeed_modifier(satchel_movespeed_modifier)
-
+		user.update_movespeed()
 /*
  * Backpack Types
  */
@@ -857,7 +857,7 @@
 	desc = "A surprisingly flexible and durable bag, capable of carrying up to three mining guns at once, for those who prowl the wastes with a passion for marksmanship. Due to its flexibility, it doesn't interfere with movement as badly as most bags when paired with a satchel."
 	icon_state = "rockspider"
 	inhand_icon_state = "backpack"
-	satchel_movespeed_modifier = /datum/movespeed_modifier/belt_satchel/light
+	satchel_movespeed_modifier = 0.3
 
 /obj/item/storage/backpack/rockspider/Initialize(mapload)
 	. = ..()
@@ -884,7 +884,7 @@
 	desc = "A bag with a mount and holster, capable of carrying any crusher type weapon and a gun, for the aspiring duelist who needs a bit more than just a blade. Due to its flexibility, it doesn't interfere with movement as badly as most bags when paired with a satchel."
 	icon_state = "ashenduelist"
 	inhand_icon_state = "backpack"
-	satchel_movespeed_modifier = /datum/movespeed_modifier/belt_satchel/light
+	satchel_movespeed_modifier = 0.3
 
 /obj/item/storage/backpack/ashduelist/Initialize(mapload)
 	. = ..()
@@ -919,7 +919,7 @@
 	desc = "A exceptionally spacious bag full of slots and pouches for different kinds of ammunition, for those who really need more than just one extra round. Despite its weight, it fits incredibly well with a satchel, and does not hinder your movement as much as a regular backpack would."
 	icon_state = "trenchjockey"
 	inhand_icon_state = "backpack"
-	satchel_movespeed_modifier = /datum/movespeed_modifier/belt_satchel/light
+	satchel_movespeed_modifier = 0.3
 
 /obj/item/storage/backpack/trenchjockey/Initialize(mapload)
 	. = ..()

--- a/code/modules/movespeed/modifiers/items.dm
+++ b/code/modules/movespeed/modifiers/items.dm
@@ -18,7 +18,4 @@
 	multiplicative_slowdown = -0.5
 
 /datum/movespeed_modifier/belt_satchel
-	multiplicative_slowdown = 2
-
-/datum/movespeed_modifier/belt_satchel/light
-	multiplicative_slowdown = 0.3
+	variable = TRUE


### PR DESCRIPTION
## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: The ashen duelist, rockspider, and trench jockey packs no longer have the full belt-satchel slowdowns, as the description says they shouldn't (and it's part of their whole point)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
