### PR TITLE
Adds loafer spawers to maps that don't have them

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -74626,6 +74626,13 @@
 /obj/structure/trash_pile,
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine/atmos)
+"xTd" = (
+/obj/structure/chair/wood{
+	dir = 8
+	},
+/obj/effect/spawner/random/loafer,
+/turf/open/floor/carpet/green,
+/area/station/service/abandoned_gambling_den)
 "xTe" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/light/small/directional/north,
@@ -123307,7 +123314,7 @@ fsH
 vfK
 mTR
 vUf
-lhs
+xTd
 lhs
 lhs
 vfK

--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -65980,6 +65980,12 @@
 	},
 /turf/open/floor/engine,
 /area/station/science/explab)
+"rYi" = (
+/obj/structure/chair/stool/bar/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/loafer,
+/turf/open/floor/wood/large,
+/area/station/service/abandoned_gambling_den)
 "rYj" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -101913,7 +101919,7 @@ mSK
 oZh
 dsm
 wCR
-wCR
+rYi
 wCR
 mSK
 xHN

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -297,6 +297,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/lounge)
+"agv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/spawner/random/loafer,
+/turf/open/floor/wood,
+/area/station/maintenance/aft/greater)
 "agC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/broken_floor,
@@ -68100,13 +68105,6 @@
 	dir = 1
 	},
 /area/station/engineering/main)
-"uSM" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/spawner/random/loafer,
-/turf/open/floor/plating,
-/area/station/security/prison/safe)
 "uTc" = (
 /obj/machinery/chem_heater/withbuffer,
 /obj/structure/window/reinforced/spawner/directional/north{
@@ -174590,7 +174588,7 @@ wRa
 vVH
 nRO
 ulz
-uSM
+ulz
 ulz
 pNm
 eOz
@@ -249987,7 +249985,7 @@ iBz
 npD
 baz
 rev
-mYf
+agv
 tbQ
 iye
 sZF

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -1465,6 +1465,12 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted,
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
+"atn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/random/loafer,
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/toilet/restrooms)
 "atB" = (
 /obj/machinery/porta_turret/ai{
 	dir = 4
@@ -101370,7 +101376,7 @@ utj
 hTw
 xWt
 mIh
-sPY
+atn
 kZW
 osy
 dAd

--- a/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
+++ b/_maps/map_files/LeadPoisoningStation/LeadPoisoningStation.dmm
@@ -8709,6 +8709,11 @@
 "erH" = (
 /turf/closed/wall,
 /area/station/hallway/primary/central)
+"esj" = (
+/obj/structure/cable,
+/obj/effect/spawner/random/loafer,
+/turf/open/floor/iron/diagonal,
+/area/station/hallway/primary/central/aft)
 "esn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -89108,7 +89113,7 @@ ykv
 ykv
 kcE
 cEL
-cdR
+esj
 dOm
 sjO
 iGY

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -36329,6 +36329,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/morgue)
+"mAt" = (
+/obj/effect/spawner/random/loafer,
+/turf/open/floor/wood,
+/area/station/maintenance/port/aft)
 "mAy" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -84799,7 +84803,7 @@ sBL
 fJs
 uxS
 ehn
-uxS
+mAt
 uxS
 vcg
 sBL

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -38887,6 +38887,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"lkJ" = (
+/obj/effect/spawner/random/loafer,
+/turf/open/floor/engine,
+/area/station/service/abandoned_gambling_den/gaming)
 "lkK" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
@@ -75588,7 +75592,7 @@ bGL
 wXr
 bJe
 bKj
-bLv
+lkJ
 bMB
 tDS
 bOz

--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -15567,6 +15567,7 @@
 "eDB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weldingtool/empty,
+/obj/effect/spawner/random/loafer,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port/lesser)
 "eDD" = (

--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -59756,6 +59756,7 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/engineering/break_room)
 "qAJ" = (
+/obj/effect/spawner/random/loafer,
 /turf/open/floor/light,
 /area/station/common/night_club)
 "qAN" = (


### PR DESCRIPTION

## About The Pull Request

this makes it so ALL maps have a `/obj/structure/disposalconstruct/loafer` somewhere.

this doesn't guarantee a loafer spawn, as it's only a 20% chance if i read the code correctly.

also moved the icebox one to a less stupid spot.

## Changelog
:cl:
map: All maps should have a chance to have a loafer somewhere in maints now.
/:cl:
