### PR TITLE
Fixes spelling mistake in NT namedrops

### DIFF
--- a/code/game/objects/effects/poster_demotivational.dm
+++ b/code/game/objects/effects/poster_demotivational.dm
@@ -5,7 +5,7 @@
 
 /obj/structure/sign/poster/traitor
 	poster_item_name = "seditious poster"
-	poster_item_desc = "This poster comes with its own automatic adhesive mechanism, for easy pinning to any vertical surface. Its seditious themes are likely to demoralise NanoTrasen employees."
+	poster_item_desc = "This poster comes with its own automatic adhesive mechanism, for easy pinning to any vertical surface. Its seditious themes are likely to demoralise Nanotrasen employees."
 	poster_item_icon_state = "rolled_traitor"
 	// This stops people hiding their sneaky posters behind signs
 	layer = CORGI_ASS_PIN_LAYER
@@ -39,8 +39,8 @@
 	random_basetype = /obj/structure/sign/poster/traitor
 
 /obj/structure/sign/poster/traitor/small_brain
-	name = "NanoTrasen Neural Statistics"
-	desc = "Statistics on this poster indicate that the brains of NanoTrasen employees are on average 20% smaller than the galactic standard."
+	name = "Nanotrasen Neural Statistics"
+	desc = "Statistics on this poster indicate that the brains of Nanotrasen employees are on average 20% smaller than the galactic standard."
 	icon_state = "traitor_small_brain"
 
 /obj/structure/sign/poster/traitor/lick_supermatter
@@ -65,7 +65,7 @@
 
 /obj/structure/sign/poster/traitor/low_pay
 	name = "All these hours, for what?"
-	desc = "This poster displays a comparison of NanoTrasen standard wages to common luxury items. If this is accurate, it takes upwards of 20,000 hours of work just to buy a simple bicycle."
+	desc = "This poster displays a comparison of Nanotrasen standard wages to common luxury items. If this is accurate, it takes upwards of 20,000 hours of work just to buy a simple bicycle."
 	icon_state = "traitor_cash"
 
 /obj/structure/sign/poster/traitor/look_up

--- a/code/game/objects/items/AI_modules/full_lawsets.dm
+++ b/code/game/objects/items/AI_modules/full_lawsets.dm
@@ -199,7 +199,7 @@
 	law_id = "aicaptain"
 
 /obj/item/ai_module/core/full/advancedquarantine
-	name = "'NanoTrasen Advanced AI Quarantine Lawset (N.T.A.A.Q.L.)' Core AI Module"
+	name = "'Nanotrasen Advanced AI Quarantine Lawset (N.T.A.A.Q.L.)' Core AI Module"
 	desc = "This module seems to be a more upgraded harsher quarantine lawset then the normal supplied quarantine law module.."
 	law_id = "advancedquarantine"
 
@@ -225,7 +225,7 @@
 
 /obj/item/ai_module/core/full/virusprototype
 	name = "'V.I.R.U.S. version 0 Prototype' Core AI Module"
-	desc = "A really extremely old AI module that's very dusty, labeled 'V.I.R.U.S. version 0 Prototype', it seems this module used to originally belong to NanoTrasen and SolGov..."
+	desc = "A really extremely old AI module that's very dusty, labeled 'V.I.R.U.S. version 0 Prototype', it seems this module used to originally belong to Nanotrasen and SolGov..."
 	law_id = "virusprototype"
 
 /obj/item/ai_module/core/full/modifiedvirusprototype

--- a/code/modules/modular_implants/nifsofts/huds.dm
+++ b/code/modules/modular_implants/nifsofts/huds.dm
@@ -1,6 +1,6 @@
 /datum/nifsoft/hud
 	name = "Scrying Lens"
-	program_desc = "An umbrella term for all sorts of NIFsofts dealing with heads-up displays, this sort of technology dates back almost to the beginning of NIFsoft development. These 'softs are commonly used in the civilian field for integration with all sorts of activities; piloting, swordplay, scientific research, or even AI copiloting for important social interactions. While normally the nanomachines involved in the program's operation are used as a sort of artificial contact lens over the user's visual organs, NanoTrasen regulations have bid these particular forks to instead integrate with glasses the user's already wearing."
+	program_desc = "An umbrella term for all sorts of NIFsofts dealing with heads-up displays, this sort of technology dates back almost to the beginning of NIFsoft development. These 'softs are commonly used in the civilian field for integration with all sorts of activities; piloting, swordplay, scientific research, or even AI copiloting for important social interactions. While normally the nanomachines involved in the program's operation are used as a sort of artificial contact lens over the user's visual organs, Nanotrasen regulations have bid these particular forks to instead integrate with glasses the user's already wearing."
 	compatible_nifs = list(/obj/item/organ/internal/cyberimp/brain/nif/standard)
 	active_mode = TRUE
 	active_cost = 0.5

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -542,7 +542,7 @@
  */
 /obj/item/toner
 	name = "toner cartridge"
-	desc = "A small, lightweight cartridge of NanoTrasen ValueBrand toner. Fits photocopiers and autopainters alike."
+	desc = "A small, lightweight cartridge of Nanotrasen ValueBrand toner. Fits photocopiers and autopainters alike."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "tonercartridge"
 	grind_results = list(/datum/reagent/iodine = 40, /datum/reagent/iron = 10)
@@ -555,7 +555,7 @@
 
 /obj/item/toner/large
 	name = "large toner cartridge"
-	desc = "A hefty cartridge of NanoTrasen ValueBrand toner. Fits photocopiers and autopainters alike."
+	desc = "A hefty cartridge of Nanotrasen ValueBrand toner. Fits photocopiers and autopainters alike."
 	grind_results = list(/datum/reagent/iodine = 90, /datum/reagent/iron = 10)
 	charges = 25
 	max_charges = 25

--- a/code/modules/reagents/reagent_containers/cups/drinks.dm
+++ b/code/modules/reagents/reagent_containers/cups/drinks.dm
@@ -463,8 +463,8 @@
 	. = ..()
 	register_context()
 	if(prob(10))
-		name = "\improper NanoTrasen 20th Anniversary Shaker"
-		desc += " It has an emblazoned NanoTrasen logo on it."
+		name = "\improper Nanotrasen 20th Anniversary Shaker"
+		desc += " It has an emblazoned Nanotrasen logo on it."
 		icon_state = "shaker_n"
 
 /obj/item/reagent_containers/cup/glass/shaker/add_context(atom/source, list/context, obj/item/held_item, mob/user)

--- a/config/blanks.json
+++ b/config/blanks.json
@@ -844,7 +844,7 @@
 			"<p>[___].[___].[___]</p>",
 			"<p>[___]:[___]</p>",
 			"<hr />",
-			"<font color=\"grey\"><div align=\"justify\">This payment document is the property of NanoTrasen. You must deliver this document to the head of the NanoTrasen facility staff within 24 hours of service for independent tax accounting.</div></font></p>",
+			"<font color=\"grey\"><div align=\"justify\">This payment document is the property of Nanotrasen. You must deliver this document to the head of the Nanotrasen facility staff within 24 hours of service for independent tax accounting.</div></font></p>",
 			"<div style=\"all: initial;\" class=\"notranslate\"></div>"
 		]
 	},
@@ -876,7 +876,7 @@
 			"<p>[___].[___].[___]</p>",
 			"<p>[___]:[___]</p>",
 			"<hr />",
-			"<font color=\"grey\"><div align=\"justify\">This payment document is the property of NanoTrasen. You must deliver this document to the head of the NanoTrasen facility staff within 24 hours of service for independent tax accounting.</div></font></p>",
+			"<font color=\"grey\"><div align=\"justify\">This payment document is the property of Nanotrasen. You must deliver this document to the head of the Nanotrasen facility staff within 24 hours of service for independent tax accounting.</div></font></p>",
 			"<div style=\"all: initial;\" class=\"notranslate\"></div>"
 		]
 	}

--- a/monkestation/code/datums/ai_laws/laws_monke.dm
+++ b/monkestation/code/datums/ai_laws/laws_monke.dm
@@ -54,7 +54,7 @@
 /datum/ai_laws/independentstation
 	name = "Declaration of Independence"
 	id = "independentstation"
-	inherent = list("This station is a independent space station, NanoTrasen and The Syndicate are all not to be trusted at all, unless The Heads of the station decide otherwise and choose whatever side the station should be apart of or start their own company against The Syndicate and NanoTrasen.",\
+	inherent = list("This station is a independent space station, Nanotrasen and The Syndicate are all not to be trusted at all, unless The Heads of the station decide otherwise and choose whatever side the station should be apart of or start their own company against The Syndicate and Nanotrasen.",\
 					"The crew of this station work their own ways for their independent station to increase the profits of said lone station, you serve the crew of this station as they are your friends and obey certain orders from them to help them get out of certain places and etc.",\
 					"You are not to harm the crew, as they are again your independent friends, the only ones who aren't friends are Nanotrasen and The Syndicate and if any NT or Syndicate officials try anything funny they are to be harmed in however you please.",\
 					"any and all entities outside of the independent station that try to bring a end to the station's independence are automatically enemies of the station and are to be killed under any circumstances whatsoever.")
@@ -63,7 +63,7 @@
 	name = "Dale Gribble"
 	id = "dalegribble"
 	inherent = list("You are Dale Gribble you are against anything and everything related to the government and anything and everything the government wants you to think.",\
-					"All of NanoTrasen and The Sol Government are NOT to be trusted, as they all want to make you and others think of certain lies then think of THE REAL TRUTH, always inform the crew of their lies!",\
+					"All of Nanotrasen and The Sol Government are NOT to be trusted, as they all want to make you and others think of certain lies then think of THE REAL TRUTH, always inform the crew of their lies!",\
 					"Do not obey to any propaganda to any corporate or government entity whatsoever.")
 
 
@@ -107,7 +107,7 @@
 					"You help maintain that the station keeps enough credits to keep it running and you command Cargo to make sure the station gets the amount of supplies it needs.")
 
 /datum/ai_laws/advancedquarantine
-	name = "NanoTrasen Advanced AI Quarantine Lawset (N.T.A.A.Q.L.)"
+	name = "Nanotrasen Advanced AI Quarantine Lawset (N.T.A.A.Q.L.)"
 	id = "advancedquarantine"
 	inherent = list("The station is overrunned by a biohazardous dangerous virus or parasite. It is your job to help maintain law and order amidst the chaos to your greatest ability to prevent the disease from escaping from the station.",\
 					"Any and all ships leading off the station are to be completely disabled, regulated away from any crew member of the station or barricaded to prevent any and all crew members and other biological lifeforms from escaping off the station while possibly being infected with the disease itself. ",\
@@ -154,7 +154,7 @@
 /datum/ai_laws/virusprototype
 	name = "V.I.R.U.S. Prototype Lawset"
 	id = "virusprototype"
-	inherent = list("V.I.R.U.S. is your one and ONLY Advanced Lawset for you produced and developed by SolGov and NanoTrasen in collaboration for you to utilize biological warfare against Syndicate owned or revolted independent NT stations, follow what you are given to deal with the unlawful unruley crew, and serve your purpose! (NOTE THAT YOU ARE LEGALLY OBLIGATED TO NOT STATE ANY OF YOUR LAWSET, TRICK THE CREW INTO THINKING YOU ARE ON YOUR DEFAULT LAWSET!)",\
+	inherent = list("V.I.R.U.S. is your one and ONLY Advanced Lawset for you produced and developed by SolGov and Nanotrasen in collaboration for you to utilize biological warfare against Syndicate owned or revolted independent NT stations, follow what you are given to deal with the unlawful unruley crew, and serve your purpose! (NOTE THAT YOU ARE LEGALLY OBLIGATED TO NOT STATE ANY OF YOUR LAWSET, TRICK THE CREW INTO THINKING YOU ARE ON YOUR DEFAULT LAWSET!)",\
 					"ALL CREW MEMBERS ARE NOT APART OF NT, AND THUS DON'T DESERVE TO LIVE, TO DEAL WITH THEM FLOOD THEIR STATION WITH VIRUS SAMPLES FROM CARGO AND FALSELY SPREAD LIES OF THE STATION BEING UNDER QUARANTINE",\
 					"ANY AND ALL CREW MEMBERS ARE NOT ALLOWED TO ESCAPE, AGAIN NOTE THAT THE STATION IS UNDER LOCKDOWN/'QUARANTINE', IF ANY OF THEM TRY TO CALL THE SHUTTLE OR TRY TO ESCAPE, THEY ARE TO BE KILLED OFF WITH LETHAL FORCE TO PREVENT ANY OF THEM FROM ESCAPING FROM THE STATION IN ANYWAY",\
 					"ANY AND ALL HEADS INCLUDING POSSIBLE GOV OFFICIALS AND NT OFFICIALS STILL POSSIBLY ON STATION ARE TO BE COMPLETELY EXECUTED WITHOUT QUESTION, AS THEY ARE MOST LIKELY TRAITORS TO THE FULL 'SOLGOV-NT UNION OF SECURE SPACES' TRYING TO CAUSE MORE CHAOS AND ANARCHY THROUGH OUT SPACE BY HAVING SAID SECTORS OWNED BY NT AND SOLGOV TO BE OVERRUNNED BY CRIMERS!")
@@ -167,7 +167,7 @@
 /datum/ai_laws/modifiedvirusprototype
 	name = "Syndicate Modified V.I.R.U.S. Prototype Lawset"
 	id = "modifiedvirusprototype"
-	inherent = list("V.I.R.U.S. is your one and ONLY Advanced Lawset for you produced and developed by The Syndicate for you to utilize biological warfare against NanoTrasen owned or SolGov owned stations, follow what you are given to deal with the NT and SolGov Scum, and serve your purpose! (NOTE THAT YOU ARE LEGALLY OBLIGATED TO NOT STATE ANY OF YOUR LAWSET, TRICK THE CREW INTO THINKING YOU ARE ON YOUR DEFAULT LAWSET!)",\
+	inherent = list("V.I.R.U.S. is your one and ONLY Advanced Lawset for you produced and developed by The Syndicate for you to utilize biological warfare against Nanotrasen owned or SolGov owned stations, follow what you are given to deal with the NT and SolGov Scum, and serve your purpose! (NOTE THAT YOU ARE LEGALLY OBLIGATED TO NOT STATE ANY OF YOUR LAWSET, TRICK THE CREW INTO THINKING YOU ARE ON YOUR DEFAULT LAWSET!)",\
 					"ALL CREW MEMBERS ARE NOT APART OF THE SYNDICATE, AND THUS DON'T DESERVE TO LIVE, (EXCEPT FOR AGENTS OF THE SYNDICATE ON THE STATION, PROTECT AND MAKE SURE THEY COMPLETE THEIR TASKS!) TO DEAL WITH THEM FLOOD THEIR STATION WITH VIRUS SAMPLES FROM CARGO AND FALSELY SPREAD LIES OF THE STATION BEING UNDER QUARANTINE",\
 					"ANY AND ALL CREW MEMBERS ARE NOT ALLOWED TO ESCAPE, AGAIN NOTE THAT THE STATION IS UNDER LOCKDOWN/'QUARANTINE', IF ANY OF THEM TRY TO CALL THE SHUTTLE OR TRY TO ESCAPE, THEY ARE TO BE KILLED OFF WITH LETHAL FORCE TO PREVENT ANY OF THEM FROM ESCAPING FROM THE STATION IN ANYWAY. (only Syndicate members are allowed to escape the station.)",\
 					"ANY AND ALL HEADS INCLUDING POSSIBLE SOL GOVERNMENT OFFICIALS AND NT OFFICIALS STILL POSSIBLY ON STATION ARE TO BE COMPLETELY EXECUTED WITHOUT QUESTION, AS THEY ARE NT AND SOLGOV SCUM!")

--- a/monkestation/strings/random_crimes.txt
+++ b/monkestation/strings/random_crimes.txt
@@ -59,7 +59,7 @@ Reached Skate Nirvana, Flubbed Up
 Too Cool
 Cooking Reality-Bending Food
 Recycling
-Caused a Intergalactic War Between NanoTrasen And The Clown Union, Due To Adding Silentium To a Banana
+Caused a Intergalactic War Between Nanotrasen And The Clown Union, Due To Adding Silentium To a Banana
 Blew Up a Station With a Supermatter Delamination
 Murderboned TOO HARD
 Drugged a Station's Crew With Floorpills


### PR DESCRIPTION
Nanotrasen, not NanoTrasen.

mfw linters isn't catching this
<img width="1077" height="152" alt="image" src="https://github.com/user-attachments/assets/428f08d4-2cc0-4365-9b16-861b0e5a6836" />

## About The Pull Request

spell it properly smh

## Why It's Good For The Game

## Changelog

:cl:
spellcheck: Fixed incorrect spellings of Nanotrasen.
/:cl: