### PR TITLE
A Check At Power

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -680,7 +680,7 @@
 	var/obj/item/stock_parts/power_store/cell/potato/pocell = new /obj/item/stock_parts/power_store/cell/potato(user.loc)
 	pocell.icon = our_plant.icon // Just in case the plant icons get spread out in different files eventually, this trait won't cause error sprites (also yay downstreams)
 	pocell.icon_state = our_plant.icon_state
-	pocell.maxcharge = our_seed.potency * 0.02 * STANDARD_CELL_CHARGE
+	pocell.maxcharge = our_seed.potency * 0.005 * STANDARD_CELL_CHARGE
 
 	// The secret of potato supercells!
 	var/datum/plant_gene/trait/cell_charge/electrical_gene = our_seed.get_gene(/datum/plant_gene/trait/cell_charge)

--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -685,7 +685,7 @@
 	// The secret of potato supercells!
 	var/datum/plant_gene/trait/cell_charge/electrical_gene = our_seed.get_gene(/datum/plant_gene/trait/cell_charge)
 	if(electrical_gene) // Like the good old days
-		pocell.maxcharge *= (electrical_gene.rate * 1000)
+		pocell.maxcharge *= (electrical_gene.rate * 750)
 	pocell.charge = pocell.maxcharge
 	pocell.name = "[our_plant.name] battery"
 	pocell.desc = "A rechargeable plant-based power cell. This one has a rating of [display_energy(pocell.maxcharge)], and you should not swallow it."


### PR DESCRIPTION

# A Bringing of Common Sense

After the recent power changes, as a botanist, i was curious on the still effectiveness of botany batteries, and to my surprise, they, while with less funny names (Gigajoules i will miss you), are still as strong as ever.

So, even though you may see MJ's on a battery now, much more often than a GJ (you will never see this again), the power is still quite strong as ever.

So, as a way to find a middle ground, and until i figure out log calculations (if anyone wants to work with me on this feel free to DM me), i've come to recognize the following points:

* Botany cells are hardly affected by EMP's due to the amount of power they have 
(then again, EMP shielding exists, so that's a whole other can of worms)

* Borgs and Mechs can easily abuse this in their favour (more about durands and borgs, from what i understand).

* Botany Cells ***shouldn't*** cause people's engineering jobs to be trivial
(Then again, less work for ya'll??? anyways)

![line-sticker-sticker](https://github.com/user-attachments/assets/a0857bce-d314-4503-9f28-7ad24e65daf5)


### However

* Botany cells have multiple times saved stations after disasters, providing relief and a sense of teaming up for botany and crew, creating good fun moments for everyone involved.

* Botany cells have often provided much breathing room and opportunity for other departments like Chemistry, Robotics, Service,  and even sometimes engineering itself by being a late/mid shift solution to many needs

## So What is Proposal?
![fig](https://github.com/user-attachments/assets/76e1df32-c8e5-403a-9bbe-fb962f7464f8)

For one, the common issue i see to be addressed is ***how fast*** those are obtainable, and how ***effective*** they are.

Now, as a way to knock this down a notch, i have changed the 

`pocell.maxcharge = our_seed.potency * 0.02 * STANDARD_CELL_CHARGE`

to

`pocell.maxcharge = our_seed.potency * 0.005 * STANDARD_CELL_CHARGE`

Which should be a ***significant*** reduction to botany's power generation, by making the initial base far lower, and thus, requiring even more potency, and yes, time investment on a same tray to get it done.

However, and let me make this quite clear: 

### I am not above nerfing ***Eletrical Activity's Synergy***
![goku](https://github.com/user-attachments/assets/e98cc497-0cd0-4ad7-bc8c-99918acafc7e)


`pocell.maxcharge *= (electrical_gene.rate * 1000)`

See, many people think that the other one is the issue, when ***this*** is a far bigger outliar.

So, as a way to knock down botany quite a notch, i've also reduced this formula to....

`pocell.maxcharge *= (electrical_gene.rate * 750)`

This should provide a ***considerable*** reduction of total botany cell power generation, while also still allowing those eletrical addicts to get their fix, just far later in the shift.

## The Expectactions

What i expected from this PR mostly, is:

* Engineers to still be angry because the batteries are still capable of ***becoming strong***, even though not nearly as fast

* Botanists to be sad that they no longer can make as powerful batteries in 15 minutes, even though if they spend enough time, they can eventually get something good enough to have fun with.

* Our current headcoder to see this and laugh at me for attempting to do this without the help of log (x) 
( I should probably learn that, eventually)

## But Most Importantly

This is to be test-merged, to see how effective it is as providing a way for this to be knocked down a notch.

If needed to be further reduced, then it shall, but in a way that:
* Botany can still provide late shift battery solutions that go above and beyond BS batteries 
#### But
* Cant be obtained as early, as to provide a way for engineering to also eat their cake

Therefore, the end goal for this proposal is for them to still possess their relevance and provide their funny moments, albeit later and with a reduced power display.

## Changelog

:cl:
balance: Botany batteries have their effectiveness reduced to around 1/5, while still being able to eventually grow enough to have significant play later in shifts, albeit requiring more care and attention to the plants stats.
/:cl:
