### PR TITLE
fixes chemmasters having half their usual buffer

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -114,8 +114,7 @@ GLOBAL_LIST_INIT(chem_master_containers, list(
 	for(var/obj/item/reagent_containers/cup/beaker/beaker in component_parts)
 		reagents.maximum_volume += beaker.reagents.maximum_volume
 		if(!CHECK_BITFIELD(beaker.reagents.flags, NO_REACT))
-			cryogenic = FALSE //at least one of the beakers is not a cryo beaker
-			break // thus we can really just stop here.
+			cryogenic = FALSE
 	if(cryogenic == TRUE)
 		ENABLE_BITFIELD(reagents.flags, NO_REACT)
 	else


### PR DESCRIPTION
This reverts commit c674700632f9b146237d6f70a94ce3456bf9bfd6.
## About The Pull Request
Im... a little silly, blehhhh :P
## Why It's Good For The Game
bugfix? where will all the bugs go?
## Testing
Yeah i actually did this time.
## Changelog
:cl:
fix: fixed chem masters not considering the second beakers size in its buffer if the first wasnt a cryo beaker.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
