### PR TITLE
[PORT] Airlock pump improvements

### DIFF
--- a/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/airlock_pump.dm
@@ -480,11 +480,22 @@
 	internal_airlocks = get_adjacent_airlocks(internal_airlocks_origin, perpendicular_dirs)
 	external_airlocks = get_adjacent_airlocks(external_airlocks_origin, perpendicular_dirs)
 
-	if(!internal_airlocks.len || !external_airlocks.len)
+	// This is support for awkwardly shaped airlocks that cycle on a group ID
+	if(!length(internal_airlocks))
+		for(var/obj/machinery/door/airlock/external_airlock as anything in external_airlocks)
+			internal_airlocks |= external_airlock.close_others
+		// For double-wide airlocks, so we don't end up with doors in both lists
+		internal_airlocks -= external_airlocks
+	if(!length(external_airlocks))
+		for(var/obj/machinery/door/airlock/internal_airlock as anything in internal_airlocks)
+			external_airlocks |= internal_airlock.close_others
+		external_airlocks -= internal_airlocks
+
+	if(!length(external_airlocks) || !length(internal_airlocks))
 		if(!can_unwrench) //maploaded pump
 			CRASH("[type] couldn't find airlocks to cycle with!")
-		internal_airlocks = list()
-		external_airlocks = list()
+		internal_airlocks.Cut()
+		external_airlocks.Cut()
 		say("Cycling setup failed. No opposite airlocks found.")
 		return
 
@@ -584,6 +595,21 @@
 	if((SOUTH|WEST) & direction)
 		user.ventcrawl_layer = clamp(user.ventcrawl_layer - 2, PIPING_LAYER_DEFAULT - 1, PIPING_LAYER_DEFAULT + 1)
 	to_chat(user, "You align yourself with the [user.ventcrawl_layer == 2 ? 1 : 2]\th output.")
+
+/obj/machinery/atmospherics/components/unary/airlock_pump/on_set_is_operational(was_operational)
+	if(was_operational && !is_operational)
+		// unbolt all the doors but don't open them
+		for(var/obj/machinery/door/airlock/airlock as anything in (internal_airlocks + external_airlocks))
+			airlock.unbolt()
+		audible_message(span_notice("[src] whirrs as [p_they()] loses power, disengaging airlock bolts."))
+	else if(!was_operational && is_operational)
+		// upon regaining power, re-bolt relevant airlocks
+		for(var/obj/machinery/door/airlock/airlock as anything in external_airlocks)
+			INVOKE_ASYNC(airlock, TYPE_PROC_REF(/obj/machinery/door/airlock, secure_close))
+		for(var/obj/machinery/door/airlock/airlock as anything in internal_airlocks)
+			if(open_airlock_on_cycle)
+				INVOKE_ASYNC(airlock, TYPE_PROC_REF(/obj/machinery/door/airlock, secure_open))
+		audible_message(span_notice("[src] whirrs as [p_they()] regains power, re-engaging airlock bolts."))
 
 /obj/machinery/atmospherics/components/unary/airlock_pump/unbolt_only
 	open_airlock_on_cycle = FALSE


### PR DESCRIPTION

## About The Pull Request
Ports the improvements from https://github.com/tgstation/tgstation/pull/91457 and https://github.com/tgstation/tgstation/pull/91458
## Why It's Good For The Game
Door not stuck
## Changelog
:cl: EssentialTomato
qol: (MrMelbert) Airlock pumps will unbolt their linked airlocks on losing power, allowing them to be forced through
qol: (MrMelbert) Airlock pumps work on L shaped airlocks, assuming [the airlocks] are already linked.
/:cl:
