### PR TITLE
Mending touch on a person with blood loss no longer causes you to kill yourself usually.

### DIFF
--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -337,7 +337,7 @@
 		var/datum/blood_type/blood = hurtguy.get_blood_type()
 		to_chat(mendicant, span_notice("Your veins (and brain) feel a bit lighter."))
 		. = TRUE
-		mendicant.blood_volume = min(hurtguy.blood_volume - round(blood_to_hurtguy, 0.1), BLOOD_VOLUME_MAXIMUM)
+		mendicant.blood_volume = min(mendicant.blood_volume - round(blood_to_hurtguy, 0.1), BLOOD_VOLUME_MAXIMUM)
 		hurtguy.blood_volume = min(hurtguy.blood_volume + round(blood_to_hurtguy, 0.1), BLOOD_VOLUME_MAXIMUM)
 		if(!(mendicant.dna.human_blood_type in blood.compatible_types))
 		// MONKESTATION EDIT NEW END
@@ -364,7 +364,7 @@
 		var/datum/blood_type/mendicant_blood = mendicant.get_blood_type()
 		to_chat(hurtguy, span_notice("Your veins don't feel quite so swollen anymore."))
 		. = TRUE
-		mendicant.blood_volume = min(hurtguy.blood_volume + round(blood_to_mendicant, 0.1), BLOOD_VOLUME_MAXIMUM)
+		mendicant.blood_volume = min(mendicant.blood_volume + round(blood_to_mendicant, 0.1), BLOOD_VOLUME_MAXIMUM)
 		hurtguy.blood_volume = min(hurtguy.blood_volume - round(blood_to_mendicant, 0.1), BLOOD_VOLUME_MAXIMUM)
 		if(!(hurtguy.dna.human_blood_type in mendicant_blood.compatible_types))
 		// MONKESTATION EDIT NEW END


### PR DESCRIPTION

## About The Pull Request
- Makes it so mending touch doesn't vanish blood into thin air.
## Why It's Good For The Game
Mending touch is about ontaking one's burdens. From what I gathered, it's only expected to give you about 56 blood/transfer that amount. However the baseline for the blood jumps to the recipients bloodless - the transfer. Meaning ironically, it's a good self-restoration blood loss option if you have less blood than your target.
## Testing
## Changelog
:cl:
fix: Mending touch no longer levels you to the targets blood level, rather just adjusting the transfer rate.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
