### PR TITLE
Sprint nerf

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -37,7 +37,7 @@ COMMENDATION_PERCENT_POLL 0.05
 ## To speed things up make the number negative, to slow things down, make the number positive.
 
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
-SPRINT_DELAY 1.2
+SPRINT_DELAY 1.4
 RUN_DELAY 1.8
 WALK_DELAY 4
 

--- a/monkestation/code/datums/components/carbon_sprint.dm
+++ b/monkestation/code/datums/components/carbon_sprint.dm
@@ -3,6 +3,7 @@
 	var/sprint_key_down = FALSE
 	var/sprinting = FALSE
 	var/sustained_moves = 0
+	var/sprint_stamina_modifier = 1
 	var/last_dust
 	///Our very own dust
 	var/obj/effect/sprint_dust/dust = new(null)
@@ -55,10 +56,13 @@
 					dust.appear("sprint_cloud_tiny", direct, get_turf(carbon_parent), 0.3 SECONDS)
 					last_dust = world.time
 				sustained_moves = 0
-		if(HAS_TRAIT(carbon_parent, TRAIT_FREERUNNING))
-			carbon_parent.stamina.adjust(-STAMINA_SPRINT_COST * 0.7) //0.5 * cost Means almost infinnite sprint due to regen
+		if(carbon_parent.has_status_effect(/datum/status_effect/stacking/debilitated))
+			sprint_stamina_modifier = 1.3
 		else
-			carbon_parent.stamina.adjust(-STAMINA_SPRINT_COST)
+			sprint_stamina_modifier = 1
+		if(HAS_TRAIT(carbon_parent, TRAIT_FREERUNNING))
+			sprint_stamina_modifier *= 0.7
+		carbon_parent.stamina.adjust(-STAMINA_SPRINT_COST * sprint_stamina_modifier)
 		if(HAS_TRAIT(carbon_parent, TRAIT_EXERTION_OVERHEAT))
 			carbon_parent.adjust_bodytemperature((carbon_parent.bodytemp_heat_damage_limit - carbon_parent.standard_body_temperature) * 0.15)
 	else if(sprinting)


### PR DESCRIPTION

## About The Pull Request
Decreases the speed increase from sprinting and causes sprinting to use more stamina when you are under the affects of debilitated.
## Why It's Good For The Game
Slows down players a little bit compared to projectiles.
Gives people with bad ping a little more leeway due to things moving a little bit slower.
Makes primary sources of ranged non-lethals more effective at catching people who are running away without making them apply slow or being more powerful in combat.
Last time it was testmerged several people liked it, I don't recall any complaints.
## Testing
## Changelog
:cl:
balance: Sprint speed somewhat reduced
balance: Debilitation stacks now increase stamina drain from sprinting more
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
