### PR TITLE
[PORT] Fixes atmospherics components air relocation and unsafe pressure release, cryo chambers now use gas connector component

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -274,7 +274,7 @@
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/engineering)
 "dt" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell{
+/obj/machinery/cryo_cell{
 	dir = 4
 	},
 /turf/open/floor/iron/white/small,

--- a/_maps/RandomZLevels/SnowCabin.dmm
+++ b/_maps/RandomZLevels/SnowCabin.dmm
@@ -481,7 +481,7 @@
 /turf/open/floor/iron/white,
 /area/awaymission/cabin)
 "bF" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /turf/open/floor/iron/white,
 /area/awaymission/cabin)
 "bG" = (

--- a/_maps/RandomZLevels/research.dmm
+++ b/_maps/RandomZLevels/research.dmm
@@ -1071,7 +1071,7 @@
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/cryo)
 "fc" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/cryo)
 "fd" = (
@@ -1112,7 +1112,7 @@
 /area/awaymission/research/interior/cryo)
 "fh" = (
 /obj/effect/decal/cleanable/blood/drip,
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /turf/open/floor/iron/white,
 /area/awaymission/research/interior/cryo)
 "fi" = (

--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -3404,7 +3404,7 @@
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
 "aHV" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /turf/open/floor/iron,
 /area/station/medical/cryo)
 "aHY" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -30776,7 +30776,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "jSO" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -25179,7 +25179,7 @@
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "fUr" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell{
+/obj/machinery/cryo_cell{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/textured_large,
@@ -66126,7 +66126,7 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/security/armory)
 "pDy" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell{
+/obj/machinery/cryo_cell{
 	dir = 8
 	},
 /obj/machinery/status_display/ai/directional/south,

--- a/_maps/map_files/Graveyard/Graveyard.dmm
+++ b/_maps/map_files/Graveyard/Graveyard.dmm
@@ -48515,7 +48515,7 @@
 /turf/open/floor/grass,
 /area/station/service/hydroponics/garden)
 "sUV" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
@@ -55497,7 +55497,7 @@
 /turf/open/floor/iron/dark,
 /area/graveyard/bunker/command)
 "vCI" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -47420,7 +47420,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
 "kZC" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "kZH" = (

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -33775,7 +33775,7 @@
 /turf/open/floor/plating,
 /area/mine/eva/lower)
 "krx" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -59564,7 +59564,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
 "slK" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -23041,7 +23041,7 @@
 /area/station/medical/chemistry)
 "hjC" = (
 /obj/machinery/airalarm/directional/west,
-/obj/machinery/atmospherics/components/unary/cryo_cell{
+/obj/machinery/cryo_cell{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
@@ -70010,7 +70010,7 @@
 /area/station/security/checkpoint/supply)
 "vRs" = (
 /obj/machinery/status_display/evac/directional/west,
-/obj/machinery/atmospherics/components/unary/cryo_cell{
+/obj/machinery/cryo_cell{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,

--- a/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
+++ b/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
@@ -34449,7 +34449,7 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/storage)
 "qBx" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell{
+/obj/machinery/cryo_cell{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -38280,7 +38280,7 @@
 "smJ" = (
 /obj/machinery/light/directional/south,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/machinery/atmospherics/components/unary/cryo_cell{
+/obj/machinery/cryo_cell{
 	dir = 1
 	},
 /turf/open/floor/iron/diagonal,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -48520,7 +48520,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "qIR" = (
@@ -65790,7 +65790,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "wKg" = (

--- a/_maps/map_files/Ouroboros/Ouroboros.dmm
+++ b/_maps/map_files/Ouroboros/Ouroboros.dmm
@@ -39198,7 +39198,7 @@
 /area/station/ai_monitored/command/nuke_storage)
 "lxv" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/treatment_center)
 "lxN" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -39946,7 +39946,7 @@
 "mgW" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/blue/fourcorners,
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /turf/open/floor/iron,
 /area/station/medical/cryo)
 "mhw" = (

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -23984,7 +23984,7 @@
 /turf/open/floor/plating,
 /area/station/science/lower)
 "heq" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell{
+/obj/machinery/cryo_cell{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/blue{
@@ -37509,7 +37509,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/pumproom)
 "kXr" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell{
+/obj/machinery/cryo_cell{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/blue{

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -19963,7 +19963,7 @@
 /turf/open/floor/iron/large,
 /area/station/commons/fitness/recreation/entertainment)
 "fKN" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,
 /turf/open/floor/iron/dark/textured,
@@ -28586,7 +28586,7 @@
 /turf/closed/wall/r_wall,
 /area/station/medical/pharmacy)
 "ifS" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/dark_blue/fourcorners,

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -11912,7 +11912,7 @@
 /turf/open/floor/glass/reinforced,
 /area/station/engineering/break_room)
 "cEy" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell{
+/obj/machinery/cryo_cell{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -55533,7 +55533,7 @@
 /turf/open/floor/stone,
 /area/station/science/xenobiology)
 "qlk" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell{
+/obj/machinery/cryo_cell{
 	dir = 4
 	},
 /obj/machinery/light/directional/west,

--- a/_maps/shuttles/emergency_cere.dmm
+++ b/_maps/shuttles/emergency_cere.dmm
@@ -544,7 +544,7 @@
 /turf/open/floor/iron/white,
 /area/shuttle/escape)
 "ck" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},

--- a/_maps/shuttles/emergency_cruise.dmm
+++ b/_maps/shuttles/emergency_cruise.dmm
@@ -1573,7 +1573,7 @@
 /turf/open/floor/plastic,
 /area/shuttle/escape)
 "DJ" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -1913,7 +1913,7 @@
 /turf/open/floor/noslip,
 /area/shuttle/escape)
 "Jm" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},

--- a/_maps/shuttles/ert_generic.dmm
+++ b/_maps/shuttles/ert_generic.dmm
@@ -1373,7 +1373,7 @@
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/shuttle/ert/bridge)
 "Tv" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell{
+/obj/machinery/cryo_cell{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue/opposingcorners,

--- a/_maps/shuttles/pirate_ex_interdyne.dmm
+++ b/_maps/shuttles/pirate_ex_interdyne.dmm
@@ -280,7 +280,7 @@
 /area/shuttle/pirate)
 "aW" = (
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /turf/open/floor/iron/dark,
 /area/shuttle/pirate)
 "be" = (

--- a/_maps/shuttles/whiteship_box.dmm
+++ b/_maps/shuttles/whiteship_box.dmm
@@ -593,7 +593,7 @@
 "bs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -622,7 +622,7 @@
 "bu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},

--- a/_maps/templates/battlecruiser_starfury.dmm
+++ b/_maps/templates/battlecruiser_starfury.dmm
@@ -4057,7 +4057,7 @@
 /turf/open/floor/engine,
 /area/shuttle/sbc_starfury)
 "qQ" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/cryo_cell,
 /turf/open/floor/plating,
 /area/shuttle/sbc_starfury)
 "qS" = (

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -63,9 +63,9 @@
 #define COMSIG_SUPERMATTER_DELAM_ALARM "sm_delam_alarm"
 
 
-// /obj/machinery/atmospherics/components/unary/cryo_cell signals
+// /obj/machinery/cryo_cell signals
 
-/// from /obj/machinery/atmospherics/components/unary/cryo_cell/set_on(bool): (on)
+/// from /obj/machinery/cryo_cell/set_on(bool): (on)
 #define COMSIG_CRYO_SET_ON "cryo_set_on"
 
 /// from /obj/proc/unfreeze()

--- a/code/_globalvars/phobias.dm
+++ b/code/_globalvars/phobias.dm
@@ -286,7 +286,7 @@ GLOBAL_LIST_INIT(phobia_objs, list(
 		/obj/item/storage/pill_bottle,
 		/obj/item/surgical_drapes,
 		/obj/item/surgicaldrill,
-		/obj/machinery/atmospherics/components/unary/cryo_cell,
+		/obj/machinery/cryo_cell,
 		/obj/machinery/dna_scannernew,
 		/obj/machinery/door/airlock/medical,
 		/obj/machinery/sleeper,

--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -822,7 +822,7 @@
 /obj/item/circuitboard/machine/cryo_tube
 	name = "Cryotube"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
-	build_path = /obj/machinery/atmospherics/components/unary/cryo_cell
+	build_path = /obj/machinery/cryo_cell
 	req_components = list(
 		/datum/stock_part/matter_bin = 1,
 		/obj/item/stack/cable_coil = 1,

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -400,6 +400,9 @@
 			var/datum/gas_mixture/gas_mix = all_gas_mixes[gas_mix_number]
 			if(!gas_mix.total_moles())
 				empty_mixes++
+			if(!nodes[gas_mix_number] || (istype(nodes[gas_mix_number], /obj/machinery/atmospherics/components/unary/portables_connector) && !portable_device_connected(gas_mix_number)))
+				var/pressure_delta = all_gas_mixes[gas_mix_number].return_pressure() - env_air.return_pressure()
+				internal_pressure = internal_pressure > pressure_delta ? internal_pressure : pressure_delta
 		if(empty_mixes == device_type)
 			empty_pipe = TRUE
 	if(!int_air.total_moles())
@@ -620,6 +623,13 @@
 /obj/machinery/atmospherics/proc/set_pipe_color(pipe_colour)
 	src.pipe_color = uppertext(pipe_colour)
 	update_name()
+
+/// Return TRUE if there is device connected to portables_connector
+/obj/machinery/atmospherics/proc/portable_device_connected(node)
+	var/obj/machinery/atmospherics/components/unary/portables_connector/portable_devices_connector = nodes[node]
+	if(portable_devices_connector.connected_device)
+		return TRUE
+	return FALSE
 
 #undef PIPE_VISIBLE_LEVEL
 #undef PIPE_HIDDEN_LEVEL

--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -107,6 +107,10 @@
 	. = ..()
 	update_parents()
 
+/obj/machinery/atmospherics/components/on_deconstruction()
+	relocate_airs()
+	return ..()
+
 /obj/machinery/atmospherics/components/rebuild_pipes()
 	. = ..()
 	if(update_parents_after_rebuild)
@@ -174,31 +178,6 @@
 /obj/machinery/atmospherics/components/replace_pipenet(datum/pipeline/Old, datum/pipeline/New)
 	parents[parents.Find(Old)] = New
 
-/obj/machinery/atmospherics/components/unsafe_pressure_release(mob/user, pressures)
-	. = ..()
-
-	var/turf/current_turf = get_turf(src)
-	if(!current_turf)
-		return
-	//Remove the gas from airs and assume it
-	var/datum/gas_mixture/environment = current_turf.return_air()
-	var/lost = null
-	var/times_lost = 0
-	for(var/i in 1 to device_type)
-		var/datum/gas_mixture/air = airs[i]
-		lost += pressures*environment.volume/(air.temperature * R_IDEAL_GAS_EQUATION)
-		times_lost++
-	var/shared_loss = lost/times_lost
-
-	var/datum/gas_mixture/to_release
-	for(var/i in 1 to device_type)
-		var/datum/gas_mixture/air = airs[i]
-		if(!to_release)
-			to_release = air.remove(shared_loss)
-			continue
-		to_release.merge(air.remove(shared_loss))
-	current_turf.assume_air(to_release)
-
 // Helpers
 
 /**
@@ -246,6 +225,73 @@
 
 /obj/machinery/atmospherics/components/return_analyzable_air()
 	return airs
+
+/**
+ * Handles machinery deconstruction and unsafe pressure release
+ */
+/obj/machinery/atmospherics/components/proc/crowbar_deconstruction_act(mob/living/user, obj/item/tool, internal_pressure = 0)
+	if(!panel_open)
+		balloon_alert(user, "open panel!")
+		return ITEM_INTERACT_SUCCESS
+
+	var/unsafe_wrenching = FALSE
+	var/filled_pipe = FALSE
+	var/datum/gas_mixture/environment_air = loc.return_air()
+
+	for(var/i in 1 to device_type)
+		var/datum/gas_mixture/inside_air = airs[i]
+		if(inside_air.total_moles() > 0 || internal_pressure)
+			filled_pipe = TRUE
+		if(!nodes[i] || (istype(nodes[i], /obj/machinery/atmospherics/components/unary/portables_connector) && !portable_device_connected(i)))
+			internal_pressure = internal_pressure > airs[i].return_pressure() ? internal_pressure : airs[i].return_pressure()
+
+	if(!filled_pipe)
+		default_deconstruction_crowbar(tool)
+		return ITEM_INTERACT_SUCCESS
+
+	to_chat(user, span_notice("You begin to unfasten \the [src]..."))
+
+	internal_pressure -= environment_air.return_pressure()
+
+	if(internal_pressure > 2 * ONE_ATMOSPHERE)
+		to_chat(user, span_warning("As you begin deconstructing \the [src] a gush of air blows in your face... maybe you should reconsider?"))
+		unsafe_wrenching = TRUE
+
+	if(!do_after(user, 2 SECONDS, src))
+		return
+	if(unsafe_wrenching)
+		unsafe_pressure_release(user, internal_pressure)
+	tool.play_tool_sound(src, 50)
+	deconstruct(TRUE)
+	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/atmospherics/components/default_change_direction_wrench(mob/user, obj/item/I)
+	. = ..()
+	if(!.)
+		return FALSE
+	set_init_directions()
+	reconnect_nodes()
+	return TRUE
+
+/obj/machinery/atmospherics/components/proc/reconnect_nodes()
+	for(var/i in 1 to device_type)
+		var/obj/machinery/atmospherics/node = nodes[i]
+		if(node)
+			if(src in node.nodes)
+				node.disconnect(src)
+			nodes[i] = null
+		if(parents[i])
+			nullify_pipenet(parents[i])
+	for(var/i in 1 to device_type)
+		var/obj/machinery/atmospherics/node = nodes[i]
+		atmos_init()
+		node = nodes[i]
+		if(node)
+			node.atmos_init()
+			node.add_member(src)
+			update_parents()
+		SSair.add_to_rebuild_queue(src)
+	return TRUE
 
 /obj/machinery/atmospherics/components/paint(paint_color)
 	if(paintable)
@@ -300,3 +346,21 @@
 /obj/machinery/atmospherics/components/container_resist_act(mob/living/user)
 	INVOKE_ASYNC(user, TYPE_PROC_REF(/mob/living, handle_ventcrawl), src)
 // monkestation edit end
+
+/**
+ * Handles air relocation to the pipenet/environment
+ */
+/obj/machinery/atmospherics/components/proc/relocate_airs(datum/gas_mixture/to_release)
+	var/turf/local_turf = get_turf(src)
+	for(var/i in 1 to device_type)
+		var/datum/gas_mixture/air = airs[i]
+		if(!nodes[i] || (istype(nodes[i], /obj/machinery/atmospherics/components/unary/portables_connector) && !portable_device_connected(i)))
+			if(!to_release)
+				to_release = air
+				continue
+			to_release.merge(air)
+			continue
+		var/datum/gas_mixture/parents_air = parents[i].air
+		parents_air.merge(air)
+	if(to_release)
+		local_turf.assume_air(to_release)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_core.dm
@@ -198,3 +198,18 @@
 	QDEL_NULL(soundloop)
 	machine_parts = null
 	return..()
+
+/obj/machinery/atmospherics/components/unary/hypertorus/core/on_deconstruction()
+	var/turf/local_turf = get_turf(loc)
+	var/datum/gas_mixture/to_release = moderator_internal || internal_fusion
+	if(to_release == moderator_internal)
+		to_release.merge(internal_fusion)
+	if(to_release)
+		local_turf.assume_air(to_release)
+	return ..()
+
+/obj/machinery/atmospherics/components/unary/hypertorus/core/crowbar_deconstruction_act(mob/living/user, obj/item/tool, internal_pressure = 0)
+	internal_pressure = max(internal_fusion.return_pressure(), moderator_internal.return_pressure())
+	if(internal_pressure)
+		say("WARNING - Core can contain hazardous gases, deconstruct with caution!")
+	return ..(user, tool, internal_pressure)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_parts.dm
@@ -55,22 +55,8 @@
 		cracked = FALSE
 		update_appearance()
 
-/obj/machinery/atmospherics/components/unary/hypertorus/default_change_direction_wrench(mob/user, obj/item/I)
-	. = ..()
-	if(.)
-		set_init_directions()
-		var/obj/machinery/atmospherics/node = nodes[1]
-		if(node)
-			node.disconnect(src)
-			nodes[1] = null
-			if(parents[1])
-				nullify_pipenet(parents[1])
-		atmos_init()
-		node = nodes[1]
-		if(node)
-			node.atmos_init()
-			node.add_member(src)
-		SSair.add_to_rebuild_queue(src)
+/obj/machinery/atmospherics/components/unary/hypertorus/crowbar_act(mob/living/user, obj/item/tool)
+	return crowbar_deconstruction_act(user, tool)
 
 /obj/machinery/atmospherics/components/unary/hypertorus/update_icon_state()
 	if(panel_open)
@@ -201,6 +187,7 @@
 			ui.open()
 	else
 		to_chat(user, span_notice("Activate the machine first by using a multitool on the interface."))
+		ui?.close()
 
 /obj/machinery/hypertorus/interface/proc/gas_list_to_gasid_list(list/gas_list)
 	var/list/gasid_list = list()

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -41,6 +41,12 @@
 	internal = new
 	register_context()
 
+/obj/machinery/atmospherics/components/binary/crystallizer/on_deconstruction()
+	var/turf/local_turf = get_turf(loc)
+	if(internal.total_moles())
+		local_turf.assume_air(internal)
+	return ..()
+
 /obj/machinery/atmospherics/components/binary/crystallizer/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 	context[SCREENTIP_CONTEXT_CTRL_LMB] = "Turn [on ? "off" : "on"]"
@@ -59,42 +65,10 @@
 			return
 	if(default_change_direction_wrench(user, attacking_item))
 		return
-	if(default_deconstruction_crowbar(attacking_item))
-		return
 	return ..()
 
-/obj/machinery/atmospherics/components/binary/crystallizer/default_change_direction_wrench(mob/user, obj/item/I)
-	. = ..()
-	if(!.)
-		return FALSE
-	set_init_directions()
-	var/obj/machinery/atmospherics/node1 = nodes[1]
-	var/obj/machinery/atmospherics/node2 = nodes[2]
-	if(node1)
-		if(src in node1.nodes) //Only if it's actually connected. On-pipe version would is one-sided.
-			node1.disconnect(src)
-		nodes[1] = null
-	if(node2)
-		if(src in node2.nodes) //Only if it's actually connected. On-pipe version would is one-sided.
-			node2.disconnect(src)
-		nodes[2] = null
-
-	if(parents[1])
-		nullify_pipenet(parents[1])
-	if(parents[2])
-		nullify_pipenet(parents[2])
-
-	atmos_init()
-	node1 = nodes[1]
-	if(node1)
-		node1.atmos_init()
-		node1.add_member(src)
-	node2 = nodes[2]
-	if(node2)
-		node2.atmos_init()
-		node2.add_member(src)
-	SSair.add_to_rebuild_queue(src)
-	return TRUE
+/obj/machinery/atmospherics/components/binary/crystallizer/crowbar_act(mob/living/user, obj/item/tool)
+	return crowbar_deconstruction_act(user, tool, internal.return_pressure())
 
 /obj/machinery/atmospherics/components/binary/crystallizer/update_overlays()
 	. = ..()

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -24,7 +24,7 @@
 	/// The current occupant being presented
 	var/mob/living/occupant
 
-/atom/movable/visual/cryo_occupant/Initialize(mapload, obj/machinery/atmospherics/components/unary/cryo_cell/parent)
+/atom/movable/visual/cryo_occupant/Initialize(mapload, obj/machinery/cryo_cell/parent)
 	. = ..()
 	// Alpha masking
 	// It will follow this as the animation goes, but that's no problem as the "mask" icon state
@@ -65,7 +65,7 @@
 		animate(src)
 
 /// Cryo cell
-/obj/machinery/atmospherics/components/unary/cryo_cell
+/obj/machinery/cryo_cell
 	name = "cryo cell"
 	icon = 'icons/obj/medical/cryogenics.dmi'
 	icon_state = "pod-off"
@@ -75,7 +75,6 @@
 	layer = MOB_LAYER
 	state_open = FALSE
 	circuit = /obj/item/circuitboard/machine/cryo_tube
-	pipe_flags = PIPING_ONE_PER_TURF | PIPING_DEFAULT_LAYER_ONLY
 	occupant_typecache = list(/mob/living/carbon, /mob/living/simple_animal)
 	processing_flags = NONE
 
@@ -84,8 +83,6 @@
 	active_power_usage = BASE_MACHINE_ACTIVE_CONSUMPTION * 1.5
 	flags_1 = PREVENT_CLICK_UNDER_1
 	interaction_flags_mouse_drop = NEED_DEXTERITY
-
-	showpipe = FALSE
 
 	var/autoeject = TRUE
 	var/volume = 100
@@ -103,7 +100,6 @@
 	var/obj/item/radio/radio
 	var/radio_key = /obj/item/encryptionkey/headset_med
 	var/radio_channel = RADIO_CHANNEL_MEDICAL
-	vent_movement = NONE
 
 	/// Visual content - Occupant
 	var/atom/movable/visual/cryo_occupant/occupant_vis
@@ -117,15 +113,18 @@
 	payment_department = ACCOUNT_MED
 	var/adjusted_occupant = FALSE
 
+	/// Reference to the datum connector we're using to interface with the pipe network
+	var/datum/gas_machine_connector/internal_connector
+	/// Check if the machine has been turned on
+	var/on = FALSE
 
 /datum/armor/unary_cryo_cell
 	energy = 100
 	fire = 30
 	acid = 30
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/Initialize(mapload)
+/obj/machinery/cryo_cell/Initialize(mapload)
 	. = ..()
-	initialize_directions = dir
 	if(is_operational)
 		begin_processing()
 
@@ -137,17 +136,16 @@
 
 	occupant_vis = new(null, src)
 	vis_contents += occupant_vis
-	if(airs[1])
-		airs[1].volume = CELL_VOLUME * 0.5
 	register_context()
+	internal_connector = new(loc, src, dir, CELL_VOLUME * 0.5)
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
+/obj/machinery/cryo_cell/on_changed_z_level(turf/old_turf, turf/new_turf, same_z_layer, notify_contents)
 	. = ..()
 	if(same_z_layer)
 		return
 	SET_PLANE(occupant_vis, PLANE_TO_TRUE(occupant_vis.plane), new_turf)
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/set_occupant(atom/movable/new_occupant)
+/obj/machinery/cryo_cell/set_occupant(atom/movable/new_occupant)
 	if(occupant && isnull(new_occupant))
 		REMOVE_TRAIT(occupant, TRAIT_ASSISTED_BREATHING, REF(src))
 		if(isliving(occupant) && adjusted_occupant)
@@ -163,10 +161,10 @@
 			living.bodytemp_cold_damage_limit -= 270 KELVIN
 	update_appearance()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/on_construction(mob/user)
+/obj/machinery/cryo_cell/on_construction(mob/user)
 	..(user, dir, dir)
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/RefreshParts()
+/obj/machinery/cryo_cell/RefreshParts()
 	. = ..()
 	var/C
 	for(var/datum/stock_part/matter_bin/M in component_parts)
@@ -178,12 +176,12 @@
 	heat_capacity = initial(heat_capacity) / C
 	conduction_coefficient = initial(conduction_coefficient) * C
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/examine(mob/user) //this is leaving out everything but efficiency since they follow the same idea of "better beaker, better results"
+/obj/machinery/cryo_cell/examine(mob/user) //this is leaving out everything but efficiency since they follow the same idea of "better beaker, better results"
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
 		. += span_notice("The status display reads: Efficiency at <b>[efficiency*100]%</b>.")
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/add_context(atom/source, list/context, obj/item/held_item, mob/user)
+/obj/machinery/cryo_cell/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()
 	context[SCREENTIP_CONTEXT_CTRL_LMB] = "Turn [on ? "off" : "on"]"
 	context[SCREENTIP_CONTEXT_ALT_LMB] = "[state_open ? "Close" : "Open"] door"
@@ -196,23 +194,17 @@
 			context[SCREENTIP_CONTEXT_LMB] = "Rotate"
 	return CONTEXTUAL_SCREENTIP_SET
 
-
-/obj/machinery/atmospherics/components/unary/cryo_cell/Destroy()
+/obj/machinery/cryo_cell/Destroy()
 	vis_contents.Cut()
 
 	QDEL_NULL(occupant_vis)
 	QDEL_NULL(radio)
 	QDEL_NULL(beaker)
-	///Take the turf the cryotube is on
-	var/turf/T = get_turf(src)
-	if(T)
-		///Take the air composition inside the cryotube
-		var/datum/gas_mixture/air1 = airs[1]
-		T.assume_air(air1)
+	QDEL_NULL(internal_connector)
 
 	return ..()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/contents_explosion(severity, target)
+/obj/machinery/cryo_cell/contents_explosion(severity, target)
 	. = ..()
 	if(!beaker)
 		return
@@ -225,12 +217,12 @@
 		if(EXPLODE_LIGHT)
 			SSexplosions.low_mov_atom += beaker
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/handle_atom_del(atom/A)
+/obj/machinery/cryo_cell/handle_atom_del(atom/gone)
 	..()
-	if(A == beaker)
+	if(gone == beaker)
 		beaker = null
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/on_deconstruction()
+/obj/machinery/cryo_cell/on_deconstruction()
 	if(occupant)
 		occupant.vis_flags &= ~VIS_INHERIT_PLANE
 		REMOVE_TRAIT(occupant, TRAIT_IMMOBILIZED, CRYO_TRAIT)
@@ -240,15 +232,15 @@
 		beaker.forceMove(drop_location())
 		beaker = null
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/update_icon_state()
+/obj/machinery/cryo_cell/update_icon_state()
 	icon_state = (state_open) ? "pod-open" : ((on && is_operational) ? "pod-on" : "pod-off")
 	return ..()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/update_icon()
+/obj/machinery/cryo_cell/update_icon()
 	. = ..()
 	SET_PLANE_IMPLICIT(src, initial(plane))
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/update_overlays()
+/obj/machinery/cryo_cell/update_overlays()
 	. = ..()
 	if(panel_open)
 		. += "pod-panel"
@@ -257,13 +249,12 @@
 	if(on && is_operational)
 		. += mutable_appearance('icons/obj/medical/cryogenics.dmi', "cover-on", ABOVE_ALL_MOB_LAYER, src, plane = ABOVE_GAME_PLANE)
 	else
-		. += mutable_appearance('icons/obj/medical/cryogenics.dmi', "cover-on", ABOVE_ALL_MOB_LAYER, src, plane = ABOVE_GAME_PLANE)
+		. += mutable_appearance('icons/obj/medical/cryogenics.dmi', "cover-off", ABOVE_ALL_MOB_LAYER, src, plane = ABOVE_GAME_PLANE)
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/nap_violation(mob/violator)
+/obj/machinery/cryo_cell/nap_violation(mob/violator)
 	open_machine()
 
-
-/obj/machinery/atmospherics/components/unary/cryo_cell/set_on(active)
+/obj/machinery/cryo_cell/proc/set_on(active)
 	if(on == active)
 		return
 	SEND_SIGNAL(src, COMSIG_CRYO_SET_ON, active)
@@ -289,15 +280,14 @@
 			var/mob/living/living = occupant
 			living.bodytemp_cold_damage_limit += 270 KELVIN
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/on_set_is_operational(old_value)
+/obj/machinery/cryo_cell/on_set_is_operational(old_value)
 	if(old_value) //Turned off
 		set_on(FALSE)
 		end_processing()
 	else //Turned on
 		begin_processing()
 
-
-/obj/machinery/atmospherics/components/unary/cryo_cell/process(seconds_per_tick)
+/obj/machinery/cryo_cell/process(seconds_per_tick)
 	..()
 	if(!occupant)
 		return
@@ -360,7 +350,7 @@
 			radio.talk_into(src, msg, radio_channel)
 			return
 
-	var/datum/gas_mixture/air1 = airs[1]
+	var/datum/gas_mixture/air1 = internal_connector.gas_connector.airs[1]
 
 	if(air1.total_moles() > CRYO_MIN_GAS_MOLES)
 		if(beaker)
@@ -368,7 +358,7 @@
 			consume_gas = TRUE
 	return TRUE
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/process_atmos()
+/obj/machinery/cryo_cell/process_atmos()
 	..()
 	for(var/obj/item/organ/internal/brain/slime/malpractice_vic in src.contents)
 		malpractice_vic.forceMove(src.drop_location())
@@ -378,9 +368,9 @@
 	if(!on)
 		return
 
-	var/datum/gas_mixture/air1 = airs[1]
+	var/datum/gas_mixture/air1 = internal_connector.gas_connector.airs[1]
 
-	if(!nodes[1] || !airs[1] || !air1.gases.len || air1.total_moles() < CRYO_MIN_GAS_MOLES) // Turn off if the machine won't work.
+	if(!internal_connector.gas_connector.nodes[1] || !internal_connector.gas_connector.airs[1] || !air1.gases.len || air1.total_moles() < CRYO_MIN_GAS_MOLES) // Turn off if the machine won't work.
 		var/msg = "Insufficient cryogenic gas, shutting down."
 		radio.talk_into(src, msg, radio_channel)
 		set_on(FALSE)
@@ -409,25 +399,25 @@
 		if(air1.temperature > 2000)
 			take_damage(clamp((air1.temperature)/200, 10, 20), BURN)
 
-		update_parents()
+		internal_connector.gas_connector.update_parents()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/handle_internal_lifeform(mob/lifeform_inside_me, breath_request)
+/obj/machinery/cryo_cell/handle_internal_lifeform(mob/lifeform_inside_me, breath_request)
 
 	if(breath_request <= 0)
 		return null
-	var/datum/gas_mixture/air1 = airs[1]
+	var/datum/gas_mixture/air1 = internal_connector.gas_connector.airs[1]
 	var/breath_percentage = breath_request / air1.volume
 	return air1.remove(air1.total_moles() * breath_percentage)
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/assume_air(datum/gas_mixture/giver)
-	return airs[1].merge(giver)
+/obj/machinery/cryo_cell/assume_air(datum/gas_mixture/giver)
+	return internal_connector.gas_connector.airs[1].merge(giver)
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/relaymove(mob/living/user, direction)
+/obj/machinery/cryo_cell/relaymove(mob/living/user, direction)
 	if(message_cooldown <= world.time)
 		message_cooldown = world.time + 50
 		to_chat(user, span_warning("[src]'s door won't budge!"))
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/open_machine(drop = FALSE, density_to_set = FALSE)
+/obj/machinery/cryo_cell/open_machine(drop = FALSE, density_to_set = FALSE)
 	if(!state_open && !panel_open)
 		set_on(FALSE)
 	for(var/mob/M in contents) //only drop mobs
@@ -436,7 +426,7 @@
 	flick("pod-open-anim", src)
 	return ..()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/close_machine(mob/living/carbon/user, density_to_set = TRUE)
+/obj/machinery/cryo_cell/close_machine(mob/living/carbon/user, density_to_set = TRUE)
 	treating_wounds = FALSE
 	if((isnull(user) || istype(user)) && state_open && !panel_open)
 		if(loc == user?.loc)
@@ -446,7 +436,7 @@
 		..(user)
 		return occupant
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/container_resist_act(mob/living/user)
+/obj/machinery/cryo_cell/container_resist_act(mob/living/user)
 	user.changeNext_move(CLICK_CD_BREAKOUT)
 	user.last_special = world.time + CLICK_CD_BREAKOUT
 	user.visible_message(span_notice("You see [user] kicking against the glass of [src]!"), \
@@ -459,7 +449,7 @@
 			span_notice("You successfully break out of [src]!"))
 		open_machine()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/examine(mob/user)
+/obj/machinery/cryo_cell/examine(mob/user)
 	. = ..()
 	if(occupant)
 		if(on)
@@ -469,7 +459,7 @@
 	else
 		. += "[src] seems empty."
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/mouse_drop_receive(mob/living/dropped, mob/user, params)
+/obj/machinery/cryo_cell/mouse_drop_receive(mob/living/dropped, mob/user, params)
 	if(user.incapacitated() || !Adjacent(user) || !user.Adjacent(dropped) || !iscarbon(dropped) || !ISADVANCEDTOOLUSER(user))
 		return
 	if(isliving(dropped))
@@ -481,7 +471,7 @@
 		if (do_after(user, 2.5 SECONDS, target = dropped))
 			close_machine(dropped)
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/screwdriver_act(mob/living/user, obj/item/tool)
+/obj/machinery/cryo_cell/screwdriver_act(mob/living/user, obj/item/tool)
 
 	if(!on && !occupant && !state_open && (default_deconstruction_screwdriver(user, "pod-off", "pod-off", tool)))
 		update_appearance()
@@ -490,20 +480,20 @@
 		+ (on ? "active" : (occupant ? "full" : "open")) + "!</span>")
 	return ITEM_INTERACT_SUCCESS
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/crowbar_act(mob/living/user, obj/item/tool)
+/obj/machinery/cryo_cell/crowbar_act(mob/living/user, obj/item/tool)
 	if(on || state_open)
 		return FALSE
 	if(default_pry_open(tool) || default_deconstruction_crowbar(tool))
 		return ITEM_INTERACT_SUCCESS
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/wrench_act(mob/living/user, obj/item/tool)
+/obj/machinery/cryo_cell/wrench_act(mob/living/user, obj/item/tool)
 	if(on || occupant || state_open)
 		return FALSE
 	if(default_change_direction_wrench(user, tool))
 		update_appearance()
 		return ITEM_INTERACT_SUCCESS
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+/obj/machinery/cryo_cell/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	if(istype(attacking_item, /obj/item/reagent_containers/cup))
 		. = 1 //no afterattack
 		if(beaker)
@@ -519,17 +509,16 @@
 		return
 	return ..()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/ui_state(mob/user)
+/obj/machinery/cryo_cell/ui_state(mob/user)
 	return GLOB.notcontained_state
 
-
-/obj/machinery/atmospherics/components/unary/cryo_cell/ui_interact(mob/user, datum/tgui/ui)
+/obj/machinery/cryo_cell/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
 	if(!ui)
 		ui = new(user, src, "Cryo", name)
 		ui.open()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/ui_data(mob/user)
+/obj/machinery/cryo_cell/ui_data(mob/user)
 	var/list/data = list()
 	data["isOperating"] = on
 	data["hasOccupant"] = occupant ? TRUE : FALSE
@@ -564,7 +553,7 @@
 		data["occupant"]["toxLoss"] = round(mob_occupant.getToxLoss(), 1)
 		data["occupant"]["fireLoss"] = round(mob_occupant.getFireLoss(), 1)
 
-	var/datum/gas_mixture/air1 = airs[1]
+	var/datum/gas_mixture/air1 = internal_connector.gas_connector.airs[1]
 	data["cellTemperature"] = round(air1.temperature, 1)
 
 	data["isBeakerLoaded"] = beaker ? TRUE : FALSE
@@ -578,7 +567,7 @@
 	data["beakerContents"] = beakerContents
 	return data
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/ui_act(action, params)
+/obj/machinery/cryo_cell/ui_act(action, params)
 	. = ..()
 	if(.)
 		return
@@ -606,16 +595,16 @@
 				beaker = null
 				. = TRUE
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/can_interact(mob/user)
+/obj/machinery/cryo_cell/can_interact(mob/user)
 	return ..() && user.loc != src
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/click_ctrl(mob/user)
+/obj/machinery/cryo_cell/click_ctrl(mob/user)
 	if(can_interact(user) && !state_open)
 		if(set_on(!on))
 			balloon_alert(user, "turned [on ? "on" : "off"]")
 	return ..()
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/click_alt(mob/user)
+/obj/machinery/cryo_cell/click_alt(mob/user)
 	//Required so players don't close the cryo on themselves without a doctor's help
 	if(get_turf(user) == get_turf(src))
 		return CLICK_ACTION_BLOCKING
@@ -627,7 +616,7 @@
 	balloon_alert(user, "door [state_open ? "opened" : "closed"]")
 	return CLICK_ACTION_SUCCESS
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/mouse_drop_receive(mob/target, mob/user, params)
+/obj/machinery/cryo_cell/mouse_drop_receive(mob/target, mob/user, params)
 	if(!iscarbon(target))
 		return
 
@@ -641,39 +630,15 @@
 	if (do_after(user, 2.5 SECONDS, target=target))
 		close_machine(target)
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/get_remote_view_fullscreens(mob/user)
+/obj/machinery/cryo_cell/get_remote_view_fullscreens(mob/user)
 	user.overlay_fullscreen("remote_view", /atom/movable/screen/fullscreen/impaired, 1)
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/can_see_pipes()
-	return FALSE // you can't see the pipe network when inside a cryo cell.
-
-/obj/machinery/atmospherics/components/unary/cryo_cell/return_temperature()
-	var/datum/gas_mixture/G = airs[1]
+/obj/machinery/cryo_cell/return_temperature()
+	var/datum/gas_mixture/G = internal_connector.gas_connector.airs[1]
 
 	if(G.total_moles() > 10)
 		return G.temperature
 	return ..()
-
-/obj/machinery/atmospherics/components/unary/cryo_cell/default_change_direction_wrench(mob/user, obj/item/wrench/W)
-	. = ..()
-	if(.)
-		set_init_directions()
-		var/obj/machinery/atmospherics/node = nodes[1]
-		if(node)
-			node.disconnect(src)
-			nodes[1] = null
-			if(parents[1])
-				nullify_pipenet(parents[1])
-
-		atmos_init()
-		node = nodes[1]
-		if(node)
-			node.atmos_init()
-			node.add_member(src)
-		SSair.add_to_rebuild_queue(src)
-
-/obj/machinery/atmospherics/components/unary/cryo_cell/update_layer()
-	return
 
 #undef MAX_TEMPERATURE
 #undef CRYO_MULTIPLY_FACTOR

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -483,8 +483,44 @@
 /obj/machinery/cryo_cell/crowbar_act(mob/living/user, obj/item/tool)
 	if(on || state_open)
 		return FALSE
-	if(default_pry_open(tool) || default_deconstruction_crowbar(tool))
+	if(!panel_open)
+		balloon_alert(user, "open panel!")
 		return ITEM_INTERACT_SUCCESS
+
+	var/unsafe_wrenching = FALSE
+	var/filled_pipe = FALSE
+	var/datum/gas_mixture/environment_air = loc.return_air()
+	var/datum/gas_mixture/inside_air = internal_connector.gas_connector.airs[1]
+	var/obj/machinery/atmospherics/node = internal_connector.gas_connector.nodes[1]
+	var/internal_pressure = 0
+
+	if(istype(node, /obj/machinery/atmospherics/components/unary/portables_connector))
+		var/obj/machinery/atmospherics/components/unary/portables_connector/portable_devices_connector = node
+		internal_pressure = !portable_devices_connector.connected_device ? 1 : 0
+
+	if(inside_air.total_moles() > 0)
+		filled_pipe = TRUE
+		if(!node || internal_pressure > 0)
+			internal_pressure = inside_air.return_pressure() - environment_air.return_pressure()
+
+	if(!filled_pipe)
+		default_deconstruction_crowbar(tool)
+		return ITEM_INTERACT_SUCCESS
+
+	to_chat(user, span_notice("You begin to unfasten \the [src]..."))
+
+	if(internal_pressure > 2 * ONE_ATMOSPHERE)
+		to_chat(user, span_warning("As you begin deconstructing \the [src] a gush of air blows in your face... maybe you should reconsider?"))
+		unsafe_wrenching = TRUE
+
+	if(!do_after(user, 2 SECONDS, src))
+		return
+	if(unsafe_wrenching)
+		internal_connector.gas_connector.unsafe_pressure_release(user, internal_pressure)
+
+	tool.play_tool_sound(src, 50)
+	deconstruct(TRUE)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/cryo_cell/wrench_act(mob/living/user, obj/item/tool)
 	if(on || occupant || state_open)

--- a/code/modules/atmospherics/machinery/components/unary_devices/machine_connector.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/machine_connector.dm
@@ -1,0 +1,146 @@
+///To be used when there is the need of an atmos connection without repathing everything (eg: cryo.dm)
+/datum/gas_machine_connector
+
+	var/obj/machinery/connected_machine
+	var/obj/machinery/atmospherics/components/unary/gas_connector
+
+/datum/gas_machine_connector/New(location, obj/machinery/connecting_machine = null, direction = SOUTH, gas_volume)
+	connected_machine = connecting_machine
+	if(!connected_machine)
+		qdel(src)
+		return
+
+	gas_connector = new(location)
+	gas_connector.dir = connected_machine.dir
+	gas_connector.airs[1].volume = gas_volume
+
+	SSair.start_processing_machine(connected_machine)
+	register_with_machine()
+	gas_connector.set_init_directions()
+	gas_connector.atmos_init()
+	SSair.add_to_rebuild_queue(gas_connector)
+	RegisterSignal(gas_connector, COMSIG_QDELETING, PROC_REF(connector_deleted))
+
+/datum/gas_machine_connector/Destroy()
+	connected_machine = null
+	QDEL_NULL(gas_connector)
+	return ..()
+
+/datum/gas_machine_connector/proc/connector_deleted()
+	SIGNAL_HANDLER
+	gas_connector = null
+	if(!QDELETED(connected_machine))
+		qdel(connected_machine)
+
+/**
+ * Register various signals that are required for the proper work of the connector
+ */
+/datum/gas_machine_connector/proc/register_with_machine()
+	RegisterSignal(connected_machine, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(pre_move_connected_machine))
+	RegisterSignal(connected_machine, COMSIG_MOVABLE_MOVED, PROC_REF(moved_connected_machine))
+	RegisterSignal(connected_machine, COMSIG_MACHINERY_DEFAULT_ROTATE_WRENCH, PROC_REF(wrenched_connected_machine))
+	RegisterSignal(connected_machine, COMSIG_OBJ_DECONSTRUCT, PROC_REF(deconstruct_connected_machine))
+	RegisterSignal(connected_machine, COMSIG_QDELETING, PROC_REF(destroy_connected_machine))
+
+/**
+ * Unregister the signals previously registered
+ */
+/datum/gas_machine_connector/proc/unregister_from_machine()
+	UnregisterSignal(connected_machine, list(
+		COMSIG_MOVABLE_MOVED,
+		COMSIG_MOVABLE_PRE_MOVE,
+		COMSIG_MACHINERY_DEFAULT_ROTATE_WRENCH,
+		COMSIG_OBJ_DECONSTRUCT,
+		COMSIG_QDELETING
+	))
+
+/**
+ * Called when the machine has been moved, reconnect to the pipe network
+ */
+/datum/gas_machine_connector/proc/moved_connected_machine(obj/machinery/source, atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
+	SIGNAL_HANDLER
+	if(forced) // Called from parent doing abstract_move()
+		gas_connector.abstract_move(get_turf(connected_machine))
+		return // No side-effects means no disconnections
+
+	gas_connector.forceMove(get_turf(connected_machine))
+	reconnect_connector()
+
+/**
+ * Called before the machine moves, disconnect from the pipe network
+ */
+/datum/gas_machine_connector/proc/pre_move_connected_machine()
+	SIGNAL_HANDLER
+	disconnect_connector()
+
+/**
+ * Called when the machine has been rotated, resets the connection to the pipe network with the new direction
+ */
+/datum/gas_machine_connector/proc/wrenched_connected_machine()
+	SIGNAL_HANDLER
+	disconnect_connector()
+	reconnect_connector()
+
+/**
+ * Called when the machine has been deconstructed
+ */
+/datum/gas_machine_connector/proc/deconstruct_connected_machine()
+	SIGNAL_HANDLER
+
+	relocate_airs()
+
+/**
+ * Called when the machine has been destroyed
+ */
+/datum/gas_machine_connector/proc/destroy_connected_machine()
+	SIGNAL_HANDLER
+
+	disconnect_connector()
+	SSair.stop_processing_machine(connected_machine)
+	unregister_from_machine()
+	qdel(src)
+
+/**
+ * Handles the disconnection from the pipe network
+ */
+/datum/gas_machine_connector/proc/disconnect_connector()
+	var/obj/machinery/atmospherics/node = gas_connector.nodes[1]
+	if(node)
+		if(gas_connector in node.nodes) //Only if it's actually connected. On-pipe version would is one-sided.
+			node.disconnect(gas_connector)
+		gas_connector.nodes[1] = null
+	if(gas_connector.parents[1])
+		gas_connector.nullify_pipenet(gas_connector.parents[1])
+
+/**
+ * Handles the reconnection to the pipe network
+ */
+/datum/gas_machine_connector/proc/reconnect_connector()
+	gas_connector.dir = connected_machine.dir
+	gas_connector.set_init_directions()
+	var/obj/machinery/atmospherics/node = gas_connector.nodes[1]
+	gas_connector.atmos_init()
+	node = gas_connector.nodes[1]
+	if(node)
+		node.atmos_init()
+		node.add_member(gas_connector)
+		gas_connector.update_parents()
+	SSair.add_to_rebuild_queue(gas_connector)
+
+/**
+ * Handles air relocation to the pipe network/environment
+ */
+/datum/gas_machine_connector/proc/relocate_airs(mob/user)
+	var/turf/local_turf = get_turf(connected_machine)
+	var/datum/gas_mixture/inside_air = gas_connector.airs[1]
+	if(inside_air.total_moles() > 0)
+		if(!gas_connector.nodes[1])
+			local_turf.assume_air(inside_air)
+			return
+		var/datum/gas_mixture/parents_air = gas_connector.parents[1].air
+		if(istype(gas_connector.nodes[1], /obj/machinery/atmospherics/components/unary/portables_connector))
+			var/obj/machinery/atmospherics/components/unary/portables_connector/portable_devices_connector = gas_connector.nodes[1]
+			if(!portable_devices_connector.connected_device)
+				local_turf.assume_air(inside_air)
+				return
+		parents_air.merge(inside_air)

--- a/code/modules/atmospherics/machinery/pipes/multiz.dm
+++ b/code/modules/atmospherics/machinery/pipes/multiz.dm
@@ -9,7 +9,7 @@
 	initialize_directions = SOUTH
 
 	layer = HIGH_OBJ_LAYER
-	device_type = UNARY
+	device_type = TRINARY
 	paintable = FALSE
 
 	construction_type = /obj/item/pipe/directional
@@ -52,8 +52,8 @@
 	for(var/obj/machinery/atmospherics/pipe/multiz/above in GET_TURF_ABOVE(local_turf))
 		if(!is_connectable(above, piping_layer))
 			continue
-		nodes += above
-		above.nodes += src //Two way travel :)
+		nodes[2] = above
+		above.nodes[3] = src //Two way travel :)
 	for(var/obj/machinery/atmospherics/pipe/multiz/below in GET_TURF_BELOW(local_turf))
 		if(!is_connectable(below, piping_layer))
 			continue

--- a/code/modules/experisci/experiment/experiments.dm
+++ b/code/modules/experisci/experiment/experiments.dm
@@ -224,7 +224,7 @@
 		/obj/machinery/biogenerator = 3,
 		/obj/machinery/gibber = 3,
 		/obj/machinery/chem_master = 3,
-		/obj/machinery/atmospherics/components/unary/cryo_cell = 3,
+		/obj/machinery/cryo_cell = 3,
 		/obj/machinery/harvester = 5,
 		/obj/machinery/quantumpad = 5
 	)

--- a/monkestation/code/modules/blood_datum/vital_monitor/vital_reader.dm
+++ b/monkestation/code/modules/blood_datum/vital_monitor/vital_reader.dm
@@ -51,7 +51,7 @@
 	/// By default it will connect to these and grab their occupant to display as a patient.
 	var/static/list/connectable_typecache = typecacheof(list(
 		/obj/machinery/abductor/experiment,
-		/obj/machinery/atmospherics/components/unary/cryo_cell,
+		/obj/machinery/cryo_cell,
 		/obj/machinery/computer/operating, // Snowflaked
 		/obj/machinery/dna_scannernew,
 		/obj/machinery/gulag_teleporter,

--- a/monkestation/code/modules/blueshift/machines/sterling_generator.dm
+++ b/monkestation/code/modules/blueshift/machines/sterling_generator.dm
@@ -1,147 +1,4 @@
-///To be used when there is the need of an atmos connection without repathing everything (eg: cryo.dm)
-/datum/gas_machine_connector
-
-	var/obj/machinery/connected_machine
-	var/obj/machinery/atmospherics/components/unary/gas_connector
-
-/datum/gas_machine_connector/New(location, obj/machinery/connecting_machine = null, direction = SOUTH, gas_volume)
-	connected_machine = connecting_machine
-	if(!connected_machine)
-		qdel(src)
-		return
-
-	gas_connector = new(location)
-	gas_connector.dir = connected_machine.dir
-	gas_connector.airs[1].volume = gas_volume
-
-	SSair.start_processing_machine(connected_machine)
-	register_with_machine()
-	gas_connector.set_init_directions()
-	gas_connector.atmos_init()
-	SSair.add_to_rebuild_queue(gas_connector)
-	RegisterSignal(gas_connector, COMSIG_QDELETING, PROC_REF(connector_deleted))
-
-/datum/gas_machine_connector/Destroy()
-	connected_machine = null
-	QDEL_NULL(gas_connector)
-	return ..()
-
-/datum/gas_machine_connector/proc/connector_deleted()
-	SIGNAL_HANDLER
-	gas_connector = null
-	if(!QDELETED(connected_machine))
-		qdel(connected_machine)
-
-/**
- * Register various signals that are required for the proper work of the connector
- */
-/datum/gas_machine_connector/proc/register_with_machine()
-	RegisterSignal(connected_machine, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(pre_move_connected_machine))
-	RegisterSignal(connected_machine, COMSIG_MOVABLE_MOVED, PROC_REF(moved_connected_machine))
-	RegisterSignal(connected_machine, COMSIG_MACHINERY_DEFAULT_ROTATE_WRENCH, PROC_REF(wrenched_connected_machine))
-	RegisterSignal(connected_machine, COMSIG_OBJ_DECONSTRUCT, PROC_REF(deconstruct_connected_machine))
-	RegisterSignal(connected_machine, COMSIG_QDELETING, PROC_REF(destroy_connected_machine))
-
-/**
- * Unregister the signals previously registered
- */
-/datum/gas_machine_connector/proc/unregister_from_machine()
-	UnregisterSignal(connected_machine, list(
-		COMSIG_MOVABLE_MOVED,
-		COMSIG_MOVABLE_PRE_MOVE,
-		COMSIG_MACHINERY_DEFAULT_ROTATE_WRENCH,
-		COMSIG_OBJ_DECONSTRUCT,
-		COMSIG_QDELETING
-	))
-
-/**
- * Called when the machine has been moved, reconnect to the pipe network
- */
-/datum/gas_machine_connector/proc/moved_connected_machine()
-	SIGNAL_HANDLER
-	gas_connector.forceMove(get_turf(connected_machine))
-	reconnect_connector()
-
-/**
- * Called before the machine moves, disconnect from the pipe network
- */
-/datum/gas_machine_connector/proc/pre_move_connected_machine()
-	SIGNAL_HANDLER
-	disconnect_connector()
-
-/**
- * Called when the machine has been rotated, resets the connection to the pipe network with the new direction
- */
-/datum/gas_machine_connector/proc/wrenched_connected_machine()
-	SIGNAL_HANDLER
-	disconnect_connector()
-	reconnect_connector()
-
-/**
- * Called when the machine has been deconstructed
- */
-/datum/gas_machine_connector/proc/deconstruct_connected_machine()
-	SIGNAL_HANDLER
-
-	relocate_airs()
-
-/**
- * Called when the machine has been destroyed
- */
-/datum/gas_machine_connector/proc/destroy_connected_machine()
-	SIGNAL_HANDLER
-
-	disconnect_connector()
-	SSair.stop_processing_machine(connected_machine)
-	unregister_from_machine()
-	qdel(src)
-
-/**
- * Handles the disconnection from the pipe network
- */
-/datum/gas_machine_connector/proc/disconnect_connector()
-	var/obj/machinery/atmospherics/node = gas_connector.nodes[1]
-	if(node)
-		if(gas_connector in node.nodes) //Only if it's actually connected. On-pipe version would is one-sided.
-			node.disconnect(gas_connector)
-		gas_connector.nodes[1] = null
-	if(gas_connector.parents[1])
-		gas_connector.nullify_pipenet(gas_connector.parents[1])
-
-/**
- * Handles the reconnection to the pipe network
- */
-/datum/gas_machine_connector/proc/reconnect_connector()
-	gas_connector.dir = connected_machine.dir
-	gas_connector.set_init_directions()
-	var/obj/machinery/atmospherics/node = gas_connector.nodes[1]
-	gas_connector.atmos_init()
-	node = gas_connector.nodes[1]
-	if(node)
-		node.atmos_init()
-		node.add_member(gas_connector)
-		gas_connector.update_parents()
-	SSair.add_to_rebuild_queue(gas_connector)
-
-/**
- * Handles air relocation to the pipe network/environment
- */
-/datum/gas_machine_connector/proc/relocate_airs(mob/user)
-	var/turf/local_turf = get_turf(connected_machine)
-	var/datum/gas_mixture/inside_air = gas_connector.airs[1]
-	if(inside_air.total_moles() > 0)
-		if(!gas_connector.nodes[1])
-			local_turf.assume_air(inside_air)
-			return
-		var/datum/gas_mixture/parents_air = gas_connector.parents[1].air
-		if(istype(gas_connector.nodes[1], /obj/machinery/atmospherics/components/unary/portables_connector))
-			var/obj/machinery/atmospherics/components/unary/portables_connector/portable_devices_connector = gas_connector.nodes[1]
-			if(!portable_devices_connector.connected_device)
-				local_turf.assume_air(inside_air)
-				return
-		parents_air.merge(inside_air)
-
-// Stirling generator, like a miniature TEG, pipe hot air in, and keep the air around it cold
+/// Stirling generator, like a miniature TEG, pipe hot air in, and keep the air around it cold
 
 /obj/machinery/power/stirling_generator
 	name = "stirling generator"
@@ -171,7 +28,6 @@
 	/// Our looping fan sound that we play when turned on
 	var/datum/looping_sound/ore_thumper_fan/soundloop
 
-
 /obj/machinery/power/stirling_generator/Initialize(mapload)
 	. = ..()
 	soundloop = new(src, FALSE)
@@ -182,7 +38,6 @@
 	// This is just to make sure our atmos connection spawns facing the right way
 	setDir(dir)
 
-
 /obj/machinery/power/stirling_generator/examine(mob/user)
 	. = ..()
 	. += span_notice("You can use a <b>wrench</b> with <b>Left-Click</b> to rotate the generator.")
@@ -190,11 +45,9 @@
 	. += span_notice("It is currently generating <b>[current_power_generation / 1000] kW</b> of power.")
 	. += span_notice("It has a maximum power output of <b>[max_power_output / 1000] kW</b> at a temperature difference of <b>[max_efficient_heat_difference] K</b>.")
 
-
 /obj/machinery/power/stirling_generator/Destroy()
 	QDEL_NULL(connected_chamber)
 	return ..()
-
 
 /obj/machinery/power/stirling_generator/process_atmos()
 	if(!powernet)
@@ -225,7 +78,6 @@
 	var/effective_energy_transfer = round((max_efficient_heat_difference / min(gas_temperature_delta, max_efficient_heat_difference)), 0.01)
 	current_power_generation = round(max_power_output / effective_energy_transfer)
 
-
 /obj/machinery/power/stirling_generator/process()
 	var/power_output = round(current_power_generation)
 	add_avail(power_output)
@@ -236,18 +88,14 @@
 	else if(!soundloop.is_active() && power_output)
 		soundloop.start()
 
-
 /obj/machinery/power/stirling_generator/default_deconstruction_screwdriver(mob/user, icon_state_open, icon_state_closed, obj/item/screwdriver)
 	return
-
 
 /obj/machinery/power/stirling_generator/default_deconstruction_crowbar(obj/item/crowbar, ignore_panel, custom_deconstruct)
 	return
 
-
 /obj/machinery/power/stirling_generator/wrench_act(mob/living/user, obj/item/tool)
 	return default_change_direction_wrench(user, tool)
-
 
 /obj/machinery/power/stirling_generator/default_change_direction_wrench(mob/user, obj/item/wrench)
 	if(wrench.tool_behaviour != TOOL_WRENCH)
@@ -263,7 +111,6 @@
 /obj/machinery/power/stirling_generator/Destroy()
 	QDEL_NULL(connected_chamber)
 	return ..()
-
 
 // Item for creating stirling generators
 

--- a/monkestation/code/modules/virology/immune_systems/_immune_system.dm
+++ b/monkestation/code/modules/virology/immune_systems/_immune_system.dm
@@ -127,7 +127,7 @@
 						tally += 1
 					else
 						tally += 2//if we're sleeping in a bed, we get up to 4
-			else if(istype(host.loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
+			else if(istype(host.loc, /obj/machinery/cryo_cell))
 				tally += 2.5
 
 			tally *= boost
@@ -151,7 +151,7 @@
 						tally += 1
 					else
 						tally += 2//if we're sleeping in a bed, we get up to 5.5
-			else if(istype(host.loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
+			else if(istype(host.loc, /obj/machinery/cryo_cell))
 				tally += 3.5
 
 			if(!HAS_TRAIT(host, TRAIT_NOHUNGER))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3495,6 +3495,7 @@
 #include "code\modules\atmospherics\machinery\components\unary_devices\bluespace_sender.dm"
 #include "code\modules\atmospherics\machinery\components\unary_devices\cryo.dm"
 #include "code\modules\atmospherics\machinery\components\unary_devices\heat_exchanger.dm"
+#include "code\modules\atmospherics\machinery\components\unary_devices\machine_connector.dm"
 #include "code\modules\atmospherics\machinery\components\unary_devices\outlet_injector.dm"
 #include "code\modules\atmospherics\machinery\components\unary_devices\passive_vent.dm"
 #include "code\modules\atmospherics\machinery\components\unary_devices\portables_connector.dm"

--- a/tools/UpdatePaths/Scripts/78273_cryo_removed_atmosmachinery_path.txt
+++ b/tools/UpdatePaths/Scripts/78273_cryo_removed_atmosmachinery_path.txt
@@ -1,0 +1,2 @@
+#Updates cryo cells pathing by removing the atmosmachinery path
+/obj/machinery/atmospherics/components/unary/cryo_cell : /obj/machinery/cryo_cell{@OLD}


### PR DESCRIPTION
## About The Pull Request

Ports:
https://github.com/tgstation/tgstation/pull/76933
https://github.com/tgstation/tgstation/pull/78273 (`gas_machine_connect` was ported before, so only cryo cell changes)
https://github.com/tgstation/tgstation/pull/88526
https://github.com/tgstation/tgstation/pull/80244

>- Each /obj/machinery/atmospherics/components deconstruction will move air into connected pipeline if any, otherwise it will be released from open nodes, HFR internals or if there is portable connector that has no device connected will also release air outside. The user will also be notified of deconstruction and if pressure inside is safe for action.
>- The /obj/machinery/atmospherics/components/unsafe_pressure_release() will act like a normal pipe unsafe_pressure_release() if there is an empty node with air.
>- When HFR interface is turned off - UI will be closed.
>- Thermomachine and Bluespace sender will always try to connect to pipe if they are anchored.
>- Air inside of nodes will move to connected pipenet after the machinery is rotated.

## Why It's Good For The Game

Losing(deleting) air when disconnecting pumps/vents/etc doesn't feel good.

## Changelog
:cl:
fix: (mogeoko) Atmospherics components will now move air into connected pipeline on deconstruction if possible. Otherwise, air will be released to the outside from open nodes.
fix: (mogeoko) Unsafe pressure release on atmos components will now work the same way it does in the normal pipes if there is an empty node with air.
fix: (mogeoko) Atmospherics machinery will now share air from nodes after being rotated and reconnected to pipenet.
fix: (JohnFulpWillard) Cryo cells no longer appear on when off.
/:cl:
