### PR TITLE
Super Syndie-Kitty Ears now lock you out of secondary objectives (progtot)

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_traitor.dm
+++ b/code/__DEFINES/dcs/signals/signals_traitor.dm
@@ -1,7 +1,7 @@
 /// Called when the hack_comm_console objective is completed.
 #define COMSIG_GLOB_TRAITOR_OBJECTIVE_COMPLETED "!traitor_objective_completed"
 
-/// Called whenever the uplink handler receives any sort of update. Used by uplinks to update their UI. No arguments passed
+/// Called whenever the uplink handler receives any sort of update. Used by uplinks to update their UI.
 #define COMSIG_UPLINK_HANDLER_ON_UPDATE "uplink_handler_on_update"
 /// Sent from the uplink handler when the traitor uses the syndicate uplink beacon to order a replacement uplink.
 #define COMSIG_UPLINK_HANDLER_REPLACEMENT_ORDERED "uplink_handler_replacement_ordered"

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -99,6 +99,7 @@
 /datum/component/uplink/proc/handle_uplink_handler_update()
 	SIGNAL_HANDLER
 	SStgui.update_uis(src)
+	SStgui.update_static_data_for_all_viewers()
 
 /// When a new uplink is made via the syndicate beacon it locks all lockable uplinks and destroys replacement uplinks
 /datum/component/uplink/proc/handle_uplink_replaced()

--- a/code/modules/antagonists/traitor/uplink_handler.dm
+++ b/code/modules/antagonists/traitor/uplink_handler.dm
@@ -86,6 +86,12 @@
 	if(shop_locked)
 		return FALSE
 
+	if(to_purchase.lock_secondary_objectives)
+		// don't check active objectives, bc we'll just auto-cancel them if this is bought
+		for(var/datum/traitor_objective/objective as anything in completed_objectives)
+			if(objective.objective_state == OBJECTIVE_STATE_COMPLETED)
+				return FALSE
+
 //monkestation edit start
 	if(!(ignore_locked) && (to_purchase.type in locked_entries))
 		return FALSE
@@ -276,3 +282,14 @@
 		return
 
 	to_act_on.ui_perform_action(user, action)
+
+/datum/uplink_handler/proc/disable_secondary_objectives()
+	for(var/datum/traitor_objective/objective as anything in active_objectives)
+		objective.fail_objective(penalty_cost = 0, trigger_update = FALSE)
+	has_objectives = FALSE
+	can_take_objectives = FALSE
+	potential_objectives.Cut()
+	maximum_active_objectives = 0
+	maximum_potential_objectives = 0
+	SStraitor.uplink_handlers -= src
+	on_update()

--- a/code/modules/asset_cache/assets/uplink.dm
+++ b/code/modules/asset_cache/assets/uplink.dm
@@ -36,7 +36,8 @@
 				"restricted_species" = item.restricted_species,
 				"progression_minimum" = item.progression_minimum,
 				"cost_override_string" = item.cost_override_string,
-				"lock_other_purchases" = item.lock_other_purchases
+				"lock_other_purchases" = item.lock_other_purchases,
+				"lock_secondary_objectives" = item.lock_secondary_objectives,
 			))
 		}
 		SStraitor.uplink_items += item

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -96,6 +96,9 @@
 	/// Uses the purchase log, so items purchased that are not visible in the purchase log will not count towards this.
 	/// However, they won't be purchasable afterwards.
 	var/lock_other_purchases = FALSE
+	/// Whether this item prevents secondary objectives from being taken.
+	/// In addition, if any secondary objectives have been taken or completed, this item will not be available for purchase.
+	var/lock_secondary_objectives = FALSE
 
 /datum/uplink_item/New()
 	. = ..()
@@ -138,6 +141,8 @@
 		uplink_handler.purchase_log.LogPurchase(A, src, cost)
 	if(lock_other_purchases)
 		uplink_handler.shop_locked = TRUE
+	if(lock_secondary_objectives)
+		uplink_handler.disable_secondary_objectives()
 
 /// Spawns an item in the world
 /datum/uplink_item/proc/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)

--- a/monkestation/code/modules/uplink/uplink_items/misc.dm
+++ b/monkestation/code/modules/uplink/uplink_items/misc.dm
@@ -48,6 +48,7 @@
 	cost = 16 // double the price of stealth implant
 	surplus = 5
 	limited_stock = 1
+	lock_secondary_objectives = TRUE // no you can't cheese progtot with ventcrawling
 
 /datum/uplink_item/device_tools/magboots
 	name = "Blood-Red Magboots"

--- a/tgui/packages/tgui/interfaces/Uplink/index.tsx
+++ b/tgui/packages/tgui/interfaces/Uplink/index.tsx
@@ -42,6 +42,7 @@ type UplinkItem = {
   progression_minimum: number;
   cost_override_string: string;
   lock_other_purchases: BooleanLike;
+  lock_secondary_objectives: BooleanLike;
   ref?: string;
 };
 
@@ -246,6 +247,14 @@ export class Uplink extends Component<{}, UplinkState> {
                 Taking this item will lock you from further purchasing from the
                 marketplace. Additionally, if you have already purchased an
                 item, you will not be able to purchase this.
+              </NoticeBox>
+            )) ||
+              null}
+            {(item.lock_secondary_objectives && (
+              <NoticeBox mt={1}>
+                Taking this item will lock you from completing any secondary
+                objectives. Additionally, if you have already completed any
+                secondary objectives, you will not be able to purchase this.
               </NoticeBox>
             )) ||
               null}


### PR DESCRIPTION
## About The Pull Request

This makes it so buying the Super Syndie-Kitty Ears now has the effect of locking you out of secondary objectives, and cannot be bought if you have completed any secondary objectives.

If you have active but uncompleted secondaries, they will be canceled without TC reward or penalty when you buy the ears.

## Why It's Good For The Game

Because the ability to ventcrawl trivializes progtot and encourages turbototting, which is icky.
I intended these to be a silly item more than anything, something for gimmicks or just goobering around, not for Gaming(tm)

## Testing

<img width="895" height="420" alt="2025-11-23 (1763938900)" src="https://github.com/user-attachments/assets/aa7b4379-b5fc-4b75-a844-4e72c749b2cb" />

<img width="730" height="716" alt="2025-11-23 (1763939656) ~ dreamseeker" src="https://github.com/user-attachments/assets/f790fda6-2b14-4a8e-a1dd-43bb427a77e4" />

## Changelog
:cl:
balance: Buying Super Syndie-Kitty Ears will now prevent you from taking any secondary objectives, and you will also not be able to buy them if you have completed any secondary objectives already.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
