### PR TITLE
voltaic heart no longer heals you while crit

### DIFF
--- a/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
+++ b/code/modules/surgery/organs/internal/heart/heart_anomalock.dm
@@ -181,14 +181,6 @@
 	alert_type = /atom/movable/screen/alert/status_effect/anomalock_active
 	show_duration = TRUE
 
-/datum/status_effect/voltaic_overdrive/tick(seconds_between_ticks)
-	. = ..()
-
-	if(owner.health <= owner.crit_threshold)
-		owner.heal_overall_damage(5, 5)
-		owner.adjustOxyLoss(-5)
-		owner.adjustToxLoss(-5)
-
 /datum/status_effect/voltaic_overdrive/on_apply()
 	. = ..()
 	owner.add_movespeed_mod_immunities(type, /datum/movespeed_modifier/damage_slowdown)


### PR DESCRIPTION
## About The Pull Request
voltaic hear no longer heals while you are in crit
## Why It's Good For The Game
being crit immune for 30 seconds and healing 5 damage every tick is not good while also providing many other benefits 
the heart it self being balanced around requiring an anomaly core is flawed a person who has never done toxins before can refine anomaly cores in 6-8 minutes 
https://streamable.com/jka2o4 here is a video of me refining a flux core i have never made a ttv before on monkestation or any other server
## Testing
ran on local crit self with heart didint heal
## Changelog
:cl:
balance: voltaic overdrive no longer heals you
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
