### PR TITLE
Removes a citrus from Theseus

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -48929,7 +48929,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/trash/mess,
-/mob/living/basic/sloth/citrus,
 /obj/effect/spawner/random/trash/garbage,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)


### PR DESCRIPTION
## About The Pull Request

Would've been longer to make a bug report than to just fix it.
Removes a Citrus from Theseus

there's 2
<img width="1009" height="768" alt="image" src="https://github.com/user-attachments/assets/cb8265d0-96a8-4a9e-a8f8-83a849af8429" />

## Why It's Good For The Game



## Testing


## Changelog

:cl:
fix: Removed a Citrus from Theseus (there were 2)
/:cl:
