### PR TITLE
make the MOD ash accretion module work underwater

### DIFF
--- a/code/modules/mod/modules/modules_supply.dm
+++ b/code/modules/mod/modules/modules_supply.dm
@@ -396,6 +396,7 @@
 			/turf/open/misc/asteroid,
 			/turf/open/misc/ashplanet,
 			/turf/open/misc/dirt,
+			/turf/open/floor/plating/ocean,
 		))
 	if(!keep_turfs)
 		keep_turfs = typecacheof(list(


### PR DESCRIPTION

## About The Pull Request

exactly what it says on the tin: it make the MOD ash accretion module work on ocean tiles (as in, it counts them as ash)

## Why It's Good For The Game

so this module is useful on Oshan

## Testing

<img width="1708" height="1349" alt="image" src="https://github.com/user-attachments/assets/6e5c6741-9a87-4a8f-a536-85b1802886fd" />

## Changelog
:cl:
qol: The MOD ash accretion module now works when mining underwater on Oshan.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
