### PR TITLE
Ckey hiding hides achievement ckeys

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -989,7 +989,8 @@ GLOBAL_LIST_INIT(round_end_images, world.file2list("data/image_urls.txt")) // MO
 		parts += "<span class='infoplain'>Total Achievements Earned: <B>[length(GLOB.achievements_unlocked)]!</B></span><BR>"
 		parts += "<ul class='playerlist'>"
 		for(var/datum/achievement_report/cheevo_report in GLOB.achievements_unlocked)
-			parts += "<BR>[cheevo_report.winner_key] was <b>[cheevo_report.winner]</b>, who earned the [span_greentext("'[cheevo_report.cheevo]'")] achievement at [cheevo_report.award_location]!<BR>"
+			var/show_key = GLOB.roundend_hidden_ckeys[cheevo_report.winner_key]
+			parts += "<BR>[show_key ? "[cheevo_report.winner_key] was " : ""]<b>[cheevo_report.winner]</b>, who earned the [span_greentext("'[cheevo_report.cheevo]'")] achievement at [cheevo_report.award_location]!<BR>"
 		parts += "</ul>"
 		return "<div class='panel greenborder'><ul>[parts.Join()]</ul></div>"
 


### PR DESCRIPTION
## About The Pull Request

Another part of the roundend report that gets scrubbed off if you're using the pref to hide it.

## Why It's Good For The Game


## Testing

Used EZDB and tested with the preference on and off.

## Changelog

:cl:
fix: Using the setting to hide your preference from the roundend report will now also hide your ckey if you got an achievement.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
