### PR TITLE
riposte now returns successful block

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -174,6 +174,8 @@
 	riposte_ready = FALSE
 	addtimer(CALLBACK(src, PROC_REF(reset_riposte), source), BLADE_DANCE_COOLDOWN)
 
+	return SUCCESSFUL_BLOCK
+
 /datum/heretic_knowledge/blade_dance/proc/counter_attack(mob/living/carbon/human/source, mob/living/target, obj/item/melee/sickly_blade/weapon, attack_text)
 	playsound(get_turf(source), 'sound/weapons/parry.ogg', 100, TRUE)
 	source.balloon_alert(source, "riposte used")


### PR DESCRIPTION
## About The Pull Request

Dance of the Brand (Riposte passive) is now considered successful block and will block the attack alongside delivering a counter attack
yes i kinda stole this from heretic rework

## Why It's Good For The Game

its blade's first spell after grasp and honestly it kinda sucks compared to first spells of other paths (its also right behind another spell that barely does anything (yes you realignment)) 
since paths main thing is melee combat and it has no good spells until later on i think making riposte less shit would be for better
its also fits blade more since parry into counter attack is much cooler than getting slapped and slapping someone back

## Testing

https://github.com/user-attachments/assets/705559e7-0421-48a2-a668-ad8c42641d0b


## Changelog

:cl:
balance: dance of the brand (blade heretic's riposte) now blocks attacks
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
