### PR TITLE
adds justice helmets to sectech contraband

### DIFF
--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -27,6 +27,8 @@
 		/obj/item/clothing/glasses/sunglasses = 2,
 		/obj/item/storage/fancy/donut_box = 4,
 		/obj/item/melee/flyswatter = 1,
+		/obj/item/clothing/head/helmet/toggleable/justice = 2,
+		/obj/item/clothing/head/helmet/toggleable/justice/escape = 2,
 	)
 	premium = list(
 		/obj/item/storage/belt/security/webbing = 5,


### PR DESCRIPTION

## About The Pull Request
read title

## Why It's Good For The Game
wee woo funny

## Testing

## Changelog

:cl:
add: added justice helmets to the sectech contraband section
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

