### PR TITLE
Generate ore vents for Oshan mining

### DIFF
--- a/_maps/RandomRuins/OshanRuins/oshan_surface_ore_vent.dmm
+++ b/_maps/RandomRuins/OshanRuins/oshan_surface_ore_vent.dmm
@@ -1,0 +1,27 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"t" = (
+/obj/structure/ore_vent/random,
+/turf/open/floor/plating/ocean/dark,
+/area/ocean/generated)
+"Z" = (
+/turf/open/floor/plating/ocean/dark,
+/area/ocean/generated)
+
+(1,1,1) = {"
+a
+Z
+a
+"}
+(2,1,1) = {"
+Z
+t
+Z
+"}
+(3,1,1) = {"
+a
+Z
+a
+"}

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -366,6 +366,11 @@
 	integer = FALSE
 	min_val = 0
 
+/datum/config_entry/number/oshan_budget
+	default = 60
+	integer = FALSE
+	min_val = 0
+
 /datum/config_entry/flag/allow_random_events // Enables random events mid-round when set
 
 /datum/config_entry/flag/forbid_station_traits

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -265,22 +265,27 @@ SUBSYSTEM_DEF(mapping)
 /datum/controller/subsystem/mapping/proc/setup_ruins()
 	// Generate mining ruins
 	var/list/lava_ruins = levels_by_trait(ZTRAIT_LAVA_RUINS)
-	if (lava_ruins.len)
+	if (length(lava_ruins))
 		seedRuins(lava_ruins, CONFIG_GET(number/lavaland_budget), list(/area/lavaland/surface/outdoors/unexplored), themed_ruins[ZTRAIT_LAVA_RUINS], clear_below = TRUE)
 
 	var/list/ice_ruins = levels_by_trait(ZTRAIT_ICE_RUINS)
-	if (ice_ruins.len)
+	if (length(ice_ruins))
 		// needs to be whitelisted for underground too so place_below ruins work
 		seedRuins(ice_ruins, CONFIG_GET(number/icemoon_budget), list(/area/icemoon/surface/outdoors/unexplored, /area/icemoon/underground/unexplored), themed_ruins[ZTRAIT_ICE_RUINS], clear_below = TRUE)
 
 	var/list/ice_ruins_underground = levels_by_trait(ZTRAIT_ICE_RUINS_UNDERGROUND)
-	if (ice_ruins_underground.len)
+	if (length(ice_ruins_underground))
 		seedRuins(ice_ruins_underground, CONFIG_GET(number/icemoon_budget), list(/area/icemoon/underground/unexplored), themed_ruins[ZTRAIT_ICE_RUINS_UNDERGROUND], clear_below = TRUE, mineral_budget = 21)
 
 	// Generate deep space ruins
 	var/list/space_ruins = levels_by_trait(ZTRAIT_SPACE_RUINS)
-	if (space_ruins.len)
+	if (length(space_ruins))
 		seedRuins(space_ruins, CONFIG_GET(number/space_budget), list(/area/space), themed_ruins[ZTRAIT_SPACE_RUINS], mineral_budget = 0)
+
+	// Generate oshan ruins
+	var/list/oshan_ruins = levels_by_trait(ZTRAIT_OSHAN_MINING)
+	if (length(oshan_ruins))
+		seedRuins(oshan_ruins, CONFIG_GET(number/oshan_budget), list(/area/ocean/generated, /area/ocean/dark), themed_ruins[ZTRAIT_OSHAN_MINING], clear_below = TRUE)
 
 /// Sets up rivers, and things that behave like rivers. So lava/plasma rivers, and chasms
 /// It is important that this happens AFTER generating mineral walls and such, since we rely on them for river logic

--- a/code/datums/ruins/oshan.dm
+++ b/code/datums/ruins/oshan.dm
@@ -1,0 +1,14 @@
+/datum/map_template/ruin/oshan
+	ruin_type = ZTRAIT_OSHAN_MINING
+	prefix = "_maps/RandomRuins/OshanRuins/"
+	default_area = /area/ocean/generated
+
+/datum/map_template/ruin/oshan/vent
+	name = "Ore Vent"
+	id = "ore_vent_o"
+	description = "A vent that spews out ore. Seems to be a natural phenomenon."
+	suffix = "oshan_surface_ore_vent.dmm"
+	allow_duplicates = TRUE
+	cost = 0
+	mineral_cost = 1
+	always_place = TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1818,6 +1818,7 @@
 #include "code\datums\records\record.dm"
 #include "code\datums\ruins\icemoon.dm"
 #include "code\datums\ruins\lavaland.dm"
+#include "code\datums\ruins\oshan.dm"
 #include "code\datums\ruins\space.dm"
 #include "code\datums\screentips\atom_context.dm"
 #include "code\datums\screentips\item_context.dm"


### PR DESCRIPTION

## About The Pull Request

exactly what it says on the tin: makes it so Oshan has ore vents.

## Why It's Good For The Game

one less thing missing from Oshan

## Testing

<img width="1708" height="1349" alt="2025-11-20 (1763683188) ~ dreamseeker" src="https://github.com/user-attachments/assets/30a789d4-268c-48b4-9f75-c18a9262f46a" />


## Changelog
:cl:
add: Ore Vents now generate on Oshan's mining level.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
