### PR TITLE
[PORT] Destructive Analyzer input fixes and response

### DIFF
--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -52,7 +52,6 @@
 	belt_icon_state = "crowbar_alien"
 	toolspeed = 0.1
 
-
 /obj/item/crowbar/large
 	name = "large crowbar"
 	desc = "It's a big crowbar. It doesn't fit in your pockets, because it's big."

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -48,7 +48,7 @@
 		return TRUE
 	busy = TRUE
 	loaded_item = weapon
-	to_chat(user, span_notice("You add the [weapon.name] to the [name]!"))
+	to_chat(user, span_notice("You place the [weapon.name] inside the [name]."))
 	flick("[base_icon_state]_la", src)
 	addtimer(CALLBACK(src, PROC_REF(finish_loading)), 1 SECONDS)
 	return TRUE
@@ -116,9 +116,25 @@
 				say("Destructive analysis failed!")
 			return TRUE
 
+//Let emags in on a right click
+/obj/machinery/rnd/destructive_analyzer/item_interaction(mob/living/user, obj/item/tool, list/modifiers, is_right_clicking)
+	if(is_right_clicking && istype(tool, /obj/item/card/emag))
+		return NONE
+	return ..()
+
 //This allows people to put syndicate screwdrivers in the machine. Secondary act still passes.
 /obj/machinery/rnd/destructive_analyzer/screwdriver_act(mob/living/user, obj/item/tool)
 	return FALSE
+
+//We need to call default_deconstruction_screwdriver here since its parent will call screwdriver_act on this level which will stop us from ever deconstructing.
+/obj/machinery/rnd/destructive_analyzer/screwdriver_act_secondary(mob/living/user, obj/item/tool)
+	return default_deconstruction_screwdriver(user, "[initial(icon_state)]_t", initial(icon_state), tool)
+
+//We need to let wire cutter in (not block) so we can analyze alien wirecutters.
+/obj/machinery/rnd/destructive_analyzer/wirecutter_act(mob/living/user, obj/item/tool)
+	if(panel_open)
+		wires.interact(user)
+		return ITEM_INTERACT_SUCCESS
 
 ///Drops the loaded item where it can and nulls it.
 /obj/machinery/rnd/destructive_analyzer/proc/unload_item()

--- a/tgui/packages/tgui/interfaces/DestructiveAnalyzer.tsx
+++ b/tgui/packages/tgui/interfaces/DestructiveAnalyzer.tsx
@@ -114,20 +114,21 @@ export const DestructiveAnalyzer = (props) => {
           )}
           {node_data.map((node) => (
             <Button.Confirm
-              content={node.node_name}
               icon="cash-register"
               mt={1}
               disabled={!node.node_hidden}
               key={node.node_id}
               tooltip={
                 node.node_hidden
-                  ? 'Deconstructing this will allow you to research the node in question by making it visible to R&D consoles.'
-                  : 'This node has already been researched, and does not need to be deconstructed.'
+                  ? 'Deconstruct this to research the selected node.'
+                  : 'This node has already been researched.'
               }
               onClick={() =>
                 act('deconstruct', { deconstruct_id: node.node_id })
               }
-            />
+            >
+              {node.node_name}
+            </Button.Confirm>
           ))}
         </Section>
       </Window.Content>


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/82386

Fixes https://github.com/Monkestation/Monkestation2.0/issues/9017
Fixes https://github.com/Monkestation/Monkestation2.0/issues/9047

> Fixes destructive analyzers to let it get screwed, and accept wire cutters, and emags. Changes some messages to be more helpful.

## Why It's Good For The Game

> Fixes destructive analyzers can now get screwdrivered instead of put it in.
> Changes some messages to be more helpful and technically correct.

## Testing

<img width="400" height="260" alt="image" src="https://github.com/user-attachments/assets/949938c9-970e-4ac2-921c-052d38c698a0" />

## Changelog
:cl: Absolucy, Bilbo367
fix: destructive analyzers can now get screwdrivered instead of put it in.
fix: destructive analyzer now accepts alien wire cutters, and emags.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
