### PR TITLE
Maybe blueshield shouldnt get a hellfire gun with 140 bullets

### DIFF
--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -10,7 +10,7 @@
 
 /obj/item/ammo_casing/energy/laser/hellfire/blueshield
 	projectile_type = /obj/projectile/beam/laser/hellfire
-	e_cost = LASER_SHOTS(13, 1000)
+	e_cost = LASER_SHOTS(13, STANDARD_CELL_CHARGE)
 	select_name = "maim"
 
 /obj/item/ammo_casing/energy/lasergun


### PR DESCRIPTION

## About The Pull Request
Fixes blue shield hellfire to have the intended 13 shots
## Why It's Good For The Game
Bullet
## Changelog
:cl:
fix: Blueshield modified hellfire will once again only have 13 shots. How 'lucky'
/:cl:
