### PR TITLE
Today I am putting bread into the ai upload. (Box station fix)

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -45572,7 +45572,7 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/door/window/brigdoor/left/directional/west{
 	name = "Core Modules";
-	req_access = list("captain")
+	req_access = list("rd")
 	},
 /obj/effect/spawner/random/aimodule/neutral{
 	pixel_x = -3;
@@ -61642,7 +61642,7 @@
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/door/window/brigdoor/right/directional/west{
 	name = "High-Risk Modules";
-	req_access = list("captain")
+	req_access = list("rd")
 	},
 /obj/item/ai_module/reset/purge{
 	pixel_y = 4;


### PR DESCRIPTION

## About The Pull Request
AI upload boards are now RD access. Thinking on it. It probably should be AI upload access, but is a thing for another update, right now its about consistancy and access
## Why It's Good For The Game
PLEASE GOD THE AI THINKS WERE ALL CLOWNS AND NEEDS 28 GUITARS MY COAT CLOSET HAS RAN OUT OF ROOM.
## Testing
## Changelog
:cl:
map: Boxstation AI boards are now accessible via RD access.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
