### PR TITLE
Give shaft miners external airlock access on planetary maps

### DIFF
--- a/code/datums/id_trim/jobs.dm
+++ b/code/datums/id_trim/jobs.dm
@@ -1109,7 +1109,7 @@
 
 /datum/id_trim/job/shaft_miner/refresh_trim_access()
 	. = ..()
-	if(SSmapping.is_planetary())
+	if(. && SSmapping.is_planetary())
 		access |= list(ACCESS_EXTERNAL_AIRLOCKS)
 
 /// ID card obtained from the mining Disney dollar points vending machine.


### PR DESCRIPTION

## About The Pull Request

this makes it so shaft miners will have external airlock access by default on any planetary maps (such as Icebox)

## Why It's Good For The Game

I mean, they're supposed to _mine_, and you can mine perfectly fine on the top floor, and sometimes there are ruins on the top floor you need to go out an airlock to get to (i.e clockwork signal), and going around from arrivals/escape sucks ass.

## Changelog
:cl:
qol: Shaft Miners now have external airlock access on Icebox and any other planetary maps.
/:cl:
