### PR TITLE
Bots are no longer affected by temperatures

### DIFF
--- a/code/modules/mob/living/basic/bots/_bots.dm
+++ b/code/modules/mob/living/basic/bots/_bots.dm
@@ -39,6 +39,9 @@ GLOBAL_LIST_INIT(command_strings, list(
 	speed = 3
 	interaction_flags_click = ALLOW_SILICON_REACH
 	req_one_access = list(ACCESS_ROBOTICS)
+	unsuitable_cold_damage = 0
+	unsuitable_heat_damage = 0
+
 	///The Robot arm attached to this robot - has a 50% chance to drop on death.
 	var/robot_arm = /obj/item/bodypart/arm/right/robot
 	///The inserted (if any) pAI in this bot.


### PR DESCRIPTION
## About The Pull Request

I think a mixup from https://github.com/Monkestation/Monkestation2.0/pull/3301 & https://github.com/Monkestation/Monkestation2.0/pull/1842 led to basic bots not being given temperature immunity like simple bots are

## Why It's Good For The Game

Closes https://github.com/Monkestation/Monkestation2.0/issues/9580

## Testing

yea

## Changelog

:cl:
fix: Medbots, cleanbots, and hygienebots are no longer affected by temperatures.
/:cl: