### PR TITLE
Makes baton inspect reflect current stamina values

### DIFF
--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -64,7 +64,7 @@
 	. = ..()
 	// Adding an extra break for the sake of presentation
 	if(stamina_damage != 0)
-		offensive_notes = "It takes [span_warning("[CEILING(100 / stamina_damage, 1)] stunning hit\s")] to stun an enemy."
+		offensive_notes = "It takes [span_warning("[CEILING(STAMINA_MAX  / stamina_damage, 1)] stunning hit\s")] to stun an enemy."
 
 	register_item_context()
 


### PR DESCRIPTION

## About The Pull Request
Updates it from hard value of 100 to STAMINA_MAX which is 250 for baton inspects
## Why It's Good For The Game
My security baton infact, does not stun people in one hit surprisingly.
## Testing
## Changelog
:cl:
fix: Baton inspects should reflect accurate number of hits to stun
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
