### PR TITLE
You can now use regenerative cores while resting

### DIFF
--- a/code/modules/mining/equipment/monster_organs/monster_organ.dm
+++ b/code/modules/mining/equipment/monster_organs/monster_organ.dm
@@ -140,7 +140,7 @@
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/organ/internal/monster_core/attack_self(mob/user)
-	if (!user.can_perform_action(src, FORBID_TELEKINESIS_REACH))
+	if (!user.can_perform_action(src, FORBID_TELEKINESIS_REACH|ALLOW_RESTING))
 		return
 	try_apply(user, user)
 


### PR DESCRIPTION
## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/81548

Can now use regenerative cores (and other monster cores) using "Z" if you're resting

## Why It's Good For The Game

You can already use it by clicking on your sprite, it's a little silly you can't just use the hotkey.

## Testing

Booted up the game, spawned regenerative core, rested, pressed Z.

## Changelog

:cl:
fix: You can use regenerative cores/rush glands/brimdust sacs while resting.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
