### PR TITLE
Allow cargo to print quantum pad boards (and also allow engi to print quantum keycards)

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -132,7 +132,7 @@
 	category = list(
 		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_TELEPORT
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/board/botpad
 	name = "Bot launchpad" // Monkesation edit:

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -384,7 +384,7 @@
 	category = list(
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_SCIENCE
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE
+	departmental_flags = DEPARTMENT_BITFLAG_ENGINEERING | DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_CARGO
 
 /datum/design/botpad_remote
 	name = "Bot Launchpad Controller"


### PR DESCRIPTION
## About The Pull Request

this allows quantum pad boards and quantum keycards to also be printed by the cargo fab, in addition to the engi and sci fabs

also allows engi to print quantum keycards, bc they could already print quantum pad boards, just not the keycards, which was weird

## Why It's Good For The Game

allows for more interesting cargo delivery setups, or mining stuff, and such

## Changelog
:cl:
add: Quantum Pad boards and Quantum Keycards can now be printed by the cargo techfab, so they can do interesting setups with deliveries or mining.
add: Engineering can now print Quantum Keycards, because it was silly that they could print Quantum Pad boards but not the keycards.
/:cl:
