### PR TITLE
darkspawn shadow caster now embeds and disables lights

### DIFF
--- a/code/modules/antagonists/darkspawn/darkspawn_objects/shadow_caster.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_objects/shadow_caster.dm
@@ -17,6 +17,7 @@
 	. = ..()
 	update_icon_state()
 	ADD_TRAIT(src, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
+	AddComponent(/datum/component/light_eater)
 
 
 /obj/item/gun/ballistic/bow/shadow_caster/shoot_live_shot(mob/living/user, pointblank, atom/pbtarget, message)
@@ -62,19 +63,22 @@
 	icon_state = "caster_arrow"
 	inhand_icon_state = null
 	embedding = list("embed_chance" = 20, "embedded_fall_chance" = 0)
-	projectile_type = /obj/projectile/energy/shadow_arrow
+	projectile_type = /obj/projectile/bullet/shadow_arrow
 
 //the projectile being shot from the bow
-/obj/projectile/energy/shadow_arrow
+/obj/projectile/bullet/shadow_arrow
 	name = "shadow arrow"
 	icon = 'icons/obj/darkspawn_projectiles.dmi'
 	icon_state = "caster_arrow"
 	damage = 25 //reduced damage per arrow compared to regular ones
+	damage_type = BURN
+	wound_bonus = -100
+	embedding = list("embed_chance" = 20, "embedded_fall_chance" = 0)
 
-/obj/projectile/energy/shadow_arrow/Initialize(mapload)
+/obj/projectile/bullet/shadow_arrow/Initialize(mapload)
 	. = ..()
 	update_appearance(UPDATE_OVERLAYS)
 
-/obj/projectile/energy/shadow_arrow/update_overlays()
+/obj/projectile/bullet/shadow_arrow/update_overlays()
 	. = ..()
 	. += emissive_appearance(icon, "[icon_state]_emissive", src)


### PR DESCRIPTION
<!-- Write **BELOW** The 
Headers and **ABOVE** The comments else it may
not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull
request process. -->

## About The Pull Request

fix shadow catcher

## Why It's Good For The Game
its supposed to embed and says it disables lights so it does that now
<!-- Argue for the merits of your changes and how they benefit the game,
especially if they are controversial and/or far reaching. If you can't
actually explain WHY what you are doing will improve the game, then it
probably isn't good for the game in the first place. -->

<!-- You can use multiple of the same prefix (they're only used for the
icon ingame) and delete the unneeded ones. Despite some of the tags,
changelogs should generally represent how a player might be affected by
the changes rather than a summary of the PR's contents. -->

:cl:
fix: shadow caster projectiles now eat lights
fix: shadow caster projectiles now embed
/:cl:
