### PR TITLE
[PORT] Ports soup recipes reacting proportionally to spawn the right amount of items

### DIFF
--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -110,7 +110,7 @@
 			BLACKBOX_LOG_FOOD_MADE(created)
 		// Re-add required reagents that were not used in this step
 		if(created_volume > ingredient_max_multiplier)
-			for(var/reagent_path as anything in required_reagents)
+			for(var/reagent_path in required_reagents)
 				holder.add_reagent(reagent_path,(required_reagents[reagent_path])*(created_volume-ingredient_max_multiplier))
 
 	// This only happens if we're being instant reacted so let's just skip to what we really want

--- a/code/modules/food_and_drinks/recipes/soup_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/soup_mixtures.dm
@@ -85,6 +85,33 @@
 /datum/chemical_reaction/food/soup/on_reaction(datum/reagents/holder, datum/equilibrium/reaction, created_volume)
 	if(!length(required_ingredients))
 		return
+	// If a food item is supposed to be made, remove relevant ingredients from the pot, then make the item
+	if(!isnull(resulting_food_path))
+		var/list/tracked_ingredients
+		LAZYINITLIST(tracked_ingredients)
+		var/ingredient_max_multiplier = INFINITY
+		var/obj/item/reagent_containers/cup/soup_pot/pot = holder.my_atom
+
+		// Tracked ingredients are indexed by type and point to a list containing the actual items
+		for(var/obj/item/ingredient as anything in pot.added_ingredients)
+			if(is_type_in_list(ingredient, required_ingredients))
+				LAZYADD(tracked_ingredients[ingredient.type],ingredient)
+		// Find the max number of ingredients that may be used for making the food item
+		for(var/list/ingredient_type as anything in tracked_ingredients)
+			ingredient_max_multiplier = min(ingredient_max_multiplier,LAZYLEN(tracked_ingredients[ingredient_type]))
+		// Create the food items, removing the relavent ingredients at the same time
+		for(var/i in 1 to (min(created_volume,ingredient_max_multiplier)))
+			for(var/list/ingredient_type as anything in tracked_ingredients)
+				var/ingredient = tracked_ingredients[ingredient_type][i]
+				LAZYREMOVE(pot.added_ingredients,ingredient)
+				qdel(ingredient)
+			var/obj/item/created = new resulting_food_path(get_turf(pot))
+			created.pixel_y += 8
+			BLACKBOX_LOG_FOOD_MADE(created)
+		// Re-add required reagents that were not used in this step
+		if(created_volume > ingredient_max_multiplier)
+			for(var/reagent_path as anything in required_reagents)
+				holder.add_reagent(reagent_path,(required_reagents[reagent_path])*(created_volume-ingredient_max_multiplier))
 
 	// This only happens if we're being instant reacted so let's just skip to what we really want
 	if(isnull(reaction))
@@ -114,7 +141,6 @@
 /datum/chemical_reaction/food/soup/reaction_step(datum/reagents/holder, datum/equilibrium/reaction, delta_t, delta_ph, step_reaction_vol)
 	if(!length(required_ingredients))
 		return
-
 	testing("Soup reaction step progressing with an increment volume of [step_reaction_vol] and delta_t of [delta_t].")
 	var/obj/item/reagent_containers/cup/soup_pot/pot = holder.my_atom
 	var/list/cached_ingredients = reaction.data["ingredients"]
@@ -164,7 +190,7 @@
 	. = ..()
 	var/obj/item/reagent_containers/cup/soup_pot/pot = holder.my_atom
 	if(!istype(pot))
-		CRASH("[pot ? "Non-pot atom" : "Null pot"]) made it to the end of the [type] reaction chain.")
+		CRASH("[pot ? "Non-pot atom" : "Null pot"] made it to the end of the [type] reaction chain.")
 
 	testing("Soup reaction finished with a total react volume of [react_vol] and [length(pot.added_ingredients)] ingredients. Cleaning up.")
 	clean_up(holder, reaction, react_vol)
@@ -172,7 +198,7 @@
 /**
  * Cleans up the ingredients and adds whatever leftover reagents to the mixture
  *
- * * holder: The sou ppot
+ * * holder: The soup pot
  * * reaction: The reaction being cleaned up, note this CAN be null if being instant reacted
  * * react_vol: How much soup was produced
  */
@@ -181,34 +207,25 @@
 
 	reaction?.data["ingredients"] = null
 
-	for(var/obj/item/ingredient as anything in pot.added_ingredients)
-		// Let's not mess with  indestructible items.
-		// Chef doesn't need more ways to delete things with cooking.
-		if(ingredient.resistance_flags & INDESTRUCTIBLE)
-			continue
+	// If soup is made, remove ingredients as their reagents were added to the soup
+	if(react_vol)
+		for(var/obj/item/ingredient as anything in pot.added_ingredients)
+			// Let's not mess with  indestructible items.
+			// Chef doesn't need more ways to delete things with cooking.
+			if(ingredient.resistance_flags & INDESTRUCTIBLE)
+				continue
 
-		// Things that had reagents or ingredients in the soup will get deleted
-		else if(!isnull(ingredient.reagents) || is_type_in_list(ingredient, required_ingredients))
+			// Everything else will just get fried
+			if(isnull(ingredient.reagents) && !is_type_in_list(ingredient, required_ingredients))
+				ingredient.AddElement(/datum/element/fried_item, 30)
+				continue
+
+			// Things that had reagents or ingredients in the soup will get deleted
 			LAZYREMOVE(pot.added_ingredients, ingredient)
 			// Send everything left behind
 			transfer_ingredient_reagents(ingredient, holder)
 			// Delete, it's done
 			qdel(ingredient)
-			continue
-
-		// Everything else will just get fried
-		ingredient.AddElement(/datum/element/fried_item, 30)
-
-	// Spawning physical food results
-	if(resulting_food_path)
-		var/obj/item/created = new resulting_food_path(get_turf(pot))
-		created.pixel_y += 8
-		BLACKBOX_LOG_FOOD_MADE(created)
-	else
-		var/results_length = length(results)
-		var/datum/reagent/reagent = results[results_length]
-		if(reagent)
-			BLACKBOX_LOG_FOOD_MADE(initial(reagent.name))
 
 	// Anything left in the ingredient list will get dumped out
 	pot.dump_ingredients(get_turf(pot), y_offset = 8)


### PR DESCRIPTION
## About The Pull Request
Ports:
tgstation/tgstation#78120
The previous code caused all ingredients/reagents involved in recipes to be deleted and only for a base amount of product to be created (i.e. checking for a set minimum amount of reagents then producing ONE batch of product). Now the amount of product is based on the limiting ingredient (based on ratios) and any excess reagents/ingredients are leftover/expelled after the reaction.
Also misc typo fixes. Edited the food production logging as well to be in line with the ported code.

## Why It's Good For The Game
Make chef happy to not get karate, they can make food in batches (for soup pot reactions).

Fixes #7578
Fixes #7634
Fixes #8108

Fixes #8204 (indirect fix by allowing batch cooking; recipe rebalance low priority)

## Changelog
:cl: Lawlolawl
fix: Ports fix for cooking. Soup recipes (boiling on a burner using soup pots) now spawn proportionate cooked food to ingredients used. Also no longer causes excess unused ingredients to disappear.
/:cl:
