### PR TITLE
Adds an Astral Carpet Crate, with those beautiful fake space carpets

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -976,6 +976,9 @@
 /obj/item/stack/tile/fakespace/loaded
 	amount = 30
 
+/obj/item/stack/tile/fakespace/sixty
+	amount = 60
+
 /obj/item/stack/tile/fakepit
 	name = "fake pits"
 	singular_name = "fake pit"

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -139,6 +139,14 @@
 				)
 	crate_name = "neon carpet crate"
 
+/datum/supply_pack/service/carpet_astral
+	name = "Astral Carpet Crate"
+	desc = "Beautiful carpets with a convincing star pattern. Contains 180 tiles."
+	cost = CARGO_CRATE_VALUE * 10
+	contains = list(/obj/item/stack/tile/fakespace/sixty = 3)
+	crate_name = "astral carpet crate"
+	contraband = TRUE
+
 /datum/supply_pack/service/lightbulbs
 	name = "Replacement Lights"
 	desc = "May the light of Aether shine upon this station! Or at least, the light of \


### PR DESCRIPTION

## About The Pull Request

adds a new crate, the Astral Carpet Crate.
Contains 3 stacks (60 each) of fake space carpets.
2000 credits, needs a hacked cargo console (or service departmental console i think)

## Why It's Good For The Game

look at this, it's so pretty...

<img width="1708" height="1349" alt="2025-11-11 (1762906243) ~ dreamseeker" src="https://github.com/user-attachments/assets/0deca3fa-801f-45f9-93ad-ac789ae853a1" />

## Testing
## Changelog
:cl:
add: You can now buy an Astral Carpet Crate from a hacked cargo console for 2000 credits, containing carpets with a beautifully convincing star pattern.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
