### PR TITLE
Prevent Darkspawn from recalling an admin-forced shuttle

### DIFF
--- a/code/modules/antagonists/darkspawn/darkspawn_abilities/core_abilities.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_abilities/core_abilities.dm
@@ -187,7 +187,7 @@
 		return
 	if(SSshuttle.emergency_no_recall || SSshuttle.admin_emergency_no_recall)
 		to_chat(owner, span_warning("The ruse was a failure, the shuttle will arrive anyways."))
-		return FALSE
+		return
 	SSshuttle.emergency.cancel()
 	to_chat(owner, span_velvet("The ruse was a success. The shuttle is on its way back."))
 	owner.log_message("recalled the shuttle using [src]", LOG_GAME)


### PR DESCRIPTION
Fixes https://github.com/Monkestation/Monkestation2.0/issues/9040
Fixes https://github.com/Monkestation/Monkestation2.0/issues/9041

## Changelog
:cl:
fix: Darkspawn can no longer use Silver Tongue to recall a shuttle when admins have disabled recalling.
admin: Darkspawn recalling the shuttle with Silver Tongue is now logged.
/:cl:
