### PR TITLE
monster hunter abilities follow their mind if they switch bodies

### DIFF
--- a/code/modules/antagonists/monster_hunters/hunter_datum.dm
+++ b/code/modules/antagonists/monster_hunters/hunter_datum.dm
@@ -193,6 +193,7 @@
 	var/datum/action/cooldown/spell/summonitem/recall = new
 	recall.mark_item(weapon)
 	recall.Grant(user)
+	powers += recall
 
 	podspawn(list(
 		"target" = get_turf(user),

--- a/code/modules/antagonists/monster_hunters/hunter_datum.dm
+++ b/code/modules/antagonists/monster_hunters/hunter_datum.dm
@@ -83,6 +83,7 @@
 	gun_holder.drop_gun = TRUE
 	var/datum/action/cooldown/spell/track_monster/track = new
 	track.Grant(owner.current)
+	powers += track
 	return ..()
 
 /datum/antagonist/monsterhunter/on_removal()

--- a/code/modules/antagonists/monster_hunters/monsters/monster_effects/white_rabbit.dm
+++ b/code/modules/antagonists/monster_hunters/monsters/monster_effects/white_rabbit.dm
@@ -96,6 +96,7 @@
 	var/datum/action/cooldown/spell/conjure_item/blood_silver/silverblood = new(user)
 	silverblood.StartCooldown()
 	silverblood.Grant(user)
+	hunter_antag.powers += silverblood
 
 /// Janky workaround to avoid the 512x512 sprite always occuping the user's right click menu
 /obj/effect/bnnuy/proc/update_mouse_opacity(mob/living/user)


### PR DESCRIPTION
## About The Pull Request

mfw i find more unused vars and broken code

so turns out, monster hunters have a `powers` list, which is used to transfer abilities on body transfer.

nothing ever actually gets put into that list

so uh, let's at least put instant recall and hunter vision in that list...

## Why It's Good For The Game

mfw i lose my main abilities bc i died and got revived as an oozeling

## Changelog
:cl:
fix: Monster Hunters will now keep their Instant Recall and Hunter Vision abilities if they ever change bodies, i.e if they're cloned or whatever.
/:cl:
