### PR TITLE
I am a little guy, however that does not mean I want to freeze to death.

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -55,7 +55,7 @@
 		if(stat != DEAD)
 			//Random events (vomiting etc)
 			handle_random_events(seconds_per_tick, times_fired)
-			// Handle alerts
+			// Handle tempature alerts
 			body_temperature_alerts()
 
 		//Handle temperature/pressure differences between body and environment


### PR DESCRIPTION
## About The Pull Request
- Nonhumans will be alerted of high or low tempatures, instead of only while on fire.
## Why It's Good For The Game
If I am dying to the cold vacuum of space. I should probably be alerted to it
## Testing
<img width="758" height="569" alt="Screenshot 2025-10-16 203707" src="https://github.com/user-attachments/assets/2ef3cf86-9cff-4455-a1ba-892bbdeae554" />
Via a vent with 0 pressure

## Changelog
:cl:
fix: Mobs will be alerted of temperature while not on fire. 
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
