### PR TITLE
fix godslayer armor healing triggering if you're unconscious but fully healthy

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -320,7 +320,10 @@
 
 /obj/item/clothing/suit/hooded/cloak/godslayer/proc/on_health_update(mob/living/carbon/user)
 	SIGNAL_HANDLER
-	if(user.stat != DEAD && user.health <= user.hardcrit_threshold) // so it still works if they don't have normal crit
+	if(user.stat == DEAD)
+		return
+	var/health_threshold = HAS_TRAIT(user, TRAIT_NOSOFTCRIT) ? user.hardcrit_threshold : user.crit_threshold
+	if(user.health <= health_threshold) // so it still works if they don't have normal crit
 		resurrection_butterfly(user)
 
 /obj/item/clothing/suit/hooded/cloak/godslayer/proc/resurrection_butterfly(mob/living/carbon/user)


### PR DESCRIPTION
## About The Pull Request

this makes it so the godslayer armor won't trigger if the user's health is above the crit threshold, even if they're unconscious

## Why It's Good For The Game

so going eepy doesn't waste my free revive

## Testing

https://github.com/user-attachments/assets/b04ffb52-f7d6-4152-b334-2a98ee12f959

## Changelog
:cl:
fix: Fixed godslayer armor healing triggering if you're unconscious but fully healthy.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
