### PR TITLE
Sets default accuracy falloff to 0 because reverse random crits are in fact not fun

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -223,7 +223,7 @@
 
 	var/static/list/projectile_connections = list(COMSIG_ATOM_ENTERED = PROC_REF(on_entered))
 	/// How much accuracy is lost for each tile travelled
-	var/accuracy_falloff = 7
+	var/accuracy_falloff = 0
 	/// How much accuracy before falloff starts to matter. Formula is range - falloff * tiles travelled
 	var/accurate_range = 100
 	/// If true directly targeted turfs can be hit

--- a/code/modules/projectiles/projectile/bullets/crossbow.dm
+++ b/code/modules/projectiles/projectile/bullets/crossbow.dm
@@ -13,6 +13,7 @@
 	embed_falloff_tile = -5
 	wound_falloff_tile = -2
 	shrapnel_type = /obj/item/ammo_casing/rebar
+	accuracy_falloff = 7
 
 /obj/projectile/bullet/rebar/proc/handle_drop(datum/source, obj/item/ammo_casing/rebar/newcasing)
 


### PR DESCRIPTION

## About The Pull Request

See title

## Why It's Good For The Game

RNG based combat for _downsides_ is fun for nobody

## Testing
## Changelog
:cl:
balance: Default projectile falloff is now 0
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
