### PR TITLE
Fix the pre-built voltaic heart not having shock immunity

### DIFF
--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -172,6 +172,7 @@
 /obj/item/organ/internal/heart/cybernetic/anomalock/prebuilt/Initialize(mapload)
 	. = ..()
 	core = new /obj/item/assembly/signaler/anomaly/flux(src)
+	add_organ_trait(TRAIT_SHOCKIMMUNE)
 	update_icon_state()
 
 /datum/status_effect/voltaic_overdrive


### PR DESCRIPTION

## About The Pull Request
Fix the pre-built voltaic heart not having shock immunity
## Why It's Good For The Game
This is admin-spawn only (I hope?)
But it's still a bug
Closes: https://github.com/Monkestation/Monkestation2.0/issues/8136
## Changelog
:cl:
fix: Fixed Voltaic combat cyberheart not giving shock immunity
/:cl:
