### PR TITLE
Atmos Roundstart PipeNet changes

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -1013,7 +1013,6 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain/private)
 "akk" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped,
 /turf/open/floor/iron/smooth_edge{
 	dir = 4
 	},
@@ -4425,10 +4424,6 @@
 /turf/open/floor/iron/shuttle/evac/airless,
 /area/space/nearstation)
 "aSG" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Plasma injector"
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/test_chambers)
@@ -9210,13 +9205,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"bNO" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/test_chambers)
 "bNQ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -10829,13 +10817,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/upper)
-"cdE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cdK" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -12634,9 +12615,6 @@
 /area/station/engineering/supermatter/room)
 "cuE" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 8
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/test_chambers)
 "cuH" = (
@@ -16224,12 +16202,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
-"dbE" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/test_chambers)
 "dbJ" = (
 /turf/open/floor/iron/dark/side{
 	dir = 6
@@ -21417,10 +21389,6 @@
 /turf/open/floor/iron,
 /area/station/ai_monitored/command/storage/eva)
 "eeE" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4;
-	initialize_directions = 8
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -22292,13 +22260,6 @@
 "emO" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/console_room)
-"end" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/test_chambers)
 "enh" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/water_cooler,
@@ -22348,10 +22309,6 @@
 /obj/structure/urinal/directional/west,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/toilet/auxiliary)
-"eof" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/test_chambers)
 "eoj" = (
 /obj/structure/table,
 /obj/item/folder/white{
@@ -22487,13 +22444,6 @@
 /obj/machinery/station_map/engineering/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/patients_rooms)
-"epH" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/test_chambers)
 "epI" = (
 /obj/item/stack/sheet/cardboard,
 /turf/open/floor/plating,
@@ -24866,7 +24816,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "eLa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
 	},
@@ -24920,7 +24869,6 @@
 /turf/open/floor/circuit,
 /area/station/science/research/abandoned)
 "eLw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/smooth_edge{
 	dir = 8
@@ -26962,7 +26910,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
-/obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
@@ -28826,9 +28773,6 @@
 /turf/open/floor/engine,
 /area/station/command/heads_quarters/rd)
 "fyk" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
@@ -29941,12 +29885,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"fLS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/test_chambers)
 "fLW" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/work)
@@ -32194,7 +32132,7 @@
 /area/station/security/checkpoint)
 "gjr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/components/binary/pump{
+/obj/machinery/atmospherics/components/binary/pump/off/orange{
 	dir = 8;
 	name = "Mix to Engine"
 	},
@@ -37417,7 +37355,6 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/miningdock)
 "hjp" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/test_chambers)
@@ -39770,10 +39707,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/storage)
-"hIj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hIo" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -43255,9 +43188,6 @@
 /area/station/hallway/primary/upper)
 "iqx" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	name = "Waste connector port"
-	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -43418,11 +43348,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
 "isg" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/duct,
-/turf/open/floor/iron/dark,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/turf/open/floor/iron,
 /area/station/engineering/atmos/test_chambers)
 "isi" = (
 /obj/structure/chair/sofa/bench/right{
@@ -61434,12 +61361,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/barber)
-"lQB" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "To Port"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lQD" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/item/stack/spacecash/c500,
@@ -61876,10 +61797,9 @@
 /turf/open/floor/eighties/red,
 /area/station/common/arcade)
 "lUF" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/obj/machinery/duct,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos/test_chambers)
 "lUG" = (
 /obj/structure/cable,
@@ -66841,11 +66761,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
-"mTU" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/test_chambers)
 "mTW" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Janitorial Closet"
@@ -69630,13 +69545,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/carpet,
 /area/station/service/theater/abandoned)
-"nyl" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/test_chambers)
 "nyo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt,
@@ -73490,10 +73398,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/port)
-"oki" = (
-/obj/machinery/atmospherics/components/binary/pump,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/test_chambers)
 "okl" = (
 /obj/item/kirbyplants/organic/plant21,
 /turf/open/floor/iron,
@@ -82958,8 +82862,6 @@
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qce" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
-/obj/machinery/meter,
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -83219,9 +83121,6 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/primary)
 "qeW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/duct,
 /turf/open/floor/iron/dark,
@@ -83232,11 +83131,6 @@
 	},
 /turf/open/floor/iron/dark/small,
 /area/station/cargo/storage)
-"qfd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qfl" = (
 /obj/structure/table,
 /obj/machinery/newscaster/directional/east,
@@ -88513,12 +88407,6 @@
 /obj/effect/turf_decal/tile/red/real_red/diagonal_centre,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"rew" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rex" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -88679,12 +88567,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"rgd" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/test_chambers)
 "rgg" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -88757,9 +88639,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engineering/lesser)
 "rgW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes{
 	dir = 1
 	},
@@ -101952,13 +101831,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"tHX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 6
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/maintenance/disposal/incinerator)
 "tHY" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/central)
@@ -102235,10 +102107,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/port)
-"tKQ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/test_chambers)
 "tKU" = (
 /obj/structure/table/wood,
 /obj/item/clipboard{
@@ -104571,7 +104439,6 @@
 /turf/closed/wall,
 /area/station/medical/coldroom)
 "uhE" = (
-/obj/machinery/pipedispenser/disposal/transit_tube,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "uhH" = (
@@ -106306,9 +106173,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "uxO" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal/incinerator)
 "uxR" = (
@@ -106342,13 +106206,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
-"uxW" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/trinary/mixer/flipped{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/test_chambers)
 "uyi" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/structure/table/rolling,
@@ -108871,7 +108728,6 @@
 	},
 /area/station/ai_monitored/security/armory)
 "uWV" = (
-/obj/machinery/pipedispenser,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 6
 	},
@@ -115290,10 +115146,6 @@
 "wgo" = (
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
-"wgp" = (
-/obj/machinery/pipedispenser/disposal,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "wgs" = (
 /obj/machinery/microwave,
 /obj/machinery/light/directional/west,
@@ -115384,6 +115236,7 @@
 /area/station/security/prison/upper)
 "whj" = (
 /obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/test_chambers)
 "whk" = (
@@ -115886,12 +115739,6 @@
 /obj/machinery/duct,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
-"wlM" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/test_chambers)
 "wlO" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -117475,9 +117322,6 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "wBn" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Filter"
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -120187,9 +120031,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "xcO" = (
-/obj/machinery/atmospherics/components/tank/plasma{
-	dir = 1
-	},
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden{
 	dir = 4
@@ -122320,10 +122161,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"xyi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/test_chambers)
 "xyx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance,
@@ -122520,9 +122357,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "xBs" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
@@ -122792,9 +122626,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "xDM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "xDN" = (
@@ -158675,7 +158506,7 @@ cDI
 bkc
 lpr
 uhE
-wgp
+uhE
 uWV
 dBG
 hMm
@@ -159190,8 +159021,8 @@ eYP
 oxX
 qdj
 jqa
-hIj
-lQB
+xDM
+xDM
 xDM
 fyk
 mhJ
@@ -159449,7 +159280,7 @@ mIx
 jMW
 qce
 csn
-qfd
+xDM
 rgW
 mhJ
 icR
@@ -159704,9 +159535,9 @@ mEg
 bTt
 eCi
 stR
-rew
-lQB
-hIj
+xDM
+xDM
+xDM
 xBs
 mhJ
 lIn
@@ -159963,7 +159794,7 @@ nbC
 wel
 wel
 stY
-cdE
+wBn
 wBn
 pki
 xLV
@@ -163058,10 +162889,10 @@ vLv
 fkL
 qmT
 xcP
-isg
+xcP
 jXB
 qeW
-xcP
+lUF
 hZm
 cnV
 sQQ
@@ -163314,11 +163145,11 @@ akL
 vLv
 fZH
 lZe
-mTU
+onq
 cuE
 vhR
-uxW
-wlM
+cuE
+onq
 sQQ
 biL
 sQQ
@@ -163572,9 +163403,9 @@ oCM
 gzG
 hYS
 onq
-dbE
+onq
 sQQ
-dbE
+onq
 onq
 sQQ
 biL
@@ -163837,15 +163668,15 @@ sQQ
 biL
 sQQ
 lmd
-nyl
-xyi
-epH
-fLS
+eeE
+sQQ
+sQQ
+sQQ
 sQQ
 lmd
 sQQ
 sQQ
-sQQ
+isg
 gkT
 onq
 gkT
@@ -164088,7 +163919,7 @@ cnV
 biL
 hJL
 hjp
-bNO
+hjp
 biL
 biL
 biL
@@ -164351,15 +164182,15 @@ sQQ
 biL
 sQQ
 lmd
-tKQ
-oki
-end
-rgd
-lUF
+sQQ
+sQQ
+sQQ
+sQQ
+sQQ
 lmd
 sQQ
 sQQ
-sQQ
+isg
 gkT
 cdu
 gkT
@@ -165115,8 +164946,8 @@ cyC
 veU
 cnV
 ygq
-eof
-wlM
+onq
+onq
 sQQ
 sQQ
 hYG
@@ -165630,7 +165461,7 @@ fth
 fYp
 euL
 ecj
-tHX
+laI
 aSG
 xcO
 nZT

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -5041,12 +5041,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/station/solars/starboard/aft)
-"bDY" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port Mix to Ports"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "bEa" = (
 /obj/effect/turf_decal/trimline/neutral/filled/warning,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5198,13 +5192,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/locker)
-"bGO" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Ports to Port Mix";
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "bGX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -5342,12 +5329,6 @@
 /obj/item/stamp/head/cmo,
 /turf/open/floor/iron/dark/side,
 /area/station/command/heads_quarters/cmo)
-"bIu" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/disposal/incinerator)
 "bID" = (
 /turf/closed/wall,
 /area/station/medical/break_room)
@@ -6546,12 +6527,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"ccW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "ccZ" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners{
 	dir = 1
@@ -6660,11 +6635,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
-"cdI" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "cdN" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable,
@@ -7604,7 +7574,10 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "N2 to Pure"
+	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
 "ctM" = (
@@ -16873,12 +16846,6 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/commons/dorms/laundry)
-"fwt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "fwv" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -19117,9 +19084,6 @@
 /area/station/maintenance/disposal)
 "gje" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "gji" = (
@@ -20709,12 +20673,6 @@
 	dir = 8
 	},
 /area/station/service/chapel)
-"gHv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "gHw" = (
 /obj/machinery/firealarm/directional/north{
 	pixel_x = -5
@@ -23668,13 +23626,6 @@
 	dir = 10
 	},
 /area/station/commons/locker)
-"hCx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "hCz" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/rack,
@@ -26214,11 +26165,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"itB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "itE" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -28951,12 +28897,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"joY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "jpg" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
@@ -30205,10 +30145,6 @@
 /area/station/maintenance/port)
 "jII" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "N2 to Pure"
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jIO" = (
@@ -38400,9 +38336,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "mnW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
-	},
+/obj/machinery/light/directional/west,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "mnY" = (
@@ -40939,9 +40874,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "nga" = (
@@ -41341,11 +41273,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/courtroom)
-"nlI" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "nlU" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/item/radio/intercom/directional/west,
@@ -42189,13 +42116,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
-"nzT" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "nzX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -44523,13 +44443,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"oma" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/brown/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "omu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/gary,
@@ -45899,13 +45812,6 @@
 /obj/effect/landmark/navigate_destination,
 /turf/open/floor/iron/dark/textured,
 /area/station/command/heads_quarters/hop)
-"oKE" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "oKM" = (
 /obj/effect/turf_decal/siding/thinplating{
 	dir = 8
@@ -47609,12 +47515,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/locker)
-"ppj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "ppm" = (
 /obj/effect/turf_decal/trimline/dark_blue/warning{
 	dir = 8
@@ -49479,6 +49379,7 @@
 /area/station/medical/medbay/aft)
 "pSV" = (
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "pSW" = (
@@ -51804,10 +51705,6 @@
 /obj/structure/closet/emcloset/wall/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"qHq" = (
-/obj/machinery/atmospherics/components/tank/plasma,
-/turf/open/floor/iron,
-/area/station/maintenance/disposal/incinerator)
 "qHu" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -52098,13 +51995,6 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"qNN" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "qNW" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -52510,13 +52400,6 @@
 /obj/structure/sign/warning/radiation/directional/north,
 /turf/open/space/basic,
 /area/space/nearstation)
-"qUp" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "qUs" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/machinery/computer/robotics{
@@ -54043,9 +53926,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
 "rwa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold/dark/visible/layer4{
 	dir = 4
 	},
@@ -54140,9 +54020,7 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
 "rxo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 8
-	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "rxs" = (
@@ -56285,12 +56163,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
-"sgT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "shc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/gary/rare,
@@ -56907,12 +56779,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"spG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "sqj" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/chair{
@@ -57002,9 +56868,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "stI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/trinary/mixer/layer4{
 	dir = 1;
 	name = "turbine mixer"
@@ -60860,11 +60723,6 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/prison)
-"tEg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "tEm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -62768,12 +62626,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/fore)
-"ukC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "ukF" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -66225,10 +66077,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
-"vnO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "vnP" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -67283,10 +67131,6 @@
 /area/station/service/library/private)
 "vDa" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "O2 to Pure"
-	},
 /obj/machinery/atmospherics/components/binary/pump/layer4{
 	dir = 8;
 	name = "O2 to Turbine"
@@ -67475,13 +67319,6 @@
 /obj/structure/drain,
 /turf/open/floor/iron/showroomfloor,
 /area/station/medical/virology)
-"vEP" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Engine"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "vEV" = (
 /obj/structure/chair{
 	dir = 8
@@ -68995,12 +68832,6 @@
 "wen" = (
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
-"wev" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/pumproom)
 "weB" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/wood,
@@ -70376,12 +70207,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/research)
-"wzM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "wzV" = (
 /obj/effect/turf_decal/tile/purple/opposingcorners{
 	dir = 1
@@ -70468,10 +70293,6 @@
 /turf/open/floor/wood,
 /area/station/security/prison/rec)
 "wBy" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 1;
-	name = "plasma mixer"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer4{
 	dir = 4
 	},
@@ -71217,12 +71038,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/hallway/secondary/entry)
-"wNL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/pumproom)
 "wOd" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -72179,12 +71994,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/service/library/lounge)
-"xgo" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Pure to Port Mix"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "xgp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72564,10 +72373,6 @@
 /obj/machinery/dish_drive/bullet,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
-"xny" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "xnz" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/sign/warning/electric_shock/directional/north,
@@ -73316,13 +73121,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
-"xzf" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port Mix to Waste";
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "xzm" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -108878,11 +108676,11 @@ pfo
 pfo
 pfo
 pfo
-rhD
-pfo
-pfo
-pfo
-rhD
+mnW
+rxo
+rxo
+rxo
+mnW
 pSV
 kvL
 pfo
@@ -109644,11 +109442,11 @@ lGd
 qKy
 dgR
 pfo
-xzf
 pfo
-qUp
-qUp
-qUp
+pfo
+pfo
+pfo
+pfo
 pfo
 cSQ
 pfo
@@ -109901,12 +109699,12 @@ ryX
 lMb
 vkL
 xDl
-xny
-bGO
-ccW
-qNN
-ccW
-spG
+pfo
+pfo
+pfo
+pfo
+pfo
+pfo
 bXv
 pfo
 pfo
@@ -110158,12 +109956,12 @@ bHT
 xHp
 yjc
 aoc
-cdI
+pfo
 pfo
 pfo
 pfo
 ulR
-rxo
+pfo
 wJm
 pfo
 pfo
@@ -110410,17 +110208,17 @@ xbz
 iln
 eVB
 thm
-wNL
+crl
 ctz
-joY
-nlI
-xgo
-xny
-bDY
-fwt
-nzT
-fwt
-mnW
+pfo
+pfo
+pfo
+pfo
+pfo
+pfo
+pfo
+pfo
+pfo
 pfo
 pfo
 pfo
@@ -110667,16 +110465,16 @@ kQX
 uXP
 geR
 ble
-wev
+crl
 euK
-sgT
 pfo
 pfo
-vEP
 pfo
-oKE
-oKE
-oKE
+pfo
+pfo
+pfo
+pfo
+pfo
 pfo
 pfo
 pfo
@@ -110926,10 +110724,10 @@ xId
 crl
 jBr
 euK
-sgT
 pfo
 pfo
-ukC
+pfo
+pfo
 pZY
 wQa
 wQa
@@ -110945,13 +110743,13 @@ wQa
 wQa
 wQa
 rwa
-itB
-itB
+wQa
+wQa
 stI
-vnO
-vnO
-vnO
-ppj
+pfo
+pfo
+pfo
+pfo
 pfo
 pfo
 pfo
@@ -111183,25 +110981,25 @@ kOi
 tRs
 oDU
 euK
-gHv
-vnO
-vnO
-oma
+pfo
+pfo
+pfo
+pfo
 wBy
-vnO
-vnO
-vnO
-joY
-vnO
-vnO
-vnO
-vnO
-tEg
-hCx
-vnO
-vnO
-vnO
-wzM
+pfo
+pfo
+pfo
+pfo
+pfo
+pfo
+pfo
+pfo
+pfo
+wBy
+pfo
+pfo
+pfo
+pfo
 pfo
 iwk
 nfR
@@ -115567,8 +115365,8 @@ oqK
 rHp
 hyb
 efB
-qHq
-bIu
+mwK
+mwK
 lZA
 nZX
 nZX

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -2193,9 +2193,6 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/prison/visit)
 "axg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
@@ -2771,11 +2768,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"aEA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "aEE" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -2962,9 +2954,6 @@
 /area/station/science/robotics/lab)
 "aGW" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
@@ -3401,13 +3390,6 @@
 /obj/machinery/light/small/red/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"aLN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "aLO" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -4476,7 +4458,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/department/science)
 "aZF" = (
-/obj/machinery/duct,
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
 	},
@@ -5970,6 +5951,10 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Port Mix to Engine"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bsA" = (
@@ -8333,15 +8318,11 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "bSx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bSN" = (
@@ -9507,12 +9488,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"chn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "chp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -9602,7 +9577,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/supermatter/room)
 "ciD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -10960,16 +10934,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/security/prison/rec)
-"cyR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/yellow/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "czf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood/large,
@@ -11478,9 +11442,6 @@
 /area/station/service/kitchen)
 "cEM" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cEO" = (
@@ -11535,17 +11496,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/research)
-"cFe" = (
-/obj/machinery/duct,
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "cFq" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
 "cFs" = (
@@ -12093,9 +12044,6 @@
 /area/station/engineering/atmos)
 "cMI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/iron,
 /area/station/maintenance/department/engine/atmos)
@@ -12495,14 +12443,6 @@
 /obj/item/pen,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/medical/medsci)
-"cSr" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	color = "#FFFF00"
-	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cSD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -12729,11 +12669,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"cVf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/mix)
 "cVh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -13216,10 +13151,6 @@
 "dbT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Mix to Filter"
-	},
 /obj/effect/turf_decal/box,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -13404,7 +13335,6 @@
 "ded" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -13621,7 +13551,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit)
 "dgo" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
@@ -14544,10 +14473,11 @@
 /area/station/commons/dorms)
 "dtS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 10
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/pump/off/dark{
+	dir = 8;
+	name = "Gas to Turbine"
+	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "dtW" = (
@@ -15200,9 +15130,6 @@
 /area/station/science/xenobiology)
 "dDT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
@@ -16136,9 +16063,6 @@
 /turf/closed/wall/r_wall,
 /area/station/science/lobby)
 "dNU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -16642,10 +16566,10 @@
 /turf/open/floor/wood,
 /area/station/security/prison/rec)
 "dUx" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Engine"
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dUF" = (
@@ -17577,7 +17501,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "egd" = (
-/obj/machinery/duct,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -18040,17 +17963,6 @@
 /obj/structure/sign/poster/random/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/department/crew_quarters/bar)
-"emr" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/camera/directional/south{
-	c_tag = "Atmospherics - Project Room Fore";
-	dir = 5;
-	name = "atmospherics camera"
-	},
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/trimline/yellow/line,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "ems" = (
 /obj/machinery/netpod,
 /obj/machinery/light/neon_lining{
@@ -18082,13 +17994,6 @@
 "emR" = (
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
-"emW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
 "emZ" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -19000,9 +18905,6 @@
 /area/station/service/abandoned_gambling_den)
 "exi" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
 "exq" = (
@@ -19076,7 +18978,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/north{
 	pixel_x = 8
@@ -20244,7 +20145,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "eNj" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
@@ -20712,13 +20612,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/cafeteria)
-"eSJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "eSU" = (
 /obj/machinery/computer/atmos_alert,
 /obj/effect/turf_decal/bot,
@@ -20931,7 +20824,6 @@
 /turf/open/floor/carpet/grimey,
 /area/station/service/chapel/office)
 "eVy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -22056,9 +21948,6 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "fhQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
@@ -22599,6 +22488,10 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/glasses/meson/engine/tray,
 /obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Port Mix to Engine"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "foR" = (
@@ -23475,7 +23368,6 @@
 /turf/open/floor/carpet,
 /area/station/command/heads_quarters/captain)
 "fyP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 4
@@ -23566,7 +23458,6 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "fzD" = (
@@ -25047,9 +24938,6 @@
 "fTC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/dark{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -27035,14 +26923,6 @@
 /obj/structure/sign/poster/official/there_is_no_gas_giant/directional/east,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos/project)
-"gqH" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix to Ports"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "gqR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -28236,10 +28116,6 @@
 /area/station/cargo/storage)
 "gEB" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port Mix to Port Ports"
-	},
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
@@ -28478,9 +28354,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
@@ -28789,9 +28662,6 @@
 /area/station/maintenance/solars/port/fore)
 "gKW" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -28844,10 +28714,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"gMl" = (
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "gMt" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -30533,13 +30399,6 @@
 	},
 /turf/open/floor/iron/dark/herringbone,
 /area/station/security/prison)
-"hgs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hgz" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/effect/turf_decal/tile/neutral{
@@ -31951,7 +31810,6 @@
 /turf/open/floor/iron,
 /area/station/commons/locker)
 "hxj" = (
-/obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -33323,13 +33181,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/cargo/office)
-"hPJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hPN" = (
 /obj/effect/turf_decal/trimline/hot_pink/filled/line,
 /obj/effect/turf_decal/trimline/hot_pink/line{
@@ -33387,7 +33238,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pathology)
 "hQu" = (
-/obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/warning,
 /turf/open/floor/iron,
@@ -33577,14 +33427,6 @@
 	},
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/blueshield)
-"hSx" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hSE" = (
 /obj/structure/chair/stool/bar/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -33683,14 +33525,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/service/chapel/storage)
-"hUb" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port Mix to Engine"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hUm" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/vending/coffee,
@@ -33732,7 +33566,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "hUB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -37377,10 +37210,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/gravity_generator)
-"iMf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "iMg" = (
 /obj/machinery/light_switch/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -37592,15 +37421,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
-"iOj" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/meter,
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "iOu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -38065,8 +37885,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "iVT" = (
@@ -39142,10 +38960,6 @@
 /area/station/hallway/primary/port)
 "jhl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port Mix to Starboard Ports"
-	},
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
@@ -39512,7 +39326,6 @@
 /area/station/medical/pathology)
 "jly" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/item/kirbyplants/random,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -39706,12 +39519,8 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "jnH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/meter,
 /obj/effect/turf_decal/box/corners{
 	dir = 4
 	},
@@ -41334,7 +41143,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
 "jGI" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
@@ -41477,13 +41285,6 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
-"jIB" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/meter,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jIH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -41934,13 +41735,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/fore)
-"jNU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jOo" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/stripes/line{
@@ -42836,12 +42630,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
-"jXN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "jXQ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -43900,11 +43688,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
-"kiQ" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/project)
 "kiZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -44102,14 +43885,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
-"klb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "klc" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -44648,7 +44423,6 @@
 /turf/open/floor/engine,
 /area/station/science/xenobiology)
 "ksH" = (
-/obj/machinery/duct,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
@@ -45690,9 +45464,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -45972,11 +45743,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/service/library/lounge)
-"kKf" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/radiation,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/project)
 "kKg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/small/directional/east,
@@ -47428,12 +47194,6 @@
 /obj/structure/sink/directional/south,
 /turf/open/floor/iron/cafeteria,
 /area/station/medical/break_room)
-"lcA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lcB" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -47512,9 +47272,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -47636,9 +47393,6 @@
 "len" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -47682,12 +47436,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron,
 /area/station/security/office)
-"leU" = (
-/obj/machinery/duct,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "lfn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -48798,8 +48546,6 @@
 /area/station/medical/treatment_center)
 "ltD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ltG" = (
@@ -49068,14 +48814,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/checker,
 /area/station/service/hydroponics/garden/abandoned)
-"lwF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lwH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -49509,7 +49247,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
 "lCg" = (
-/obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -50170,10 +49907,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"lJc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lJh" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -50463,14 +50196,6 @@
 /obj/machinery/vending/wallmed/directional/south,
 /turf/open/floor/iron,
 /area/station/medical/surgery/theatre)
-"lLY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lMd" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -51298,11 +51023,8 @@
 "lVG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
 /obj/effect/turf_decal/box/corners,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "lWi" = (
@@ -51805,8 +51527,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs/fore)
 "mef" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/machinery/meter,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "mej" = (
@@ -54039,14 +53759,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"mGm" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mGo" = (
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/effect/decal/cleanable/dirt,
@@ -54107,13 +53819,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/hallway/secondary/service)
-"mGH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mGT" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
@@ -55230,8 +54935,6 @@
 "mTe" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/obj/machinery/meter/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "mTn" = (
@@ -55632,12 +55335,7 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port)
 "mZj" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	color = "#FFFF00";
-	name = "plasma mixer"
-	},
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "mZk" = (
@@ -55861,9 +55559,6 @@
 /turf/open/floor/iron/white/smooth_large,
 /area/station/medical/pathology/isolation)
 "nbU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -56039,11 +55734,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/research)
-"nfn" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "nfq" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 1
@@ -56176,9 +55866,6 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "nhA" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /obj/machinery/light/small/directional/east,
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
@@ -57884,8 +57571,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "nDd" = (
-/obj/machinery/duct,
-/obj/machinery/light/directional/west,
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 8
 	},
@@ -58900,6 +58585,9 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nQi" = (
@@ -59075,10 +58763,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"nRD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/closed/wall,
-/area/station/maintenance/disposal/incinerator)
 "nRF" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /obj/structure/disposalpipe/segment{
@@ -59495,7 +59179,6 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron/dark/corner,
 /area/station/maintenance/disposal/incinerator)
 "nXA" = (
@@ -59761,10 +59444,6 @@
 	},
 /obj/effect/turf_decal/tile/purple/anticorner/contrasted{
 	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	dir = 4;
-	name = "Plasma to Turbine"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -61843,7 +61522,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "oCo" = (
@@ -62798,13 +62476,6 @@
 /obj/effect/turf_decal/siding/blue,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"oNI" = (
-/obj/machinery/duct,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/project)
 "oOh" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -64390,10 +64061,6 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "phJ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Ports"
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/box/corners{
 	dir = 8
@@ -66126,7 +65793,6 @@
 "pDE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
@@ -67200,11 +66866,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
-"pPv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "pPw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -68590,9 +68251,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
 "qgl" = (
@@ -69803,9 +69461,6 @@
 "qwg" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 1
@@ -70931,11 +70586,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"qJb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qJh" = (
 /obj/effect/spawner/random/structure/tank_holder,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -71935,7 +71585,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
 	},
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 6
 	},
@@ -72296,14 +71945,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/morgue,
 /turf/open/floor/iron,
 /area/station/medical/morgue)
-"raz" = (
-/obj/machinery/shower/directional/south{
-	name = "emergency shower"
-	},
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/trimline/blue/end,
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/atmos/project)
 "raI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72795,9 +72436,6 @@
 /turf/open/floor/iron,
 /area/station/medical/abandoned)
 "rhC" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -74350,10 +73988,6 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	dir = 4;
-	name = "O2 to Turbine"
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rAC" = (
@@ -75078,11 +74712,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"rKb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/mix)
 "rKi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/closed/wall/r_wall,
@@ -75684,7 +75313,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/execution/education)
 "rQw" = (
-/obj/machinery/light/directional/east,
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
 	},
@@ -75975,7 +75603,6 @@
 /turf/open/floor/iron,
 /area/station/security/office)
 "rTH" = (
-/obj/machinery/duct,
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 8
 	},
@@ -76471,16 +76098,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"saE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port to Filter"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "saK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77481,7 +77098,6 @@
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
 "snK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
@@ -78876,9 +78492,6 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sFh" = (
@@ -79517,15 +79130,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/science/research/abandoned)
-"sLV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/trinary/mixer/flipped/layer4{
-	name = "Turbine Mixer'"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "sLY" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "rdoffice";
@@ -80396,9 +80000,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "sWO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -80415,11 +80016,9 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "sXb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sXd" = (
@@ -81518,14 +81117,6 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
-"tme" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "tmk" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/iron/dark,
@@ -81971,7 +81562,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "tsx" = (
@@ -82643,10 +82233,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
 "tAM" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Air to Ports"
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/box/corners,
@@ -83283,12 +82869,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/commons/locker)
-"tHF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "tHI" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -83537,12 +83117,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port)
-"tLh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "tLm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84680,10 +84254,6 @@
 /turf/open/floor/iron,
 /area/station/science/research)
 "tYd" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Distro"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/box/corners{
@@ -85477,14 +85047,10 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/aft)
 "uhY" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/siding/yellow/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "uin" = (
@@ -86493,13 +86059,16 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "uvg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/project)
 "uvl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -86919,7 +86488,6 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "uzJ" = (
-/obj/machinery/duct,
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 1
 	},
@@ -87048,11 +86616,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "uBf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/meter,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/box/corners{
 	dir = 8
@@ -88502,17 +88066,6 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
-"uUd" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "uUg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -88556,13 +88109,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"uUJ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/obj/machinery/meter,
-/obj/effect/mapping_helpers/burnt_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine/atmos)
 "uUV" = (
 /obj/structure/table,
 /obj/item/transfer_valve{
@@ -89085,13 +88631,6 @@
 	},
 /area/station/commons/fitness/recreation)
 "vbp" = (
-/obj/machinery/duct,
-/obj/machinery/light/directional/north,
-/obj/machinery/camera/directional/north{
-	c_tag = "Atmospherics - Project Room Aft";
-	name = "atmospherics camera"
-	},
-/obj/machinery/status_display/ai/directional/north,
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 1
 	},
@@ -89638,12 +89177,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/genetics)
 "viX" = (
-/obj/item/wrench,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 1
-	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "vji" = (
@@ -91764,9 +91300,11 @@
 /area/station/engineering/atmos)
 "vHo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -92618,9 +92156,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Pure to Mix"
-	},
 /turf/open/floor/iron/dark/corner{
 	dir = 1
 	},
@@ -92821,9 +92356,6 @@
 /area/station/security/prison/workout)
 "vXF" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -92985,12 +92517,15 @@
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
 "vYI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix to Ports"
+	},
 /turf/open/floor/iron/dark/corner,
 /area/station/engineering/atmos/mix)
 "vYR" = (
@@ -93328,8 +92863,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/aft)
 "wdu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wdv" = (
@@ -94683,7 +94216,6 @@
 /area/station/engineering/supermatter/room)
 "wri" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/item/kirbyplants/random,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
@@ -95653,7 +95185,6 @@
 /turf/open/floor/iron,
 /area/station/engineering/main)
 "wBn" = (
-/obj/machinery/duct,
 /obj/effect/turf_decal/trimline/yellow/warning,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
@@ -95776,7 +95307,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
 "wCB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -97178,17 +96708,6 @@
 /obj/item/food/sandwich/cheese/grilled,
 /turf/open/floor/iron/cafeteria,
 /area/station/medical/break_room)
-"wWy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "wWH" = (
 /obj/structure/plaque/static_plaque/golden{
 	pixel_y = -32
@@ -97941,13 +97460,6 @@
 /obj/machinery/status_display/ai/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
-"xeP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "xeR" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/mapping_helpers/broken_floor,
@@ -98687,11 +98199,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/medical/psychology)
-"xpY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "xqc" = (
 /obj/effect/turf_decal/trimline/hot_pink/filled/line{
 	dir = 4
@@ -100180,16 +99687,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/eva/abandoned)
-"xGL" = (
-/obj/effect/turf_decal/bot,
-/obj/machinery/shower/directional/north{
-	name = "emergency shower"
-	},
-/obj/effect/turf_decal/trimline/blue/end{
-	dir = 1
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/atmos/project)
 "xGN" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
@@ -100612,14 +100109,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
-"xMi" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/maintenance/disposal/incinerator)
 "xMo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -102528,6 +102017,7 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/light/directional/south,
+/obj/structure/closet/radiation,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/project)
 "ylT" = (
@@ -123717,7 +123207,7 @@ qvw
 dtS
 snK
 snK
-xMi
+ltx
 dvA
 eiK
 kXV
@@ -125004,36 +124494,36 @@ gFb
 qUE
 mTe
 nXw
-nRD
-uUd
-lJc
-sLV
-iVz
-wdu
-wdu
-cSr
-iVz
+wSR
+aqc
 wdu
 wdu
 iVz
 wdu
-jNU
-hgs
-jXN
+wdu
+mZj
+iVz
+wdu
+wdu
+iVz
+wdu
+wdu
+qSm
+quR
 sXb
-jNU
+wdu
 ltD
 wdu
-tLh
+ltD
 mZj
-iMf
-qJb
+wdu
+ltD
 dUx
-lcA
-tHF
-iMf
+wdu
+wdu
+wdu
 jGI
-rKb
+hhM
 vUk
 tsB
 sch
@@ -125284,10 +124774,10 @@ sID
 sID
 nmP
 sID
-uvg
-lwF
+nmP
 sID
-tme
+sID
+sID
 nmP
 oUh
 hYD
@@ -125537,17 +125027,17 @@ fXF
 ijC
 cEM
 cEM
-mGm
-mGm
+mZj
+mZj
 nmP
 nmP
-hUb
+sID
 sID
 nmP
-lLY
-eSJ
+nmP
+sID
 eNj
-cVf
+hhM
 hUB
 ciD
 vYI
@@ -125792,17 +125282,17 @@ vFC
 eso
 kSt
 nWL
-iOj
-aLN
-klb
+gEB
+sID
+pUW
 uBf
 gEB
-nfn
-nfn
+sID
+sID
 phJ
-pPv
-mGH
-xeP
+sID
+sID
+sID
 etL
 vQj
 hhM
@@ -126049,17 +125539,17 @@ tlA
 qSm
 quR
 inv
-hSx
+nmP
 sID
 urV
 pUW
 nMT
 sID
-jIB
-gqH
-chn
-chn
-aEA
+nmP
+sID
+nmP
+nmP
+sID
 cTy
 gen
 cTp
@@ -126297,22 +125787,22 @@ jti
 jti
 uGJ
 uGJ
-uGJ
+uvg
 cUF
 uAA
 sID
 sID
 ivg
-xpY
+eso
 wCB
-saE
+nWL
 jnH
-hPJ
+sID
 viX
 lVG
 jhl
-nfn
-nfn
+sID
+sID
 tAM
 eVy
 fyP
@@ -126830,7 +126320,7 @@ vHo
 rYj
 bsc
 tyj
-wWy
+bSx
 pDW
 dCH
 itF
@@ -127320,8 +126810,8 @@ vZX
 umm
 yhw
 mYo
-cUF
-kKf
+rGb
+rGb
 kAX
 yhw
 rGb
@@ -127344,7 +126834,7 @@ aMw
 eLo
 bsx
 xDf
-cyR
+uhY
 eQu
 tgn
 cUQ
@@ -127577,9 +127067,9 @@ tTf
 umm
 doR
 mYo
-cUF
-raz
-cFe
+rGb
+rGb
+kAX
 doR
 rGb
 jti
@@ -127833,9 +127323,9 @@ epV
 cIn
 rGb
 doR
-emr
-cUF
-cUF
+mYo
+rGb
+rGb
 vbp
 doR
 umm
@@ -128091,8 +127581,8 @@ cIn
 rGb
 yhw
 hQu
-xGL
-cUF
+rGb
+rGb
 ksH
 yhw
 rGb
@@ -128348,9 +127838,9 @@ cIn
 umm
 fWN
 wBn
-kiQ
-cUF
-oNI
+rGb
+rGb
+vbp
 yhw
 umm
 fPf
@@ -128864,7 +128354,7 @@ fWN
 yhw
 fWN
 yhw
-leU
+fWN
 yhw
 umm
 nVf
@@ -129121,8 +128611,8 @@ rGb
 umm
 umm
 rGb
-gMl
-gMl
+rGb
+rGb
 egd
 lCg
 aBX
@@ -129388,7 +128878,7 @@ fBk
 aZp
 mef
 dDT
-uUJ
+wCz
 oCJ
 cFq
 boR
@@ -129645,7 +129135,7 @@ ugc
 nCd
 nhA
 aGW
-emW
+sCx
 bCX
 cMI
 boR

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -1410,18 +1410,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"agI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Air to Ports"
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/engineering/atmos)
 "agJ" = (
 /obj/structure/chair/office,
 /obj/machinery/firealarm/directional/west,
@@ -4446,12 +4434,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
-"aAO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "aAP" = (
 /obj/machinery/light/red/dim/directional/north,
 /obj/effect/decal/cleanable/dirt,
@@ -8032,13 +8014,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/lawyer,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
-"aQF" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/trinary/filter/flipped{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "aQJ" = (
 /obj/machinery/computer/holodeck{
 	dir = 4
@@ -10257,13 +10232,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/station/service/chapel)
-"aZY" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Pure to Mix"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "baa" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -22558,12 +22526,6 @@
 "czV" = (
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"cAe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cAf" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -23047,12 +23009,6 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"cDX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cEf" = (
 /obj/machinery/duct,
 /obj/structure/disposalpipe/segment{
@@ -23228,10 +23184,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/large,
 /area/station/maintenance/department/science/central)
-"cFi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cFk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -31232,17 +31184,6 @@
 /obj/structure/sign/poster/contraband/smoke/directional/north,
 /turf/open/floor/plating,
 /area/station/medical/abandoned)
-"eSD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/engineering/atmos)
 "eSO" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -31879,7 +31820,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "fjd" = (
@@ -32437,14 +32377,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/solars/starboard/aft)
-"fvH" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Port to Filter"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "fvI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33111,9 +33043,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "fKB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
 	},
@@ -34476,10 +34405,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"gmt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "gmN" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -34859,11 +34784,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"gwe" = (
-/obj/machinery/atmospherics/components/binary/pump/on,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "gwg" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -35924,17 +35844,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/maintenance/aft/lesser)
-"gRw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/station/engineering/atmos)
 "gRz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
@@ -35960,7 +35869,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "gSj" = (
@@ -36678,14 +36586,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/lab)
-"hfE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/meter,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "hfI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36833,6 +36733,7 @@
 /area/station/command/teleporter)
 "hja" = (
 /obj/machinery/light/directional/west,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "hjb" = (
@@ -37296,9 +37197,6 @@
 /area/station/medical/abandoned)
 "hpY" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
@@ -37680,14 +37578,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/checkpoint)
-"hxz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/meter,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "hxC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/south,
@@ -38994,12 +38884,6 @@
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"hVb" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hVT" = (
 /obj/machinery/light/directional/east,
 /obj/structure/chair/sofa/bench/right{
@@ -40207,18 +40091,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/command/teleporter)
-"isT" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Ports"
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/engineering/atmos)
 "itl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 1
@@ -43725,13 +43597,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/maintenance/solars/port/aft)
-"jIW" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Pure to Ports"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "jIZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -44318,12 +44183,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"jUL" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jUT" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/siding/green/end,
@@ -45099,8 +44958,7 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "kjx" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -47496,13 +47354,6 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
-"ljo" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port Mix to North Ports"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "ljq" = (
 /obj/structure/chair{
 	dir = 8
@@ -49435,13 +49286,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"lWk" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Filter"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "lWq" = (
 /obj/structure/window/spawner/directional/north,
 /obj/structure/table/glass,
@@ -51081,13 +50925,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"mBw" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Air to Mix"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mBK" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 4
@@ -51577,13 +51414,6 @@
 /obj/machinery/space_heater,
 /turf/open/floor/iron,
 /area/station/maintenance/port)
-"mLR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mLT" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
@@ -55673,9 +55503,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "omW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -56722,8 +56549,8 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "oGj" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
-/turf/open/floor/iron,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "oGl" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -56770,13 +56597,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/engine,
 /area/station/science/explab)
-"oHA" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "oHT" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/effect/turf_decal/trimline/neutral/warning,
@@ -57181,13 +57001,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/department/science/xenobiology)
-"oPg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "oPj" = (
 /obj/machinery/door/airlock/research{
 	name = "Research and Development Lab"
@@ -57860,12 +57673,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/office)
-"paD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "pbe" = (
 /obj/structure/sign/calendar/directional/north,
 /obj/effect/turf_decal/bot,
@@ -59841,6 +59648,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "pPR" = (
@@ -59865,13 +59673,6 @@
 /obj/machinery/light/dim/directional/west,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"pQu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "pQx" = (
 /obj/effect/spawner/random/vending/snackvend,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -60946,12 +60747,6 @@
 /obj/effect/turf_decal/tile/red/anticorner/contrasted,
 /turf/open/floor/iron/freezer,
 /area/station/security/lockers)
-"qoP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "qoY" = (
 /obj/effect/spawner/random/structure/barricade,
 /obj/machinery/door/airlock/research{
@@ -61899,9 +61694,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
@@ -63680,11 +63472,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
 "roc" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix to Port"
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Mix to SM";
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "rod" = (
@@ -63788,9 +63580,6 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
 "rqA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -64794,17 +64583,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/command/bridge)
-"rJF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos/pumproom)
 "rJV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -65329,9 +65107,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos/storage/gas)
 "rVM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -65523,11 +65298,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"scf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "scg" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /obj/structure/cable,
@@ -66981,13 +66751,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"sGv" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port Mix to South Ports"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "sGz" = (
 /obj/structure/table/reinforced/rglass,
 /obj/machinery/computer/records/medical/laptop{
@@ -67534,13 +67297,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"sRi" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "sRz" = (
 /obj/structure/table,
 /obj/item/storage/fancy/candle_box{
@@ -68055,13 +67811,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"tbh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "tbj" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap{
@@ -69522,12 +69271,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/station/maintenance/department/science/xenobiology)
-"tCc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "tCf" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -71322,11 +71065,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
-"uma" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ume" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
@@ -72184,11 +71922,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"uEo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "uEv" = (
 /obj/machinery/computer/bank_machine{
 	dir = 4
@@ -72244,13 +71977,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"uGc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "uGf" = (
 /obj/machinery/door/airlock/glass{
 	name = "Legal Consultation"
@@ -72663,14 +72389,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/brig)
-"uOJ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "uOY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -72951,20 +72669,6 @@
 /obj/effect/turf_decal/trimline/blue/corner,
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
-"uUv" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/side{
-	dir = 4
-	},
-/area/station/engineering/atmos)
 "uUE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /obj/machinery/meter,
@@ -73228,10 +72932,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison/safe)
 "vaf" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -75546,9 +75246,6 @@
 /area/station/medical/chemistry)
 "vTj" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
@@ -75720,13 +75417,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/service/cafeteria)
-"vWP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "vWV" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/customs/fore)
@@ -78106,13 +77796,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/ce)
-"wUi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "wUo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -79632,11 +79315,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8;
-	name = "Exfiltrate Port"
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -80450,13 +80128,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"xPa" = (
-/obj/machinery/atmospherics/components/trinary/mixer/flipped{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "xPj" = (
 /obj/structure/moisture_trap,
 /obj/effect/decal/cleanable/dirt,
@@ -81147,13 +80818,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/port)
-"yeb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/brown/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "yeh" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
@@ -100283,7 +99947,7 @@ fdm
 npJ
 hci
 hja
-cwt
+oGj
 jSV
 coW
 aaa
@@ -100785,19 +100449,19 @@ lVp
 cIx
 dya
 kWr
-cDX
-cFi
+crj
+crj
 gSe
-paD
+crj
 gSe
-cFi
-cFi
-jUL
+crj
+crj
+crj
 cyL
 crj
 crj
-crj
-crj
+kjx
+kjx
 sWU
 vhN
 tiy
@@ -101042,7 +100706,7 @@ uyy
 crh
 huR
 off
-cAe
+crj
 crj
 cHw
 ekr
@@ -101299,7 +100963,7 @@ fVj
 cID
 xVa
 jDE
-oGj
+crj
 crj
 crj
 crj
@@ -101556,7 +101220,7 @@ uyy
 coW
 ngB
 off
-cAe
+crj
 crj
 xTb
 crj
@@ -101813,15 +101477,15 @@ lVp
 jpO
 xvK
 sld
-gRw
+tlG
 tlG
 tlG
 qhb
 tlG
 tlG
 vaf
-uUv
-uUv
+vaf
+vaf
 tlG
 tlG
 tlG
@@ -102072,15 +101736,15 @@ xgb
 syn
 vTj
 roc
-uEo
-wUi
-ljo
-wUi
-yeb
-yeb
-yeb
-uEo
-hfE
+uFJ
+uFJ
+uFJ
+uFJ
+uFJ
+uFJ
+uFJ
+uFJ
+uFJ
 mCv
 gYx
 mjd
@@ -102327,17 +101991,17 @@ pZc
 cID
 rwH
 pge
-xPa
 uFJ
-wZf
-pQu
-uFJ
-sRi
 uFJ
 wZf
 uFJ
 uFJ
-fvH
+uFJ
+uFJ
+wZf
+uFJ
+uFJ
+uFJ
 uFJ
 bmG
 jul
@@ -102584,19 +102248,19 @@ aak
 coW
 xUt
 off
-vWP
-jIW
-wUi
-scf
-sGv
-yeb
-uOJ
-aQF
-uOJ
-lWk
-hxz
-gwe
-qoP
+uFJ
+uFJ
+uFJ
+uFJ
+uFJ
+uFJ
+uFJ
+uFJ
+uFJ
+uFJ
+uFJ
+uFJ
+bmG
 evW
 xaP
 xaP
@@ -102841,10 +102505,10 @@ gLX
 cIx
 pvj
 qDd
-eSD
 uPO
-isT
-agI
+uPO
+uPO
+uPO
 uPO
 uPO
 xyg
@@ -103098,10 +102762,10 @@ aak
 crh
 nIW
 mbq
-cAe
 crj
-mLR
-tbh
+crj
+crj
+crj
 crj
 crj
 crj
@@ -103355,10 +103019,10 @@ pZc
 cID
 ozs
 rKd
-oGj
 crj
-aAO
-cyL
+crj
+crj
+crj
 crj
 dyf
 ood
@@ -103612,10 +103276,10 @@ aak
 coW
 ngB
 off
-aZY
 crj
-aAO
-uGc
+crj
+crj
+nlQ
 fCA
 crj
 crj
@@ -103869,10 +103533,10 @@ gLX
 cIx
 ujv
 tti
-uma
 crj
-aAO
-uGc
+crj
+crj
+nlQ
 crj
 crj
 nCM
@@ -104126,7 +103790,7 @@ aak
 crh
 iqA
 tnE
-mBw
+crj
 crj
 rVM
 omW
@@ -104382,10 +104046,10 @@ rgD
 hyE
 gNr
 qwz
-oHA
-kjx
-gmt
-hVb
+tnE
+crj
+crj
+crj
 omW
 crj
 pDh
@@ -105153,7 +104817,7 @@ uGE
 uGE
 myZ
 weM
-tCc
+cwt
 cwt
 rrX
 cwt
@@ -105667,7 +105331,7 @@ myZ
 myZ
 myZ
 feK
-rJF
+ggE
 exW
 bTw
 iwW
@@ -105924,7 +105588,7 @@ xbA
 vab
 eOB
 tzW
-oPg
+deM
 ggE
 twq
 deM

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -2637,8 +2637,6 @@
 /area/station/science/ordnance/office)
 "aSS" = (
 /obj/effect/turf_decal/trimline/dark_red/end,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix)
@@ -3223,14 +3221,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"bbs" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4;
-	initialize_directions = 8
-	},
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/project)
 "bbv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -4160,12 +4150,6 @@
 "bol" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
-"bos" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/project)
 "bov" = (
 /obj/structure/stairs/south,
 /turf/open/floor/stone,
@@ -4264,10 +4248,6 @@
 /obj/item/book/codex_gigas,
 /turf/open/floor/engine/cult,
 /area/station/service/library)
-"bpR" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "bpT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -4857,10 +4837,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/plating/icemoon,
 /area/station/science/ordnance/bomb)
-"byH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/project)
 "byK" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -5200,9 +5176,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bCW" = (
@@ -5627,12 +5600,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
-"bIs" = (
-/obj/structure/chair/stool/directional/east,
-/turf/open/floor/iron/half{
-	dir = 1
-	},
-/area/station/engineering/atmos)
 "bIt" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -6083,9 +6050,6 @@
 /area/station/science/xenobiology)
 "bOY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 10
-	},
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
@@ -7630,10 +7594,6 @@
 /obj/effect/turf_decal/trimline/dark_red/arrow_ccw{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/valve/digital/on{
-	dir = 4;
-	name = "Exfiltrate Control"
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage)
@@ -7658,9 +7618,6 @@
 /area/station/security/prison/workout)
 "cmJ" = (
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 6
-	},
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -7985,9 +7942,6 @@
 "cqO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -10173,9 +10127,6 @@
 /obj/effect/turf_decal/trimline/dark_blue/mid_joiner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/mix)
@@ -10556,17 +10507,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"dcE" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_green/end{
-	dir = 1
-	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/mix)
 "dcO" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering Emitter Room Starboard";
@@ -12331,9 +12271,6 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "dFC" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dFD" = (
@@ -12459,13 +12396,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plastic,
 /area/station/maintenance/starboard/fore)
-"dIl" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot_red,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/project)
 "dIx" = (
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
@@ -13398,9 +13328,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
 "dYK" = (
@@ -15286,13 +15213,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"eDj" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/project)
 "eDq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -16409,10 +16329,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"eVI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "eVL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/cable,
@@ -16855,12 +16771,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"fcN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "fcP" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 9
@@ -17170,10 +17080,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/disposal/incinerator)
-"fiA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/project)
 "fiD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18002,13 +17908,6 @@
 	dir = 8
 	},
 /area/station/security/prison)
-"fwq" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Filter"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "fws" = (
 /obj/structure/flora/bush/fullgrass/style_random,
 /obj/structure/flora/bush/generic/style_random,
@@ -18419,9 +18318,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/warden)
 "fDe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/dark_green/end{
 	dir = 1
 	},
@@ -18499,12 +18395,6 @@
 	dir = 4
 	},
 /area/station/security/brig/entrance)
-"fER" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/glass/reinforced,
-/area/station/engineering/atmos/pumproom)
 "fEV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18541,9 +18431,6 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "fFv" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port Mix to West Ports"
-	},
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron,
@@ -18657,9 +18544,6 @@
 /turf/open/floor/carpet,
 /area/station/command/meeting_room)
 "fHQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/dark_green/corner{
 	dir = 4
 	},
@@ -19130,12 +19014,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
-"fQc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "fQl" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -19971,11 +19849,6 @@
 /obj/structure/sign/warning/fire/directional/south,
 /turf/open/openspace/icemoon/keep_below,
 /area/icemoon/underground/explored)
-"gdv" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "gdx" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -20468,12 +20341,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
-"gmJ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Infiltrate/Filter"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "gmL" = (
 /obj/structure/table,
 /obj/item/stock_parts/subspace/transmitter,
@@ -20529,10 +20396,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/security/general,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
-"gnw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "gnH" = (
 /obj/structure/sign/painting/large/library{
 	dir = 1
@@ -20610,12 +20473,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
-"goE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Pure to Port"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "goF" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21445,13 +21302,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/storage)
-"gBx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "gBI" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/plating,
@@ -25386,15 +25236,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
-"hQu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hQF" = (
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/flasher/directional/west{
@@ -26405,12 +26246,6 @@
 /obj/machinery/portable_atmospherics/pipe_scrubber,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
-"igx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "igB" = (
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/glass,
@@ -27138,10 +26973,6 @@
 	},
 /area/station/service/chapel)
 "isb" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	dir = 1;
-	name = "Infiltrate to Exfiltrate"
-	},
 /obj/effect/turf_decal/loading_area{
 	color = "#439C1E";
 	dir = 1
@@ -28865,12 +28696,6 @@
 	},
 /turf/open/openspace,
 /area/station/science/ordnance/office)
-"iSl" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Port"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "iSn" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/three,
@@ -29338,6 +29163,10 @@
 "iZO" = (
 /obj/machinery/status_display/ai/directional/west,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4;
+	initialize_directions = 8
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
 "iZQ" = (
@@ -29390,9 +29219,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 4
 	},
@@ -29532,16 +29358,6 @@
 "jbU" = (
 /turf/closed/wall,
 /area/station/command/heads_quarters/rd)
-"jco" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "jcw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -29674,14 +29490,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/supermatter/room)
-"jes" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Exfiltrate to Port"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/mix)
 "jeF" = (
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/glass/reinforced,
@@ -30603,11 +30411,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"jvS" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jvU" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/tile/green/half/contrasted{
@@ -30978,14 +30781,6 @@
 /obj/machinery/coffeemaker,
 /turf/open/floor/iron,
 /area/station/cargo/miningdock)
-"jDi" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Exfiltrate to Waste"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/mix)
 "jDm" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "robotics2";
@@ -31798,13 +31593,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
-"jPo" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/project)
 "jPs" = (
 /obj/effect/spawner/random/engineering/canister,
 /obj/structure/railing{
@@ -33012,13 +32800,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"khf" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/obj/machinery/atmospherics/pipe/layer_manifold/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "kho" = (
 /obj/item/radio/intercom/directional/south,
 /obj/structure/table/wood,
@@ -33634,9 +33415,6 @@
 	dir = 1;
 	name = "Air Outlet Pump"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 5
-	},
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
@@ -34028,14 +33806,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"kwm" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 4
-	},
-/obj/item/wrench,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "kwK" = (
 /obj/effect/turf_decal/tile/purple/half,
 /turf/open/floor/iron/half,
@@ -34443,10 +34213,6 @@
 /turf/open/floor/glass/reinforced,
 /area/station/medical/treatment_center)
 "kDb" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped{
-	dir = 4;
-	name = "Exfiltrate Filter"
-	},
 /obj/effect/turf_decal/trimline/dark_red/filled/warning{
 	dir = 10
 	},
@@ -36687,9 +36453,6 @@
 "lmA" = (
 /obj/effect/turf_decal/trimline/dark_green/corner,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 6
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage)
@@ -36890,9 +36653,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "loW" = (
@@ -37345,13 +37105,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"lwi" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Mix to Filter"
-	},
-/turf/open/floor/glass/reinforced,
-/area/station/engineering/atmos/pumproom)
 "lwF" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -37455,13 +37208,6 @@
 	dir = 1
 	},
 /area/mine/eva)
-"lxU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lye" = (
 /obj/effect/turf_decal/bot_white/right,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -38616,12 +38362,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/science/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
-"lRR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lRW" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -38845,9 +38585,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "lVw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/dark_green/line,
 /obj/effect/turf_decal/trimline/dark_green/line{
 	dir = 1
@@ -40229,10 +39966,6 @@
 /area/station/maintenance/disposal/incinerator)
 "msT" = (
 /obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/atmospherics/components/binary/valve/digital/on{
-	dir = 4;
-	name = "Infiltrate Control"
-	},
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -40318,12 +40051,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/icemoon,
 /area/station/science/ordnance/bomb)
-"mvG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mvU" = (
 /obj/machinery/button/door/directional/east{
 	id = "cmoprivacy";
@@ -40406,12 +40133,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
-"mxj" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port Mix to East Ports"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mxD" = (
 /obj/machinery/holopad,
 /obj/structure/cable,
@@ -41341,15 +41062,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"mNF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "mNJ" = (
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
@@ -42344,12 +42056,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
-"ncl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/project)
 "ncp" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Arrivals Bay 3 & 4"
@@ -43227,13 +42933,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
 /area/station/engineering/lobby)
-"noY" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "npa" = (
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 1
@@ -43310,10 +43009,6 @@
 /obj/item/reagent_containers/cup/bucket,
 /turf/open/floor/iron/dark,
 /area/mine/laborcamp)
-"npJ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/violet/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "npL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43395,11 +43090,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"nqX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/pink/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/mix)
 "nrm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43423,12 +43113,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
-"nrA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "nrB" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/evac/directional/west,
@@ -44139,7 +43823,6 @@
 /area/icemoon/surface/outdoors/nospawn)
 "nBG" = (
 /obj/item/cigbutt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nBH" = (
@@ -44543,12 +44226,6 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/maintenance/port/fore)
-"nGG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 6
-	},
-/turf/open/floor/glass/reinforced,
-/area/station/engineering/atmos/pumproom)
 "nGQ" = (
 /obj/machinery/flasher/directional/north{
 	id = "Cell 3"
@@ -45410,9 +45087,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "nSD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 1
 	},
@@ -46885,7 +46559,6 @@
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage)
 "oqg" = (
@@ -47458,13 +47131,6 @@
 "oyW" = (
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/aisat/hallway)
-"oyX" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ozn" = (
 /obj/machinery/photocopier,
 /turf/open/floor/iron/dark,
@@ -47560,9 +47226,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "oAp" = (
@@ -47587,7 +47250,6 @@
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1,
 /obj/machinery/portable_atmospherics/canister/freon,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
@@ -47763,9 +47425,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 1
 	},
@@ -48733,9 +48392,6 @@
 /area/icemoon/underground/unexplored/rivers/deep)
 "oSX" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "oTa" = (
@@ -49825,13 +49481,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"pkY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/project)
 "plg" = (
 /obj/machinery/atmospherics/components/tank/air,
 /obj/effect/turf_decal/delivery,
@@ -50751,9 +50400,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
 "pzs" = (
@@ -51160,12 +50806,6 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/range)
-"pGf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "pGo" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -51644,9 +51284,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
 "pMv" = (
@@ -53203,9 +52840,6 @@
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qnU" = (
@@ -53391,14 +53025,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/space_hut/cabin)
-"qqh" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8;
-	name = "Exfiltrate Port"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/mix)
 "qqn" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/iron/smooth,
@@ -54044,9 +53670,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qAV" = (
@@ -54740,12 +54363,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/station/ai_monitored/turret_protected/aisat/maint)
-"qMM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qMN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -56758,17 +56375,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
-"rtt" = (
-/obj/effect/turf_decal/trimline/dark_green/line,
-/obj/effect/turf_decal/trimline/dark_green/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/mix)
 "rtv" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced/spawner/directional/east,
@@ -56823,13 +56429,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos/storage/gas)
-"ruw" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 1;
-	name = "plasma mixer"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ruC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56905,12 +56504,6 @@
 	},
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"rwC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/general/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rwD" = (
 /obj/structure/rack,
 /obj/item/clothing/head/soft/mime,
@@ -57270,12 +56863,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
-"rBQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rBV" = (
 /turf/closed/wall,
 /area/station/tcommsat/computer)
@@ -57836,9 +57423,6 @@
 "rLs" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rLu" = (
@@ -58069,9 +57653,6 @@
 /obj/machinery/camera{
 	c_tag = "Atmospherics - South East";
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -58693,12 +58274,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"rZE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/project)
 "rZG" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/pathology)
@@ -59174,12 +58749,6 @@
 "shh" = (
 /turf/open/floor/wood,
 /area/station/hallway/secondary/service)
-"shj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "sht" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -59381,7 +58950,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "skJ" = (
@@ -59670,9 +59238,6 @@
 /obj/effect/turf_decal/trimline/dark_red/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/dark_blue/corner{
 	dir = 1
 	},
@@ -59894,10 +59459,6 @@
 /area/station/cargo/office)
 "ssh" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -61503,7 +61064,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
 "sTg" = (
@@ -61796,9 +61356,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/aft/greater)
 "sXQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/dark_green/corner{
 	dir = 1
 	},
@@ -61953,6 +61510,9 @@
 "taN" = (
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/components/binary/crystallizer{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
 "taV" = (
@@ -64734,12 +64294,6 @@
 /obj/item/melee/roastingstick,
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"tWI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Turbine"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "tWK" = (
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/icemoon,
@@ -64955,12 +64509,8 @@
 /turf/open/floor/plating/snowed/icemoon,
 /area/icemoon/underground/explored)
 "tZG" = (
-/obj/machinery/meter,
 /obj/effect/turf_decal/trimline/dark_red/arrow_ccw{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold/pink/visible{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -65075,10 +64625,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore)
-"ubF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ubG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -65531,9 +65077,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
 "uiv" = (
@@ -66304,9 +65847,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
 "uuw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 1
 	},
@@ -67001,8 +66541,9 @@
 /turf/open/openspace,
 /area/station/security/brig/upper)
 "uGy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible/layer1{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump/off/dark/visible/layer1{
+	dir = 4;
+	name = "Gas to Turbine"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -67703,9 +67244,6 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
 "uRV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
 	dir = 9
 	},
@@ -68619,13 +68157,6 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/iron/smooth,
 /area/mine/eva)
-"vgM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/mix)
 "vgP" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -68760,12 +68291,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/research)
-"vjk" = (
-/obj/machinery/atmospherics/components/binary/crystallizer{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/project)
 "vjx" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/iron/dark/telecomms,
@@ -69344,13 +68869,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/station/maintenance/aft/greater)
-"vtv" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Infiltrate/Filter"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vtz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -69960,13 +69478,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
-"vBC" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vBD" = (
 /obj/structure/chair{
 	dir = 1
@@ -71684,9 +71195,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wgI" = (
@@ -71743,10 +71251,6 @@
 	dir = 4
 	},
 /area/station/science/xenobiology)
-"whf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
-/turf/open/floor/glass/reinforced,
-/area/station/engineering/atmos/pumproom)
 "whh" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
@@ -72069,9 +71573,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/prison/mess)
 "wlZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 1
@@ -72754,12 +72255,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
-"wwu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/general/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "wwB" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72959,13 +72454,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/server)
-"wAB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "wAQ" = (
 /obj/machinery/computer/shuttle/labor/one_way{
 	dir = 4
@@ -73241,9 +72729,6 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pathology)
 "wDl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_red/line,
 /obj/effect/turf_decal/trimline/dark_red/line{
 	dir = 1
@@ -74553,9 +74038,6 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics - Central"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Infiltrate"
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wWJ" = (
@@ -74942,10 +74424,6 @@
 /area/mine/eva/lower)
 "xbC" = (
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/layer_manifold/violet/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage)
@@ -75157,10 +74635,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/north,
-/obj/machinery/atmospherics/components/binary/pump/layer2{
-	dir = 8;
-	name = "Exfiltrate to Waste"
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/storage)
 "xfZ" = (
@@ -75641,9 +75115,6 @@
 "xmL" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/structure/sign/warning/no_smoking{
 	pixel_x = -28
 	},
@@ -76107,9 +75578,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "xvn" = (
@@ -76858,13 +76326,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
-"xGI" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "xGJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -77154,9 +76615,6 @@
 "xKX" = (
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw{
 	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 9
 	},
 /obj/machinery/portable_atmospherics/canister/freon,
 /turf/open/floor/iron,
@@ -78717,9 +78175,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_green/arrow_ccw,
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible/layer1{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
 "ylU" = (
@@ -182482,9 +181937,9 @@ ljL
 ljL
 wHg
 lub
-dIl
 azB
-bbs
+azB
+azB
 bWK
 bWK
 xJw
@@ -182739,9 +182194,9 @@ ljL
 ljL
 wHg
 lub
-pkY
-fiA
-ncl
+bWK
+bWK
+bWK
 bWK
 bWK
 lub
@@ -182996,7 +182451,7 @@ amg
 amg
 uBA
 fKr
-vjk
+bWK
 one
 upV
 bWK
@@ -183253,9 +182708,9 @@ ndH
 qWK
 oDn
 aiJ
-jPo
-byH
-bos
+bWK
+bWK
+bWK
 bWK
 bWK
 neu
@@ -183510,9 +182965,9 @@ nmL
 rIF
 uBA
 rFI
-rZE
 bWK
-rZE
+bWK
+bWK
 bWK
 bWK
 lub
@@ -183759,7 +183214,7 @@ myZ
 gdg
 kpC
 eMU
-vgM
+sIA
 syn
 fDe
 fHQ
@@ -183767,9 +183222,9 @@ nmL
 qpr
 wHg
 aiJ
-eDj
 rEx
-eDj
+rEx
+rEx
 bWK
 bWK
 lub
@@ -184016,7 +183471,7 @@ eJf
 eJf
 upH
 uuw
-jDi
+sIA
 nzT
 eGl
 lVw
@@ -184273,7 +183728,7 @@ eJf
 buW
 kpC
 kDb
-nqX
+sIA
 qoZ
 sIA
 lVw
@@ -184530,10 +183985,10 @@ eJf
 eJf
 kpC
 wlZ
-jes
+sIA
 qdx
 sIA
-rtt
+lVw
 dgZ
 ffe
 bPn
@@ -184787,10 +184242,10 @@ eJf
 nfG
 upH
 cYi
-qqh
+sIA
 naX
 sIA
-rtt
+lVw
 rgB
 ffe
 nsp
@@ -185303,7 +184758,7 @@ sXb
 soF
 aSS
 isb
-dcE
+fDe
 sXQ
 ckN
 ffe
@@ -242355,7 +241810,7 @@ rPd
 uop
 caS
 hHN
-wAB
+hHN
 jkW
 laV
 hHN
@@ -242612,10 +242067,10 @@ cEw
 cEw
 cEw
 jaN
-fwq
 hHN
-lRR
-bpR
+hHN
+hHN
+hHN
 skx
 gkY
 mIk
@@ -242869,9 +242324,9 @@ rLs
 xmL
 cEw
 cmJ
-rwC
+hHN
 tyb
-nrA
+hHN
 flH
 lxu
 dAg
@@ -243119,17 +242574,17 @@ vBv
 kjy
 grI
 ruI
-ubF
+hHN
 fFv
-wwu
-kwm
-wwu
+hHN
+hHN
+hHN
 wWt
-eVI
-gmJ
-npJ
-xGI
-mNF
+hHN
+hHN
+hHN
+hHN
+jlV
 baQ
 cYC
 rsW
@@ -243371,22 +242826,22 @@ kRP
 csZ
 gcV
 jug
-lwi
-jco
+jug
+nSD
 sTe
-jvS
-iSl
-gdv
-yiv
-tbh
-bIs
-tbh
-yiv
-vtv
 hHN
 hHN
-nrA
-hQu
+hHN
+yiv
+tbh
+tbh
+tbh
+yiv
+hHN
+hHN
+hHN
+hHN
+jlV
 eBT
 snW
 hpI
@@ -243627,22 +243082,22 @@ gDp
 boQ
 lgW
 drh
-nGG
-fER
+jug
+jug
 nSD
 uID
-vBC
-goE
-ubF
-mxj
-fcN
-lxU
-fcN
-fcN
+hHN
+hHN
+hHN
+hHN
+hHN
+hHN
+hHN
+hHN
 nBG
-tWI
-qMM
-rBQ
+hHN
+hHN
+hHN
 ssh
 skx
 kqS
@@ -243884,22 +243339,22 @@ sqN
 kRP
 spq
 tyS
-whf
+jug
 sjk
 uht
 ehR
-gnw
 hHN
-pGf
-igx
+hHN
+hHN
+hHN
 dFC
 dFC
 jBR
 fnA
 hHN
-lRR
-khf
-shj
+hHN
+hHN
+hHN
 qnO
 lxu
 ijK
@@ -244145,16 +243600,16 @@ aSe
 kFH
 aen
 hIA
-rBQ
-fQc
-fQc
-noY
-ruw
-fQc
-fQc
-fQc
-mvG
-shj
+hHN
+hHN
+hHN
+hHN
+hHN
+hHN
+hHN
+hHN
+hHN
+hHN
 uGy
 hHN
 cqO
@@ -244402,19 +243857,19 @@ fqA
 dFp
 nJI
 hoV
-oyX
+oSX
 xfB
 khe
 oSX
-oyX
+oSX
 xfB
 cHm
 xfB
-oyX
+oSX
 xfB
 jHQ
 xfB
-gBx
+xfB
 rkm
 sEX
 hpI

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -31,7 +31,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/turf_decal/tile/red/opposingcorners{
 	dir = 1
@@ -896,7 +895,6 @@
 "ajv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -2861,7 +2859,6 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -5249,10 +5246,6 @@
 /turf/open/floor/iron,
 /area/station/security/brig)
 "bKa" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Air to Ports"
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
@@ -6721,14 +6714,6 @@
 "cdZ" = (
 /turf/closed/wall/rust,
 /area/station/ai_monitored/turret_protected/ai)
-"cec" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "East Ports to West Ports"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ceg" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner{
@@ -7164,14 +7149,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/security/office)
-"cjv" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cjx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7320,11 +7297,6 @@
 "clr" = (
 /turf/closed/wall,
 /area/station/medical/cryo)
-"clt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "clv" = (
 /obj/structure/table/glass,
 /obj/item/folder/white,
@@ -8384,10 +8356,6 @@
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
 "cCJ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port Mix to East Ports"
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -8486,9 +8454,6 @@
 /area/station/service/library/abandoned)
 "cFk" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
@@ -9204,9 +9169,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 5
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "cRq" = (
@@ -9340,14 +9302,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/disposal/incinerator)
-"cUM" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cUN" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/medical/central)
@@ -11189,14 +11143,6 @@
 "dwz" = (
 /turf/closed/wall/rust,
 /area/station/maintenance/space_hut/plasmaman)
-"dwB" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "dxl" = (
 /obj/machinery/conveyor{
 	dir = 6;
@@ -11449,7 +11395,6 @@
 /area/station/science/explab)
 "dBW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -12372,9 +12317,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -13635,9 +13577,6 @@
 /turf/open/misc/asteroid,
 /area/space/nearstation)
 "emw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "emx" = (
@@ -14282,10 +14221,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "eyA" = (
@@ -14630,15 +14565,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/station/security/prison/safe)
-"eFn" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Mix to Filter"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "eFE" = (
 /obj/structure/transit_tube/crossing,
 /obj/effect/turf_decal/sand/plating,
@@ -15016,10 +14942,6 @@
 /turf/open/floor/iron/dark,
 /area/station/commons/fitness/recreation)
 "eKY" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Pure to Ports"
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -20502,15 +20424,8 @@
 /obj/structure/grille,
 /turf/closed/wall/r_wall/rust,
 /area/station/engineering/atmos)
-"gvh" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "gvu" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/box,
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
@@ -23281,16 +23196,6 @@
 "hmO" = (
 /turf/closed/wall,
 /area/station/security/processing)
-"hnb" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Pure to Mix"
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "hne" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -23402,9 +23307,6 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -24165,9 +24067,6 @@
 "hBk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
 "hBm" = (
@@ -25415,10 +25314,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/abandon_wrestle)
 "hRj" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Ports"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/anticorner/contrasted{
 	dir = 8
@@ -28674,9 +28569,6 @@
 /area/station/maintenance/starboard)
 "iLQ" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/box,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
@@ -29969,13 +29861,6 @@
 /obj/machinery/oven/range,
 /turf/open/floor/iron/kitchen,
 /area/station/security/prison/mess)
-"jfL" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jfV" = (
 /obj/structure/closet/secure_closet/captains,
 /obj/effect/turf_decal/bot,
@@ -31383,10 +31268,6 @@
 /area/station/engineering/gravity_generator)
 "jEh" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Filter"
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -32347,9 +32228,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "jTt" = (
@@ -32891,15 +32769,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"kbZ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "kcl" = (
 /obj/machinery/computer/records/medical{
 	dir = 4
@@ -34988,7 +34857,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/showroomfloor,
@@ -35023,7 +34891,6 @@
 "kMY" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/newscaster/directional/east,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -36136,7 +36003,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/components/trinary/mixer/flipped,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -36424,14 +36290,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/aft)
-"llR" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port Mix to West Ports"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "llZ" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/digital_clock/directional/north,
@@ -37424,9 +37282,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore)
 "lAV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -37641,9 +37496,6 @@
 "lFe" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -38352,13 +38204,6 @@
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard)
-"lPJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lPU" = (
 /obj/machinery/shower/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -38617,9 +38462,6 @@
 "lVf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -41443,9 +41285,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
@@ -43735,16 +43574,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/science/explab)
 "nDi" = (
-/obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 8
 	},
@@ -44068,10 +43903,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "nHY" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -44320,7 +44151,6 @@
 "nKQ" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nLa" = (
@@ -44869,9 +44699,6 @@
 	},
 /obj/machinery/light_switch/directional/north,
 /obj/machinery/light/directional/north,
-/obj/item/kirbyplants{
-	icon_state = "plant-05"
-	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
 	},
@@ -46380,9 +46207,6 @@
 /area/station/maintenance/central)
 "owT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
@@ -46677,13 +46501,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/starboard)
-"oBN" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "oBP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48578,7 +48395,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -51129,7 +50945,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
@@ -53269,14 +53084,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
-"qGR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/trinary/mixer,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qHe" = (
 /turf/closed/wall/r_wall/rust,
 /area/station/ai_monitored/command/storage/eva)
@@ -53876,9 +53683,6 @@
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Distribution Loop"
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
-	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
@@ -53979,12 +53783,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"qSe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qSg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -55330,18 +55128,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/department/crew_quarters/bar)
-"rov" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rox" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55774,9 +55560,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/abandoned)
 "rtF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 8
-	},
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -56063,9 +55846,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "ryZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -56556,18 +56336,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard)
-"rHp" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rHs" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -58429,9 +58197,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "slu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -59428,9 +59193,6 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -59883,9 +59645,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "sKy" = (
@@ -63449,11 +63208,6 @@
 /obj/machinery/digital_clock/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
-"tTG" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "tUc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
@@ -64154,9 +63908,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/kitchen)
 "ufI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -64191,9 +63942,6 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central/fore)
 "ugr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -64756,9 +64504,6 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
 "uoN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -66360,12 +66105,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/sorting)
-"uPX" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "uQl" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -66809,9 +66548,6 @@
 "uYw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -69251,15 +68987,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/station/engineering/atmos)
-"vIN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "vIR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -71394,9 +71121,6 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
@@ -71491,15 +71215,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/port/greater)
-"wpa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "wpf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73346,7 +73061,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
@@ -73402,13 +73116,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
-"wTz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "wTP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -73779,14 +73486,6 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating,
 /area/space/nearstation)
-"xae" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/effect/turf_decal/tile/neutral/half/contrasted,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "xaf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -74211,9 +73910,6 @@
 "xfL" = (
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/violet/visible,
 /turf/open/floor/iron,
@@ -77613,12 +77309,6 @@
 /obj/machinery/composters,
 /turf/open/floor/iron/dark,
 /area/station/service/hydroponics/garden)
-"ylD" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/box,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "ylI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -105640,7 +105330,7 @@ cSe
 kPv
 hoI
 aSv
-qGR
+ajv
 ajv
 wSL
 ajv
@@ -105894,13 +105584,13 @@ gry
 rMi
 bDP
 tst
-xae
+yfr
 dBW
 kMY
 piD
-lPJ
+jUz
 aLP
-tTG
+jUz
 xfL
 hmD
 xcA
@@ -106157,8 +105847,8 @@ wRU
 wRU
 jEh
 jUz
-tTG
-jfL
+jUz
+jUz
 cQX
 fYm
 pet
@@ -106412,8 +106102,8 @@ yfr
 iwT
 wRU
 cWb
-wTz
-cec
+jUz
+jUz
 nKQ
 xzi
 uYw
@@ -106668,10 +106358,10 @@ wxv
 doN
 iwT
 nsX
-ylD
-gvh
+iLQ
+jUz
 vqv
-cjv
+eKY
 iLQ
 sKp
 pWY
@@ -106926,9 +106616,9 @@ hWd
 dgg
 wRU
 gvu
-oBN
+jUz
 aGM
-kbZ
+eKY
 iLQ
 lVf
 gzC
@@ -107182,12 +106872,12 @@ svs
 hWd
 ebp
 wRU
-ylD
-gvh
-rah
-cjv
 iLQ
-rov
+jUz
+rah
+eKY
+iLQ
+sKp
 nPN
 pet
 uZZ
@@ -107440,7 +107130,7 @@ hWd
 riI
 vRK
 enr
-llR
+jUz
 jUz
 cCJ
 fdd
@@ -107698,10 +107388,10 @@ wRU
 wRU
 wRU
 lFe
-cUM
-qSe
+jUz
+eKY
 xAW
-rHp
+mOg
 kMq
 vWa
 blX
@@ -109240,9 +108930,9 @@ ouk
 qVp
 bSg
 loV
-wpa
-vIN
-hnb
+aYN
+aYN
+aYN
 aYN
 tUc
 sGV
@@ -109497,10 +109187,10 @@ iNm
 iCq
 lqU
 rHG
-eFn
-clt
 owT
-uPX
+xLN
+owT
+xLN
 cPp
 vxr
 tKi
@@ -109755,7 +109445,7 @@ iTB
 vVx
 vzt
 oqW
-dwB
+xLN
 rtF
 ipJ
 fxB

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -5702,15 +5702,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"auX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "auY" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/vault,
@@ -6490,9 +6481,6 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
 	name = "Air to Distro"
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -21336,22 +21324,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"bMd" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Distro"
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"bMe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "bMh" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -21527,13 +21499,6 @@
 /obj/machinery/recharge_station,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"bMX" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Pure to Port"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "bMY" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
@@ -21554,10 +21519,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
-"bNb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "bNg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -21822,21 +21783,9 @@
 /area/station/engineering/atmos)
 "bOn" = (
 /obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Air to Port"
-	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"bOo" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Port"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"bOp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -21998,16 +21947,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"bPc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Mix"
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -22346,16 +22285,10 @@
 "bQK" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bQM" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bQP" = (
@@ -22700,11 +22633,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"bSf" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "bSg" = (
 /obj/structure/grille,
 /turf/open/space,
@@ -22843,7 +22771,6 @@
 /area/station/engineering/atmos/office)
 "bSR" = (
 /obj/item/wrench,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bSS" = (
@@ -22855,10 +22782,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
-"bST" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "bSU" = (
 /obj/machinery/pipedispenser/disposal/transit_tube,
 /turf/open/floor/iron,
@@ -23106,13 +23029,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/atmos,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/office)
-"bTK" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 1;
-	name = "plasma mixer"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "bTL" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -23125,9 +23041,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
 "bTO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -23147,14 +23060,7 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bTS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /obj/structure/chair/stool/bar/directional/east,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"bTT" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 8
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "bTV" = (
@@ -23297,12 +23203,6 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"bUv" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -23737,12 +23637,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"bVY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "bVZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -24151,9 +24045,6 @@
 /area/station/engineering/atmos)
 "bXC" = (
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
@@ -24607,9 +24498,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -29782,9 +29670,6 @@
 	c_tag = "Atmospherics Mixing"
 	},
 /obj/structure/reagent_dispensers/fueltank/large,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
@@ -31147,9 +31032,6 @@
 /area/station/engineering/engine_smes)
 "eDR" = (
 /obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -31916,11 +31798,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
-"feN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "feU" = (
 /obj/structure/table,
 /obj/item/storage/medkit/o2{
@@ -32295,7 +32172,10 @@
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
 "fuR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
+/obj/machinery/atmospherics/components/binary/pump/layer2{
+	dir = 8;
+	name = "Gas to Engine"
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "fvq" = (
@@ -32458,13 +32338,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"fDm" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "fEo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -32576,15 +32449,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/main)
-"fIA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Port"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "fIH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32620,14 +32484,6 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"fJw" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Supermatter Mix Pump"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "fKa" = (
 /obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron/freezer,
@@ -32975,13 +32831,6 @@
 /mob/living/basic/butterfly,
 /turf/open/floor/grass,
 /area/station/medical/psychology)
-"gbu" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Filter"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "gbK" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -34171,14 +34020,6 @@
 /obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
-"hfi" = (
-/obj/machinery/light/directional/west,
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Filter"
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "hfw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -35786,14 +35627,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library)
-"iBq" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "incinerator mix pump"
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "iBw" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/landmark/start/prisoner,
@@ -35968,16 +35801,6 @@
 	},
 /turf/open/floor/carpet/grimey,
 /area/station/security/detectives_office)
-"iJc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "iJH" = (
 /obj/structure/table,
 /obj/item/stack/sheet/plasteel{
@@ -36664,12 +36487,6 @@
 /obj/effect/turf_decal/tile/green/anticorner/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"jty" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jtJ" = (
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
@@ -37041,10 +36858,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/library/lounge)
-"jMl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "jMA" = (
 /obj/machinery/computer/apc_control,
 /obj/machinery/requests_console/directional/north{
@@ -37472,13 +37285,6 @@
 	dir = 8
 	},
 /area/station/service/chapel)
-"keN" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "N2 to Pure"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "kfl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -37819,9 +37625,6 @@
 "krn" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -41610,7 +41413,6 @@
 /area/station/science/xenobiology)
 "nEp" = (
 /obj/item/cigbutt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "nES" = (
@@ -41941,10 +41743,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/grass,
 /area/station/medical/treatment_center)
-"nUq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "nUL" = (
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 4
@@ -44116,13 +43914,6 @@
 "pGZ" = (
 /turf/open/space/basic,
 /area/station/cargo/mining/asteroid_magnet)
-"pHb" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Air to Pure"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "pHf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -44824,13 +44615,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
-"qkk" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "O2 to Pure"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qko" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -45124,9 +44908,6 @@
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
 "qux" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
@@ -45620,7 +45401,6 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
 "qQx" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
 	dir = 4
@@ -47311,13 +47091,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/mechbay)
-"shs" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "shv" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
@@ -47885,11 +47658,6 @@
 /obj/structure/cable,
 /turf/open/floor/carpet/grimey,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"sGc" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "sGr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -50324,9 +50092,6 @@
 /area/station/science/explab)
 "uvr" = (
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
@@ -50875,9 +50640,6 @@
 /area/station/maintenance/department/science/central)
 "uTt" = (
 /obj/machinery/firealarm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
@@ -51595,10 +51357,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
-"vsJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vtl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -51607,12 +51365,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
-"vtD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vtT" = (
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port)
@@ -53678,13 +53430,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/security/range)
-"wSR" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "wTu" = (
 /turf/closed/wall,
 /area/station/security/medical)
@@ -53747,7 +53492,6 @@
 "wUN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wVC" = (
@@ -53837,13 +53581,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/range)
-"wYC" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "wYH" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -55301,11 +55038,6 @@
 /obj/structure/flora/bush/flowers_yw/style_random,
 /turf/open/floor/grass,
 /area/station/security/bitden)
-"xXv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "xXQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -90962,7 +90694,7 @@ wBF
 wBF
 wBF
 bWP
-fuR
+bWO
 bWO
 bWO
 bXx
@@ -91219,7 +90951,7 @@ bSe
 bSU
 bPQ
 bXB
-fuR
+bWO
 bWO
 eVD
 qsH
@@ -91723,7 +91455,7 @@ bIC
 bJK
 fBp
 bMa
-wSR
+aAK
 lyB
 bOV
 bWO
@@ -91732,8 +91464,8 @@ bWO
 bWO
 bWO
 bTQ
-ksv
-sGc
+bWO
+aAK
 eUb
 wCz
 mvA
@@ -91990,7 +91722,7 @@ bQJ
 bRx
 bPQ
 bXC
-sGc
+aAK
 bWO
 wCz
 wwr
@@ -92247,9 +91979,9 @@ bPQ
 bPQ
 bPQ
 bZT
-sGc
-bVY
-shs
+aAK
+bWO
+wCz
 euv
 dHc
 vJD
@@ -92493,7 +92225,7 @@ bHt
 bIE
 apv
 fBp
-bMd
+qux
 aAK
 bIG
 bOX
@@ -92504,8 +92236,8 @@ bQK
 bQK
 bPQ
 dsR
-sGc
-pyH
+aAK
+bWO
 wCz
 pyH
 uWA
@@ -92751,18 +92483,18 @@ bAy
 bCO
 fBp
 uvr
-feN
-vsJ
-fIA
-bST
+aAK
+bWO
+wCz
+bWO
 bOn
-bST
-bSf
+bWO
+bWO
 bSR
-hfi
-nUq
-fDm
-pyH
+bOn
+bWO
+aAK
+bWO
 lRh
 kRL
 frC
@@ -93011,16 +92743,16 @@ uTt
 bWO
 bWO
 wCz
-bSf
+bWO
 bWO
 bWO
 bSj
 bWO
 bTR
-gbu
-fJw
-qkk
-keN
+bWO
+aAK
+bWO
+bWO
 bWO
 taw
 xgG
@@ -93264,21 +92996,21 @@ bCP
 bHw
 bCP
 fBp
-iJc
+uvr
 bWO
 bWO
 wCz
-bST
-bOo
-bST
-bSf
-bST
+bWO
+bWO
+bWO
+bWO
+bWO
 bTS
 nEp
-xXv
-jty
-bMe
-pHb
+aAK
+bWO
+bWO
+bWO
 gQj
 xca
 fda
@@ -93525,15 +93257,15 @@ eDR
 eUb
 bWO
 wCz
-bMX
+bWO
 bWO
 bQM
 bQM
 bQM
-bTT
-bUv
-iBq
-vtD
+bWO
+bWO
+aAK
+bWO
 bWO
 bWO
 bYs
@@ -93778,19 +93510,19 @@ wZx
 pmq
 bJO
 vMt
-iJc
+uvr
 bWO
-bOp
-bPc
-bNb
-vsJ
-vsJ
-vsJ
-bTK
-bMe
-bMe
+bWO
+wCz
+bWO
+bWO
+bWO
+bWO
+bWO
+bWO
+bWO
 qQx
-jMl
+bWO
 bWO
 bWO
 bYt
@@ -94035,11 +93767,11 @@ pDe
 eAa
 aqO
 fBp
-auX
+qux
 bWO
 bOq
 nbE
-wYC
+bTO
 eNC
 bRz
 eNC

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -1045,13 +1045,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
-"apU" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "apV" = (
 /turf/open/floor/grass,
 /area/station/service/hydroponics/chicken)
@@ -1080,10 +1073,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/obj/machinery/meter/layer4{
-	pixel_x = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
@@ -3192,14 +3181,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/security/range)
-"aXf" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port Mix to North Ports"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "aXh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4364,14 +4345,6 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
-"bnX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/pumproom)
 "bob" = (
 /obj/machinery/door/airlock/command{
 	name = "Gateway Atrium"
@@ -4842,14 +4815,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"bwi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/pumproom)
 "bwu" = (
 /obj/machinery/light{
 	dir = 4
@@ -5252,13 +5217,6 @@
 /obj/machinery/power/floodlight,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"bDT" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "bEd" = (
 /obj/effect/turf_decal/tile/red/half,
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -5630,16 +5588,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/carpet/purple,
 /area/station/command/heads_quarters/rd)
-"bIS" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/meter{
-	pixel_y = -4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "bIZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/structure/cable,
@@ -6324,9 +6272,6 @@
 /turf/open/floor/iron/white,
 /area/station/science/explab)
 "bVU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -6406,9 +6351,6 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "bWT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -7006,13 +6948,6 @@
 /obj/item/banner/cargo/mundane,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"cer" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "ceB" = (
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/dark,
@@ -10252,13 +10187,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"dbK" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/layer_manifold/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "dbO" = (
 /obj/effect/turf_decal/tile/blue/anticorner{
 	dir = 1
@@ -10585,14 +10513,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"djr" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "djz" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/effect/turf_decal/bot,
@@ -10821,19 +10741,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/genetics)
-"dnx" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "dnz" = (
 /obj/structure/table/reinforced/rglass,
 /obj/item/storage/medkit/fire{
@@ -11550,18 +11457,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/brig/entrance)
-"dvF" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 5
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "dvW" = (
 /obj/structure/railing{
 	dir = 4
@@ -12746,14 +12641,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"dNH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "dNI" = (
 /obj/item/paper_bin{
 	pixel_x = 7
@@ -13204,17 +13091,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
-"dUJ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/window/reinforced/plasma/spawner/directional/west,
-/obj/structure/window/reinforced/plasma/spawner/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "dUK" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -13538,12 +13414,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/security/prison)
-"dZP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "dZQ" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/closet/secure_closet/security/science,
@@ -15763,15 +15633,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
-"eIm" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "eIu" = (
 /obj/effect/turf_decal/trimline/dark_green/corner{
 	dir = 1
@@ -16022,11 +15883,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/upper)
-"eNH" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "eNJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16417,11 +16273,6 @@
 /obj/effect/turf_decal/siding/yellow,
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
-"eTD" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "eTI" = (
@@ -17355,17 +17206,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"fgu" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer2{
-	dir = 3
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/atmos)
 "fgz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/west,
@@ -17766,14 +17606,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"fmt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "fmv" = (
 /obj/structure/table,
 /obj/item/storage/medkit/regular,
@@ -18118,7 +17950,6 @@
 /turf/open/floor/wood,
 /area/station/maintenance/port/lesser)
 "frO" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -18833,13 +18664,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/commons/fitness)
-"fEX" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "fFj" = (
 /obj/structure/rack,
 /obj/item/storage/bag/plants/portaseeder,
@@ -20004,7 +19828,6 @@
 /area/station/service/library/lounge)
 "fWK" = (
 /obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/engineering/atmos/pumproom)
@@ -20153,14 +19976,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
-"fYV" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/atmos)
 "fYW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmoslock";
@@ -26702,7 +26517,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
 "hUw" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
@@ -27550,10 +27364,6 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
-"ihW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/pumproom)
 "ihZ" = (
 /obj/structure/kitchenspike,
 /obj/effect/mob_spawn/corpse/human/clown,
@@ -28130,17 +27940,6 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/science/cytology)
-"ipe" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/window/reinforced/plasma/spawner/directional/east,
-/obj/structure/window/reinforced/plasma/spawner/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "ipn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -28297,13 +28096,6 @@
 /obj/structure/shipping_container/nthi,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"isv" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "isA" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/structure/disposalpipe/segment,
@@ -30105,13 +29897,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
-"iSe" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "iSm" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -32947,18 +32732,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
-"jIT" = (
-/obj/machinery/door/firedoor/heavy,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer2{
-	dir = 3
-	},
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/atmos)
 "jJe" = (
 /obj/item/radio/intercom/directional/east{
 	broadcasting = 1;
@@ -33358,17 +33131,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
-"jPr" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "jPI" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -33561,13 +33323,6 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"jTf" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "jTh" = (
 /obj/effect/turf_decal/tile/gray/half/contrasted{
 	dir = 4
@@ -34349,12 +34104,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"kex" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "key" = (
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/siding/wood{
@@ -34711,19 +34460,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/janitor)
-"kka" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "kkb" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable,
@@ -36138,14 +35874,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
-"kFm" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Pure to Mix"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "kFo" = (
 /obj/effect/spawner/random/trash/grime,
 /turf/open/floor/engine,
@@ -36311,9 +36039,6 @@
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
 "kGQ" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -36477,9 +36202,6 @@
 /turf/open/floor/plating,
 /area/station/engineering/storage/tech)
 "kIz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 5
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
 "kIF" = (
@@ -36892,14 +36614,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"kON" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port Mix to South Ports"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "kPb" = (
 /obj/effect/decal/cleanable/confetti,
 /obj/structure/cable,
@@ -37553,7 +37267,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "kXS" = (
@@ -37884,13 +37597,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/lowered/iron/pool/cobble,
 /area/station/commons/fitness)
-"laT" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/binary/pump/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "laW" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -38438,9 +38144,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Mix to Filter"
-	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
@@ -38797,13 +38500,10 @@
 	},
 /area/station/medical/morgue)
 "loj" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/window/reinforced/plasma/spawner/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "lok" = (
@@ -39367,9 +39067,9 @@
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance/testlab)
 "luT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/warm/directional/south,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "lvb" = (
@@ -40120,11 +39820,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"lGt" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "lGG" = (
 /obj/machinery/pdapainter{
 	pixel_y = 2
@@ -41256,8 +40951,6 @@
 "lYs" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "lYx" = (
@@ -42114,27 +41807,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"mkg" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Filter"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "mkn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"mkw" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Ports"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "mkS" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -43180,13 +42857,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/medical/pathology)
-"mBD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "mBO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -43557,13 +43227,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/security/bitden)
-"mGO" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "mGS" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/landmark/start/station_engineer,
@@ -43722,12 +43385,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"mJw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/meter,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "mJB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flashlight/glowstick/blue,
@@ -46212,11 +45869,6 @@
 /turf/closed/wall,
 /area/station/service/kitchen)
 "nwb" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Distro Staging to Distro"
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
@@ -46289,9 +45941,6 @@
 "nxM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 9
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
 "nxT" = (
@@ -48362,14 +48011,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/storage/tech)
-"odZ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Pure to Ports"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "oec" = (
 /obj/effect/turf_decal/tile/green/half,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48430,15 +48071,6 @@
 /obj/effect/spawner/random/trash/botanical_waste,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"oeS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "oeT" = (
 /obj/structure/chair{
 	dir = 4
@@ -50172,7 +49804,6 @@
 /area/station/hallway/primary/starboard)
 "oDW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
 "oEk" = (
@@ -50252,7 +49883,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /obj/structure/cable,
 /obj/structure/sign/poster/official/work_for_a_future/directional/east,
 /turf/open/floor/iron/dark,
@@ -50599,13 +50229,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/misc/dirt/station,
 /area/station/service/hydroponics)
-"oMl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "oMm" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
@@ -51883,12 +51506,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron,
 /area/station/security/courtroom)
-"phf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "phj" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -53430,11 +53047,6 @@
 "pHL" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/supermatter)
-"pHR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "pHS" = (
 /obj/structure/sink/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -57002,18 +56614,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical)
-"qFb" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 6
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "qFg" = (
 /obj/machinery/vending/wardrobe/law_wardrobe,
 /obj/effect/turf_decal/bot,
@@ -58820,7 +58420,6 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /obj/structure/cable,
 /obj/machinery/light/warm/directional/east,
 /obj/effect/turf_decal/siding/yellow/corner{
@@ -59134,19 +58733,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/office)
-"rln" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Waste to Filter"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "rlo" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/iron/dark,
@@ -59495,8 +59081,8 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/tcommsat/computer)
 "rrb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "rrd" = (
@@ -63353,12 +62939,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"sxo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
-/obj/machinery/meter,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "sxu" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod 2";
@@ -63937,11 +63517,13 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /obj/effect/turf_decal/siding/yellow,
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/atmospherics/components/binary/pump/on/dark/visible/layer4{
+	name = "Gast to Turbine"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "sDV" = (
@@ -65669,14 +65251,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/ordnance/office)
-"tfn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "tfs" = (
 /obj/effect/spawner/random/structure/barricade,
 /obj/machinery/door/airlock/maintenance{
@@ -66444,7 +66018,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer2{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "tpC" = (
@@ -66671,7 +66244,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/warehouse)
 "tss" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -67665,12 +67237,6 @@
 "tGd" = (
 /turf/closed/wall,
 /area/station/service/hydroponics/garden)
-"tGx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/light/floor/has_bulb/warm,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "tGG" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -68051,9 +67617,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/components/binary/pump/layer4{
-	name = "O2 to Turbine"
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "tLU" = (
@@ -68751,14 +68314,6 @@
 	},
 /turf/open/floor/iron/white/corner,
 /area/station/security/execution/education)
-"tVZ" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "tWb" = (
 /obj/effect/turf_decal/tile/blue/half{
 	dir = 1
@@ -69121,15 +68676,6 @@
 "ubk" = (
 /turf/closed/wall,
 /area/station/science/lab)
-"ubs" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "ubB" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/item/radio/intercom/directional/north,
@@ -69985,13 +69531,6 @@
 "upf" = (
 /turf/closed/wall/r_wall,
 /area/station/service/theater)
-"upg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "upn" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72088,11 +71627,6 @@
 /obj/machinery/light/warm/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"uSc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/machinery/meter/monitored/waste_loop,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/pumproom)
 "uSf" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable,
@@ -73146,7 +72680,6 @@
 "vhB" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/atmos)
 "vhI" = (
@@ -74643,11 +74176,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"vDu" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/wrench,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "vDC" = (
 /obj/structure/flora/bush/sparsegrass/style_2,
 /obj/machinery/light/directional/west,
@@ -74823,18 +74351,6 @@
 "vGO" = (
 /turf/closed/wall,
 /area/station/construction/mining/aux_base)
-"vGS" = (
-/obj/effect/turf_decal/stripes/red/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Filter"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "vGU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -75508,9 +75024,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "vRG" = (
@@ -75627,14 +75140,6 @@
 "vTc" = (
 /turf/open/floor/plating,
 /area/station/engineering/shipbreaker_hut)
-"vTj" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 6
-	},
-/obj/machinery/light/floor/has_bulb/warm,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "vTq" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -75700,15 +75205,6 @@
 /obj/item/kirbyplants/organic/plant22,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
-"vUm" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "vUz" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -78015,7 +77511,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/yellow/corner,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light/warm/directional/east,
 /obj/machinery/button/door/directional/east{
@@ -79092,17 +78587,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/freezer,
 /area/station/science/xenobiology/hallway)
-"wUa" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Distro Staging"
-	},
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "wUk" = (
 /obj/machinery/vending/autodrobe,
 /obj/structure/sign/poster/contraband/clown/directional/north,
@@ -79506,10 +78990,10 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible/layer2{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump/off/orange/visible/layer2{
+	dir = 8;
+	name = "Gas to Engine"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "xbt" = (
@@ -80126,7 +79610,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "xkk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -80419,16 +79902,6 @@
 	dir = 4
 	},
 /area/station/science/ordnance/office)
-"xoM" = (
-/obj/effect/turf_decal/tile/neutral/half/contrasted{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/obj/effect/turf_decal/siding/yellow,
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "xph" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
@@ -80652,14 +80125,6 @@
 "xrv" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/upper)
-"xrH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/item/crowbar,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos)
 "xrI" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -83182,7 +82647,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
@@ -130907,7 +130371,7 @@ lzI
 xyP
 axJ
 ltV
-upg
+wiJ
 niM
 iIQ
 rtR
@@ -131164,7 +130628,7 @@ rlV
 tdf
 xDr
 bCP
-mBD
+wiJ
 niM
 rZo
 lJm
@@ -131421,7 +130885,7 @@ lzI
 lHO
 okL
 vCp
-mBD
+wiJ
 niM
 iIQ
 aem
@@ -131935,7 +131399,7 @@ lzI
 xyP
 axJ
 tLJ
-dZP
+wiJ
 niM
 iIQ
 aem
@@ -132192,7 +131656,7 @@ fNV
 ohm
 wso
 sHT
-vUm
+kGQ
 gGF
 fkG
 lJm
@@ -132449,7 +131913,7 @@ lzI
 lHO
 okL
 pNh
-tfn
+wiJ
 wiJ
 iIQ
 grW
@@ -132706,7 +132170,7 @@ fNV
 ohm
 nzy
 eCg
-dZP
+wiJ
 wiJ
 omG
 gzx
@@ -132963,14 +132427,14 @@ lzI
 oWE
 sMM
 jCd
-dnx
 qDR
 qDR
 qDR
 qDR
 qDR
 qDR
-rln
+qDR
+qDR
 aIO
 rTR
 huU
@@ -133220,14 +132684,14 @@ fqu
 hPf
 ikY
 elt
-jIT
 dUP
 dUP
 dUP
-fgu
+dUP
+dUP
 tpn
 vhB
-fYV
+vhB
 rBI
 eXW
 huU
@@ -133477,13 +132941,13 @@ lXw
 oWE
 uLx
 nmX
-kka
+kHe
 oCk
-qFb
-vGS
-jPr
+kHe
+kHe
+kHe
 xbd
-dvF
+kHe
 kHe
 iDM
 aPo
@@ -133734,13 +133198,13 @@ tyH
 tdf
 qMY
 gTd
-tfn
-vBt
-rrb
 wiJ
-mkg
-bIS
-dtG
+vBt
+wiJ
+wiJ
+wiJ
+wiJ
+wiJ
 hDV
 mwD
 suP
@@ -133991,13 +133455,13 @@ lXw
 lHO
 orl
 ePy
-tfn
+wiJ
 frO
-sxo
-dUJ
-kex
-apU
-dtG
+rrb
+loj
+wiJ
+wiJ
+wiJ
 qIj
 wiJ
 kjy
@@ -134248,13 +133712,13 @@ dJr
 ntw
 duP
 jBR
-dZP
+wiJ
 frO
 luT
 loj
-jTf
-apU
-dtG
+wiJ
+wiJ
+wiJ
 qIj
 wiJ
 sMp
@@ -134505,13 +133969,13 @@ lXw
 lHO
 xxs
 uKD
-tfn
+wiJ
 frO
 rrb
-ipe
-kex
-laT
-dtG
+loj
+wiJ
+wiJ
+wiJ
 qIj
 wiJ
 qJD
@@ -134762,13 +134226,13 @@ tyH
 tdf
 iRh
 pID
-tfn
 wiJ
-kON
-vDu
-aXf
-dbK
-dtG
+wiJ
+wiJ
+wiJ
+wiJ
+wiJ
+wiJ
 qIj
 wiJ
 xMM
@@ -135019,13 +134483,13 @@ lXw
 lHO
 lFe
 nyK
-tfn
 wiJ
-xrH
 wiJ
-oMl
-cer
-dtG
+wiJ
+wiJ
+wiJ
+wiJ
+wiJ
 qIj
 wiJ
 jsZ
@@ -135276,13 +134740,13 @@ dJr
 ntw
 duP
 xmb
-djr
+wiJ
 fia
-oMl
-fmt
-tGx
-bDT
-mGO
+wiJ
+wiJ
+fia
+wiJ
+wiJ
 qIj
 wiJ
 jsZ
@@ -135533,12 +134997,12 @@ lXw
 lHO
 xxs
 uKD
-tfn
 wiJ
-odZ
-mkw
+wiJ
+wiJ
+wiJ
 xMl
-dtG
+wiJ
 wiJ
 qIj
 wiJ
@@ -135790,12 +135254,12 @@ cRg
 tdf
 qMY
 crr
-tfn
+wiJ
 qoC
-oeS
-eIm
+buw
+buw
 buS
-ubs
+hDV
 hDV
 hDV
 qyq
@@ -135803,8 +135267,8 @@ eTB
 hcx
 jaT
 sJg
-ihW
-uSc
+kIz
+kIz
 nwb
 kIz
 nTG
@@ -136047,22 +135511,22 @@ lXw
 lHO
 orl
 iuN
-tfn
-eNH
-tfn
-oMl
+wiJ
+wiJ
+wiJ
+wiJ
 liS
-mGO
-isv
-eTD
-eTD
-xoM
+wiJ
+wiJ
+wiJ
+wiJ
+eTB
 fWK
 xkk
 tss
 bWT
 vBR
-bwi
+vBR
 bVU
 xdJ
 gxU
@@ -136304,20 +135768,20 @@ fIg
 ntw
 duP
 aDu
-mJw
-pHR
-dNH
-iSe
-wUa
-eTD
-cer
+wiJ
+wiJ
+wiJ
+wiJ
+liS
+wiJ
+wiJ
 wiJ
 wiJ
 xLo
 mri
 uEz
 ruI
-bnX
+xMq
 oDW
 nxM
 kBZ
@@ -136561,10 +136025,10 @@ lXw
 lHO
 xxs
 uKD
-kFm
-vTj
+wiJ
+fia
 lYs
-cer
+wiJ
 cQR
 nSI
 wiJ
@@ -136820,7 +136284,7 @@ fOz
 bcM
 pIs
 vRD
-phf
+tis
 iay
 xcY
 wiJ
@@ -137076,8 +136540,8 @@ lHO
 orl
 lhI
 vIG
-fEX
-eNH
+wiJ
+wiJ
 oGW
 bFK
 wiJ
@@ -137333,8 +136797,8 @@ yfb
 gxp
 oEH
 hUw
-lGt
-eNH
+wiJ
+wiJ
 oGW
 qWB
 wiJ
@@ -137590,8 +137054,8 @@ oWE
 dNp
 tKD
 lnv
-tVZ
-phf
+kGQ
+tis
 kyR
 qxb
 ycY
@@ -137848,7 +137312,7 @@ mEH
 gAK
 kyR
 bOj
-eNH
+wiJ
 aqv
 wIK
 kXQ

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -365,10 +365,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/effect/turf_decal/bot{
+/obj/machinery/atmospherics/components/binary/crystallizer{
 	dir = 1
 	},
 /turf/open/floor/iron/textured,
@@ -727,12 +727,6 @@
 	},
 /turf/open/floor/iron/dark/textured_edge,
 /area/station/science/robotics/lab)
-"ajK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "ajL" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/space_heater,
@@ -1071,14 +1065,6 @@
 /obj/machinery/light/cold/directional/south,
 /turf/open/floor/iron/white/diagonal,
 /area/station/science/research)
-"aoi" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix to Ports"
-	},
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "aot" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1;
@@ -3190,12 +3176,6 @@
 /obj/machinery/anesthetic_machine,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
-"aUj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos/pumproom)
 "aUp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3399,13 +3379,6 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/textured_large,
 /area/station/command/cc_dock)
-"aWz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/engineering/atmos/pumproom)
 "aWC" = (
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay"
@@ -4105,19 +4078,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/pod/dark,
 /area/station/service/chapel/office)
-"bfE" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/textured_edge{
-	dir = 4
-	},
-/area/station/engineering/atmos)
 "bfF" = (
 /obj/machinery/requests_console/auto_name/directional/south,
 /obj/effect/turf_decal/stripes/red/line{
@@ -5278,14 +5238,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/grimey,
 /area/station/commons/dorms)
-"bzI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/iron/textured_corner,
-/area/station/engineering/atmos)
 "bzU" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -5403,9 +5355,6 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
 	},
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics - Nitrogen Cell";
@@ -5682,26 +5631,12 @@
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/wood,
 /area/station/security/prison/garden)
-"bHP" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "bHW" = (
 /obj/machinery/atmospherics/components/tank/oxygen{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/station/science/ordnance/storage)
-"bIs" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "bIx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/red/line{
@@ -6896,18 +6831,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"cci" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron/textured_edge{
-	dir = 4
-	},
-/area/station/engineering/atmos)
 "cck" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7372,9 +7295,6 @@
 /area/station/hallway/primary/central)
 "ciQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
@@ -9180,18 +9100,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/science/research)
-"cLl" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/iron/textured_edge,
-/area/station/engineering/atmos)
 "cLr" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -9224,18 +9132,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"cMm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_edge,
-/area/station/engineering/atmos)
 "cMC" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/flora/bush/sparsegrass/style_random,
@@ -9758,13 +9654,6 @@
 /obj/structure/trash_pile,
 /turf/open/floor/iron/textured,
 /area/station/maintenance/aft)
-"cUg" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port to Filter"
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "cUk" = (
 /obj/effect/turf_decal/siding/thinplating_new/terracotta/corner{
 	dir = 4
@@ -9906,9 +9795,6 @@
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/atmospherics/components/binary/crystallizer{
-	dir = 1
-	},
 /turf/open/floor/iron/textured_edge{
 	dir = 8
 	},
@@ -12000,13 +11886,6 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/hallway/primary/fore)
-"dAj" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port Mix to Starboard Ports"
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "dAp" = (
 /obj/machinery/door/airlock/external/ruin,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -12163,9 +12042,6 @@
 	},
 /area/station/hallway/primary/fore)
 "dBV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
@@ -12778,11 +12654,6 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/maintenance/aft/greater)
-"dKm" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "dKE" = (
 /turf/open/floor/iron/chapel{
 	dir = 6
@@ -14810,13 +14681,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/textured,
 /area/station/maintenance/department/science/ordnance_maint)
-"elk" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Ports"
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "elm" = (
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 1
@@ -15522,18 +15386,6 @@
 	},
 /turf/open/floor/pod,
 /area/station/service/chapel/funeral)
-"ewu" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_edge,
-/area/station/engineering/atmos)
 "ewC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/dark_red{
@@ -16087,9 +15939,6 @@
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/entry)
 "eDQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16336,11 +16185,13 @@
 "eGi" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/components/binary/pump/off/dark/visible{
+	name = "Gas to Turbine"
+	},
 /turf/open/floor/iron/textured_edge{
 	dir = 1
 	},
@@ -16495,7 +16346,6 @@
 /turf/open/floor/iron/freezer,
 /area/station/medical/chemistry)
 "eIP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -17380,12 +17230,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
-"eVM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "eVW" = (
 /obj/effect/spawner/random/trash/garbage,
 /obj/effect/decal/cleanable/dirt,
@@ -18661,9 +18505,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/textured_edge,
 /area/station/engineering/atmos)
@@ -19929,18 +19770,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"fKt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/textured_edge,
-/area/station/engineering/atmos)
 "fKv" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20900,13 +20729,6 @@
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/wood,
 /area/station/service/hydroponics/chicken)
-"fYF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 6
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "fYK" = (
 /obj/structure/sign/warning/biohazard/directional/south,
 /turf/open/space/basic,
@@ -24164,9 +23986,6 @@
 	},
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
@@ -26528,14 +26347,6 @@
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/iron/textured,
 /area/station/maintenance/department/science/ordnance_maint)
-"hAR" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "hAU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27989,7 +27800,6 @@
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
 "hVk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -28108,9 +27918,6 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos)
 "hXV" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -28555,13 +28362,6 @@
 /obj/structure/window/reinforced/survival_pod/spawner/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/commons/fitness/recreation/entertainment)
-"ieQ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "ieX" = (
 /obj/structure/table/wood,
 /obj/structure/extinguisher_cabinet/directional/east,
@@ -28641,13 +28441,6 @@
 "igv" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/work)
-"igG" = (
-/obj/machinery/atmospherics/components/trinary/filter{
-	dir = 1
-	},
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "ihg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -28792,13 +28585,13 @@
 	},
 /area/station/hallway/primary/central/aft)
 "ijx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/textured_edge,
 /area/station/engineering/atmos)
 "ijy" = (
@@ -28925,11 +28718,6 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/science/ordnance/testlab)
-"ilm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "iln" = (
 /obj/structure/table,
 /obj/machinery/firealarm/directional/east,
@@ -30632,9 +30420,6 @@
 	},
 /area/station/science/robotics/lab)
 "iGg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -31641,19 +31426,6 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"iVz" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/turf/open/floor/iron/textured_edge{
-	dir = 4
-	},
-/area/station/engineering/atmos)
 "iVF" = (
 /obj/structure/filingcabinet/employment,
 /obj/effect/turf_decal/bot,
@@ -33200,7 +32972,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/machinery/light/warm/directional/south,
 /obj/machinery/camera/directional/south{
 	c_tag = "Atmospherics - Project Room Side Entrance";
@@ -33911,9 +33682,6 @@
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/storage)
 "jyF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
 	},
@@ -35926,7 +35694,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/directional/east{
@@ -37171,7 +36938,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /turf/open/floor/iron/textured_edge{
 	dir = 4
 	},
@@ -37297,12 +37063,6 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron/textured,
 /area/station/cargo/storage)
-"kwl" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "kwv" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/small,
@@ -38354,10 +38114,6 @@
 /turf/open/floor/iron/freezer,
 /area/station/service/kitchen/coldroom)
 "kIi" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Distro"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -38373,21 +38129,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/textured_large,
 /area/station/hallway/primary/aft)
-"kIq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron/textured_edge{
-	dir = 8
-	},
-/area/station/engineering/atmos)
 "kIt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -39877,14 +39618,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
-"ldr" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "ldB" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
@@ -40432,10 +40165,6 @@
 	},
 /area/station/hallway/primary/aft)
 "llW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -40464,7 +40193,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/machinery/light/warm/directional/north,
 /obj/machinery/camera/directional/north{
 	c_tag = "Atmospherics - Oxygen Supply";
@@ -40618,11 +40346,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/small,
 /area/station/hallway/secondary/exit/departure_lounge)
-"loe" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "lol" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -40787,20 +40510,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"lri" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_edge{
-	dir = 4
-	},
-/area/station/engineering/atmos)
 "lry" = (
 /obj/structure/chair/sofa/bench{
 	dir = 1
@@ -41973,10 +41682,6 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/security/checkpoint/supply)
-"lGS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "lGT" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -42915,10 +42620,6 @@
 	},
 /turf/open/floor/iron/white/side,
 /area/station/science/research)
-"lSY" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "lSZ" = (
 /obj/structure/cable,
 /turf/open/floor/iron/textured_large,
@@ -43384,7 +43085,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /turf/open/floor/iron/textured_edge{
 	dir = 4
 	},
@@ -43576,13 +43276,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/station/engineering/main)
-"mcR" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "mcW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/duct,
@@ -43889,19 +43582,6 @@
 	dir = 4
 	},
 /turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
-"mhQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_edge,
 /area/station/engineering/atmos)
 "mhR" = (
 /turf/open/floor/light/colour_cycle/dancefloor_a,
@@ -44666,12 +44346,6 @@
 /obj/effect/turf_decal/box/blue,
 /turf/open/floor/iron/freezer,
 /area/station/medical/surgery)
-"muc" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Fuel Pipe"
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "mui" = (
 /obj/structure/railing{
 	dir = 8
@@ -45124,16 +44798,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
-"mBF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/turf/open/floor/iron/textured_edge{
-	dir = 1
-	},
-/area/station/engineering/atmos)
 "mBJ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46192,13 +45856,6 @@
 	},
 /turf/open/floor/iron/white/textured_edge,
 /area/station/medical/surgery)
-"mPM" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "mQl" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/fore)
@@ -46903,13 +46560,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/atmos/hfr_room)
-"mZX" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port Mix to Port Ports"
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "nac" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47079,9 +46729,6 @@
 	dir = 1
 	},
 /obj/machinery/light/warm/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/textured_edge,
 /area/station/engineering/atmos)
@@ -48937,12 +48584,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos/lesser)
-"nEW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "nFa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -50171,12 +49812,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/vault,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"nUN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "nUU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -50619,12 +50254,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/xenobiology)
-"odh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 6
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "odp" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/textured_large,
@@ -51628,13 +51257,6 @@
 /obj/effect/spawner/random/food_or_drink/seed,
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden/abandoned)
-"orM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "orN" = (
 /obj/effect/turf_decal/nova_decals/enclave/top/left{
 	color = "#52B4E9"
@@ -51687,9 +51309,6 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
 	},
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -52015,10 +51634,6 @@
 /turf/open/floor/iron/textured_edge{
 	dir = 1
 	},
-/area/station/engineering/atmos)
-"oxa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/closed/wall,
 /area/station/engineering/atmos)
 "oxb" = (
 /obj/structure/cable,
@@ -54370,17 +53985,11 @@
 /turf/open/floor/wood/large,
 /area/station/hallway/primary/central/fore)
 "pdO" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/textured_edge{
-	dir = 4
+	dir = 1
 	},
 /area/station/engineering/atmos)
 "pdU" = (
@@ -55231,8 +54840,9 @@
 	},
 /area/station/hallway/primary/central/aft)
 "por" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 9
+/obj/machinery/atmospherics/components/binary/pump/off/orange{
+	name = "Gas to Engine";
+	dir = 1
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos)
@@ -55798,7 +55408,6 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "pye" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/status_display/ai/directional/east,
@@ -59145,17 +58754,6 @@
 /obj/effect/landmark/start/prisoner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/prison)
-"qrH" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "qrI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60105,13 +59703,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
-"qGv" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "qGO" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
@@ -61171,16 +60762,6 @@
 /obj/effect/landmark/start/chaplain,
 /turf/open/floor/carpet/black,
 /area/station/service/chapel/office)
-"qTQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning,
-/obj/effect/turf_decal/trimline/blue/filled/warning,
-/obj/machinery/atmospherics/pipe/smart/manifold/orange/visible{
-	dir = 1
-	},
-/turf/open/floor/iron/textured_edge{
-	dir = 1
-	},
-/area/station/engineering/atmos)
 "qUl" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -61241,12 +60822,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/fore)
-"qUI" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos/pumproom)
 "qUM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -61361,9 +60936,6 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/orange/visible,
 /turf/open/floor/iron/textured_edge,
@@ -61745,12 +61317,6 @@
 	dir = 8
 	},
 /turf/open/floor/iron/textured,
-/area/station/engineering/atmos)
-"rch" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_large,
 /area/station/engineering/atmos)
 "rcl" = (
 /turf/closed/wall,
@@ -63037,13 +62603,6 @@
 /obj/machinery/duct,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/department/medical)
-"rvY" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Port Mix to Engine"
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "rwg" = (
 /obj/machinery/firealarm/directional/east,
 /obj/structure/closet/firecloset,
@@ -63064,9 +62623,6 @@
 "rwT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
 	},
 /turf/open/floor/iron/textured_edge{
 	dir = 8
@@ -63238,6 +62794,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/airalarm/directional/east,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/textured_edge{
 	dir = 8
 	},
@@ -64660,26 +64217,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/station/maintenance/starboard/lesser)
-"rUO" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Pure to Mix"
-	},
-/turf/open/floor/iron/textured_edge{
-	dir = 4
-	},
-/area/station/engineering/atmos)
 "rUQ" = (
 /turf/open/floor/carpet/black,
 /area/station/commons/dorms)
@@ -64833,12 +64370,6 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/commons/fitness/recreation/entertainment)
-"rXo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "rXp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/airalarm/directional/north,
@@ -69707,9 +69238,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
-	},
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics - Distribution Loop";
 	name = "atmospherics camera"
@@ -71218,9 +70746,6 @@
 /turf/open/floor/wood/large,
 /area/station/command/heads_quarters/hop)
 "tFh" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
 /turf/open/floor/iron/textured_corner{
 	dir = 4
 	},
@@ -71402,20 +70927,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/commons/vacant_room/commissary)
-"tIh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 10
-	},
-/turf/open/floor/iron/textured_edge{
-	dir = 4
-	},
-/area/station/engineering/atmos)
 "tIo" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -72478,12 +71989,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/iron/half,
 /area/station/hallway/primary/central)
-"uar" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "uat" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/effect/decal/cleanable/dirt,
@@ -72663,12 +72168,6 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/command/cc_dock)
-"ucH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/dark/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "ucK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -72695,20 +72194,6 @@
 	dir = 4
 	},
 /area/station/security/prison)
-"ucY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/textured_edge{
-	dir = 4
-	},
-/area/station/engineering/atmos)
 "udg" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/small,
@@ -73982,13 +73467,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/textured_large,
 /area/station/cargo/miningdock)
-"utx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "uty" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
@@ -76185,20 +75663,6 @@
 /obj/structure/sign/warning/no_smoking/directional/west,
 /turf/closed/wall/r_wall,
 /area/station/medical/chemistry)
-"uYv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/textured_corner{
-	dir = 1
-	},
-/area/station/engineering/atmos)
 "uYH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -76406,9 +75870,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible,
@@ -77414,9 +76875,6 @@
 /turf/open/floor/plating,
 /area/station/cargo/quartermaster)
 "vrU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
@@ -77848,13 +77306,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/service/hydroponics/chicken)
-"vxF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "vxH" = (
 /turf/closed/wall,
 /area/station/construction/mining/aux_base)
@@ -78167,7 +77618,6 @@
 "vDL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
 	dir = 4
 	},
@@ -78453,12 +77903,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/textured_large,
 /area/station/science/ordnance)
-"vHo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "vHx" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/secure_closet/atmospherics,
@@ -80694,10 +80138,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/fore)
-"woC" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "woG" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -81495,7 +80935,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /turf/open/floor/iron/textured_edge{
 	dir = 4
 	},
@@ -81995,10 +81434,17 @@
 /turf/open/floor/noslip,
 /area/station/service/janitor)
 "wEJ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 6
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
-/turf/open/floor/iron/textured_large,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron/textured_edge{
+	dir = 8
+	},
 /area/station/engineering/atmos)
 "wEK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -83593,18 +83039,6 @@
 /obj/structure/sign/poster/official/random/directional/west,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/break_room)
-"xgj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/warning{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/warning{
-	dir = 5
-	},
-/turf/open/floor/iron/textured,
-/area/station/engineering/atmos)
 "xgy" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -84547,20 +83981,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/power_room)
-"xrZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/textured_corner{
-	dir = 4
-	},
-/area/station/engineering/atmos)
 "xsd" = (
 /obj/effect/turf_decal/trimline/green/filled/warning{
 	dir = 4
@@ -86946,13 +86366,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/service/kitchen/abandoned)
-"ybS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 4
-	},
-/obj/machinery/light/floor/has_bulb,
-/turf/open/floor/iron/textured_large,
-/area/station/engineering/atmos)
 "ybV" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -111926,33 +111339,33 @@ njd
 rcg
 pJO
 iLm
-tIh
+pJO
 wyv
-cci
-bfE
-lri
+pJO
+iLm
+pJO
 wyv
 lYR
-bfE
+iLm
 lYR
 jpN
-oxa
+luV
 lmS
-cci
-bfE
-lri
-kuw
-cci
-bfE
-lri
-kuw
-cci
-bfE
-iVz
-rUO
-ucY
+pJO
 iLm
-pdO
+pJO
+kuw
+pJO
+iLm
+pJO
+kuw
+pJO
+iLm
+pJO
+kuw
+pJO
+iLm
+pJO
 aQl
 vof
 toq
@@ -112194,22 +111607,22 @@ dYh
 hqu
 sXd
 luV
-cLl
-gqc
-gqc
-cUg
-ajK
-ajK
-orM
-ajK
-mZX
-ucH
-elk
-vHo
-odh
-lGS
-ajK
-ilm
+pao
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
 dYh
 wvK
 vUL
@@ -112451,23 +111864,23 @@ dYh
 hqu
 ixv
 fIQ
-cMm
-fYF
-lSY
-lSY
-bIs
-qrH
-qrH
-qrH
-rvY
-loe
-muc
-woC
-mPM
-woC
-bHP
-qGv
-woC
+pao
+dYh
+dYh
+dYh
+dYh
+hXV
+hXV
+hXV
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
 eGi
 djI
 tLl
@@ -112708,22 +112121,22 @@ dYh
 hqu
 ixv
 fIQ
-cMm
-nEW
-lyr
-odh
-rch
-ajK
-igG
-ajK
-dAj
-eVM
-aoi
-lGS
-uar
+pao
 dYh
-ybS
-rXo
+lyr
+dYh
+dYh
+dYh
+lyr
+dYh
+dYh
+dYh
+lyr
+dYh
+dYh
+dYh
+lyr
+dYh
 dYh
 ilY
 toq
@@ -112966,21 +112379,21 @@ sBt
 nQW
 raX
 foE
-ieQ
 ace
-mcR
+ace
+ace
 ace
 llW
 llW
 llW
 ace
 ace
-hAR
-dKm
-dKm
+ace
+ace
+ace
 hVk
-ldr
-utx
+ace
+ace
 eeX
 rde
 toq
@@ -113223,15 +112636,15 @@ nyT
 cjC
 fIQ
 bBn
-nEW
 dYh
-vxF
-kwl
-lGS
-lGS
-lGS
-lGS
-lGS
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
+dYh
 vDL
 kbj
 pye
@@ -113480,9 +112893,9 @@ nyT
 sEd
 luV
 nca
-nEW
 dYh
-nUN
+dYh
+dYh
 dYh
 dYh
 dYh
@@ -113736,10 +113149,10 @@ dYh
 nyT
 cQn
 fIQ
-cMm
-bzI
+pao
+qPY
 dVG
-xrZ
+kLU
 pYf
 dVG
 dVG
@@ -113993,11 +113406,11 @@ dYh
 vLz
 hTr
 pie
-ewu
-qTQ
-fDu
-fKt
+nAn
 fTR
+fDu
+ijx
+pdO
 vGe
 dWY
 nAn
@@ -114250,11 +113663,11 @@ dYh
 hqu
 ixv
 fIQ
-cMm
-mBF
+pao
+fTR
 rEk
 ijx
-fTR
+pdO
 kiN
 ohI
 nAn
@@ -114507,10 +113920,10 @@ dYh
 hqu
 ixv
 fIQ
-mhQ
+pao
 vrU
 pJO
-uYv
+aQl
 oYv
 pJO
 pJO
@@ -114767,7 +114180,7 @@ dbp
 qWi
 por
 dYh
-nUN
+dYh
 dYh
 dYh
 dYh
@@ -114780,7 +114193,7 @@ ciQ
 rwT
 tFh
 dYh
-wEJ
+dYh
 owP
 toq
 uat
@@ -115025,7 +114438,7 @@ nOQ
 opI
 eCM
 vcr
-opI
+wEJ
 rzR
 pPE
 kMj
@@ -115033,11 +114446,11 @@ kMj
 nbD
 tDe
 luV
-xgj
+lXa
 jyF
 gSO
 cXk
-kIq
+xsj
 afb
 toq
 dKF
@@ -115281,7 +114694,7 @@ bMR
 tHE
 pRI
 lig
-aWz
+pRI
 bMR
 tFt
 pir
@@ -115795,7 +115208,7 @@ bMR
 sBq
 agm
 deq
-aUj
+agm
 rRL
 tFt
 pLI
@@ -116052,7 +115465,7 @@ pYv
 eyQ
 aot
 iGg
-qUI
+agm
 kbv
 tFt
 dHe

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -3079,9 +3079,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/quartermaster)
 "apr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 6
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "apv" = (
@@ -3101,9 +3098,6 @@
 /turf/open/floor/iron,
 /area/station/security/checkpoint/engineering)
 "apy" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -3133,22 +3127,11 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/pumproom)
 "apI" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
-"apJ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Pure to Mix"
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -5955,7 +5938,6 @@
 /area/station/medical/medbay/central)
 "aOV" = (
 /obj/effect/turf_decal/trimline/red/filled/corner,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -10332,13 +10314,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/security)
-"cev" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "cew" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -13148,9 +13123,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "dbi" = (
@@ -16236,12 +16208,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/pharmacy)
-"dYm" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port Mix to East Ports"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "dYn" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -21920,12 +21886,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"fMm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "fMs" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table/wood,
@@ -23167,12 +23127,6 @@
 /obj/item/stack/ore/glass,
 /turf/open/misc/asteroid,
 /area/station/science/lower)
-"gjC" = (
-/obj/machinery/atmospherics/components/binary/pump/off{
-	name = "Port to Incinerator"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "gjM" = (
 /obj/structure/industrial_lift/tram/subfloor/window,
 /obj/structure/window/reinforced/tram/front{
@@ -28704,11 +28658,6 @@
 	},
 /turf/open/floor/stone,
 /area/station/science/xenobiology)
-"hYK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/pumproom)
 "hYM" = (
 /obj/item/stack/rods,
 /turf/open/misc/asteroid,
@@ -34425,9 +34374,6 @@
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 1
 	},
@@ -35681,12 +35627,6 @@
 /obj/machinery/smartfridge,
 /turf/open/floor/iron/cafeteria,
 /area/station/security/prison/mess)
-"kdw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "kdI" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
@@ -36011,10 +35951,6 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"kkc" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kkd" = (
@@ -36458,9 +36394,6 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "kqD" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/purple/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Mix"
 	},
@@ -36588,9 +36521,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "ksq" = (
@@ -38359,13 +38289,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"kSA" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Pure to Port"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "kSE" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/light/small/directional/east,
@@ -38661,6 +38584,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kXd" = (
@@ -39319,13 +39243,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/starboard/greater)
-"lgo" = (
-/obj/machinery/atmospherics/pipe/smart/simple/violet/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lgu" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/smooth,
@@ -40069,10 +39986,6 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/treatment_center)
 "lrX" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -40560,13 +40473,6 @@
 /obj/structure/industrial_lift/public,
 /turf/open/floor/plating/elevatorshaft,
 /area/station/hallway/secondary/construction/engineering)
-"lAO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lBK" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -41011,11 +40917,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/medical)
-"lKI" = (
-/obj/structure/chair/stool/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lLq" = (
 /obj/structure/bed{
 	dir = 8
@@ -41840,12 +41741,6 @@
 /obj/machinery/computer/records/pathology,
 /turf/open/floor/iron/dark,
 /area/station/medical/pathology/isolation)
-"lXH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "lXK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45186,13 +45081,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"nbl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "nbm" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -45499,13 +45387,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
-"ngl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ngo" = (
 /mob/living/basic/clown{
 	name = "The Forbidden One";
@@ -48452,12 +48333,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/central)
-"oaX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "obh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -49356,13 +49231,6 @@
 	dir = 9
 	},
 /area/station/service/chapel)
-"ora" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ore" = (
 /obj/structure/railing{
 	dir = 4;
@@ -52044,6 +51912,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/camera/emp_proof/directional/west,
 /obj/machinery/light/directional/west,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "pmh" = (
@@ -53421,7 +53290,6 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/dark/visible{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -55509,12 +55377,6 @@
 /obj/effect/spawner/random/food_or_drink/cups,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/cargo)
-"qkS" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qkV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
@@ -55965,19 +55827,6 @@
 /obj/item/stock_parts/power_store/cell/crap,
 /turf/open/floor/wood,
 /area/station/command/meeting_room)
-"qsM" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port Mix to West Ports"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
-"qtb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qtf" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Hallway - Port Tram Platform North"
@@ -56904,6 +56753,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 9
 	},
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "qGM" = (
@@ -57127,12 +56979,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
-"qJY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "qKd" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -58197,12 +58043,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/ai_monitored/security/armory)
-"ram" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "rao" = (
 /obj/machinery/door/airlock/security{
 	id_tag = "laborexit";
@@ -58745,7 +58585,6 @@
 /area/station/command/heads_quarters/captain/private)
 "riD" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
 	dir = 4
 	},
@@ -58929,6 +58768,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rlX" = (
@@ -59083,11 +58923,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"rnY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/pumproom)
 "roj" = (
 /obj/structure/railing{
 	dir = 8
@@ -59813,12 +59648,6 @@
 	network = list("ss13","engineering")
 	},
 /turf/open/floor/engine/n2,
-/area/station/engineering/atmos)
-"rAg" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Mix to Port"
-	},
-/turf/open/floor/iron,
 /area/station/engineering/atmos)
 "rAB" = (
 /obj/structure/table,
@@ -61786,13 +61615,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
-"sjc" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port to Filter"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "sji" = (
 /turf/closed/wall/rock,
 /area/station/engineering/supermatter/room)
@@ -62008,9 +61830,6 @@
 /area/station/security/bitden)
 "snC" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
@@ -62306,12 +62125,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/construction/mining/aux_base)
-"ssw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ssC" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -64527,10 +64340,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white,
 /area/station/maintenance/department/cargo)
-"taw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "taB" = (
 /obj/structure/railing{
 	dir = 4
@@ -65840,12 +65649,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"tts" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/violet/visible{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "ttw" = (
 /obj/structure/table/glass,
 /obj/item/folder/red{
@@ -69298,11 +69101,6 @@
 	},
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/department/security)
-"uxG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron,
-/area/station/engineering/atmos/pumproom)
 "uxM" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -70402,6 +70200,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/heater{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
@@ -73430,12 +73231,6 @@
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
 /area/station/maintenance/starboard/central)
-"vEq" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vEH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -74199,12 +73994,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/escape)
-"vRm" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Port to Filter"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vRp" = (
 /obj/machinery/corral_corner{
 	mapping_id = "2"
@@ -74643,13 +74432,6 @@
 /obj/effect/turf_decal/tile/brown/fourcorners,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/disposal)
-"vYX" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 1;
-	name = "plasma mixer"
-	},
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "vZD" = (
 /obj/item/kirbyplants/random/dead,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -76360,6 +76142,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "wAe" = (
@@ -77182,10 +76965,6 @@
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/central)
-"wNK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/violet/visible,
-/turf/open/floor/iron,
-/area/station/engineering/atmos)
 "wNV" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/stripes/white/full,
@@ -115497,7 +115276,7 @@ wQm
 gqL
 uZJ
 wQm
-kdw
+wQm
 aOV
 wXO
 doa
@@ -115754,7 +115533,7 @@ wQm
 eaq
 uZJ
 wQm
-oaX
+wQm
 tsp
 vXS
 gRl
@@ -116011,7 +115790,7 @@ wQm
 wQm
 aYB
 wQm
-oaX
+wQm
 lLP
 iqL
 jLU
@@ -116258,17 +116037,17 @@ bmX
 wUv
 roD
 ldy
-nbl
-qsM
-ram
-lAO
-ram
-vRm
-fMm
-kkc
+fja
+wQm
+wQm
+wQm
+wQm
+wQm
+wQm
+wQm
 kkb
 wQm
-oaX
+wQm
 fhG
 hBH
 oNq
@@ -116515,17 +116294,17 @@ pAD
 apG
 nNQ
 wQm
-lgo
+wQm
 wQm
 vkO
 wAG
 rvK
 vkO
-sjc
+wQm
 wQm
 dxd
 wQm
-lXH
+wQm
 riD
 wXQ
 doa
@@ -116768,21 +116547,21 @@ pgS
 beG
 eEl
 naD
-uxG
+apr
 apH
-hYK
-rAg
-wNK
-dYm
-tts
-qtb
-tts
-tts
-lKI
-gjC
+nNQ
+wQm
+wQm
+wQm
+wQm
+wQm
+wQm
+wQm
+wQm
+wQm
 sPC
 wQm
-oaX
+wQm
 vwz
 idq
 gRl
@@ -117029,17 +116808,17 @@ apy
 apI
 nNQ
 dsH
-kSA
 wQm
-ora
-ora
-ora
-qkS
-vEq
+wQm
+lrX
+lrX
+lrX
+wQm
+wQm
 wQm
 omj
 wQm
-oaX
+wQm
 sGQ
 szs
 hIW
@@ -117283,20 +117062,20 @@ mwK
 ulS
 kqD
 ipe
-apJ
-rnY
-qJY
-cev
-taw
-taw
-vYX
-taw
-taw
-taw
-ngl
+apH
+nNQ
+wQm
+wQm
+wQm
+wQm
+wQm
+wQm
+wQm
+wQm
+wQm
 pEL
-taw
-ssw
+wQm
+wQm
 fja
 cPD
 oNq


### PR DESCRIPTION
## About The Pull Request
Adjusted rounstart pipenet for atmos to remove the unncessary spaghetti.

## Why It's Good For The Game

I have nearly 150 hours on atmos just on monke. I can asure you no one uses the default spaghetti pipenet at roundstart. Its best for everyone if it is removed.
## Changelog
:cl:
map: Removed lots of pointless atmos spaghetti unrelated to distro,.
/:cl:

