### PR TITLE
Being dusted by a death bolt (colossus, wendigo, demonic frost miner) now drops items

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -201,7 +201,7 @@
 		var/mob/living/dust_mob = target
 		if(dust_mob.stat == DEAD)
 			dust_mob.investigate_log("has been dusted by a death bolt (colossus).", INVESTIGATE_DEATHS)
-			dust_mob.dust()
+			dust_mob.dust(drop_items = TRUE)
 		return
 	if(!explode_hit_objects || istype(target, /obj/vehicle/sealed))
 		return


### PR DESCRIPTION
## About The Pull Request

exactly what it says on the tin: being dusted by a colossus bolt will no longer delete your items.
you still get dusted, but you drop all of your shit too.

## Why It's Good For The Game

i had to pray for a wendigo skull last night bc the other miner died to the demonic frost miner after fighting wendigo, and got dusted by the miner, causing the wendigo skull to be deleted :(

## Testing
## Changelog
:cl:
qol: Being dusted by a death bolt (colossus, wendigo, demonic frost miner) now drops items.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
