### PR TITLE
Just, get em a blanket why would they care if they are cold.

### DIFF
--- a/monkestation/code/modules/factory_type_beat/mobs/node_drone.dm
+++ b/monkestation/code/modules/factory_type_beat/mobs/node_drone.dm
@@ -16,7 +16,6 @@
 	icon_state = "mining_node_active"
 	icon_living = "mining_node_active"
 	icon_dead = "mining_node_active"
-
 	maxHealth = 300 // We adjust the max health based on the vent size in the arrive() proc.
 	health = 300
 	density = TRUE
@@ -30,6 +29,7 @@
 	move_resist = MOVE_FORCE_VERY_STRONG
 	pull_force = MOVE_FORCE_VERY_STRONG
 	weather_immunities = list(TRAIT_ASHSTORM_IMMUNE)
+	bodytemp_cold_damage_limit = -1
 
 	speak_emote = list("chirps")
 	response_help_continuous = "pets"


### PR DESCRIPTION

## About The Pull Request
- Node drones no longer die passively on icebox from cold.
## Why It's Good For The Game
It's a robot, and capping hp even lower without the use of legion cores is very rough expierence.
## Testing
## Changelog
:cl:
fix: NODE Drones no longer freeze to death on Icebox
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
