### PR TITLE
stops waste pins firing when within range of a blacklisted area + fixed golem ships getting hit by radstorms

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -30,7 +30,7 @@
 							/area/station/cargo/power_station, /area/station/engineering/power_station, /area/station/science/power_station,
 							/area/station/science/power_station, /area/station/security/power_station, /area/station/service/power_station,
 							/area/station/medical/aslyum, /area/station/medical/virology/isolation, /area/graveyard/tunnels, /area/graveyard/bunker,
-							/area/ruin/space/ancientstation,
+							/area/ruin/space/ancientstation, /area/ruin/powered/golem_ship,
 						)
 	target_trait = ZTRAIT_STATION
 


### PR DESCRIPTION
## About The Pull Request
prevents waste pinned guns from firing within 5(modifiable) tiles of a blacklisted area (station, space, space ruin).

fixed a bug with golem ships getting hit by radstorms.

## Why It's Good For The Game
mostly used to prevent waste pinned guns from firing into the lower station level of icebox from right outside.

also a bug fix.
## Testing
1. spawn as a miner with a kinetic LMG on the lower station level of icebox outside of botany.
2.  try and fire the gun, gun doesnt shoot giving a warning saying a blacklisted zone is nearby.
3. walk further out.
4. try and fire the gun, it fires since i am past the blacklist range.

## Changelog

:cl:
balance: waste pinned guns cannot be fired near blacklisted areas.
fix: added radstorm shielding to the golem ship.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

