### PR TITLE
MGS Alert Emote

### DIFF
--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -68,6 +68,8 @@
 	var/extra_range = 0
 	/// The volume to play an audible emote at.
 	var/volume = 50
+	/// Lets emote proceed without early returning in the event the message is empty.
+	var/empty_message_intentional
 
 /datum/emote/New()
 	switch(mob_type_allowed_typecache)
@@ -107,12 +109,12 @@
 
 	msg = replace_pronoun(user, msg)
 
-	if(!msg)
+	if(!msg && !empty_message_intentional)
 		return
 
 	if(user.client)
 		user.log_message(msg, LOG_EMOTE)
-	var/dchatmsg = "<b>[user]</b> [msg]"
+	var/dchatmsg = "<b>[user]</b> [msg ? msg : "preformed an emote"]"
 
 	var/tmp_sound = get_sound(user)
 	if(tmp_sound && should_play_sound(user, intentional) && TIMER_COOLDOWN_FINISHED(user, type))
@@ -135,14 +137,15 @@
 				continue
 			if((ghost.client?.prefs?.chat_toggles & CHAT_GHOSTSIGHT) && !(ghost in viewers(user_turf, null)))
 				ghost.show_message("<span class='emote'>[FOLLOW_LINK(ghost, user)] [dchatmsg]</span>")
-	if(emote_type & (EMOTE_AUDIBLE | EMOTE_VISIBLE)) //emote is audible and visible
-		user.audible_message(msg, deaf_message = "<span class='emote'>You see how <b>[user]</b> [msg]</span>", audible_message_flags = EMOTE_MESSAGE)
-	else if(emote_type & EMOTE_VISIBLE)	//emote is only visible
-		user.visible_message(msg, visible_message_flags = EMOTE_MESSAGE)
-	if(emote_type & EMOTE_IMPORTANT)
-		for(var/mob/living/viewer in viewers())
-			if(viewer.is_blind() && !viewer.can_hear())
-				to_chat(viewer, msg)
+	if(msg)
+		if(emote_type & (EMOTE_AUDIBLE | EMOTE_VISIBLE)) //emote is audible and visible
+			user.audible_message(msg, deaf_message = "<span class='emote'>You see how <b>[user]</b> [msg]</span>", audible_message_flags = EMOTE_MESSAGE)
+		else if(emote_type & EMOTE_VISIBLE)	//emote is only visible
+			user.visible_message(msg, visible_message_flags = EMOTE_MESSAGE)
+		if(emote_type & EMOTE_IMPORTANT)
+			for(var/mob/living/viewer in viewers())
+				if(viewer.is_blind() && !viewer.can_hear())
+					to_chat(viewer, msg)
 
 	SEND_SIGNAL(user, COMSIG_MOB_EMOTED(key))
 	// SSblackbox.record_feedback("tally", "emote_used", 1, name)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -114,7 +114,7 @@
 
 	if(user.client)
 		user.log_message(msg, LOG_EMOTE)
-	var/dchatmsg = "<b>[user]</b> [msg ? msg : "preformed an emote"]"
+	var/dchatmsg = "<b>[user]</b> [msg ? msg : "preformed an emote."]"
 
 	var/tmp_sound = get_sound(user)
 	if(tmp_sound && should_play_sound(user, intentional) && TIMER_COOLDOWN_FINISHED(user, type))

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -113,7 +113,7 @@
 		return
 
 	if(user.client)
-		user.log_message(msg, LOG_EMOTE)
+		user.log_message(msg ? msg : "preformed a messageless emote. ([type])", LOG_EMOTE)
 	var/dchatmsg = "<b>[user]</b> [msg ? msg : "preformed an emote."]"
 
 	var/tmp_sound = get_sound(user)

--- a/code/datums/emotes.dm
+++ b/code/datums/emotes.dm
@@ -113,8 +113,8 @@
 		return
 
 	if(user.client)
-		user.log_message(msg ? msg : "preformed a messageless emote. ([type])", LOG_EMOTE)
-	var/dchatmsg = "<b>[user]</b> [msg ? msg : "preformed an emote."]"
+		user.log_message(msg ? msg : "performed a messageless emote. ([type])", LOG_EMOTE)
+	var/dchatmsg = "<b>[user]</b> [msg ? msg : "performed an emote."]"
 
 	var/tmp_sound = get_sound(user)
 	if(tmp_sound && should_play_sound(user, intentional) && TIMER_COOLDOWN_FINISHED(user, type))

--- a/monkestation/code/modules/emotes/code/emote.dm
+++ b/monkestation/code/modules/emotes/code/emote.dm
@@ -528,3 +528,16 @@
 /datum/emote/living/breatheout/can_run_emote(mob/user, status_check, intentional)
 	return ..() && IS_SLASHER(user)
 //End
+
+/datum/emote/living/alert
+	key = "!"
+	name = "Alert"
+	cooldown = 1 SECONDS
+	audio_cooldown = 1 SECONDS
+	emote_type = EMOTE_VISIBLE
+	sound = 'sound/machines/chime.ogg'
+	empty_message_intentional = TRUE
+
+/datum/emote/living/alert/run_emote(mob/user, params, type_override, intentional)
+	. = ..()
+	user.do_alert_animation()

--- a/monkestation/code/modules/emotes/code/emote.dm
+++ b/monkestation/code/modules/emotes/code/emote.dm
@@ -532,8 +532,8 @@
 /datum/emote/living/alert
 	key = "!"
 	name = "Alert"
-	cooldown = 1 SECONDS
-	audio_cooldown = 1 SECONDS
+	cooldown = 5 SECONDS
+	audio_cooldown = 10 SECONDS //no free *chime
 	emote_type = EMOTE_VISIBLE
 	sound = 'sound/machines/chime.ogg'
 	empty_message_intentional = TRUE


### PR DESCRIPTION

## About The Pull Request
Adds a emote to manually trigger the ! that appears when someone exits a cardboard box, in the process, emote code has been bastardized to permit this.

If your wondering, yes this shows up at the front of the *help and keybindings emote lists. It also shows up at the front of the emote panel list, but for different naming reasons.


https://github.com/user-attachments/assets/0d38eeeb-bf0f-43b5-aec8-c4d080c6a136

*delay between triggers reduced in video to test/showcase better.*
## Why It's Good For The Game
Lets me engage in my Hip, Epic Metal Gear Guard Roleplay even harder.
Codewise, its probably not.
## Changelog
:cl:
add: Added a new emote, !, which manually triggers the MGS alert that appears when someone exits a cardboard box.
code: Emotes can now support having no message.
/:cl:
