### PR TITLE
[PORT] Art gallery PDA port (no printing)

### DIFF
--- a/code/modules/modular_computers/computers/item/role_tablet_presets.dm
+++ b/code/modules/modular_computers/computers/item/role_tablet_presets.dm
@@ -389,6 +389,7 @@
 	starting_programs = list(
 		/datum/computer_file/program/emojipedia,
 		/datum/computer_file/program/newscaster,
+		/datum/computer_file/program/portrait_printer,
 	)
 
 /* monkestation removal: don't force ringer off by default

--- a/code/modules/modular_computers/file_system/programs/portrait_printer.dm
+++ b/code/modules/modular_computers/file_system/programs/portrait_printer.dm
@@ -4,19 +4,17 @@
 
 
 /**
- * ## portrait printer!
+ * ## the art gallery viewer/printer!
  *
- * Program that lets the curator browse all of the portraits in the database
- * They are free to print them out as they please.
+ * Program that lets the curator (or anyone really) browse all of the portraits in the database
+ * Stationary consoles can also print them out as they please as long as they've enough paper
  */
 /datum/computer_file/program/portrait_printer
 	filename = "PortraitPrinter"
 	filedesc = "Marlowe Treeby's Art Galaxy"
 	downloader_category = PROGRAM_CATEGORY_EQUIPMENT
 	program_open_overlay = "dummy"
-	extended_desc = "This program connects to a Spinward Sector community art site for viewing and printing art."
-	download_access = list(ACCESS_LIBRARY)
-	can_run_on_flags = PROGRAM_CONSOLE
+	extended_desc = "This program connects to a Spinward Sector community art site for viewing and printing art, the latter only available on stationary consoles."
 	program_flags = PROGRAM_ON_NTNET_STORE | PROGRAM_REQUIRES_NTNET
 	size = 9
 	tgui_id = "NtosPortraitPrinter"
@@ -30,6 +28,10 @@
 	var/search_mode = PAINTINGS_FILTER_SEARCH_TITLE
 	/// Stores the result of the search, for later access.
 	var/list/matching_paintings
+
+/datum/computer_file/program/portrait_printer/ui_static_data(mob/user)
+	. = ..()
+	.["is_console"] = computer.hardware_flag & PROGRAM_CONSOLE
 
 /datum/computer_file/program/portrait_printer/ui_data(mob/user)
 	var/list/data = list()
@@ -64,6 +66,8 @@
 	matching_paintings = SSpersistent_paintings.painting_ui_data(filter = search_mode, search_text = search_string)
 
 /datum/computer_file/program/portrait_printer/proc/print_painting(selected_painting)
+	if(!(computer.hardware_flag & PROGRAM_CONSOLE))
+		return
 	if(computer.stored_paper < CANVAS_PAPER_COST)
 		to_chat(usr, span_notice("Printing error: Your printer needs at least [CANVAS_PAPER_COST] paper to print a canvas."))
 		return

--- a/tgui/packages/tgui/interfaces/NtosPortraitPrinter.jsx
+++ b/tgui/packages/tgui/interfaces/NtosPortraitPrinter.jsx
@@ -6,7 +6,7 @@ import { NtosWindow } from '../layouts';
 export const NtosPortraitPrinter = (props) => {
   const { act, data } = useBackend();
   const [listIndex, setListIndex] = useLocalState('listIndex', 0);
-  const { paintings, search_string, search_mode } = data;
+  const { paintings, search_string, search_mode, is_console } = data;
   const got_paintings = !!paintings.length;
   const current_portrait_title = got_paintings && paintings[listIndex]['title'];
   const current_portrait_author =
@@ -99,8 +99,8 @@ export const NtosPortraitPrinter = (props) => {
                     <Stack.Item grow={3}>
                       <Button
                         icon="check"
-                        content="Print Portrait"
-                        disabled={!got_paintings}
+                        content={!is_console ? 'View Only' : 'Print Portrait'}
+                        disabled={!got_paintings || !is_console}
                         onClick={() =>
                           act('select', {
                             selected: paintings[listIndex]['ref'],


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/92615 because somebody asked for it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Doomscrolling before the shuttle arrives
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: EssentialTomato
balance: (Ghommie) As a continued effort to promote art and culture among the crew, the "Marlowe Treeby's Art Galaxy" application has been made available for download on all computer devices, with no access restrictions. Printing can still only be done on a stationary console. The curator's PDA has it preinstalled now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
