### PR TITLE
Siphoning Vault money don't yell to everyone if it's authorizezd.

### DIFF
--- a/code/game/machinery/bank_machine.dm
+++ b/code/game/machinery/bank_machine.dm
@@ -18,7 +18,7 @@
 	///The machine's internal radio, used to broadcast alerts.
 	var/obj/item/radio/radio
 	///The channel we announce a siphon over.
-	var/radio_channel = RADIO_CHANNEL_COMMON
+	var/radio_channel = RADIO_CHANNEL_SUPPLY
 
 	///What department to check to link our bank account to.
 	var/account_department = ACCOUNT_CAR
@@ -27,11 +27,12 @@
 
 /obj/machinery/computer/bank_machine/Initialize(mapload)
 	. = ..()
+
 	radio = new(src)
+	radio.set_frequency(FREQ_SUPPLY)
 	radio.subspace_transmission = TRUE
-	radio.canhear_range = 0
 	radio.set_listening(FALSE)
-	radio.recalculateChannels()
+
 	synced_bank_account = SSeconomy.get_dep_account(account_department)
 
 /obj/machinery/computer/bank_machine/Destroy()
@@ -112,15 +113,14 @@
 /obj/machinery/computer/bank_machine/proc/end_siphon()
 	siphoning = FALSE
 	unauthorized = FALSE
+	radio.set_frequency(FREQ_SUPPLY)
+	next_warning = 0
 	new /obj/item/holochip(drop_location(), syphoning_credits) //get the loot
 	syphoning_credits = 0
 
 /obj/machinery/computer/bank_machine/proc/start_siphon(mob/living/carbon/user)
 	siphoning = TRUE
-	unauthorized = FALSE
 	var/obj/item/card/id/card = user.get_idcard(hand_first = TRUE)
-	if(!istype(card))
-		return
-	if(!check_access(card))
-		return
-	unauthorized = TRUE
+	if(!istype(card) || !check_access(card))
+		unauthorized = TRUE
+		radio.set_frequency(FREQ_COMMON)


### PR DESCRIPTION
## About The Pull Request

Vaults will now calmly tell Supply that credits are being siphoned if it's done by someone authorized (Quartermaster, Head of Personnel, Captain)

<img width="633" height="418" alt="image" src="https://github.com/user-attachments/assets/4501003b-4a4d-48b7-9049-a1bae0b1baf2" />

## Why It's Good For The Game

I don't think the whole station needs to be alerted when the QM is taking credits from the budget, but letting the rest of Supply know is fine and may get the eyes of the HoP/Captain if it's a QM doing something they aren't supposed to do.

## Testing

In screenshot posted above.

## Changelog

:cl:
fix: Bank Machines (in the Vault) now properly yell when unauthorized and don't when authorized.
balance: Speaking of, they also now only speak in Supply chat when authorized, rather than alert the whole station.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
