### PR TITLE
Making mining boulders not give Carpal tunnel syndrome

### DIFF
--- a/monkestation/code/modules/factory_type_beat/boulder.dm
+++ b/monkestation/code/modules/factory_type_beat/boulder.dm
@@ -81,7 +81,7 @@
 	if(HAS_TRAIT(user, TRAIT_BOULDER_BREAKER))
 		manual_process(null, user, INATE_BOULDER_SPEED_MULTIPLIER)
 		for(var/obj/item/boulder/rock in view(1, get_turf(user)))
-			rock.manual_process(weapon, user, INATE_BOULDER_SPEED_MULTIPLIER)
+			rock.manual_process(null, user, INATE_BOULDER_SPEED_MULTIPLIER)
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 /obj/item/boulder/CanAllowThrough(atom/movable/mover, border_dir)


### PR DESCRIPTION

## About The Pull Request
Breaking a boulder with a drilling tool, will attempt to drill a new boulder in range.
## Why It's Good For The Game
Manual processing should be a pain on my time, not my wrist.
## Testing
## Changelog
:cl:
balance: Cracking a boulder will attempt to mine a new boulder in range.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
