### PR TITLE
fix baton charge cost and advanced 12ga boxes reload delay bypass

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -442,7 +442,7 @@
 	var/throw_stun_chance = 35
 	var/obj/item/stock_parts/power_store/cell/cell
 	var/preload_cell_type //if not empty the baton starts with this type of cell
-	var/cell_hit_cost = 1000
+	var/cell_hit_cost = STANDARD_CELL_CHARGE
 	var/can_remove_cell = TRUE
 	var/convertible = TRUE //if it can be converted with a conversion kit
 

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -452,8 +452,8 @@
 				return COMPONENT_CANCEL_ATTACK_CHAIN
 		to_chat(user, span_notice("You start unloading a shell from the [src]..."))
 		old_ammo_count = length(stored_ammo)
-		if(do_after(user, reload_delay, src, timed_action_flags = IGNORE_USER_LOC_CHANGE, interaction_key = "doafter_reloading"))
-			return FALSE
+		if(!do_after(user, reload_delay, src, timed_action_flags = IGNORE_USER_LOC_CHANGE, interaction_key = "doafter_reloading"))
+			return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /obj/item/ammo_box/advanced/s12gauge/afterattack(atom/target, mob/user, proximity_flag, click_parameters) //why did i do this, i guess it's funny?
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

fixes advanced shotgun ammo boxes loading the shell into shotgun even if action is cancelled 
closes https://github.com/Monkestation/Monkestation2.0/issues/7526
fixes stun batons only using 1% of charge per hit with roundstart cells (lol)
## Why It's Good For The Game

bug bad

## Changelog
:cl:
fix: roundstart cell stun batons no longer only use 1% of its cell charge per hit and use 10%, like intended
fix: you can no longer bypass advanced shotgun ammo boxes reload delay by cancelling the action
/:cl:
