### PR TITLE
blacklist oozelings from roundstart morgue bodies

### DIFF
--- a/code/modules/mapping/mapping_helpers.dm
+++ b/code/modules/mapping/mapping_helpers.dm
@@ -825,6 +825,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/mapping_helpers/no_lava)
 	/// These species IDs will be barred from spawning if morgue_cadaver_disable_nonhumans is disabled (In the future, we can also dehardcode this)
 	var/list/blacklisted_from_rng_placement = list(
 		SPECIES_ETHEREAL, // they revive on death which is bad juju
+		SPECIES_OOZELING, // they become a core, which clogs up GPSes
 		SPECIES_HUMAN,  // already have a 50% chance of being selected
 	)
 


### PR DESCRIPTION

## About The Pull Request

this just blacklists oozelings from the random species selection for roundstart morgue bodies

ethereals are also already blacklisted bc they have their own unique death/revival stuff

## Why It's Good For The Game

so there's not random roundstart cores clogging up GPSes

## Testing
## Changelog
:cl:
del: Oozelings will no longer be selected as random morgue corpses.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
