### PR TITLE
chips popping when stepped on no longer causes all food to lag the shit out of the server when stepped on

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_food.dm
+++ b/code/__DEFINES/dcs/signals/signals_food.dm
@@ -6,6 +6,7 @@
 #define COMSIG_FOOD_EATEN "food_eaten"
 	#define DESTROY_FOOD (1<<0)
 /// From base of datum/component/edible/on_entered: (mob/crosser, bitecount)
+/// You must call enable_food_crossed() on the edible component in order for this signal to be sent.
 #define COMSIG_FOOD_CROSSED "food_crossed"
 /// From base of Component/edible/On_Consume: (mob/living/eater, mob/living/feeder)
 #define COMSIG_FOOD_CONSUMED "food_consumed"

--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -46,7 +46,8 @@ Behavior that's still missing from this component that original food items had t
 	var/total_bites = 0
 	var/current_mask
 	///required trait
-	var/required_trait // MONKESTATION EDIT
+	var/required_trait
+	var/tracking_entered = FALSE
 
 /datum/component/edible/Initialize(
 	list/initial_reagents,
@@ -93,12 +94,6 @@ Behavior that's still missing from this component that original food items had t
 	RegisterSignal(parent, COMSIG_OOZE_EAT_ATOM, PROC_REF(on_ooze_eat))
 	RegisterSignal(parent, COMSIG_TRY_EAT_TRAIT, PROC_REF(try_eat_trait))
 	RegisterSignal(parent, COMSIG_ATOM_ATTACK_HAND_SECONDARY, PROC_REF(show_radial_recipes)) //Monkestation edit: CHEWIN COOKING
-
-	if(isturf(parent))
-		RegisterSignal(parent, COMSIG_ATOM_ENTERED, PROC_REF(on_entered))
-	else
-		var/static/list/loc_connections = list(COMSIG_ATOM_ENTERED = PROC_REF(on_entered))
-		AddComponent(/datum/component/connect_loc_behalf, parent, loc_connections)
 
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_ATTACK, PROC_REF(UseFromHand))
@@ -720,9 +715,8 @@ Behavior that's still missing from this component that original food items had t
 		playsound(get_turf(eater),'sound/items/eatfood.ogg', rand(30,50), TRUE)
 		qdel(eaten_food)
 		return COMPONENT_ATOM_EATEN
-//MONKESTATION EDIT START
-/datum/component/edible/proc/UseByMouse(datum/source, mob/user)
 
+/datum/component/edible/proc/UseByMouse(datum/source, mob/user)
 	SIGNAL_HANDLER
 
 	var/atom/owner = parent
@@ -748,4 +742,16 @@ Behavior that's still missing from this component that original food items had t
 	else
 		if(prob(50))
 			L.manual_emote("nibbles away at \the [parent].")
-//MONKESTATION EDIT STOP
+
+/// Enables sending the COMSIG_FOOD_CROSSED signal.
+/// This is an optional signal because very few things use this signal,
+/// and mass tracking COMSIG_ATOM_ENTERED can be very performance-heavy.
+/datum/component/edible/proc/enable_food_crossed()
+	if(tracking_entered)
+		return
+	tracking_entered = TRUE
+	if(isturf(parent))
+		RegisterSignal(parent, COMSIG_ATOM_ENTERED, PROC_REF(on_entered))
+	else
+		var/static/list/loc_connections = list(COMSIG_ATOM_ENTERED = PROC_REF(on_entered))
+		AddComponent(/datum/component/connect_loc_behalf, parent, loc_connections)

--- a/code/datums/elements/food/food_trash.dm
+++ b/code/datums/elements/food/food_trash.dm
@@ -21,6 +21,8 @@
 	if(flags & FOOD_TRASH_OPENABLE)
 		RegisterSignal(target, COMSIG_ITEM_ATTACK_SELF, PROC_REF(open_trash))
 	if(flags & FOOD_TRASH_POPABLE)
+		var/datum/component/edible/edible_component = target.GetComponent(/datum/component/edible)
+		edible_component?.enable_food_crossed()
 		RegisterSignal(target, COMSIG_FOOD_CROSSED, PROC_REF(food_crossed))
 	RegisterSignal(target, COMSIG_ITEM_ON_GRIND, PROC_REF(generate_trash))
 	RegisterSignal(target, COMSIG_ITEM_ON_JUICE, PROC_REF(generate_trash))
@@ -38,7 +40,8 @@
 		COMSIG_ITEM_ON_JUICE,
 		COMSIG_ITEM_USED_AS_INGREDIENT,
 		COMSIG_ITEM_ON_COMPOSTED,
-		COMSIG_ITEM_SOLD_TO_CUSTOMER,))
+		COMSIG_ITEM_SOLD_TO_CUSTOMER,
+	))
 
 /datum/element/food_trash/proc/generate_trash(datum/source, mob/living/eater, mob/living/feeder)
 	SIGNAL_HANDLER


### PR DESCRIPTION
## About The Pull Request

this changes up `/datum/component/edible` so that the `COMSIG_FOOD_CROSSED` signal needs to be _enabled_ for it to be sent, so that every single food that doesn't care about it doesn't register `COMSIG_ATOM_ENTERED` on its current turf, causing massive lag whenever someone steps on a shitload of pumpkins or whatever

## Why It's Good For The Game

OH GOD THE LAG

## Changelog

no player-facing changes (besides less lag i guess)