### PR TITLE
Prevents PDA App Kidnapping attempts

### DIFF
--- a/code/modules/modular_computers/computers/item/computer_power.dm
+++ b/code/modules/modular_computers/computers/item/computer_power.dm
@@ -18,7 +18,7 @@
 		return TRUE
 	INVOKE_ASYNC(src, PROC_REF(close_all_programs))
 	for(var/datum/computer_file/program/programs as anything in stored_files)
-		if((programs.program_flags & PROGRAM_RUNS_WITHOUT_POWER) && open_program(program = programs))
+		if((programs.program_flags & PROGRAM_RUNS_WITHOUT_POWER) && open_program(program = programs, open_ui = FALSE))
 			return TRUE
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request
- You'll no longer be booted to messenger upon receiving a PDA message.
## Why It's Good For The Game
Being kicked out of your PDA app when not intended seems annoying.

```
Dear Gershua Moon, 

I made this for you, I expect within 144 hours for 1.3 billion monkecoins to be deposited to an anonymous stealthmin admin who shall message you on the 13th of November. If this demand is failed to be met, this pr shall be closed and all future lawyers and Phycologists shall harass you and your canary app peaceful station repairs. 

Time is ticking Gersh, make your choice. 
``` 
## Testing

<img width="1503" height="993" alt="image" src="https://github.com/user-attachments/assets/d142574a-e565-466f-91c0-1c3a567bae1b" />

## Changelog
:cl:
fix: Messenger will no longer kick you out of your PDA app into messenger.
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
