### PR TITLE
[BALANCE] Makes chest disembowelment wounds much rarer

### DIFF
--- a/code/__DEFINES/wounds.dm
+++ b/code/__DEFINES/wounds.dm
@@ -313,8 +313,8 @@ GLOBAL_LIST_INIT(biotypes_to_scar_file, list(
 #define WOUND_SLASH_DAMAGE_FLOW_COEFF 0.025
 /// if we suffer a bone wound to the head that creates brain traumas, the timer for the trauma cycle is +/- by this percent (0-100)
 #define WOUND_BONE_HEAD_TIME_VARIANCE 20
-
-
+/// the modifier applied to the final chance for rolling chest disemboweling wounds
+#define WOUND_DISEMBOWEL_MODIFIER 0.1
 
 // ~mangling defines
 // With the wounds pt. 2 update, general dismemberment now requires 2 things for a limb to be dismemberable (exterior/bone only creatures just need the second):

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -210,6 +210,9 @@
 	for (var/datum/wound/iterated_wound as anything in wounds)
 		base_chance += iterated_wound.get_dismember_chance_bonus(base_chance)
 
+	if (body_zone == BODY_ZONE_CHEST)
+		base_chance = base_chance * WOUND_DISEMBOWEL_MODIFIER
+
 	if(prob(base_chance))
 		var/datum/wound/loss/dismembering = new
 		return dismembering.apply_dismember(src, wounding_type)


### PR DESCRIPTION
## About The Pull Request

Significantly reduces the frequency of chest disembowelment wounds, in particular the chance of getting them before someone is actually dead. 

I have tested the number I ended up settling on and it's still pretty easy to intentionally disembowel someone AFTER you kill them, because the probability keeps increasing with every additional strike (actually, once you have enough modifiers you are just guaranteed to disembowel too, which my PR doesn't touch). But it is now MUCH rarer to disembowel someone with wounds BEFORE you actually kill them.

## Why It's Good For The Game

I have no clue why it seems to be different from tg, but I noticed this when using slug shotguns against unarmored targets - VERY frequently they would get disemboweled BEFORE they even died, completely unintentionally on my part. I tested this with slugs specifically, and it actually happens about FIFTY PERCENT of the time that someone will get disemboweled before they have even taken enough damage to die. That number was with slugs specifically but I tested a number of other weapons and it was incredibly frequent to disembowel someone before even killing them, which is consistent with what I see happen often on live.

Considering how disemboweling substantially increases the time and difficulty of reviving a victim, as well as making it much harder to prevent organ rot, it should be relegated to at least a semi-intentional act rather than something that is incredibly likely to happen before you even kill the poor guy. 

## Changelog

:cl:
balance: The frequency of chest disembowelment wounds has been substantially reduced.
/:cl:
