### PR TITLE
update darkspawn resistance descriptions to be accurate

### DIFF
--- a/code/modules/antagonists/darkspawn/darkspawn_upgrades/passive_upgrades.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_upgrades/passive_upgrades.dm
@@ -61,7 +61,7 @@
 
 /datum/psi_web/stamina_res
 	name = "Vigor Sigils"
-	desc = "Unlocking this sigil reduces stamina damage taken by 50%, stacks diminishingly."
+	desc = "Unlocking this sigil reduces stamina damage taken by 40%, stacks diminishingly."
 	lore_description = "The Kalak sigils, representing eternity, are etched onto the legs."
 	icon_state = "vigor"
 	willpower_cost = 2
@@ -160,7 +160,7 @@
 //Halves lightburn damage.
 /datum/psi_web/light_resistance
 	name = "Shadowskin Sigil"
-	desc = "Unlocking this sigil reduces light damage taken by 40%, stacks diminishingly."
+	desc = "Unlocking this sigil reduces light damage taken by 25%, stacks diminishingly."
 	lore_description = "The Xlynsh sigil, representing refraction, is etched onto the abdomen."
 	icon_state = "shadow_skin"
 	willpower_cost = 3
@@ -176,7 +176,7 @@
 
 /datum/psi_web/brute_res
 	name = "Callous Sigil"
-	desc = "Unlocking this sigil reduces brute damage taken by 40%, stacks diminishingly."
+	desc = "Unlocking this sigil reduces brute damage taken by 25%, stacks diminishingly."
 	lore_description = "The Hh'sha sigil, representing perserverance, is etched onto the abdomen."
 	icon_state = "callous"
 	willpower_cost = 3
@@ -192,7 +192,7 @@
 
 /datum/psi_web/burn_res
 	name = "Stifle Sigil"
-	desc = "Unlocking this sigil reduces burn damage taken by 40%, stacks diminishingly."
+	desc = "Unlocking this sigil reduces burn damage taken by 25%, stacks diminishingly."
 	lore_description = "The Khophg sigil, representing suffocation, is etched onto the abdomen."
 	icon_state = "stifle"
 	willpower_cost = 3


### PR DESCRIPTION
## About The Pull Request
updates darkspawn damage resistance sigil descriptions to be accurate 
## Why It's Good For The Game
being told you get a 40% damage resistance when  its actually 25% is not good
## Changelog
:cl:

fix: darkspawn resistance sigil descriptions now show correct % 
