### PR TITLE
Ice ice box. Now with notabley the same amount of ice

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -17966,7 +17966,6 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/engineering/atmos)
 "fsS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},


### PR DESCRIPTION

## About The Pull Request
- Icebox gulag has a connection to power now.
- Icebox security dorms Maintenace external airlock is no longer walled off
- Icebox security has flowing distro now. 
- Icebox dorms, arrivals, and locker room areas have had their distro adjusted to be a bit more Maintenace based
## Why It's Good For The Game
- Gulag is a old bug fix, amplified by new power
- Security distro now having flow techically balance? But honestly should be considered more a fix. Weird balance those always strike
- Maintenace distro is both sensible and makes distribution generally more healthy in sustainability. This allows for a more general loop flow than one path through the crowded hallways. And incentivizes a practical use to Maintenace. Especially as it creates two paths to arrivals rather than just one easily sabotaged one.
## Changelog
:cl:
map: Ice box gulag is now hooked to power
map: Ice box security will have a flowing distro
map: Ice box security - dorms Maintenace no longer has a walled off external airlock
map: Ice box arrivals and dorms are slightly less hallway heavy for it's distro
/:cl:
