### PR TITLE
Oozelings now properly lose blood when starving

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -966,6 +966,12 @@
 /mob/living/carbon/human/species/oozeling
 	race = /datum/species/oozeling
 
+/mob/living/carbon/human/species/oozeling/Initialize(mapload)
+	. = ..()
+	// stupid snowflake code to ensure oozelings will always start at least fed, so they don't have to IMMEDIATELY eat to avoid melting
+	if(nutrition < NUTRITION_LEVEL_FED)
+		set_nutrition(rand(NUTRITION_LEVEL_FED, NUTRITION_LEVEL_START_MAX))
+
 /mob/living/carbon/human/species/oozeling/stargazer
 	race = /datum/species/oozeling/stargazer
 

--- a/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
@@ -56,6 +56,8 @@
 	var/list/actions_given = list()
 	/// Cooldown for balloon alerts when being melted from water exposure.
 	COOLDOWN_DECLARE(water_alert_cooldown)
+	/// Cooldown for balloon alerts when being melted from starvation.
+	COOLDOWN_DECLARE(starvation_alert_cooldown)
 	/// Cooldown for balloon alerts when being melted from being dripping wet.
 	COOLDOWN_DECLARE(wet_alert_cooldown)
 
@@ -126,15 +128,17 @@
 /datum/species/oozeling/proc/spec_slime_hunger(mob/living/carbon/human/slime, seconds_per_tick)
 	if(slime.nutrition <= NUTRITION_LEVEL_STARVING)
 		slime.blood_volume = max(slime.blood_volume - (4 * seconds_per_tick), 0)
-		if(SPT_PROB(2.5, seconds_per_tick))
+		if(COOLDOWN_FINISHED(src, starvation_alert_cooldown))
 			to_chat(slime, span_danger("You're starving! Get some food!"))
 			slime.balloon_alert(slime, "you're starving!")
+			COOLDOWN_START(src, starvation_alert_cooldown, 10 SECONDS)
 	else
 		if(SPT_PROB(17.5, seconds_per_tick))
 			slime.blood_volume = max(slime.blood_volume - seconds_per_tick, 0)
-		if(SPT_PROB(5, seconds_per_tick))
-			to_chat(slime, span_warning("You're feeling pretty hungry..."))
-			slime.balloon_alert(slime, "you're pretty hungry...")
+			if(COOLDOWN_FINISHED(src, starvation_alert_cooldown))
+				to_chat(slime, span_warning("You're feeling pretty hungry..."))
+				slime.balloon_alert(slime, "you're pretty hungry...")
+				COOLDOWN_START(src, starvation_alert_cooldown, 10 SECONDS)
 
 ///////
 /// CHEMICAL HANDLING

--- a/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
@@ -99,10 +99,15 @@
 
 /datum/species/oozeling/spec_life(mob/living/carbon/human/slime, seconds_per_tick, times_fired)
 	. = ..()
-	if(HAS_TRAIT(slime, TRAIT_SLIME_HYDROPHOBIA) || HAS_TRAIT(slime, TRAIT_GODMODE))
+	if(HAS_TRAIT(slime, TRAIT_GODMODE) || slime.blood_volume <= 0)
 		return
-	if(slime.blood_volume <= 0) // stop, stop they're already dead!
-		return
+	if(!HAS_TRAIT(slime, TRAIT_NOHUNGER) && slime.nutrition <= NUTRITION_LEVEL_HUNGRY && !IS_BLOODSUCKER(slime)) // bloodsuckers have snowflake nutrition handling
+		spec_slime_hunger(slime, seconds_per_tick)
+	if(!HAS_TRAIT(slime, TRAIT_SLIME_HYDROPHOBIA))
+		spec_slime_wetness(slime, seconds_per_tick)
+
+/// Handles slimes losing blood from having wet stacks.
+/datum/species/oozeling/proc/spec_slime_wetness(mob/living/carbon/human/slime, seconds_per_tick)
 	var/datum/status_effect/fire_handler/wet_stacks/wetness = locate() in slime.status_effects // locate should be slightly faster in theory, as this has no subtypes hopefully, so we don't need to check ids
 	if(!wetness)
 		return
@@ -117,12 +122,19 @@
 		slime.blood_volume = max(slime.blood_volume - (1 * seconds_per_tick), 0)
 		slime.balloon_alert(slime, "you're dripping wet!")
 
-//////
-/// DEATH OF BODY SECTION
-///	Handles gibbing
-
-/datum/species/oozeling/spec_death(gibbed, mob/living/carbon/human/H)
-	. = ..()
+/// Handles slimes losing blood from starving.
+/datum/species/oozeling/proc/spec_slime_hunger(mob/living/carbon/human/slime, seconds_per_tick)
+	if(slime.nutrition <= NUTRITION_LEVEL_STARVING)
+		slime.blood_volume = max(slime.blood_volume - (4 * seconds_per_tick), 0)
+		if(SPT_PROB(2.5, seconds_per_tick))
+			to_chat(slime, span_danger("You're starving! Get some food!"))
+			slime.balloon_alert(slime, "you're starving!")
+	else
+		if(SPT_PROB(17.5, seconds_per_tick))
+			slime.blood_volume = max(slime.blood_volume - seconds_per_tick, 0)
+		if(SPT_PROB(5, seconds_per_tick))
+			to_chat(slime, span_warning("You're feeling pretty hungry..."))
+			slime.balloon_alert(slime, "you're pretty hungry...")
 
 ///////
 /// CHEMICAL HANDLING

--- a/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
@@ -66,15 +66,18 @@
 	QDEL_LIST(actions_given)
 	return ..()
 
-/datum/species/oozeling/on_species_gain(mob/living/carbon/slime, datum/species/old_species)
+/datum/species/oozeling/on_species_gain(mob/living/carbon/slime, datum/species/old_species, pref_load)
 	. = ..()
 	RegisterSignal(slime, COMSIG_ATOM_EXPOSE_REAGENTS, PROC_REF(on_reagent_expose))
 	for(var/action_type in default_actions + extra_actions)
 		var/datum/action/action = new action_type(src)
 		action.Grant(slime)
 		actions_given += action
+	// oozelings will always start at least fed, so they don't have to immediately eat to avoid melting
+	if(pref_load && slime.nutrition < NUTRITION_LEVEL_FED)
+		slime.set_nutrition(rand(NUTRITION_LEVEL_FED, NUTRITION_LEVEL_START_MAX))
 
-/datum/species/oozeling/on_species_loss(mob/living/carbon/former_slime)
+/datum/species/oozeling/on_species_loss(mob/living/carbon/human/former_slime, datum/species/new_species, pref_load)
 	UnregisterSignal(former_slime, COMSIG_ATOM_EXPOSE_REAGENTS)
 	QDEL_LIST(actions_given)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This makes it so oozelings lose blood when starving.

I believe this is fine during the feature freeze, as it seems **they were already meant to do this**, as one of their species menu descriptions says this:

> Once **hungry enough**, Oozelings will begin to consume their own blood and limbs.

and this was one of the things discussed about oozeling balance before the feature freeze was put in place.

Also slightly reorganized the code

## Why It's Good For The Game

things working as described is nice, and this does help with giving them a disadvantage to further balance them.

## Changelog
:cl:
balance: Oozelings will now begin to lose blood if they're starving, as intended.
/:cl:
