### PR TITLE
Blacklists the singularity engines from being zapped

### DIFF
--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -240,6 +240,7 @@
 		/obj/structure/cable = FALSE,
 		/obj/machinery/power/smes = FALSE,
 		/obj/item/mcobject/teleporter = FALSE,
+		/obj/machinery/the_singularitygen = FALSE,
 	))
 
 	//Ok so we are making an assumption here. We assume that view() still calculates from the center out.


### PR DESCRIPTION

## About The Pull Request
Blacklists the engines from being shocked and destroyed
## Why It's Good For The Game
I was asked to do this back in https://github.com/Monkestation/Monkestation2.0/pull/8624 but I misunderstood the assignments and WELP here we are
## Testing
## Changelog
:cl:
add: Singularity generators are now immune to being zapped. Enjoy your 100 tesla death cube I suppose
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
