### PR TITLE
Beepsky no longer gets mad if you're holding a Spatial Rift Nullifier

### DIFF
--- a/code/modules/projectiles/guns/special/SRN.dm
+++ b/code/modules/projectiles/guns/special/SRN.dm
@@ -8,6 +8,7 @@
 	righthand_file = 'monkestation/icons/mob/inhands/weapons/guns_righthand.dmi'
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/SRN_rocket
 	fire_sound = 'sound/weapons/gun/general/rocket_launch.ogg'
+	item_flags = NONE
 	bolt_type = BOLT_TYPE_NO_BOLT
 	fire_sound_volume = 80
 	w_class = WEIGHT_CLASS_BULKY


### PR DESCRIPTION

## About The Pull Request

this gets rid of the `NEEDS_PERMIT` flag from the SRN, because, well, it's an engineering tool more than it is a "gun".

## Changelog
:cl:
fix: Beepsky no longer gets mad if you're holding a Spatial Rift Nullifier
/:cl:

