### PR TITLE
Fix bronze chairs not spinning automatically

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -464,6 +464,9 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/structure/chair/stool/bar, 0)
 	STOP_PROCESSING(SSfastprocess, src)
 	. = ..()
 
+/obj/structure/chair/bronze/MakeRotate() // we have our own rotation handler
+	return
+
 /obj/structure/chair/bronze/process()
 	setDir(turn(dir,-90))
 	playsound(src, 'sound/effects/servostep.ogg', 50, FALSE)


### PR DESCRIPTION
## Testing

tested on live by deleting the simple_rotation component from a chair, which allowed it to work

## Changelog
:cl:
fix: Bronze chairs now spin automatically once more.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
