### PR TITLE
Removes golden wheelchair from Blueshift

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/abandonedunknownsite1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/abandonedunknownsite1.dmm
@@ -5992,11 +5992,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
-/obj/item/wheelchair/gold,
 /obj/effect/mapping_helpers/broken_floor,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/glass/plastitanium/screws,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/wheelchair,
 /turf/open/floor/iron/dark/textured,
 /area/ruin/space/has_grav/abandonedscpsite/czmedbay)
 "wl" = (

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -124832,9 +124832,10 @@
 /obj/structure/safe{
 	name = "gilded safe"
 	},
-/obj/item/wheelchair/gold,
 /obj/item/instrument/violin/golden,
 /obj/item/food/grown/apple/gold,
+/obj/item/fish/goldfish,
+/obj/item/reagent_containers/cup/glass/trophy/gold_cup,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/department/security/prison_upper)
 "xZc" = (


### PR DESCRIPTION
## About The Pull Request

Removes the golden wheelchair from Blueshift, replaces it with a Goldfish (get it?) & gold cup trophy.
Removes it from a space ruin as well, replaced with a regular wheelchair.

The golden wheelchair is currently unique to people who got 5000 hardcore random score, removing potential FRAUDS from CLAIMING to have gotten 5000 hardcore random score is an insult to the hard workers who, through blood, sweat, tears, and a lot of random blind rounds, earned their score.

## Why It's Good For The Game

Closes https://github.com/Monkestation/Monkestation2.0/issues/8372

## Changelog

:cl:
del: Removed golden wheelchairs from being accessible outside of hardcore random benefits.
/:cl: