### PR TITLE
Fixes Overlapping keybinds

### DIFF
--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -61,7 +61,7 @@
 	return TRUE
 
 /datum/keybinding/living/rest
-	hotkey_keys = list("R") // monke: move this, so LOOC can be U, adjacent to other communication keys.
+	hotkey_keys = list("U") // monke: move this, so LOOC can be U, adjacent to other communication keys.
 	name = "rest"
 	full_name = "Rest"
 	description = "Lay down, or get up."

--- a/monkestation/code/datums/keybinding/communication.dm
+++ b/monkestation/code/datums/keybinding/communication.dm
@@ -1,5 +1,5 @@
 /datum/keybinding/client/communication/looc
-	hotkey_keys = list("U")
+	hotkey_keys = list("I")
 	name = LOOC_CHANNEL
 	full_name = "Local Out Of Character Say (LOOC)"
 	keybind_signal = COMSIG_KB_CLIENT_LOOC_DOWN

--- a/monkestation/code/datums/keybinding/living.dm
+++ b/monkestation/code/datums/keybinding/living.dm
@@ -83,7 +83,7 @@
 	SEND_SIGNAL(user.mob, COMSIG_KB_LIVING_ITEM_PIXEL_SHIFT_UP)
 
 /datum/keybinding/living/pixel_shift
-	hotkey_keys = list("B")
+	hotkey_keys = list("N")
 	name = "pixel_shift"
 	full_name = "Pixel Shift"
 	description = "Shift your characters offset."


### PR DESCRIPTION
## About The Pull Request

Fixes rest and toggle throw being on the same button, also moves pixelshift to N to avoid overlap with resist

## Why It's Good For The Game

Since probably the day looc was added, this overlap existed, someone just shoved rest into R and called it a day, now every returning player new to the servers first time throwing something is them face-planting on the floor

This PR just moves the default looc bind to i, and puts rest back to U where is belongs.

Pixel-shift was also moved to N as it was overlapping with resist on B.

## Testing

Ran fine locally, defaults are correct.

## Changelog

:cl:
fix: LOOC's Default is now i
fix: Rest's Default is now U again
balance: Pixel-shift's Default has been moved from B to N 
/:cl:

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
