### PR TITLE
FIX/ Grabs No Longer Have a Range

### DIFF
--- a/code/game/atoms/atoms_movable.dm
+++ b/code/game/atoms/atoms_movable.dm
@@ -1654,29 +1654,35 @@
  * This exists to act as a hook for behaviour
  */
 /atom/movable/proc/setGrabState(newstate)
-	if(newstate == grab_state)
-		return
-	SEND_SIGNAL(src, COMSIG_MOVABLE_SET_GRAB_STATE, newstate)
-	. = grab_state
-	grab_state = newstate
-	switch(grab_state) // Current state.
-		if(GRAB_PASSIVE)
-			pulling.remove_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), CHOKEHOLD_TRAIT)
-			if(. >= GRAB_NECK) // Previous state was a a neck-grab or higher.
-				REMOVE_TRAIT(pulling, TRAIT_FLOORED, CHOKEHOLD_TRAIT)
-			if(ismob(src))
-				var/mob/grabbed = src
-				if(grabbed.stat == SOFT_CRIT || grabbed.stat == HARD_CRIT)
-					pulling.add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), CHOKEHOLD_TRAIT)
+    if(newstate == grab_state)
+        return
 
-		if(GRAB_AGGRESSIVE)
-			if(. >= GRAB_NECK) // Grab got downgraded.
-				REMOVE_TRAIT(pulling, TRAIT_FLOORED, CHOKEHOLD_TRAIT)
-			else // Grab got upgraded from a passive one.
-				pulling.add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), CHOKEHOLD_TRAIT)
-		if(GRAB_NECK, GRAB_KILL)
-			if(. <= GRAB_AGGRESSIVE)
-				ADD_TRAIT(pulling, TRAIT_FLOORED, CHOKEHOLD_TRAIT)
+    // 🚨 Prevent grab upgrades if grabber is not adjacent
+    if(pulledby && get_dist(src, pulledby) > 1)
+        return FALSE
+
+    SEND_SIGNAL(src, COMSIG_MOVABLE_SET_GRAB_STATE, newstate)
+    . = grab_state
+    grab_state = newstate
+    switch(grab_state)
+        if(GRAB_PASSIVE)
+            pulling.remove_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), CHOKEHOLD_TRAIT)
+            if(. >= GRAB_NECK)
+                REMOVE_TRAIT(pulling, TRAIT_FLOORED, CHOKEHOLD_TRAIT)
+            if(ismob(src))
+                var/mob/grabbed = src
+                if(grabbed.stat == SOFT_CRIT || grabbed.stat == HARD_CRIT)
+                    pulling.add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), CHOKEHOLD_TRAIT)
+
+        if(GRAB_AGGRESSIVE)
+            if(. >= GRAB_NECK)
+                REMOVE_TRAIT(pulling, TRAIT_FLOORED, CHOKEHOLD_TRAIT)
+            else
+                pulling.add_traits(list(TRAIT_IMMOBILIZED, TRAIT_HANDS_BLOCKED), CHOKEHOLD_TRAIT)
+
+        if(GRAB_NECK, GRAB_KILL)
+            if(. <= GRAB_AGGRESSIVE)
+                ADD_TRAIT(pulling, TRAIT_FLOORED, CHOKEHOLD_TRAIT)
 
 /**
  * Adds the deadchat_plays component to this atom with simple movement commands.


### PR DESCRIPTION
About The Pull Request

Fixes grabs being able to upgrade regardless of distance.
Previously, players could move away and still escalate a grab (passive → aggressive → neck → kill), effectively teleporting the victim.
This PR restores the intended behavior: grabs can only upgrade when the grabber is adjacent to the target.

Why It's Good For The Game

Prevents abuse of grab mechanics for instant repositioning.

Restores balance to combat, especially in security/antag encounters.

Fixes a long-standing bug that made grabs unreliable and inconsistent.

Changelog

:cl:
fix: Fixed grab upgrades applying at any distance. Grabs now only upgrade when the grabber is adjacent to their target, preventing teleport abuse.
balance: Restores intended combat behavior for grabs (no long-range chokeholds).
