### PR TITLE
[BOUNTY] Fixes Craig watering plants

### DIFF
--- a/code/modules/mob/living/basic/jungle/seedling/seedling.dm
+++ b/code/modules/mob/living/basic/jungle/seedling/seedling.dm
@@ -100,23 +100,25 @@
 
 ///seedlings can water trays, remove weeds, or remove dead plants
 /mob/living/basic/seedling/proc/treat_hydro_tray(atom/movable/hydro)
-	var/datum/component/plant_growing/growing = hydro.GetComponent(/datum/component/plant_growing)
+	var/datum/component/plant_growing/growing = \
+			hydro.GetComponent(/datum/component/plant_growing)
 	if(!growing)
 		return
 
-	for(var/item in growing.managed_seeds)
-		var/obj/item/seeds/seed = growing.managed_seeds[item]
+	for(var/_item, seed_item in growing.managed_seeds)
+		var/obj/item/seeds/seed = seed_item
 		if(!seed)
 			continue
-		var/datum/component/growth_information/info = seed.GetComponent(/datum/component/growth_information)
+		var/datum/component/growth_information/info = \
+				seed.GetComponent(/datum/component/growth_information)
 
 		if(info.plant_state == HYDROTRAY_PLANT_DEAD)
-			balloon_alert(src, "dead plant removed")
-			SEND_SIGNAL(hydro, COMSIG_REMOVE_PLANT, item)
+			balloon_alert_to_viewers(src, "dead plant removed")
+			SEND_SIGNAL(hydro, COMSIG_REMOVE_PLANT, seed_item)
 			return
 
 		if(growing.weed_level > 0)
-			balloon_alert(src, "weeds uprooted")
+			balloon_alert_to_viewers(src, "weeds uprooted")
 			SEND_SIGNAL(hydro, COMSIG_PLANT_ADJUST_WEED, -10)
 			return
 

--- a/code/modules/mob/living/basic/jungle/seedling/seedling.dm
+++ b/code/modules/mob/living/basic/jungle/seedling/seedling.dm
@@ -113,12 +113,12 @@
 				seed.GetComponent(/datum/component/growth_information)
 
 		if(info.plant_state == HYDROTRAY_PLANT_DEAD)
-			balloon_alert_to_viewers(src, "dead plant removed")
+			balloon_alert_to_viewers("dead plant removed")
 			SEND_SIGNAL(hydro, COMSIG_REMOVE_PLANT, seed_item)
 			return
 
 		if(growing.weed_level > 0)
-			balloon_alert_to_viewers(src, "weeds uprooted")
+			balloon_alert_to_viewers("weeds uprooted")
 			SEND_SIGNAL(hydro, COMSIG_PLANT_ADJUST_WEED, -10)
 			return
 

--- a/monkestation/code/modules/botany/potty.dm
+++ b/monkestation/code/modules/botany/potty.dm
@@ -8,7 +8,6 @@
 	icon_dead = "potty_dead"
 
 	dexterous = TRUE
-	held_items = list(null, null)
 
 	ai_controller = /datum/ai_controller/basic_controller/craig
 
@@ -26,6 +25,7 @@
 
 /mob/living/basic/pet/potty/Initialize(mapload)
 	..()
+	// Allows Craig to be given different watering cans. You can change the transfer amount so Craig uses more water.
 	AddComponent(/datum/component/item_receiver, list(/obj/item/reagent_containers/cup/watering_can), "happily takes")
 	AddComponent(/datum/component/plant_tray_overlay, icon, null, null, null, null, null, null, 3, 8)
 	AddComponent(/datum/component/plant_growing)
@@ -39,11 +39,6 @@
 
 	return INITIALIZE_HINT_LATELOAD
 
-/mob/living/basic/pet/potty/LateInitialize()
-	for(var/obj/item/reagent_containers/cup/watering_can/can in range(1, src))
-		if(pick_up_watering_can(can))
-			break
-
 /mob/living/basic/pet/potty/Destroy()
 	drop_all_held_items()
 	return ..()
@@ -52,73 +47,47 @@
 	drop_all_held_items()
 	return ..()
 
-/mob/living/basic/pet/potty/melee_attack(atom/target, list/modifiers, ignore_cooldown = FALSE)
-	face_atom(target)
-	if (!ignore_cooldown)
-		changeNext_move(melee_attack_cooldown)
-	if(SEND_SIGNAL(src, COMSIG_HOSTILE_PRE_ATTACKINGTARGET, target, Adjacent(target), modifiers) & COMPONENT_HOSTILE_NO_ATTACK)
-		return FALSE //but more importantly return before attack_animal called
-	var/result
-	if(held_items[active_hand_index])
-		var/obj/item/W = get_active_held_item()
-		result = W.melee_attack_chain(src, target)
-		SEND_SIGNAL(src, COMSIG_HOSTILE_POST_ATTACKINGTARGET, target, result)
-		return result
-	result = target.attack_basic_mob(src, modifiers)
-	SEND_SIGNAL(src, COMSIG_HOSTILE_POST_ATTACKINGTARGET, target, result)
-	return result
-
-/*
-/mob/living/basic/pet/potty/attackby(obj/item/thing, mob/user, params)
-	// no forcing it into the hands of a sentient craig
-	if(QDELETED(client) && istype(thing, /obj/item/reagent_containers/cup/watering_can))
-		if(user.temporarilyRemoveItemFromInventory(thing) && !pick_up_watering_can(thing, user))
-			user.put_in_hands(thing)
-		return TRUE
-	return ..()
-*/
-
-/mob/living/basic/pet/potty/proc/pick_up_watering_can(obj/item/reagent_containers/cup/watering_can/can, mob/living/feedback)
-	// make sure it's actually a watering can, and that its not deleted
-	if(!istype(can) || QDELING(can) || stat == DEAD)
-		return FALSE
-	// check if we're already holding a watering can
-	var/obj/item/held_can = is_holding_item_of_type(/obj/item/reagent_containers/cup/watering_can)
-	if(held_can)
-		var/holding_advanced = istype(held_can, /obj/item/reagent_containers/cup/watering_can/advanced)
-		var/giving_advanced = istype(can, /obj/item/reagent_containers/cup/watering_can/advanced)
-		if(holding_advanced || !giving_advanced)
-			if(feedback)
-				balloon_alert(feedback, "already has watering can!")
-			return FALSE
-		else
-			// we can hand craig an advanced can and they'll switch it out if their current can isn't advanced
-			dropItemToGround(held_can)
-	// make sure our hands aren't full
-	if(!length(get_empty_held_indexes()))
-		if(feedback)
-			balloon_alert(feedback, "hands full!")
-		return FALSE
-	can.forceMove(src)
-	// just make SURE we pick up the can - drop it back to the floor if we somehow fail
-	if(!put_in_hands(can))
-		if(feedback)
-			balloon_alert(feedback, "couldn't pick up!")
-		can.forceMove(drop_location())
-		return FALSE
-	// remove all non-water reagents from the can
-	for(var/datum/reagent/reagent in can.reagents.reagent_list)
-		if(reagent.type == /datum/reagent/water)
-			continue
-		can.reagents.remove_reagent(reagent.type, reagent.volume)
-	if(feedback)
-		balloon_alert(feedback, "took watering can")
-	return TRUE
 
 /mob/living/basic/pet/potty/UnarmedAttack(atom/attack_target, proximity_flag, list/modifiers)
+	var/obj/item/reagent_containers/cup/watering_can/W = \
+			is_holding_item_of_type(/obj/item/reagent_containers/cup/watering_can)
+
+	// waters the obj that can grow plants
+	if(attack_target.GetComponent(/datum/component/plant_growing) && W)
+		treat_hydro_tray(attack_target)
+		INVOKE_ASYNC(W, TYPE_PROC_REF(/obj/item, melee_attack_chain), src, attack_target)
+		return
+
+	// fills the watering can
+	if(istype(attack_target, /obj/structure/sink) \
+			|| istype(attack_target, /obj/structure/reagent_dispensers))
+		if(W)
+			INVOKE_ASYNC(W, TYPE_PROC_REF(/obj/item, melee_attack_chain), src, attack_target)
+			return
 	. = ..()
-	if(. && proximity_flag)
-		pick_up_watering_can(attack_target)
+	return
+
+///Craig can remove weeds or remove dead plants
+/mob/living/basic/pet/potty/proc/treat_hydro_tray(atom/movable/hydro)
+	var/datum/component/plant_growing/growing = hydro.GetComponent(/datum/component/plant_growing)
+	if(!growing)
+		return
+
+	for(var/item in growing.managed_seeds)
+		var/obj/item/seeds/seed = growing.managed_seeds[item]
+		if(!seed)
+			continue
+		var/datum/component/growth_information/info = seed.GetComponent(/datum/component/growth_information)
+
+		if(info.plant_state == HYDROTRAY_PLANT_DEAD)
+			balloon_alert(src, "dead plant removed")
+			SEND_SIGNAL(hydro, COMSIG_REMOVE_PLANT, item)
+			return
+
+		if(growing.weed_level > 0)
+			balloon_alert(src, "weeds uprooted")
+			SEND_SIGNAL(hydro, COMSIG_PLANT_ADJUST_WEED, -10)
+			return
 
 // craig's living icons are movement states, so we gotta ensure icon2html handles that properly
 /mob/living/basic/pet/potty/get_examine_string(mob/user, thats = FALSE)

--- a/monkestation/code/modules/botany/potty.dm
+++ b/monkestation/code/modules/botany/potty.dm
@@ -94,12 +94,12 @@
 				seed.GetComponent(/datum/component/growth_information)
 
 		if(info.plant_state == HYDROTRAY_PLANT_DEAD)
-			balloon_alert_to_viewers(src, "dead plant removed")
+			balloon_alert_to_viewers("dead plant removed")
 			SEND_SIGNAL(hydro, COMSIG_REMOVE_PLANT, seed_item)
 			return
 
 		if(growing.weed_level > 0)
-			balloon_alert_to_viewers(src, "weeds uprooted")
+			balloon_alert_to_viewers("weeds uprooted")
 			SEND_SIGNAL(hydro, COMSIG_PLANT_ADJUST_WEED, -10)
 			return
 

--- a/monkestation/code/modules/botany/potty.dm
+++ b/monkestation/code/modules/botany/potty.dm
@@ -25,13 +25,25 @@
 
 /mob/living/basic/pet/potty/Initialize(mapload)
 	..()
-	// Allows Craig to be given different watering cans. You can change the transfer amount so Craig uses more water.
-	AddComponent(/datum/component/item_receiver, list(/obj/item/reagent_containers/cup/watering_can), "happily takes")
-	AddComponent(/datum/component/plant_tray_overlay, icon, null, null, null, null, null, null, 3, 8)
+	// Allows Craig to be given different watering cans.
+	// You can change the transfer amount so Craig uses more water.
+	AddComponent(/datum/component/item_receiver, \
+		list(/obj/item/reagent_containers/cup/watering_can), "happily takes")
+	AddComponent(/datum/component/plant_tray_overlay, icon, \
+			null, null, null, null, null, null, 3, 8)
 	AddComponent(/datum/component/plant_growing)
 	AddComponent(/datum/component/obeys_commands, pet_commands)
 	AddComponent(/datum/component/emotion_buffer)
-	AddComponent(/datum/component/friendship_container, list(FRIENDSHIP_HATED = -100, FRIENDSHIP_DISLIKED = -50, FRIENDSHIP_STRANGER = 0, FRIENDSHIP_NEUTRAL = 1, FRIENDSHIP_ACQUAINTANCES = 3, FRIENDSHIP_FRIEND = 5, FRIENDSHIP_BESTFRIEND = 10), FRIENDSHIP_FRIEND)
+	AddComponent(/datum/component/friendship_container, list(
+		FRIENDSHIP_HATED = -100,
+		FRIENDSHIP_DISLIKED = -50,
+		FRIENDSHIP_STRANGER = 0,
+		FRIENDSHIP_NEUTRAL = 1,
+		FRIENDSHIP_ACQUAINTANCES = 3,
+		FRIENDSHIP_FRIEND = 5,
+		FRIENDSHIP_BESTFRIEND = 10
+		), \
+		FRIENDSHIP_FRIEND)
 	AddComponent(/datum/component/basic_inhands)
 	AddElement(/datum/element/waddling)
 
@@ -49,43 +61,45 @@
 
 
 /mob/living/basic/pet/potty/UnarmedAttack(atom/attack_target, proximity_flag, list/modifiers)
-	var/obj/item/reagent_containers/cup/watering_can/W = \
+	var/obj/item/reagent_containers/cup/watering_can/held_can = \
 			is_holding_item_of_type(/obj/item/reagent_containers/cup/watering_can)
 
 	// waters the obj that can grow plants
-	if(attack_target.GetComponent(/datum/component/plant_growing) && W)
+	if(attack_target.GetComponent(/datum/component/plant_growing) && held_can)
 		treat_hydro_tray(attack_target)
-		INVOKE_ASYNC(W, TYPE_PROC_REF(/obj/item, melee_attack_chain), src, attack_target)
+		INVOKE_ASYNC(held_can, TYPE_PROC_REF(/obj/item, melee_attack_chain), src, attack_target)
 		return
 
 	// fills the watering can
 	if(istype(attack_target, /obj/structure/sink) \
 			|| istype(attack_target, /obj/structure/reagent_dispensers))
-		if(W)
-			INVOKE_ASYNC(W, TYPE_PROC_REF(/obj/item, melee_attack_chain), src, attack_target)
+		if(held_can)
+			INVOKE_ASYNC(held_can, TYPE_PROC_REF(/obj/item, melee_attack_chain), src, attack_target)
 			return
 	. = ..()
 	return
 
 ///Craig can remove weeds or remove dead plants
 /mob/living/basic/pet/potty/proc/treat_hydro_tray(atom/movable/hydro)
-	var/datum/component/plant_growing/growing = hydro.GetComponent(/datum/component/plant_growing)
+	var/datum/component/plant_growing/growing = \
+			hydro.GetComponent(/datum/component/plant_growing)
 	if(!growing)
 		return
 
-	for(var/item in growing.managed_seeds)
-		var/obj/item/seeds/seed = growing.managed_seeds[item]
+	for(var/_item, seed_item in growing.managed_seeds)
+		var/obj/item/seeds/seed = seed_item
 		if(!seed)
 			continue
-		var/datum/component/growth_information/info = seed.GetComponent(/datum/component/growth_information)
+		var/datum/component/growth_information/info = \
+				seed.GetComponent(/datum/component/growth_information)
 
 		if(info.plant_state == HYDROTRAY_PLANT_DEAD)
-			balloon_alert(src, "dead plant removed")
-			SEND_SIGNAL(hydro, COMSIG_REMOVE_PLANT, item)
+			balloon_alert_to_viewers(src, "dead plant removed")
+			SEND_SIGNAL(hydro, COMSIG_REMOVE_PLANT, seed_item)
 			return
 
 		if(growing.weed_level > 0)
-			balloon_alert(src, "weeds uprooted")
+			balloon_alert_to_viewers(src, "weeds uprooted")
 			SEND_SIGNAL(hydro, COMSIG_PLANT_ADJUST_WEED, -10)
 			return
 


### PR DESCRIPTION

## About The Pull Request

Apparently UnarmedAttack() was causing issues. As most ai planners use UnarmedAttack() as the action after having caught the target, a fix was used where upon checking for a watering can an attack is called directly from the watering can to the target. Also a bunch of unused / outdated code was removed.

While Craig has 2 hands it is generally not good to have him harvest your plants given you typically want to let the plant stay in the tray to get past mutation thresholds. If your plant gets harvested and you don't get your mutation then you need to wait another 2 mins (with bioboost) to roll again, so such features would only grief botanists and would not really contribute anything.

Craig can use treat_hydro_tray() from seedlings to remove dead plants, but if you or Craig are watering plants then there's no way you ever have dead plants unless you're a complete noob, so it's not really necessary.

tl;dr: Craig can water plants again (as well as fill his can from water sources).

## Why It's Good For The Game
Botanist bros, we are SO BACK.
Fixes #8131

## Changelog
:cl: Lawlolawl
fix: Fixed Craig and he is able to water plants again. Also you can give him different watering cans (using the "give" hotkey, check settings).
/:cl:


