### PR TITLE
[BALANCE] Prisoner balance to reduce severity/frequency of self-antagging

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -624,6 +624,7 @@ SUBSYSTEM_DEF(job)
 
 /datum/controller/subsystem/job/proc/setup_officer_positions()
 	var/datum/job/J = SSjob.GetJob(JOB_SECURITY_OFFICER)
+	var/datum/job/P = SSjob.GetJob(JOB_PRISONER)
 	if(!J)
 		CRASH("setup_officer_positions(): Security officer job is missing")
 
@@ -634,6 +635,8 @@ SUBSYSTEM_DEF(job)
 			JobDebug("Setting open security officer positions to [officer_positions]")
 			J.total_positions = officer_positions
 			J.spawn_positions = officer_positions
+			P.total_positions = ceil(officer_positions / 3) // 3 secoff to 1 perma ratio
+			P.spawn_positions = ceil(officer_positions / 3)
 
 	//Spawn some extra eqipment lockers if we have more than 5 officers
 	var/equip_needed = J.total_positions

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -359,6 +359,8 @@
 		info += related_policy
 	if(supervisors)
 		info += "As the [title] you answer directly to [supervisors]. Special circumstances may change this."
+		if(title == JOB_PRISONER)
+			info += "Remember, you are not an antagonist unless explicitly assigned or converted to be one."
 	if(radio_info)
 		info += radio_info
 	if(req_admin_notify)

--- a/code/modules/jobs/job_types/prisoner.dm
+++ b/code/modules/jobs/job_types/prisoner.dm
@@ -1,9 +1,9 @@
 /datum/job/prisoner
 	title = JOB_PRISONER
-	description = "Keep yourself occupied in permabrig."
+	description = "Keep yourself occupied in permabrig. (Note: not an antagonist role by default.)"
 	department_head = list("The Security Team")
 	faction = FACTION_STATION
-	total_positions = 5
+	total_positions = 2
 	spawn_positions = 5
 	supervisors = "the security team"
 	exp_granted_type = EXP_TYPE_CREW
@@ -53,7 +53,8 @@
 	target_record?.crimes += past_crime
 	target_record.recreate_manifest_photos(add_height_chart = TRUE)
 	monkestation end */
-	to_chat(crewmember, span_warning("You are imprisoned for \"[crime_name]\"."))
+	to_chat(crewmember, span_warning("You are imprisoned for \"[crime_name]\". \
+			Remember, you are not an antagonist unless explicitly assigned or converted to be one."))
 	crewmember.add_mob_memory(/datum/memory/key/permabrig_crimes, crimes = crime_name)
 
 /datum/outfit/job/prisoner


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


Preliminary changes:
Reduces the amount of open prisoner slots (2-3, scales using formula ceil(secoff_slots / 3, with 5-12 secoffs that means 2-3 prisoner slots). This also makes sense because there are only up to 3 bitrunner pods available, and once antags are placed in perma overcrowding is potentially an issue.

Adds text to the policy text displayed on spawn to further emphasize that prisoners without an assigned antag role are not antagonists, as a further reminder.

More discussion for further changes in the discord thread, at this point in time I am considering options for nerfing perma botany, but I am aware that this will also affect the viability of antags escaping permabrig.

## Why It's Good For The Game
Prisoners self-antagging has always been a nuisance.
There isn't much job content (botany and then bitrunning) which results in those who tend to pick prisoner just self-antagging (making lethal plants to kill sec) or just trying to break out once the 20min time limit is reached. And then after breaking out there is the potential for them to continue self-antagging (fighting secoffs coming to arrest them, or assaulting crew) or just being the equivalent of a validhunted assistant on station for the rest of the shift (not necessarily rule breaking on its own).

The amount of self-antagging potential is large enough that the rules explicitly mention multiple times:
"Warning: Prisoners without an added role such as Traitors or heretics are not antagonists Prisoners require extra escalation for any sort of aggression versus security. This is up to admin interpretation."
"Prisoners that wish to conduct a prison break need to wait at least 20 minutes into the round before starting. This is to allow regular station staff, security and the antagonists alike time to get settled in. Speedrunning prison breaks are less fun for everybody."
"Prisoners are not antagonists on their own. If you don't have explicit antagonist status, you will require significantly more escalation before you can get violent with anyone -- even security. Remember: you're lower than scum and the AI can ignore you unless you are actively dying."

This highlights the fact that prisoner is fundamentally a bit of a broken role in the context of the standard round: While there is a potential for significant RP such as parole RP, working in exchange for money/items/favors with sec (e.g. via license plates or gulag or making plants), court hearing RP with lawyers, the fact is that prison breaks and self-antagging are more "interesting" and action-packed forms of gameplay which people who willingly choose the role gravitate towards.

This has many negative impacts on the other players in the round:

For antags, while the chaos caused may initially seem good, once perma is insecure and unusable by security, they have valid reason to then execute the antags when caught, or throwing them in a holding cell as a replacement for permabrigging, which is a lot more boring for the antags (given that they had to ROLL for antag), which ruins antag rounds. Normally, if permas behave, then antags who are permabrigged still have a chance to attempt to escape; but if permabrig is already unsuitable for containing them, then security is more likely to execute them if they have committed execution worthy crimes instead of deescalating to perma first or holding a trial for execution.

If the prisoners attempt to use lethal force, security will be more likely to respond with lethal force, and once guns are out of armory, the probability of it going back in is usually lower, which increases security power level prematurely. If the antags are taking their time to increase the perceived threat level on station, this once again makes antag rounds worse. This is especially the case if sec is in maints actively hunting the prisoners (with new IC reason due to the prisoner) and antags just happen to get caught by chance.

Another factor in not putting guns back in armory is the knowledge that permas have made plants like bluespace tomatoes, which renders the armory insecure and they now have IC reason to keep the guns on their person instead of in the armory, as intended; and if the prisoner has stolen weapons from armory then that is already some IC reason to open armory as well.

For crew, there is the threat of a prisoner who may (mistakenly) believe they are antags and can then assault/harm/kill crew freely so long as they are not caught by security, who may be armed with weapons via botany.

For security, a large number of self-antagging permas would impact the balance of antagonists vs security during a round.

While in theory administrative action can be taken against such behavior, it just adds workload for staff to deal with up to 5 permas who may have orchestrated non-escalated, violent prison breaks and are loose on the station, in addition to the regular tickets from crew/antags.

## Testing
Demo for shiftstart policy notification:
<img width="643" height="324" alt="demo1_gamestart_policy" src="https://github.com/user-attachments/assets/feb6d39c-5060-4043-824e-ee409ca65d84" />
Demo for potential nerf/removal of composter from permabrig botany:
<img width="1619" height="818" alt="demo1_composter" src="https://github.com/user-attachments/assets/fb59f5ed-0d00-4d8f-b64a-6b259e66fd66" />
Top image is without the composter (and its 2 roundstart biocubes), bottom is with them. Round time is about 11 minutes. The first pumpkin batch won't be ready for harvest until 15 minutes without biocubes, while all the biogen biomass and composter biomatter were filled using the lower batch of plants. This shows how biocubes and the composter speeds up the ability to mutate plants for use in prison breaks, as opposed to its original intent as a means for prisoners to feed themselves without access to the crew kitchen.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added new mechanics or gameplay changes
add: Added more things
del: Removed old things
qol: made something easier to use
balance: rebalanced something
fix: fixed a few things
sound: added/modified/removed audio or sound effects
image: added/modified/removed some icons or images
map: added/modified/removed map content
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
