### PR TITLE
Reduces cult visions range.

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/annoying/cult_syndrome.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/annoying/cult_syndrome.dm
@@ -18,7 +18,7 @@
 	mob.whisper("...[pick(rune_words_rune)]...")
 
 	var/list/turf_list = list()
-	for(var/turf/T in spiral_block(get_turf(mob), 40))
+	for(var/turf/T in spiral_block(get_turf(mob), 10))
 		if(locate(/obj/structure/grille) in T.contents)
 			continue
 		if(istype(get_area(T), /area/station/service/chapel))


### PR DESCRIPTION

## About The Pull Request
Reduces cult syndrome to 15 tiles from 40, 
## Why It's Good For The Game
So to help visualize. 
This is 40 tiles
<img width="583" height="213" alt="image" src="https://github.com/user-attachments/assets/870b932b-6144-49e2-b6f7-fa5f39a4cf0b" />
Now to my understand, this is 40 tiles. Radius. And accounting for the fact height is involved it would look more akin to....
<img width="768" height="769" alt="image" src="https://github.com/user-attachments/assets/6b62282b-6d87-426e-b215-20bb43b0e32b" />
So standing in blueshields office to my understanding you can imagine a fake rune only you can see, in botany and library. 80 tiles is a third of our maps height. 
Now mind you its not every single tile, as it checks it in this spiral pattern (I dont understand it frankly), but either way nerf to 15. 
40 tiles is bigger than runtime statations actual station
<img width="1111" height="1083" alt="Screenshot 2025-09-25 164626" src="https://github.com/user-attachments/assets/67f865d9-516a-4e33-bd01-6ea9e45f3a46" />
## Changelog
:cl:
code:  Cult hallucinations now only proc in a 15 tile radius, not 40.
/:cl:
