### PR TITLE
Hotwire Round-Removal fix

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -520,9 +520,17 @@
 			power_source = cell
 			shock_damage = cell_damage
 		drained_hp = victim.electrocute_act(shock_damage, source, siemens_coeff) //zzzzzzap!
-	else if(PN && (PN?.netexcess >= 150 MW))
+	else if(PN && (PN?.netexcess < 250 MW))
 		tesla_zap(victim, 7, PN.netexcess)
 		drained_hp = PN.netexcess * 0.01
+	else
+		playsound(victim.loc, 'sound/magic/lightningbolt.ogg', 100, TRUE, extrarange = 30)
+
+		victim.visible_message(span_danger("\The [victim] starts to glow wildly!"),
+			span_userdanger("Sparks fly in all directions, Electricity courses through you, and as your body stiffens up, your last thought is \"Oh, fuck.\""),
+			span_hear("You hear an unimaginably loud ringing and crackling."))
+
+		victim.gib()
 
 	log_combat(source, victim, "electrocuted")
 


### PR DESCRIPTION

## About The Pull Request

"Fixes" and unintentional bug when touching high voltage cables, that causes you to get round removed.

## Why It's Good For The Game

What was SUPPOSED to happen was you get dusted, your brain gets left alive
However whoever put this in did not test it or the dust function got changed, 
as calling the dust function removes every trace of your being including any organs lying about

instead of dusting and round removing you this gibs you with some flavor-text, and plays a loud noise!

## Testing

Works! no runtime and chat displays correctly.
<img width="624" height="287" alt="funny_text" src="https://github.com/user-attachments/assets/aa1eed5e-e36c-41cd-bcda-f5b79a69c362" />
![funny](https://github.com/user-attachments/assets/78e4ee1c-27de-44cb-b263-0e3a6c7e3c90)


## Changelog
:cl:
fix: Touching ultra-high voltage electronics will now gib instead of dust you.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
