### PR TITLE
Allow RCDing plating over ocean tiles

### DIFF
--- a/monkestation/code/modules/liquids/liquid_ocean.dm
+++ b/monkestation/code/modules/liquids/liquid_ocean.dm
@@ -129,6 +129,37 @@ GLOBAL_LIST_EMPTY(initalized_ocean_areas)
 		adjacent_ocean.rebuild_adjacent()
 	return ..()
 
+/turf/open/floor/plating/ocean/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
+	switch(the_rcd.mode)
+		if(RCD_FLOORWALL)
+			var/obj/structure/lattice/lattice = locate(/obj/structure/lattice, src)
+			if(lattice)
+				return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 1)
+			else
+				return list("mode" = RCD_FLOORWALL, "delay" = 0, "cost" = 3)
+		if(RCD_CATWALK)
+			var/obj/structure/lattice/lattice = locate(/obj/structure/lattice, src)
+			if(lattice)
+				return list("mode" = RCD_CATWALK, "delay" = 0, "cost" = 2)
+			else
+				return list("mode" = RCD_CATWALK, "delay" = 0, "cost" = 4)
+	return FALSE
+
+/turf/open/floor/plating/ocean/rcd_act(mob/user, obj/item/construction/rcd/the_rcd, passed_mode)
+	switch(passed_mode)
+		if(RCD_FLOORWALL)
+			to_chat(user, span_notice("You build a floor."))
+			PlaceOnTop(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
+			return TRUE
+		if(RCD_CATWALK)
+			to_chat(user, span_notice("You build a catwalk."))
+			var/obj/structure/lattice/lattice = locate(/obj/structure/lattice, src)
+			if(lattice)
+				qdel(lattice)
+			new /obj/structure/lattice/catwalk(src)
+			return TRUE
+	return FALSE
+
 /turf/open/floor/plating/ocean/attackby(obj/item/C, mob/user, params)
 	if(..())
 		return


### PR DESCRIPTION

## About The Pull Request

this allows you to RCD plating over ocean tiles. simple as that.

## Why It's Good For The Game

makes building better on oshan, and makes repairing breaches MUCH better.

## Testing

https://github.com/user-attachments/assets/1ddb06de-6f53-4519-80ef-88d5c3d00f88

## Changelog
:cl:
qol: You can now use the RCD to place plating over ocean tiles.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
