### PR TITLE
Allow bloodsuckers to set custom objectives

### DIFF
--- a/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
+++ b/monkestation/code/modules/bloodsuckers/bloodsucker/bloodsucker_datum.dm
@@ -17,6 +17,7 @@
 	ui_name = "AntagInfoBloodsucker"
 	preview_outfit = /datum/outfit/bloodsucker_outfit
 	stinger_sound = 'monkestation/sound/bloodsuckers/BloodsuckerAlert.ogg'
+	can_assign_self_objectives = TRUE
 	/// How much blood we have, starting off at default blood levels.
 	var/bloodsucker_blood_volume = BLOOD_VOLUME_NORMAL
 	/// How much blood we can have at once, increases per level.

--- a/tgui/packages/tgui/interfaces/AntagInfoBloodsucker.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoBloodsucker.tsx
@@ -1,7 +1,12 @@
+import { BooleanLike } from 'common/react';
 import { useBackend, useLocalState } from '../backend';
 import { Box, Button, DmIcon, Flex, Section, Stack, Tabs } from '../components';
 import { Window } from '../layouts';
-import { Objective, ObjectivePrintout } from './common/Objectives';
+import {
+  Objective,
+  ObjectivePrintout,
+  ReplaceObjectivesButton,
+} from './common/Objectives';
 
 type BloodsuckerInformation = {
   clan?: ClanInfo;
@@ -24,6 +29,7 @@ type PowerInfo = {
 
 type Info = {
   objectives: Objective[];
+  can_change_objective: BooleanLike;
 };
 
 export const AntagInfoBloodsucker = (props: any) => {
@@ -64,7 +70,7 @@ export const AntagInfoBloodsucker = (props: any) => {
 
 const BloodsuckerIntro = () => {
   const {
-    data: { objectives },
+    data: { objectives, can_change_objective },
   } = useBackend<Info>();
   return (
     <Stack vertical fill>
@@ -76,7 +82,16 @@ const BloodsuckerIntro = () => {
               living aboard Space Station 13
             </Stack.Item>
             <Stack.Item>
-              <ObjectivePrintout objectives={objectives} />
+              <ObjectivePrintout
+                objectives={objectives}
+                objectiveFollowup={
+                  <ReplaceObjectivesButton
+                    can_change_objective={can_change_objective}
+                    button_title={'Acquire New Tastes'}
+                    button_colour={'red'}
+                  />
+                }
+              />
             </Stack.Item>
           </Stack>
         </Section>


### PR DESCRIPTION

## About The Pull Request

this allows bloodsuckers to set a new objective, just like traitors, heretics, changelings, and wizards can.

## Why It's Good For The Game

bloodsuckers is an antag that's best with rp, and well, it's often more fun to do a gimmick or just goober around than trying to do a normal greentext.

## Testing

<img width="1240" height="700" alt="2025-11-26 (1764218269)" src="https://github.com/user-attachments/assets/236e9d13-f776-4cfc-9619-14519082fbc4" />

## Changelog
:cl:
add: Bloodsuckers can now set custom objectives.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
