### PR TITLE
Cameras in my walls

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -46283,13 +46283,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"ofT" = (
-/obj/machinery/camera{
-	c_tag = "Service Botany - Backroom";
-	dir = 9
-	},
-/turf/closed/wall,
-/area/station/maintenance/starboard/fore)
 "ogc" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
@@ -244468,7 +244461,7 @@ tkV
 qwP
 kxX
 kKL
-ofT
+kKL
 kKL
 uDV
 ojD


### PR DESCRIPTION

## About The Pull Request
- deletes a camera in the wall in maintence on iceboxe
## Why It's Good For The Game
## Testing
## Changelog
:cl:
map: Icebox maintence bar backroom/dorms no longer has a camera inside the wall
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
