### PR TITLE
Fixes mentor manager

### DIFF
--- a/code/modules/requests/request_manager.dm
+++ b/code/modules/requests/request_manager.dm
@@ -141,7 +141,7 @@ GLOBAL_DATUM_INIT(requests, /datum/request_manager, new)
 	if (!requests[C.ckey])
 		requests[C.ckey] = list()
 	requests[C.ckey] += request
-	requests_by_id[request.id] = request
+	requests_by_id["[request.id]"] = request
 
 /datum/request_manager/ui_interact(mob/user, datum/tgui/ui = null)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION

## About The Pull Request
Apparently, whatever was done in #8336 broke mentor manager. I have no idea what im doing, so i just went to the previous commit of that line and replaced it. Works so. *shrug

Also for some reason !localhost! doesnt have mentor perms so that made debugging a little harder.
## Why It's Good For The Game
bug fix, mentor requests that appeared before a mentor that can answer it got on no longer go unanswered.
## Changelog
:cl:
code: partially reverted a change to Mentor Manager to hopefully fix it being broken. Please report any issues!
/:cl:
