### PR TITLE
[Port] Fixes SS_KEEP_TIMING causing RUNLEVEL_LOBBY subsystems to fire with 75% their set wait 

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -542,7 +542,8 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, FALSE, "Controller Overview
 			var/delay = SS.wait
 			if(SS.flags & SS_TICKER)
 				delay = TICKS2DS(delay)
-			SS.next_fire = world.time + rand(0, min(delay, 2 SECONDS))
+			// Gotta convert to ticks cause rand needs integers
+			SS.next_fire = world.time + TICKS2DS(rand(0, DS2TICKS(min(delay, 2 SECONDS))))
 
 		var/ss_runlevels = SS.runlevels
 		var/added_to_any = FALSE
@@ -643,7 +644,7 @@ ADMIN_VERB(cmd_controller_view_ui, R_SERVER|R_DEBUG, FALSE, "Controller Overview
 					var/delay = SS.wait
 					if(SS.flags & SS_TICKER)
 						delay = TICKS2DS(delay)
-					SS.next_fire = world.time + rand(0, min(delay, 2 SECONDS))
+					SS.next_fire = world.time + TICKS2DS(rand(0, DS2TICKS(min(delay, 2 SECONDS))))
 
 			subsystems_to_check = current_runlevel_subsystems
 		else


### PR DESCRIPTION
Port of https://github.com/tgstation/tgstation/pull/93802
# About the pull request

Fixes SS_KEEP_TIMING causing RUNLEVEL_LOBBY subsystems to fire with 75% their set wait

Ok so this explanation is gonna suck a bit I'm sorry. I was sittin in codebus and @flleeppyy mentioned this problem where SSticker counted down to rounstart signficantly faster then it should.

I poked on tg, and saw the same behavior. I did further poking, and realized that despite wait being 20ds, the actual delay between fires was 15ds.

I'll spare you the rest of the story, it turned out that SSticker's next_fire was set to 0 at the start instead of world.time, so when we did the KEEP_TIMING thing of incrementing next_fire by wait, we were pretty much always going to be trying to fire on the very next tick.

This was prevented by the existing sanity check which limits how fast KEEP_TIMING subsystems are allowed to try and recover their tick locked nature, reducing it to 15ds instead of 1ds delay.

The actual problem here was next_fire not being set properly, which is normally handled by a block in the while(1) block that checks to see if the run level has changed. Unfortunately if you have the starting run level, this never happens.

This impacts EXACTLY SSticker, and nothing else. For now at least.

Solution is to write similar code in Loop's setup block. This has the nice side effect of achieving the randomized starting delays we want for subsystems, to prevent clumping. See discussion on #71730 for more on that.

I'm going straight off the dome on this one. Didn't wanna bug mto about it if I feel comfortable and all.

Please note, this does mean the roundstart lobby time is slower now, it's accurate but it's slower. Might need config changes idk.

# Why it's good for the game

When we say the round starts in 5 minutes, it should actually do that.

## Changelog
:cl: LemonInTheDark, Flleeppyy
fix: Fixed a timing issue with SS_KEEP_TIMING subsystems, which impacts exactly SSticker. TLDR is roundstart will now actually take the time it says it does, instead of 75% of it.
config: The roundstart delay config is now accurate, so you may want to decrease it to not overlengthen lobby time. IDK you decide.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
