### PR TITLE
flares now burn for 5-7 minutes instead of 25-35 minutes

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -406,7 +406,7 @@
 /obj/item/flashlight/flare/Initialize(mapload)
 	. = ..()
 	if(randomize_fuel)
-		fuel = rand(1 MINUTES, 2 MINUTES)
+		fuel = rand(5 MINUTES, 7 MINUTES)
 	if(on)
 		attack_verb_continuous = string_list(list("burns", "singes"))
 		attack_verb_simple = string_list(list("burn", "singe"))


### PR DESCRIPTION
## About The Pull Request
flares cant be extinquished and burn for 25 minutes this fixes that

## Why It's Good For The Game
flares cannot be extinquished yet last for 25 minutes at a mininum this allows you to still use them in combat or as a temporary light source but prevents blocking areas for 25 minutes

## Changelog

:cl:
balance: flares now burn for 5-7 minutes
/:cl:

