### PR TITLE
Allows cargo to order the Hotspot Stomping Kit and Hotspot Vent Kit again

### DIFF
--- a/monkestation/code/modules/cargo/crates/engineering.dm
+++ b/monkestation/code/modules/cargo/crates/engineering.dm
@@ -13,7 +13,6 @@
 	contains = list(/obj/item/clothing/head/cone = 6)
 	crate_name = "engineering hat crate"
 
-/* // Commented out to remove from cargo orders as no maps in rotation require this. This will remain until it is changed. -Dexee 4/21/24
 /datum/supply_pack/engineering/stompers
 	name = "Hotspot Stomping Kit"
 	desc = "Everything you need to stomp hotspots."
@@ -27,7 +26,7 @@
 	cost = CARGO_CRATE_VALUE * 10
 	contains = list(/obj/item/vent_package = 5)
 	crate_name = "engineering vent crate"
-*/
+
 /datum/supply_pack/engineering/servicefab
 	name = "Service Techfab Replacement"
 	desc = "You're telling me botany broke it with a lemon?"


### PR DESCRIPTION
## About The Pull Request

Oshan's back now... so we can allow these to be ordered once more.

## Why It's Good For The Game

i need to harness the unmatched power of the sun

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Hotspot Stomping Kits and Hotspot Vent Kits can be ordered from cargo once more.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
