### PR TITLE
Adds boulder smelter and refinery to protolathe printing

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -35,8 +35,7 @@
 /turf/open/floor/grass,
 /area/station/security/prison/safe)
 "aaT" = (
-/obj/machinery/airalarm/directional/north,
-/obj/machinery/computer/mech_bay_power_console,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "abb" = (
@@ -339,10 +338,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/project)
-"ahk" = (
-/obj/effect/spawner/structure/window/hollow/reinforced/middle,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
 "ahm" = (
 /obj/machinery/newscaster/directional/west,
 /obj/machinery/firealarm/directional/south,
@@ -3231,11 +3226,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/department/chapel)
 "baV" = (
-/obj/structure/ore_vent/starter_resources{
-	icon_state = "ore_vent_ice_active"
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth_large,
+/area/station/cargo/warehouse)
 "bba" = (
 /obj/item/stack/medical/mesh,
 /obj/item/wrench/medical,
@@ -4970,10 +4964,7 @@
 /turf/open/floor/iron/smooth,
 /area/mine/mechbay)
 "bzN" = (
-/obj/structure/closet/crate/secure/freezer/pizza,
-/obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/item/food/pizza/donkpocket,
-/obj/item/knife/shiv,
+/obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "bzQ" = (
@@ -9789,10 +9780,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/checkpoint/supply)
-"cQp" = (
-/obj/machinery/suit_storage_unit/industrial/loader,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "cQs" = (
 /obj/structure/table,
 /obj/item/computer_disk{
@@ -19190,7 +19177,6 @@
 "fPB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate,
-/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "fPK" = (
@@ -24222,10 +24208,6 @@
 /obj/structure/tank_holder/oxygen,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"hsS" = (
-/obj/vehicle/sealed/mecha/ripley/cargo,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "htc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -28386,8 +28368,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/aft)
 "iKp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/smooth_large,
+/obj/structure/sign/warning/gas_mask/directional/south{
+	desc = "A sign that warns of dangerous gasses in the air, instructing you to wear internals."
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "iKr" = (
 /obj/machinery/light/small/directional/north,
@@ -33783,8 +33768,21 @@
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
 "kqV" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm/directional/south,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "cargo-warehouse-external"
+	},
+/obj/machinery/door/airlock/external{
+	glass = 1;
+	name = "Cargo Warehouse External Airlock";
+	opacity = 0
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/supply/mining_station,
+/turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "kra" = (
 /obj/structure/railing{
@@ -34005,11 +34003,8 @@
 /turf/open/floor/iron,
 /area/station/science/ordnance/testlab)
 "kuC" = (
-/obj/structure/sign/warning/gas_mask/directional/south{
-	desc = "A sign that warns of dangerous gasses in the air, instructing you to wear internals."
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/catwalk_floor/iron_smooth,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "kuR" = (
 /obj/structure/barricade/wooden,
@@ -34040,10 +34035,6 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"kve" = (
-/obj/structure/sign/warning/cold_temp/directional/north,
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/cargo/warehouse)
 "kvf" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -34844,9 +34835,7 @@
 /area/station/engineering/storage)
 "kII" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/machinery/light/small/directional/west,
+/obj/structure/closet/crate/secure/freezer/pizza,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "kIX" = (
@@ -36829,14 +36818,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
-"lmR" = (
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed{
-	pixel_x = 0;
-	pixel_y = 5
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "lmW" = (
 /obj/structure/railing{
 	dir = 8
@@ -37056,12 +37037,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
-"lqc" = (
-/obj/effect/spawner/random/trash/bin,
-/obj/item/paper/crumpled,
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "lqj" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -37172,16 +37147,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_half,
 /area/station/service/hydroponics)
-"lrm" = (
-/obj/structure/table,
-/obj/item/reagent_containers/cup/glass/coffee{
-	pixel_x = -5;
-	pixel_y = 11
-	},
-/obj/item/binoculars,
-/obj/structure/sign/poster/contraband/random/directional/west,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "lry" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -38295,11 +38260,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
-"lKb" = (
-/obj/effect/spawner/random/structure/closet_empty/crate,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "lKk" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -39008,10 +38968,6 @@
 	},
 /turf/closed/wall,
 /area/station/commons/dorms/laundry)
-"lWo" = (
-/obj/effect/spawner/random/trash/moisture_trap,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "lWp" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39890,8 +39846,6 @@
 	dir = 4
 	},
 /obj/structure/sign/poster/official/random/directional/south,
-/obj/effect/spawner/random/maintenance/three,
-/obj/structure/closet/crate/engineering,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "mmo" = (
@@ -40426,10 +40380,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage)
-"muj" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "muy" = (
 /turf/open/openspace,
 /area/station/commons/locker)
@@ -45239,6 +45189,8 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "nOK" = (
+/obj/machinery/light/small/directional/east,
+/obj/structure/sign/warning/xeno_mining/directional/east,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
@@ -49263,12 +49215,6 @@
 "paM" = (
 /turf/closed/wall,
 /area/station/engineering/storage/tech)
-"paN" = (
-/obj/structure/ore_vent/starter_resources{
-	icon_state = "ore_vent_ice_active"
-	},
-/turf/closed/mineral/random/snow,
-/area/icemoon/underground/explored)
 "paT" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "maint3"
@@ -52159,12 +52105,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/freezer,
 /area/mine/laborcamp)
-"pSh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "pSn" = (
 /obj/machinery/seed_extractor,
 /obj/structure/window/reinforced/spawner/directional/west,
@@ -53205,9 +53145,6 @@
 /obj/machinery/power/smes/engineering,
 /turf/open/floor/iron/dark,
 /area/station/engineering/engine_smes)
-"qmd" = (
-/turf/open/floor/catwalk_floor/iron_smooth,
-/area/station/cargo/warehouse)
 "qmi" = (
 /turf/open/floor/iron,
 /area/station/cargo/lobby)
@@ -54549,12 +54486,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
-"qHp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "qHt" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/status_display/evac/directional/east,
@@ -55348,8 +55279,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/machinery/light_switch/directional/south,
-/obj/structure/closet/crate/trashcart/filled,
-/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "qUe" = (
@@ -56325,11 +56254,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
-"rjm" = (
-/obj/effect/spawner/random/structure/closet_empty/crate,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "rjs" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2
@@ -60271,7 +60195,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/stack/ore/glass,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "svF" = (
@@ -60570,11 +60493,8 @@
 /turf/closed/mineral/random/snow/high_chance,
 /area/icemoon/underground/explored)
 "szJ" = (
-/obj/structure/chair/plastic{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_large,
+/obj/structure/sign/warning/cold_temp/directional/north,
+/turf/open/floor/iron/smooth,
 /area/station/cargo/warehouse)
 "sAa" = (
 /obj/structure/stairs/north,
@@ -62737,8 +62657,6 @@
 /obj/machinery/light/small/directional/south,
 /obj/item/radio/intercom/directional/south,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/random/structure/crate,
-/obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "tlE" = (
@@ -65187,14 +65105,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"uaE" = (
-/obj/structure/sign/warning/xeno_mining/directional/east,
-/obj/machinery/light/small/directional/east,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/spawner/random/structure/closet_empty/crate,
-/obj/effect/spawner/random/maintenance/two,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "uaG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -67610,10 +67520,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"uNr" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "uNt" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /turf/open/floor/plating,
@@ -67721,13 +67627,6 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
-"uOF" = (
-/obj/item/pickaxe{
-	pixel_x = 12;
-	pixel_y = 0
-	},
-/turf/open/misc/asteroid/snow/icemoon,
-/area/icemoon/underground/explored)
 "uOL" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -68404,11 +68303,6 @@
 /obj/machinery/power/smes/full,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
-"vbq" = (
-/obj/machinery/mech_bay_recharge_port,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "vbz" = (
 /obj/item/toy/snowball{
 	pixel_y = -7;
@@ -68993,7 +68887,7 @@
 /area/station/medical/pathology/isolation)
 "vjM" = (
 /obj/machinery/light/floor/has_bulb,
-/turf/open/space/basic,
+/turf/open/floor/iron,
 /area/station/cargo/storage)
 "vjP" = (
 /obj/structure/table/wood,
@@ -69420,10 +69314,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/station/service/kitchen/coldroom)
-"vrz" = (
-/obj/structure/closet/cardboard,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "vrC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -69896,12 +69786,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/station/science/explab)
-"vyI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "vyO" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -70189,6 +70073,7 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/suit_storage_unit/industrial/loader,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -70265,10 +70150,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"vDI" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/station/cargo/warehouse)
 "vDS" = (
 /obj/machinery/computer/department_orders/security{
 	dir = 4
@@ -78288,11 +78169,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"yaS" = (
-/obj/machinery/space_heater,
-/obj/machinery/light/small/directional/east,
-/turf/open/floor/iron/smooth_large,
-/area/station/cargo/warehouse)
 "yaT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/oxygen_output{
 	dir = 1
@@ -78548,7 +78424,7 @@
 "yef" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/random/structure/crate,
 /turf/open/floor/iron/smooth_large,
 /area/station/cargo/warehouse)
 "yej" = (
@@ -165451,10 +165327,10 @@ myZ
 fKv
 gjq
 gjq
-jpS
-jpS
-jpS
-jpS
+gjq
+gjq
+gjq
+gjq
 jpS
 kNW
 kNW
@@ -165708,12 +165584,12 @@ myZ
 fKv
 gjq
 gjq
+gjq
+gjq
+gjq
+gjq
+gjq
 jpS
-lrm
-cQp
-lqc
-rjm
-lmR
 bzN
 oXo
 piV
@@ -165965,15 +165841,15 @@ myZ
 fKv
 gjq
 gjq
-ahk
-szJ
-uNr
+gjq
+gjq
+gjq
+gjq
+gjq
+jpS
 oXo
-iKp
-pSh
-vyI
 yef
-yef
+baV
 svy
 cLq
 wUL
@@ -166222,13 +166098,13 @@ myZ
 psb
 eJf
 eJf
+eJf
+eJf
+eJf
+eJf
+eJf
 jpS
 aaT
-oXo
-oXo
-lKb
-qHp
-oXo
 bWV
 fPB
 ljz
@@ -166479,13 +166355,13 @@ myZ
 ajz
 gjq
 gjq
+gjq
+gjq
+gjq
+gjq
+gjq
 jpS
-vbq
-uNr
-muj
-uNr
-oXo
-oXo
+kuC
 oXo
 nOK
 clz
@@ -166736,16 +166612,16 @@ myZ
 psb
 eJf
 eJf
+eJf
+eJf
+eJf
+eJf
+eJf
 jpS
-hsS
-oXo
-rjm
-lWo
-yaS
-lKb
-vrz
-uaE
-qmd
+kNW
+sxb
+kNW
+aOE
 kqV
 kNW
 vCe
@@ -166993,17 +166869,17 @@ myZ
 fKv
 gjq
 gjq
+gjq
+iDt
+iDt
+iDt
+iDt
+iDt
 jpS
+jlK
 jpS
-vDI
-sxb
-jpS
-jpS
-jpS
-sxb
-jpS
-aOE
-aOE
+szJ
+iKp
 kNW
 rrV
 xGt
@@ -167256,11 +167132,11 @@ iDt
 iDt
 ijY
 iDt
-jlK
-jlK
-jpS
-kve
-kuC
+iDt
+iDt
+aEM
+gKd
+gKd
 rsY
 hdb
 avh
@@ -167515,9 +167391,9 @@ iDt
 iDt
 iDt
 iDt
-aEM
-gKd
-gKd
+rcY
+iDt
+iDt
 rsY
 mqs
 dTs
@@ -168289,7 +168165,7 @@ iDt
 rcY
 scw
 iDt
-uOF
+iDt
 scw
 scw
 scw
@@ -168546,7 +168422,7 @@ iDt
 rcY
 iDt
 scw
-baV
+iDt
 iDt
 scw
 uWE
@@ -169830,7 +169706,7 @@ scw
 psb
 thA
 thA
-paN
+xMq
 ijY
 jZN
 scw


### PR DESCRIPTION

## About The Pull Request
- Adds boulder smelter and refinery to protolathe printing
## Why It's Good For The Game
The rest of the boulder setup is printable from the protolathe with the exception of these two, no need to overcomplicate things with arbitrary placements
## Testing
## Changelog
:cl:
add: boulder smelter and refinery are printable from a protolathe
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
