### PR TITLE
Burning items now emit smoke/pollution

### DIFF
--- a/code/datums/components/burning.dm
+++ b/code/datums/components/burning.dm
@@ -66,7 +66,11 @@ GLOBAL_DATUM_INIT(fire_overlay, /mutable_appearance, mutable_appearance('icons/e
 	if(atom_parent.resistance_flags & FIRE_PROOF)
 		atom_parent.extinguish()
 		return
-	atom_parent.take_damage(5 * seconds_per_tick, BURN, FIRE, FALSE) //monkestation edit: 10 to 5 damage
+	atom_parent.take_damage(5 * seconds_per_tick, BURN, FIRE, FALSE)
+	var/turf/open/my_turf = get_turf(src)
+	if(istype(my_turf) && !my_turf.planetary_atmos) //Pollute, but only when we're not on planetary atmos
+		var/delta_time = DELTA_WORLD_TIME(SSburning) // don't use this for take_damage, so we don't take a shitload of damage at once during lag. but it's fine for smoke generation :)
+		my_turf.pollute_turf_list(list(/datum/pollutant/smoke = 10 * delta_time, /datum/pollutant/carbon_air_pollution = 2 * delta_time), POLLUTION_PASSIVE_EMITTER_CAP)
 
 /// Alerts any examiners that the parent is on fire (even though it should be rather obvious)
 /datum/component/burning/proc/on_examine(atom/source, mob/user, list/examine_list)

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -168,7 +168,8 @@
 		return
 	var/turf/open/my_turf = get_turf(src)
 	if(istype(my_turf) && !my_turf.planetary_atmos) //Pollute, but only when we're not on planetary atmos
-		my_turf.pollute_turf_list(list(/datum/pollutant/smoke = 15, /datum/pollutant/carbon_air_pollution = 5), POLLUTION_PASSIVE_EMITTER_CAP)
+		var/delta_time = DELTA_WORLD_TIME(SSobj)
+		my_turf.pollute_turf_list(list(/datum/pollutant/smoke = 15 * delta_time, /datum/pollutant/carbon_air_pollution = 5 * delta_time), POLLUTION_PASSIVE_EMITTER_CAP)
 	bonfire_burn(seconds_per_tick)
 
 /obj/structure/bonfire/extinguish()

--- a/monkestation/code/modules/pollution/generic_turf_pollutions.dm
+++ b/monkestation/code/modules/pollution/generic_turf_pollutions.dm
@@ -5,8 +5,6 @@
 	return
 
 /turf/open/pollute_turf(pollution_type, amount, cap)
-	if(QDELING(src))
-		return
 	if(QDELETED(pollution))
 		pollution = new(src)
 	if(cap && pollution.total_amount >= cap)
@@ -14,8 +12,6 @@
 	pollution.add_pollutant(pollution_type, amount)
 
 /turf/open/pollute_turf_list(list/pollutions, cap)
-	if(QDELING(src))
-		return
 	if(QDELETED(pollution))
 		pollution = new(src)
 	if(cap && pollution.total_amount >= cap)


### PR DESCRIPTION

## About The Pull Request

this makes it so burning objects (i.e when you set a piece of paper on fire) emits smoke.

also made it so bonfire smoke emission uses SSobj delta time

## Why It's Good For The Game

fun little immersion / detail thing.

## Changelog
:cl:
add: Burning items now emit smoke/pollution.
qol: Bonfire smoke emission now compensates for lag.
/:cl:
