### PR TITLE
Thesues has a hallway split in two parts across the entire map

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -1318,7 +1318,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "auv" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -1542,6 +1542,10 @@
 /obj/structure/marker_beacon/yellow,
 /turf/open/space/basic,
 /area/space/nearstation)
+"ayn" = (
+/obj/structure/cable/layer3,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "ayx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2657,6 +2661,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"aOe" = (
+/turf/closed/wall/r_wall,
+/area/station/hallway/primary/central/aft)
 "aOg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3117,7 +3124,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "aVy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -3853,7 +3860,7 @@
 	dir = 9
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "bgg" = (
 /obj/structure/flora/bush/large/style_random,
 /turf/open/floor/grass,
@@ -4305,7 +4312,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "bmK" = (
 /obj/item/kirbyplants/random,
 /obj/structure/cable,
@@ -4719,7 +4726,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "bue" = (
 /obj/structure/flora/bush/pointy/style_random,
 /turf/open/floor/grass/lavaland{
@@ -4790,7 +4797,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "bvA" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -5333,7 +5340,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "bEK" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -5882,7 +5889,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "bOL" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
@@ -7117,7 +7124,7 @@
 /obj/machinery/camera/autoname/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "cfW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -7769,7 +7776,7 @@
 /obj/machinery/airalarm/directional/north,
 /obj/item/kirbyplants/organic/plant1,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "cpb" = (
 /obj/structure/chair/plastic{
 	dir = 8
@@ -7790,7 +7797,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "cpB" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line,
@@ -7851,7 +7858,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "crm" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -8763,7 +8770,7 @@
 /obj/structure/chair/sofa/bench/right,
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "cDP" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/nitrogen_input,
 /turf/open/floor/engine/n2,
@@ -10294,7 +10301,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/lesser)
 "dcR" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -11027,7 +11033,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "dpo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
@@ -11079,7 +11085,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "dqA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/sink/directional/south,
@@ -12124,7 +12130,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "dFN" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/west,
@@ -13576,6 +13582,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/station/cargo/drone_bay)
+"eas" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "eaP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -14085,7 +14096,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "efX" = (
 /obj/effect/spawner/random/structure/steam_vent,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16323,7 +16334,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "eSx" = (
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
 	dir = 4
@@ -16448,7 +16459,7 @@
 	invisibility = 101
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "eUi" = (
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
@@ -17000,7 +17011,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "fbM" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
@@ -17379,7 +17390,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "fgC" = (
 /obj/machinery/light,
 /obj/structure/cable,
@@ -17437,6 +17448,8 @@
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
 "fhB" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "fhC" = (
@@ -17734,7 +17747,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "flQ" = (
 /obj/effect/turf_decal/siding/purple/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17923,7 +17936,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "fpC" = (
 /obj/machinery/status_display/evac/directional/east,
 /obj/machinery/light/directional/east,
@@ -18088,7 +18101,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "frA" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -18265,7 +18278,7 @@
 	spawn_scatter_radius = 1
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "fuN" = (
 /obj/machinery/power/smes/engineering,
 /obj/machinery/power/terminal{
@@ -18410,6 +18423,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison)
+"fxa" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "fxv" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/security_all,
@@ -18442,7 +18459,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "fyG" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/rubbershot{
@@ -19888,7 +19905,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "fTB" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -20638,7 +20655,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "ggk" = (
 /obj/effect/turf_decal/trimline/darkest_green/filled/line{
 	dir = 1
@@ -20865,6 +20882,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white,
 /area/station/science/cytology)
+"gjw" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "gjD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -21248,7 +21270,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "gpG" = (
 /obj/structure/cable,
 /obj/effect/spawner/random/engineering/tank,
@@ -21325,6 +21347,13 @@
 /obj/structure/broken_flooring/singular/directional,
 /turf/open/floor/plating,
 /area/station/security/prison/workout)
+"gqN" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/gray/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "gqO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -21773,7 +21802,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "gxZ" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/spawner/directional/east,
@@ -21981,6 +22010,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/library)
+"gAT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "gAZ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -22120,6 +22155,7 @@
 /obj/effect/landmark/start/cargo_technician,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "gEh" = (
@@ -23072,7 +23108,7 @@
 /obj/machinery/power/terminal{
 	dir = 8
 	},
-/obj/structure/cable/multilayer/connected,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "gQx" = (
@@ -24687,7 +24723,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "hoJ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -25111,7 +25147,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "hwg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -26095,7 +26131,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/effect/spawner/random/structure/tank_holder,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "hLl" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -27006,7 +27042,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "hYO" = (
 /obj/machinery/flasher/directional/east{
 	id = "secentranceflasher";
@@ -27238,6 +27274,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/pathology/isolation)
+"iaS" = (
+/turf/closed/wall,
+/area/station/hallway/primary/central/aft)
 "iaZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -27288,7 +27327,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "ibC" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/dark/textured,
@@ -27914,7 +27953,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "iml" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/kirbyplants/organic/plant22,
@@ -30501,6 +30540,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/port/lesser)
+"iYw" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "iYJ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/plaque{
@@ -31155,6 +31200,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "jhg" = (
@@ -31544,7 +31590,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "jou" = (
 /obj/machinery/door/airlock{
 	name = "Pool Room"
@@ -32353,6 +32399,10 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
+"jAG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/station/hallway/primary/central/aft)
 "jAY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33385,7 +33435,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "jPp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -33576,7 +33626,7 @@
 "jSy" = (
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "jSF" = (
 /obj/effect/artifact_spawner,
 /obj/effect/turf_decal/delivery,
@@ -33609,7 +33659,7 @@
 	},
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "jTj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/beebox,
@@ -33918,6 +33968,7 @@
 	name = "AI Chamber"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "jYn" = (
@@ -34206,7 +34257,7 @@
 	pixel_x = 2
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "kcc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 9
@@ -34337,7 +34388,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "kdH" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -34483,7 +34534,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "kfU" = (
 /obj/structure/table/wood,
 /obj/item/camera,
@@ -34558,7 +34609,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "kgJ" = (
 /obj/structure/bed/dogbed/cayenne,
 /obj/effect/turf_decal/tile/neutral/half{
@@ -35466,7 +35517,7 @@
 /obj/item/borg/upgrade/uwu,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "kux" = (
 /obj/machinery/door/poddoor/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
@@ -35875,6 +35926,11 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/upper)
+"kAD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "kAJ" = (
 /mob/living/basic/chicken,
 /turf/open/floor/grass,
@@ -36832,6 +36888,11 @@
 /obj/effect/turf_decal/bot,
 /turf/closed/wall,
 /area/station/maintenance/starboard/upper)
+"kMO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "kMY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37699,7 +37760,7 @@
 	},
 /obj/structure/sign/departments/medbay/alt/directional/south,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "kYz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -38306,7 +38367,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "lfP" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden{
 	dir = 4
@@ -38379,7 +38440,7 @@
 /obj/machinery/status_display/evac/directional/north,
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "lhr" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
@@ -39044,7 +39105,7 @@
 /obj/item/radio/intercom/directional/north,
 /obj/item/kirbyplants/organic/plant1,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "lpZ" = (
 /obj/machinery/air_sensor/oxygen_tank,
 /turf/open/floor/engine/o2,
@@ -39333,7 +39394,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "luk" = (
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 4
@@ -39680,7 +39741,7 @@
 	dir = 1
 	},
 /turf/open/floor/carpet/grimey,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "lyK" = (
 /obj/structure/window/reinforced/spawner/directional/north,
 /obj/machinery/airalarm/directional/west,
@@ -41717,7 +41778,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "meZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -42403,7 +42464,7 @@
 /obj/structure/cable,
 /obj/machinery/holopad/secure,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "mnY" = (
 /obj/effect/turf_decal/stripes/red/line{
 	dir = 10
@@ -42940,7 +43001,7 @@
 	},
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "mwX" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/blood/drip,
@@ -43869,7 +43930,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "mMk" = (
 /turf/open/floor/iron/dark/textured_edge{
 	dir = 1
@@ -43968,8 +44029,8 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
 "mNY" = (
-/obj/structure/cable,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "mNZ" = (
@@ -44502,7 +44563,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "mVn" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /turf/open/floor/wood,
@@ -46294,7 +46355,7 @@
 "nwZ" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "nxe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46676,7 +46737,7 @@
 	},
 /obj/structure/sign/poster/official/walk/directional/east,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "nCR" = (
 /obj/structure/flora/bush/lavendergrass/style_random,
 /turf/open/floor/grass,
@@ -47546,7 +47607,6 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "nQR" = (
-/obj/structure/cable,
 /obj/machinery/teleport/hub,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/dark,
@@ -47993,6 +48053,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/west,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "nXZ" = (
@@ -49894,7 +49955,7 @@
 	},
 /obj/effect/turf_decal/tile/gray/anticorner/contrasted,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "ozP" = (
 /obj/effect/turf_decal/trimline/blue/corner{
 	dir = 1
@@ -49910,7 +49971,7 @@
 	invisibility = 101
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "ozZ" = (
 /obj/structure/chair/sofa/bench,
 /obj/effect/turf_decal/tile/dark/fourcorners,
@@ -50169,7 +50230,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "oDL" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -50944,7 +51005,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "oQA" = (
 /obj/structure/bodycontainer/morgue,
 /obj/structure/window/reinforced/spawner/directional/north,
@@ -51101,7 +51162,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "oTc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -52458,7 +52519,7 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "ppm" = (
 /turf/open/floor/iron,
 /area/station/service/hydroponics/garden)
@@ -52594,7 +52655,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "prb" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -52680,7 +52741,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "prZ" = (
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/ai)
@@ -54164,7 +54225,6 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "pSm" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/bluespace_beacon,
@@ -54746,7 +54806,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "qab" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Starboard Bow Maintenance"
@@ -55452,9 +55512,9 @@
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
 "qib" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "qik" = (
@@ -55547,6 +55607,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/holopad/secure,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "qjq" = (
@@ -55617,7 +55678,7 @@
 /obj/effect/decal/cleanable/confetti,
 /obj/effect/mob_spawn/corpse/human/clown,
 /turf/open/floor/plating,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "qkP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -56027,7 +56088,7 @@
 "qqR" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "qqU" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -56969,7 +57030,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "qEm" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/head_of_security,
@@ -57428,6 +57489,16 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/processing)
+"qLs" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/gray/half/contrasted{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "qLu" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/preopen{
@@ -57618,7 +57689,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "qOm" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -57774,7 +57845,7 @@
 	invisibility = 101
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "qQn" = (
 /obj/machinery/power/port_gen/pacman/pre_loaded,
 /turf/open/floor/plating,
@@ -58661,9 +58732,9 @@
 /obj/machinery/computer/monitor{
 	dir = 1
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/satellite)
 "ree" = (
@@ -58894,6 +58965,11 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/station/commons/vacant_room/commissary)
+"rhL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "rhQ" = (
 /obj/machinery/door/airlock/research{
 	frequency = 1449;
@@ -58922,7 +58998,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "rhY" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -60501,7 +60577,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "rEz" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 10
@@ -60658,7 +60734,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "rFZ" = (
 /obj/structure/closet/secure_closet/freezer/kitchen{
 	req_access = null
@@ -62053,7 +62129,7 @@
 	},
 /obj/effect/turf_decal/tile/darkest_green/half/contrasted,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "saZ" = (
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/structure/cable,
@@ -63921,7 +63997,7 @@
 /obj/effect/landmark/start/hangover,
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/showroomfloor,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "sDu" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -64993,7 +65069,7 @@
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "sUG" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -65300,6 +65376,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/fore)
+"sZI" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/gray,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "sZQ" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/tile/blue{
@@ -65603,7 +65684,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "tdJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -66662,7 +66743,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "trD" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/item/flashlight/lantern{
@@ -67554,7 +67635,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "tDY" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -67641,7 +67722,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "tFz" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/structure/cable,
@@ -67867,6 +67948,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"tJG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
+/turf/open/floor/iron/dark,
+/area/station/ai_monitored/turret_protected/aisat/foyer)
 "tJH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
@@ -68102,7 +68190,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "tMm" = (
 /obj/structure/table/wood,
 /obj/structure/showcase/machinery/tv{
@@ -69721,7 +69809,7 @@
 	dir = 10
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "ukb" = (
 /obj/structure/table/glass/plasmaglass,
 /obj/item/storage/medkit/toxin{
@@ -70635,7 +70723,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "uya" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -70871,7 +70959,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "uzU" = (
 /obj/effect/decal/cleanable/vomit/old,
 /obj/structure/disposalpipe/segment{
@@ -71627,7 +71715,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "uKW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
@@ -72708,7 +72796,7 @@
 	},
 /obj/structure/sign/poster/official/do_not_question/directional/east,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "vaV" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
 	dir = 1
@@ -73344,7 +73432,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "vjG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -73641,7 +73729,7 @@
 	pixel_y = 3
 	},
 /turf/open/floor/iron/showroomfloor,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "vnI" = (
 /obj/effect/turf_decal/tile/neutral/full,
 /obj/effect/turf_decal/stripes/line{
@@ -73878,7 +73966,6 @@
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Access"
 	},
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -74160,7 +74247,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "vvS" = (
 /obj/item/device/antibody_scanner,
 /obj/item/device/antibody_scanner,
@@ -74764,7 +74851,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "vFn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -74981,7 +75068,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "vIG" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -75820,7 +75907,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "vVw" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -76111,6 +76198,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat_interior)
 "vZB" = (
@@ -76223,7 +76311,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "wbZ" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 1
@@ -76801,7 +76889,7 @@
 /turf/open/floor/carpet,
 /area/station/command/meeting_room/council)
 "wmS" = (
-/obj/structure/cable,
+/obj/structure/cable/layer3,
 /turf/open/floor/iron/stairs{
 	dir = 4
 	},
@@ -76999,7 +77087,7 @@
 /obj/effect/spawner/structure/window,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "wqg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -77224,11 +77312,11 @@
 /obj/structure/sign/warning/secure_area{
 	pixel_y = -32
 	},
-/obj/structure/cable,
 /obj/machinery/door/airlock/command{
 	name = "AI Core"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/minisat,
+/obj/structure/cable/multilayer/connected,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
 "wtL" = (
@@ -79416,7 +79504,7 @@
 	pixel_y = 9
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "wYc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/flashlight/glowstick/pink,
@@ -80399,7 +80487,7 @@
 /area/station/science/explab)
 "xnI" = (
 /turf/open/floor/iron/showroomfloor,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "xoa" = (
 /obj/structure/flora/bush/generic/style_random,
 /obj/effect/spawner/random/food_or_drink/seed_rare,
@@ -82527,7 +82615,7 @@
 	pixel_y = 32
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "xTU" = (
 /obj/machinery/door/airlock/external/glass{
 	name = "Port Bow Solars External Access"
@@ -82824,7 +82912,7 @@
 "xZa" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "xZo" = (
 /obj/machinery/door/airlock/public/glass,
 /obj/effect/decal/cleanable/dirt,
@@ -82835,7 +82923,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "xZp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -83139,6 +83227,12 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/command/corporate_showroom)
+"ydG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "ydQ" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
@@ -83152,7 +83246,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "yei" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -83262,7 +83356,7 @@
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/station/hallway/primary/central/fore)
+/area/station/hallway/primary/central/aft)
 "ygt" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/computer/communications{
@@ -112696,14 +112790,14 @@ gfm
 gfm
 mpy
 dqq
-yei
-yei
-yei
-yei
-yei
+eas
+eas
+eas
+eas
+eas
 qQd
-fGL
-ejx
+gAT
+rhL
 bvz
 rFR
 meW
@@ -112722,8 +112816,8 @@ rEx
 uzP
 mVj
 fbJ
-yei
-fGL
+eas
+gAT
 bOG
 pZZ
 eSi
@@ -112952,40 +113046,40 @@ dsj
 dsj
 dsj
 oih
-nPO
-nPO
-nPO
-nPO
-nPO
-nPO
+fxa
+fxa
+fxa
+fxa
+fxa
+fxa
 ozX
-nPO
-nPO
-nPO
-vfx
-nPO
-nPO
+fxa
+fxa
+fxa
+kMO
+fxa
+fxa
 wpX
 fpu
-nPQ
-nPO
+kAD
+fxa
 vvP
 btZ
-nPO
+fxa
 wpX
-nPO
-nPO
-vfx
-nPO
-nPO
-nPO
-nPO
-nPO
+fxa
+fxa
+kMO
+fxa
+fxa
+fxa
+fxa
+fxa
 ydT
-fGL
-joT
-joT
-joT
+gAT
+iYw
+iYw
+iYw
 tFx
 usf
 qMw
@@ -113211,10 +113305,10 @@ mJh
 acJ
 ygc
 wXX
-gwn
-hAE
-tWj
-tWj
+sZI
+qLs
+gqN
+gqN
 bfY
 jTh
 qEj
@@ -113240,7 +113334,7 @@ oDu
 oDu
 ujS
 uKN
-vEb
+gjw
 qqR
 qqR
 tMc
@@ -113469,35 +113563,35 @@ qvR
 jPh
 dFx
 ozE
-aOy
-ibe
-ibe
-ibe
-aOy
-aOy
+aOe
+jAG
+jAG
+jAG
+aOe
+aOe
 pfJ
 fgQ
 pfJ
-aOy
-aOy
-kBB
-kBB
-kBB
-kBB
-kBB
-kBB
-kBB
-kBB
-kBB
-kBB
-kBB
-kBB
-kBB
-kBB
-kBB
+aOe
+aOe
+iaS
+iaS
+iaS
+iaS
+iaS
+iaS
+iaS
+iaS
+iaS
+iaS
+iaS
+iaS
+iaS
+iaS
+iaS
 tDX
-yei
-nPO
+eas
+fxa
 jSy
 iby
 mwS
@@ -113724,19 +113818,19 @@ eRZ
 xIk
 qvR
 qvR
-aOy
-aOy
-aOy
+aOe
+aOe
+aOe
 lXw
 lXw
 lXw
-aOy
+aOe
 kuw
 pfJ
 ezl
 pfJ
 qky
-aOy
+aOe
 gOW
 tpP
 yal
@@ -113751,10 +113845,10 @@ qoa
 kTO
 hSs
 bSY
-kBB
+iaS
 fTz
-yei
-nPO
+eas
+fxa
 xZa
 snA
 snA
@@ -113987,13 +114081,13 @@ nhC
 nhC
 iYr
 nhC
-aOy
-aOy
+aOe
+aOe
 pfJ
 tct
 pfJ
-aOy
-aOy
+aOe
+aOe
 rwL
 oYm
 pIj
@@ -114008,10 +114102,10 @@ bcJ
 ltC
 mJc
 wCI
-kBB
+iaS
 coU
-yei
-nPO
+eas
+fxa
 rhX
 snA
 aAI
@@ -114265,10 +114359,10 @@ hzH
 bSY
 tQY
 vlS
-kBB
+iaS
 cDM
-yei
-nPO
+eas
+fxa
 xZa
 snA
 iaN
@@ -114522,10 +114616,10 @@ ris
 gIz
 uVI
 gIz
-kBB
+iaS
 lhn
-yei
-nPO
+eas
+fxa
 xZa
 rWc
 uxB
@@ -114779,9 +114873,9 @@ qyF
 otW
 axp
 kEY
-kBB
+iaS
 lpY
-yei
+eas
 mnX
 xZa
 snA
@@ -115033,13 +115127,13 @@ rwL
 xLF
 rwL
 rwL
-kBB
+iaS
 nwZ
-kBB
-kBB
+iaS
+iaS
 cqY
-ejx
-nPO
+rhL
+fxa
 xZa
 snA
 lLv
@@ -115290,13 +115384,13 @@ jGA
 jGA
 jGA
 jGA
-aOy
+aOe
 fuH
 vnH
-kBB
+iaS
 flJ
-ejx
-nPO
+rhL
+fxa
 ppd
 snA
 lLv
@@ -115547,13 +115641,13 @@ aFa
 xPT
 ghg
 iZG
-aOy
+aOe
 sDt
 xnI
 lui
 fTz
-nTI
-nPO
+ydG
+fxa
 xZa
 snA
 vln
@@ -115804,13 +115898,13 @@ psI
 aFa
 aFa
 omo
-aOy
-aOy
-aOy
-aOy
+aOe
+aOe
+aOe
+aOe
 imj
-ejx
-nPO
+rhL
+fxa
 sUw
 snA
 vln
@@ -116046,7 +116140,7 @@ kem
 frr
 ven
 qpL
-eID
+ayn
 cPt
 jgm
 nec
@@ -116064,10 +116158,10 @@ ira
 ira
 ira
 ira
-aOy
+aOe
 kfM
-ejx
-nPO
+rhL
+fxa
 aVw
 wVX
 vln
@@ -116321,10 +116415,10 @@ xNK
 nKG
 iQC
 otV
-aOy
+aOe
 xTT
-ejx
-nPQ
+rhL
+kAD
 fry
 wVX
 lLv
@@ -116578,10 +116672,10 @@ ira
 hMs
 maN
 ffR
-aOy
+aOe
 hoo
-ejx
-nPO
+rhL
+fxa
 hLd
 wVX
 vln
@@ -116817,7 +116911,7 @@ irB
 vZw
 jYh
 jgY
-dcR
+tJG
 nQR
 jgm
 xrW
@@ -116838,7 +116932,7 @@ kmC
 lyv
 oQz
 gfX
-nPO
+fxa
 xZa
 wVX
 vln
@@ -117092,10 +117186,10 @@ ira
 tRM
 iTz
 pLx
-aOy
+aOe
 gxX
-ejx
-nPO
+rhL
+fxa
 xZa
 wVX
 lLv
@@ -117349,10 +117443,10 @@ spY
 bdb
 tca
 aPf
-aOy
+aOe
 fTz
-ejx
-nPO
+rhL
+fxa
 xZa
 snA
 vln
@@ -117606,10 +117700,10 @@ ira
 ira
 ira
 ira
-aOy
+aOe
 kca
-ejx
-nPO
+rhL
+fxa
 cfV
 snA
 lLv


### PR DESCRIPTION
## About The Pull Request
- Splits fore hallway into fore and aft hallway
- reconnects drone bay to power network
- AI sat and AI core smes are charging and functioning normally
- Gives a APC to AI Sat foyer. Because it didnt have one apparently
## Why It's Good For The Game
This is one of the biggest hallways and isn't fully connected. The eva/public mining room cutting it off. Ive seen so many folks look for a nonexistant apc
## Testing
## Changelog
:cl:
map: Theseus fore hallway has had it south side split into aft hallway 
map: Reconnects drone bay to power network on thesues
map: Gives AI sat Foyer a APC on thesues
map: Fixes thesues satelitte power net
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
