### PR TITLE
makes malf AI doomsday delay deterministic

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -193,7 +193,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 		active = FALSE
 		return
 	to_chat(owner, "<span class='small boldannounce'>Running executable 'selfdestruct'...</span>")
-	sleep(rand(10, 30))
+	sleep(2 SECONDS)
 	if(QDELETED(owner) || !isturf(owner_AI.loc))
 		active = FALSE
 		return
@@ -240,7 +240,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 		active = FALSE
 		return
 	to_chat(owner, "<span class='small boldannounce'>Y</span>")
-	sleep(rand(15, 25))
+	sleep(2 SECONDS)
 	if(QDELETED(owner) || !isturf(owner_AI.loc))
 		active = FALSE
 		return


### PR DESCRIPTION

## About The Pull Request
Removes all randomness from the delays of the malf AI doomsday arming, making it always approximately 27.2 seconds between confirmation and the alert going out. This isnt really a balance change unless you NEED that extra potential of 3 second delays.
## Why It's Good For The Game
i want to be able to strap my websocket into my doomsday to play Epic Gamer Hacknet Music when I go evil mode. Heres a showcase of that!


https://github.com/user-attachments/assets/209800b7-d070-4eaf-8fe4-421b501054e0

**TURN ON AUDIO, THIS DEMONSTRATION VIDEO STINKS WITHOUT IT.**
## Testing
was timed via phone at the same time the button was pressed, coming out to about 28 seconds, give or take A LOT of human error.

The first soundbyte used has a playback of exactly 27.2 seconds, so it should be nearly seamless with the next one going out, as seen in the video.
## Changelog
:cl:
code: the AIs doomsday will now always take 27.2 seconds to send the alert to the station once armed, instead of 3 seconds of random delay from that number.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
