### PR TITLE
You can no longer talk red

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -171,7 +171,6 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	ENCODE_HTML_EMPHASIS(input, "\\|", "i", italics)
 	ENCODE_HTML_EMPHASIS(input, "\\+", "b", bold)
 	ENCODE_HTML_EMPHASIS(input, "_", "u", underline)
-	ENCODE_HTML_EMPHASIS(input, "\\`", "font color= 'red'", redtext) //MONKESTATION ADDITION: makes your text red
 	var/static/regex/remove_escape_backlashes = regex("\\\\(_|\\+|\\|)", "g") // Removes backslashes used to escape text modification.
 	input = remove_escape_backlashes.Replace_char(input, "$1")
 	return input


### PR DESCRIPTION

## About The Pull Request

Removes the ability to produce messages with red text.

## Why It's Good For The Game

Firstly, what even IS talking red? Like, what IS THAT. Sarcasm is italics. Emphasis is bold. So, what the FUCK is red? What emotion is this trying to convey? How are you actually supposed to understand what someone means when they talk red? Is it emphasis? Sarcasm? It could be EITHER. No good.

God made two text modifiers **BOLD** and _ITALICS_. There's no need for a magical third modifier!

Thank you.

## Testing
## Changelog
:cl:
change: you can no longer talk red. I mean what the fuck is talking red anyway.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
