### PR TITLE
Bridge Assistant is no longer 'Command'.

### DIFF
--- a/code/modules/jobs/job_types/bridgeassistant.dm
+++ b/code/modules/jobs/job_types/bridgeassistant.dm
@@ -25,10 +25,15 @@ Bridge Assistant
 	liver_traits = list(TRAIT_PRETENDER_ROYAL_METABOLISM)
 
 	display_order = JOB_DISPLAY_ORDER_BRIDGE_ASSISTANT
-	departments_list = list(/datum/job_department/command)
 	department_for_prefs = /datum/job_department/captain //hes the only person who is exclusively subordinate to the captain and not running another dept
 
-	family_heirlooms = list(/obj/item/banner/command/mundane, /obj/item/pen/fountain, /obj/item/stamp/granted, /obj/item/reagent_containers/cup/glass/mug/nanotrasen, /obj/item/reagent_containers/cup/coffeepot/bluespace/synthesiser)
+	family_heirlooms = list(
+		/obj/item/banner/command/mundane,
+		/obj/item/pen/fountain,
+		/obj/item/stamp/granted,
+		/obj/item/reagent_containers/cup/glass/mug/nanotrasen,
+		/obj/item/reagent_containers/cup/coffeepot/bluespace/synthesiser,
+	)
 
 	mail_goodies = list(
 		/obj/item/storage/fancy/cigarettes = 1,


### PR DESCRIPTION
## About The Pull Request

This is a copy paste of my text from the link in why it's good for the game
- Includes them in 'Command' deathrattle implant station trait
- Give extra monkecoins for Mentors to play as (why is this only for mentors lol??)
- Get shot by turrets targeting 'Command'
- Valid 'Head' target for Heretics to ascend
- Valid 'Head' target for Bloodsucker vassalizing.
- Valid 'Head' assassination/eyesnatching for Traitors.
- Show up as 'Command' on latejoin menu.
- Worth 3x more than crew when sold by pirates (also their tracker will point them to the bridge assistant).
- Ineligable for hardcore random
- Bonus chance to open champagne
- Auto opt-into "yes, round removal" description.

Also a target for Revs but that's disabled.

While deathrattle and latejoin menu stuff is nice, everything else doesn't really make sense for what is essentially a glorified Assistant. The latejoin menu issue could and should be fixed in the future because it also messes up the look of a few other jobs (Assistants and Prisoners, most notably), but is itself not enough of a reason to keep Bridge Assistant as command.

### Important thing I forgot

This excludes bridge assistants from 'command' bans, they will have to manually click on Bridge Assistant or just let them play as it (it isn't command so ig it's fine for them to? idk)
This PR most definitely will need admin input.

## Why It's Good For The Game

Closes https://github.com/Monkestation/Monkestation2.0/issues/8498

## Testing

i did

## Changelog

:cl:
balance: Bridge Assistants are no longer 'Command' personnel.
/:cl: