### PR TITLE
fix the cursed katana's combo attacks not working

### DIFF
--- a/code/datums/components/combo_attacks.dm
+++ b/code/datums/components/combo_attacks.dm
@@ -84,14 +84,13 @@
 	if(deltimer && timerid)
 		deltimer(timerid)
 
-/datum/component/combo_attacks/proc/on_attack(datum/source, mob/living/target, mob/user, click_parameters)
+/datum/component/combo_attacks/proc/on_attack(datum/source, mob/living/target, mob/user, list/modifiers)
 	SIGNAL_HANDLER
 
 	if(can_attack_callback && !can_attack_callback.Invoke(user, target))
 		return NONE
 	if(HAS_TRAIT(user, TRAIT_PACIFISM))
 		return NONE
-	var/list/modifiers = params2list(click_parameters)
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
 		input_list += RIGHT_ATTACK
 	if(LAZYACCESS(modifiers, LEFT_CLICK))


### PR DESCRIPTION
## Changelog
:cl:
fix: Fixed the cursed katana's combo attacks not working.
/:cl:
