### PR TITLE
[QOL] Updates the citationinator to have a brand new looking ticket + reduces its price

### DIFF
--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -9,28 +9,28 @@
 	req_access = list(ACCESS_SECURITY)
 	products = list(
 		/obj/item/restraints/handcuffs = 8,
-		/obj/item/restraints/handcuffs/cable/zipties = 16, //monkestation edit 10 to 16
-		/obj/item/grenade/flashbang = 7, //monkestation edit: 4 to 7
-		/obj/item/grenade/smokebomb/security = 7, //monkestation edit
-		/obj/item/assembly/flash/handheld = 6, //monkestation edit: 5 to 6
+		/obj/item/restraints/handcuffs/cable/zipties = 16,
+		/obj/item/grenade/flashbang = 7,
+		/obj/item/grenade/smokebomb/security = 7,
+		/obj/item/assembly/flash/handheld = 6,
 		/obj/item/food/donut/plain = 12,
 		/obj/item/storage/box/evidence = 6,
 		/obj/item/flashlight/seclite = 4,
 		/obj/item/restraints/legcuffs/bola/energy = 7,
-		/obj/item/ammo_box/magazine/m35/rubber = 14, //monkestation edit: Paco sec
-		/obj/item/clothing/mask/gas/sechailer = 6, ////monkestation edit
-		/obj/item/clothing/mask/whistle = 3, //monkestation edit
-		/obj/item/bodycam_upgrade = 10, //monkestation edit: Security Liability Act
+		/obj/item/ammo_box/magazine/m35/rubber = 14,
+		/obj/item/clothing/mask/gas/sechailer = 6,
+		/obj/item/clothing/mask/whistle = 3,
+		/obj/item/citationinator = 10,
+		/obj/item/bodycam_upgrade = 10,
 	)
 	contraband = list(
 		/obj/item/clothing/glasses/sunglasses = 2,
-		/obj/item/storage/fancy/donut_box = 4, //monkestation edit 2 to 4
-		/obj/item/melee/flyswatter = 1, //monkestation edit: everytime they play a round, there are two ahelp tickets about them
+		/obj/item/storage/fancy/donut_box = 4,
+		/obj/item/melee/flyswatter = 1,
 	)
 	premium = list(
 		/obj/item/storage/belt/security/webbing = 5,
 		/obj/item/coin/antagtoken = 1,
-		//monkestation removal
 		// /obj/item/clothing/head/helmet/blueshirt = 1,
 		// /obj/item/clothing/suit/armor/vest/blueshirt = 1,
 		//moved to secdrobe
@@ -39,12 +39,11 @@
 		/obj/item/grenade/stingbang = 1,
 		/obj/item/watertank/pepperspray = 2,
 		/obj/item/storage/belt/holster/energy = 4,
-		/obj/item/citationinator = 3, // monkestation edit: security assistants
-		/obj/item/holosign_creator/security = 2, //monkestation edit
-		/obj/item/modular_computer/laptop/preset/security = 3, //monkestation edit
-		/obj/item/storage/box/pinpointer_pairs = 2, //monkestation edit
-		/obj/item/dragnet_beacon = 3, //monkestation edit
-		/obj/item/implanter/mindshield = 2, //monkestation edit
+		/obj/item/holosign_creator/security = 2,
+		/obj/item/modular_computer/laptop/preset/security = 3,
+		/obj/item/storage/box/pinpointer_pairs = 2,
+		/obj/item/dragnet_beacon = 3,
+		/obj/item/implanter/mindshield = 2,
 	)
 	refill_canister = /obj/item/vending_refill/security
 	default_price = PAYCHECK_CREW


### PR DESCRIPTION
## About The Pull Request

Gives the citationinator a new way more official looking ticket. Reduces its price to 50cr (for security) and moves it to the default section of the sectech vendor. 

## Why It's Good For The Game

The ticket was really bland and short before, so I made it look way more official now, with a stamp and a bunch of extra text. I also made it cheaper because I wanna be able to afford one as a secoff without having to burn my utility voucher or half my starting credits!!

## Testing

New ticket looks like this: 
<img width="418" height="501" alt="Screenshot 2025-10-23 223118" src="https://github.com/user-attachments/assets/fbeb31ef-0955-4007-8482-8012d21a6b90" />

## Changelog
:cl:
qol: Updates the citationinator to print a way more official-looking ticket, as well as moving it to the default section of the SecTech vendor and reducing its price.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
