### PR TITLE
Escape menu closes the minimap

### DIFF
--- a/code/__DEFINES/keybinding.dm
+++ b/code/__DEFINES/keybinding.dm
@@ -98,3 +98,6 @@
 #define COMSIG_KB_MOVEMENT_EAST_DOWN "keybinding_movement_east_down"
 #define COMSIG_KB_MOVEMENT_ZLEVEL_MOVEUP_DOWN "keybinding_mob_zlevel_moveup_down"
 #define COMSIG_KB_MOVEMENT_ZLEVEL_MOVEDOWN_DOWN "keybinding_mob_zlevel_movedown_down"
+
+///The key for 'Escape' since it's not as obvious as normal keyboard keys.
+#define ESCAPE_KEY "Escape"

--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -38,7 +38,7 @@ VERB_MANAGER_SUBSYSTEM_DEF(input)
 	"Any+UP" = "\"KeyUp \[\[*\]\]\"",
 	"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"",
 	"Tab" = "\".winset \\\"input.focus=true?map.focus=true:input.focus=true\\\"\"",
-	"Escape" = "Open-Escape-Menu",
+	ESCAPE_KEY = "Open-Escape-Menu",
 	)
 
 // Badmins just wanna have fun ♪

--- a/monkestation/code/modules/holomaps/machinery.dm
+++ b/monkestation/code/modules/holomaps/machinery.dm
@@ -87,7 +87,8 @@
 	holomap_datum.base_map.loc = user_hud.holomap  // Put the image on the holomap hud
 	holomap_datum.base_map.alpha = 0 // Set to transparent so we can fade in
 
-	RegisterSignal(user, COMSIG_MOVABLE_MOVED, .proc/check_position)
+	RegisterSignal(user, COMSIG_MOB_KEYDOWN, PROC_REF(keydown))
+	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(check_position))
 
 	playsound(src, 'monkestation/code/modules/holomaps/sounds/holomap_open.ogg', 125)
 	animate(holomap_datum.base_map, alpha = 255, time = 5, easing = LINEAR_EASING)
@@ -120,6 +121,12 @@
 	if((machine_stat & (NOPOWER | BROKEN)) || !anchored)
 		close_map()
 
+/obj/machinery/station_map/proc/keydown(mob/source, key)
+	SIGNAL_HANDLER
+
+	if(key == ESCAPE_KEY)
+		INVOKE_ASYNC(src, PROC_REF(close_map))
+
 /obj/machinery/station_map/proc/check_position()
 	SIGNAL_HANDLER
 
@@ -130,7 +137,7 @@
 	if(!watching_mob)
 		return
 
-	UnregisterSignal(watching_mob, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(watching_mob, list(COMSIG_MOB_KEYDOWN, COMSIG_MOVABLE_MOVED))
 	playsound(src, 'monkestation/code/modules/holomaps/sounds/holomap_close.ogg', 125)
 	icon_state = initial(icon_state)
 	if(watching_mob?.client)


### PR DESCRIPTION
## About The Pull Request

Opening the escape menu and having the minimap still open in the background is just bad UX in my opinion.

## Why It's Good For The Game

Better UX and another way of closing the minimap.

## Testing

Open game
Open minimap
Hit Esc x2
Repeat a few times

## Changelog

:cl:
qol: You can close the minimap by opening the Escape menu.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
