### PR TITLE
makes the staff of storms normal sized

### DIFF
--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -753,7 +753,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
 	slot_flags = ITEM_SLOT_BACK
-	w_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_NORMAL
 	force = 20
 	damtype = BURN
 	hitsound = 'sound/weapons/taserhit.ogg'

--- a/code/modules/mining/lavaland/megafauna_loot.dm
+++ b/code/modules/mining/lavaland/megafauna_loot.dm
@@ -807,11 +807,13 @@
 	affected_weather.wind_down()
 	user.log_message("has dispelled a storm at [AREACOORD(user_turf)].", LOG_GAME)
 
+/obj/item/storm_staff/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(!isturf(interacting_with) && (user.istate & ISTATE_HARM))
+		return NONE
+	return ranged_interact_with_atom(interacting_with, user, modifiers)
+
 /obj/item/storm_staff/ranged_interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	return thunder_blast(interacting_with, user) ? ITEM_INTERACT_SUCCESS : ITEM_INTERACT_BLOCKING
-
-/obj/item/storm_staff/afterattack(atom/target, mob/user, click_parameters)
-	thunder_blast(target, user)
 
 /obj/item/storm_staff/proc/thunder_blast(atom/target, mob/user)
 	if(!thunder_charges)


### PR DESCRIPTION

## About The Pull Request

this makes it so the Staff of Storms (legion megafauna drop) is a normal-sized item, instead of bulky, allowing it to fit in a backpack.

## Why It's Good For The Game

this thing is really only useful for clearing out ash storms, as its attacks are INCREDIBLY telegraphed, and anyone with half a brain cell can dodge them. why the hell should it occupy an entire back slot.

## Changelog
:cl:
balance: The Staff of Storms is now normal sized, instead of bulky.
/:cl:
