### PR TITLE
Hallucination core item!

### DIFF
--- a/code/datums/components/crafting/misc.dm
+++ b/code/datums/components/crafting/misc.dm
@@ -42,3 +42,13 @@
 	reqs = list(/obj/item/stack/sheet/plastic = 10)
 	tool_behaviors = list(TOOL_WELDER)
 	category = CAT_MISC
+
+/datum/crafting_recipe/sciencevog
+	name = "Compulsive Linguisynthesizer"
+	time = 10 SECONDS
+	reqs = list(
+		/obj/item/organ/internal/tongue = 1,
+		/obj/item/assembly/signaler/anomaly/hallucination = 1,
+	)
+	result = /obj/item/organ/internal/vocal_cords/colossus/science
+	category = CAT_MISC

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -124,5 +124,5 @@
 /obj/item/organ/internal/vocal_cords/colossus/science
 	name = "Compulsive Lingui-synthesizer"
 	desc = "This strange bio-technological implant enables its user to alter the world by voice alone."
-	cooldown_mod = 0.6
+	cooldown_mod = 0.7
 	base_multiplier = 0.5

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -120,3 +120,9 @@
 /obj/item/organ/internal/vocal_cords/colossus/speak_with(message)
 	var/cooldown = voice_of_god(uppertext(message), owner, spans, base_multiplier)
 	next_command = world.time + (cooldown * cooldown_mod)
+
+/obj/item/organ/internal/vocal_cords/colossus/science
+	name = "Compulsive Lingui-synthesizer"
+	desc = "This strange bio-technological implant enables its user to alter the world by voice alone."
+	cooldown_mod = 0.6
+	base_multiplier = 0.5


### PR DESCRIPTION
## About The Pull Request
Its just shittier VOG but anomalocked instead of fauna-locked
it's got a somewhat lowered cooldown because most of the best combat effects depend mainly on having a long duration rather than a short cooldown
so this lets you do stuff like heal people almost as good as the real one without being able to kill people too megaultradeath
## Why It's Good For The Game
1. fun
2. thematic for hallucination cores
3. mining is just frankly a silly job for silly people who like guns that deal a thousand damage per shot
4. no hallucination core specific items exist
5. vog is a neat mechanic
## Changelog
:cl: that one amphibian goofball who continuously and inexplicably appears in these changelogs
add: Shittier VoG craftable with a halucination core
/:cl:
