### PR TITLE
Prevent legions from smashing the necropolis chests they drop

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -25,6 +25,11 @@
 	if(broken || spawned_loot)
 		return ..()
 
+/obj/structure/closet/crate/necropolis/tendril/move_crushed(atom/movable/pusher, force, direction)
+	if(broken || spawned_loot)
+		return ..()
+	return FALSE
+
 /obj/structure/closet/crate/necropolis/tendril/attackby(obj/item/item, mob/user, params)
 	if(!istype(item, /obj/item/skeleton_key) || spawned_loot)
 		return ..()


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/8861

## Why It's Good For The Game

bugfix good

## Testing
## Changelog
:cl:
fix: Legions (as in the megafauna) will no longer smash the necropolis chests they drop.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
