### PR TITLE
S? S what. (Fixes buildmode help button)

### DIFF
--- a/code/modules/buildmode/buttons.dm
+++ b/code/modules/buildmode/buttons.dm
@@ -34,7 +34,7 @@
 
 /atom/movable/screen/buildmode/help
 	icon_state = "buildhelp"
-	screen_loc = "S"
+	screen_loc = "NORTH,WEST+1"
 	name = "Buildmode Help"
 
 /atom/movable/screen/buildmode/help/Click(location, control, params)


### PR DESCRIPTION
## About The Pull Request
- Buildmode Help button is back.
## Why It's Good For The Game
We need help
We all need help.
More than just with buildmode but especially build mode

closes: #9393 
closes: #9316 
closes: #8446
## Testing

<img width="369" height="132" alt="image" src="https://github.com/user-attachments/assets/1871825d-011a-4efa-801c-f5bd5b038ccb" />
<img width="590" height="147" alt="image" src="https://github.com/user-attachments/assets/65543dda-6387-4a8e-b1d5-efed97c140ba" />


## Changelog
:cl:
admin: Build mode Help button is existent again.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
