### PR TITLE
Adjusts "Alternate Names" UI widths

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/names.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/names.tsx
@@ -57,7 +57,7 @@ export const MultiNameInput = (props: {
           <Modal
             style={{
               margin: '0 auto',
-              width: '40%',
+              width: '100%',
             }}
           >
             <TrackOutsideClicks onOutsideClick={props.handleClose}>
@@ -104,7 +104,7 @@ export const MultiNameInput = (props: {
                                   event.stopPropagation();
                                 }}
                               >
-                                <FitText maxFontSize={12} maxWidth={130}>
+                                <FitText maxFontSize={12} maxWidth={90}>
                                   {props.names[key]}
                                 </FitText>
                               </Button>


### PR DESCRIPTION

## About The Pull Request
Not sure why the modal width for the alt names ui was only 40%. Also reduced max width of names so they fit within the edit name button.
## Why It's Good For The Game
Fixes #8711
## Changelog
UI visual fix, changelog unnecessary.
