### PR TITLE
Darkspawn thralls cannot resist while buckled and cuffed

### DIFF
--- a/code/modules/antagonists/darkspawn/darkspawn_objects/thrall_tumor.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_objects/thrall_tumor.dm
@@ -81,6 +81,7 @@
 		span_progenitor(span_bolditalic("NOT LIKE THIS!")),
 		span_hear("You hear a massive, violent thump!"),
 	)
+	angery.uncuff()
 	angery.buckled?.unbuckle_mob(angery)
 	angery.stamina?.revitalize(forced = TRUE)
 	angery.SetAllImmobility(0)


### PR DESCRIPTION
## About The Pull Request
Darkspawn thralls will faill resisting deconversion if they are buckled cuffed. Say to a surgical table.
## Why It's Good For The Game
I get the thematic of it but mechanically this is a really ugly knowledge check that disincentivizes any form of nonlethaling from security.
The only ways around it are to have the thrall be unconcious, say from n20, or dead. Security gets a defib, they do not get n20. So theres going to be a preference there.

Failing this knowledge check gives the thrall a free breakout of their cuffs and instantly can fight and kill as a 15 second confusion and 4 second knockdown occurs.

We want security to be less insane they need less insane options. Other conversion antags have mechanics to get folks out of conversion sure, but nothing on the account of this that takes no input from the convertees.
## Testing
<img width="666" height="361" alt="image" src="https://github.com/user-attachments/assets/790bdb18-5bf8-48eb-bb2a-553e72623204" />

## Changelog
:cl:
balance: Darkspawn thrall will not resist conversion if buckle cuffed to a table.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
