### PR TITLE
fixes worn icon unit test

### DIFF
--- a/code/modules/unit_tests/inhands.dm
+++ b/code/modules/unit_tests/inhands.dm
@@ -41,6 +41,9 @@
 		var/lefthand_file = initial(item_path.lefthand_file)
 		var/righthand_file = initial(item_path.righthand_file)
 
+		if(isnull(lefthand_file && isnull(righthand_file))) //no inhand sprite for the item.
+			continue
+
 		var/held_icon_state = initial(item_path.inhand_icon_state)
 		if(!held_icon_state)
 			var/base_icon_state = initial(item_path.icon_state)

--- a/code/modules/unit_tests/worn_icons.dm
+++ b/code/modules/unit_tests/worn_icons.dm
@@ -39,6 +39,8 @@
 
 		if(isnull(icon_state))
 			continue //no sprite for the item.
+		if(isnull(worn_icon))
+			continue // no worn sprite for the item.
 		if(icon_state in already_warned_icons)
 			continue
 
@@ -51,9 +53,6 @@
 			if(!(icon_state in icon_states(worn_icon, 1)))
 				TEST_FAIL("[item_path] using invalid [worn_icon_state ? "worn_icon_state" : "icon_state"], \"[icon_state]\" in worn_icon override file, '[worn_icon]'[match_message]")
 			continue
-
-		if(isnull(worn_icon))
-			continue // no worn icon
 
 		var/icon_file //checks against all the default icon locations if one isn't defined.
 		var/fail_reasons


### PR DESCRIPTION
## About The Pull Request
fixes the worn icon unit test so if the worn icon is null it skips it
## Why It's Good For The Game
bug fix i made :)
## Testing

## Changelog

:cl:
fix: fixed the worn icon unit test flagging objects with null worn icon.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

