### PR TITLE
Moves Show Map Vote Tallies to the OOC tab

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -485,5 +485,5 @@ ADMIN_VERB(reset_ooc_color, R_FUN, FALSE, "Reset Player OOC Color", "Returns pla
 /client/verb/map_vote_tally_count()
 	set name = "Show Map Vote Tallies"
 	set desc = "View the current map vote tally counts."
-	set category = "Server"
+	set category = "OOC"
 	to_chat(mob, SSmap_vote.tally_printout)


### PR DESCRIPTION

## About The Pull Request
If you are not currently adminned, this creates a entire new tab dedicated entirely to itself. Its a little pet peeve of mine, and its *literally* inside the OOC file already!
## Why It's Good For The Game
Less tab bloat? or whatever? idk, i just dont particularly like it having a fridge butter penthouse personally.
## Testing
Trust me bro. (i did test it but i forgor to grab a screenshot)
## Changelog
:cl:
qol: moved View Map Vote Tallies from Server to OOC.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
