### PR TITLE
Adds more generic maint spawners

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -19865,6 +19865,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/commons/toilet)
+"bYl" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/port/fore)
 "bYv" = (
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
@@ -49674,6 +49678,14 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
+"lUU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/iron/textured_large,
+/area/station/maintenance/department/medical)
 "lVm" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Arrivals Maintenance"
@@ -73902,6 +73914,7 @@
 "veW" = (
 /obj/effect/turf_decal/bot_white,
 /obj/effect/mapping_helpers/burnt_floor,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/smooth,
 /area/station/maintenance/port)
 "veY" = (
@@ -101429,7 +101442,7 @@ aCR
 aCR
 aCR
 aCR
-aCR
+bYl
 aQe
 azQ
 azQ
@@ -109640,7 +109653,7 @@ aaa
 azQ
 aAh
 aCR
-aCR
+bYl
 aGU
 aCR
 hsq
@@ -122244,7 +122257,7 @@ srm
 tKc
 bwG
 aEd
-jtU
+lUU
 smX
 jtU
 fII

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -20808,6 +20808,7 @@
 /area/station/service/abandoned_gambling_den/gaming)
 "bJh" = (
 /obj/structure/sign/poster/contraband/random/directional/east,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/iron/dark,
 /area/station/service/abandoned_gambling_den/gaming)
 "bJi" = (
@@ -29039,6 +29040,10 @@
 /obj/effect/turf_decal/tile/purple/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"cKO" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/security/brig)
 "cKQ" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -30153,6 +30158,7 @@
 "dMI" = (
 /obj/item/clothing/suit/apron/surgical,
 /obj/effect/mapping_helpers/broken_floor,
+/obj/effect/landmark/generic_maintenance_landmark,
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/xenobiology)
 "dMO" = (
@@ -30791,6 +30797,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/science/central)
+"env" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/cargo)
 "enL" = (
 /obj/machinery/door/airlock{
 	name = "Garden"
@@ -33064,6 +33074,10 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"gih" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/engine)
 "gii" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/nt_rep)
@@ -34759,6 +34773,12 @@
 "hEC" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/abandoned)
+"hER" = (
+/obj/structure/chair/stool/bar/directional/north,
+/obj/effect/mapping_helpers/broken_floor,
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/wood,
+/area/station/service/abandoned_gambling_den)
 "hEX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -35039,6 +35059,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
 /area/station/science/lab)
+"hTD" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/crew_quarters/dorms)
 "hUx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -41019,6 +41043,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"nhC" = (
+/obj/effect/landmark/generic_maintenance_landmark,
+/turf/open/floor/plating,
+/area/station/maintenance/department/science/central)
 "nih" = (
 /obj/structure/closet,
 /obj/effect/spawner/random/clothing/costume,
@@ -72334,7 +72362,7 @@ aaa
 aaa
 aiu
 aiX
-ajD
+cKO
 aks
 aiu
 ait
@@ -80136,7 +80164,7 @@ bDi
 bRF
 bDi
 uIR
-bDi
+gih
 bva
 bPA
 ftp
@@ -92890,7 +92918,7 @@ aiU
 jHP
 aju
 ajt
-alQ
+hER
 mnG
 xjl
 otM
@@ -93414,7 +93442,7 @@ ajv
 ajv
 ajv
 ajv
-ajv
+hTD
 asl
 aiS
 aqT
@@ -100653,7 +100681,7 @@ aaa
 vgm
 jEL
 uSW
-yet
+nhC
 uSW
 lEn
 vYN
@@ -101145,7 +101173,7 @@ aEj
 aFi
 ezQ
 aFi
-aFi
+env
 odG
 aEj
 wmE


### PR DESCRIPTION
## About The Pull Request

Most maps tend to have ~30 generic maint spawners, Pubby has 13 and I noticed Helio also had a lot less, so I added more and biased it to be more in maintenance (as the name suggests), which adds a lot more "dark" maint spawn locations for stuff like Nightmares.

## Why It's Good For The Game

Closes https://github.com/Monkestation/Monkestation2.0/issues/9530

## Testing

<img width="1895" height="981" alt="image" src="https://github.com/user-attachments/assets/33f090df-ce74-4016-91eb-ff3b79ecf717" />

## Changelog

:cl:
fix: Fixed an edge case where Nightmares can't spawn on Pubbystation (and potentially Heliostation).
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.