### PR TITLE
Soldier deathmatch loadout now has correct ammo

### DIFF
--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -166,7 +166,7 @@
 
 	backpack_contents = list(
 		/obj/item/grenade/smokebomb = 2,
-		/obj/item/ammo_box/strilka310 = 2,
+		/obj/item/ammo_box/a762 = 2,
 	)
 
 /datum/outfit/deathmatch_loadout/battler/druid


### PR DESCRIPTION

## About The Pull Request
Soldier deathmatch loadout now has correct ammo, so now you can reload.
Fixes #8199

## Why It's Good For The Game
Bugfixing

## Changelog
:cl:
fix: Soldier deathmatch loadout now has correct ammo
/:cl:
