### PR TITLE
Mouse Cubes can now be shaken to create rats

### DIFF
--- a/monkestation/code/modules/virology/items/mousecubes.dm
+++ b/monkestation/code/modules/virology/items/mousecubes.dm
@@ -3,6 +3,7 @@
 	tastes = list("the sewers" = 1, "cheese" = 1)
 	food_reagents = list(/datum/reagent/blood = 30)
 	spawned_mob = /mob/living/basic/mouse
+	shaken_mob = /mob/living/basic/mouse/rat
 
 /obj/item/storage/box/monkeycubes/mousecubes
 	name = "mouse cube box"


### PR DESCRIPTION

## About The Pull Request
I saw shions PR in the changelogs, and i was wondering if it would accidentally make mouse cubes create monkeys, thankfully it doesnt, but it gave me the idea to add this.
## Why It's Good For The Game
I... feel like it probably isnt THAT great, but it *is* probably funny! Anyways uhh um consistency or something.
## Testing
Tested locally.
## Changelog
:cl:
add: Mouse cubes can now be shaken to create rats.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
