### PR TITLE
Adds a clipboard to NT Rep locker

### DIFF
--- a/monkestation/code/game/objects/structures/crates_lockers/closets/secure/nanotrasen_rep.dm
+++ b/monkestation/code/game/objects/structures/crates_lockers/closets/secure/nanotrasen_rep.dm
@@ -14,3 +14,4 @@
 	new /obj/item/circuitboard/machine/fax(src)
 	new /obj/item/storage/photo_album/nt_rep(src)
 	new /obj/item/storage/briefcase/sponsorship(src)
+	new /obj/item/clipboard(src)


### PR DESCRIPTION

## About The Pull Request
Adds a clipboard to NT Rep locker
## Why It's Good For The Game
IDK who thought it was a good idea to make the fax-machine job not have access to a clipboard.
Seems like an oversight to me tbh.
## Changelog
:cl:
add: Adds a clipboard to the NT Rep locker
/:cl:
