### PR TITLE
some minor oozeling qol

### DIFF
--- a/code/datums/wounds/loss.dm
+++ b/code/datums/wounds/loss.dm
@@ -17,7 +17,7 @@
 		return
 	// Stupid way of preventing weird organ dupes with oozelings.
 	// Any extra implants/organs they have will be inside of their core when they die anyways.
-	if(is_oozeling_core(limb.owner?.get_organ_slot(ORGAN_SLOT_BRAIN)))
+	if(isoozeling(limb.owner))
 		return FALSE
 
 /datum/wound/loss

--- a/monkestation/code/modules/surgery/organs/internal/brain.dm
+++ b/monkestation/code/modules/surgery/organs/internal/brain.dm
@@ -42,26 +42,28 @@ GLOBAL_LIST_EMPTY_TYPED(dead_oozeling_cores, /obj/item/organ/internal/brain/slim
 	var/list/stored_quirks = list()
 	var/list/stored_items = list()
 	///Item types that should never be stored in core and will drop on death. Takes priority over allowed lists.
-	var/static/list/bannedcore = typecacheof(list(/obj/item/disk/nuclear,))
+	var/static/list/bannedcore = typecacheof(list(/obj/item/disk/nuclear))
 	//Allowed implants usually given by cases and injectors
 	var/static/list/allowed_implants = typecacheof(list(
 		//obj/item/implant
 	))
 	//Extraneous organs not of oozeling origin. Usually cyber implants.
 	var/static/list/allowed_organ_types = typecacheof(list(
-		/obj/item/organ/internal/cyberimp,
-		/obj/item/organ/external/wings,
-		/obj/item/organ/external/tail,
+		/obj/item/organ/external/antennae,
 		/obj/item/organ/external/frills,
 		/obj/item/organ/external/horns,
-		/obj/item/organ/external/snout,
-		/obj/item/organ/external/antennae,
-		/obj/item/organ/external/spines,
-		/obj/item/organ/internal/eyes/robotic/glow,
 		/obj/item/organ/external/plumage,
+		/obj/item/organ/external/snout,
+		/obj/item/organ/external/spines,
+		/obj/item/organ/external/tail,
+		/obj/item/organ/external/wings,
+		/obj/item/organ/internal/alien,
+		/obj/item/organ/internal/cyberimp,
 		/obj/item/organ/internal/ears/cat/super,
+		/obj/item/organ/internal/eyes/robotic/glow,
+		/obj/item/organ/internal/heart/cursed,
 		/obj/item/organ/internal/tongue/polyglot_voicebox,
-		/obj/item/organ/internal/alien/hivenode,
+		/obj/item/organ/internal/vocal_cords,
 	))
 	//Quirks that roll unique effects or gives items to each new body should be saved between bodies.
 	var/static/list/saved_quirks = typecacheof(list(
@@ -121,43 +123,49 @@ GLOBAL_LIST_EMPTY_TYPED(dead_oozeling_cores, /obj/item/organ/internal/brain/slim
 	. = ..()
 	if(gps_active)
 		. += span_notice("A dim light lowly pulsates from the center of the core, indicating an outgoing signal from a tracking microchip.")
-		. += span_red("You could probably snuff that out.")
+		. += span_red("You could probably use the core in-hand to snuff out the tracking signal and retrieve the items within it.")
+	else
+		. += span_red("You could probably use the core in-hand to retrieve the items within it.")
 	if((brainmob && (brainmob.client || brainmob.get_ghost())) || (mind?.current && (mind.current.client || mind.current.get_ghost())) || decoy_override)
 		if(isnull(stored_dna))
 			. += span_hypnophrase("Something looks wrong with this core, you don't think plasma will fix this one, maybe there's another way?")
 		else
-			. += span_hypnophrase("You remember that pouring a big beaker of ground plasma on it, if it's non-embodied, would make it regrow one.")
+			. += span_hypnophrase("You remember that <i>slowly</i> pouring a big beaker of ground plasma on it by hand, if it's non-embodied, would make it regrow one.")
 
 /obj/item/organ/internal/brain/slime/attack_self(mob/living/user) // Allows a player (presumably an antag) to deactivate the GPS signal on a slime core
+	if(DOING_INTERACTION_WITH_TARGET(user, src))
+		return
 	user.visible_message(
-		span_warning("[user] begins jamming their hand into a slime core! Slime goes everywhere!"),
-		gps_active ? span_notice("You jam your hand into the core, feeling for the densest point! Slime covers your arm.") : span_notice("You jam your hand into the core, feeling for any dense objects. Slime covers your arm."),
+		span_warning("[user] begins jamming their hand into [src]! Slime goes everywhere!"),
+		gps_active ? span_notice("You jam your hand into [src], feeling for the densest point! Slime covers your arm.") : span_notice("You jam your hand into [src], feeling for any dense objects. Slime covers your arm."),
 		span_notice("You hear an obscene squelching sound.")
 	)
 	playsound(user, 'sound/surgery/organ1.ogg', 80, TRUE)
 
 	if(!do_after(user, 30 SECONDS, src))
 		user.visible_message(
-			span_warning("[user]'s hand slips out of the core before they can cause any harm!"),
+			span_warning("[user]'s hand slips out of [src] before they can cause any harm!"),
 			gps_active ? span_notice("Your hand slips out of the goopy core before you can find it's densest point.") : span_notice("Your hand slips out of the goopy core before you can find any dense points."),
 			span_notice("You hear a resounding plop.")
 		)
 		return
 
-	if((gps_active))
-		user.visible_message(span_warning("[user] crunches something deep in the slime core! It gradually stops glowing."),
-		span_notice("You find the densest point, crushing it in your palm. The blinking light in the core slowly dissapates and items start to come out."),
-		span_notice("You hear a wet crunching sound."))
-		gps_active =  FALSE
+	if(gps_active)
+		user.visible_message(
+			span_warning("[user] crunches something deep in [src]! It gradually stops glowing."),
+			span_notice("You find the densest point, crushing it in your palm. The blinking light in the core slowly dissapates and items start to come out."),
+			span_notice("You hear a wet crunching sound."),
+		)
+		gps_active = FALSE
 		qdel(GetComponent(/datum/component/gps/no_bsa))//Actually remove the gps signal
-
 	else
-		user.visible_message(span_warning("[user] crunches something deep in the slime core! It gradually stops glowing."),
-		span_notice("You find several dense objects, forcing them out of the core, items start to spill."),
-		span_notice("You hear a wet sqlenching sounds."))
+		user.visible_message(
+			span_warning("[user] crunches something deep in [src]! It gradually stops glowing."),
+			span_notice("You find several dense objects, forcing them out of the core, items start to spill."),
+			span_notice("You hear a wet squelching sounds.")
+		)
 	playsound(user, 'sound/effects/wounds/crackandbleed.ogg', 80, TRUE)
-
-	drop_items_to_ground(get_turf(user))
+	drop_items_to_ground(user.drop_location())
 
 /obj/item/organ/internal/brain/slime/Insert(mob/living/carbon/organ_owner, special = FALSE, drop_if_replaced, no_id_transfer)
 	. = ..()
@@ -227,10 +235,7 @@ GLOBAL_LIST_EMPTY_TYPED(dead_oozeling_cores, /obj/item/organ/internal/brain/slim
 		Remove(victim)
 	//Make this check more generalized later. For antags that eat people as they kill. Make sure they drop their
 	//contents after death; that is if that is how that item or antag works.
-	if(legionbody)
-		forceMove(legionbody)
-	else if(death_turf)
-		forceMove(death_turf)
+	forceMove(legionbody || death_turf)
 	wash(CLEAN_WASH)
 	new death_melt_type(death_turf, victim.dir)
 
@@ -285,6 +290,11 @@ GLOBAL_LIST_EMPTY_TYPED(dead_oozeling_cores, /obj/item/organ/internal/brain/slim
 			span_notice("You start to slowly pour the contents of [item] onto [src]. It seems to bubble and roil, beginning to stretch its membrane outwards..."),
 			span_hear("You hear bubbling.")
 		)
+		user.balloon_alert_to_viewers("pouring plasma...")
+
+		if(brainmob)
+			brainmob.notify_ghost_cloning("Someone is pouring plasma on your core!")
+			brainmob.grab_ghost()
 
 		if(!do_after(user, 30 SECONDS, src))
 			to_chat(user, span_warning("You failed to pour the contents of [item] onto [src]!"))
@@ -392,7 +402,6 @@ GLOBAL_LIST_EMPTY_TYPED(dead_oozeling_cores, /obj/item/organ/internal/brain/slim
 			break
 
 	if(gps_active) // making sure the gps signal is removed if it's active on revival
-		gps_active = FALSE
 		qdel(GetComponent(/datum/component/gps))
 
 	//we have the plasma. we can rebuild them.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this is just a few relatively minor qol changes for oozelings:

i improved the wording of oozeling examine text:

before:
> A dim light lowly pulsates from the center of the core, indicating an outgoing signal from a tracking microchip.
> You could probably snuff that out.
> You remember that pouring a big beaker of ground plasma on it, if it's non-embodied, would make it regrow one.

after:
> A dim light lowly pulsates from the center of the core, indicating an outgoing signal from a tracking microchip.
> You could probably use the core in-hand to snuff out the tracking signal and retrieve the items within it.
>
> You remember that _slowly_ pouring a big beaker of ground plasma on it by hand, if it's non-embodied, would make it regrow one.

i made it so that more organs (vocal cords, all xeno organs, cursed heart) also get "sucked" into the oozeling core's storage upon death (similar to most implants, wings, etc)

also made it so that it makes a balloon alert (so people hopefully won't run into you and interrupt it) and notifies the ghost of the oozeling when you begin pouring plasma on the core.

## Why It's Good For The Game

makes how oozeling cores work less confusing for other people and such

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Improved the wording of the examine text of oozeling cores, to clarify what snuffing it does, and that you need to CAREFULLY pour plasma.
qol: Oozeling cores now properly store more implanted organs (vocal cords, cursed heart, all xeno organs) instead of deleting them.
qol: Pouring plasma on an oozeling core now notifies their ghost that they're being revived, similar to being defibbed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
