### PR TITLE
Quick fix to privately bought cargo crates (and miner order crates)

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/secure.dm
+++ b/code/game/objects/structures/crates_lockers/crates/secure.dm
@@ -127,7 +127,7 @@
 						locked = !locked
 						user.visible_message(span_notice("[user] unlocks [src]'s privacy lock."),
 										span_notice("You unlock [src]'s privacy lock."))
-						privacy_lock = FALSE
+						// privacy_lock = FALSE // temporary fix while closets are being fixed
 						update_appearance()
 					else if(!silent)
 						to_chat(user, span_warning("Bank account does not match with buyer!"))
@@ -137,4 +137,4 @@
 				to_chat(user, span_warning("No ID detected!"))
 		else if(!silent)
 			to_chat(user, span_warning("[src] is broken!"))
-	else ..()
+	else ..() // calls /obj/structure/closet/proc/togglelock()


### PR DESCRIPTION
## About The Pull Request
`/obj/structure/closet/crate/secure/owned/togglelock(mob/living/user, silent)` changes the flag `privacy_lock` after the first unlocking which then causes it to call the parent class `/obj/structure/closet/proc/togglelock()` which itself may be broken. See #8155. I don't have time to look at #8155 issues regarding lockable closets in general atm so this is the quick fix for now.

Tldr; new behavior is that only the buyer's ID with the correct bank account can lock/relock/unlock ALL privately bought cargo crates (includes miners' orders and privately bought orders which can come in large crates). The issue was that once `/obj/structure/closet/proc/togglelock()` was called issues in the logic not taking into account the child class calling it resulted in it being unable to unlock after the first relocking of the crate (which happens easily if you spam right click and click twice by accident).

Alternatively, if the new behaviour is to remove the privacy lock after the first unlock (therefore becoming a "public lock" after the first opening) then changes to the parent `togglelock()` will definitely be needed, along with fixes for ID detection during locking which is absent in the current code.

Also, it used to be that privately bought crates (not miner orders) could actually be unlocked by anyone for some reason? This has somehow been fixed by this fix. No wonder my private orders always got stolen by cargonians, if they weren't in a goody case (which has locks which actually work). So uh yeah cool.

As a side note, I checked the tg codebase and the code is apparently identical, so I guess I wasn't misremembering when I said tg also had this issue since like forever. From git blame the problem code doesn't seem to have been changed in years so I guess most people (including myself since I remember this bug so well) have seemed to just adapted to it.

## Why It's Good For The Game
Fixes #8614

## Testing
Privately bought crates (including miner purchases) can only be locked/unlocked by the correct buyer ID and bank account.

https://github.com/user-attachments/assets/c42a48da-e086-4ce9-b708-e057444d63a3



## Changelog
:cl: Lawlolawl
fix: Fixed relocking of privately bought cargo crates (including miner purchases). Only the correct bank account can unlock/lock the crate now. Previously, mining crates were stuck locked permanently after relocking.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
