### PR TITLE
Disease, airborne, something something, no spread if your not able to be infected evenways.

### DIFF
--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -106,18 +106,14 @@ GLOBAL_LIST_INIT(inspectable_diseases, list())
 	if(!(spread_flags & DISEASE_SPREAD_AIRBORNE) && !force_spread)
 		return
 
-	if(HAS_TRAIT(affected_mob, TRAIT_VIRUS_RESISTANCE) || (affected_mob.satiety > 0 && prob(affected_mob.satiety/10)))
+	if(HAS_TRAIT(affected_mob, TRAIT_VIRUS_RESISTANCE) || (affected_mob.satiety > 0 && prob(affected_mob.satiety/10)) || HAS_TRAIT(affected_mob, TRAIT_NOBREATH) || affected_mob.check_airborne_sterility())
+		return
+
+	if((affected_mob.stat == DEAD) && process_dead == FALSE) // Only create clouds if we process our dead.
 		return
 
 	affected_mob.spread_airborne_diseases()
-	/*
-	var/turf/T = affected_mob.loc
-	if(istype(T))
-		for(var/mob/living/carbon/C in oview(spread_range, affected_mob))
-			var/turf/V = get_turf(C)
-			if(disease_air_spread_walk(T, V))
-				C.AirborneContractDisease(src, force_spread)
-	*/
+
 /proc/disease_air_spread_walk(turf/start, turf/end)
 	if(!start || !end)
 		return FALSE

--- a/monkestation/code/modules/virology/disease/premades/debug_disease.dm
+++ b/monkestation/code/modules/virology/disease/premades/debug_disease.dm
@@ -38,7 +38,11 @@
 	cached_data |= "[/datum/disease/acute/premade/disease_debug]"
 	src.data = cached_data
 
-/obj/item/storage/box/disease_debug/PopulateContents()
+/obj/item/storage/box/debugbox/tools
+	name = "box of a debug disease"
+	icon_state = "syndiebox"
+
+/obj/item/storage/box/debugbox/disease/PopulateContents()
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/hypospray/medipen/tuberculosiscure/debug(src)
 	new /obj/item/reagent_containers/syringe(src)

--- a/monkestation/code/modules/virology/living/infection_procs.dm
+++ b/monkestation/code/modules/virology/living/infection_procs.dm
@@ -64,18 +64,6 @@
 			for(var/datum/disease/acute/V as anything in C.diseases)
 				if(V.spread_flags & DISEASE_SPREAD_AIRBORNE)
 					infect_disease(V, notes="(Airborne, from [C])")
-		/*
-		for(var/obj/effect/rune/R in T)
-			if(istype(R.virus2,/list) && R.virus2.len > 0)
-				for(var/datum/disease/acute/V as anything in R.diseases)
-					if(V.spread_flags & DISEASE_SPREAD_AIRBORNE)
-						infect_disease(V, notes="(Airborne, from [R])")
-		*/
-
-		spawn (1)
-			//we don't want the rest of the mobs to start breathing clouds before they've settled down
-			//otherwise it can produce exponential amounts of lag if many mobs are in an enclosed space
-			spread_airborne_diseases()
 
 /mob/living/proc/breath_airborne_diseases_from_clouds()
 	var/sanity = 0

--- a/monkestation/code/modules/virology/living/mouse.dm
+++ b/monkestation/code/modules/virology/living/mouse.dm
@@ -66,3 +66,5 @@
 		if(TICK_CHECK)
 			break
 		share_contact_diseases(mouse)//Mice automatically share contact diseases among themselves
+		if(!(stat == DEAD))
+			spread_airborne_diseases()

--- a/monkestation/code/modules/virology/living/spread_disease.dm
+++ b/monkestation/code/modules/virology/living/spread_disease.dm
@@ -7,9 +7,6 @@
 	var/image/pathogen
 
 /mob/living/proc/spread_airborne_diseases()
-	if((stat == DEAD) || HAS_TRAIT(src, TRAIT_NOBREATH) || check_airborne_sterility())
-		return
-
 	//spreading our own airborne viruses
 	if (diseases && diseases.len > 0)
 		var/list/airborne_viruses = filter_disease_by_spread(diseases, required = DISEASE_SPREAD_AIRBORNE)

--- a/monkestation/code/modules/virology/living/spread_disease.dm
+++ b/monkestation/code/modules/virology/living/spread_disease.dm
@@ -7,6 +7,9 @@
 	var/image/pathogen
 
 /mob/living/proc/spread_airborne_diseases()
+	if((stat == DEAD) || HAS_TRAIT(src, TRAIT_NOBREATH) || check_airborne_sterility())
+		return
+
 	//spreading our own airborne viruses
 	if (diseases && diseases.len > 0)
 		var/list/airborne_viruses = filter_disease_by_spread(diseases, required = DISEASE_SPREAD_AIRBORNE)


### PR DESCRIPTION
## About The Pull Request
- Airborne pathogen clouds wont be created from mobs that can't breathe, pass biochecks for protection, or are a corspe.
- Moves disease_debug boxes into a debug subtype
- Pathogen clouds no longer occur at twice the rate or so they should
## Why It's Good For The Game
Besides adding some prevention methods and encouraging mask usage even if your already infected.
Corspes not creating pathogens helps on two fronts, simplemobs who can't be cured not acting as a permanent AOE vector, and preformance in general, imagine a pile of 8 monkeys constantly making 5-6 clouds each, that check the surrounding area all for mobs to infect.

No breathe and sterility on the other hand act more for general countermeasures. Among things like satiety and virus resistance.

Debug boxes were subtyped wrong, simple fix.

Removing the double proc allows for the appropriate checks to run for if a cloud should even be made. Such as spaceallin stopping infections.

While technically balance, I imagine it'll help ALOT with performance putting less strain on the pathogen cloud subsystem by ignoring random corpses.
## Changelog
:cl:
balance: Airborne diseases won't spread if you are a corpse, have no need to breathe, or are wearing appropriate protection.
fix: Debug disease kits are now properly subtyped.
fix: Airbrone diseases no longer proc twice, and will properly respect TRAIT_VIRUS_RESISTANCE and satiety.
/:cl:
