### PR TITLE
[Donator] Makes the invincible mask fit in both the head and face slot

### DIFF
--- a/monkestation/code/modules/donator/code/item/clothing.dm
+++ b/monkestation/code/modules/donator/code/item/clothing.dm
@@ -904,6 +904,7 @@
 	worn_icon = 'monkestation/code/modules/donator/icons/mob/clothing.dmi'
 	icon_state = "invicible_mask"
 	inhand_icon_state = null
+	slot_flags = ITEM_SLOT_MASK | ITEM_SLOT_HEAD
 	flags_inv = HIDEFACE|HIDEEYES
 
 /obj/item/clothing/gloves/fingerless/invicible_invisible


### PR DESCRIPTION

## About The Pull Request
Makes the invincible mask fit in both the head and face slot.

This was requested by bullke.

## Testing
I compiled the game, spawned the invincible mask, was able to put it into both mask and head slots.

## Changelog
Makes the invincible mask fit in both the head and face slot.
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
