### PR TITLE
The BSA now has a 5 second fire cooldown

### DIFF
--- a/code/modules/station_goals/bsa.dm
+++ b/code/modules/station_goals/bsa.dm
@@ -278,6 +278,8 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 	var/notice
 	var/target
 	var/area_aim = FALSE //should also show areas for targeting
+	COOLDOWN_DECLARE(fire_cooldown) //the "cooldown" for firing the BSA normally is it consuming a absolutely absurd amount of power.
+	var/fire_cooldown_length = 5 SECONDS // (duration the beam exists) When this is (very easily) circumvented, then shit becomes an issue.
 
 /obj/machinery/computer/bsa_control/ui_state(mob/user)
 	return GLOB.physical_state
@@ -366,6 +368,10 @@ GLOBAL_VAR_INIT(bsa_unlock, FALSE)
 		notice = "Cannon unpowered!"
 		return
 	notice = null
+	if(!COOLDOWN_FINISHED(src, fire_cooldown) && fire_cooldown_length)
+		notice = "Cannon overheated!"
+		return
+	COOLDOWN_START(src, fire_cooldown, fire_cooldown_length)
 	var/turf/target_turf = get_impact_turf()
 	cannon.fire(user, target_turf)
 


### PR DESCRIPTION

## About The Pull Request
Adds a 5 second delay (the same duration as the beam that shows up when firing) to the BSA being allowed to fire again.
## Why It's Good For The Game
Some people have an issue with flashing lights. Firing the BSA at lavaland 60 times in 10 seconds is very much a factor to cause this, should help be better.
## Testing

I have GIFs demonstrating but they are too large for the PR. I'll post them on discord.
## Changelog
:cl:
balance: The BSA can only fire once every 5 seconds.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
