### PR TITLE
Heliooooooooooooooooooo fixes

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -16384,6 +16384,7 @@
 /obj/structure/table,
 /obj/item/reagent_containers/cup/glass/shaker,
 /obj/item/holosign_creator/robot_seat/bar,
+/obj/machinery/barsign/directional/north,
 /turf/open/floor/carpet,
 /area/station/service/bar)
 "byC" = (
@@ -33529,13 +33530,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/prison/visit)
-"fPW" = (
-/obj/machinery/barsign{
-	pixel_y = -30
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/station/hallway/primary/central)
 "fPZ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -113808,7 +113802,7 @@ btd
 bwl
 bwl
 bwl
-fPW
+caP
 bxd
 byA
 bAp


### PR DESCRIPTION

## About The Pull Request
- Heliostaiton no longer has two Telecommunications request consoles
- Heliostation bar sign has been flipped on what side of the wall its on, this way it renames the bar and not the adjacent hallway
## Why It's Good For The Game
I fix
yes yes

Fixes: #9050
Fixes: #9366 
## Testing
## Changelog
:cl:
map: Heliostation telecommunications only has one request console,
map: Heliostation bar sign will now rename the bar.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
