### PR TITLE
some soulscythe qol

### DIFF
--- a/code/game/objects/items/soulscythe.dm
+++ b/code/game/objects/items/soulscythe.dm
@@ -100,7 +100,9 @@
 
 	soul.PossessByPlayer(ghost.ckey)
 	soul.copy_languages(master, LANGUAGE_MASTER) //Make sure the sword can understand and communicate with the master.
-	soul.faction = list("[REF(master)]")
+	if(!soul.mind)
+		soul.mind_initialize()
+	soul.mind.enslave_mind_to_creator(master)
 	balloon_alert(master, "the scythe glows")
 	add_overlay("soulscythe_gem")
 	density = TRUE
@@ -258,6 +260,10 @@
 	faction = list()
 	blood_volume = MAX_BLOOD_LEVEL
 	hud_type = /datum/hud/soulscythe
+	lighting_cutoff = LIGHTING_CUTOFF_HIGH
+	lighting_cutoff_red = 25
+	lighting_cutoff_green = 8
+	lighting_cutoff_blue = 5
 
 /mob/living/basic/soulscythe/Initialize(mapload)
 	. = ..()
@@ -266,7 +272,7 @@
 
 /mob/living/basic/soulscythe/proc/on_life(datum/source, seconds_per_tick, times_fired) // done like this because there's no need to go through all of life since the item does the work anyways
 	if(stat == CONSCIOUS)
-		blood_volume = min(MAX_BLOOD_LEVEL, blood_volume + round(1 * seconds_per_tick))
+		blood_volume = min(MAX_BLOOD_LEVEL, blood_volume + round(DELTA_WORLD_TIME(SSmobs), 1))
 	return COMPONENT_LIVING_CANCEL_LIFE_PROCESSING
 
 /// Special projectile for the soulscythe.


### PR DESCRIPTION

## About The Pull Request

this adds some minor qol to soulscythes:
- they inherit all of their master's factions
- they have night vision now, allowing them to actually see what's going on in lavaland
  - their vision is tinted red, because blood, get it?
- their blood regen now uses actual delta time

## Why It's Good For The Game

makes playing a soulscythe less annoying

## Testing

<img width="1708" height="1349" alt="2025-10-13 (1760377091) ~ dreamseeker" src="https://github.com/user-attachments/assets/24e0b777-8509-4159-8992-5747d72dc102" />

## Changelog
:cl:
qol: Soulscythe spirits now have night vision.
qol: Soulscythe spirits now inherit all of their master's factions.
qol: Soulscythe's blood regeneration is now based on delta time, so they will still regenerate blood at normal speeds when the server is lagging.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
