### PR TITLE
Fix not being able to toggle/configure air conditioning in air alarms

### DIFF
--- a/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
+++ b/code/modules/atmospherics/machinery/air_alarm/_air_alarm.dm
@@ -471,6 +471,25 @@ GLOBAL_LIST_EMPTY_TYPED(air_alarms, /obj/machinery/airalarm)
 			togglelock(user)
 			return TRUE
 
+		if("air_conditioning")
+			if(!isnum(params["value"]))
+				return TRUE
+			if(params["value"])
+				stop_ac()
+			else
+				start_ac()
+			investigate_log("has had its air conditioning turned [air_conditioning ? "on" : "off"] by [key_name(user)]", INVESTIGATE_ATMOS)
+
+		if("set_ac_target")
+			if(!isnum(params["target"]))
+				return TRUE
+			set_ac_target(params["target"])
+			investigate_log("has had its air conditioning target set to [params["target"]] by [key_name(user)]", INVESTIGATE_ATMOS)
+
+		if("default_ac_target")
+			set_ac_target(initial(ac_temp_target))
+			investigate_log("has had its air conditioning target reset to default by [key_name(user)]", INVESTIGATE_ATMOS)
+
 	update_appearance()
 
 	return TRUE


### PR DESCRIPTION

## About The Pull Request

https://github.com/Monkestation/Monkestation2.0/pull/8013 broke this by removing the relevant `ui_act` codeblocks...

## Why It's Good For The Game
## Testing
## Changelog
:cl:
fix: Fixed not being able to toggle/configure air conditioning in air alarms.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
