### PR TITLE
Medbeam no longer needs a weapon permit

### DIFF
--- a/code/modules/projectiles/guns/special/medbeam.dm
+++ b/code/modules/projectiles/guns/special/medbeam.dm
@@ -5,7 +5,7 @@
 	icon_state = "chronogun"
 	inhand_icon_state = "chronogun"
 	w_class = WEIGHT_CLASS_NORMAL
-	item_flags = NONE
+	item_flags = parent_type::item_flags & ~NEEDS_PERMIT
 
 	var/mob/living/current_target
 	var/last_check = 0


### PR DESCRIPTION
## About The Pull Request

Beepsky's set to arrest for guns will no longer target people with medbeams.

## Why It's Good For The Game

It's not a real gun.
Closes https://github.com/Monkestation/Monkestation2.0/issues/3470

## Changelog

:cl:
fix: Medbeams are no longer considered guns (for beepsky and honorbound Chaplains).
/:cl: