### PR TITLE
Removes screwdrivering food processor boards

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -1247,14 +1247,9 @@
 	build_path = /obj/machinery/processor
 	req_components = list(
 		/datum/stock_part/matter_bin = 1,
-		/datum/stock_part/manipulator = 1)
+		/datum/stock_part/manipulator = 1,
+	)
 	needs_anchored = FALSE
-
-/obj/item/circuitboard/machine/processor/screwdriver_act(mob/living/user, obj/item/tool)
-	name = "Food Processor"
-	build_path = /obj/machinery/processor
-	to_chat(user, span_notice("Defaulting name protocols."))
-	return TRUE
 
 /obj/item/circuitboard/machine/protolathe/department/service
 	name = "Departmental Protolathe - Service"

--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -573,8 +573,8 @@
 	departmental_flags = DEPARTMENT_BITFLAG_SERVICE | DEPARTMENT_BITFLAG_ENGINEERING //Monkestation edit: Engi circuit
 
 /datum/design/board/processor
-	name = "Food/Slime Processor Board"
-	desc = "The circuit board for a processing unit. Screwdriver the circuit to switch between food (default) or slime processing."
+	name = "Food Processor Board"
+	desc = "The circuit board for a food processing unit."
 	id = "processor"
 	build_path = /obj/item/circuitboard/machine/processor
 	category = list(


### PR DESCRIPTION
## About The Pull Request

As part of the xenobio rework, Slime processors no longer exist; this rendered the screwdriver and name/bio of the food processor board pointless. This removes it so it no longer confuses players.

## Why It's Good For The Game

Closes https://github.com/Monkestation/Monkestation2.0/issues/7885

## Changelog

:cl:
spellcheck: Removed references of a now-removed slime processor board and machine.
/:cl: