### PR TITLE
Banishing venus human traps back to the vine.

### DIFF
--- a/code/modules/mob/living/basic/jungle/venus_human_trap.dm
+++ b/code/modules/mob/living/basic/jungle/venus_human_trap.dm
@@ -187,8 +187,6 @@
 
 /mob/living/basic/venus_human_trap/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	. = ..()
-	if(!.)
-		return FALSE
 
 	var/vines_in_range = locate(/obj/structure/spacevine) in range(2, src)
 	if(!vines_in_range && !alert_shown)


### PR DESCRIPTION

## About The Pull Request
Removes a check that would always fail so the traps life() would call, and thus their territorial healing/damage
## Why It's Good For The Game
Bug fix, and makes it so they are actually reliant on their spread and cant bolt across the station causing havoc
## Testing
<img width="649" height="290" alt="image" src="https://github.com/user-attachments/assets/55db6148-d6b1-4512-89c5-0bf339e3761e" />
## Changelog
:cl:
fix: Venus Human Traps will now heal on vines again, and be punished for daring to leave them. 
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
