### PR TITLE
Add the colored yukatas and kimonos to the loadout store

### DIFF
--- a/monkestation/code/modules/loadouts/items/under/under.dm
+++ b/monkestation/code/modules/loadouts/items/under/under.dm
@@ -919,6 +919,18 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	name = "Yukata"
 	item_path = /obj/item/clothing/under/costume/nova/yukata
 
+/datum/loadout_item/under/miscellaneous/yukata_black //BUYABLE
+	name = "Black Yukata"
+	item_path = /obj/item/clothing/under/costume/yukata
+
+/datum/loadout_item/under/miscellaneous/yukata_green //BUYABLE
+	name = "Green Yukata"
+	item_path = /obj/item/clothing/under/costume/yukata/green
+
+/datum/loadout_item/under/miscellaneous/yukata_white //BUYABLE
+	name = "White Yukata"
+	item_path = /obj/item/clothing/under/costume/yukata/white
+
 /datum/loadout_item/under/miscellaneous/qipao_black //BUYABLE
 	name = "Qipao"
 	item_path = /obj/item/clothing/under/costume/nova/qipao
@@ -938,6 +950,18 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 /datum/loadout_item/under/miscellaneous/kimono //BUYABLE
 	name = "Fancy Kimono"
 	item_path =  /obj/item/clothing/under/costume/skyrat/kimono
+
+/datum/loadout_item/under/miscellaneous/kimono_black //BUYABLE
+	name = "Black Kimono"
+	item_path =  /obj/item/clothing/under/costume/kimono
+
+/datum/loadout_item/under/miscellaneous/kimono_red //BUYABLE
+	name = "Red Kimono"
+	item_path =  /obj/item/clothing/under/costume/kimono/red
+
+/datum/loadout_item/under/miscellaneous/kimono_purple //BUYABLE
+	name = "Purple Kimono"
+	item_path =  /obj/item/clothing/under/costume/kimono/purple
 
 /datum/loadout_item/under/miscellaneous/chaps //BUYABLE
 	name = "Black Chaps"

--- a/monkestation/code/modules/store/store_items/under.dm
+++ b/monkestation/code/modules/store/store_items/under.dm
@@ -774,6 +774,31 @@ GLOBAL_LIST_INIT(store_miscunders, generate_store_items(/datum/store_item/under/
 	item_path =  /obj/item/clothing/under/costume/skyrat/kimono
 	item_cost = 2500
 
+/datum/store_item/under/miscellaneous/kimono/black //BUYABLE
+	name = "Black Kimono"
+	item_path = /obj/item/clothing/under/costume/kimono
+
+/datum/store_item/under/miscellaneous/kimono/red //BUYABLE
+	name = "Red Kimono"
+	item_path = /obj/item/clothing/under/costume/kimono/red
+
+/datum/store_item/under/miscellaneous/kimono/purple //BUYABLE
+	name = "Purple Kimono"
+	item_path = /obj/item/clothing/under/costume/kimono/purple
+
+/datum/store_item/under/miscellaneous/yukata
+	name = "Black Yukata"
+	item_path = /obj/item/clothing/under/costume/yukata
+	item_cost = 2500
+
+/datum/store_item/under/miscellaneous/yukata/green
+	name = "Green Yukata"
+	item_path = /obj/item/clothing/under/costume/yukata/green
+
+/datum/store_item/under/miscellaneous/yukata/white
+	name = "White Yukata"
+	item_path = /obj/item/clothing/under/costume/yukata/white
+
 /datum/store_item/under/miscellaneous/chaps //BUYABLE
 	name = "Black Chaps"
 	item_path = /obj/item/clothing/under/pants/nova/chaps


### PR DESCRIPTION

## About The Pull Request

this makes it so you can buy the colored yukatas and kimonos (the non-nova ones) in the loadout store, for 2500 mc each.

## Why It's Good For The Game

drip 

## Testing
## Changelog
:cl:
add: You can now buy the colored kimonos and yukatas in the loadout store, for 2500 monkecoins each.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
