### PR TITLE
Ports AIs can now examine. from TG

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_mouse.dm
@@ -8,7 +8,8 @@
 #define COMSIG_CLICK "atom_click"
 ///from base of atom/ShiftClick(): (/mob)
 #define COMSIG_CLICK_SHIFT "shift_click"
-	#define COMPONENT_ALLOW_EXAMINATE (1<<0) //! Allows the user to examinate regardless of client.eye.
+//	#define COMSIG_MOB_CANCEL_CLICKON (1<<0) //shared with other forms of click, this is so you're aware it exists here too.
+	#define COMPONENT_ALLOW_EXAMINATE (1<<1) //! Allows the user to examinate regardless of client.eye.
 ///from base of atom/ShiftClick()
 #define COMSIG_SHIFT_CLICKED_ON "shift_clicked_on"
 ///from base of atom/CtrlClickOn(): (/mob)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -385,10 +385,10 @@
 
 /atom/proc/ShiftClick(mob/user)
 	SEND_SIGNAL(src, COMSIG_SHIFT_CLICKED_ON, user)
-	var/flags = SEND_SIGNAL(user, COMSIG_CLICK_SHIFT, src)
-	if(flags & COMSIG_MOB_CANCEL_CLICKON)
+	var/shiftclick_flags = SEND_SIGNAL(user, COMSIG_CLICK_SHIFT, src)
+	if(shiftclick_flags & COMSIG_MOB_CANCEL_CLICKON)
 		return
-	if(user.client && (user.client.eye == user || user.client.eye == user.loc || flags & COMPONENT_ALLOW_EXAMINATE))
+	if(user.client && (user.client.eye == user || user.client.eye == user.loc || shiftclick_flags & COMPONENT_ALLOW_EXAMINATE))
 		user.examinate(src)
 
 /mob/proc/TurfAdjacent(turf/tile)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -151,6 +151,12 @@
 		L.Cut()
 	return ..()
 
+///Called when the AI shiftclicks on something to examinate it.
+/mob/eye/ai_eye/proc/examinate_check(mob/user, atom/source)
+	SIGNAL_HANDLER
+	if(user.client.eye == src)
+		return COMPONENT_ALLOW_EXAMINATE
+
 /atom/proc/move_camera_by_click()
 	if(!isAI(usr))
 		return
@@ -223,6 +229,7 @@
 	eyeobj.setLoc(loc)
 	eyeobj.name = "[name] (AI Eye)"
 	eyeobj.real_name = eyeobj.name
+	eyeobj.RegisterSignal(src, COMSIG_CLICK_SHIFT, TYPE_PROC_REF(/mob/eye/ai_eye, examinate_check))
 	set_eyeobj_visible(TRUE)
 
 /mob/living/silicon/ai/proc/set_eyeobj_visible(state = TRUE)


### PR DESCRIPTION

## About The Pull Request
Ports https://github.com/tgstation/tgstation/pull/89146 

> AIs can now examine things that don't have a specific shiftclick interaction, which is solely APCs and airlocks.
Also fixes Dullahans not being able to examine through their head, because that's a thing I found accidentally.

## Why It's Good For The Game
>AIs only being able to examine things near its core has always been very annoying, and you're currently able to examine things through security cameras anyways so it's not like we're consistent on how much details the cameras are able to see. This at least makes it a consistent "yes, you can examine through cameras".
AIs also don't really have enough ShiftClick interactions to block all of examine just for their existence.

## Testing
Examined through camera console as human.
Examined things out of sight as AI.
Examined as a human.

## Changelog
:cl:
balance: AIs can now examine through their eye.
fix: Dullahans can also examine through their head again.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
