### PR TITLE
Eye of god now counts as prescription glasses

### DIFF
--- a/code/modules/mining/lavaland/tendril_loot.dm
+++ b/code/modules/mining/lavaland/tendril_loot.dm
@@ -831,7 +831,7 @@
 	icon_state = "godeye"
 	inhand_icon_state = null
 	vision_flags = SEE_TURFS
-	clothing_traits = list(TRAIT_MADNESS_IMMUNE)
+	clothing_traits = list(TRAIT_MADNESS_IMMUNE, TRAIT_NEARSIGHTED_CORRECTED)
 	// Blue, light blue
 	color_cutoffs = list(15, 30, 40)
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF


### PR DESCRIPTION

## About The Pull Request

this adds `TRAIT_NEARSIGHTED_CORRECTED` to the eye of god, so it's actually useful for nearsighted miners

## Why It's Good For The Game

like, c'mon, this is its description, why wouldn't it also cure nearsightedness:
> A strange eye, said to have been torn from an omniscient creature that used to roam the wastes.

## Testing
## Changelog
:cl:
qol: Eye of god now counts as prescription glasses
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
