### PR TITLE
Health analyzers show proper % stamina loss

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -190,7 +190,7 @@
 
 	if(target.stamina.loss)
 		if(advanced)
-			render_list += "<span class='alert ml-1'>Fatigue level: [target.stamina.loss]%.</span>\n"
+			render_list += "<span class='alert ml-1'>Fatigue level: [target.stamina.loss_as_percent]%.</span>\n"
 		else
 			render_list += "<span class='alert ml-1'>Subject appears to be suffering from fatigue.</span>\n"
 	if (target.getCloneLoss())


### PR DESCRIPTION

## About The Pull Request
Advanced health scans now show proper stamina loss
## Why It's Good For The Game
## Testing
<img width="1268" height="584" alt="image" src="https://github.com/user-attachments/assets/c36c5c5f-01e6-46c4-b3e3-ebed88e70c7f" />

Simple variable swap. From total loss to loss as a %.
## Changelog
:cl:
fix: Health analyzers now show the proper % of stamina loss
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
