### PR TITLE
Duplicate of hornet cloak

### DIFF
--- a/monkestation/code/modules/veth_misc_items/drag/drag_misc.dm
+++ b/monkestation/code/modules/veth_misc_items/drag/drag_misc.dm
@@ -39,12 +39,12 @@
 	item_cost = 5000
 
 /datum/loadout_item/neck/donator/knight_cloak/alt
-	name = "Hornet Cloak (alt)"
-	item_path = /obj/item/clothing/neck/hornetcloak/alt
+	name = "Knight Cloak (alt)"
+	item_path = /obj/item/clothing/neck/knightcloak/alt
 
 /datum/store_item/neck/knight_cloak/alt
-	name = "Hornet Cloak (alt)"
-	item_path = /obj/item/clothing/neck/hornetcloak/alt
+	name = "Knight Cloak (alt)"
+	item_path = /obj/item/clothing/neck/knightcloak/alt
 	item_cost = 5000
 
 /datum/sprite_accessory/hair/hornet


### PR DESCRIPTION

## About The Pull Request
Changes the visual duplicate of hornet cloak into knight cloak
## Why It's Good For The Game
## Testing
## Changelog
:cl:
fix: The duplicate of hornets cloak is now knights cloak in the monkestore
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
