### PR TITLE
Makes photo albums indestructible

### DIFF
--- a/code/modules/photography/photos/album.dm
+++ b/code/modules/photography/photos/album.dm
@@ -122,3 +122,4 @@
 
 /obj/item/storage/photo_album/personal
 	icon_state = "album_green"
+	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF


### PR DESCRIPTION
## About The Pull Request

Photo albums, the personal ones, from the photographer quirk, now have the same level of everything resistance as the disk.

## Why It's Good For The Game

Losing all your photos that you wanna keep across rounds is no fun

## Testing

I tested it in localhost. seemed to work.

## Changelog


:cl:
qol: Personal photo albums, from the photographer quirk, are now indestructible
/:cl:


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [I-DUNNO-WHAT-THAT-WORD-MEANS] This code did not runtime during testing.
- [x] You documented all of your changes.
