### PR TITLE
Fix crusher projectile not knowing it was fired from a crusher

### DIFF
--- a/code/modules/mining/equipment/kinetic_crusher/crusher_variants/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher/crusher_variants/kinetic_crusher.dm
@@ -227,6 +227,7 @@
 		attached_trophy.on_projectile_fire(destabilizer, user)
 	destabilizer.preparePixelProjectile(target, user, modifiers)
 	destabilizer.firer = user
+	destabilizer.fired_from = src
 	playsound(user, 'sound/weapons/plasma_cutter.ogg', 100, TRUE)
 	destabilizer.fire()
 	charged = FALSE


### PR DESCRIPTION

## About The Pull Request
Fix crusher projectile not knowing it was fired from a crusher
## Why It's Good For The Game
Fixes bileworm spewlet not mining in a 3x3
Fixes crusher not having a faster cooldown based on mining skill
## Changelog
:cl:
fix: Fixes bileworm spewlet not mining in a 3x3
fix: Fixes crusher not having a faster cooldown based on mining skill
/:cl:
