### PR TITLE
Prevent cleaning/painting polarized windows

### DIFF
--- a/code/__DEFINES/traits/declarations.dm
+++ b/code/__DEFINES/traits/declarations.dm
@@ -737,6 +737,9 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 /// Mobs with this trait can't send the mining shuttle console when used outside the station itself
 #define TRAIT_FORBID_MINING_SHUTTLE_CONSOLE_OUTSIDE_STATION "forbid_mining_shuttle_console_outside_station"
 
+/// Used to prevent spray painting/cleaning polarized windows.
+#define TRAIT_WINDOW_POLARIZED "polarized"
+
 //important_recursive_contents traits
 /*
  * Used for movables that need to be updated, via COMSIG_ENTER_AREA and COMSIG_EXIT_AREA, when transitioning areas.

--- a/code/_globalvars/traits/_traits.dm
+++ b/code/_globalvars/traits/_traits.dm
@@ -788,6 +788,9 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 	/obj/structure = list(
 		"TRAIT_RADSTORM_IMMUNE" = TRAIT_RADSTORM_IMMUNE,
 	),
+	/obj/structure/window = list(
+		"TRAIT_WINDOW_POLARIZED" = TRAIT_WINDOW_POLARIZED,
+	),
 	/obj/vehicle = list(
 		/* "TRAIT_OREBOX_FUNCTIONAL" = TRAIT_OREBOX_FUNCTIONAL, */
 	),

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -847,6 +847,10 @@
 				to_chat(user, span_warning("A color that dark on an object like this? Surely not..."))
 				return
 
+			if(HAS_TRAIT(target, TRAIT_WINDOW_POLARIZED))
+				balloon_alert(user, "can't paint polarized window!")
+				return FALSE
+
 			if(istype(target, /obj/item/pipe))
 				if(GLOB.pipe_color_name.Find(paint_color))
 					var/obj/item/pipe/target_pipe = target

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -372,6 +372,8 @@
 
 /obj/structure/window/proc/on_painted(obj/structure/window/source, is_dark_color)
 	SIGNAL_HANDLER
+	if(HAS_TRAIT(src, TRAIT_WINDOW_POLARIZED))
+		return
 	if (is_dark_color && fulltile) //Opaque directional windows restrict vision even in directions they are not placed in, please don't do this
 		set_opacity(255)
 	else
@@ -379,7 +381,7 @@
 
 /obj/structure/window/wash(clean_types)
 	. = ..()
-	if(!(clean_types & CLEAN_SCRUB))
+	if(!(clean_types & CLEAN_SCRUB) || HAS_TRAIT(src, TRAIT_WINDOW_POLARIZED))
 		return
 	set_opacity(initial(opacity))
 	remove_atom_colour(WASHABLE_COLOUR_PRIORITY)

--- a/monkestation/code/modules/blueshift/components/polarizer.dm
+++ b/monkestation/code/modules/blueshift/components/polarizer.dm
@@ -62,12 +62,14 @@ GLOBAL_LIST_EMPTY(polarization_controllers)
 		return
 
 	if(should_be_opaque)
+		ADD_TRAIT(managed_window, TRAIT_WINDOW_POLARIZED, REF(src))
 		non_polarized_color = managed_window.color
 		animate(managed_window, alpha = 255, color = polarized_color, time = polarization_process_duration)
 		addtimer(CALLBACK(managed_window, TYPE_PROC_REF(/atom, set_opacity), TRUE), polarization_process_duration) // So that is changes opacity mid-way through the animation, hopefully.
 	else
 		animate(managed_window, alpha = initial(managed_window.alpha), color = non_polarized_color, time = polarization_process_duration)
 		managed_window.set_opacity(FALSE) // So that is changes opacity mid-way through the animation, hopefully.
+		REMOVE_TRAIT(managed_window, TRAIT_WINDOW_POLARIZED, REF(src))
 
 
 


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/8741

This prevents polarized windows from being painted or washed to undo the polarization.

## Why It's Good For The Game

kinda dumb that you can use spray paint or soap to undo a window being darkened _electronically_

## Changelog
:cl:
fix: You can no longer use spray paint or soap to undo window polarization.
/:cl:
