### PR TITLE
rebalances pineapple fried rice recipe

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_martian.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_martian.dm
@@ -121,7 +121,7 @@
 	name = "Hawaiian pineapple fried rice"
 	reqs = list(
 		/obj/item/food/grown/pineapple = 1,
-		/obj/item/food/boiledrice = 5,
+		/obj/item/food/boiledrice = 1,
 		/obj/item/food/pineappleslice/grilled = 1,
 		/obj/item/food/grown/chili = 1,
 		/obj/item/food/grown/carrot = 1,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Change recipe: requires 1 boiled rice instead of 5.

## Why It's Good For The Game
Fixes #8204 completely
5 boiled rice was a bit much, no other recipe needed that much rice. Overall the nutrition provided is comparable to other fried rice recipes, while extra effort would be needed to juice lemons and limes.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: Lawlolawl
balance: rebalanced pineapple fried rice recipe to only require 1x boiled rice instead of 5x.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
