### PR TITLE
flares can now get their light eaten

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -506,7 +506,8 @@
 /obj/item/flashlight/flare/proc/on_light_eater(atom/source, datum/light_eater)
 	SIGNAL_HANDLER
 	if(light_on)
-		visible_message("The enduring flickering of \the [src] refuses to fade.")
+		new trash_type(loc)
+		qdel(src)
 	return COMPONENT_BLOCK_LIGHT_EATER
 
 /obj/item/flashlight/flare/candle


### PR DESCRIPTION
## About The Pull Request
makes flares turn into trash when light eatered

## Why It's Good For The Game
"They’re still a pretty decent choice to carry on your person against nightmares/darkspawn because they light up behind you instead of just in front like a flashlight. Crew have other options for mass lighting areas like glowshrooms or glass floors."

## Testing

https://github.com/user-attachments/assets/d0b8d442-64f3-41d2-a955-44aadac55e2c


## Changelog

:cl:
balance: flares now can be extinquished by light eaters
/:cl:

## Pre-Merge Checklist

- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.

