### PR TITLE
Adds Recharge stations to central

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -20295,6 +20295,7 @@
 /area/centcom/syndicate_mothership/firebase_trident)
 "cjJ" = (
 /obj/machinery/light/floor/has_bulb,
+/obj/machinery/recharge_station/fullupgrade,
 /turf/open/floor/circuit,
 /area/centcom/central_command_areas/medical)
 "cjY" = (
@@ -22543,6 +22544,7 @@
 /obj/structure/sign/warning/no_smoking{
 	pixel_y = 28
 	},
+/obj/machinery/recharge_station/fullupgrade,
 /turf/open/floor/circuit,
 /area/centcom/central_command_areas/medical)
 "gqw" = (


### PR DESCRIPTION

## About The Pull Request
Adds recharge stations to central
## Why It's Good For The Game
Besides having a medicinal use of recharging ethereal safely sometimes rounds get delayed or you get generally hurt/depowered as a cyborg and it be nice to have a healing option potential post round. 
## Testing
## Changelog
:cl:
map: Adds recharge stations to central command
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
