### PR TITLE
Who is randy random and why are they in my house

### DIFF
--- a/monkestation/code/modules/assault_ops/code/antagonist.dm
+++ b/monkestation/code/modules/assault_ops/code/antagonist.dm
@@ -146,7 +146,7 @@
 		objectives |= assault_team.objectives
 
 /datum/antagonist/assault_operative/proc/give_alias()
-	var/chosen_name = sanitize_text(tgui_input_text(owner.current, "Please input your desired name!", "Name", "Randy Random"))
+	var/chosen_name = sanitize_text(tgui_input_text(owner.current, "Please input your desired name!", "Name", owner.current.client?.prefs?.read_preference(/datum/preference/name/operative_alias) || "Randy Random"))
 	if(!chosen_name)
 		if(ishuman(owner.current))
 			var/mob/living/carbon/human/human = owner.current


### PR DESCRIPTION

## About The Pull Request
Assault operatives pulls from your operative name preference first as a recommendation rather than 'randy random'
## Why It's Good For The Game
I dont want to remember the puns I have for all my operative characters names
## Testing
## Changelog
:cl:
qol: Assault operatives default to a operative name rather than 'randy random'
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
