### PR TITLE
Assault operatives no longer get a second tracker to nowhere

### DIFF
--- a/code/__DEFINES/~monkestation/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/~monkestation/dcs/signals/signals_global.dm
@@ -1,5 +1,3 @@
-/// Sent whenever a new goldeneye key is spawned: (obj/item/goldeneye_key)
-#define COMSIG_GLOB_GOLDENEYE_KEY_CREATED "!goldeneye_key_created"
 /// Sent whenever a camera network broadcast is started/stopped/updated: (camera_net, is_show_active, announcement)
 #define COMSIG_GLOB_NETWORK_BROADCAST_UPDATED "!network_broadcast_updated"
 /// Sent whenever a monster hunter initiates the Wonderland Apocalypse

--- a/monkestation/code/modules/assault_ops/code/antagonist.dm
+++ b/monkestation/code/modules/assault_ops/code/antagonist.dm
@@ -34,7 +34,6 @@
 	var/datum/component/team_monitor/monitor
 
 /datum/antagonist/assault_operative/Destroy()
-	UnregisterSignal(SSdcs, COMSIG_GLOB_GOLDENEYE_KEY_CREATED)
 	QDEL_NULL(monitor)
 	return ..()
 
@@ -64,7 +63,6 @@
 
 /datum/antagonist/assault_operative/on_gain()
 	. = ..()
-	RegisterSignal(SSdcs, COMSIG_GLOB_GOLDENEYE_KEY_CREATED, PROC_REF(on_goldeneye_key_created))
 	equip_operative()
 	forge_objectives()
 	if(send_to_spawnpoint)
@@ -199,10 +197,6 @@
 	disky.Shift(NORTH, 6)
 	final_icon.Blend(disky, ICON_UNDERLAY)
 	return finish_preview_icon(final_icon)
-
-/datum/antagonist/assault_operative/proc/on_goldeneye_key_created(datum/source, obj/item/goldeneye_key/key)
-	SIGNAL_HANDLER
-	monitor?.add_to_tracking_network(key.beacon)
 
 /**
  * ASSAULT OPERATIVE TEAM DATUM

--- a/monkestation/code/modules/assault_ops/code/goldeneye.dm
+++ b/monkestation/code/modules/assault_ops/code/goldeneye.dm
@@ -102,7 +102,6 @@ SUBSYSTEM_DEF(goldeneye)
 	AddComponent(/datum/component/gps, goldeneye_tag)
 	beacon = AddComponent(/datum/component/tracking_beacon, "goldeneye_key", _colour = choose_beacon_color(), _global = TRUE, _always_update = TRUE)
 	SSpoints_of_interest.make_point_of_interest(src)
-	SEND_GLOBAL_SIGNAL(COMSIG_GLOB_GOLDENEYE_KEY_CREATED, src)
 
 /obj/item/goldeneye_key/Destroy(force)
 	SSgoldeneye.goldeneye_keys -= src


### PR DESCRIPTION
## About The Pull Request
- Assault operatives will only receive one tracker, which correctly points to the beacon
## Why It's Good For The Game
Something about the way this is done, never actually pointer to where the beacon was, leading to a ironic difficulty creep as more beacons are created more screen clutter that could never be removed.
But innately they never needed this special check for on creation to be able to track the card and would lead to our double tracking issue

In conclusion
I have no idea why this works
But it does.
## Testing

A captain extracted normally, only one beacon marker pointing directly to the said target
<img width="1497" height="704" alt="image" src="https://github.com/user-attachments/assets/30e42cd6-91e7-468a-9961-74dc25cc3b98" />


## Changelog
:cl:
fix: Assault operatives will now only receive one tracking beacon when a keycard is extracted
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
