### PR TITLE
stacking machine and xeno door prying fix

### DIFF
--- a/code/datums/elements/door_pryer.dm
+++ b/code/datums/elements/door_pryer.dm
@@ -35,11 +35,12 @@
 		attacker.balloon_alert(attacker, "busy!")
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
-	if (airlock_target.locked || airlock_target.welded || airlock_target.seal)
-		if (!(attacker.istate & ISTATE_HARM))
-			airlock_target.balloon_alert(attacker, "it's sealed!")
-			return COMPONENT_CANCEL_ATTACK_CHAIN
+	if ((attacker.istate & ISTATE_HARM))
 		return // Attack the door
+
+	if (airlock_target.locked || airlock_target.welded || airlock_target.seal)
+		airlock_target.balloon_alert(attacker, "it's sealed!")
+		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	INVOKE_ASYNC(src, PROC_REF(open_door), attacker, airlock_target)
 	return COMPONENT_CANCEL_ATTACK_CHAIN

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1529,9 +1529,9 @@
 		return
 	if(!density) //Already open
 		return ..()
+	if((user.istate & ISTATE_HARM))
+		return ..()
 	if(locked || welded || seal) //Extremely generic, as aliens only understand the basics of how airlocks work.
-		if((user.istate & ISTATE_HARM))
-			return ..()
 		to_chat(user, span_warning("[src] refuses to budge!"))
 		return
 	add_fingerprint(user)

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -2,7 +2,7 @@
 #define HEATER_MODE_HEAT "heat"
 #define HEATER_MODE_COOL "cool"
 #define HEATER_MODE_AUTO "auto"
-#define BASE_HEATING_ENERGY (40 KILO JOULES)
+#define BASE_HEATING_ENERGY (STANDARD_CELL_RATE * 0.1)
 
 /obj/machinery/space_heater
 	anchored = FALSE
@@ -20,7 +20,7 @@
 	//We don't use area power, we always use the cell
 	use_power = NO_POWER_USE
 	///The cell we spawn with
-	var/obj/item/stock_parts/power_store/cell/cell = /obj/item/stock_parts/power_store/cell
+	var/obj/item/stock_parts/power_store/cell = /obj/item/stock_parts/power_store/cell/high
 	///Is the machine on?
 	var/on = FALSE
 	///What is the mode we are in now?
@@ -464,7 +464,7 @@
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
 		capacitors_rating += capacitor.tier
 
-	heating_energy = lasers_rating * initial(heating_energy)
+	heating_energy = lasers_rating * BASE_HEATING_ENERGY
 
 	settable_temperature_range = capacitors_rating * initial(settable_temperature_range) //-20 - 80 at base
 	efficiency = (capacitors_rating + 1) * initial(efficiency) * 0.5

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -2,7 +2,7 @@
 #define HEATER_MODE_HEAT "heat"
 #define HEATER_MODE_COOL "cool"
 #define HEATER_MODE_AUTO "auto"
-#define BASE_HEATING_ENERGY (STANDARD_CELL_RATE * 0.1)
+#define BASE_HEATING_ENERGY (40 KILO JOULES)
 
 /obj/machinery/space_heater
 	anchored = FALSE
@@ -20,7 +20,7 @@
 	//We don't use area power, we always use the cell
 	use_power = NO_POWER_USE
 	///The cell we spawn with
-	var/obj/item/stock_parts/power_store/cell = /obj/item/stock_parts/power_store/cell/high
+	var/obj/item/stock_parts/power_store/cell/cell = /obj/item/stock_parts/power_store/cell
 	///Is the machine on?
 	var/on = FALSE
 	///What is the mode we are in now?
@@ -464,7 +464,7 @@
 	for(var/datum/stock_part/capacitor/capacitor in component_parts)
 		capacitors_rating += capacitor.tier
 
-	heating_energy = lasers_rating * BASE_HEATING_ENERGY
+	heating_energy = lasers_rating * initial(heating_energy)
 
 	settable_temperature_range = capacitors_rating * initial(settable_temperature_range) //-20 - 80 at base
 	efficiency = (capacitors_rating + 1) * initial(efficiency) * 0.5

--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -159,10 +159,10 @@ GLOBAL_LIST(labor_sheet_values)
 	points += inp.point_value * inp.amount
 	return ..()
 
-/obj/machinery/mineral/stacking_machine/laborstacker/attackby(obj/item/weapon, mob/user, params)
+/obj/machinery/mineral/stacking_machine/laborstacker/base_item_interaction(mob/living/user, obj/item/weapon, list/modifiers)
 	if(istype(weapon, /obj/item/stack/sheet))
 		process_sheet(weapon)
-		return
+		return ITEM_INTERACT_SUCCESS
 	return ..()
 
 /**********************Point Lookup Console**************************/


### PR DESCRIPTION
## About The Pull Request

fix xeno airlock interactions, now you properly hit airlock on combat mode and pry it open if not
closes https://github.com/Monkestation/Monkestation2.0/issues/8707
fix being unable to insert sheets into stacker on labor camp

i swear space heaters were broken but no they are fine actually maybe im insane

## Why It's Good For The Game
bug fixes
## Changelog
:cl:
fix: fixed xenos being unable to properly interact with airlocks
fix: fixed stacking machine on labor camp not accepting sheets
/:cl:
