### PR TITLE
Fix obfuscate teleporting being incredibly inconsistent

### DIFF
--- a/monkestation/code/modules/bloodsuckers/powers/tremere/obfuscation.dm
+++ b/monkestation/code/modules/bloodsuckers/powers/tremere/obfuscation.dm
@@ -70,10 +70,8 @@
 	. = ..()
 	if(!.)
 		return FALSE
-	if(!isturf(target_atom))
-		return FALSE
-	var/turf/target_turf = target_atom
-	if(target_turf.is_blocked_turf_ignore_climbable())
+	var/turf/target_turf = get_turf(target_atom)
+	if(!target_turf || target_turf.is_blocked_turf_ignore_climbable())
 		return FALSE
 	if(level_current < OBFUSCATION_ANYWHERE_LEVEL && !(target_turf in view(owner.client.view, owner.client)))
 		owner.balloon_alert(owner, "out of view!")
@@ -114,9 +112,7 @@
 
 /datum/action/cooldown/bloodsucker/targeted/tremere/obfuscation/FireSecondaryTargetedPower(atom/target, params)
 	. = ..()
-	var/mob/living/user = owner
-	var/turf/targeted_turf = get_turf(target)
-	obfuscation_blink(user, targeted_turf)
+	obfuscation_blink(owner, get_turf(target))
 	return TRUE
 
 /datum/action/cooldown/bloodsucker/targeted/tremere/obfuscation/proc/on_use_item(mob/living/source, atom/target, obj/item/weapon, click_parameters)


### PR DESCRIPTION

## About The Pull Request

> PLEASE
> PLEASE MAKE IT
> SO YOU CAN CLICK THINGS
> OTHER THAN FLOOR TURFS
> WITH OBFUSCATE
> I HATE CLICKING
> TEN GOD DAMN TIMES
> JUST TO TELEPORT ONCE
> IF A XENO
> MAKES WEEDS
> YOU JUST
> CAN'T OBFUSCATE
> ANYWHERE
> ON THAT FLOOR

~ icetype

## Testing
## Changelog
:cl:
fix: Fixed obfuscate's teleport being inconsistent, especially during situations where there's stuff like xeno weeds spread around.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
