### PR TITLE
Moves the batter attributions.txt file

### DIFF
--- a/attributions.txt.txt
+++ b/attributions.txt.txt
@@ -1,3 +1,0 @@
-Added batter uniform and batter hat sprites and made them purchasable in the autodrobe.
-
-Added by Snack-Max/Snackiversal/Snackalus

--- a/monkestation/icons/mob/clothing/attributions.txt
+++ b/monkestation/icons/mob/clothing/attributions.txt
@@ -1,3 +1,6 @@
 left_green_jester_shoes - Cmpwarrior
 right_green_jester_shoes - Cmpwarrior
 bells_green_jester_shoes - Cmpwarrior
+
+batter_hat - Snack-Max/Snackiversal/Snackalus
+batter - Snack-Max/Snackiversal/Snackalus


### PR DESCRIPTION
## About The Pull Request

moves the `attributions.txt.txt` file from the root of the repo to it's respective folder that was already created, without any of the naming problems

original pr: #7731 (commit b50c396bf149f928e3bda904e758cc2d3cb44352)

## Why It's Good For The Game

not player interactable, better attribution location

## Testing

<img width="507" height="234" alt="image" src="https://github.com/user-attachments/assets/7f569ff4-c313-4420-8fe0-5aee1aa8f64f" />


## Changelog

not player interactable, just txt file changes

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [X] You documented all of your changes.