### PR TITLE
[Partial Port] Grasp of Lock no longer yanks down your top (unless able to be adjusted) #93803

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/knock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/knock_lore.dm
@@ -61,7 +61,7 @@
 /datum/heretic_knowledge/knock_grasp/proc/on_mansus_grasp(mob/living/source, mob/living/target)
 	SIGNAL_HANDLER
 	var/obj/item/clothing/under/suit = target.get_item_by_slot(ITEM_SLOT_ICLOTHING)
-	if(istype(suit) && suit.adjusted == NORMAL_STYLE)
+	if(istype(suit) && suit.adjusted == NORMAL_STYLE && suit.can_adjust)
 		suit.toggle_jumpsuit_adjust()
 		suit.update_appearance()
 


### PR DESCRIPTION
## About The Pull Request
Partially ports https://github.com/tgstation/tgstation/pull/93803
Mainly fixes a bug where you could adjust suit clothing that could not be adjusted.
The rest isn't ported as we have knock heretic and not lock.
## Why It's Good For The Game
`I'm not entirely sure why Lock Heretics can cause you to suffer a wardrobe malfunction, but fair enough.`
## Testing
When used on a nonadjustable sprite
<img width="188" height="221" alt="Screenshot 2025-11-06 122001" src="https://github.com/user-attachments/assets/379b8f74-cd51-4f50-bead-e558ee45a524" />
## Changelog
:cl: necromanceranne
fix: Grasp of Lock can no longer yank down your jumpsuit unless it is capable of being adjusted.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
