### PR TITLE
Pro Tip: 100 * 0.01 =! 10

### DIFF
--- a/monkestation/code/modules/virology/disease/base_disease_folder/_base.dm
+++ b/monkestation/code/modules/virology/disease/base_disease_folder/_base.dm
@@ -156,7 +156,7 @@ GLOBAL_LIST_INIT(virusDB, list())
 		return
 
 	if(mob.immune_system)
-		if(prob(10 - (robustness * 0.01))) //100 robustness don't auto cure
+		if(prob(10 - (robustness * 0.1))) //100 robustness don't auto cure
 			mob.immune_system.NaturalImmune()
 
 	if(!mob.immune_system.CanInfect(src))


### PR DESCRIPTION
## About The Pull Request
so thaaaat's why my healing viruses and super-mega space ebola kept auto-curing
## Why It's Good For The Game
the comment right next to the prob says that it shouldn't happen if robustness is 100
bugfix
## Testing
## Changelog
:cl:
fix: Robustness now actually notably affects the natural immune response that a pathogen causes. Pro tip, 100 x 0.01 != 10
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
