### PR TITLE
TYPO SPOTTED, NUKE THIS THING FROM ORBIT

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -790,8 +790,8 @@
 	new_model = /obj/item/robot_model/centcom
 
 /obj/item/borg/upgrade/nvmeson
-	name = "night vision mesons upgrae"
-	desc = "An advanced mop replacement for the janiborg's standard mop."
+	name = "night vision mesons upgrade"
+	desc = "An augmentation to the standard meson sensor array seen on mining and engineering cyborgs to increase low light visibility."
 	icon_state = "cyborg_upgrade3"
 	require_model = TRUE
 	model_type = list(/obj/item/robot_model/engineering, /obj/item/robot_model/miner)


### PR DESCRIPTION

## About The Pull Request
Fixes a typo
## Why It's Good For The Game
i have a bomb strapped to my chest. it will explode in 5-10 business years if this typo is not removed.
## Testing
Ummm... uhh... look! an eagle! *runs away from my problems*
## Changelog
:cl:
spellcheck: fixed a typo in the NV Meson cyborg upgrade.
spellcheck: updated the description of the NV Meson cyborg upgrade to not use the advanced mop description.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
