### PR TITLE
Cryostatic Chem Masters

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -110,8 +110,15 @@ GLOBAL_LIST_INIT(chem_master_containers, list(
 /obj/machinery/chem_master/RefreshParts()
 	. = ..()
 	reagents.maximum_volume = 0
+	var/cryogenic = TRUE
 	for(var/obj/item/reagent_containers/cup/beaker/beaker in component_parts)
 		reagents.maximum_volume += beaker.reagents.maximum_volume
+		if(!CHECK_BITFIELD(beaker.reagents.flags, NO_REACT))
+			cryogenic = FALSE
+	if(cryogenic == TRUE)
+		ENABLE_BITFIELD(reagents.flags, NO_REACT)
+	else
+		DISABLE_BITFIELD(reagents.flags, NO_REACT)
 	printing_amount = 0
 	for(var/datum/stock_part/manipulator/manipulator in component_parts)//Monkestation Edit: We use manipulators instead of servos
 		printing_amount += manipulator.tier
@@ -492,6 +499,8 @@ GLOBAL_LIST_INIT(chem_master_containers, list(
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads:<br>Reagent buffer capacity: <b>[reagents.maximum_volume]</b> units.<br>Number of containers printed at once increased by <b>[100 * (printing_amount / initial(printing_amount)) - 100]%</b>.")
+		if(CHECK_BITFIELD(reagents.flags, NO_REACT))
+			. += span_notice("This machine has been upgraded to put reagents in the buffer on cryostasis, preventing them from reacting.")
 
 /obj/machinery/chem_master/condimaster
 	name = "CondiMaster 3000"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the ability for chem masters to become NO_REACT if all beakers inserted are NO_REACT. Because I'm not certain on if this counts as a feature or fix during the feature freeze, I'm immediately closing it unless someone says its fine, or until feature freeze ends.


https://github.com/user-attachments/assets/65e97fe1-bedd-401c-b0e2-f0340e97986c



<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Since the chemmaster pulls its buffer size from the beakers installed, you'd expect it to pull the power to not react as well. At least one person does at least.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Chem Masters can now become reactionless if installed with cryo beakers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
