### PR TITLE
Plasmamen dont ignite w one glove

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -83,7 +83,7 @@
 	var/can_burn = FALSE
 	if(!isclothing(H.w_uniform) || !(H.w_uniform.clothing_flags & PLASMAMAN_PREVENT_IGNITION))
 		can_burn = TRUE
-	else if(!isclothing(H.gloves) || H.num_hands < H.default_num_hands) //If you dont have the other glove then the suit isnt really sealed is it?
+	else if(!isclothing(H.gloves)) //If you dont have the other glove then the suit isnt really sealed is it?
 		can_burn = TRUE
 	else if(!HAS_TRAIT(H, TRAIT_NOSELFIGNITION_HEAD_ONLY) && (!isclothing(H.head) || !(H.head.clothing_flags & PLASMAMAN_PREVENT_IGNITION)))
 		can_burn = TRUE


### PR DESCRIPTION
## About The Pull Request

Plasmamen can live with only one hand if theyre wearing gloves.

## Why It's Good For The Game

Since you can now wear 1 glove it doesnt make sense for plasmamen to ignite while still having all their slots covered.

## Testing

Spawned in as a plasmaman and tore an arm off.

## Changelog

:cl:
qol: Plasmamen won't ignite with only one hand as long as they have gloves on.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
