### PR TITLE
fixes cutting lattices/catwalks out from under people

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -37,8 +37,8 @@
 	var/turf/turfloc = loc
 	. = ..()
 	if(isturf(turfloc))
-		for(var/thing_that_falls as anything in turfloc) // as anything because turfloc can only contain movables
-			turfloc.zFall((thing_that_falls))
+		for(var/thing_that_falls in turfloc) // as anything because turfloc can only contain movables
+			turfloc.zFall(thing_that_falls)
 
 /obj/structure/lattice/proc/deconstruction_hints(mob/user)
 	return span_notice("The rods look like they could be <b>cut</b>. There's space for more <i>rods</i> or a <i>tile</i>.")


### PR DESCRIPTION
Ports https://github.com/tgstation/tgstation/pull/88439

:cl: Absolucy, grungussuss
fix: fixed items not falling from a lattice after being deconstructed/destroyed
/:cl: