### PR TITLE
skittish trapping

### DIFF
--- a/code/datums/elements/skittish.dm
+++ b/code/datums/elements/skittish.dm
@@ -50,8 +50,8 @@
 		if(closet.horizontal)
 			scooby.set_resting(FALSE, silent = TRUE)
 		return
-
-	closet.togglelock(scooby, silent = TRUE)
+	if(closet.can_unlock(scooby, scooby.get_idcard(), closet.id_card))
+		closet.togglelock(scooby, silent = TRUE)
 
 	if(closet.horizontal)
 		scooby.set_resting(FALSE, silent = TRUE)


### PR DESCRIPTION

## About The Pull Request
- Skiddish no longer automatically locks crates they cannot unlock
## Why It's Good For The Game
Revert to how things worked prior to locker access update 2 months back for exclusively skittish, you still can lock the locker as per normal without access after. However, it will only automatically lock if it it's a locker/crate you could lock with your current access.
## Testing
## Changelog
:cl:
balance: Skittish will only lock a locker if you could lock the locker in the first place
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
