### PR TITLE
`TRAIT_ETHEREAL_NO_OVERCHARGE` now just makes ethereals always have "normal" charge

### DIFF
--- a/code/modules/surgery/organs/stomach/stomach_ethereal.dm
+++ b/code/modules/surgery/organs/stomach/stomach_ethereal.dm
@@ -97,7 +97,7 @@
 	var/word = pick("like you can't breathe","your lungs locking up","extremely lethargic")
 	var/blood_volume = ethereal.blood_volume
 	if(HAS_TRAIT(ethereal, TRAIT_ETHEREAL_NO_OVERCHARGE))
-		blood_volume = min(blood_volume, ETHEREAL_BLOOD_CHARGE_FULL)
+		blood_volume = ETHEREAL_BLOOD_CHARGE_ALMOSTFULL
 	switch(blood_volume)
 		if(-INFINITY to ETHEREAL_BLOOD_CHARGE_LOWEST_PASSIVE)
 			ethereal.add_mood_event("charge", /datum/mood_event/decharged)


### PR DESCRIPTION
## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/8408

this makes it so that having `TRAIT_ETHEREAL_NO_OVERCHARGE` will always just treat the ethereal as having `ETHEREAL_BLOOD_CHARGE_ALMOSTFULL` for the sake of charge processing

## Why It's Good For The Game

prevents eternal mood hell and such

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Ethereal nosferatu bloodsuckers will no longer eternally have low mood.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
