### PR TITLE
Motion cameras are no longer incredible detectors of paranomal activity.

### DIFF
--- a/code/game/machinery/camera/motion.dm
+++ b/code/game/machinery/camera/motion.dm
@@ -29,7 +29,7 @@
 	return localMotionTargets
 
 /obj/machinery/camera/proc/newTarget(mob/target)
-	if(isAI(target) || (isobserver(target)))
+	if(isAI(target) || (isobserver(target)) || iseyemob(target))
 		return FALSE
 	if (detectTime == 0)
 		detectTime = world.time // start the clock


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Prevents observers and 'eyes' from triggering motion sensitive cameras
Closes:#5929
Closes:#3317 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Motion alarm in the vault! For the 2793th time this shift from a ghost
- Then eye mobs such as a ai eye or blob are abstract ideas, thus they shouldnt trigger it upon entering the area.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing
![trust_me_bro](https://github.com/user-attachments/assets/9ad50321-a622-4bb6-9000-011fa96f4e60)

In seriousness I don't have a effective way to show this working as its about showing something... not happening. Paradoxal I know

But heres a picture of flying through the vault cameras without the `red light` popup message 
<img width="1528" height="819" alt="image" src="https://github.com/user-attachments/assets/b71514c7-be61-4c8d-af79-582c764af013" />

And heres two photos of me triggering the alarm as a ai eye and a ghost as proof this is real
<img width="1291" height="878" alt="Screenshot 2025-10-20 162639" src="https://github.com/user-attachments/assets/9d0a0d87-e0a7-4f29-9cf5-9d796d074fa0" />
<img width="1358" height="511" alt="Screenshot 2025-10-20 162415" src="https://github.com/user-attachments/assets/5cc22354-8eb1-4d2c-845f-f0186418384c" />

<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Motion sensitive cameras no longer detect observers and eye mobs entering a ai monitored area.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
