### PR TITLE
fix runtimes related to prayers / mhelps

### DIFF
--- a/code/__DEFINES/qdel.dm
+++ b/code/__DEFINES/qdel.dm
@@ -62,5 +62,5 @@
 #define QDEL_NULL(item) qdel(item); item = null
 #define QDEL_LIST(L) if(L) { for(var/I in L) qdel(I); L.Cut(); }
 #define QDEL_LIST_IN(L, time) addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(______qdel_list_wrapper), L), time, TIMER_STOPPABLE)
-#define QDEL_LIST_ASSOC(L) if(L) { for(var/I in L) { qdel(L[I]); qdel(I); } L.Cut(); }
-#define QDEL_LIST_ASSOC_VAL(L) if(L) { for(var/I in L) qdel(L[I]); L.Cut(); }
+#define QDEL_LIST_ASSOC(L) if(L) { for(var/K, V in L) { qdel(V); qdel(K); } L.Cut(); }
+#define QDEL_LIST_ASSOC_VAL(L) if(L) { for(var/_K, V in L) qdel(V); L.Cut(); }

--- a/code/modules/requests/request_manager.dm
+++ b/code/modules/requests/request_manager.dm
@@ -21,12 +21,17 @@ GLOBAL_DATUM_INIT(requests, /datum/request_manager, new)
  */
 /datum/request_manager
 	/// Associative list of ckey -> list of requests
-	var/list/requests = list()
+	var/alist/requests
 	/// List where requests can be accessed by ID
-	var/list/requests_by_id = list()
+	var/alist/requests_by_id
+
+/datum/request_manager/New()
+	. = ..()
+	requests = alist()
+	requests_by_id = alist()
 
 /datum/request_manager/Destroy(force)
-	QDEL_LIST(requests)
+	QDEL_LIST_ASSOC_VAL(requests)
 	return ..()
 
 /**
@@ -133,7 +138,6 @@ GLOBAL_DATUM_INIT(requests, /datum/request_manager, new)
 	if (!requests[C.ckey])
 		requests[C.ckey] = list()
 	requests[C.ckey] += request
-	requests_by_id.len++
 	requests_by_id[request.id] = request
 
 /datum/request_manager/mentor/request_for_client(client/C, type, message, additional_info)
@@ -141,7 +145,7 @@ GLOBAL_DATUM_INIT(requests, /datum/request_manager, new)
 	if (!requests[C.ckey])
 		requests[C.ckey] = list()
 	requests[C.ckey] += request
-	requests_by_id["[request.id]"] = request
+	requests_by_id[request.id] = request
 
 /datum/request_manager/ui_interact(mob/user, datum/tgui/ui = null)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -266,8 +270,8 @@ GLOBAL_DATUM_INIT(requests, /datum/request_manager, new)
 	. = list(
 		"requests" = list()
 	)
-	for (var/ckey in requests)
-		for (var/datum/request/request as anything in requests[ckey])
+	for (var/ckey, ckey_requests in requests)
+		for (var/datum/request/request as anything in ckey_requests)
 			var/list/data = list(
 				"id" = request.id,
 				"req_type" = request.req_type,


### PR DESCRIPTION

## About The Pull Request

this fixes some runtimes related to prayers, like this:
```
[2025-11-06 03:21:10.673] runtime error: list index out of bounds
 - proc name: request for client (/datum/request_manager/proc/request_for_client)
 -   source file: code/modules/requests/request_manager.dm,137
 -   usr: placeholder (/mob/living/carbon/human)
 -   src: /datum/request_manager (/datum/request_manager)
 -   usr.loc: the floor (69,134,2) (/turf/open/floor/iron/dark)
 -   call stack:
 - /datum/request_manager (/datum/request_manager): request for client(placeholder (/client), "request_prayer", "meow?", null)
 - /datum/request_manager (/datum/request_manager): pray(placeholder (/client), "meow?", 0)
 - placeholder (/mob/living/carbon/human): Pray("meow?")
```

by switching them to just alists instead

also made it so `QDEL_LIST_ASSOC` and `QDEL_LIST_ASSOC_VAL` use a `for(k,v)` loop.

## Why It's Good For The Game

bugfix good

## Testing

i did a mix of prayers and mhelps, and no runtimes occured

## Changelog

no player-facing changes