### PR TITLE
Cable dusting no longer tries (and fails) to remove your brain

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -524,10 +524,8 @@
 		tesla_zap(victim, 7, PN.netexcess)
 		drained_hp = PN.netexcess * 0.01
 	else
-		var/obj/item/organ/internal/brain/carbon_brain = victim.get_organ_slot(ORGAN_SLOT_BRAIN)
-		var/turf/turf = get_turf(victim)
 		playsound(victim.loc, 'sound/magic/lightningbolt.ogg', 100, TRUE, extrarange = 30)
-		victim.death(cause_of_death = "electrocution")
+		victim.death(FALSE, "electrocution")
 		victim.visible_message(span_danger("[victim] turns to ash from the electrical shock!"))
 		victim.dust()
 		drained_hp = PN.netexcess * 0.1


### PR DESCRIPTION

## About The Pull Request
This called forceMove on your brain before trying to dust you, in a attempt to keep you revivable, likely, however this just... didnt work at all, your brain still got deleted. I tried to add a Remove to it as well beforehand, but also didnt work, so eh.

Also adds a cause of death to it, because i think thats neat, why have a cause of death if it rarely ever works?
## Why It's Good For The Game
bug fix
## Testing

<img width="314" height="371" alt="image" src="https://github.com/user-attachments/assets/725f4422-a98e-4643-9f20-403c5a565a90" />

yeah i forgot to take a image of the main screen before shutting down, you know what it looks like!
## Changelog
:cl:
fix: Getting dusted by electricity will no longer fruitlessly try to keep your brain safe.
add: Getting dusted by electricity will now give a cause of death for the succumb message
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
