### PR TITLE
More Quartermaster alt in Loadout

### DIFF
--- a/monkestation/code/modules/loadouts/items/suits.dm
+++ b/monkestation/code/modules/loadouts/items/suits.dm
@@ -301,6 +301,12 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	item_path = /obj/item/clothing/suit/jacket/tailcoat/bartender
 	restricted_roles = list(JOB_BARTENDER)
 
+/datum/loadout_item/suit/qm_jacket
+	name = "Quartermaster's Jacket"
+	item_path = /obj/item/clothing/suit/toggle/jacket/supply/head
+	restricted_roles = list(JOB_QUARTERMASTER)
+
+
 /*
 *	FAMILIES
 */

--- a/monkestation/code/modules/loadouts/items/under/under.dm
+++ b/monkestation/code/modules/loadouts/items/under/under.dm
@@ -1009,6 +1009,18 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	restricted_roles = list(JOB_QUARTERMASTER)
 	requires_purchase = FALSE
 
+/datum/loadout_item/under/miscellaneous/qm_turtle
+	name = "Quartermaster's Turtleneck"
+	item_path = /obj/item/clothing/under/rank/cargo/qm/nova/turtleneck
+	restricted_roles = list(JOB_QUARTERMASTER)
+	requires_purchase = FALSE
+
+/datum/loadout_item/under/miscellaneous/qm_casual
+	name = "Quartermaster's Casualwear"
+	item_path = /obj/item/clothing/under/rank/cargo/qm/nova/casual
+	restricted_roles = list(JOB_QUARTERMASTER)
+	requires_purchase = FALSE
+
 /datum/loadout_item/under/miscellaneous/qm_gorka
 	name = "Quartermaster's Gorka Uniform"
 	item_path = /obj/item/clothing/under/rank/cargo/qm/nova/gorka


### PR DESCRIPTION

## About The Pull Request
A small little PR that brings some of the alt clothing for QM from the Command vending machine to the Loadout
## Why It's Good For The Game
So the main reason why I created this PR is that I noticed only a few of the alt quartermaster clothes were in the loadout (IE QM's Gorka and QM's Skirtleneck) and the rest of the clothing choices were in the Command vending machine that is out of QM's access. So I've included the QM's Turtleneck and Casualwear to the loadout. I didn't bring over the formal uniforms due to the rest of command not having theirs in the loadout and I didnt want to give QM super special treatment.
## Changelog
:cl:
add: Adds Quartermaster Turtleneck and Casualwear to Loadout
/:cl:
