### PR TITLE
Power fixes

### DIFF
--- a/code/__DEFINES/apc_defines.dm
+++ b/code/__DEFINES/apc_defines.dm
@@ -58,7 +58,7 @@
 /// How long it takes an ethereal to drain or charge APCs. Also used as a spam limiter.
 #define APC_DRAIN_TIME (7.5 SECONDS)
 /// How much power ethereals gain/drain from APCs.
-#define APC_POWER_GAIN (200 KILO JOULES)
+#define APC_POWER_GAIN (0.2 * STANDARD_CELL_CHARGE)
 
 // Wires & EMPs:
 /// The wire value used to reset the APCs wires after one's EMPed.

--- a/code/__DEFINES/lights.dm
+++ b/code/__DEFINES/lights.dm
@@ -1,5 +1,5 @@
 ///How much power emergency lights will consume per tick
-#define LIGHT_EMERGENCY_POWER_USE 0.2
+#define LIGHT_EMERGENCY_POWER_USE (0.0001 * STANDARD_CELL_RATE)
 // status values shared between lighting fixtures and items
 #define LIGHT_OK 0
 #define LIGHT_EMPTY 1
@@ -14,7 +14,7 @@
 ///Amount of time that takes an ethereal to take energy from the lights
 #define LIGHT_DRAIN_TIME (2.5 SECONDS)
 ///Amount of charge the ethereal gain after the drain
-#define LIGHT_POWER_GAIN 35
+#define LIGHT_POWER_GAIN (0.035 * STANDARD_CELL_CHARGE)
 
 ///How many reagents the lights can hold
 #define LIGHT_REAGENT_CAPACITY 20

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -3,8 +3,8 @@
 	desc = "It produces items using iron, glass, plastic and maybe some more."
 	icon_state = "autolathe"
 	density = TRUE
-	//Energy cost per full stack of sheets worth of materials used. Material insertion is 40% of this.
-	active_power_usage = 25 * BASE_MACHINE_ACTIVE_CONSUMPTION
+	///Energy cost per full stack of sheets worth of materials used. Material insertion is 40% of this.
+	active_power_usage = 0.025 * STANDARD_CELL_RATE
 	circuit = /obj/item/circuitboard/machine/autolathe
 	layer = BELOW_OBJ_LAYER
 	interaction_flags_atom = parent_type::interaction_flags_atom | INTERACT_ATOM_MOUSEDROP_IGNORE_CHECKS

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -8,7 +8,7 @@
 	icon_state = "defibrillator_mount"
 	density = FALSE
 	use_power = NO_POWER_USE
-	active_power_usage = 40 * BASE_MACHINE_ACTIVE_CONSUMPTION
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 40
 	power_channel = AREA_USAGE_EQUIP
 	req_one_access = list(ACCESS_MEDICAL, ACCESS_COMMAND, ACCESS_SECURITY) //used to control clamps
 	processing_flags = NONE

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -895,7 +895,7 @@
 				return
 			if(istype(attacking_object, /obj/item/electroadaptive_pseudocircuit))
 				var/obj/item/electroadaptive_pseudocircuit/raspberrypi = attacking_object
-				if(!raspberrypi.adapt_circuit(user, DEFAULT_STEP_TIME * 0.5))
+				if(!raspberrypi.adapt_circuit(user, DEFAULT_STEP_TIME * 0.0005 * STANDARD_CELL_CHARGE))
 					return
 				user.visible_message(span_notice("[user] fabricates a circuit and places it into [src]."), \
 				span_notice("You adapt a firelock circuit and slot it into the assembly."))

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -447,7 +447,7 @@
 
 				else if(istype(tool, /obj/item/electroadaptive_pseudocircuit))
 					var/obj/item/electroadaptive_pseudocircuit/pseudoc = tool
-					if(!pseudoc.adapt_circuit(user, 15))
+					if(!pseudoc.adapt_circuit(user, circuit_cost = 0.015 * STANDARD_CELL_CHARGE))
 						return
 					user.visible_message(span_notice("[user] fabricates a circuit and places it into [src]."), \
 					span_notice("You adapt a fire alarm circuit and slot it into the assembly."))

--- a/code/game/machinery/incident_display.dm
+++ b/code/game/machinery/incident_display.dm
@@ -35,7 +35,7 @@ DEFINE_BITFIELD(sign_features, list(
 	verb_say = "beeps"
 	verb_ask = "bloops"
 	verb_exclaim = "blares"
-	idle_power_usage = 450
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.5
 	max_integrity = 150
 	integrity_failure = 0.75
 	custom_materials = list(/datum/material/titanium = SHEET_MATERIAL_AMOUNT * 4, /datum/material/alloy/titaniumglass = SHEET_MATERIAL_AMOUNT * 4)

--- a/code/game/machinery/rechargestation.dm
+++ b/code/game/machinery/rechargestation.dm
@@ -9,6 +9,7 @@
 	circuit = /obj/item/circuitboard/machine/cyborgrecharger
 	occupant_typecache = list(/mob/living/silicon/robot, /mob/living/carbon/human)
 	processing_flags = NONE
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.1
 	var/recharge_speed
 	var/repairs
 	///Whether we're sending iron and glass to a cyborg. Requires Silo connection.
@@ -156,7 +157,7 @@
 /obj/machinery/recharge_station/proc/process_occupant(seconds_per_tick)
 	if(!occupant)
 		return
-	var/main_draw = use_energy(recharge_speed * seconds_per_tick) //Pulls directly from the Powernet to dump into the cell
+	var/main_draw = use_energy(recharge_speed * seconds_per_tick, force = FALSE) //Pulls directly from the Powernet to dump into the cell
 	if(!main_draw)
 		return
 	SEND_SIGNAL(occupant, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, main_draw, repairs, sendmats)

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -56,9 +56,9 @@
 	/// How long it takes to break out of the SSU.
 	var/breakout_time = 300
 	/// Power contributed by this machine to charge the mod suits cell without any capacitors
-	var/base_charge_rate = 200
+	var/base_charge_rate = 0.2 * STANDARD_CELL_RATE
 	/// Final charge rate which is base_charge_rate + contribution by capacitors
-	var/final_charge_rate = 250
+	var/final_charge_rate = 0.25 * STANDARD_CELL_RATE
 	/// is the card reader installed in this machine
 	var/card_reader_installed = FALSE
 	/// physical reference of the players id card to check for PERSONAL access level
@@ -279,7 +279,7 @@
 	. = ..()
 
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
-		final_charge_rate = base_charge_rate + (capacitor.tier * 50)
+		final_charge_rate = base_charge_rate + (capacitor.tier * 0.05 * STANDARD_CELL_RATE)
 
 	set_access()
 

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -171,7 +171,7 @@
 		if(istype(terminal.master, /obj/machinery/power/apc))
 			var/obj/machinery/power/apc/apc = terminal.master
 			if(apc.operating && apc.cell)
-				drained += 0.001 * apc.cell.use(50 KILO JOULES, force = TRUE)
+				drained += 0.001 * apc.cell.use(0.1 * STANDARD_BATTERY_CHARGE, force = TRUE)
 	internal_heat += drained
 
 /obj/item/powersink/process()

--- a/code/game/objects/items/inspector.dm
+++ b/code/game/objects/items/inspector.dm
@@ -1,3 +1,6 @@
+///Energy used to say an error message.
+#define ENERGY_TO_SPEAK (0.001 * STANDARD_CELL_CHARGE)
+
 /**
  * # N-spect scanner
  *
@@ -120,7 +123,7 @@
 		to_chat(user, "<span class='info'>\The [src] doesn't seem to be on... Perhaps it ran out of power?")
 		return
 	if(!cell.use(energy_per_print))
-		if(cell.use(energy_to_speak))
+		if(cell.use(ENERGY_TO_SPEAK))
 			say("ERROR! POWER CELL CHARGE LEVEL TOO LOW TO PRINT REPORT!")
 		return
 
@@ -266,7 +269,7 @@
 
 /obj/item/inspector/clown/bananium/proc/check_settings_legality()
 	if(print_sound_mode == INSPECTOR_PRINT_SOUND_MODE_NORMAL && time_mode == INSPECTOR_TIME_MODE_HONK)
-		if(cell.use(energy_to_speak))
+		if(cell.use(ENERGY_TO_SPEAK))
 			say("Setting combination forbidden by Geneva convention revision CCXXIII selected, reverting to defaults")
 		time_mode = INSPECTOR_TIME_MODE_SLOW
 		print_sound_mode = INSPECTOR_PRINT_SOUND_MODE_NORMAL
@@ -304,7 +307,7 @@
 	if(time_mode != INSPECTOR_TIME_MODE_HONK)
 		return ..()
 	if(paper_charges == 0)
-		if(cell.use(energy_to_speak))
+		if(cell.use(ENERGY_TO_SPEAK))
 			say("ERROR! OUT OF PAPER! MAXIMUM PRINTING SPEED UNAVAIBLE! SWITCH TO A SLOWER SPEED TO OR PROVIDE PAPER!")
 		else
 			to_chat(user, "<span class='info'>\The [src] doesn't seem to be on... Perhaps it ran out of power?")
@@ -394,3 +397,5 @@
 	to_chat(user, span_notice("As you try to fold [src] into the shape of a plane, it disintegrates into water!"))
 	qdel(src)
 	return CLICK_ACTION_SUCCESS
+
+#undef ENERGY_TO_SPEAK

--- a/code/game/objects/items/rcd/RCD.dm
+++ b/code/game/objects/items/rcd/RCD.dm
@@ -677,7 +677,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	desc = "A reverse-engineered RCD with black market upgrades that allow this device to deconstruct reinforced walls. Property of Donk Co."
 	icon_state = "ircd"
 	inhand_icon_state = "ircd"
-	energyfactor = 66
+	energyfactor = 0.066 * STANDARD_CELL_CHARGE
 	canRturf = TRUE
 
 /obj/item/construction/rcd/loaded
@@ -760,7 +760,7 @@ GLOBAL_VAR_INIT(icon_holographic_window, init_holographic_window())
 	upgrade = RCD_UPGRADE_FRAMES | RCD_UPGRADE_SIMPLE_CIRCUITS | RCD_UPGRADE_FURNISHING | RCD_UPGRADE_ANTI_INTERRUPT | RCD_UPGRADE_NO_FREQUENT_USE_COOLDOWN
 
 ///How much charge is used up for each matter unit.
-#define MASS_TO_ENERGY (16)
+#define MASS_TO_ENERGY (0.016 * STANDARD_CELL_CHARGE)
 
 /obj/item/construction/rcd/exosuit
 	name = "mounted RCD"

--- a/code/game/objects/items/robot/items/generic.dm
+++ b/code/game/objects/items/robot/items/generic.dm
@@ -13,7 +13,7 @@
 	icon = 'icons/mob/silicon/robot_items.dmi'
 
 /// Cost to use the stun arm
-#define CYBORG_STUN_CHARGE_COST (10 * STANDARD_CELL_CHARGE)
+#define CYBORG_STUN_CHARGE_COST (STANDARD_CELL_CHARGE * 0.1)
 
 /obj/item/borg/stun
 	name = "electrically-charged arm"

--- a/code/game/objects/items/robot/items/generic.dm
+++ b/code/game/objects/items/robot/items/generic.dm
@@ -12,11 +12,12 @@
 /obj/item/borg
 	icon = 'icons/mob/silicon/robot_items.dmi'
 
+/// Cost to use the stun arm
+#define CYBORG_STUN_CHARGE_COST (10 * STANDARD_CELL_CHARGE)
+
 /obj/item/borg/stun
 	name = "electrically-charged arm"
 	icon_state = "elecarm"
-	/// Cost to use the stun arm
-	var/charge_cost = 1000
 	COOLDOWN_DECLARE(non_charge_cooldown)
 
 /obj/item/borg/stun/attack(mob/living/attacked_mob, mob/living/user)
@@ -27,7 +28,7 @@
 			return FALSE
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/robot_user = user
-		if(!robot_user.cell.use(charge_cost))
+		if(!robot_user.cell.use(CYBORG_STUN_CHARGE_COST))
 			return
 
 	user.do_attack_animation(attacked_mob)

--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -98,7 +98,7 @@
 	 */
 	var/max_volume_per_reagent = 30
 	/// Cell cost for charging a reagent
-	var/charge_cost = 50
+	var/charge_cost = 0.05 * STANDARD_CELL_CHARGE
 	/// Counts up to the next time we charge
 	var/charge_timer = 0
 	/// Time it takes for shots to recharge (in seconds)
@@ -297,7 +297,7 @@
 		Also metabolizes potassium iodide for radiation poisoning, inacusiate for ear damage and morphine for offense."
 	icon_state = "borghypo_s"
 	tgui_theme = "syndicate"
-	charge_cost = 20
+	charge_cost = 0.02 * STANDARD_CELL_CHARGE
 	recharge_time = 2
 	default_reagent_types = BASE_SYNDICATE_REAGENTS
 	bypass_protection = TRUE
@@ -310,7 +310,7 @@
 	icon_state = "shaker"
 	possible_transfer_amounts = list(5,10,20)
 	// Lots of reagents all regenerating at once, so the charge cost is lower. They also regenerate faster.
-	charge_cost = 20
+	charge_cost = 0.02 * STANDARD_CELL_CHARGE
 	recharge_time = 3
 	dispensed_temperature = WATER_MATTERSTATE_CHANGE_TEMP //Water stays wet, ice stays ice
 	default_reagent_types = BASE_SERVICE_REAGENTS
@@ -380,7 +380,7 @@
 	icon_state = "flour"
 	possible_transfer_amounts = list(5,10,20,1)
 	// Lots of reagents all regenerating at once, so the charge cost is lower. They also regenerate faster.
-	charge_cost = 40 //Costs double the power of the borgshaker due to synthesizing solids
+	charge_cost = 0.04 * STANDARD_CELL_CHARGE //Costs double the power of the borgshaker due to synthesizing solids
 	recharge_time = 6 //Double the recharge time too, for the same reason.
 	dispensed_temperature = WATER_MATTERSTATE_CHANGE_TEMP
 	default_reagent_types = HACKED_SERVICE_REAGENTS
@@ -444,7 +444,7 @@
 
 /obj/item/reagent_containers/borghypo/borgshaker/centcom
 	max_volume_per_reagent = 50
-	charge_cost = 5
+	charge_cost = 0.05 * STANDARD_CELL_CHARGE
 	recharge_time = 1
 
 /obj/item/reagent_containers/borghypo/borgshaker/centcom/Initialize(mapload)

--- a/code/game/objects/items/robot/items/tools.dm
+++ b/code/game/objects/items/robot/items/tools.dm
@@ -1,4 +1,5 @@
 #define PKBORG_DAMPEN_CYCLE_DELAY (2 SECONDS)
+#define POWER_RECHARGE_CYBORG_DRAIN_MULTIPLIER (0.4 KILO WATTS)
 
 /obj/item/cautery/prt //it's a subtype of cauteries so that it inherits the cautery sprites and behavior and stuff, because I'm too lazy to make sprites for this thing
 	name = "plating repair tool"
@@ -143,7 +144,7 @@
 			energy = clamp(energy + energy_recharge * seconds_per_tick, 0, maxenergy)
 			return
 	if(host.cell && (host.cell.charge >= (host.cell.maxcharge * cyborg_cell_critical_percentage)) && (energy < maxenergy))
-		host.cell.use(energy_recharge * seconds_per_tick * 0.4) // On TG POWER_RECHARGE_CYBORG_DRAIN_MULTIPLIER is 0.4
+		host.cell.use(energy_recharge * seconds_per_tick * POWER_RECHARGE_CYBORG_DRAIN_MULTIPLIER)
 		energy += energy_recharge * seconds_per_tick
 
 /obj/item/borg/projectile_dampen/proc/dampen_projectile(datum/source, obj/projectile/projectile)
@@ -157,3 +158,4 @@
 	tracked_bullet_cost -= REF(projectile)
 
 #undef PKBORG_DAMPEN_CYCLE_DELAY
+#undef POWER_RECHARGE_CYBORG_DRAIN_MULTIPLIER

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -295,7 +295,7 @@
 	/// Minimum time between repairs in seconds
 	var/repair_cooldown = 4
 	var/on = FALSE
-	var/powercost = 10
+	var/energy_cost = 0.01 * STANDARD_CELL_CHARGE
 	var/datum/action/toggle_action
 
 /obj/item/borg/upgrade/selfrepair/action(mob/living/silicon/robot/R, user = usr)
@@ -355,7 +355,7 @@
 			deactivate_sr()
 			return
 
-		if(cyborg.cell.charge < powercost * 2)
+		if(cyborg.cell.charge < energy_cost * 2)
 			to_chat(cyborg, span_alert("Self-repair module deactivated. Please recharge."))
 			deactivate_sr()
 			return
@@ -363,14 +363,14 @@
 		if(cyborg.health < cyborg.maxHealth)
 			if(cyborg.health < 0)
 				repair_amount = -2.5
-				powercost = 30
+				energy_cost = 0.03 * STANDARD_CELL_CHARGE
 			else
 				repair_amount = -1
-				powercost = 10
+				energy_cost = 0.01 * STANDARD_CELL_CHARGE
 			cyborg.adjustBruteLoss(repair_amount)
 			cyborg.adjustFireLoss(repair_amount)
 			cyborg.updatehealth()
-			cyborg.cell.use(powercost)
+			cyborg.cell.use(0.005 * STANDARD_CELL_CHARGE)
 		else
 			cyborg.cell.use(5)
 		next_repair = world.time + repair_cooldown * 10 // Multiply by 10 since world.time is in deciseconds

--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -1,3 +1,6 @@
+#define ACTIVATION_COST (0.3 * STANDARD_CELL_CHARGE)
+#define ACTIVATION_UP_KEEP (0.025 * STANDARD_CELL_RATE)
+
 /obj/item/borg_chameleon
 	name = "cyborg chameleon projector"
 	icon = 'icons/obj/device.dmi'
@@ -11,8 +14,6 @@
 	var/friendlyName
 	var/savedName
 	var/active = FALSE
-	var/activationCost = 300
-	var/activationUpkeep = 50
 	var/disguise = "engineer"
 	var/mob/listeningTo
 	var/static/list/signalCache = list( // list here all signals that should break the camouflage
@@ -44,13 +45,13 @@
 	disrupt(user)
 
 /obj/item/borg_chameleon/attack_self(mob/living/silicon/robot/user)
-	if (user && user.cell && user.cell.charge >  activationCost)
+	if (user && user.cell && user.cell.charge > ACTIVATION_COST)
 		if (isturf(user.loc))
 			toggle(user)
 		else
 			to_chat(user, span_warning("You can't use [src] while inside something!"))
 	else
-		to_chat(user, span_warning("You need at least [activationCost] charge in your cell to use [src]!"))
+		to_chat(user, span_warning("You need at least [display_energy(ACTIVATION_COST)] charge in your cell to use [src]!"))
 
 /obj/item/borg_chameleon/proc/toggle(mob/living/silicon/robot/user)
 	if(active)
@@ -65,7 +66,7 @@
 		to_chat(user, span_notice("You activate \the [src]."))
 		playsound(src, 'sound/effects/seedling_chargeup.ogg', 100, TRUE, -6)
 		apply_wibbly_filters(user)
-		if (do_after(user, 5 SECONDS, target = user, hidden = TRUE) && user.cell.use(activationCost))
+		if (do_after(user, 5 SECONDS, target = user, hidden = TRUE) && user.cell.use(ACTIVATION_COST))
 			playsound(src, 'sound/effects/bamf.ogg', 100, TRUE, -6)
 			to_chat(user, span_notice("You are now disguised as the Nanotrasen engineering borg \"[friendlyName]\"."))
 			activate(user)
@@ -75,9 +76,9 @@
 		remove_wibbly_filters(user)
 		animation_playing = FALSE
 
-/obj/item/borg_chameleon/process()
+/obj/item/borg_chameleon/process(seconds_per_tick)
 	if (user)
-		if (!user.cell || !user.cell.use(activationUpkeep))
+		if (!user.cell || !user.cell.use(ACTIVATION_UP_KEEP * seconds_per_tick))
 			disrupt(user)
 	else
 		return PROCESS_KILL
@@ -119,3 +120,6 @@
 	if(active)
 		to_chat(user, span_danger("Your chameleon field deactivates."))
 		deactivate(user)
+
+#undef ACTIVATION_COST
+#undef ACTIVATION_UP_KEEP

--- a/code/modules/atmospherics/machinery/air_alarm/air_alarm_interact.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/air_alarm_interact.dm
@@ -142,7 +142,7 @@
 
 			if(istype(attacking_item, /obj/item/electroadaptive_pseudocircuit))
 				var/obj/item/electroadaptive_pseudocircuit/P = attacking_item
-				if(!P.adapt_circuit(user, 25))
+				if(!P.adapt_circuit(user, 0.025 * STANDARD_CELL_CHARGE))
 					return
 				user.visible_message(span_notice("[user] fabricates a circuit and places it into [src]."), \
 				span_notice("You adapt an air alarm circuit and slot it into the assembly."))

--- a/code/modules/atmospherics/machinery/other/miner.dm
+++ b/code/modules/atmospherics/machinery/other/miner.dm
@@ -26,8 +26,8 @@
 	var/power_draw_dynamic_kpa_coeff = 0.5
 	var/broken = FALSE
 	var/broken_message = "ERROR"
-	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 1.5
-	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 2
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.15
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.2
 
 /obj/machinery/atmospherics/miner/Initialize(mapload)
 	. = ..()

--- a/code/modules/explorer_drone/loot.dm
+++ b/code/modules/explorer_drone/loot.dm
@@ -152,7 +152,6 @@ GLOBAL_LIST_INIT(adventure_loot_generator_index,generate_generator_index())
 	lefthand_file = 'icons/mob/inhands/items/firelance_lefthand.dmi'
 	var/windup_time = 10 SECONDS
 	var/melt_range = 3
-	var/charge_per_use = 200
 	var/obj/item/stock_parts/power_store/cell/cell
 
 /obj/item/firelance/Initialize(mapload)
@@ -175,7 +174,7 @@ GLOBAL_LIST_INIT(adventure_loot_generator_index,generate_generator_index())
 		return .
 	if(LAZYACCESS(user.do_afters, "firelance"))
 		return .
-	if(!cell.use(200))
+	if(!cell.use(0.2 * STANDARD_CELL_CHARGE))
 		to_chat(user,span_warning("[src]'s battery ran dry!"))
 		return .
 	ADD_TRAIT(user, TRAIT_IMMOBILIZED, REF(src))

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -6,6 +6,8 @@
 	density = TRUE
 	circuit = /obj/item/circuitboard/machine/plantgenes
 	pass_flags = PASSTABLE
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.5
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.5
 
 	var/obj/item/seeds/seed
 	var/obj/item/disk/plantgene/disk

--- a/code/modules/mob/living/basic/festivus_pole.dm
+++ b/code/modules/mob/living/basic/festivus_pole.dm
@@ -1,3 +1,6 @@
+///how much charge we give off to cells around us when rubbed
+#define FESTIVUS_RECHARGE_VALUE (0.075 * STANDARD_CELL_CHARGE)
+
 /mob/living/basic/festivus
 	name = "festivus pole"
 	desc = "Serenity now... SERENITY NOW!"
@@ -72,16 +75,16 @@
 	for(var/atom/affected in range(2, get_turf(src)))
 		if(istype(affected, /obj/item/stock_parts/power_store/cell))
 			var/obj/item/stock_parts/power_store/cell/cell = affected
-			cell.give(recharge_value)
+			cell.give(FESTIVUS_RECHARGE_VALUE)
 			cell.update_appearance()
 		if(istype(affected, /mob/living/silicon/robot))
 			var/mob/living/silicon/robot/robot = affected
 			if(robot.cell)
-				robot.cell.give(recharge_value)
+				robot.cell.give(FESTIVUS_RECHARGE_VALUE)
 		if(istype(affected, /obj/machinery/power/apc))
 			var/obj/machinery/power/apc/apc_target = affected
 			if(apc_target.cell)
-				apc_target.cell.give(recharge_value)
+				apc_target.cell.give(FESTIVUS_RECHARGE_VALUE)
 
 /datum/ai_planning_subtree/find_and_hunt_target/look_for_apcs
 	hunting_behavior = /datum/ai_behavior/hunt_target/apcs
@@ -119,3 +122,5 @@
 			return FALSE
 
 	return can_see(source, dinner, radius)
+
+#undef FESTIVUS_RECHARGE_VALUE

--- a/code/modules/mod/mod_link.dm
+++ b/code/modules/mod/mod_link.dm
@@ -239,7 +239,7 @@ GLOBAL_LIST_INIT(scryer_auto_link_freqs, zebra_typecacheof(list(
 /obj/item/clothing/neck/link_scryer/process(seconds_per_tick)
 	if(!mod_link.link_call)
 		return
-	cell.use(min(20 * seconds_per_tick, cell.charge))
+	cell.use(0.02 * STANDARD_CELL_RATE * seconds_per_tick, force = TRUE)
 
 /obj/item/clothing/neck/link_scryer/attackby(obj/item/attacked_by, mob/user, params)
 	. = ..()

--- a/code/modules/mod/modules/modules_ninja.dm
+++ b/code/modules/mod/modules/modules_ninja.dm
@@ -121,10 +121,6 @@
 	icon_state = "hacker"
 	removable = FALSE
 	incompatible_modules = list(/obj/item/mod/module/hacker)
-	/// Minimum amount of power we can drain in a single drain action
-	var/mindrain = 200
-	/// Maximum amount of power we can drain in a single drain action
-	var/maxdrain = 400
 	/// Whether or not the communication console hack was used to summon another antagonist.
 	var/communication_console_hack_success = FALSE
 	/// How many times the module has been used to force open doors.

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -30,9 +30,9 @@
 	///Light luminosity when turned on
 	var/light_strength = 2
 	///Power usage when the computer is open (screen is active) and can be interacted with.
-	var/base_active_power_usage = 500
+	var/base_active_power_usage = 50 WATTS
 	///Power usage when the computer is idle and screen is off (currently only applies to laptops)
-	var/base_idle_power_usage = 100
+	var/base_idle_power_usage = 10 WATTS
 
 	///CPU that handles most logic while this type only handles power and other specific things.
 	var/obj/item/modular_computer/processor/cpu

--- a/code/modules/power/apc/apc_attack.dm
+++ b/code/modules/power/apc/apc_attack.dm
@@ -119,7 +119,7 @@
 			if(machine_stat & BROKEN)
 				balloon_alert(user, "frame is too damaged!")
 				return
-			if(!pseudocircuit.adapt_circuit(user, 50))
+			if(!pseudocircuit.adapt_circuit(user, 0.05 * STANDARD_CELL_CHARGE))
 				return
 			user.visible_message(span_notice("[user] fabricates a circuit and places it into [src]."), \
 			span_notice("You adapt a power control board and click it into place in [src]'s guts."))
@@ -131,7 +131,7 @@
 			if(machine_stat & MAINT)
 				balloon_alert(user, "no board for a cell!")
 				return
-			if(!pseudocircuit.adapt_circuit(user, 500))
+			if(!pseudocircuit.adapt_circuit(user, 0.5 * STANDARD_CELL_CHARGE))
 				return
 			var/obj/item/stock_parts/power_store/cell/crap/empty/bad_cell = new(src)
 			bad_cell.forceMove(src)

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -13,6 +13,7 @@
 #define APC_CHANNEL_EQUIP_TRESHOLD 30
 ///Charge percentage at which the APC icon indicates discharging
 #define APC_CHANNEL_ALARM_TRESHOLD 75
+#define ROUNDSTART_APC_CHARGE 95
 
 /obj/machinery/power/apc
 	name = "area power controller"
@@ -39,7 +40,7 @@
 	///Reference to our internal cell
 	var/obj/item/stock_parts/power_store/cell
 	///Initial cell charge %
-	var/start_charge = 90
+	var/start_charge = ROUNDSTART_APC_CHARGE
 	///Type of cell we start with
 	var/cell_type = /obj/item/stock_parts/power_store/battery/upgraded //Base cell has 2500 capacity. Enter the path of a different cell you want to use. cell determines charge rates, max capacity, ect. These can also be changed with other APC vars, but isn't recommended to minimize the risk of accidental usage of dirty editted APCs
 	///State of the cover (closed, opened, removed)
@@ -769,3 +770,4 @@
 #undef APC_CHANNEL_LIGHT_TRESHOLD
 #undef APC_CHANNEL_EQUIP_TRESHOLD
 #undef APC_CHANNEL_ALARM_TRESHOLD
+#undef ROUNDSTART_APC_CHARGE

--- a/code/modules/power/lighting/light.dm
+++ b/code/modules/power/lighting/light.dm
@@ -314,11 +314,11 @@
 		if(is_full_charge() && !reagents)
 			return PROCESS_KILL
 		if(cell)
-			cell.charge = min(cell.maxcharge, cell.charge + LIGHT_EMERGENCY_POWER_USE) //Recharge emergency power automatically while not using it
+			charge_cell(LIGHT_EMERGENCY_POWER_USE * seconds_per_tick, cell = cell) //Recharge emergency power automatically while not using it
 	if(reagents) //with most reagents coming out at 300, and with most meaningful reactions coming at 370+, this rate gives a few seconds of time to place it in and get out of dodge regardless of input.
 		reagents.adjust_thermal_energy(8 * reagents.total_volume * SPECIFIC_HEAT_DEFAULT * seconds_per_tick)
 		reagents.handle_reactions()
-	if(low_power_mode && !use_emergency_power(LIGHT_EMERGENCY_POWER_USE))
+	if(low_power_mode && !use_emergency_power(LIGHT_EMERGENCY_POWER_USE * seconds_per_tick))
 		update(FALSE) //Disables emergency mode and sets the color to normal
 
 /obj/machinery/light/proc/burn_out()

--- a/code/modules/research/xenobiology/crossbreeding/_misc.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_misc.dm
@@ -84,8 +84,8 @@ Slimecrossing Items
 	name = "hypercharged slime core"
 	desc = "A charged yellow slime extract, infused with plasma. It almost hurts to touch. Its organic nature makes it immune to EMPs."
 	rating = 7
-	maxcharge = 50000
-	chargerate = 2500
+	maxcharge = STANDARD_CELL_CHARGE * 50
+	chargerate = STANDARD_CELL_RATE * 0.25
 
 //Barrier cube - Chilling Grey
 /obj/item/barriercube

--- a/code/modules/wiremod/shell/gun.dm
+++ b/code/modules/wiremod/shell/gun.dm
@@ -30,7 +30,7 @@
 	range = 7
 
 /obj/item/stock_parts/power_store/cell/emproof/wiremod_gun
-	maxcharge = 100
+	maxcharge = STANDARD_CELL_CHARGE
 
 /obj/item/gun/energy/wiremod_gun/Initialize(mapload)
 	. = ..()

--- a/monkestation/code/game/objects/items/devices/pocket_heater.dm
+++ b/monkestation/code/game/objects/items/devices/pocket_heater.dm
@@ -1,13 +1,7 @@
-/// How long one of these lasts with a 10 MJ cell, in seconds.
-#define HEATER_TIME 1800
-
-/// How much charge this consumes per second.
-#define CHARGE_PER_SECOND (10000 / HEATER_TIME)
-
-/obj/item/pocket_heater/loaded/Initialize(mapload)
-	. = ..()
-	cell = new /obj/item/stock_parts/power_store/cell/high(src)
-	capacitor = new /obj/item/stock_parts/capacitor(src)
+/// How long one of these lasts with a 10 KJ cell.
+#define HEATER_TIME (30 MINUTES)
+/// How much charge this consumes per second, using the define above.
+#define CHARGE_PER_SECOND ((10 * STANDARD_CELL_CHARGE) / HEATER_TIME)
 
 /obj/item/pocket_heater
 	name = "pocket heater"
@@ -20,6 +14,11 @@
 	var/obj/item/stock_parts/capacitor/capacitor
 
 	var/on = FALSE
+
+/obj/item/pocket_heater/loaded/Initialize(mapload)
+	. = ..()
+	cell = new /obj/item/stock_parts/power_store/cell/high(src)
+	capacitor = new /obj/item/stock_parts/capacitor(src)
 
 /obj/item/pocket_heater/Destroy(force)
 	. = ..()

--- a/monkestation/code/modules/antagonists/clock_cult/ark_subsystem/_ark_subsystem.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/ark_subsystem/_ark_subsystem.dm
@@ -25,9 +25,9 @@ PROCESSING_SUBSYSTEM_DEF(the_ark)
 	///How many clockwork airlocks have been created on reebe, used for limiting airlock spam
 	var/reebe_clockwork_airlock_count = 0
 	///How much power does the cult have stored
-	var/clock_power = 250
+	var/clock_power = STANDARD_CELL_CHARGE * 0.25
 	///What is the maximum amount of power the cult can have stored
-	var/max_clock_power = 250
+	var/max_clock_power = STANDARD_CELL_CHARGE * 0.25
 	///How much passive power does the cult have access to, this gets used for things like turning on structures
 	var/passive_power = 15
 	///The list of areas that has been marked by the cult, formatted as a filled with 1s for anti duplication

--- a/monkestation/code/modules/antimatter/code/control.dm
+++ b/monkestation/code/modules/antimatter/code/control.dm
@@ -11,8 +11,8 @@
 	anchored = FALSE
 	density = TRUE
 	use_power = IDLE_POWER_USE
-	idle_power_usage = 100
-	active_power_usage = 1000
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.1
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 10
 
 	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_UI_INTERACT | INTERACT_ATOM_REQUIRES_ANCHORED
 

--- a/monkestation/code/modules/art_sci_overrides/artifact_testers/zapper.dm
+++ b/monkestation/code/modules/art_sci_overrides/artifact_testers/zapper.dm
@@ -45,7 +45,7 @@
 		if("strength")
 			chosen_level = clamp(params["target"], 0, max_shock)
 			. = TRUE
-			active_power_usage = chosen_level * 5
+			active_power_usage = chosen_level * 5 KILO JOULES
 			return
 		if("shock")
 			shock()

--- a/monkestation/code/modules/blueshift/appliances/multi_charger.dm
+++ b/monkestation/code/modules/blueshift/appliances/multi_charger.dm
@@ -5,8 +5,8 @@
 	icon_state = "cchargermulti"
 	base_icon_state = "cchargermulti"
 	use_power = IDLE_POWER_USE
-	idle_power_usage = 5
-	active_power_usage = 60
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.05
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.6
 	power_channel = AREA_USAGE_EQUIP
 	circuit = /obj/item/circuitboard/machine/cell_charger_multi
 	pass_flags = PASSTABLE

--- a/monkestation/code/modules/cargoborg/code/cargoborg_items.dm
+++ b/monkestation/code/modules/cargoborg/code/cargoborg_items.dm
@@ -74,7 +74,7 @@
 	icon = 'icons/mecha/mecha_equipment.dmi' // Just some temporary sprites because I don't have any unique one yet
 	icon_state = "mecha_clamp"
 	/// How much power does it draw per operation?
-	var/charge_cost = 20
+	var/charge_cost = 0.02 * STANDARD_CELL_CHARGE
 	/// How many items can it hold at once in its internal storage?
 	var/storage_capacity = 5
 	/// Does it require the items it takes in to be wrapped in paper wrap? Can have unforeseen consequences, change to FALSE at your own risks.
@@ -445,7 +445,7 @@
 	check_amount()
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/robot_user = user
-		if(!robot_user.cell.use(10))
+		if(!robot_user.cell.use(0.012 * STANDARD_CELL_CHARGE))
 			to_chat(user, span_warning("Not enough power."))
 			return FALSE
 		shoot(target, user, click_params)

--- a/monkestation/code/modules/clothing/spacesuits/hardsuits/_hardsuit.dm
+++ b/monkestation/code/modules/clothing/spacesuits/hardsuits/_hardsuit.dm
@@ -1,6 +1,6 @@
 /// How much damage you take from an emp when wearing a hardsuit
 #define HARDSUIT_EMP_BURN 2 // a very orange number
-#define THERMAL_REGULATOR_COST 6 // this runs out fast if 18
+#define THERMAL_REGULATOR_COST (0.006 * STANDARD_CELL_CHARGE) // this runs out fast if 18 like spacesuits
 
 /obj/item/clothing/suit/space/hardsuit
 	name = "hardsuit"

--- a/monkestation/code/modules/holomaps/machinery.dm
+++ b/monkestation/code/modules/holomaps/machinery.dm
@@ -12,8 +12,8 @@
 	icon_state = "station_map"
 	layer = ABOVE_WINDOW_LAYER
 	use_power = IDLE_POWER_USE
-	idle_power_usage = 16
-	active_power_usage = 128
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.16
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION
 	circuit = /obj/item/circuitboard/machine/station_map
 	light_color = HOLOMAP_HOLOFIER
 

--- a/monkestation/code/modules/hydroponics/machines/splicer.dm
+++ b/monkestation/code/modules/hydroponics/machines/splicer.dm
@@ -5,6 +5,8 @@
 	base_icon_state = "splicer"
 	icon_state = "splicer"
 	circuit = /obj/item/circuitboard/machine/splicer
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.5
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.5
 
 	var/obj/item/seeds/seed_1
 	var/obj/item/seeds/seed_2

--- a/monkestation/code/modules/liquids/liquid_plumbers.dm
+++ b/monkestation/code/modules/liquids/liquid_plumbers.dm
@@ -7,8 +7,8 @@
 	icon_state = "active_input"
 	anchored = FALSE
 	density = FALSE
-	idle_power_usage = 10
-	active_power_usage = 1000
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.1
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION
 	buffer = 300
 	category="Distribution"
 	reagent_flags = NO_REACT

--- a/monkestation/code/modules/machining/machining_exclusives.dm
+++ b/monkestation/code/modules/machining/machining_exclusives.dm
@@ -160,9 +160,12 @@
 
 /obj/item/stock_parts/power_store/cell/pulsepack
 	name = "Pulse pack fusion core"
-	desc = "Exposed fusion product outside of containment field on an already sketchy ass power pack. There should be no reason you have this, and honestly you should tell an admin if you somehow got this, I'm too fucking lazy to code in an explosion if you somehow have this in your hand so good job, you broke the game. Now get back to beating the ERPers into a pulp spessman. Your server depends on you."
-	maxcharge = 500000
-	chargerate = 50000
+	desc = "Exposed fusion product outside of containment field on an already sketchy ass power pack. \
+		There should be no reason you have this, and honestly you should tell an admin if you somehow got this, \
+		I'm too fucking lazy to code in an explosion if you somehow have this in your hand so good job, you broke the game. \
+		Now get back to beating the ERPers into a pulp spessman. Your server depends on you."
+	maxcharge = STANDARD_CELL_CHARGE * 500
+	chargerate = STANDARD_CELL_RATE * 5
 
 //mecha armor plates
 /obj/item/mecha_parts/mecha_equipment/armor/hardened_exosuit_part

--- a/monkestation/code/modules/microfusion/code/microfusion_cell.dm
+++ b/monkestation/code/modules/microfusion/code/microfusion_cell.dm
@@ -12,7 +12,7 @@ Essentially, power cells that malfunction if not used in an MCR, and should only
 	icon = 'monkestation/code/modules/microfusion/icons/microfusion_cells.dmi'
 	icon_state = "microfusion"
 	w_class = WEIGHT_CLASS_NORMAL
-	maxcharge = 1200 //12 shots
+	maxcharge = STANDARD_CELL_CHARGE * 0.012 //12 shots
 	chargerate = 0 //MF cells should be unable to recharge if they are not currently inside of an MCR
 	microfusion_readout = TRUE
 	empty = TRUE //MF cells should start empty
@@ -169,7 +169,7 @@ Essentially, power cells that malfunction if not used in an MCR, and should only
 	name = "makeshift microfusion cell"
 	desc = "An... Apparatus, comprised of an everyday aluminum can with several civilian-grade batteries tightly packed together and plugged in. This vaguely resembles a microfusion cell, if you tilt your head to a precise fifty degree angle. While the effects on enemy combatants may be dubious, it will certainly do incredible damage to the gun's warranty. What the hell were you thinking when you came up with this?"
 	icon_state = "microfusion_makeshift"
-	maxcharge = 600
+	maxcharge = STANDARD_CELL_CHARGE * 0.06
 	max_attachments = 0
 
 /obj/item/stock_parts/power_store/cell/microfusion/makeshift/use(amount, force)
@@ -181,26 +181,26 @@ Essentially, power cells that malfunction if not used in an MCR, and should only
 	name = "enhanced microfusion cell"
 	desc = "A second generation microfusion cell, weighing about the same as the standard-issue cell and having the same space for attachments; however, it has a higher capacity."
 	icon_state = "microfusion_enhanced"
-	maxcharge = 1500
+	maxcharge = STANDARD_CELL_CHARGE * 0.15
 
 /obj/item/stock_parts/power_store/cell/microfusion/advanced
 	name = "advanced microfusion cell"
 	desc = "A third generation microfusion cell, boasting a much higher shot count. Additionally, these come with support for up to three modifications to the cell itself."
 	icon_state = "microfusion_advanced"
-	maxcharge = 1700
+	maxcharge = STANDARD_CELL_CHARGE * 0.17
 	max_attachments = 3
 
 /obj/item/stock_parts/power_store/cell/microfusion/bluespace
 	name = "bluespace microfusion cell"
 	desc = "A fourth generation microfusion cell, employing bluespace technology to store power in a medium that's bigger on the inside. This has capacity for four modifications to the cell."
 	icon_state = "microfusion_bluespace"
-	maxcharge = 2000
+	maxcharge = STANDARD_CELL_CHARGE * 0.2
 	max_attachments = 4
 
 /obj/item/stock_parts/power_store/cell/microfusion/nanocarbon
 	name = "nanocarbon fusion cell"
 	desc = "This cell combines both top-of-the-line nanotech and advanced microfusion power to brute force the most common issue of Nanotrasen Asset Protection operatives, ammunition, through sheer volume. Intended for use with Nanotrasen-brand capacitor arrays only. Warranty void if dropped in toilet."
 	icon_state = "microfusion_nanocarbon"
-	maxcharge = 30000
+	maxcharge = STANDARD_CELL_CHARGE * 3
 	max_attachments = 420
 

--- a/monkestation/code/modules/power/singularity/particle_accelerator/particle_controller.dm
+++ b/monkestation/code/modules/power/singularity/particle_accelerator/particle_controller.dm
@@ -6,8 +6,8 @@
 	anchored = FALSE
 	density = TRUE
 	use_power = NO_POWER_USE
-	idle_power_usage = 500
-	active_power_usage = 10000
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 5
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 10
 	dir = NORTH
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	var/strength_upper_limit = 2

--- a/monkestation/code/modules/ranching/items.dm
+++ b/monkestation/code/modules/ranching/items.dm
@@ -132,8 +132,8 @@
 	icon_state = "feed_producer"
 
 	use_power = IDLE_POWER_USE
-	idle_power_usage = 5
-	active_power_usage = 100
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.05
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.1
 	max_integrity = 300
 
 	circuit = /obj/item/circuitboard/machine/feed_machine
@@ -290,8 +290,8 @@
 	name = "Incubator"
 	desc = "For most eggs this can force them to hatch, that is unless a fresh mutation."
 	use_power = IDLE_POWER_USE
-	idle_power_usage = 2
-	active_power_usage = 500
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.02
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.5
 
 	max_integrity = 300
 	circuit = /obj/item/circuitboard/machine/egg_incubator

--- a/monkestation/code/modules/ranching/machines/grinder.dm
+++ b/monkestation/code/modules/ranching/machines/grinder.dm
@@ -3,8 +3,8 @@
 	desc = "This is how chicken nuggets are made boys and girls."
 	density = TRUE
 	use_power = IDLE_POWER_USE
-	idle_power_usage = 2
-	active_power_usage = 500
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.02
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.5
 
 	///placeholder
 	icon = 'icons/obj/kitchen.dmi'

--- a/monkestation/code/modules/slimecore/corral/machines/corral_corner.dm
+++ b/monkestation/code/modules/slimecore/corral/machines/corral_corner.dm
@@ -33,15 +33,13 @@
 	icon = 'monkestation/code/modules/slimecore/icons/machinery.dmi'
 	icon_state = "corral_corner"
 	circuit = /obj/item/circuitboard/machine/corral_corner
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.25
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.5
 
 	density = TRUE
 	var/max_range = 9
 	var/datum/corral_data/connected_data
 	var/mapping_id
-
-/obj/machinery/corral_corner/Initialize(mapload)
-	. = ..()
-	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/corral_corner/post_machine_initialize()
 	. = ..()

--- a/monkestation/code/modules/slimecore/machines/slime_market.dm
+++ b/monkestation/code/modules/slimecore/machines/slime_market.dm
@@ -7,8 +7,8 @@
 	density = TRUE
 	use_power = IDLE_POWER_USE
 	interaction_flags_machine = INTERACT_MACHINE_OPEN|INTERACT_MACHINE_ALLOW_SILICON|INTERACT_MACHINE_OFFLINE|INTERACT_MACHINE_OPEN_SILICON|INTERACT_MACHINE_SET_MACHINE|INTERACT_MACHINE_WIRES_IF_OPEN
-	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION
-	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.5
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.5
 	circuit = /obj/item/circuitboard/machine/slime_market_pad
 	var/obj/machinery/computer/slime_market/console
 

--- a/monkestation/code/modules/slimecore/machines/slime_market_computer.dm
+++ b/monkestation/code/modules/slimecore/machines/slime_market_computer.dm
@@ -10,6 +10,8 @@ GLOBAL_DATUM(default_slime_market, /obj/machinery/computer/slime_market)
 	keyboard_change_icon = FALSE
 	light_color = LIGHT_COLOR_LAVENDER
 	circuit = /obj/item/circuitboard/computer/slime_market
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.5
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.5
 	var/obj/machinery/slime_market_pad/market_pad
 	var/obj/machinery/slime_extract_requestor/request_pad
 	var/stored_credits = 0

--- a/monkestation/code/modules/slimecore/machines/slime_pen_controller.dm
+++ b/monkestation/code/modules/slimecore/machines/slime_pen_controller.dm
@@ -16,6 +16,8 @@ GLOBAL_LIST_EMPTY_TYPED(slime_pen_controllers, /obj/machinery/slime_pen_controll
 	icon = 'monkestation/code/modules/slimecore/icons/machinery.dmi'
 	base_icon_state = "slime_panel"
 	icon_state = "slime_panel"
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.25
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.5
 
 	var/obj/machinery/plumbing/ooze_sucker/linked_sucker
 	var/datum/corral_data/linked_data

--- a/monkestation/code/modules/smithing/machines/arc_forge.dm
+++ b/monkestation/code/modules/smithing/machines/arc_forge.dm
@@ -9,8 +9,8 @@
 	max_integrity = 1000
 	density = TRUE
 	use_power = IDLE_POWER_USE
-	idle_power_usage = 10
-	active_power_usage = 3000
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.1
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 3
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	circuit = null
 	light_outer_range = 5

--- a/monkestation/code/modules/smithing/machines/electroplater.dm
+++ b/monkestation/code/modules/smithing/machines/electroplater.dm
@@ -8,8 +8,8 @@
 	anchored = TRUE
 	density = TRUE
 
-	idle_power_usage = 10
-	active_power_usage = 2000
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.1
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 2
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	circuit = /obj/item/circuitboard/machine/electroplater
 

--- a/monkestation/code/modules/smithing/machines/material_alloyer.dm
+++ b/monkestation/code/modules/smithing/machines/material_alloyer.dm
@@ -9,8 +9,8 @@
 	max_integrity = 200
 	density = TRUE
 	use_power = IDLE_POWER_USE
-	idle_power_usage = 10
-	active_power_usage = 1500
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.1
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 1.5
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	circuit = /obj/item/circuitboard/machine/material_alloyer
 	light_outer_range = 3

--- a/monkestation/code/modules/smithing/machines/material_analyzer.dm
+++ b/monkestation/code/modules/smithing/machines/material_analyzer.dm
@@ -25,8 +25,8 @@
 	anchored = TRUE
 	density = TRUE
 
-	idle_power_usage = 10
-	active_power_usage = 750
+	idle_power_usage = BASE_MACHINE_IDLE_CONSUMPTION * 0.1
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.75
 	circuit = /obj/item/circuitboard/machine/material_analyzer
 
 	///the time we need to analyze a material

--- a/monkestation/code/modules/virology/machines/analyzer.dm
+++ b/monkestation/code/modules/virology/machines/analyzer.dm
@@ -11,8 +11,7 @@
 
 	circuit = /obj/item/circuitboard/machine/diseaseanalyser
 
-	idle_power_usage = 100
-	active_power_usage = 100//1000 extra power once per analysis
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.1 //1000 extra power once per analysis
 
 	var/process_time = 5
 	var/minimum_growth = 100

--- a/monkestation/code/modules/virology/machines/centrifuge.dm
+++ b/monkestation/code/modules/virology/machines/centrifuge.dm
@@ -30,8 +30,7 @@
 
 	circuit = /obj/item/circuitboard/machine/centrifuge
 
-	idle_power_usage = 100
-	active_power_usage = 300
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.3
 
 	var/base_efficiency = 1
 	var/upgrade_efficiency = 0.3 // the higher, the better will upgrade affect efficiency

--- a/monkestation/code/modules/virology/machines/incubator.dm
+++ b/monkestation/code/modules/virology/machines/incubator.dm
@@ -17,8 +17,7 @@
 	light_outer_range = 2
 	light_power = 1
 
-	idle_power_usage = 100
-	active_power_usage = 200
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.2
 
 	// Contains instances of /datum/dish_incubator_dish.
 	var/list/dish_data = list(null, null, null)

--- a/monkestation/code/modules/virology/machines/splicer.dm
+++ b/monkestation/code/modules/virology/machines/splicer.dm
@@ -6,6 +6,8 @@
 	name = "disease splicer"
 	icon = 'monkestation/code/modules/virology/icons/virology.dmi'
 	icon_state = "splicer"
+	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 0.6
+	light_color = "#00FF00"
 
 	icon_keyboard = null
 	icon_screen = null
@@ -21,10 +23,6 @@
 
 	///the slot we are set to grab from
 	var/target_slot = 1
-	idle_power_usage = 100
-	active_power_usage = 600
-
-	light_color = "#00FF00"
 
 /obj/machinery/computer/diseasesplicer/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(!isvirusdish(tool) && !istype(tool, /obj/item/disk/disease))


### PR DESCRIPTION
## About The Pull Request

Ports:
https://github.com/tgstation/tgstation/pull/82594
https://github.com/tgstation/tgstation/pull/88568
https://github.com/tgstation/tgstation/pull/82204

Minus the Ethereal and borg charger related stuff, because I really don't want to be touching that.

Also rebalances the power usage of certain machines around Atmospherics, Hydroponics and Xenobiology. They are the 3 biggest hoarders of power, and while they are still big they aren't massive anymore.
Also makes APCs start with 95% power rather than 90%, so they eat half as much power as they did previously.

With testing on local on MetaStation with no power input, it takes a little over 9 minutes for the SMES' to drain, that leaves 5-7 minutes until APCs start depowering. This hits the goal of ~15 minutes of power, leaving ample time for Engineering to get an engine (or solars/turbine/pacman) running to start charging SMES'.

If any mapper wishes, there's https://github.com/tgstation/tgstation/pull/74365 which reduces the overall number of lights on the station, which in turn lowers the power cost of lighting.

## Why It's Good For The Game

Power lasts for longer on the station and fixes some bad instances of powersinks on the station.

## Changelog

:cl:
fix: Power in several areas have been fixed, and the station should start to lose power by 9 minutes in, and start to depower by ~15 minutes.
/:cl:
