### PR TITLE
A salt PR about Mayo

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -286,3 +286,8 @@
 	required_reagents = list(/datum/reagent/consumable/grapejuice = 5)
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
 	mix_message = "The smell of the mixture reminds you of how you lost access to the country club..."
+
+/datum/chemical_reaction/food/mayonnaise
+	results = list(/datum/reagent/consumable/mayonnaise = 11)
+	required_reagents = list(/datum/reagent/consumable/eggyolk = 2, /datum/reagent/consumable/eggwhite = 4, /datum/reagent/consumable/cooking_oil = 5)
+	mix_message = "The ingredients mix together to form a thick creamy mayonnaise"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_guide.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_guide.dm
@@ -147,6 +147,10 @@
 	reaction = /datum/chemical_reaction/food/pancakebatter
 	category = CAT_BREAD
 
+/datum/crafting_recipe/food/reaction/mayonnaise
+	result = /datum/reagent/consumable/mayonnaise
+	reaction = /datum/chemical_reaction/food/mayonnaise
+
 /datum/crafting_recipe/food/reaction/uncooked_rice
 	result = /obj/item/food/uncooked_rice
 	reaction = /datum/chemical_reaction/food/uncooked_rice


### PR DESCRIPTION

## About The Pull Request
Adds an alternative bulk recipe for mayonnaise

## Why It's Good For The Game
Mayonnaise not only wastes 2/3s of every egg, egg whites have very few uses in game beyond making piles of macarons. Mayonnaise in real life is egg whites and oil held together by the binding agents in egg yolk. This not only gives realism, but in adding instead of changes means it sits more in the "bulk recipe" variant for sauces.

## Changelog
Adds a new recipe for mayonnaise
Adds a food guide for the new recipe for mayo so it shows up in the cooking search tab

:cl:
add: new mayo recipe
/:cl:

