### PR TITLE
readd ranged plant composting

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -54,8 +54,8 @@
 		else
 			return user_unbuckle_mob(buckled_mobs[1], user)
 
-/atom/movable/mouse_drop_receive(mob/living/M, mob/user, params)
-	return mouse_buckle_handling(M, user)
+/atom/movable/mouse_drop_receive(atom/dropped, mob/user, params)
+	return mouse_buckle_handling(dropped, user)
 
 /**
  * Does some typechecks and then calls user_buckle_mob

--- a/monkestation/code/modules/hydroponics/machines/composter.dm
+++ b/monkestation/code/modules/hydroponics/machines/composter.dm
@@ -5,6 +5,7 @@
 	icon_state = "composter"
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/composters
+	interaction_flags_atom = INTERACT_ATOM_MOUSEDROP_IGNORE_ADJACENT
 
 	/// Current level of biomatter in the composter.
 	var/biomatter = 0
@@ -165,27 +166,12 @@
 	balloon_alert(user, "safeties overriden")
 	return TRUE
 
-/obj/item/seeds/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
-	. = ..()
-	// ensure user is next to what we're mouse dropping into
-	if(!Adjacent(usr, over) || !isatom(src_location))
+/obj/machinery/composters/mouse_drop_receive(atom/dropped, mob/user, params)
+	if(!istype(dropped, /obj/item/food) && !istype(dropped, /obj/item/seeds))
 		return
-	var/atom/seed_loc = src_location
-	// ensure the stuff we're mouse dropping is ALSO adjacent
-	var/obj/machinery/composters/dropped = over
-	if(istype(dropped) && Adjacent(src_location, over_location))
-		dropped.compost(seed_loc.contents)
-
-/obj/item/food/mouse_drop_dragged(atom/over, mob/user, src_location, over_location, params)
-	. = ..()
-	// ensure user is next to what we're mouse dropping into
-	if(!Adjacent(usr, over) || !isatom(src_location))
-		return
-	var/atom/food_loc = src_location
-	// ensure the stuff we're mouse dropping is ALSO adjacent
-	var/obj/machinery/composters/dropped = over
-	if(istype(dropped) && Adjacent(src_location, over_location))
-		dropped.compost(food_loc.contents)
+	var/atom/seed_loc = dropped.loc
+	if(user.Adjacent(seed_loc))
+		compost(seed_loc.contents)
 
 /obj/item/stack/biocube
 	name = "biocube"


### PR DESCRIPTION
## About The Pull Request

click refactor got rid of this bc xander thought it was a bug - i mean, it _was_ a bug, but it kind of got canonized into being a feature, so this re-adds it. also slightly improves the code of composter drag-dropping.

## Why It's Good For The Game

helps clean up botany when they make 500000 pumpkins.

## Changelog
:cl:
fix: You can now drag and drop plants into a composter on the other side of the room again.
/:cl:
