### PR TITLE
Fix multi-cell charging racks rapidly sucking the APC's power

### DIFF
--- a/monkestation/code/modules/blueshift/appliances/multi_charger.dm
+++ b/monkestation/code/modules/blueshift/appliances/multi_charger.dm
@@ -91,7 +91,7 @@
 		return ..()
 
 /obj/machinery/cell_charger_multi/process(seconds_per_tick)
-	if(!charging_batteries.len || !anchored || (machine_stat & (BROKEN|NOPOWER)))
+	if(!length(charging_batteries) || !anchored || (machine_stat & (BROKEN|NOPOWER)))
 		return
 
 	// create a charging queue, we only want cells that require charging to use the power budget
@@ -110,9 +110,11 @@
 	if(!charge_current)
 		return
 
+	var/charge_given = 0
 	for(var/obj/item/stock_parts/power_store/cell/charging_cell in charging_queue)
-		use_energy(charge_current * 0.01) //use a small bit for the charger itself, but power usage scales up with the part tier
-		charge_cell(charge_current, charging_cell, grid_only = TRUE)
+		charge_given += charge_cell(charge_current, charging_cell, grid_only = TRUE)
+	if(charge_given)
+		use_energy((charge_given + active_power_usage) * 0.01) //use a small bit for the charger itself, but power usage scales up with the part tier
 
 	LAZYNULL(charging_queue)
 	update_appearance()


### PR DESCRIPTION
## Changelog
:cl:
fix: Multi-cell charging racks now use power from the grid like normal cell chargers do, instead of rapidly draining the APC.
/:cl:
