### PR TITLE
some mitigations to reduce botany-related lag

### DIFF
--- a/monkestation/code/modules/botany/components/plant_growing.dm
+++ b/monkestation/code/modules/botany/components/plant_growing.dm
@@ -226,7 +226,7 @@
 		return
 
 	pollinated = TRUE
-	var/set_time =  rand(600, 900)
+	var/set_time =  rand(1 MINUTES, 1.5 MINUTES)
 	for(var/_item, seed_item in managed_seeds)
 		var/obj/item/seeds/seed = seed_item
 		SEND_SIGNAL(seed, COMSIG_PLANT_TRY_POLLINATE, parent, set_time)


### PR DESCRIPTION

## About The Pull Request

this makes it so you can't harvest plans from an unanchored hydrotray. simple as that.

## Why It's Good For The Game

STOP DRAGGING SHIT AROUND TO CAUSE MASSIVE LAG.

## Changelog
:cl:
del: You can no longer harvest plants from unanchored hydroponics trays.
/:cl:
