### PR TITLE
the darkspawn Extinguish spell now also extinguishes atmos bullshit

### DIFF
--- a/code/modules/antagonists/darkspawn/darkspawn_abilities/warlock_abilities.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_abilities/warlock_abilities.dm
@@ -116,7 +116,7 @@
 			if(turf_air.temperature > T20C)
 				turf_air.temperature = T20C
 			// remove flammable gases in general
-			for(var/gas_type in list(/datum/gas/plasma, /datum/gas/tritium, /datum/gas/hydrogen))
+			for(var/gas_type in list(/datum/gas/plasma, /datum/gas/tritium, /datum/gas/hydrogen, /datum/gas/freon))
 				turf_air.assert_gas(gas_type)
 				turf_air.gases[gas_type][MOLES] = 0
 			turf_air.garbage_collect()


### PR DESCRIPTION
## About The Pull Request

this makes it so the darkspawn Extinguish spell goes even further when extinguishing:
- any fire hotspots in the radius are removed
- plasma, tritium, hydrogen, and freon are removed from the air (unsure if any other gases are really viable to use in a flamethrower)
- if air temperature is higher than room temperature, it gets reset to room temperature
- any mobs that are extinguished also have their body temperature reset to normal if they're hotter than they should be.

## Why It's Good For The Game

means darkspawn can actually counter flamethrower spam (as long as actually stick together)

also it's called "extinguish", so, like, makes sense if it extinguishes fires, right?

## Testing

https://github.com/user-attachments/assets/f906ef9e-ae0e-4b9c-8b63-34d5c6d8cb52

## Changelog
:cl:
balance: The Darkspawn Extinguish spell now also extinguishes the air, putting out fires and purging plasma.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
