### PR TITLE
Health Analyzers no longer show dormants

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -437,7 +437,7 @@
 					</span>"
 
 		else
-			if(!((disease.visibility_flags & HIDDEN_SCANNER) && (disease.disease_flags & DISEASE_ANALYZED) && !(D.disease_flags & DISEASE_DORMANT)))
+			if(!((disease.visibility_flags & HIDDEN_SCANNER) && (disease.disease_flags & DISEASE_ANALYZED) && !(disease.disease_flags & DISEASE_DORMANT)))
 				render_list += "<span class='alert ml-1'><b>Warning: [disease.form] disease detected</b>\n\
 				<div class='ml-2'>Name: [disease.name].\nType: [disease.get_spread_string()].\nStage: [disease.stage]/[disease.max_stages].\nPossible Cure: [disease.cure_text]</div>\
 				</span>"


### PR DESCRIPTION

## About The Pull Request
Health Analyzers no longer show dormant diseases
## Why It's Good For The Game
I forgor and they are unimportant to a health analyzer scan.
## Testing
## Changelog
:cl:
fix: Dormant disease no longer shows on a health analyzer scan
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
