### PR TITLE
Adds the ability to change prisoner ID names without a console through right click with a sec ID

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1305,6 +1305,10 @@
 	var/time_to_assign
 	/// Time left on a card till they can leave.
 	var/time_left = 0
+	/// if the card has been given a custom name.
+	var/named = FALSE
+
+
 
 /obj/item/card/id/advanced/prisoner/attackby(obj/item/card/id/C, mob/user)
 	..()
@@ -1314,14 +1318,6 @@
 	if(loc != user)
 		to_chat(user, span_warning("You must be holding the ID to continue!"))
 		return FALSE
-	if(named)
-		named = FALSE
-		timed = FALSE
-		time_to_assign = initial(time_to_assign)
-		regisitered_name = initial(registered_name)
-		name = initial(name)
-		to_chat(user, "Restating prisoner ID to default parameters.")
-		return
 	if(timed)
 		timed = FALSE
 		time_to_assign = initial(time_to_assign)
@@ -1337,16 +1333,35 @@
 		time_to_assign = choice
 		to_chat(user, "You set the sentence time to [time_to_assign] seconds.")
 		timed = TRUE
-	var/name_input=tgui_input_text(user, "Enter prisoner name (will appear on sensors)", "Prisoner Identification", registered_name, MAX_NAME_LEN)
+/obj/item/card/id/advanced/prisoner/proc/start_timer()
+	say("Sentence started, welcome to the corporate rehabilitation center!")
+	START_PROCESSING(SSobj, src)
+
+/obj/item/card/id/advanced/prisoner/attackby_secondary(obj/item/card/id/C, mob/user)
+	..()
+	var/list/id_access = C.GetAccess()
+	if(!(ACCESS_BRIG in id_access))
+		return FALSE
+	if(loc != user)
+		to_chat(user, span_warning("You must be holding the ID to continue!"))
+		return FALSE
+	if(named)
+		named = FALSE
+		registered_name = initial(registered_name)
+		name = initial(name)
+		to_chat(user, "Restating prisoner ID to default parameters.")
+		return
+	var/name_input = tgui_input_text(user, "Enter prisoner name. (Will appear on suit sensors.)", "Prisoner Identification", registered_name, MAX_NAME_LEN)
+	if( QDELETED(user) || QDELETED(src) || !usr.can_perform_action(src, FORBID_TELEKINESIS_REACH) || loc != user)
+		return FALSE
 	if(!name_input || QDELETED(user) || QDELETED(src) || !usr.can_perform_action(src, FORBID_TELEKINESIS_REACH) || loc != user)
 		return FALSE
 	registered_name = name_input
 	name = "[name_input]'s ID Card (Prisoner)"
 	to_chat(user, "You set the ID's identification to [name_input].")
 	named = TRUE
-/obj/item/card/id/advanced/prisoner/proc/start_timer()
-	say("Sentence started, welcome to the corporate rehabilitation center!")
-	START_PROCESSING(SSobj, src)
+
+
 
 /obj/item/card/id/advanced/prisoner/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Right so, after an entire rework of how it works, when you right click a prisoner ID, itll rename it instead of set timer. Setting time still applies on left click


video showcase:
https://youtu.be/TanMhJyrWc0

might need to be included in sop for permabrigging, but thats not up to me
## Why It's Good For The Game

ensures that prisoner ID's for permas and such get renamed, reflect on sensors, stuff like that. really just makes it easier to rename prisoner id's without having to go to hos/hop office or something (no one EVER does this anyway) 
I have a feeling someone is gonna try to bring up "this will remove hop interaction!!" but literally no one goes to the hop for this anyway, and the hop gets enough interaction as is

## Changelog


:cl:
add: Adds the ability to change prisoner ID names through right clicking ID with a secoff or higher ID card.

/:cl:


