### PR TITLE
Only allow Ghost Wizard to roll after 60 minutes

### DIFF
--- a/monkestation/code/modules/storytellers/converted_events/solo/ghosts/wizard.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/ghosts/wizard.dm
@@ -26,6 +26,7 @@
 	min_players = 35
 	max_occurrences = 1
 	prompted_picking = TRUE
+	earliest_start = 60 MINUTES
 
 /datum/round_event_control/antagonist/solo/from_ghosts/wizard/can_spawn_event(players_amt, allow_magic = FALSE, fake_check = FALSE)
 	. = ..()


### PR DESCRIPTION
YEAH.

## Changelog
:cl:
balance: Ghost Wizard (as in, a wizard ghost role) will only be considered by the storyteller starting at 60 minutes into the round.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
