### PR TITLE
Getting dusted by electrocution saves your brain

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -527,6 +527,8 @@
 		var/obj/item/organ/internal/brain/carbon_brain = victim.get_organ_slot(ORGAN_SLOT_BRAIN)
 		var/turf/turf = get_turf(victim)
 		playsound(victim.loc, 'sound/magic/lightningbolt.ogg', 100, TRUE, extrarange = 30)
+		victim.death(FALSE, "electrocution")
+		carbon_brain.Remove(victim)
 		carbon_brain.forceMove(turf)
 		victim.visible_message(span_danger("[victim] turns to ash from the electrical shock!"))
 		victim.dust()


### PR DESCRIPTION
## About The Pull Request
closes #9364
technically a fix but also balance.
also adds a death reason for the same reasons as my last PR said.
> Also adds a cause of death to it, because i think thats neat, why have a cause of death if it rarely ever works?
## Why It's Good For The Game
codewise, bugfix, balance wise, getting immediately round removed from something you potentially couldnt have foreseen beforehand might be a little icky.
## Testing

<img width="290" height="397" alt="image" src="https://github.com/user-attachments/assets/e957f67b-4b20-4b47-be14-d45ebe0cd688" />

## Changelog
:cl:
balance: getting dusted by high voltages now keeps your brain safe.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
