### PR TITLE
Fixes wormhole gun orange portals

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -249,6 +249,13 @@
 			if(istype(WH))
 				WH.gun = WEAKREF(src)
 
+/obj/item/gun/energy/wormhole_projector/ranged_interact_with_atom_secondary(atom/interacting_with, mob/living/user, list/modifiers)
+	// overrides from /obj/item/gun as both ranged interacts result in firing the gun
+	// identical to primary ranged attack
+	if(try_fire_gun(interacting_with, user, list2params(modifiers)))
+		return ITEM_INTERACT_SUCCESS
+	return ITEM_INTERACT_BLOCKING
+
 /obj/item/gun/energy/wormhole_projector/try_fire_gun(atom/target, mob/living/user, params)
 	if(LAZYACCESS(params2list(params), RIGHT_CLICK))
 		if(select == AMMO_SELECT_BLUE) //Last fired in left click mode. Switch to orange wormhole (right click).


### PR DESCRIPTION
## About The Pull Request
It seemed that interaction changes resulted in guns' secondary ranged interaction not attacking / firing. This caused a problem with the portal gun which relied on secondary interaction to shoot the orange portal (hence why only shooting blue portals was possible). This fixes the issue by overriding the ranged secondary interaction and allowing shooting for the portal gun on right clicks.

## Why It's Good For The Game
Fixes #7975
(& duplicate issues)
Fixes #8078
Fixes #8128
Fixes #8195

Bug caused by #7826

## Changelog
:cl: Lawlolawl
fix: Wormhole Projector can now shoot orange portals again.
/:cl:
