### PR TITLE
[BALANCE] [REWORK] Vampire rework part 2: THE BIG ONE (Sol removed, changes to leveling system, many buffs, some nerfs, fixes, and more)

### DIFF
--- a/code/__DEFINES/bloodsuckers.dm
+++ b/code/__DEFINES/bloodsuckers.dm
@@ -102,8 +102,10 @@
 #define BP_AM_SINGLEUSE (1<<1)
 /// This Power has a Static cooldown
 #define BP_AM_STATIC_COOLDOWN (1<<2)
+/// This Power has a custom cooldown scaling (do not use automatic cooldown reduction per level)
+#define BP_AM_CUSTOM_COOLDOWN (1<<3)
 /// This Power doesn't cost bloot to run while unconscious
-#define BP_AM_COSTLESS_UNCONSCIOUS (1<<3)
+#define BP_AM_COSTLESS_UNCONSCIOUS (1<<4)
 
 /**
  * Bloodsucker Signals

--- a/code/datums/actions/cooldown_action.dm
+++ b/code/datums/actions/cooldown_action.dm
@@ -1,4 +1,4 @@
-#define COOLDOWN_NO_DISPLAY_TIME (180 SECONDS)
+#define COOLDOWN_NO_DISPLAY_TIME (999 SECONDS)
 
 /// Preset for an action that has a cooldown.
 /datum/action/cooldown

--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -447,12 +447,12 @@
 	if(!COOLDOWN_FINISHED(src, crystalize_cooldown) || ethereal.stat != DEAD)
 		return //Should probably not happen, but lets be safe.
 
-	//Monkestation Edit Begin
+	/*
 	if(IS_BLOODSUCKER(ethereal) && SSsol.sunlight_active)
 		to_chat(ethereal, span_warning("You were unable to finish your crystallization as Sol has halted your attempt to crystallize."))
 		stop_crystalization_process(ethereal, FALSE)
 		return
-	//Monkestation Edit End
+	*/
 
 	if(ismob(location) || isitem(location) || iseffect(location) || HAS_TRAIT_FROM(src, TRAIT_HUSK, CHANGELING_DRAIN)) //Stops crystallization if they are eaten by a dragon, turned into a legion, consumed by his grace, etc.
 		to_chat(ethereal, span_warning("You were unable to finish your crystallization, for obvious reasons."))

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_hud.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_hud.dm
@@ -23,6 +23,7 @@
 	icon_state = "rank"
 	screen_loc = UI_VAMPRANK_DISPLAY
 
+/*
 /atom/movable/screen/bloodsucker/sunlight_counter
 	name = "Solar Flare Timer"
 	icon_state = "sunlight"
@@ -60,6 +61,7 @@
 		valuecolor, \
 		(SSsol.time_til_cycle >= 60) ? "[round(SSsol.time_til_cycle / 60, 1)] m" : "[round(SSsol.time_til_cycle, 1)] s" \
 	)
+*/
 
 /// Update Blood Counter + Rank Counter
 /datum/antagonist/bloodsucker/proc/update_hud()
@@ -78,7 +80,7 @@
 			vamprank_display.icon_state = initial(vamprank_display.icon_state)
 		vamprank_display.maptext = FORMAT_BLOODSUCKER_HUD_TEXT(valuecolor, bloodsucker_level)
 
-	update_sunlight_hud()
+	//update_sunlight_hud()
 
 /// 1 tile down
 #undef UI_BLOOD_DISPLAY

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_life.dm
@@ -94,7 +94,7 @@
 	// Don't heal if I'm staked or on Masquerade (+ not in a Coffin). Masqueraded Bloodsuckers in a Coffin however, will heal.
 	if(owner.current.am_staked())
 		return FALSE
-	if(!in_torpor && (HAS_TRAIT(owner.current, TRAIT_MASQUERADE) || owner.current.has_status_effect(/datum/status_effect/bloodsucker_sol)))
+	if(!in_torpor && (HAS_TRAIT(owner.current, TRAIT_MASQUERADE) /*|| owner.current.has_status_effect(/datum/status_effect/bloodsucker_sol) */))
 		return FALSE
 	var/in_coffin = istype(owner.current.loc, /obj/structure/closet/crate/coffin)
 	var/actual_regen = bloodsucker_regen_rate + additional_regen
@@ -307,6 +307,8 @@
 		COMSIG_MOVABLE_MOVED,
 		COMSIG_HUMAN_ON_HANDLE_BLOOD,
 	))
+	UnregisterSignal(SSsol, COMSIG_SOL_RANKUP_BLOODSUCKERS)
+	/*
 	UnregisterSignal(SSsol, list(
 		COMSIG_SOL_RANKUP_BLOODSUCKERS,
 		COMSIG_SOL_NEAR_START,
@@ -314,6 +316,7 @@
 		COMSIG_SOL_RISE_TICK,
 		COMSIG_SOL_WARNING_GIVEN,
 	))
+	*/
 	final_death = TRUE
 	free_all_vassals()
 	DisableAllPowers(forced = TRUE)

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_misc_procs.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_misc_procs.dm
@@ -64,6 +64,7 @@
 	if(!owner?.current || IS_FAVORITE_VASSAL(owner.current))
 		return
 	bloodsucker_level_unspent++
+	owner.current.balloon_alert(owner.current, "You have grown more ancient!")
 	if(!my_clan)
 		to_chat(owner.current, span_notice("You have gained a rank. Join a Clan to spend it."))
 		return
@@ -116,7 +117,7 @@
 		all_vassals.owner.add_antag_datum(/datum/antagonist/ex_vassal)
 		all_vassals.owner.remove_antag_datum(/datum/antagonist/vassal)
 
-// Blood level gain is used to give Bloodsuckers more levels if they are being agressive and drinking from real, sentient people.
+// Blood level gain is used to give Bloodsuckers more levels if they are being aggressive and drinking from real, sentient people.
 // The maximum blood that counts towards this
 /datum/antagonist/bloodsucker/proc/blood_level_gain()
 	var/level_cost = get_level_cost()
@@ -136,7 +137,7 @@
 	blood_level_gain_amount += 1 // Increments the variable that makes future levels more expensive
 
 /datum/antagonist/bloodsucker/proc/get_level_cost()
-	var/level_cost = (0.3 + (0.05 * blood_level_gain_amount))
+	var/level_cost = (0.25 + (0.05 * blood_level_gain_amount))
 	level_cost = min(level_cost, BLOOD_LEVEL_GAIN_MAX)
 	level_cost = max_blood_volume * level_cost
 	return level_cost

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_objectives.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_objectives.dm
@@ -85,14 +85,14 @@
 /// Space_Station_13_areas.dm  <--- all the areas
 
 //////////////////////////////////////////////////////////////////////////////////////
-
+/*
 /datum/objective/bloodsucker/survive
 	name = "bloodsuckersurvive"
 	explanation_text = "Survive the entire shift without succumbing to Final Death."
 
 /datum/objective/bloodsucker/survive/check_completion()
 	return ..() || (!QDELETED(owner.current) && !bloodsucker_datum?.final_death)
-
+*/
 // WIN CONDITIONS?
 // Handled by parent
 

--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_sol.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_sol.dm
@@ -21,12 +21,16 @@
 ///Ranks the Bloodsucker up, called by Sol.
 /datum/antagonist/bloodsucker/proc/sol_rank_up(atom/source)
 	SIGNAL_HANDLER
+
 	if(sol_levels_remaining > 0)
 		sol_levels_remaining--
 		INVOKE_ASYNC(src, PROC_REF(RankUp))
+	/*
 	else
 		to_chat(owner.current, span_announce("You have already got as powerful as you can through surviving Sol."))
+	*/
 
+/*
 ///Called when Sol is near starting.
 /datum/antagonist/bloodsucker/proc/sol_near_start(atom/source)
 	SIGNAL_HANDLER
@@ -39,10 +43,14 @@
 	check_end_torpor()
 	for(var/datum/action/cooldown/bloodsucker/gohome/power in powers)
 		RemovePower(power)
+*/
 
+/*
 /// Cycle through all vamp antags and check if they're inside a closet.
 /datum/antagonist/bloodsucker/proc/handle_sol()
 	SIGNAL_HANDLER
+	return
+
 	if(!owner?.current)
 		return
 
@@ -57,7 +65,8 @@
 	if(!is_in_torpor())
 		check_begin_torpor(TRUE)
 		owner.current.add_mood_event("vampsleep", /datum/mood_event/coffinsleep)
-
+	*/
+/*
 /datum/antagonist/bloodsucker/proc/give_warning(atom/source, danger_level, vampire_warning_message, vassal_warning_message)
 	SIGNAL_HANDLER
 	if(!owner || !owner.current)
@@ -75,7 +84,7 @@
 			owner.current.playsound_local(null, 'sound/ambience/ambimystery.ogg', vol = 75, vary = TRUE)
 		if(DANGER_LEVEL_SOL_ENDED)
 			owner.current.playsound_local(null, 'sound/misc/ghosty_wind.ogg', vol = 90, vary = TRUE)
-
+*/
 /**
  * # Torpor
  *
@@ -107,7 +116,7 @@
 	var/total_burn = user.getFireLoss_nonProsthetic()
 	var/total_damage = total_brute + total_burn
 	/// Checks - Not daylight & Has more than 10 Brute/Burn & not already in Torpor
-	if(!SSsol.sunlight_active && (total_damage >= 10 || typecached_item_in_list(user.organs, yucky_organ_typecache)) && !is_in_torpor())
+	if(/* !SSsol.sunlight_active && */ (total_damage >= 10 || typecached_item_in_list(user.organs, yucky_organ_typecache)) && !is_in_torpor())
 		torpor_begin()
 
 /datum/antagonist/bloodsucker/proc/check_end_torpor()
@@ -119,8 +128,10 @@
 	var/total_damage = total_brute + total_burn
 	if(total_burn >= 199)
 		return FALSE
+	/*
 	if(SSsol.sunlight_active)
 		return FALSE
+	*/
 	// You are in a Coffin, so instead we'll check TOTAL damage, here.
 	if(istype(user.loc, /obj/structure/closet/crate/coffin))
 		if(total_damage <= 10)
@@ -162,7 +173,7 @@
 	if(!COOLDOWN_FINISHED(src, bloodsucker_torpor_max_time))
 		COOLDOWN_RESET(src, bloodsucker_torpor_max_time)
 	//monkestation end
-	current.remove_status_effect(/datum/status_effect/bloodsucker_sol)
+	//current.remove_status_effect(/datum/status_effect/bloodsucker_sol)
 	current.grab_ghost()
 	to_chat(current, span_warning("You have recovered from Torpor."))
 	current.remove_traits(torpor_traits, TORPOR_TRAIT)
@@ -172,7 +183,7 @@
 	current.pain_controller?.remove_all_pain()
 	current.update_stat()
 	SEND_SIGNAL(src, COMSIG_BLOODSUCKER_EXIT_TORPOR)
-
+/*
 /datum/status_effect/bloodsucker_sol
 	id = "bloodsucker_sol"
 	tick_interval = 2 SECONDS
@@ -244,4 +255,4 @@
 	icon = 'monkestation/icons/bloodsuckers/actions_bloodsucker.dmi'
 	base_icon_state = "sol_alert"
 	icon_state = "sol_alert"
-
+*/

--- a/monkestation/code/modules/bloodsuckers/clans/_clan_base.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/_clan_base.dm
@@ -52,6 +52,10 @@
 
 	give_clan_objective()
 
+	for(var/datum/action/cooldown/bloodsucker/power as anything in bloodsuckerdatum.all_bloodsucker_powers)
+		if((initial(power.purchase_flags) & BLOODSUCKER_CAN_BUY))
+			bloodsuckerdatum.BuyPower(new power)
+
 	for(var/banned_power in banned_powers)
 		var/datum/action/power = locate(banned_power) in bloodsuckerdatum.powers
 		if(power)
@@ -155,12 +159,12 @@
 	INVOKE_ASYNC(src, PROC_REF(spend_rank), bloodsuckerdatum, target, cost_rank, blood_cost)
 
 /datum/bloodsucker_clan/proc/spend_rank(datum/antagonist/bloodsucker/source, mob/living/carbon/target, cost_rank = TRUE, blood_cost)
-	// Purchase Power Prompt
+	// Upgrade Power Prompt
 	var/list/options = list()
-	for(var/datum/action/cooldown/bloodsucker/power as anything in bloodsuckerdatum.all_bloodsucker_powers)
+	for(var/datum/action/cooldown/bloodsucker/power as anything in bloodsuckerdatum.powers)
 		if(!(power::purchase_flags & BLOODSUCKER_CAN_BUY))
 			continue
-		if(locate(power) in bloodsuckerdatum.powers)
+		if (power::purchase_flags & BLOODSUCKER_DEFAULT_POWER)
 			continue
 		if(power in banned_powers)
 			continue
@@ -169,34 +173,32 @@
 	if(length(options) < 1)
 		to_chat(bloodsuckerdatum.owner.current, span_notice("You grow more ancient by the night!"))
 	else
-		// Give them the UI to purchase a power.
-		var/choice = tgui_input_list(bloodsuckerdatum.owner.current, "You have the opportunity to grow more ancient.[blood_cost > 0 ? " Spend [round(blood_cost, 1)] blood to advance your rank" : ""]", "Your Blood Thickens...", options)
-		// Prevent Bloodsuckers from closing/reopning their coffin to spam Levels.
+		// Give them the UI to upgrade a power.
+		var/choice = tgui_input_list(bloodsuckerdatum.owner.current, "You have the opportunity to grow more ancient. Select a power to upgrade.[blood_cost > 0 ? " Spend [round(blood_cost, 1)] blood to advance your rank" : ""]", "Your Blood Thickens...", options)
+		// Prevent Bloodsuckers from closing/reopening their coffin to spam Levels.
 		if(cost_rank && bloodsuckerdatum.bloodsucker_level_unspent <= 0)
 			return
 		// Did you choose a power?
 		if(!choice || !options[choice])
 			to_chat(bloodsuckerdatum.owner.current, span_notice("You prevent your blood from thickening just yet, but you may try again later."))
 			return
-		// Prevent Bloodsuckers from closing/reopning their coffin to spam Levels.
-		if(locate(options[choice]) in bloodsuckerdatum.powers)
-			to_chat(bloodsuckerdatum.owner.current, span_notice("You prevent your blood from thickening just yet, but you may try again later."))
-			return
-		// Prevent Bloodsuckers from purchasing a power while outside of their Coffin.
+		// Prevent Bloodsuckers from upgrading a power while outside of their Coffin.
 		if(!istype(bloodsuckerdatum.owner.current.loc, /obj/structure/closet/crate/coffin))
-			to_chat(bloodsuckerdatum.owner.current, span_warning("You must be in your Coffin to purchase Powers."))
+			to_chat(bloodsuckerdatum.owner.current, span_warning("You must be in your Coffin to upgrade Powers."))
 			return
 
-		// Good to go - Buy Power!
-		var/datum/action/cooldown/bloodsucker/purchased_power = options[choice]
-		bloodsuckerdatum.BuyPower(new purchased_power)
-		bloodsuckerdatum.owner.current.balloon_alert(bloodsuckerdatum.owner.current, "learned [choice]!")
-		to_chat(bloodsuckerdatum.owner.current, span_notice("You have learned how to use [choice]!"))
+		// Good to go - Upgrade Power!
+		var/datum/action/cooldown/bloodsucker/upgraded_power = options[choice]
+		upgraded_power.upgrade_power()
+		bloodsuckerdatum.owner.current.balloon_alert(bloodsuckerdatum.owner.current, "upgraded [choice]!")
+		to_chat(bloodsuckerdatum.owner.current, span_notice("You have upgraded [choice]!"))
 
 	finalize_spend_rank(bloodsuckerdatum, cost_rank, blood_cost)
 
+	if (bloodsuckerdatum.bloodsucker_level_unspent > 0)
+		spend_rank(source, target, cost_rank, blood_cost)
+
 /datum/bloodsucker_clan/proc/finalize_spend_rank(datum/antagonist/bloodsucker/source, cost_rank = TRUE, blood_cost)
-	bloodsuckerdatum.LevelUpPowers()
 	bloodsuckerdatum.bloodsucker_regen_rate += 0.05
 	bloodsuckerdatum.max_blood_volume += 100
 
@@ -220,8 +222,7 @@
 		bloodsuckerdatum.SelectReputation(am_fledgling = FALSE, forced = TRUE)
 
 	to_chat(bloodsuckerdatum.owner.current, span_notice("You are now a rank [bloodsuckerdatum.bloodsucker_level] Bloodsucker. \
-		Your strength, feed rate, regen rate, and maximum blood capacity have all increased! \n\
-		* Your existing powers have all ranked up as well!"))
+		Your strength, feed rate, regen rate, and maximum blood capacity have all increased!"))
 	bloodsuckerdatum.owner.current.playsound_local(null, 'sound/effects/pope_entry.ogg', 25, TRUE, pressure_affected = FALSE)
 	bloodsuckerdatum.update_hud()
 

--- a/monkestation/code/modules/bloodsuckers/clans/nosferatu.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/nosferatu.dm
@@ -3,10 +3,10 @@
 	description = "The Nosferatu Clan is unable to blend in with the crew, with no abilities such as Masquerade and Veil. \n\
 		Additionally, has a permanent bad back and looks like a Bloodsucker upon a simple examine by those in touch with the occult, and is entirely unidentifiable, \n\
 		they can fit in the vents regardless of their form and equipment. \n\
-		The Favorite Vassal is permanetly disfigured, and can also ventcrawl, but only while entirely nude."
+		The Favorite Vassal is permanently disfigured, and can also ventcrawl, but only while entirely nude."
 	clan_objective = /datum/objective/bloodsucker/kindred
 	join_icon_state = "nosferatu"
-	join_description = "You are permanetly disfigured, look like a Bloodsucker to all who examine you, \
+	join_description = "You are permanently disfigured, look like a Bloodsucker to all who examine you, \
 		lose your Masquerade ability, but gain the ability to Ventcrawl even while clothed."
 	blood_drink_type = BLOODSUCKER_DRINK_INHUMANELY
 	banned_powers = list(/datum/action/cooldown/bloodsucker/masquerade, /datum/action/cooldown/bloodsucker/veil)

--- a/monkestation/code/modules/bloodsuckers/clans/tremere.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/tremere.dm
@@ -7,7 +7,7 @@
 	clan_objective = /datum/objective/bloodsucker/tremere_power
 	join_icon_state = "tremere"
 	join_description = "You will burn if you enter the Chapel, lose all default powers, \
-		but gain Blood Magic instead, powers you level up overtime."
+		but gain special Blood Magic instead, and gain ranks by Vassalizing crew."
 
 /datum/bloodsucker_clan/tremere/New(mob/living/carbon/user)
 	. = ..()

--- a/monkestation/code/modules/bloodsuckers/clans/ventrue.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/ventrue.dm
@@ -1,5 +1,5 @@
 ///The maximum level a Ventrue Bloodsucker can be, before they have to level up their vassal instead.
-#define VENTRUE_MAX_LEVEL 3
+#define VENTRUE_MAX_LEVEL 4
 ///How much it costs for a Ventrue to rank up without a spare rank to spend.
 #define BLOODSUCKER_BLOOD_RANKUP_COST (550)
 

--- a/monkestation/code/modules/bloodsuckers/controllers/sunlight.dm
+++ b/monkestation/code/modules/bloodsuckers/controllers/sunlight.dm
@@ -1,16 +1,16 @@
 ///How long Sol will last until it's night again.
-#define TIME_BLOODSUCKER_DAY 60
+//#define TIME_BLOODSUCKER_DAY 60
 ///Base time nighttime should be in for, until Sol rises.
 #define TIME_BLOODSUCKER_NIGHT 600
 ///Time left to send an alert to Bloodsuckers about an incoming Sol.
-#define TIME_BLOODSUCKER_DAY_WARN 90
+//#define TIME_BLOODSUCKER_DAY_WARN 90
 ///Time left to send an urgent alert to Bloodsuckers about an incoming Sol.
-#define TIME_BLOODSUCKER_DAY_FINAL_WARN 30
+//#define TIME_BLOODSUCKER_DAY_FINAL_WARN 30
 ///Time left to alert that Sol is rising.
-#define TIME_BLOODSUCKER_BURN_INTERVAL 5
+//#define TIME_BLOODSUCKER_BURN_INTERVAL 5
 
 ///How much time Sol can be 'off' by, keeping the time inconsistent.
-#define TIME_BLOODSUCKER_SOL_DELAY 90
+//#define TIME_BLOODSUCKER_SOL_DELAY 90
 
 SUBSYSTEM_DEF(sol)
 	name = "Sol"
@@ -19,7 +19,7 @@ SUBSYSTEM_DEF(sol)
 	flags = SS_NO_INIT | SS_BACKGROUND | SS_TICKER | SS_KEEP_TIMING
 
 	///If the Sun is currently out our not.
-	var/sunlight_active = FALSE
+	//var/sunlight_active = FALSE
 	///The time between the next cycle, randomized every night.
 	var/time_til_cycle = TIME_BLOODSUCKER_NIGHT
 	///If Bloodsucker levels for the night has been given out yet.
@@ -27,12 +27,23 @@ SUBSYSTEM_DEF(sol)
 
 /datum/controller/subsystem/sol/Recover()
 	can_fire = SSsol.can_fire
-	sunlight_active = SSsol.sunlight_active
+	//sunlight_active = SSsol.sunlight_active
 	time_til_cycle = SSsol.time_til_cycle
 	issued_XP = SSsol.issued_XP
 
 /datum/controller/subsystem/sol/fire(resumed = FALSE)
 	time_til_cycle--
+
+	if (time_til_cycle > 0 && time_til_cycle <= 15)
+		if (!issued_XP)
+			issued_XP = TRUE
+			SEND_SIGNAL(src, COMSIG_SOL_RANKUP_BLOODSUCKERS)
+
+	if (time_til_cycle < 1)
+		issued_XP = FALSE
+		time_til_cycle = TIME_BLOODSUCKER_NIGHT
+
+/*
 	if(sunlight_active)
 		if(time_til_cycle > 0)
 			SEND_SIGNAL(src, COMSIG_SOL_RISE_TICK)
@@ -52,7 +63,9 @@ SUBSYSTEM_DEF(sol)
 				vassal_warning_message = span_announce("The solar flare has ended, and the daylight danger has passed... for now."),
 			)
 		return
+*/
 
+/*
 	switch(time_til_cycle)
 		if(TIME_BLOODSUCKER_DAY_WARN)
 			SEND_SIGNAL(src, COMSIG_SOL_NEAR_START)
@@ -82,14 +95,21 @@ SUBSYSTEM_DEF(sol)
 				vampire_warning_message = span_userdanger("Solar flares bombard the station with deadly UV light! Stay in cover for the next [DisplayTimeText(TIME_BLOODSUCKER_DAY * 10)] or risk Final Death!"),
 				vassal_warning_message = span_userdanger("Solar flares bombard the station with UV light!"),
 			)
+*/
 
+/*
 /datum/controller/subsystem/sol/proc/warn_daylight(danger_level, vampire_warning_message, vassal_warning_message)
-	SEND_SIGNAL(src, COMSIG_SOL_WARNING_GIVEN, danger_level, vampire_warning_message, vassal_warning_message)
+	SEND_SIGNAL(src, COMSIG_SOL_WARNING_GIVEN, danger_level, vampire_warning_message, vassal_warning_message
+*/
 
+/*
 #undef TIME_BLOODSUCKER_SOL_DELAY
 
 #undef TIME_BLOODSUCKER_DAY
+*/
 #undef TIME_BLOODSUCKER_NIGHT
+/*
 #undef TIME_BLOODSUCKER_DAY_WARN
 #undef TIME_BLOODSUCKER_DAY_FINAL_WARN
 #undef TIME_BLOODSUCKER_BURN_INTERVAL
+*/

--- a/monkestation/code/modules/bloodsuckers/powers/_base_power.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/_base_power.dm
@@ -33,7 +33,7 @@
 	/// If the Power is currently active, differs from action cooldown because of how powers are handled.
 	var/active = FALSE
 	///Can increase to yield new abilities - Each Power ranks up each Rank
-	var/level_current = 0
+	var/level_current = 1
 	///The cost to ACTIVATE this Power
 	var/bloodcost = 0
 	///The cost to MAINTAIN this Power - Only used for Constant Cost Powers
@@ -74,8 +74,10 @@
 		. = constant ? constant_bloodcost : bloodcost
 	else
 		. = cost_override
+	/*
 	if(bloodsuckerdatum_power && sol_multiplier && SSsol.sunlight_active)
 		. *= sol_multiplier
+	*/
 
 /datum/action/cooldown/bloodsucker/IsAvailable(feedback = FALSE)
 	return COOLDOWN_FINISHED(src, next_use_time)
@@ -191,9 +193,11 @@
 		if(!can_upkeep)
 			to_chat(user, span_warning("You don't have the blood to upkeep [src]!"))
 			return FALSE
+	/*
 	if((check_flags & BP_CANT_USE_DURING_SOL) && user.has_status_effect(/datum/status_effect/bloodsucker_sol))
 		to_chat(user, span_warning("You can't use [src] during Sol!"))
 		return FALSE
+	*/
 	return TRUE
 
 /// NOTE: With this formula, you'll hit half cooldown at level 8 for that power.
@@ -201,7 +205,7 @@
 	// Calculate Cooldown (by power's level)
 	if(power_flags & BP_AM_STATIC_COOLDOWN)
 		cooldown_time = initial(cooldown_time)
-	else
+	else if (!(power_flags & BP_AM_CUSTOM_COOLDOWN))
 		cooldown_time = max(initial(cooldown_time) / 2, initial(cooldown_time) - (initial(cooldown_time) / 16 * (level_current - 1)))
 
 	. = ..()
@@ -275,8 +279,10 @@
 /datum/action/cooldown/bloodsucker/proc/ContinueActive(mob/living/user, mob/living/target)
 	if(QDELETED(user))
 		return FALSE
+	/*
 	if((check_flags & BP_CANT_USE_DURING_SOL) && user.has_status_effect(/datum/status_effect/bloodsucker_sol))
 		return FALSE
+	*/
 	if (!(check_flags & BP_ALLOW_WHILE_SILVER_CUFFED) && user.has_status_effect(/datum/status_effect/silver_cuffed))
 		return FALSE
 	var/constant_bloodcost = get_blood_cost(constant = TRUE)
@@ -310,10 +316,10 @@
 /datum/action/cooldown/bloodsucker/proc/get_power_explanation()
 	SHOULD_CALL_PARENT(TRUE)
 	. = list()
-	if(level_current != 0)
-		. += "LEVEL: [level_current] [name]:"
-	else
+	if(purchase_flags & BLOODSUCKER_DEFAULT_POWER)
 		. += "(Inherent Power) [name]:"
+	else
+		. += "LEVEL: [level_current] [name]:"
 
 	. += get_power_explanation_extended()
 
@@ -323,10 +329,10 @@
 /datum/action/cooldown/bloodsucker/proc/get_power_desc()
 	SHOULD_CALL_PARENT(TRUE)
 	var/new_desc = ""
-	if(level_current != 0)
-		new_desc += "<br><b>LEVEL:</b> [level_current]"
-	else
+	if(purchase_flags & BLOODSUCKER_DEFAULT_POWER)
 		new_desc += "<br><b>(Inherent Power)</b>"
+	else
+		new_desc += "<br><b>LEVEL:</b> [level_current]"
 	if(bloodcost > 0)
 		new_desc += "<br><br><b>COST:</b> [bloodcost] Blood"
 	if(constant_bloodcost > 0)

--- a/monkestation/code/modules/bloodsuckers/powers/cloak.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/cloak.dm
@@ -4,42 +4,30 @@
 	button_icon_state = "power_cloak"
 	power_explanation = "Cloak of Darkness:\n\
 		Activate this Power in the shadows and you will slowly turn nearly invisible.\n\
-		While using Cloak of Darkness, attempting to run will crush you.\n\
+		While using Cloak of Darkness, you are unable to sprint.\n\
 		Additionally, while Cloak is active, you are completely invisible to the AI.\n\
-		Higher levels will increase how invisible you are."
+		If you attack anyone or get attacked, your cloak will break and you will be revealed.\n\
+		Higher levels will increase how invisible you are, and reduce the cooldown to cloak again should it be broken."
 	power_flags = BP_AM_TOGGLE
 	check_flags = BP_CANT_USE_IN_TORPOR | BP_CANT_USE_IN_FRENZY | BP_CANT_USE_WHILE_UNCONSCIOUS
 	purchase_flags = BLOODSUCKER_CAN_BUY | VASSAL_CAN_BUY
 	bloodcost = 5
 	constant_bloodcost = 0.2
-	sol_multiplier = 2.5
-	cooldown_time = 5 SECONDS
-	var/was_running
-
-/// Must have nobody around to see the cloak
-/datum/action/cooldown/bloodsucker/cloak/can_use(mob/living/carbon/user, trigger_flags)
-	. = ..()
-	if(!.)
-		return FALSE
-	for(var/mob/living/watcher in viewers(9, owner) - owner)
-		if(watcher.stat == DEAD || QDELETED(watcher.client) || watcher.client?.is_afk())
-			continue
-		if(HAS_MIND_TRAIT(watcher, TRAIT_BLOODSUCKER_ALIGNED) || HAS_TRAIT(watcher, TRAIT_GHOST_CRITTER))
-			continue
-		if(watcher.is_blind())
-			continue
-		owner.balloon_alert(owner, "you can only vanish unseen.")
-		return FALSE
-	return TRUE
+	//sol_multiplier = 2.5
+	cooldown_time = 10 SECONDS
 
 /datum/action/cooldown/bloodsucker/cloak/ActivatePower(trigger_flags)
 	. = ..()
 	var/mob/living/user = owner
-	was_running = ((user.m_intent == MOVE_INTENT_RUN) || user.m_intent == MOVE_INTENT_SPRINT)
-	if(was_running)
-		user.set_move_intent(MOVE_INTENT_WALK)
+
 	user.add_traits(list(TRAIT_NO_SPRINT, TRAIT_UNKNOWN), REF(src))
 	user.AddElement(/datum/element/digitalcamo)
+
+	user.AddElement(/datum/element/relay_attackers)
+	RegisterSignal(user, COMSIG_ATOM_WAS_ATTACKED, PROC_REF(on_attacked))
+	RegisterSignals(user, list(COMSIG_USER_ITEM_INTERACTION, COMSIG_USER_ITEM_INTERACTION_SECONDARY), PROC_REF(on_use_item))
+	RegisterSignals(user, list(COMSIG_LIVING_UNARMED_ATTACK, COMSIG_HUMAN_MELEE_UNARMED_ATTACK), PROC_REF(on_unarmed_attack))
+
 	user.balloon_alert(user, "cloak turned on.")
 
 /datum/action/cooldown/bloodsucker/cloak/process(seconds_per_tick)
@@ -51,11 +39,6 @@
 		return
 	var/mob/living/user = owner
 	animate(user, alpha = max(25, owner.alpha - min(75, 10 + 5 * level_current)), time = 1.5 SECONDS)
-	// Prevents running while on Cloak of Darkness
-	if(user.m_intent != MOVE_INTENT_WALK)
-		owner.balloon_alert(owner, "you attempt to run, crushing yourself.")
-		user.set_move_intent(MOVE_INTENT_WALK)
-		user.adjustBruteLoss(rand(5,15))
 
 /datum/action/cooldown/bloodsucker/cloak/ContinueActive(mob/living/user, mob/living/target)
 	. = ..()
@@ -70,9 +53,35 @@
 /datum/action/cooldown/bloodsucker/cloak/DeactivatePower()
 	var/mob/living/user = owner
 	animate(user, alpha = 255, time = 1 SECONDS)
+
 	user.RemoveElement(/datum/element/digitalcamo)
-	if(was_running && user.m_intent == MOVE_INTENT_WALK)
-		user.set_move_intent(MOVE_INTENT_RUN)
-	user.balloon_alert(user, "cloak turned off.")
 	user.remove_traits(list(TRAIT_NO_SPRINT, TRAIT_UNKNOWN), REF(src))
+
+	user.RemoveElement(/datum/element/relay_attackers)
+	UnregisterSignal(user, list(
+		COMSIG_ATOM_WAS_ATTACKED,
+		COMSIG_USER_ITEM_INTERACTION,
+		COMSIG_USER_ITEM_INTERACTION_SECONDARY,
+		COMSIG_LIVING_UNARMED_ATTACK,
+		COMSIG_HUMAN_MELEE_UNARMED_ATTACK,
+	))
+
+	user.balloon_alert(user, "cloak turned off.")
 	return ..()
+
+/datum/action/cooldown/bloodsucker/cloak/proc/on_use_item(mob/living/source, atom/target, obj/item/weapon, click_parameters)
+	SIGNAL_HANDLER
+	if(source == target)
+		return
+	if(istype(weapon, /obj/item/gun) || weapon.force)
+		DeactivatePower()
+
+/datum/action/cooldown/bloodsucker/cloak/proc/on_unarmed_attack(mob/living/source, atom/target, proximity, modifiers)
+	SIGNAL_HANDLER
+	if(source != target && proximity && isliving(target) && (source.istate & (ISTATE_HARM | ISTATE_SECONDARY)))
+		DeactivatePower()
+
+/datum/action/cooldown/bloodsucker/cloak/proc/on_attacked(mob/living/source, atom/attacker, attack_flags)
+	SIGNAL_HANDLER
+	if(source != attacker)
+		DeactivatePower()

--- a/monkestation/code/modules/bloodsuckers/powers/fortitude.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/fortitude.dm
@@ -3,19 +3,20 @@
 	desc = "Withstand egregious physical wounds and walk away from attacks that would stun, pierce, and dismember lesser beings."
 	button_icon_state = "power_fortitude"
 	power_explanation = "Fortitude:\n\
-		Activating Fortitude will provide pierce, stun and dismember immunity.\n\
-		You will additionally gain resistance to Brute and Stamina damge, scaling with level.\n\
-		While using Fortitude, attempting to run will crush you.\n\
+		Activating Fortitude will provide pierce, shove, and dismember immunity for 10 seconds.\n\
+		Everyone around you will know that you have activated it.\n\
+		You will additionally gain resistance to Brute and Stamina damage, scaling with level.\n\
+		While using Fortitude, you will be unable to sprint.\n\
 		At level 4, you gain complete stun immunity.\n\
-		Higher levels will increase Brute and Stamina resistance."
-	power_flags = BP_AM_TOGGLE | BP_AM_COSTLESS_UNCONSCIOUS
+		Higher levels will increase Brute and Stamina resistance, increase the duration, and reduce the cooldown."
+	power_flags = BP_AM_TOGGLE | BP_AM_CUSTOM_COOLDOWN | BP_AM_COSTLESS_UNCONSCIOUS
 	check_flags = BP_CANT_USE_IN_TORPOR | BP_CANT_USE_IN_FRENZY
 	purchase_flags = BLOODSUCKER_CAN_BUY | VASSAL_CAN_BUY
 	bloodcost = 30
-	cooldown_time = 8 SECONDS
+	cooldown_time = 30 SECONDS
 	constant_bloodcost = 0.2
-	sol_multiplier = 3
-	var/was_running
+	//sol_multiplier = 3
+
 	var/fortitude_resist // So we can raise and lower your brute resist based on what your level_current WAS.
 	/// Base traits granted by fortitude.
 	var/static/list/base_traits = list(
@@ -31,23 +32,51 @@
 	/// Upgraded traits granted by fortitude.
 	var/static/list/upgraded_traits = list(TRAIT_STUNIMMUNE, TRAIT_CANT_STAMCRIT)
 
+	///How long fortitude lasts, in seconds
+	var/power_duration = 10
+	///How much time is left on this current usage of fortitude, in seconds
+	var/seconds_remaining = 10
+	///The user's brute mod before fortitude was enabled
+	var/old_brute_mod = 1
+	///The user's stamina mod before fortitude was enabled
+	var/old_stamina_mod = 1
+
+/datum/action/cooldown/bloodsucker/fortitude/upgrade_power()
+	. = ..()
+
+	power_duration += 1
+	seconds_remaining = power_duration
+
+	//Reduce cooldown by 5 seconds for every level, can't go below 10 seconds.
+	cooldown_time = max(10 SECONDS, (35 SECONDS - ((5 SECONDS) * level_current)))
+
 /datum/action/cooldown/bloodsucker/fortitude/ActivatePower(trigger_flags)
 	. = ..()
-	owner.balloon_alert(owner, "fortitude turned on.")
-	to_chat(owner, span_notice("Your flesh, skin, and muscles become as steel."))
+
 	// Traits & Effects
 	owner.add_traits(base_traits, FORTITUDE_TRAIT)
+
 	if(level_current >= 4)
-		owner.add_traits(upgraded_traits, FORTITUDE_TRAIT) // They'll get stun resistance + this, who cares.
+		owner.add_traits(upgraded_traits, FORTITUDE_TRAIT)
+		owner.visible_message(span_warning("[owner]'s skin turns extremely hard! Stuns will be completely ineffective!"))
+		owner.balloon_alert_to_viewers("skin turns extremely hard!", "your skin turns extremely hard!")
+	else
+		owner.visible_message(span_warning("[owner]'s skin hardens!"))
+		owner.balloon_alert_to_viewers("skin hardens!", "your skin hardens!")
+
 	var/mob/living/carbon/human/bloodsucker_user = owner
 	if(HAS_MIND_TRAIT(owner, TRAIT_BLOODSUCKER_ALIGNED))
 		fortitude_resist = max(0.3, 0.7 - level_current * 0.1)
-		bloodsucker_user.physiology.brute_mod *= fortitude_resist
-		bloodsucker_user.physiology.stamina_mod *= fortitude_resist
 
-	was_running = ((owner.m_intent == MOVE_INTENT_RUN) || (owner.m_intent == MOVE_INTENT_SPRINT))
-	if(was_running)
-		bloodsucker_user.set_move_intent(MOVE_INTENT_WALK)
+		old_brute_mod = bloodsucker_user.physiology.brute_mod
+		old_stamina_mod = bloodsucker_user.physiology.stamina_mod
+
+		bloodsucker_user.physiology.brute_mod *= fortitude_resist
+
+		if (level_current >= 4)
+			bloodsucker_user.physiology.stamina_mod = 0
+		else
+			bloodsucker_user.physiology.stamina_mod *= fortitude_resist
 
 /datum/action/cooldown/bloodsucker/fortitude/process(seconds_per_tick)
 	// Checks that we can keep using this.
@@ -57,25 +86,34 @@
 	if(!active)
 		return
 	var/mob/living/carbon/user = owner
-	/// Prevents running while on Fortitude
-	if(user.m_intent != MOVE_INTENT_WALK)
-		user.set_move_intent(MOVE_INTENT_WALK)
-		user.balloon_alert(user, "you attempt to run, crushing yourself.")
-		user.take_overall_damage(brute = rand(5, 15))
+
 	/// We don't want people using fortitude being able to use vehicles
 	if(istype(user.buckled, /obj/vehicle))
 		user.buckled.unbuckle_mob(src, force=TRUE)
 
+	if (seconds_remaining > 0)
+		seconds_remaining -= seconds_per_tick
+		build_all_button_icons(UPDATE_BUTTON_STATUS)
+	else
+		DeactivatePower()
+
+/datum/action/cooldown/bloodsucker/fortitude/update_button_status(atom/movable/screen/movable/action_button/button, force = FALSE)
+	. = ..()
+
+	if (active)
+		button.maptext = MAPTEXT_TINY_UNICODE("[round(seconds_remaining, 1)]")
+
 /datum/action/cooldown/bloodsucker/fortitude/DeactivatePower()
 	if(ishuman(owner) && HAS_MIND_TRAIT(owner, TRAIT_BLOODSUCKER_ALIGNED))
 		var/mob/living/carbon/human/bloodsucker_user = owner
-		bloodsucker_user.physiology.brute_mod /= fortitude_resist
-		bloodsucker_user.physiology.stamina_mod /= fortitude_resist
+		bloodsucker_user.physiology.brute_mod = old_brute_mod
+		bloodsucker_user.physiology.stamina_mod = old_stamina_mod
 	// Remove Traits & Effects
 	owner.remove_traits(base_traits + upgraded_traits, FORTITUDE_TRAIT)
 
-	if(was_running && owner.m_intent == MOVE_INTENT_WALK)
-		owner.set_move_intent(MOVE_INTENT_RUN)
-	owner.balloon_alert(owner, "fortitude turned off.")
+	seconds_remaining = power_duration
+
+	owner.visible_message(span_warning("[owner]'s skin softens & returns to normal."))
+	owner.balloon_alert_to_viewers("skin softens", "your skin softens.")
 
 	return ..()

--- a/monkestation/code/modules/bloodsuckers/powers/go_home.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/go_home.dm
@@ -1,9 +1,4 @@
 
-#define GOHOME_START 0
-#define GOHOME_FLICKER_ONE 2
-#define GOHOME_FLICKER_TWO 4
-#define GOHOME_TELEPORT 6
-
 /**
  * Given to Bloodsuckers near Sol if they have a Coffin claimed.
  * Teleports them to their Coffin after a delay.
@@ -11,23 +6,20 @@
  */
 /datum/action/cooldown/bloodsucker/gohome
 	name = "Vanishing Act"
-	desc = "As dawn aproaches, disperse into mist and return directly to your Lair.<br><b>WARNING:</b> You will drop <b>ALL</b> of your possessions if observed by mortals."
+	desc = "Disperse into mist and return directly to your Lair.<br><b>WARNING:</b> You will drop <b>ALL</b> of your possessions if observed by mortals."
 	button_icon_state = "power_gohome"
 	active_background_icon_state = "vamp_power_off_oneshot"
 	base_background_icon_state = "vamp_power_off_oneshot"
 	power_explanation = "Vanishing Act: \n\
 		Activating Vanishing Act will, after a short delay, teleport the user to their Claimed Coffin. \n\
-		The power will cancel out if the Claimed Coffin is somehow destroyed. \n\
-		Immediately after activating, lights around the user will begin to flicker. \n\
+		Immediately after activating, lights around the user will temporarily flicker. \n\
 		Once the user teleports to their coffin, in their place will be a Rat or Bat."
-	power_flags = BP_AM_TOGGLE | BP_AM_SINGLEUSE | BP_AM_STATIC_COOLDOWN
+	power_flags = BP_AM_STATIC_COOLDOWN
 	check_flags = BP_CANT_USE_IN_TORPOR | BP_CANT_USE_WHILE_STAKED | BP_CANT_USE_WHILE_INCAPACITATED | BP_CANT_USE_WHILE_UNCONSCIOUS | BP_CANT_USE_IN_FRENZY
 	purchase_flags = NONE
 	bloodcost = 100
-	constant_bloodcost = 2
-	cooldown_time = 100 SECONDS
-	///What stage of the teleportation are we in
-	var/teleporting_stage = GOHOME_START
+	cooldown_time = 30 SECONDS
+
 	///The types of mobs that will drop post-teleportation.
 	var/static/list/spawning_mobs = list(
 		/mob/living/basic/mouse = 3,
@@ -46,44 +38,22 @@
 	if (!check_teleport_valid(owner, bloodsuckerdatum_power.coffin, TELEPORT_CHANNEL_MAGIC))
 		owner.balloon_alert(owner, "something holds you back!")
 		return FALSE
-	
+
 	if((bloodsuckerdatum_power.bloodsucker_blood_volume-get_blood_cost()) <= bloodsuckerdatum_power.frenzy_threshold)
 		owner.balloon_alert(owner, "using this would send you into a frenzy!")
 		return FALSE
-	
+
+	if(!isturf(owner.loc))
+		owner.balloon_alert(owner, "you cannot teleport right now!")
+		return FALSE
+
 	return TRUE
 
 /datum/action/cooldown/bloodsucker/gohome/ActivatePower(trigger_flags)
 	. = ..()
-	owner.balloon_alert(owner, "preparing to teleport...")
 
-/datum/action/cooldown/bloodsucker/gohome/process(seconds_per_tick)
-	. = ..()
-	if(!.)
-		return FALSE
-
-	switch(teleporting_stage)
-		if(GOHOME_START)
-			INVOKE_ASYNC(src, PROC_REF(flicker_lights), 3, 20)
-		if(GOHOME_FLICKER_ONE)
-			INVOKE_ASYNC(src, PROC_REF(flicker_lights), 4, 40)
-		if(GOHOME_FLICKER_TWO)
-			INVOKE_ASYNC(src, PROC_REF(flicker_lights), 4, 60)
-		if(GOHOME_TELEPORT)
-			INVOKE_ASYNC(src, PROC_REF(teleport_to_coffin), owner)
-	teleporting_stage++
-
-/datum/action/cooldown/bloodsucker/gohome/ContinueActive(mob/living/user, mob/living/target)
-	. = ..()
-	if(!.)
-		return FALSE
-	if(!isturf(owner.loc))
-		return FALSE
-	if(QDELETED(bloodsuckerdatum_power.coffin))
-		user.balloon_alert(user, "coffin destroyed!")
-		to_chat(owner, span_warning("Your coffin has been destroyed! You no longer have a destination."))
-		return FALSE
-	return TRUE
+	teleport_to_coffin(owner)
+	flicker_lights(4, 60)
 
 /datum/action/cooldown/bloodsucker/gohome/proc/flicker_lights(flicker_range, beat_volume)
 	for(var/obj/machinery/light/nearby_lights in view(flicker_range, get_turf(owner)))
@@ -130,8 +100,3 @@
 
 /datum/effect_system/steam_spread/bloodsucker
 	effect_type = /obj/effect/particle_effect/fluid/smoke/vampsmoke
-
-#undef GOHOME_START
-#undef GOHOME_FLICKER_ONE
-#undef GOHOME_FLICKER_TWO
-#undef GOHOME_TELEPORT

--- a/monkestation/code/modules/bloodsuckers/powers/targeted/brawn.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/targeted/brawn.dm
@@ -22,7 +22,7 @@
 /datum/action/cooldown/bloodsucker/targeted/brawn/upgrade_power()
 	. = ..()
 
-	if (level_current == 5)
+	if (level_current >= 5)
 		check_flags |= BP_ALLOW_WHILE_SILVER_CUFFED
 
 /datum/action/cooldown/bloodsucker/targeted/brawn/ActivatePower(trigger_flags)
@@ -159,7 +159,7 @@
 		playsound(get_turf(user), 'sound/effects/grillehit.ogg', 80, TRUE, -1)
 	// Target Type: Door
 	else if(istype(target_atom, /obj/machinery/door))
-		if(!check_level(3, "tear open doors"))
+		if(!check_level(4, "tear open doors"))
 			return
 		var/obj/machinery/door/target_airlock = target_atom
 		playsound(get_turf(user), 'sound/machines/airlock_alien_prying.ogg', 40, TRUE, -1)

--- a/monkestation/code/modules/bloodsuckers/powers/targeted/haste.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/targeted/haste.dm
@@ -4,24 +4,29 @@
  */
 
 /datum/action/cooldown/bloodsucker/targeted/haste
-	name = "Immortal Haste"
-	desc = "Dash somewhere with supernatural speed. Those nearby may be knocked away, stunned, or left empty-handed."
+	name = "Dash Attack"
+	desc = "Dash somewhere with supernatural speed. Those nearby will be knocked to the ground."
 	button_icon_state = "power_speed"
-	power_explanation = "Immortal Haste:\n\
-		Click anywhere to immediately dash towards that location.\n\
+	power_explanation = "Dash Attack:\n\
+		Click anywhere within 2 tiles to immediately dash towards that location.\n\
 		The Power will not work if you are lying down, in no gravity, or are aggressively grabbed.\n\
-		Anyone in your way during your Haste will be knocked down.\n\
-		Higher levels will increase the knockdown dealt to enemies."
+		Anyone in your way during your Dash will be knocked down.\n\
+		Higher levels will increase the range and knockdown dealt to enemies."
 	power_flags = BP_AM_TOGGLE
 	check_flags = BP_CANT_USE_IN_TORPOR | BP_CANT_USE_IN_FRENZY | BP_CANT_USE_WHILE_INCAPACITATED | BP_CANT_USE_WHILE_UNCONSCIOUS
 	purchase_flags = BLOODSUCKER_CAN_BUY | VASSAL_CAN_BUY
 	bloodcost = 6
 	sol_multiplier = 10
 	cooldown_time = 12 SECONDS
-	target_range = 15
+	target_range = 2
 	power_activates_immediately = TRUE
 	///List of all people hit by our power, so we don't hit them again.
 	var/list/hit = list()
+
+/datum/action/cooldown/bloodsucker/targeted/haste/upgrade_power()
+	. = ..()
+
+	target_range++
 
 /datum/action/cooldown/bloodsucker/targeted/haste/can_use(mob/living/carbon/user, trigger_flags)
 	. = ..()
@@ -35,11 +40,11 @@
 		user.balloon_alert(user, "you cannot dash while floating!")
 		return FALSE
 	if(user.body_position == LYING_DOWN)
-		user.balloon_alert(user, "you must be standing to tackle!")
+		user.balloon_alert(user, "you must be standing to dash!")
 		return FALSE
 	return TRUE
 
-/// Anything will do, if it's not me or my square
+/// Anything in range will do, if it's not me or my square
 /datum/action/cooldown/bloodsucker/targeted/haste/CheckValidTarget(atom/target_atom)
 	. = ..()
 	if(!.)
@@ -56,7 +61,7 @@
 	user.pulledby?.stop_pulling()
 	// Go to target turf
 	// DO NOT USE WALK TO.
-	owner.balloon_alert(owner, "you dash into the air!")
+	owner.balloon_alert_to_viewers("dashes into the air!", "you dash into the air!")
 	playsound(get_turf(owner), 'sound/weapons/punchmiss.ogg', 25, 1, -1)
 	var/safety = get_dist(user, targeted_turf) * 3 + 1
 	var/consequetive_failures = 0

--- a/monkestation/code/modules/bloodsuckers/powers/targeted/lunge.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/targeted/lunge.dm
@@ -4,13 +4,14 @@
 	button_icon_state = "power_lunge"
 	power_explanation = "Predatory Lunge:\n\
 		Click any player to start spinning wildly and, after a short delay, dash at them.\n\
+		This has a max range of 4 tiles.\n\
 		When lunging at someone, you will grab them, immediately starting off at aggressive.\n\
 		Riot gear and Monster Hunters are protected and will only be passively grabbed.\n\
 		You cannot use the Power if you are already grabbing someone, or are being grabbed.\n\
 		If you grab from behind, or from darkness (Cloak of Darkness works), you will knock the target down.\n\
 		If used on a dead body, will tear their heart out.\n\
-		Higher levels increase the knockdown dealt to enemies.\n\
-		At level 4, you will no longer spin, but you will be limited to tackling from only 6 tiles away."
+		Higher levels increase the knockdown dealt to enemies & the range of the ability.\n\
+		At level 3, you will no longer spin and will instead lunge immediately."
 	power_flags = NONE
 	check_flags = BP_CANT_USE_IN_TORPOR | BP_CANT_USE_IN_FRENZY | BP_CANT_USE_WHILE_INCAPACITATED | BP_CANT_USE_WHILE_UNCONSCIOUS
 	purchase_flags = BLOODSUCKER_CAN_BUY | VASSAL_CAN_BUY
@@ -18,12 +19,12 @@
 	sol_multiplier = 15
 	cooldown_time = 10 SECONDS
 	power_activates_immediately = FALSE
+	target_range = 4
 
 /datum/action/cooldown/bloodsucker/targeted/lunge/upgrade_power()
 	. = ..()
-	//range is lowered when you get stronger.
-	if(level_current > 3)
-		target_range = 6
+
+	target_range++
 
 /datum/action/cooldown/bloodsucker/targeted/lunge/can_use(mob/living/carbon/user, trigger_flags)
 	. = ..()
@@ -66,7 +67,7 @@
 /datum/action/cooldown/bloodsucker/targeted/lunge/FireTargetedPower(atom/target_atom)
 	. = ..()
 	owner.face_atom(target_atom)
-	if(level_current > 3)
+	if(level_current >= 3)
 		do_lunge(target_atom)
 		return
 
@@ -86,7 +87,7 @@
 		var/y_offset = base_y + rand(-3, 3)
 		animate(pixel_x = x_offset, pixel_y = y_offset, time = 1)
 
-	if(!do_after(owner, 4 SECONDS, timed_action_flags = (IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE|IGNORE_SLOWDOWNS), extra_checks = CALLBACK(src, PROC_REF(CheckCanTarget), target_atom), hidden = TRUE))
+	if(!do_after(owner, 1 SECONDS, timed_action_flags = (IGNORE_USER_LOC_CHANGE|IGNORE_TARGET_LOC_CHANGE|IGNORE_SLOWDOWNS), extra_checks = CALLBACK(src, PROC_REF(CheckCanTarget), target_atom), hidden = TRUE))
 		end_target_lunge(base_x, base_y)
 
 		return FALSE

--- a/monkestation/code/modules/bloodsuckers/powers/targeted/mesmerize.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/targeted/mesmerize.dm
@@ -2,12 +2,10 @@
  *	MEZMERIZE
  *	 Locks a target in place for a certain amount of time.
  *
- * 	Level 2: Additionally mutes
  * 	Level 3: Can be used through face protection
  * 	Level 5: Doesn't need to be facing you anymore
  */
 
-#define MESMERIZE_MUTE_LEVEL 2
 #define MESMERIZE_GLASSES_LEVEL 3
 #define MESMERIZE_FACING_LEVEL 5
 /datum/action/cooldown/bloodsucker/targeted/mesmerize
@@ -38,23 +36,22 @@
 	/// at this protection mesmerize will fail
 	var/max_eye_protection = 2
 /datum/action/cooldown/bloodsucker/targeted/mesmerize/get_power_desc_extended()
-	. += "[src] a target, locking them in place for a short time[level_current >= MESMERIZE_MUTE_LEVEL ? " and muting them" : ""].<br>"
+	. += "[src] a target, locking them in place for a short time and muting them.<br>"
 
 /datum/action/cooldown/bloodsucker/targeted/mesmerize/get_power_explanation_extended()
 	. = list()
-	. += "Click any player to attempt to mesmerize them. This will stun the victim."
-	. += "The victim will realize they are being mesmerized, but will be unable to talk, but at level [MESMERIZE_MUTE_LEVEL] they will be also muted."
+	. += "Click any player to attempt to mesmerize them. If successful, will stun the victim."
+	. += "The victim will realize they are being mesmerized, but will be muted for [DisplayTimeText(get_mute_time())]."
 	if(blocked_by_glasses && requires_facing_target)
 		. += "[src] requires you to not be wearing glasses and to be facing your target."
 	else if(blocked_by_glasses)
 		. += "[src] requires you to not be wearing glasses."
 	else if(requires_facing_target)
 		. += "[src] requires you to be facing your target."
-	. += "You cannot wear anything covering your face, and both parties must be facing eachother."
 	. += "Obviously, both parties need to not be blind."
 	. += "If your target is already mesmerized or a bloodsucker, the Power will fail."
 	. += "Flash protection will slow down mesmerize, but welding protection will completely stop it."
-	. += "Once mesmerized, the target will be unable to move for [DisplayTimeText(get_power_time())] and muted for [DisplayTimeText(get_mute_time())], scaling with level."
+	. += "Once mesmerized, the target will be unable to move for [DisplayTimeText(get_power_time())], scaling with level."
 	. += "At level [MESMERIZE_GLASSES_LEVEL], you will be able to use the power through items covering your face."
 	. += "At level [MESMERIZE_FACING_LEVEL], you will be able to mesmerize regardless of your target's direction."
 	. += "Additionally it works on silicon lifeforms, causing a EMP effect instead of a freeze."
@@ -68,7 +65,7 @@
 		to_chat(user, span_warning("You have no eyes with which to mesmerize."))
 		return FALSE
 	// Check: Eyes covered?
-	if(blocked_by_glasses && istype(user) && (user.is_eyes_covered() && level_current <= 2) || !isturf(user.loc))
+	if(blocked_by_glasses && istype(user) && (user.is_eyes_covered() && level_current < MESMERIZE_GLASSES_LEVEL) || !isturf(user.loc))
 		user.balloon_alert(user, "your eyes are concealed from sight.")
 		return FALSE
 	return TRUE
@@ -194,9 +191,8 @@
 	mesmerized_target.become_blind(MESMERIZE_TRAIT)
 
 /datum/action/cooldown/bloodsucker/targeted/mesmerize/proc/mute_target(mob/living/mesmerized_target)
-	if(level_current >= MESMERIZE_MUTE_LEVEL)
-		mesmerized_target.set_silence_if_lower(get_mute_time())
-		mesmerized_target.set_emote_mute_if_lower(get_mute_time())
+	mesmerized_target.set_silence_if_lower(get_mute_time())
+	mesmerized_target.set_emote_mute_if_lower(get_mute_time())
 
 /datum/action/cooldown/bloodsucker/targeted/mesmerize/DeactivatePower(deactivate_flags)
 	. = ..()
@@ -228,4 +224,3 @@
 
 #undef MESMERIZE_GLASSES_LEVEL
 #undef MESMERIZE_FACING_LEVEL
-#undef MESMERIZE_MUTE_LEVEL

--- a/monkestation/code/modules/bloodsuckers/powers/targeted/trespass.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/targeted/trespass.dm
@@ -1,11 +1,11 @@
 /datum/action/cooldown/bloodsucker/targeted/trespass
 	name = "Trespass"
-	desc = "Become mist and advance two tiles in one direction. Useful for skipping past doors and barricades."
+	desc = "Become mist and advance past obstacles in one direction. Useful for skipping past doors and barricades."
 	button_icon_state = "power_tres"
 	power_explanation = "Trespass:\n\
-		Click anywhere from 1-2 tiles away from you to teleport.\n\
+		Click anywhere within 2 tiles from you to teleport.\n\
 		This power goes through all obstacles except Walls.\n\
-		Higher levels decrease the sound played from using the Power, and increase the speed of the transition."
+		Higher levels increase the range, decrease the sound played from using the Power, and increase the speed of the transition."
 	power_flags = BP_AM_TOGGLE
 	check_flags = BP_CANT_USE_IN_TORPOR | BP_CANT_USE_WHILE_INCAPACITATED | BP_CANT_USE_WHILE_UNCONSCIOUS
 	purchase_flags = BLOODSUCKER_CAN_BUY | VASSAL_CAN_BUY
@@ -13,8 +13,13 @@
 	sol_multiplier = 5
 	cooldown_time = 8 SECONDS
 	prefire_message = "Select a destination."
-	//target_range = 2
+	target_range = 2
 	var/turf/target_turf // We need to decide where we're going based on where we clicked. It's not actually the tile we clicked.
+
+/datum/action/cooldown/bloodsucker/targeted/trespass/upgrade_power()
+	. = ..()
+
+	target_range++
 
 /datum/action/cooldown/bloodsucker/targeted/trespass/can_use(mob/living/carbon/user, trigger_flags)
 	. = ..()
@@ -23,7 +28,6 @@
 	if(HAS_TRAIT(user, TRAIT_NO_TRANSFORM) || !get_turf(user))
 		return FALSE
 	return TRUE
-
 
 /datum/action/cooldown/bloodsucker/targeted/trespass/CheckValidTarget(atom/target_atom)
 	. = ..()
@@ -44,14 +48,14 @@
 	// Are either tiles WALLS?
 	var/turf/from_turf = get_turf(owner)
 	var/this_dir // = get_dir(from_turf, target_turf)
-	for(var/i = 1 to 2)
+	for(var/i = 1 to target_range)
 		// Keep Prev Direction if we've reached final turf
 		if(from_turf != final_turf)
 			this_dir = get_dir(from_turf, final_turf) // Recalculate dir so we don't overshoot on a diagonal.
 		from_turf = get_step(from_turf, this_dir)
 		// ERROR! Wall!
 		if(iswallturf(from_turf))
-			var/wallwarning = (i == 1) ? "in the way" : "at your destination"
+			var/wallwarning = (i < target_range) ? "in the way" : "at your destination"
 			owner.balloon_alert(owner, "There is a wall [wallwarning].")
 			return FALSE
 	// Done

--- a/monkestation/code/modules/bloodsuckers/powers/tremere/obfuscation.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/tremere/obfuscation.dm
@@ -106,6 +106,7 @@
 		recloak_timer = null
 	REMOVE_TRAIT(owner, TRAIT_UNKNOWN, REF(src))
 	animate(owner, alpha = 255, time = 2 SECONDS)
+	owner.RemoveElement(/datum/element/relay_attackers)
 	owner.RemoveElement(/datum/element/digitalcamo)
 	revealed = FALSE
 

--- a/monkestation/code/modules/bloodsuckers/structures/bloodsucker_coffin.dm
+++ b/monkestation/code/modules/bloodsuckers/structures/bloodsucker_coffin.dm
@@ -38,6 +38,10 @@
 			/datum/crafting_recipe/meatcoffin,
 		))
 		owner.current.balloon_alert(owner.current, "new recipes learned!")
+
+	if(!(locate(/datum/action/cooldown/bloodsucker/gohome) in powers))
+		BuyPower(new /datum/action/cooldown/bloodsucker/gohome)
+
 	to_chat(owner, span_userdanger("You have claimed the [claimed] as your place of immortal rest! Your lair is now [bloodsucker_lair_area]."))
 	to_chat(owner, span_announce("Bloodsucker Tip: Find new lair recipes in the Structures tab of the <i>Crafting Menu</i>, including the <i>Persuasion Rack</i> for converting crew into Vassals."))
 	return TRUE
@@ -57,7 +61,7 @@
 	. = ..()
 	if(user == resident)
 		. += span_cult("This is your Claimed Coffin.")
-		. += span_cult("Rest in it while injured to enter Torpor. Entering it with unspent Ranks will allow you to spend one.")
+		. += span_cult("Rest in it while injured to enter Torpor. Entering it with unspent Ranks will allow you to spend them.")
 		. += span_cult("Alt-Click while inside the Coffin to Lock/Unlock.")
 		. += span_cult("Alt-Click while outside of your Coffin to Unclaim it, unwrenching it and all your other structures as a result.")
 
@@ -206,6 +210,8 @@
 	if(bloodsuckerdatum?.coffin == src)
 		bloodsuckerdatum.coffin = null
 		bloodsuckerdatum.bloodsucker_lair_area = null
+		for(var/datum/action/cooldown/bloodsucker/gohome/power in bloodsuckerdatum.powers)
+			bloodsuckerdatum.RemovePower(power)
 	for(var/obj/structure/bloodsucker/bloodsucker_structure in get_area(src))
 		if(bloodsucker_structure.owner == resident)
 			bloodsucker_structure.unbolt()

--- a/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
+++ b/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
@@ -428,7 +428,7 @@
 	blood_draining = FALSE
 	return TRUE
 
-/// Offer them the oppertunity to join now.
+/// Offer them the opportunity to join now.
 /obj/structure/bloodsucker/vassalrack/proc/do_disloyalty(mob/living/user, mob/living/target)
 	if(disloyalty_offered)
 		return FALSE

--- a/monkestation/code/modules/bloodsuckers/vassals/types/favorite.dm
+++ b/monkestation/code/modules/bloodsuckers/vassals/types/favorite.dm
@@ -8,8 +8,7 @@
 	show_in_antagpanel = FALSE
 	antag_hud_name = "vassal6"
 	special_type = FAVORITE_VASSAL
-	vassal_description = "The Favorite Vassal gets unique abilities over other Vassals depending on your Clan \
-		and becomes completely immune to Mindshields. If part of Ventrue, this is the Vassal you will rank up."
+	vassal_description = "The Favorite Vassal gets unique abilities over other Vassals depending on your Clan. If part of Ventrue, this is the Vassal you will rank up."
 
 	///Bloodsucker levels, but for Vassals, used by Ventrue.
 	var/vassal_level
@@ -17,9 +16,6 @@
 /datum/antagonist/vassal/favorite/on_gain()
 	. = ..()
 	SEND_SIGNAL(master, COMSIG_BLOODSUCKER_MAKE_FAVORITE, src)
-
-/datum/antagonist/vassal/favorite/pre_mindshield(mob/implanter, mob/living/mob_override)
-	return COMPONENT_MINDSHIELD_RESISTED
 
 ///Set the Vassal's rank to their Bloodsucker level, and transfer all abilities to the Bloodsucker level.
 /datum/antagonist/vassal/favorite/proc/set_vassal_level(datum/antagonist/bloodsucker/vassal_bloodsucker_datum)

--- a/monkestation/code/modules/bloodsuckers/vassals/types/revenge.dm
+++ b/monkestation/code/modules/bloodsuckers/vassals/types/revenge.dm
@@ -54,9 +54,6 @@
 
 	return data + ..()
 
-/datum/antagonist/vassal/revenge/pre_mindshield(mob/implanter, mob/living/mob_override)
-	return COMPONENT_MINDSHIELD_RESISTED
-
 /datum/antagonist/vassal/revenge/proc/on_master_death(datum/antagonist/bloodsucker/bloodsuckerdatum, mob/living/carbon/master)
 	SIGNAL_HANDLER
 

--- a/monkestation/code/modules/bloodsuckers/vassals/vassal_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/vassals/vassal_datum.dm
@@ -121,7 +121,7 @@
 	//Free them from their Master
 	if(!QDELETED(master))
 		if(special_type && master.special_vassals[special_type])
-			master.special_vassals[special_type] -= src
+			master.special_vassals.Remove(special_type)
 		master.vassals -= src
 		owner.enslaved_to = null
 	if(owner.current)

--- a/monkestation/code/modules/smithing/material_changes/material_traits/holy.dm
+++ b/monkestation/code/modules/smithing/material_changes/material_traits/holy.dm
@@ -16,11 +16,14 @@
 	SIGNAL_HANDLER
 	var/damage_multiplier = 1
 	if(IS_BLOODSUCKER(victim))
+		damage_multiplier *= 2
+		/*
 		// extra damage during sol
 		if(victim.has_status_effect(/datum/status_effect/bloodsucker_sol))
 			damage_multiplier *= 3
 		else
 			damage_multiplier *= 2
+		*/
 
 	// werewolves have insane damage resistance, so 3x damage
 	if(iswerewolf(victim))

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -7106,7 +7106,7 @@
 #include "monkestation\code\modules\bloodsuckers\clans\nosferatu.dm"
 #include "monkestation\code\modules\bloodsuckers\clans\tremere.dm"
 #include "monkestation\code\modules\bloodsuckers\clans\vassal.dm"
-#include "monkestation\code\modules\bloodsuckers\clans\venture.dm"
+#include "monkestation\code\modules\bloodsuckers\clans\ventrue.dm"
 #include "monkestation\code\modules\bloodsuckers\controllers\sunlight.dm"
 #include "monkestation\code\modules\bloodsuckers\powers\_base_power.dm"
 #include "monkestation\code\modules\bloodsuckers\powers\cloak.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Overhauls the bloodsucker antagonist with a huge suite of re-balances, primarily intended on buffing the standard clans near roundstart (tremere is mostly untouched, although will benefit from the extra leveling) as well as removing sol, but with a couple nerfs and other changes here and there.

Full list of changes: 
- Sol is GONE, but you still get free levels every 10 mins - the cap on free levels has been increased from 3 to 6. (the code for sol has been commented out instead of deleted in case someone wants to take a stab at reworking it again later)
- All clans (except tremere, unchanged) now get every vampire ability at lvl 1 roundstart, but only level up 1 ability at a time.
- The amount of blood required to level up from drinking from sentient mobs has been slightly reduced.
- Ventrue has had its max level increased from 3 to 4 (you now advance to level 4 before having to spend levels on your favorite vassal)
- You can level up multiple times inside a coffin without having to open and re-shut it.
- Buffs/changes vanishing act: Vanishing act is now an ability every vampire gets when they make a lair, and you can use it _instantly_ at any time, but it has a 5 min cooldown. Similar to heretic blade breaks, but way more counterable. You also still drop all your shit if someone sees you in a lit area. Being full stunned, silver cuffed, or bluespace grounded will all still prevent vanishing act. 
- Buffs trespass: Higher levels now increase the range of trespass, +1 per level.
- Buffs predatory lunge - the "spinning" thing has been reduced to 1s, and is gone at level 3 instead of 4. The ability now has a range that starts at 4 tiles and increases every level. It was also previously bugged before level 4 and would never work unless you were adjacent to the target (lol), so that's been fixed.
- Buffs cloak of darkness - only makes you unable to sprint rather than forcing walking. You also can now start your cloak even if others can see you. However, similar to the current behavior of tremere's obfuscate, if you attack or get attacked while in cloak, your cloak will break. 
- Changes fortitude: Removes fortitude forcing to walk, however: you are still unable to sprint, and the ability is a limited duration, starting at 10s with a 30s cooldown. Higher levels increase the duration and reduce the cooldown. Level 4 is still full stun immunity, for the duration of the ability. Also, activating/ending fortitude gives chat messages and balloon alerts to everyone around you, as the old tell (force walking) is now gone.
- Buffs mesmerize: mesmerize now silences the target on lvl 1 instead of 2. 
- Fixes a minor bug with brawn: Brawn now doesn't let you break doors until level 4, as intended. (Was previously allowing it at level 3)
- "Immortal Haste" has been renamed to "Dash Attack" (the old name was terrible) and nerfed to have a range- the range starts at 2 tiles and increases 1 per level. The knockdown still increases with every level as well. 
- Revenge and favorite vassals can now be deconverted by mindshield - previously the only way to deconvert them was by staking the vamp (revenge vassals also used to be deconvertible by mindshield but that was changed recently, I'm changing it back). 
- Vampires get "Escape on the escape shuttle alive and not in custody" instead of just survive, and also their random vassalization objective is no longer optional.

## Why It's Good For The Game

Alright! I'll break this down into a few major parts. First of all, I am a SECURITY MAIN (believe it or not) so my goal here is not to make vampires OP. I want this PR to be testmerged for a while to make sure I didn't overtune them, and I'll gladly dial some things back if I ended up making them too strong.  However, all my changes have been well thought out from the perspective of someone who frequently fights vampires.

Sol: 
Sol was just a terrible mechanic, for so many reasons. Of course everyone has heard the argument that it stifles RP, which is very true, but even putting that aside it's just a bad way to balance an antagonist. For one, having to stop what you're doing and sit the game out for a minute or more every 10 mins (which will usually add up to like a MINIMUM of 10 mins of doing nothing in a round) is just unfun for the antagonist player. It's also a shitty way to make a weakness - if we let vampires be too strong when they ARENT in Sol, they become unfun to fight for the majority of the round. Nobody wants to lose a fight to broken OP bullshit and be told "you shoulda ran away until sol". Similarly, your weakness making you _completely defenseless_ is just a lame way to die. Oh great, I died because someone stumbled on my lair in my 60 seconds of being force sleeped, guess my round's over. 

Sol also encourages boring gameplay for security players too. I guess the intended strategy for security is just to base camp lairs, but not only is this boring for the vampire, it's also pretty boring for the seccie to sit around doing nothing camping too. Stakeouts can be fun in the right circumstances, but when they become the intended way to fight something they become a chore. 

Leveling Changes:
Vampires suffered from being way too weak roundstart while also having way overtuned power scaling from exponential growth if they can get past a certain level (about level 5-6 is where it really starts to snowball). I'd like to make vampires _substantially_ stronger at roundstart so they are encouraged to actually go out and do things. To go along with this, I've made a lot of abilities much more useful at level 1, to give people a proper toolkit they can play with at roundstart. Despite adding a _bit_ of UI clutter (although no worse than changeling), I think this will also help new players learn vampire, as being able to test out and play with (and read the description for) all your powers is a great way to learn them.

The old system also had the added downside of forcing vampires to plan out "build orders" in advance, since whatever ability you pick first is gonna end up being your most leveled one (this particularly fucked over new vamps who didn't understand how that worked/what every ability did). Now, while you can certainly still plan ahead, you can also just put ranks into things as you need them.

Vanishing Act: 
With removing sol, vanishing act needed a new purpose. Vampire was already lacking a lot in proper escape tools, so I decided to give them basically a weaker version of the heretic's blade break. It's similar to blade breaking but has a lot more counters (simple base-camping being one) and also a hard-coded cooldown as opposed to being spammable.

Predatory Lunge:
This ability was both bugged and useless before level 4, so I made it not complete shit. Gave it some range limitations to compensate (although it actually already had range coded in... but only at level 4 or higher? For some reason).

Immortal Haste/Dash Attack:
This was actually one of the more OP abilities in regular vampire's arsenal (unlimited range, near-instant, crowd control knockdown) except it was totally slept on because of the name that 90% of players didn't realize was actually an offensive ability. I seriously almost never saw this used by vampires in combat. Now, hopefully the new name and roundstart accessibility will encourage it to actually be used. Added big range limitations to compensate, but it's still a pretty strong stun especially once you put some levels into it.

Fortitude:
Fortitude was a tricky one. On the one hand, I do NOT want to make vampires more anti-stun in general, since that would go against my idea of having them be non-armory/KOS threats by default. On the other hand, I wanted to remove the force walking since it makes the ability pretty ass to use. I ended up on settling on this as a compromise- this takes the ability at low levels into an emergency 'get to cover or retaliate' button to use while you're actively getting stunned/shot, but it's not something that will make you unarrestable with stuns on its own. At high levels (i.e. if you invested into it) you can use it to totally facetank stuns and kick ass at normal movespeed for a while, but it will leave a short window of stun vulnerability which I think could encourage interesting combat. 

Other Minor Power Changes: 
Made mesmerize a bit more useful at level 1 to encourage its use as part of the roundstart arsenal. It's still pretty counterable since the rework of it. I made cloak a bit stronger since force walking was garbage, but also made it more counterable by attack/being attacked. Trespass was basically useless to level up ever, so I gave leveling some more purpose. 

Vassal Deconversion:
Non-deconvertable vassals made a lot more sense when vampires were KOS. Now, they cause 2 issues. The first is that it encourages RRs even if security captures everyone involved non-lethally, as the only way to deconvert these vassal types is by staking the vampire. The second is that if you capture the non-deconvertable vassals before the vamp, they're basically stuck in limbo because it doesn't make sense to release them while you're still actively trying to catch their master, but you also cant process them properly until you catch and stake the vamp. Best solution currently is just to stick them in perma temporarily, which is a headache on its own, but a lot of times they just end up sitting in cuffs for a while too. Simplest solution is to just let them be deconverted. 

Objective Changes:
Monkestation may not be a greentext server, but the truth is that people still chase the holy green, and who can blame them.  There is something satisfying about seeing that you have succeeded at the end of the round. However, vampire objectives previously were kind of a total nothingburger and could be greentexted by making a coffin and AFKing in maints for the whole round. Now your vassalization objectives are not optional anymore (why were they even?), so if you want that holy green you better get out there and do some things. Since vampires have also been recently changed to be more arrestable and less KOS, I also made it so that bloodsuckers actually want to escape on the shuttle in freedom rather than just being alive at end of shift.

## Changelog

:cl:
balance: Sol is GONE, but you still get free levels every 10 mins - the cap on free levels has been increased from 3 to 6. 
code: Most of the code for sol has been commented out instead of deleted in case someone wants to take a stab at reworking it again later.
balance: All clans (except tremere, unchanged) now get every vampire ability at level 1 roundstart, but only level up 1 ability at a time.
balance: The amount of blood required to level up from drinking from sentient mobs has been slightly reduced.
balance: Ventrue has had its max level increased from 3 to 4 (you now advance to level 4 before having to spend levels on your favorite vassal)
qol: You can level up multiple times inside a coffin without having to open and re-shut it.
balance: Buffs/changes vanishing act: Vanishing act is now an ability every vampire gets when they make a lair, and you can use it _instantly_ at any time, but it has a 5 min cooldown. Similar to heretic blade breaks, but way more counterable. You also still drop all your shit if someone sees you in a lit area. Being full stunned, silver cuffed, or bluespace grounded will all still prevent vanishing act. 
balance: Buffs trespass: Higher levels now increase the range of trespass, +1 per level.
fix: Fixes predatory lunge not working unless you were adjacent to target.
balance: Buffs predatory lunge - the "spinning" telegraphing effect has been reduced to 1s, and is gone at level 3 instead of 4. The ability now has a range that starts at 4 tiles and increases every level.
balance: Buffs cloak of darkness - only makes you unable to sprint rather than forcing walking. You also can now start your cloak even if others can see you. However, similar to the current behavior of tremere's obfuscate, if you attack or get attacked while in cloak, your cloak will break. 
balance: Changes fortitude: Removes fortitude forcing to walk, however: you are still unable to sprint, and the ability is a limited duration, starting at 10s with a 30s cooldown. Higher levels increase the duration and reduce the cooldown. Level 4 is still full stun immunity, for the duration of the ability. Also, activating/ending fortitude gives chat messages and balloon alerts to everyone around you, as the old tell (force walking) is now gone.
balance: Buffs mesmerize: mesmerize now silences the target on lvl 1 instead of 2. 
fix: Fixes a minor bug with brawn: Brawn now doesn't let you break doors until level 4, as intended. (Was previously allowing it at level 3)
balance: "Immortal Haste" has been renamed to "Dash Attack" and nerfed to have a range- the range starts at 2 tiles and increases 1 per level. The knockdown still increases with every level as well. 
balance: Revenge and favorite vassals can now both be deconverted by mindshield.
balance: Vampires get "Escape on the escape shuttle alive and not in custody" instead of just survive, and also their random vassalization objective is no longer optional.
spellcheck: Fixed a number of typos in vampire ability descriptions and code comments, as well as updating many ability descriptions.
:/cl:
