### PR TITLE
Fixes PACMANs saying they produce half of what they actually produce on examine

### DIFF
--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -114,7 +114,7 @@
 
 /obj/machinery/power/port_gen/pacman/examine(mob/user)
 	. = ..()
-	. += span_notice("The generator has [sheets] units of [sheet_name] fuel left, producing [display_power(power_gen)].")
+	. += span_notice("The generator has [sheets] units of [sheet_name] fuel left, producing [display_power(power_gen, convert = FALSE)].")
 	if(anchored)
 		. += span_notice("It is anchored to the ground.")
 


### PR DESCRIPTION

## About The Pull Request

Now they actually say how much power they produce on examine

## Why It's Good For The Game

Stops overestimating how many PACMANs are needed to fufill power requirements on examination i guess

## Changelog
:cl: ilikesaying

fix: Fixed PACMANs saying they produce half of what they actually produce on examine
/:cl:
