### PR TITLE
bandaid fix for the tesla issue

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -237,6 +237,7 @@
 		/obj/structure/lattice = FALSE,
 		/obj/structure/grille = FALSE,
 		/obj/structure/frame/machine = FALSE,
+		/obj/structure/cable = FALSE,
 	))
 
 	//Ok so we are making an assumption here. We assume that view() still calculates from the center out.


### PR DESCRIPTION

## About The Pull Request
Tesla will no longer zap power cables.
## Why It's Good For The Game
So tesla now after recent changes have a destructive power can destroy structrures, apparently, somehow. This includes the ability to arc and eat its own power cables and multihubs. As a lovley insane engineer puts it. 

```
problems: tesla/destruction arc (tesla arc never destroyed things)
sub problems: smes, cable desconstruction
temporary solution: blacklist cable from being destructed
```

Thus, cables will no longer be shocked by the tesla, the tesla arcing still a sub issue, but I'm no engineer
## Changelog
:cl: notghosti, A special thanks to hostileburner.
fix: Band-Aid fix for tesla destroying its own cables and multilayer hubs
/:cl:
