### PR TITLE
Cache temperature insulation, so we don't need to check every equipped item EVERY MOB LIFE TICK

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -675,11 +675,13 @@
 	item_flags &= ~IN_INVENTORY
 	UnregisterSignal(src, list(SIGNAL_ADDTRAIT(TRAIT_NO_WORN_ICON), SIGNAL_REMOVETRAIT(TRAIT_NO_WORN_ICON)))
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
-	if(user && iscarbon(user))
+	if(iscarbon(user))
 		SEND_SIGNAL(user, COMSIG_CARBON_ITEM_DROPPED, src)
 	if(!silent)
 		playsound(src, drop_sound, DROP_SOUND_VOLUME, ignore_walls = FALSE, mixer_channel = drop_mixer_channel) // monkestation edit: sound mixer
-	user?.update_equipment_speed_mods()
+	if(user)
+		user.update_cached_insulation()
+		user.update_equipment_speed_mods()
 
 /// called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
@@ -689,6 +691,7 @@
 	if(iscarbon(user))
 		SEND_SIGNAL(user, COMSIG_CARBON_ITEM_PICKED_UP, src)
 	item_flags |= IN_INVENTORY
+	user.update_cached_insulation()
 
 /// called when "found" in pockets and storage items. Returns 1 if the search should end.
 /obj/item/proc/on_found(mob/finder)
@@ -748,6 +751,7 @@
 			playsound(src, equip_sound, EQUIP_SOUND_VOLUME, TRUE, ignore_walls = FALSE, mixer_channel = equip_mixer_channel) // monkestation: sound mixer
 		else if(slot & ITEM_SLOT_HANDS)
 			playsound(src, pickup_sound, PICKUP_SOUND_VOLUME, ignore_walls = FALSE, mixer_channel = pickup_mixer_channel) // monkestation: sound mixer
+	user.update_cached_insulation()
 	user.update_equipment_speed_mods()
 
 /// Gives one of our item actions to a mob, when equipped to a certain slot

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -342,6 +342,12 @@
 		held.screen_loc = ui_hand_position(index)
 		client.screen |= held
 
+/mob/living/basic/update_cached_insulation()
+	return
+
+/mob/living/basic/get_insulation(temperature)
+	return temperature_insulation
+
 //MONKESTATION EDIT START
 /mob/living/basic/proc/get_scream_sound()
 	return

--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -28,6 +28,12 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	harvest_organs()
 	return ..()
 
+/mob/living/carbon/human/dummy/update_cached_insulation()
+	return
+
+/mob/living/carbon/human/dummy/get_insulation(temperature)
+	return temperature_insulation
+
 /*
 	MONKESTATION EDIT START
 	This causes a problem with tall players as some of their overlays will go outside of the 32x32 range which the mob's icon is restricted to

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -642,3 +642,9 @@
 
 /mob/living/simple_animal/compare_sentience_type(compare_type)
 	return sentience_type == compare_type
+
+/mob/living/simple_animal/update_cached_insulation()
+	return
+
+/mob/living/simple_animal/get_insulation(temperature)
+	return temperature_insulation


### PR DESCRIPTION
## About The Pull Request

this makes it so mob temperature insulation is cached, updated whenever an item is equipped or dropped, so we don't need to loop thru equipped items every single tick.

## Why It's Good For The Game

`get_insulation` and `get_equipped_items` are horrible for performance, so uh, let's handle those

## Changelog

no player-facing changes
