### PR TITLE
Stabilized Light Pink Extract Description Change

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -180,7 +180,7 @@ Stabilized extracts:
 
 /obj/item/slimecross/stabilized/lightpink
 	colour = "light pink"
-	effect_desc = "The owner moves at high speeds while holding this extract, also stabilizes anyone in critical condition around you using Epinephrine."
+	effect_desc = "The owner moves at high speeds while holding this extract and prevents them from harming other beings, also stabilizes anyone in critical condition around you using Epinephrine."
 
 /obj/item/slimecross/stabilized/adamantine
 	colour = "adamantine"


### PR DESCRIPTION

## About The Pull Request
The description for the stabilized light pink extract fails to mention that it will give pacifism as a side effect, this PR changes the effect description to clear that up.
## Why It's Good For The Game
This is knowledge that only veteran xenobiologists would know about and you'd never know about it unless you tried to attack someone while carrying the extract, and even then the game doesn't tell you where the pacifism came from, hopefully this will clear things up a bit.
## Testing
Just a simple description change.
<img width="376" height="123" alt="image" src="https://github.com/user-attachments/assets/0021c655-58c3-494f-89d5-75e943acfeb2" />
## Changelog
:cl:
qol: The description for the stabilized light pink extracts will now mention the pacifism effect.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
