### PR TITLE
Ashwalker clothing storage fix

### DIFF
--- a/monkestation/code/modules/blueshift/structures/ash_walker.dm
+++ b/monkestation/code/modules/blueshift/structures/ash_walker.dm
@@ -1101,6 +1101,8 @@
 	icon_state = "ashclothvendor"
 	icon_deny = "necrocrate"
 	use_power = NO_POWER_USE
+	initial_language_holder = /datum/language_holder/ashwalker
+	vend_reply = "Glory to the Necropolis."
 
 	products = list( //Relatively normal to have, I GUESS
 		/obj/item/clothing/under/costume/gladiator/ash_walker/tribal = 15,


### PR DESCRIPTION

## About The Pull Request
Fixes ashwalker clothes vendor requiring power #9425 and slightly tweaks its vending message.
## Why It's Good For The Game
Ashies get their drip back.
## Changelog
:cl: EssentialTomato
fix: Fixed ashwalker clothing storage being invisible. 
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
