### PR TITLE
Remove the custom cell from the Hyesong modular rifle

### DIFF
--- a/code/modules/projectiles/guns/energy/transforming.dm
+++ b/code/modules/projectiles/guns/energy/transforming.dm
@@ -24,7 +24,6 @@
 	inhand_icon_state = "hyeseong_kill"
 	worn_icon = 'monkestation/code/modules/blueshift/icons/mob/company_and_or_faction_based/saibasan/guns_worn.dmi'
 	worn_icon_state = "hyeseong_kill"
-	cell_type = /obj/item/stock_parts/power_store/cell/hyeseong_internal_cell
 	modifystate = FALSE
 	ammo_type = list(/obj/item/ammo_casing/energy/cybersun_big_kill)
 	can_select = FALSE
@@ -230,12 +229,6 @@
 	speak_up("[personality_mode ? "pickup" : "putdown"]", ignores_personality_toggle = TRUE)
 	return ..()
 
-// Power cell for the big rifle
-/obj/item/stock_parts/power_store/cell/hyeseong_internal_cell
-	name = "\improper Hyeseong modular laser rifle internal cell"
-	desc = "These are usually supposed to be inside of the gun, you know."
-	maxcharge = 1000 * 2
-
 /datum/action/item_action/toggle_personality
 	name = "Toggle Weapon Personality"
 	desc = "Toggles the weapon's personality core. Studies find that turning them off makes them quite sad, however."
@@ -254,7 +247,6 @@
 	worn_icon_state = "hoshi_kill"
 	base_icon_state = "hoshi"
 	charge_sections = 3
-	cell_type = /obj/item/stock_parts/power_store/cell
 	ammo_type = list(/obj/item/ammo_casing/energy/cybersun_small_hellfire)
 	slot_flags = ITEM_SLOT_BACK | ITEM_SLOT_BELT
 	SET_BASE_PIXEL(0, 0)


### PR DESCRIPTION

## About The Pull Request
This was a shitty cell only used for this gun.
All the stats already account for it to have normal charge, so the big modular gun had 1/5 of the capacity it was supposed to have.
## Why It's Good For The Game
Bugfix
## Changelog
:cl:
fix: Fixed the Hyeseong modular laser rifle having 1/5 the amount of shots it was supposed to have.
/:cl:
