### PR TITLE
damage deflection is taken into account before thrown damage ramp up

### DIFF
--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -7,6 +7,9 @@
 
 /obj/proc/hit_by_damage(atom/movable/hitting_us, datum/thrownthing/throwingdatum)
 	var/base_dam = hitting_us.throwforce
+	if(hitting_us.throwforce < damage_deflection) //yea no damage deflection was thrown out the window affecting a ton of stuff
+		take_damage(base_dam, BRUTE, MELEE, TRUE, get_dir(src, hitting_us), 0)
+		return
 	if(isliving(hitting_us))
 		var/mob/living/living_mob = hitting_us
 		var/speed_bonus = throwingdatum.speed - living_mob.throw_speed


### PR DESCRIPTION
## About The Pull Request
due to a certain year old megapr thrown objects do a lot more damage to other objects and structures. hence some interactions were thrown out the window when it comes to damage deflection. this PR makes it so damage deflection is taken into account before thrown damage ramp up.

## Why It's Good For The Game
airlocks have a damage deflection of 21 for a reason. a lot of thrown objects with thrown damage ramp up bypass their deflection easily. most notably this invalidates a few perma designs as you can easily breakdown the airlocks with thrown chairs/stools/potted plants.

## Testing
1. throw a potted plant at an airlock with a deflection of 21.
2. airlock doesnt take damage.

## Changelog

:cl:
balance: damage deflection is taken into account before thrown damage ramp up.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

