### PR TITLE
Debug outfit doesnt spawn pulse prize

### DIFF
--- a/code/game/objects/items/storage/boxes/debug_boxes.dm
+++ b/code/game/objects/items/storage/boxes/debug_boxes.dm
@@ -168,6 +168,7 @@
 
 /obj/item/storage/box/debugbox/guns/miscenergy/PopulateContents() // Misc energy guns
 	var/list/remaining_guns = typesof(/obj/item/gun/energy) - typesof(/obj/item/gun/energy/recharge) - typesof(/obj/item/gun/energy/laser) - typesof(/obj/item/gun/energy/e_gun)
+	remaining_guns =- /obj/item/gun/energy/pulse/prize // Remove prize pulse rifle so debug outfit doesnt notify ghosts
 	for(var/obj/item/gun as anything in remaining_guns)
 		new gun(src)
 


### PR DESCRIPTION

## About The Pull Request
Debug outfit doesnt spawn pulse prize
## Why It's Good For The Game
This notifies ghosts... oops
## Changelog
:cl:
fix: Debug outfit no longer notifies all ghosts when it spawns
/:cl:
