### PR TITLE
fix an oversight that causes extinguishers to become LESS effective on oozelings the more they melt

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
@@ -146,22 +146,6 @@
 		if(worn.clothing_flags & THICKMATERIAL)
 			protection_flags |= worn.body_parts_covered
 
-	var/missing_limbs = FULL_BODY & ~(CHEST|GROIN)
-	for(var/obj/item/bodypart/limb in slime.bodyparts)
-		var/bodypart_flags = limb.body_part
-		// stupid thing needed because arms/legs don't include the hand/foot flags.
-		if(bodypart_flags & ARM_LEFT)
-			bodypart_flags |= HAND_LEFT
-		if(bodypart_flags & ARM_RIGHT)
-			bodypart_flags |= HAND_RIGHT
-		if(bodypart_flags & LEG_LEFT)
-			bodypart_flags |= FOOT_LEFT
-		if(bodypart_flags & LEG_RIGHT)
-			bodypart_flags |= FOOT_RIGHT
-		missing_limbs &= ~bodypart_flags
-
-	protection_flags |= missing_limbs
-
 	if(protection_flags)
 		if(protection_flags & HEAD)
 			. -= WATER_PROTECTION_HEAD


### PR DESCRIPTION
## About The Pull Request

so, i overcomplicated https://github.com/Monkestation/Monkestation2.0/pull/7350 a bit, and thought it'd make sense if non-existent limbs counted as "covered" for the sake of being melted by water.

but this causes a problem - water becomes less effective the more you melt their limbs off... so. yeah. let's just remove those extra checks, making it so _only_ clothing is considered, not missing bodyparts.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fire extinguishers no longer become LESS effective on oozelings the more they melt.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
