### PR TITLE
Make 3-person BB teams only happen 10% of the time as intended

### DIFF
--- a/monkestation/code/modules/storytellers/converted_events/solo/brother.dm
+++ b/monkestation/code/modules/storytellers/converted_events/solo/brother.dm
@@ -46,10 +46,13 @@
 		/datum/round_event_control/antagonist/solo/bloodsucker/roundstart = 6,
 		/datum/round_event_control/antagonist/solo/heretic/roundstart = 1,
 	)
+	var/static/allow_3_person_teams
 
 /datum/round_event_control/antagonist/solo/brother/get_antag_amount()
+	if(isnull(allow_3_person_teams))
+		allow_3_person_teams = prob(10) // 3-brother teams only happen around 10% of the time
 	. = ..()
-	if(prob(90)) // 3-brother teams only happen around 10% of the time
+	if(!allow_3_person_teams)
 		return FLOOR(., 2)
 
 /datum/round_event/antagonist/solo/brother/start()


### PR DESCRIPTION

## About The Pull Request

this makes it so that 3-person BB teams are only possible 10% of the time (as it was before conversion BB was removed)

## Changelog
:cl:
balance: 3-person BB teams are now only possible around 10% of the time, as intended.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
