### PR TITLE
Fixes TK teleporting surgical tray

### DIFF
--- a/code/game/objects/items/surgery_tray.dm
+++ b/code/game/objects/items/surgery_tray.dm
@@ -133,6 +133,8 @@
 
 /obj/item/surgery_tray/attack_self(mob/user, modifiers)
 	. = ..()
+	if (loc != user) // prevents attack_self_tk from placing it on user
+		return
 	if(.)
 		return
 	var/turf/open/placement_turf = get_turf(user)


### PR DESCRIPTION
## About The Pull Request
Adds a location check and ignores deployment of surgical trays not on the player location when trays are grabbed by TK and used in (TK) hand.

## Why It's Good For The Game
Fixes #2941

## Changelog
:cl: Lawlolawl
fix: Fixed TK teleporting surgical tray by stopping TK use in hand.
/:cl:
