### PR TITLE
Synthetics can be deconverted by holy water

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -354,6 +354,7 @@
 	default_container = /obj/item/reagent_containers/cup/glass/bottle/holywater
 	turf_exposure = TRUE
 	metabolized_traits = list(TRAIT_HOLY)
+	process_flags = ORGANIC | SYNTHETIC
 
 /datum/glass_style/drinking_glass/holywater
 	required_drink_type = /datum/reagent/water/holywater


### PR DESCRIPTION
## About The Pull Request
Holy water now processes in synthetics
## Why It's Good For The Game
Beyond the ethics of pouring water on a machine, we need a way to deconvert cults
## Testing

<img width="1451" height="424" alt="Screenshot 2025-10-10 165312" src="https://github.com/user-attachments/assets/96db8935-95b1-4f7b-83ed-228a4c60d3b8" />

## Changelog

:cl:
fix: Holy water processes in synthetic mobs, meaning they can now be deconverted
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
