### PR TITLE
Repacking fixes

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -309,6 +309,7 @@
 	name = "budgeted meteor satellites"
 	desc = "The lock seems to respond to Centcom's station goal announcements. CAUTION: Do not attempt to break the lock."
 	icon_state = "engi_secure_crate"
+	base_icon_state = "engi_secure_crate"
 	secure = TRUE
 	locked = TRUE
 

--- a/monkestation/code/modules/blueshift/elements/repacking.dm
+++ b/monkestation/code/modules/blueshift/elements/repacking.dm
@@ -52,7 +52,7 @@
 /// Removes the element target and spawns a new one of whatever item_to_pack_into is
 /datum/element/repackable/proc/repack(atom/source, mob/user)
 	source.balloon_alert_to_viewers("repacking...")
-	if(!do_after(user, 3 SECONDS, target = source))
+	if(!do_after(user, repacking_time, target = source))
 		return
 
 	playsound(source, 'sound/items/ratchet.ogg', 50, TRUE)

--- a/monkestation/code/modules/blueshift/structures/flatpacker.dm
+++ b/monkestation/code/modules/blueshift/structures/flatpacker.dm
@@ -122,4 +122,3 @@
 	name = "flat-packed [initial(type_to_deploy.name)]"
 	desc = initial(type_to_deploy.desc)
 	give_deployable_component()
-	moveToNullspace() 


### PR DESCRIPTION

## About The Pull Request

- The flatpack item no longer gets sent into the shadow realm on generic repacks
- Repacking time actually used
- Also fixes budget sat crate sprite (again)
## Why It's Good For The Game
Fixes #8072 and #8296 
## Changelog
:cl: EssentialTomato
fix: Meteor satellites and vital scanner pads no longer vanish on repacking.
/:cl:
