### PR TITLE
Bomb Actualizer Oversight Fix

### DIFF
--- a/monkestation/code/game/machinery/bomb_actualizer.dm
+++ b/monkestation/code/game/machinery/bomb_actualizer.dm
@@ -68,7 +68,7 @@
 //For when the machine is destroyed
 /obj/machinery/bomb_actualizer/Destroy()
 	inserted_bomb = null
-	radio = null
+	QDEL_NULL(radio)
 	combined_gasmix = null
 	QDEL_NULL(countdown)
 	end_processing()

--- a/monkestation/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/monkestation/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -72,7 +72,6 @@
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/bomb_actualizer
 	req_components = list(
-		/obj/item/radio = 1,
 		/datum/stock_part/manipulator = 1,
 		/datum/stock_part/scanning_module = 1,
 		/datum/stock_part/matter_bin = 5)


### PR DESCRIPTION

## About The Pull Request
The bomb actualizer now requires a radio to construct, previously it would make a radio out of thin air when deconstructed.
## Why It's Good For The Game
Less infinite item generation from nowhere = better. Will close https://github.com/Monkestation/Monkestation2.0/issues/9736
## Testing
## Changelog
:cl:
fix: Bomb actualizer now requires a radio to construct, preventing infinite radio generation
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
