### PR TITLE
PDA Painters applying trims will now automatically give Maintenace Access

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -352,6 +352,8 @@
 					continue
 
 				if(SSid_access.apply_trim_to_card(stored_id_card, path, copy_access = FALSE))
+					if(CONFIG_GET(flag/everyone_has_maint_access))
+						stored_id_card.add_access(list(ACCESS_MAINT_TUNNELS))
 					return TRUE
 
 				to_chat(usr, span_warning("The trim you selected could not be added to \the [stored_id_card]. You will need a rarer ID card to imprint that trim data."))


### PR DESCRIPTION

## About The Pull Request
- When Applying a PDA trim, assuming the config for global Maintenace is active, (For which us it is), all ID's will be automatically given Maintenace access.
## Why It's Good For The Game
Maintenance access is a given for any which role. But when applying a trim via painters the ID vanishes. So even if hired by a RD directly, they won't be able to give you the full access, as maintence is a subtype of engineer access. So only CE, HOP, and Cap can actually provide the Maintenace access. Meaning getting hired by anyone besides the HOP can severely limit access. Jobs with 'extra' accesses still need to talk to HOP or other heads, like wanna-be paramedics, but a CMO wanting to hire a medical doctor directly can do so without much less headache.

This just keeps things consistent with how current accesses work. And makes hiring someone less of a headache
## Changelog
:cl:
qol: Applying a ID trim will give Maintenace access. Meaning you greyshirts can get jobs easier now!
/:cl:
