### PR TITLE
every darkspawn class can now get flash immunity

### DIFF
--- a/code/modules/antagonists/darkspawn/darkspawn_upgrades/passive_upgrades.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_upgrades/passive_upgrades.dm
@@ -139,9 +139,6 @@
 /datum/psi_web/fast_cooldown/on_loss()
 	REMOVE_TRAIT(shadowhuman, TRAIT_FAST_COOLDOWNS, type)
 
-////////////////////////////////////////////////////////////////////////////////////
-//--------------------------Fighter Passive Upgrades------------------------------//
-////////////////////////////////////////////////////////////////////////////////////
 /datum/psi_web/sunglasses
 	name = "Lightblind Sigil"
 	desc = "Protects you from strong flashes of light."
@@ -149,13 +146,17 @@
 	icon_state = "light_blind"
 	willpower_cost = 1
 	menu_tab = STORE_PASSIVE
-	shadow_flags = DARKSPAWN_FIGHTER
+	shadow_flags = ALL_DARKSPAWN_CLASSES
 
 /datum/psi_web/sunglasses/on_gain()
 	ADD_TRAIT(shadowhuman, TRAIT_NOFLASH, type)
 
 /datum/psi_web/sunglasses/on_loss()
 	REMOVE_TRAIT(shadowhuman, TRAIT_NOFLASH, type)
+
+////////////////////////////////////////////////////////////////////////////////////
+//--------------------------Fighter Passive Upgrades------------------------------//
+////////////////////////////////////////////////////////////////////////////////////
 
 //Halves lightburn damage.
 /datum/psi_web/light_resistance


### PR DESCRIPTION
## About The Pull Request
gives every darkspawn class the option to buy flash immunity

## Why It's Good For The Game
only warrior can get flash immunity and  darkspawn cannot wear anything on their eye slots leading to warlock and scout dying very easily to a flashbangs/flashes

## Changelog

:cl:
balance: every darkspawn class can now get lightblind sigils
/:cl:

