### PR TITLE
Durand Shield power usage tweaking (YOU CAN USE IT NOW)

### DIFF
--- a/code/modules/vehicles/mecha/combat/durand.dm
+++ b/code/modules/vehicles/mecha/combat/durand.dm
@@ -50,7 +50,7 @@
 
 /obj/vehicle/sealed/mecha/durand/process()
 	. = ..()
-	if(defense_mode && !use_energy(100 KILO JOULES)) //Defence mode can only be on with a occupant so we check if one of them can toggle it and toggle
+	if(defense_mode && !use_energy(0.01 * STANDARD_CELL_CHARGE)) //Defence mode can only be on with a occupant so we check if one of them can toggle it and toggle
 		for(var/O in occupants)
 			var/mob/living/occupant = O
 			var/datum/action/action = LAZYACCESSASSOC(occupant_actions, occupant, /datum/action/vehicle/sealed/mecha/mech_defense_mode)
@@ -275,7 +275,9 @@ own integrity back to max. Shield is automatically dropped if we run out of powe
 		return
 	. = ..()
 	flick("shield_impact", src)
-	if(!chassis.use_energy((max_integrity - atom_integrity) * 100))
+	if(!.)
+		return
+	if(!chassis.use_energy(. * (STANDARD_CELL_CHARGE / 150)))
 		chassis.cell?.charge = 0
 		for(var/O in chassis.occupants)
 			var/mob/living/occupant = O


### PR DESCRIPTION

## About The Pull Request
closes #7171 ... if it wasnt already cleanup flagged and closed.
Durand shields currently take 1/4th of a Bluespace Cell per process. What the fuck. Thats bullshit, and frankly, obscene.

Effective ports/semiports of the following from tg:
tgstation/tgstation#85718
tgstation/tgstation#84043
tgstation/tgstation#88414
## Why It's Good For The Game
"Oh boy! i cant wait to use the durands special ability!" -poor unsuspecting roboticist, about to consume a reactors worth of power in 4 seconds tops
## Testing
Trust me bro.
Actually did test, but i forgot images. turned on the shield, didnt consume absurd amounts of power, pitted turrets ballistic and energy against it, consumed like, 1MJ-2MJ per hit absorbed.
## Changelog
:cl:
balance: reduces the idle power usage of the durand shield by approximately 10 times. (this consumed a quarter of a T4 cell per tick you arent allowed to complain.)
balance: updated durand shield bullet absorption code to match TGstation.  
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
