### PR TITLE
Renables unique ai

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -26,7 +26,7 @@
 /datum/station_trait/unique_ai
 	name = "Unique AI"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 0
+	weight = 5
 	show_in_report = TRUE
 	report_message = "For experimental purposes, this station AI might show divergence from default lawset. Do not meddle with this experiment, we've removed \
 		access to your set of alternative upload modules because we know you're already thinking about meddling with this experiment."


### PR DESCRIPTION

## About The Pull Request
unique ai station weight 0 -> 5
## Why It's Good For The Game
Oh boy some new law configs are moving along so unique ai will mean something again, thus we should reenable it! Since the reason it was disabled (being useless) is gone!
## Testing
## Changelog
:cl:
balance: Unique AI weight 0 -> 5
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
