### PR TITLE
The AI always gets told about their lawset

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -35,7 +35,7 @@
 /datum/station_trait/unique_ai/on_round_start()
 	. = ..()
 	for(var/mob/living/silicon/ai/ai as anything in GLOB.ai_list)
-		ai.show_laws()
+		to_chat(ai, span_boldnotice("You have been loaded with a unique lawset."), MESSAGE_TYPE_INFO)
 
 /datum/station_trait/ian_adventure
 	name = "Ian's Adventure"
@@ -223,7 +223,7 @@
 	. = ..()
 	if(birthday_override_ckey)
 		if(!check_valid_override())
-			message_admins("Attempted to make [birthday_override_ckey] the birthday person but they are not a valid station role. A random birthday person has be selected instead.")
+			message_admins("Attempted to make [birthday_override_ckey] the birthday person but they are not a valid station role. A random birthday person has been selected instead.")
 
 	if(!birthday_person)
 		var/list/birthday_options = list()

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -10,6 +10,7 @@
 		end_multicam()
 	view_core()
 	INVOKE_ASYNC(src, PROC_REF(preload_vox_voices))
+	show_laws()
 
 /// Preloads the `vox_voices.json` asset
 /mob/living/silicon/ai/proc/preload_vox_voices()


### PR DESCRIPTION
## About The Pull Request
Moves the AI roundstart show laws from unique AI to login, because we basically have unique AI running every round. (not counting that other PR thats up rn)
The unique AI show laws has been replaced with a to chat for AIs. Suggestions for a more noticeable span accepted.

### Regular Spawn

<img width="316" height="523" alt="image" src="https://github.com/user-attachments/assets/749ec9d3-7704-4bac-adf9-481a6407774e" />

### Unique AI

<img width="316" height="523" alt="dreamseeker_XkeEJMNoKI" src="https://github.com/user-attachments/assets/a4b3db73-6d16-4f7e-ad92-c903137d8ba0" />

## Why It's Good For The Game
I'll be honest, i have... forgotten, to check my laws immediately multiple times. This should help make it more noticeable for AIs to check, and is more in line with their subordinate cyborgs.

## Testing
Images provided in about.

## Changelog
:cl:
add: The AI will always receive their lawset on roundstart/login.
spellcheck: fixed a typo in admin logging for admin spawned birthdays.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
