### PR TITLE
Ports [fixes the airlock power buttons for silicons #76574] from TGstation

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1702,9 +1702,9 @@
 
 	var/list/power = list()
 	power["main"] = remaining_main_outage() ? 0 : 2 // boolean
-	power["main_timeleft"] = remaining_main_outage()
+	power["main_timeleft"] = round(remaining_main_outage() / 10)
 	power["backup"] = remaining_backup_outage() ? 0 : 2 // boolean
-	power["backup_timeleft"] = remaining_backup_outage()
+	power["backup_timeleft"] = round(remaining_backup_outage() / 10)
 	data["power"] = power
 
 	data["shock"] = secondsElectrified == MACHINE_NOT_ELECTRIFIED ? 2 : 0


### PR DESCRIPTION
## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/76574
Fixing ai's ability to disrupt door power
## Why It's Good For The Game
`both values tend to be null or 0`
## Testing
<img width="964" height="215" alt="image" src="https://github.com/user-attachments/assets/c209cb31-387a-4e9e-8d89-56cba0dafd23" />

## Changelog
:cl:
fix: silicons can depower airlocks via their UI again
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
