### PR TITLE
fixes an oversight with remove_key for sealed vehicles

### DIFF
--- a/code/modules/vehicles/sealed.dm
+++ b/code/modules/vehicles/sealed.dm
@@ -118,8 +118,10 @@
 	to_chat(user, span_notice("You remove [inserted_key] from [src]."))
 	if(!HAS_TRAIT(user, TRAIT_HANDS_BLOCKED))
 		user.put_in_hands(inserted_key)
-	else
-		inserted_key.equip_to_best_slot(user)
+		inserted_key = null
+		return
+	if(!inserted_key.equip_to_best_slot(user))
+		inserted_key.forceMove(get_turf(src))
 	inserted_key = null
 
 /obj/vehicle/sealed/Destroy()


### PR DESCRIPTION
## About The Pull Request
there was an oversight where sealed vehicles wouldn't eject their key if the player had full storage. if the player's storage is full it just drops on the floor now. 

fixes: https://github.com/Monkestation/Monkestation2.0/issues/8956

## Why It's Good For The Game
bug fix good
## Testing
tested it on local about two times.
## Changelog

:cl:
fixed: fixed an oversight with sealed vehicles where the key would get stuck if the player had full storage when ejecting the key. 
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

