### PR TITLE
Plasmamen helmet works as internals

### DIFF
--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -44,7 +44,7 @@
 	desc = "A special containment helmet that allows plasma-based lifeforms to exist safely in an oxygenated environment. It is space-worthy, and may be worn in tandem with other EVA gear."
 	icon = 'icons/obj/clothing/head/plasmaman_hats.dmi'
 	worn_icon = 'icons/mob/clothing/head/plasmaman_head.dmi'
-	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SNUG_FIT | PLASMAMAN_HELMET_EXEMPT | PLASMAMAN_PREVENT_IGNITION
+	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | SNUG_FIT | PLASMAMAN_HELMET_EXEMPT | PLASMAMAN_PREVENT_IGNITION | HEADINTERNALS
 	icon_state = "plasmaman-helm"
 	inhand_icon_state = "plasmaman-helm"
 	strip_delay = 80


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/75552 letting plasmamen use internals with their helmet.

## Why It's Good For The Game

They are in a fully sealed suit so it doesn't make sense for them to also need a mask.
Also lets them use job specific masks (eg. chef) that don't double as internals.

## Testing

Opened on a local server where I joined in as a plasmaman and took off my mask to see if internals would stay on.

## Changelog

:cl:
balance: Plasmamen's helmet works to seal you for internals.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.