### PR TITLE
Makes demon hearts obtainable... with great effort

### DIFF
--- a/code/datums/components/crafting/misc.dm
+++ b/code/datums/components/crafting/misc.dm
@@ -52,3 +52,27 @@
 	reqs = list(/obj/item/stack/sheet/plastic = 10)
 	tool_behaviors = list(TOOL_WELDER)
 	category = CAT_MISC
+
+/datum/crafting_recipe/demon_heart_bubblegum
+	name = "Demon Heart"
+	result = /obj/item/organ/internal/heart/demon
+	time = 1 MINUTES
+	reqs = list(
+		/obj/item/mayhem = 1,
+		/obj/item/organ/internal/heart/cursed = 1,
+		/obj/item/stack/sheet/sinew = 25,
+	)
+	machinery = list(/obj/machinery/anomalous_crystal = CRAFTING_MACHINERY_USE)
+	category = CAT_MISC
+
+/datum/crafting_recipe/demon_heart_wendigo
+	name = "Demon Heart"
+	result = /obj/item/organ/internal/heart/demon
+	time = 1 MINUTES
+	reqs = list(
+		/obj/item/wendigo_blood = 1,
+		/obj/item/organ/internal/heart/cursed = 1,
+		/obj/item/stack/sheet/sinew = 25,
+	)
+	machinery = list(/obj/machinery/anomalous_crystal = CRAFTING_MACHINERY_USE)
+	category = CAT_MISC


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so demon hearts can be "crafted"... with some effort.
To be specific, it requires the following:
- Mayhem in a Bottle (from bubblegum) or Bottle of Wendigo Blood (from, well... wendigo)
- Cursed Heart
- 25 sinew
- Anomalous Crystal (from colossus)

@ThePooba came up with the recipe

This gives a use for mayhem in a bottle that isn't just a aoe grief device (the wendigo blood version is just so that it's obtainable on icebox too), but it requires you two defeat _two_ difficult megafauna, in addition to going through tendril chests for a cursed heart.

<img width="700" height="720" alt="image" src="https://github.com/user-attachments/assets/8c4a43ee-64b2-48c6-9b89-30983880c209" />

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Those who have conquered the king of slaughter demons may find their bottle of mayhem to be useful for... a powerful recipe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
