### PR TITLE
Dehugboxes BSA

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -16,7 +16,8 @@
 	specific_parts = TRUE
 	req_components = list(
 		/datum/stock_part/manipulator/tier4 = 5,
-		/obj/item/stack/cable_coil = 2)
+		/obj/item/stack/cable_coil = 2,
+		/obj/item/assembly/signaler/anomaly/bluespace = 1)
 
 /obj/item/circuitboard/machine/bsa/middle
 	name = "Bluespace Artillery Fusor"

--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -152,6 +152,7 @@
 		Highly advanced research is required for proper construction."
 	cost = CARGO_CRATE_VALUE * 30
 	special = TRUE
+	access = ACCESS_COMMAND
 	access_view = ACCESS_COMMAND
 	contains = list(/obj/item/circuitboard/machine/bsa/front,
 					/obj/item/circuitboard/machine/bsa/middle,
@@ -159,6 +160,7 @@
 					/obj/item/circuitboard/computer/bsa_control,
 				)
 	crate_name= "bluespace artillery parts crate"
+	crate_type = /obj/structure/closet/crate/secure/engineering
 
 /datum/supply_pack/engineering/dna_vault
 	name = "DNA Vault Parts"

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -2,7 +2,6 @@ GLOBAL_DATUM_INIT(keycard_events, /datum/events, new)
 
 #define KEYCARD_RED_ALERT "Red Alert"
 #define KEYCARD_EMERGENCY_MAINTENANCE_ACCESS "Emergency Maintenance Access"
-#define KEYCARD_BSA_UNLOCK "Bluespace Artillery Unlock"
 #define KEYCARD_PIN_UNRESTRICT "Unrestrict Permit Firing Pins"
 
 #define ACCESS_GRANTING_COOLDOWN (30 SECONDS)
@@ -51,7 +50,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 	data["red_alert"] = (SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_RED) ? 1 : 0
 	data["can_set_alert"] = SSsecurity_level.current_security_level?.can_crew_change_alert
 	data["emergency_maint"] = GLOB.emergency_access
-	data["bsa_unlock"] = GLOB.bsa_unlock
 	return data
 
 /obj/machinery/keycard_auth/ui_status(mob/user)
@@ -87,10 +85,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 		if("pin_unrestrict")
 			if(!event_source)
 				sendEvent(KEYCARD_PIN_UNRESTRICT)
-				. = TRUE
-		if("bsa_unlock")
-			if(!event_source)
-				sendEvent(KEYCARD_BSA_UNLOCK)
 				. = TRUE
 		if("give_janitor_access")
 			var/mob/living/living_user = usr
@@ -162,8 +156,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/keycard_auth, 26)
 				SSsecurity_level.set_level(SEC_LEVEL_RED)
 		if(KEYCARD_EMERGENCY_MAINTENANCE_ACCESS)
 			make_maint_all_access()
-		if(KEYCARD_BSA_UNLOCK)
-			toggle_bluespace_artillery()
 		if(KEYCARD_PIN_UNRESTRICT)
 			toggle_permit_pins()
 
@@ -192,13 +184,7 @@ GLOBAL_VAR_INIT(emergency_access, FALSE)
 	GLOB.emergency_access = FALSE
 	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("emergency maintenance access", "disabled"))
 
-/proc/toggle_bluespace_artillery()
-	GLOB.bsa_unlock = !GLOB.bsa_unlock
-	minor_announce("Bluespace Artillery firing protocols have been [GLOB.bsa_unlock? "unlocked" : "locked"]", "Weapons Systems Update:")
-	SSblackbox.record_feedback("nested tally", "keycard_auths", 1, list("bluespace artillery", GLOB.bsa_unlock? "unlocked" : "locked"))
-
 #undef ACCESS_GRANTING_COOLDOWN
 #undef KEYCARD_RED_ALERT
 #undef KEYCARD_EMERGENCY_MAINTENANCE_ACCESS
-#undef KEYCARD_BSA_UNLOCK
 #undef KEYCARD_PIN_UNRESTRICT

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -402,7 +402,7 @@
 			else
 				bsa_unlock = FALSE
 				to_chat(user, span_notice("[src] firing protocols have been locked."))
-			update_static_data(user)
+			update_static_data_for_all_viewers()
 		return
 	return ..()
 

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -405,7 +405,7 @@
 	return ..()
 
 /obj/machinery/computer/bsa_control/multitool_act(mob/living/user, obj/item/multitool/M)
-	if(!do_after(user, 5 SECONDS, src))
+	if(!do_after(user, 1 SECONDS, src))
 		return ITEM_INTERACT_SUCCESS
 	if(!rigged_to_blow)
 		balloon_alert(user, "rigged to explode")

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -407,7 +407,7 @@
 		if((ACCESS_COMMAND in card.access))
 			if(!bsa_unlock)
 				bsa_unlock = TRUE
-				to_chat(user, span_notice("[src] firing protocols have been unlocked."))	//I coped this function from mechfab code, probably code use rewording.
+				to_chat(user, span_notice("[src] firing protocols have been unlocked."))	//I copied this function from mechfab code, maybe could use rewording.
 				user.log_message("has unlocked [src].", LOG_GAME)
 			else
 				bsa_unlock = FALSE

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -133,6 +133,8 @@
 	var/ex_power = 3
 	var/power_used_per_shot = 2000000 //enough to kil standard apc - todo : make this use wires instead and scale explosion power with it
 	var/ready
+	/// How long the beam is. Is actually 6 tiles less than what is put here since we count from the center of the BSA.
+	var/beam_length = 26 //Enough to cover an entire screen.
 	pixel_y = -32
 	pixel_x = -192
 	bound_width = 352
@@ -159,11 +161,15 @@
 	return get_turf(src)
 
 /obj/machinery/bsa/full/proc/get_target_turf()
+	/// The x value of where the beam will end up at.
+	var/x_value
 	switch(dir)
 		if(WEST)
-			return locate(1,y,z)
+			x_value = max(1,x - beam_length)
+			return locate(x_value,y,z)
 		if(EAST)
-			return locate(world.maxx,y,z)
+			x_value = min(world.maxx, x + beam_length)
+			return locate(x_value,y,z)
 	return get_turf(src)
 
 /obj/machinery/bsa/full/Initialize(mapload, cannon_direction = WEST)
@@ -218,7 +224,7 @@
 			break
 		else
 			SSexplosions.highturf += tile //also fucks everything else on the turf
-	point.Beam(target, icon_state = "bsa_beam", time = 5 SECONDS, maxdistance = world.maxx) //ZZZAP
+	point.Beam(target, icon_state = "bsa_beam", time = 5 SECONDS, maxdistance = beam_length) //ZZZAP
 	new /obj/effect/temp_visual/bsa_splash(point, dir)
 
 	notify_ghosts(

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -364,11 +364,15 @@
 
 /obj/machinery/computer/bsa_control/proc/fire(mob/user)
 	var/obj/machinery/bsa/full/cannon = cannon_ref?.resolve()
+	var/datum/component/gps/G = target
 	if(!cannon)
 		notice = "No Cannon Exists!"
 		return
 	if(cannon.machine_stat)
 		notice = "Cannon unpowered!"
+		return
+	if(QDELETED(G.parent) && !rigged_to_blow) // Makes sure the signal isn't deleted. If rigged to blow, will still blow up the BSA.
+		notice = "Target does not exist! Select a new target!"
 		return
 	notice = null
 	var/turf/target_turf = get_impact_turf()

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -408,9 +408,11 @@
 			if(!bsa_unlock)
 				bsa_unlock = TRUE
 				to_chat(user, span_notice("[src] firing protocols have been unlocked."))	//I coped this function from mechfab code, probably code use rewording.
+				user.log_message("has unlocked [src].", LOG_GAME)
 			else
 				bsa_unlock = FALSE
 				to_chat(user, span_notice("[src] firing protocols have been locked."))
+				user.log_message("has locked [src].", LOG_GAME)
 			update_static_data_for_all_viewers()
 			return ITEM_INTERACT_SUCCESS
 	return NONE
@@ -421,16 +423,19 @@
 	if(!rigged_to_blow)
 		balloon_alert(user, "rigged to explode")
 		to_chat(user, span_warning("You pulse [src] and hear the focusing crystal short out. You get the feeling it wouldn't be wise to stand near [src] when the BSA fires..."))
+		user.log_message("has rigged [src] to detonate itself.", LOG_GAME)
 		rigged_to_blow = TRUE
 	else
 		balloon_alert(user, "safeties restored")
 		to_chat(user, span_warning("You pulse [src] and restore the focusing crystal. It appears someone had rigged the BSA to explode..."))
+		user.log_message("has restored the safeties of [src].", LOG_GAME)
 		rigged_to_blow = FALSE
 	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/computer/bsa_control/emp_act(severity)
 	. = ..()
 	rigged_to_blow = TRUE	//EMPs will make the BSA fire on itself if you don't check with multitool.
+	log_game("An EMP has rigged [src] to detonate itself.")
 
 /obj/machinery/computer/bsa_control/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(obj_flags & EMAGGED)
@@ -438,5 +443,6 @@
 	obj_flags |= EMAGGED
 	bsa_unlock = TRUE
 	balloon_alert(user, "unlocked")
-	to_chat(user, span_warning("You emag [src] and hear the focusing crystal short out. You get the feeling it wouldn't be wise to stand near [src] when the BSA fires..."))
+	to_chat(user, span_warning("You emag [src] bypass the authentication lock."))
+	user.log_message("has unlocked [src] with an emag.", LOG_GAME)
 	return TRUE

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -269,7 +269,9 @@
 	icon_keyboard = null
 	icon_screen = null
 
+	/// Is the BSA unlocked?
 	var/bsa_unlock = FALSE
+	/// Will the BSA target itself when it's fired?
 	var/rigged_to_blow = FALSE
 	var/datum/weakref/cannon_ref
 	var/notice
@@ -405,7 +407,7 @@
 	return ..()
 
 /obj/machinery/computer/bsa_control/multitool_act(mob/living/user, obj/item/multitool/M)
-	if(!do_after(user, 1 SECONDS, src))
+	if(!do_after(user, 5 SECONDS, src))
 		return ITEM_INTERACT_SUCCESS
 	if(!rigged_to_blow)
 		balloon_alert(user, "rigged to explode")
@@ -416,6 +418,10 @@
 		to_chat(user, span_warning("You pulse [src] and restore the focusing crystal. It appears someone had rigged the BSA to explode..."))
 		rigged_to_blow = FALSE
 	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/computer/bsa_control/emp_act(severity)
+	. = ..()
+	rigged_to_blow = TRUE	//EMPs will make the BSA fire on itself if you don't check with multitool.
 
 /obj/machinery/computer/bsa_control/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(obj_flags & EMAGGED)

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -209,6 +209,9 @@
 	var/turf/point = get_front_turf()
 	var/turf/target = get_target_turf()
 	var/atom/movable/blocker
+
+	for(var/mob/living/mob in point) //The tile next to the cannon will not destroy turfs/objects, (so you can put a holobarrier) but WILL gib everyone on that tile.
+		mob.gib()
 	for(var/T in get_line(get_step(point, dir), target))
 		var/turf/tile = T
 		if(SEND_SIGNAL(tile, COMSIG_ATOM_BSA_BEAM) & COMSIG_ATOM_BLOCKS_BSA_BEAM)

--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -387,14 +387,14 @@
 	qdel(centerpiece)
 	return cannon
 
-/obj/machinery/computer/bsa_control/attackby(obj/item/object, mob/living/user, params)
-	var/obj/item/card/id/card = object.GetID()
+/obj/machinery/computer/bsa_control/item_interaction(mob/living/user, obj/item/tool,  list/modifiers)
+	var/obj/item/card/id/card = tool.GetID()
 	if(card)
 		if(obj_flags & EMAGGED)
 			to_chat(user, span_warning("The authentification slot spits sparks at you and the display reads scrambled text!"))
 			do_sparks(1, FALSE, src)
 			bsa_unlock = TRUE // just in case it wasn't already for some reason. keycard reader is busted.
-			return
+			return ITEM_INTERACT_SUCCESS
 		if((ACCESS_COMMAND in card.access))
 			if(!bsa_unlock)
 				bsa_unlock = TRUE
@@ -403,8 +403,8 @@
 				bsa_unlock = FALSE
 				to_chat(user, span_notice("[src] firing protocols have been locked."))
 			update_static_data(user)
-		return
-	return ..()
+			return ITEM_INTERACT_SUCCESS
+	return NONE
 
 /obj/machinery/computer/bsa_control/multitool_act(mob/living/user, obj/item/multitool/M)
 	if(!do_after(user, 5 SECONDS, src))

--- a/tgui/packages/tgui/interfaces/BluespaceArtillery.tsx
+++ b/tgui/packages/tgui/interfaces/BluespaceArtillery.tsx
@@ -53,10 +53,7 @@ export const BluespaceArtillery = (props) => {
                   <Box color="bad" fontSize="18px">
                     Bluespace artillery is currently locked.
                   </Box>
-                  <Box mt={1}>
-                    Awaiting authorization via keycard reader from at minimum
-                    two station heads.
-                  </Box>
+                  <Box mt={1}>Awaiting authorization from command</Box>
                 </>
               )}
             </Section>

--- a/tgui/packages/tgui/interfaces/KeycardAuth.jsx
+++ b/tgui/packages/tgui/interfaces/KeycardAuth.jsx
@@ -49,12 +49,6 @@ export const KeycardAuth = (props) => {
                       content="Emergency Maintenance Access"
                     />
                     <Button
-                      icon="meteor"
-                      fluid
-                      onClick={() => act('bsa_unlock')}
-                      content="Bluespace Artillery Unlock"
-                    />
-                    <Button
                       icon="key"
                       fluid
                       onClick={() => act('pin_unrestrict')}


### PR DESCRIPTION
## About The Pull Request
BSA has been changed such that it has less hugbox.

- Instead of requiring keycard auth, you now swipe with command access or emag to unlock it.
- Instead of emag you use multitool to sabotage BSA. (Because emag is now used to unlock.)
- EMPs can also sabotage the BSA.
- AI is able to interact with it.

To make it so there's SOME difficulty in building illicit BSAs, I did make the BSA cargo crate locked, and it now requires a bluespace anomaly core.
I made some other changes too.

- BSA now requires a bluespace anomaly to build, to make it harder to build. (Should take more than a cargo crate and parts from a lathe.)
- BSA crate is now a secure crate.
- BSA beam now only goes 20 tiles instead of the entire map, so that the actual explosion is more destructive than the station splitting beam.
- Standing right in front of the BSA when it fires gibs you. (It used to be safe to stand there.)
- I fixed a runtime where you could fire at a GPS signal that had its parent deleted.

I COULD make it also require a flux core for the generator, but that might be overkill?

## Why It's Good For The Game
It's very hugbox for the BSA to be more or less impossible to use for evil. It's very annoying for engineers if command is too lazy to go to keycard auths to unlock BSA.

I nerfed the station splitting beam because the actual explosion should be more impactful than the beam, it's still very destructive (20 tiles of deletion) so you should still make it face away from the station.

Making the BSA a bit harder to build (secure crate + bluespace anomaly) helps in two ways:

1. It makes it harder for someone to make an illicit BSA, because an anomaly core is an item you can't get from a lathe at a whim.
2. The BSA is kinda easy to complete considering it's a station wide goal, so requiring an anomaly core makes it require more department cooperation.

## Changelog
:cl:
balance: BSA has been rebalanced. It is now possible to have illicit BSA, the beam has been shortened, and the BSA requires a bluespace anomaly among other more minor changes.
fix: Fixes a runtime where the BSA could fire at a GPS signal whose parent no longer exists.
/:cl:
