### PR TITLE
Making regeneration coma inflict a actual coma onto it's victims.

### DIFF
--- a/monkestation/code/modules/virology/disease/premades/debug_disease.dm
+++ b/monkestation/code/modules/virology/disease/premades/debug_disease.dm
@@ -4,7 +4,7 @@
 	category = DISEASE_DEBUG
 
 	symptoms = list(
-		new /datum/symptom/robotic_adaptation,
+		new /datum/symptom/coma,
 	)
 	spread_flags = DISEASE_SPREAD_BLOOD | DISEASE_SPREAD_CONTACT_SKIN | DISEASE_SPREAD_CONTACT_FLUIDS | DISEASE_SPREAD_AIRBORNE
 	strength = 100
@@ -12,18 +12,19 @@
 
 	infectionchance = 100
 	infectionchance_base = 100
+	can_kill = list()
 
-/datum/disease/acute/premade/fungal_tb/after_add()
+/datum/disease/acute/premade/disease_debug/after_add()
 	. = ..()
 	antigen = null
 	stage = 4
 
 /obj/item/reagent_containers/hypospray/medipen/tuberculosiscure/debug
 	name = "Debug Vaccine autoinjector"
-	desc = "An autoinjector to cure Debug disease, which is otherwise incurable. Has a two use system for yourself, and someone else. Inject when infected."
-	volume = 20
+	desc = "An autoinjector to cure the Debug disease, which is otherwise incurable. Has 10 uses. Inject when infected."
+	volume = 100
 	amount_per_transfer_from_this = 10
-	list_reagents = list(/datum/reagent/vaccine/debug = 20)
+	list_reagents = list(/datum/reagent/vaccine/debug = 100)
 
 /datum/reagent/vaccine/debug
 	name = "Vaccine (Debug)"

--- a/monkestation/code/modules/virology/disease/symtoms/helpful/coma.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/helpful/coma.dm
@@ -1,8 +1,8 @@
-#define COMA_COOLDOWN (5 MINUTES) // Half a reviver that defibs you.
+#define COMA_COOLDOWN (40 SECONDS)
 /datum/symptom/coma
 	name = "Regenerative Coma"
 	desc = "The virus causes the host to fall into a death-like coma when severely damaged, then rapidly fixes the damage. Waking the host up some time later."
-	max_multiplier = 12
+	max_multiplier = 6
 	max_chance = 100
 	stage = 3
 	badness = EFFECT_DANGER_HELPFUL
@@ -16,16 +16,16 @@
 
 /datum/symptom/coma/activate(mob/living/carbon/mob, datum/disease/acute/disease)
 	. = ..()
-	if(!added_to_mob && max_multiplier >= 9)
-		added_to_mob = TRUE
-		ADD_TRAIT(mob, TRAIT_NOCRITDAMAGE, type)
 	if (!COOLDOWN_FINISHED(src, last_coma))
 		cooldown_alert = FALSE
 		return
+	if(!added_to_mob && max_multiplier >= 4)
+		added_to_mob = TRUE
+		ADD_TRAIT(mob, TRAIT_NOCRITDAMAGE, type)
 	if(!cooldown_alert)
-		cooldown_alert = FALSE
-		INVOKE_ASYNC(src, TYPE_PROC_REF(/mob, emote), "yawn")
-		to_chat(victim, span_warning("You can't help the urge to yawn."))
+		cooldown_alert = !cooldown_alert
+		INVOKE_ASYNC(mob, TYPE_PROC_REF(/mob, emote), "yawn")
+		to_chat(mob, span_warning("You can't help the urge to yawn."))
 	var/effectiveness = CanHeal(mob)
 	if(!effectiveness)
 		return
@@ -58,14 +58,14 @@
 	if((victim.getBruteLoss() + victim.getFireLoss()) >= 80 && !active_coma)
 		to_chat(victim, span_warning("You feel yourself slip into a regenerative coma..."))
 		active_coma = TRUE
-		addtimer(CALLBACK(src, PROC_REF(coma), victim), 8 SECONDS)
+		addtimer(CALLBACK(src, PROC_REF(coma), victim), 6 SECONDS)
 	return FALSE
 
 /datum/symptom/coma/proc/coma(mob/living/victim)
 	if(QDELETED(victim) || victim.stat == DEAD)
 		return
 	victim.fakedeath("regenerative_coma", TRUE)
-	addtimer(CALLBACK(src, PROC_REF(uncoma), victim), 30 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(uncoma), victim), 20 SECONDS)
 
 /datum/symptom/coma/proc/uncoma(mob/living/victim)
 	if(QDELETED(victim) || !active_coma)
@@ -88,4 +88,5 @@
 	if((victim.getBruteLoss() + victim.getFireLoss()) > 30)
 		return TRUE
 	return FALSE
+
 #undef COMA_COOLDOWN


### PR DESCRIPTION
## About The Pull Request
- Regeneration coma takes a extra 15 seconds to wake you after reaching a fully healed state.
- Regeneration coma goes on a 5 minute cooldown
- Regeneration coma takes 8 (was 6) to slip you into a coma if you're above the brute/burn threshold but not in any form of crit/ect.
## Why It's Good For The Game
Surrounding patho balance can be made from this change but when properly stacked one could reach very very silly levels of healing speeds. To the point people instantly stood up again.
This insures there's a minimum ground time to how one is out cold, and going into a cooldown after waking up to prevent constant heal Spam
## Testing
<img width="998" height="599" alt="image" src="https://github.com/user-attachments/assets/ab3ee26a-1d49-4e34-90c8-622f12a45c2e" />
Already healed and still out of it

## Changelog
:cl:
balance: Regen coma now has a max strength of 6.
balance: Regen com now gives no crit damage at 4.
balance: Regeneration Coma takes 20 seconds to un-coma someone once ending.
balance: Regeneration coma now suffers from a 40 cooldown after proccing.
balance: This is signified by a yawn
code: Some touchups to the debug disease and it's autoinjector. Non influence on game play
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
