### PR TITLE
Smart runtime screen tool tip fix (#75370)

### DIFF
--- a/code/modules/food_and_drinks/machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/machinery/smartfridge.dm
@@ -121,15 +121,22 @@
 		return FALSE
 
 /obj/machinery/smartfridge/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	if(isnull(held_item))
+		return NONE
+
+	var/tool_tip_set = FALSE
 	if(held_item.tool_behaviour == TOOL_WELDER && !istype(src, /obj/machinery/smartfridge/drying_rack))
 		if(welded_down)
 			context[SCREENTIP_CONTEXT_LMB] = "Unweld"
+			tool_tip_set = TRUE
 		else if (!welded_down && anchored)
 			context[SCREENTIP_CONTEXT_LMB] = "Weld down"
+			tool_tip_set = TRUE
 		if(machine_stat & BROKEN)
 			context[SCREENTIP_CONTEXT_RMB] = "Repair"
+			tool_tip_set = TRUE
 
-	return CONTEXTUAL_SCREENTIP_SET
+	return tool_tip_set ? CONTEXTUAL_SCREENTIP_SET : NONE
 
 /obj/machinery/smartfridge/RefreshParts()
 	. = ..()


### PR DESCRIPTION
Caused when the player is not holding anything in hand, Also only return CONTEXTUAL_SCREENTIP_SET when you have actually set the tooltip and not otherwise.
## About The Pull Request
Ports

- https://github.com/tgstation/tgstation/pull/75370
## Why It's Good For The Game
Cleaner game
## Testing
<img width="697" height="440" alt="duh" src="https://github.com/user-attachments/assets/cf5fd8b7-899d-4686-ae3d-6196dd1ad24b" />
that one runtime ain't mine, just showing the fridge doesnt do that anymore

## Changelog
:cl: SyncIt21
fix: runtime with smart fridge tooltip
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
