### PR TITLE
Prevent DNA Vault from rolling useless mutations (i.e fire immunity for oozelings)

### DIFF
--- a/code/modules/station_goals/dna_vault.dm
+++ b/code/modules/station_goals/dna_vault.dm
@@ -140,6 +140,13 @@
 		/datum/mutation/quick_recovery,
 		/datum/mutation/tough,
 	)
+	// don't roll powers that the user already has through other sources!!
+	if(HAS_TRAIT(user, TRAIT_NOFIRE))
+		possible_powers -= /datum/mutation/fire_immunity
+	if(HAS_TRAIT(user, TRAIT_TOXIMMUNE) || HAS_TRAIT(user, TRAIT_TOXINLOVER))
+		possible_powers -= /datum/mutation/plasmocile
+	if(HAS_TRAIT_NOT_FROM(user, TRAIT_NOBREATH, CLOTHING_TRAIT)) // we exclude CLOTHING_TRAIT so that rebreathers won't count
+		possible_powers -= list(/datum/mutation/breathless, /datum/mutation/plasmocile) // also remove plasmocile bc they don't need to breathe anyways
 	var/list/gained_mutation = list()
 	gained_mutation += pick_n_take(possible_powers)
 	gained_mutation += pick_n_take(possible_powers)


### PR DESCRIPTION
## About The Pull Request

this simply excludes some mutations from being considered in the DNA vault's "power lottery" based on certain conditions.

Fire Immunity: excluded if user has `TRAIT_NOFIRE`
Plasmocile: excluded if user has `TRAIT_TOXIMMUNE`, `TRAIT_TOXINLOVER`, or `TRAIT_NOBREATH`
Breathless: excluded if user has `TRAIT_NOBREATH`

(note: the things that check `TRAIT_NOBREATH` will not count if wearing a rebreather, to prevent potential cheese)

## Why It's Good For The Game

me when i work my ass off completing the dna vault and get offered plasmocile and fire immunity (as an oozeling)

## Changelog
:cl:
qol: The DNA Vault will no longer roll "useless" mutations, i.e oozelings won't roll fire immunity or plasmocile,
/:cl:
