### PR TITLE
Hivequeen borers are now empowered borers

### DIFF
--- a/monkestation/code/modules/antagonists/borers/code/antagonist_stuff/midround_event.dm
+++ b/monkestation/code/modules/antagonists/borers/code/antagonist_stuff/midround_event.dm
@@ -56,7 +56,7 @@
 	var/list/candidates = SSpolling.poll_ghost_candidates(
 		role = ROLE_CORTICAL_BORER,
 		ignore_category = POLL_IGNORE_CORTICAL_BORER,
-		alert_pic = /mob/living/basic/cortical_borer,
+		alert_pic = /mob/living/basic/cortical_borer/empowered,
 	)
 
 	if(!length(candidates))
@@ -69,7 +69,7 @@
 		var/mob/dead/observer/new_borer = pick(candidates)
 		candidates -= new_borer
 		var/vent = pick(vents)
-		var/mob/living/basic/cortical_borer/spawned_cb = new /mob/living/basic/cortical_borer(get_turf(vent))
+		var/mob/living/basic/cortical_borer/empowered/spawned_cb = new /mob/living/basic/cortical_borer/empowered(get_turf(vent))
 		spawned_cb.move_into_vent(vent)
 		spawned_cb.PossessByPlayer(new_borer.ckey)
 		spawned_cb.mind.add_antag_datum(/datum/antagonist/cortical_borer/hivemind)
@@ -115,7 +115,7 @@
 
 /datum/dynamic_ruleset/midround/from_ghosts/cortical_borer/generate_ruleset_body(mob/applicant)
 	var/obj/vent = pick_n_take(vents)
-	var/mob/living/basic/cortical_borer/new_borer = new(vent.loc)
+	var/mob/living/basic/cortical_borer/empowered/new_borer = new(vent.loc)
 	new_borer.PossessByPlayer(applicant.key)
 	new_borer.move_into_vent(vent)
 	message_admins("[ADMIN_LOOKUPFLW(new_borer)] has been made into a borer by the midround ruleset.")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Hivequeen borers are now "empowered," making them stronger to start with.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Being a borer before objectives have been completed is just a TON of waiting. You need a lot of evolution points before you can do much. Hivequeens suffer the most from this because they're the first.

This lets the hivequeens not get smashed before they can breed, (removing a high threat antag without them doing anything,) and reduces the boring waiting for evo points period. (Besides you expect the queens to be strong.)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Hivequeen borers are now empowered.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
