### PR TITLE
Warlock's staff is no longer consider lethally chambered

### DIFF
--- a/code/modules/antagonists/darkspawn/darkspawn_objects/warlock_staff.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_objects/warlock_staff.dm
@@ -108,6 +108,7 @@
 /obj/item/ammo_casing/magic/darkspawn
 	projectile_type = /obj/projectile/magic/darkspawn
 	firing_effect_type = null
+	harmful = FALSE
 
 /obj/projectile/magic/darkspawn
 	name = "bolt of nothingness"


### PR DESCRIPTION

## About The Pull Request
- Warlock's staff is no longer considered lethally chambered
## Why It's Good For The Game
Warlocks staff can do any of the following
- Heal
- Stamina damage
- Confusion
None of these are actually lethal effects. Thus pacafism should not apply
## Testing
## Changelog
:cl:
balance: Warlocks staff is no longer considered lethally chambered
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
