### PR TITLE
Gives the syndicate renoster an 8 shell magazine as advertized

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -42,6 +42,11 @@
 	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	max_ammo = 6
 
+/obj/item/ammo_box/magazine/internal/shot/riot/evil
+	name = "syndicate renoster shotgun internal magazine"
+	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
+	max_ammo = 8
+
 /obj/item/ammo_box/magazine/internal/shot/bounty
 	name = "triple-barrel shotgun internal magazine"
 	ammo_type = /obj/item/ammo_casing/shotgun/incapacitate

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -120,7 +120,7 @@
 	inhand_icon_state = "renoster_evil"
 	projectile_wound_bonus = 15
 	pin = /obj/item/firing_pin/implant/pindicate
-
+	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/riot/evil
 /obj/item/gun/ballistic/shotgun/riot/sol/evil/unrestricted
 	pin = /obj/item/firing_pin
 


### PR DESCRIPTION
## About The Pull Request

So, syndicate renoster shotguns actually got their internal magazine from the same source that a riot shotgun did, meaning it didnt have the 8 shell capacity as advertized, and also started loaded with nonlethals

## Why It's Good For The Game

Its a syndicate shotgun, should be better than the normal riot shotgun other than 15 wound bonus on projectiles, also shouldnt start with nonlethals (you are clearly going to kill people with it) and should be accurate to the description.

## Changelog

:cl:

fix: Recalls all Syndicate Renoster shotguns for a faulty internal magazine size, as well as being loaded with non lethal rounds. The Syndicate has replaced said faulty internal magazines with proper 8 round magazines loaded with lethal buckshot. The Syndicate apologizes for the inconvenience.

/:cl:


