### PR TITLE
Allow meteor sat capsules to fit in construction bags

### DIFF
--- a/code/datums/storage/subtypes/bags.dm
+++ b/code/datums/storage/subtypes/bags.dm
@@ -18,6 +18,7 @@
 		/obj/item/stack/sheet,
 		/obj/item/rcd_ammo,
 		/obj/item/stack/rods,
+		/obj/item/meteor_shield_capsule,
 	))
 
 ///Rebar quiver bag


### PR DESCRIPTION

## About The Pull Request

this adds meteor sat capsules to the construction bag's whitelist. simple enough.

## Why It's Good For The Game

meteor sat capsules are TINY and I hate lugging around a dufflebag just to cover the station.

## Changelog
:cl:
qol: Construction bags can now hold meteor sat capsules.
/:cl:
