### PR TITLE
Makes hotspots not explode (for now)

### DIFF
--- a/monkestation/code/modules/ocean_content/hotspot/hotspot.dm
+++ b/monkestation/code/modules/ocean_content/hotspot/hotspot.dm
@@ -169,9 +169,9 @@
 				listed_living.adjustBruteLoss(5)
 				listed_living.stamina?.adjust(-30)
 
-	// For future maintainers, explosions have been commented out
+	// For future maintainers, below are the explosions that have been commented out
 	// replace once you find a reason for a random wandering point to destroy the station.
-	// Hotspots should be cool additions to a map not a hazard
+	// Hotspots should be cool additions to a map and not just a glorified hazard
 
 	// if(!istype(calculation_point, /turf/open/floor/plating/ocean))
 	// 	if(event_flags & WEAK_FIRE)


### PR DESCRIPTION

## About The Pull Request
This more or less shelves hotspot explosions for now, 
code is commented out but can still be un-commented should someone feel like turning this back on 
(for some god forsaken reason)
## Why It's Good For The Game
Hotspot's exploding more or less, sucks at the moment.
After they gain enough heat they mostly just destroy a large section of the station,
and require spending the first 20ish minutes of the round running around stomping all of them.
from either poor design or poor code (or both) stomping the edge of a hotspot unlocks it

This by itself would be fine if they could not overlap, 
but they can and _if they have enough heat_ _**explode many many times as you try to get them unstuck.**_
Fine if you are in the middle of the oshan, stupid if the hotspots ended up in medbay **AGAIN**

If this does get merged, and someone wants to undo this, put a player cap on it (either the map or the explosions) before you do.
Low-pop hotspots are an instant 40-50 minute shuttle call for what would usually be a calm round.

## Testing

Works in local testing, does not go boom!

## Changelog
:cl:
refactor: Oshan hotspots no longer explode, Engineers rejoice! 
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [x] This code did not runtime during testing.
- [X] You documented all of your changes.
