### PR TITLE
allow berserker armor to carry PKAs in suit storage (+ helmet tweaks)

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -212,7 +212,7 @@
 		/obj/item/gun/ballistic/automatic/proto/pksmg,
 		/obj/item/gun/ballistic/revolver/grenadelauncher/kinetic,
 		/obj/item/gun/ballistic/revolver/govmining,
-		)
+	)
 	armor_type = /datum/armor/cloak_drake
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/drake
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS

--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -687,6 +687,14 @@
 		/obj/item/kinetic_crusher,
 		/obj/item/resonator,
 		/obj/item/melee/cleaving_saw,
+		/obj/item/gun/energy/recharge/kinetic_accelerator,
+		/obj/item/gun/ballistic/shotgun/autoshotgun,
+		/obj/item/gun/ballistic/automatic/proto/pksmg/kineticlmg,
+		/obj/item/gun/ballistic/shotgun/doublebarrel/kinetic,
+		/obj/item/gun/ballistic/automatic/proto/pksmg,
+		/obj/item/gun/ballistic/revolver/grenadelauncher/kinetic,
+		/obj/item/gun/ballistic/revolver/govmining,
+		/obj/item/t_scanner/adv_mining_scanner,
 	)
 
 /datum/armor/hooded_berserker
@@ -722,7 +730,8 @@
 
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF
-	clothing_flags = SNUG_FIT|THICKMATERIAL
+	clothing_flags = SNUG_FIT | THICKMATERIAL
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH | PEPPERPROOF
 	/// Current charge of berserk, goes from 0 to 100
 	var/berserk_charge = 0
 	/// Status of berserk


### PR DESCRIPTION

## About The Pull Request

this makes it so the berserker armor can carry PKAs, mining guns, and mining scanners in the suit storage slot, like the other 2 mining armors.

Also, this makes it so the berserker helmet counts as covering your eyes and mouth.

## Why It's Good For The Game

mining armor consistency

as for covering your eyes/mouth, well, look at the sprite:
<img width="116" height="129" alt="image" src="https://github.com/user-attachments/assets/9ff9f3d2-a6f9-48b1-9af3-7acc2d74d8b8" />

## Changelog
:cl:
balance: Berserker armor can now carry PKAs, mining guns, and mining scanners in its suit storage, similar to drake and godslayer armor.
balance: The berserker helmet now covers your eyes and mouth, because, well, look at the sprite.
/:cl:
