### PR TITLE
IPCs now autorevive when healed of tox or oxy

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -149,10 +149,6 @@
 			blood_volume = max(blood_volume - amount, 0)
 	else if(HAS_TRAIT(src, TRAIT_TOXIMMUNE)) //Prevents toxin damage, but not healing
 		amount = min(amount, 0)
-	if(HAS_TRAIT(src, TRAIT_REVIVES_BY_HEALING))
-		cure_husk() // If it has TRAIT_REVIVES_BY_HEALING, it probably can't be cloned. No husk cure, so we cure that here.
-		if(stat == DEAD && !HAS_TRAIT(src, TRAIT_DEFIB_BLACKLISTED) && health > 50)
-			revive(FALSE)
 	return ..()
 
 /mob/living/carbon/pre_stamina_change(diff as num, forced)


### PR DESCRIPTION
## About The Pull Request
fix bugg
## Why It's Good For The Game
bugg fix

testing video
https://github.com/user-attachments/assets/a62a242c-e48f-4156-b86f-898e6e42b67c
## Changelog
:cl: call me evil McDonalds cause I'm hatin it
fix: IPCs autorevive when they heal tox and oxy damage too.
/:cl:
