### PR TITLE
fixes remote injectors/patchers/factories

### DIFF
--- a/monkestation/code/modules/wiremod_chem/components/ouputs/factory_output.dm
+++ b/monkestation/code/modules/wiremod_chem/components/ouputs/factory_output.dm
@@ -89,6 +89,7 @@
 		var/pill_choice = show_radial_menu(user, src, pill_styles)
 		if(pill_choice)
 			pill_style = pill_choice
+	..()
 	return CLICK_ACTION_SUCCESS
 
 /obj/structure/chemical_tank/factory/attack_hand(mob/living/user, list/modifiers)

--- a/monkestation/code/modules/wiremod_chem/components/ouputs/injector_output.dm
+++ b/monkestation/code/modules/wiremod_chem/components/ouputs/injector_output.dm
@@ -37,4 +37,5 @@
 	if(inject_choice)
 		inject_amount = inject_choice
 	creator_ckey = user.client?.ckey
+	..()
 	return CLICK_ACTION_SUCCESS

--- a/monkestation/code/modules/wiremod_chem/components/ouputs/patcher_output.dm
+++ b/monkestation/code/modules/wiremod_chem/components/ouputs/patcher_output.dm
@@ -31,4 +31,5 @@
 	var/inject_choice = tgui_input_number(user, "How much to put into a patch?", "[name]", inject_amount, max_inject, 1)
 	if(inject_choice)
 		inject_amount = inject_choice
+	..()
 	return CLICK_ACTION_SUCCESS


### PR DESCRIPTION

## About The Pull Request
fixes #8787 

the click_alt got overridden, and didnt call parent, so it wouldnt print its component.
## Why It's Good For The Game
BEHOLD, MY WALL OF CEREALS, I COLLECT CEREALS. IT TOOK ME NINE YEAREALS TO COLLECT THE CEREALS, YUM YUM CEREAL _GOOOD._ (bugfix)
## Changelog
:cl:
fix: remote injectors, patchers, and factories now print their components again.
/:cl:
