### PR TITLE
Oozeling bloodsuckers now lose blood from water (and also fix the ocean not melting oozelings)

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
@@ -208,7 +208,6 @@
 		return NONE
 	if(HAS_TRAIT(slime, TRAIT_GODMODE)) // we're [title card]
 		return NONE
-	var/water_multiplier = 1
 	// thick clothing won't protect you if you just drink or inject tho
 	var/check_clothes = methods & ~(INGEST|INJECT)
 	if(!water_exposure(slime, check_clothes))

--- a/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
@@ -110,8 +110,6 @@
 		spec_slime_hunger(slime, seconds_per_tick)
 	if(!HAS_TRAIT(slime, TRAIT_SLIME_HYDROPHOBIA))
 		spec_slime_wetness(slime, seconds_per_tick)
-		if(isoceanturf(slime.loc))
-			water_exposure(slime, check_clothes = TRUE, quiet_if_protected = TRUE)
 
 /// Handles slimes losing blood from having wet stacks.
 /datum/species/oozeling/proc/spec_slime_wetness(mob/living/carbon/human/slime, seconds_per_tick)

--- a/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
+++ b/code/modules/mob/living/carbon/human/species_types/oozeling/_oozelings.dm
@@ -118,13 +118,13 @@
 		return
 
 	if(wetness.stacks > DAMAGE_WATER_STACKS)
-		remove_blood_volume(2 * seconds_per_tick)
+		remove_blood_volume(slime, 2 * seconds_per_tick)
 		slime.balloon_alert(slime, "too wet, dry off!")
 		if(SPT_PROB(25, seconds_per_tick))
 			slime.visible_message(span_danger("[slime]'s form begins to lose cohesion, seemingly diluting with the water!"), span_warning("The water starts to dilute your body, dry it off!"))
 	else if(wetness.stacks > REGEN_WATER_STACKS && SPT_PROB(25, seconds_per_tick)) //Used for old healing system. Maybe use later? For now increase loss for being soaked.
 		to_chat(slime, span_warning("You can't pull your body together, it is dripping wet!"))
-		remove_blood_volume(seconds_per_tick)
+		remove_blood_volume(slime, seconds_per_tick)
 		slime.balloon_alert(slime, "you're dripping wet!")
 
 /// Handles slimes losing blood from starving.
@@ -219,7 +219,7 @@
 	if(HAS_TRAIT(slime, TRAIT_SLIME_HYDROPHOBIA))
 		to_chat(slime, span_warning("Water splashes against your oily membrane and rolls right off your body!"))
 		return COMPONENT_NO_EXPOSE_REAGENTS
-	remove_blood_volume(30 * water_multiplier)
+	remove_blood_volume(slime, 30 * water_multiplier)
 	if(COOLDOWN_FINISHED(src, water_alert_cooldown))
 		slime.visible_message(
 			span_warning("[slime]'s form melts away from the water!"),
@@ -263,7 +263,7 @@
 		if(HAS_TRAIT(slime, TRAIT_SLIME_HYDROPHOBIA) || HAS_TRAIT(slime, TRAIT_GODMODE) || slime.blood_volume <= 0)
 			return ..()
 
-		remove_blood_volume(3 * seconds_per_tick)
+		remove_blood_volume(slime, 3 * seconds_per_tick)
 		chem.holder?.remove_reagent(chem.type, min(chem.volume * 0.22, 10))
 		if(SPT_PROB(25, seconds_per_tick))
 			to_chat(slime, span_warning("The water starts to weaken and adulterate your insides!"))

--- a/monkestation/code/modules/liquids/liquid_status_effect.dm
+++ b/monkestation/code/modules/liquids/liquid_status_effect.dm
@@ -40,12 +40,22 @@
 	duration = STATUS_EFFECT_PERMANENT
 	alert_type = null
 
+/datum/status_effect/ocean_affected/on_apply()
+	if(!isoceanturf(get_turf(owner)))
+		return FALSE
+	return TRUE
+
 /datum/status_effect/ocean_affected/tick()
 	var/turf/ocean_turf = get_turf(owner)
-	if(!istype(ocean_turf, /turf/open/floor/plating/ocean))
+	if(!isoceanturf(ocean_turf))
 		qdel(src)
+		return
 
 	if(ishuman(owner))
 		var/mob/living/carbon/human/arrived = owner
-		if(is_species(owner, /datum/species/ipc) && !(arrived.wear_suit?.clothing_flags & STOPSPRESSUREDAMAGE))
-			arrived.adjustFireLoss(5)
+		if(isipc(arrived))
+			if(!(arrived.wear_suit?.clothing_flags & STOPSPRESSUREDAMAGE))
+				arrived.take_overall_damage(burn = 5)
+		else if(isoozeling(arrived) && !HAS_TRAIT(arrived, TRAIT_SLIME_HYDROPHOBIA))
+			var/datum/species/oozeling/oozeling = arrived.dna.species
+			oozeling.water_exposure(arrived, check_clothes = TRUE, quiet_if_protected = TRUE)


### PR DESCRIPTION
## About The Pull Request

exactly what it says on the tin: bloodsucker oozelings now lose blood from being sprayed with water, just like normal oozelings.

hydrophobia still works and all. they're just now actually affected by water in the same way normal oozelings are.

also fixed Oshan's ocean tiles not melting oozelings as you'd expect them to.

## Why It's Good For The Game

shut up about oozeling bloodsuckers being OP

## Changelog
:cl:
balance: Oozeling bloodsuckers now lose blood from water, just like normal oozelings.
fix: Oozelings are now properly melted by ocean water.
/:cl:
