### PR TITLE
Fixes hiding in trash piles + Context screentips

### DIFF
--- a/monkestation/code/game/objects/structures/trash_pile.dm
+++ b/monkestation/code/game/objects/structures/trash_pile.dm
@@ -83,6 +83,12 @@
 		"brokecomp",
 	)
 
+	AddElement( \
+		/datum/element/contextual_screentip_bare_hands, \
+		lmb_text = "Rummage", \
+		rmb_text = "Hide", \
+	)
+
 /obj/structure/trash_pile/attack_hand(mob/living/user)
 	if(user in contents)
 		eject_mob(user)
@@ -136,10 +142,12 @@
 	if(user.transferItemToLoc(attacking_item, src))
 		balloon_alert(user, "item hidden!")
 
-/obj/structure/trash_pile/mouse_drop_receive(mob/living/dropped, mob/user, params)
-	if(user != dropped || !iscarbon(dropped))
+/obj/structure/trash_pile/attack_hand_secondary(mob/mob_user, list/modifiers)
+	. = ..()
+	if(!iscarbon(mob_user))
 		return ..()
-	if(DOING_INTERACTION(user, DOAFTER_SOURCE_TRASH_PILE) || !(dropped.mobility_flags & MOBILITY_MOVE))
+	var/mob/living/carbon/user = mob_user
+	if(DOING_INTERACTION(user, DOAFTER_SOURCE_TRASH_PILE) || !(user.mobility_flags & MOBILITY_MOVE))
 		return
 
 	user.visible_message(


### PR DESCRIPTION

## About The Pull Request
Fixes being unable to hide in trash piles and also adds contextual screentips (the ones you see in APC while hovering over it) for better QoL
## Why It's Good For The Game
Fixes #8835
Cool features shouldn't be hidden with no way of knowing unless you code-dived.
## Changelog
:cl:
qol: Added screentips context for trash piles
fix: Fixes being unable to hide in trash piles
/:cl:
