### PR TITLE
Fixes backpack + satchel powergaming

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -45,7 +45,7 @@
 	var/obj/item/storage/backpack/back_item = user.get_item_by_slot(ITEM_SLOT_BACK)
 	var/obj/item/storage/backpack/belt_item = user.get_item_by_slot(ITEM_SLOT_BELT)
 	if(istype(back_item) && istype(belt_item))
-		user.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/belt_satchel, min(back_item.satchel_movespeed_modifier, belt_item.satchel_movespeed_modifier))
+		user.add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/belt_satchel, TRUE, min(back_item.satchel_movespeed_modifier, belt_item.satchel_movespeed_modifier))
 	else
 		user.update_movespeed()
 /*


### PR DESCRIPTION
## About The Pull Request
- Having a backpack + satchel will no longer have a minimal to no slowdown
## Why It's Good For The Game
Gaming twice the inventory space at no cost, is very very bad thing

Fixes: #9036 
Fixes: #8984
## Testing
Tested with both rockspider and regular backpacks
Got slowdown
Different amounts
## Changelog
:cl:
fix: Satchel + backpack will apply slowdown
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
