### PR TITLE
Cleaning up rouge gps signals

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -4116,8 +4116,9 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table,
 /obj/machinery/door/window/brigdoor/right/directional/east,
-/obj/machinery/computer/upload/borg{
-	dir = 4
+/obj/machinery/computer/upload/ai{
+	dir = 4;
+	signal = 0
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/ancientstation/delta/ai)
@@ -5286,8 +5287,9 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table,
 /obj/machinery/door/window/brigdoor/right/directional/east,
-/obj/machinery/computer/upload/ai{
-	dir = 4
+/obj/machinery/computer/upload/borg{
+	dir = 4;
+	signal = 0
 	},
 /turf/open/floor/iron/dark,
 /area/ruin/space/ancientstation/delta/ai)
@@ -6737,7 +6739,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper/fluff/ruins/oldstation/damagereport,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/computer/communications,
+/obj/machinery/computer/communications{
+	signal = 0
+	},
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/bridge)
 "Ih" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -7560,7 +7560,8 @@
 /area/centcom/central_command_areas/admin)
 "aum" = (
 /obj/machinery/computer/communications{
-	dir = 1
+	dir = 1;
+	signal = 0
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -16195,7 +16196,9 @@
 /turf/open/floor/wood/large,
 /area/centcom/tdome/observation)
 "aRp" = (
-/obj/machinery/computer/communications,
+/obj/machinery/computer/communications{
+	signal = 0
+	},
 /turf/open/floor/iron/dark/herringbone,
 /area/centcom/central_command_areas/evacuation/ship)
 "aRq" = (
@@ -20983,7 +20986,8 @@
 /area/centcom/central_command_areas/evacuation)
 "dro" = (
 /obj/machinery/computer/communications{
-	dir = 8
+	dir = 8;
+	signal = 0
 	},
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark/herringbone,
@@ -22321,7 +22325,9 @@
 /turf/open/misc/dirt/jungle/dark/arena,
 /area/centcom/central_command_areas/admin)
 "fXF" = (
-/obj/machinery/computer/upload/ai,
+/obj/machinery/computer/upload/ai{
+	signal = 0
+	},
 /turf/open/floor/circuit/green/anim,
 /area/centcom/central_command_areas/admin)
 "fXH" = (
@@ -22912,7 +22918,9 @@
 	id = "donutstealthisid";
 	req_access = "cent_captain"
 	},
-/obj/machinery/computer/communications,
+/obj/machinery/computer/communications{
+	signal = 0
+	},
 /turf/open/floor/carpet/red,
 /area/centcom/central_command_areas/admin)
 "gPN" = (
@@ -27898,7 +27906,8 @@
 /area/centcom/central_command_areas/adminroom)
 "ptP" = (
 /obj/machinery/computer/communications/syndicate{
-	dir = 8
+	dir = 8;
+	signal = 0
 	},
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating/rust,

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -57,6 +57,8 @@
 	var/toggle_max_uses = 3
 	///when was emergency access last toggled
 	var/last_toggled
+	/// To cleanup singals on centcom without touching offices.
+	var/signal = TRUE
 
 /obj/machinery/computer/communications/syndicate
 	icon_screen = "commsyndie"
@@ -91,7 +93,8 @@
 	REGISTER_REQUIRED_MAP_ITEM(1, INFINITY)
 
 	GLOB.shuttle_caller_list += src
-	AddComponent(/datum/component/gps, "Secured Communications Signal")
+	if(signal)
+		AddComponent(/datum/component/gps, "Secured Communications Signal")
 
 /// Are we NOT a silicon, AND we're logged in as the captain?
 /obj/machinery/computer/communications/proc/authenticated_as_non_silicon_captain(mob/user)

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -4,10 +4,13 @@
 	var/mob/living/silicon/current = null //The target of future law uploads
 	icon_screen = "command"
 	time_to_unscrew = 6 SECONDS
+	/// To clean up gps signals from central without touching offices
+	var/signal = TRUE
 
 /obj/machinery/computer/upload/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/gps, "Encrypted Upload")
+	if(signal)
+		AddComponent(/datum/component/gps, "Encrypted Upload")
 	if(!mapload)
 		log_silicon("\A [name] was created at [loc_name(src)].")
 		message_admins("\A [name] was created at [ADMIN_VERBOSEJMP(src)].")


### PR DESCRIPTION

## About The Pull Request
Adds a variable for communication and cyborg/ai uploads for if they produce a gps signal
## Why It's Good For The Game
So these items can exist on central without clogging up the GPS list
Also given to oldstations space ruin as the uploads can only effect local z levels, if reconstructed, will produce a signal, and communications don't work there at all is honestly more of a aesthetic thing.
## Testing
## Changelog
:cl:
map: CC and oldstation will produce overall less GPS signals
code: Added a variable for communication and uploads for them to not produce a gps signal
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
