### PR TITLE
Ports TG #86995 (Silicon laws on status panel) and minor Malf AI UI Fix

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -134,7 +134,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 	return
 
 /// Modules causing destruction
-/datum/ai_module/destructive
+/datum/ai_module/malf/destructive
 	category = "Destructive Modules"
 
 /// Modules with stealthy and utility uses
@@ -867,7 +867,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 	source.lighting_color_cutoffs = blend_cutoff_colors(source.lighting_color_cutoffs, list(5, 25, 35))
 
 /// AI Turret Upgrade: Increases the health and damage of all turrets.
-/datum/ai_module/malf/malf/upgrade/upgrade_turrets
+/datum/ai_module/malf/upgrade/upgrade_turrets
 	name = "AI Turret Upgrade"
 	description = "Improves the power and health of all AI turrets. This effect is permanent. Upgrade is done immediately upon purchase."
 	cost = 30

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -484,3 +484,12 @@
 
 /mob/living/silicon/get_access()
 	return REGION_ACCESS_ALL_STATION
+
+
+///Places laws on the status panel for silicons
+/mob/living/silicon/get_status_tab_items()
+	. = ..()
+	var/list/law_list = list("Obey these laws:")
+	law_list += laws.get_law_list(include_zeroth = TRUE, render_html = FALSE)
+	for(var/borg_laws in law_list)
+		. += borg_laws


### PR DESCRIPTION

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/86995 which adds silicon's current laws to their status panel for easier viewing (especially for Cyborgs) and fixes some minor errors with Malfunctioning AI's antag panel, which had its malf modules messed up and uncatergorized.
## Why It's Good For The Game

Makes it easier for Silicons to view their laws at a glance and a bug fix.
## Testing

It works, it's like 6 lines of code.
<img width="1340" height="572" alt="image" src="https://github.com/user-attachments/assets/ae4d27f1-637e-44f5-8d9f-5017f6b17667" />
## Changelog
:cl:imedial and Sakaniko
add: Silicons can now view their laws from the status panel in the top right.
fix: Fixed uncategorized Malfunction Modules for Malf AI.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
