### PR TITLE
Adds names to machining circuitboard child classes

### DIFF
--- a/monkestation/code/modules/machining/machining_structures.dm
+++ b/monkestation/code/modules/machining/machining_structures.dm
@@ -462,7 +462,7 @@
 
 //circuits
 /obj/item/circuitboard/machine/industrial_lathe
-	name = "Manual lathe"
+	name = "Industrial Lathe"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
 	build_path = /obj/machinery/lathe
 	req_components = list(
@@ -473,21 +473,27 @@
 		)
 
 /obj/item/circuitboard/machine/industrial_lathe/workstation
+	name = "Workstation"
 	build_path = /obj/machinery/lathe/workstation
 
 /obj/item/circuitboard/machine/industrial_lathe/furnace
+	name = "Furnace"
 	build_path = /obj/machinery/lathe/furnace
 
 /obj/item/circuitboard/machine/industrial_lathe/tablesaw
+	name = "Tablesaw"
 	build_path = /obj/machinery/lathe/tablesaw
 
 /obj/item/circuitboard/machine/industrial_lathe/drophammer
+	name = "Drophammer"
 	build_path = /obj/machinery/lathe/drophammer
 
 /obj/item/circuitboard/machine/industrial_lathe/tailor
+	name = "Tailor"
 	build_path = /obj/machinery/lathe/tailor
 
 /obj/item/circuitboard/machine/industrial_lathe/drillpress
+	name = "Drill Press"
 	build_path = /obj/machinery/lathe/drillpress
 
 //machinery design


### PR DESCRIPTION

## About The Pull Request
Original PR author forgot to add individual names to child classes of the industrial lathe circuit board base class, resulting in them all being named "Industrial Lathe (Machine Board)".

The parts required for construction will remain the same across them all as there's no big reason to make them different.
## Why It's Good For The Game
Removes ambiguity for players, allows you to inspect and identify which particular board it is.
Fixes #8358
Fixes #8359 (it's in the assembly tab, not a separate machine)
Fixes #8593
Fixes #8594
## Changelog
:cl: Lawlolawl
qol: Added names to machining circuit board types so you can differentiate between them when inspecting them.
/:cl:
