### PR TITLE
Pulverises the HoP's Magnate suit on Theseus

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -52106,10 +52106,7 @@
 	dir = 1
 	},
 /obj/structure/closet/emcloset/wall/directional/north,
-/obj/item/mod/module/thermal_regulator,
-/obj/item/mod/module/paper_dispenser,
-/obj/item/mod/module/megaphone,
-/obj/machinery/suit_storage_unit/captain,
+/obj/machinery/suit_storage_unit/open,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hop)
 "pkM" = (


### PR DESCRIPTION

## About The Pull Request

magnate suits are meant to be captain exclusive god fucking damnit
replaces the suit storage unit with an open one so they can just put their cool outdated ERT suit in there instead

## Why It's Good For The Game

magnates are exclusive suits you nincompoops

## Changelog
:cl:
fix: theseus no longer has two magnate suits
/:cl:
