### PR TITLE
Fix voice of god just not working sometimes

### DIFF
--- a/code/datums/voice_of_god_command.dm
+++ b/code/datums/voice_of_god_command.dm
@@ -53,12 +53,12 @@ GLOBAL_LIST_INIT(voice_of_god_commands, init_voice_of_god_commands())
 
 			//Let's ensure the listener's name is not matched within another word or command (and viceversa). e.g. "Saul" in "somersault"
 			var/their_first_name = candidate.first_name()
-			if(!GLOB.all_voice_of_god_triggers.Find(their_first_name) && findtext(message, regex("(\\L|^)[their_first_name](\\L|$)", "i")))
+			if(!GLOB.all_voice_of_god_triggers.Find(their_first_name) && findtext(message, regex("(\\L|^)[REGEX_QUOTE(their_first_name)](\\L|$)", "i")))
 				specific_listeners += candidate //focus on those with the specified name
 				to_remove_string += "[to_remove_string ? "|" : null][their_first_name]"
 				continue
 			var/their_last_name = candidate.last_name()
-			if(their_last_name != their_first_name && !GLOB.all_voice_of_god_triggers.Find(their_last_name) && findtext(message, regex("(\\L|^)[their_last_name](\\L|$)", "i")))
+			if(their_last_name != their_first_name && !GLOB.all_voice_of_god_triggers.Find(their_last_name) && findtext(message, regex("(\\L|^)[REGEX_QUOTE(their_last_name)](\\L|$)", "i")))
 				specific_listeners += candidate // Ditto
 				to_remove_string += "[to_remove_string ? "|" : null][their_last_name]"
 


### PR DESCRIPTION

## About The Pull Request

voice of god would break on certain names due to this error:
```
[2025-12-04 19:44:03.904] runtime error: Regex fail: unmatched ()
 - proc name: voice of god (/proc/voice_of_god)
 -   source file: code/datums/voice_of_god_command.dm,61
 -   usr: Shion Rosenthal (/mob/living/carbon/human)
 -   src: null
 -   usr.loc: the floor (215,129,4) (/turf/open/floor/wood)
 -   call stack:
 - voice of god("heal.", Shion Rosenthal (/mob/living/carbon/human), /list (/list), 1, 0, null)
 - the divine vocal cords (/obj/item/organ/internal/vocal_cords/colossus): speak with("Heal.")
 - /datum/saymode/vocalcords (/datum/saymode/vocalcords): handle message(Shion Rosenthal (/mob/living/carbon/human), "Heal.", /datum/language/common (/datum/language/common))
 - Shion Rosenthal (/mob/living/carbon/human): say("Heal.", null, /list (/list), 1, /datum/language/common (/datum/language/common), 0, null, null, 7, /datum/saymode/vocalcords (/datum/saymode/vocalcords))
 - Shion Rosenthal (/mob/living/carbon/human): say(".x Heal.", null, null, null, null, null, null, null, null, null)
```

line 61:
```dm
if(their_last_name != their_first_name && !GLOB.all_voice_of_god_triggers.Find(their_last_name) && findtext(message, regex("(\\L|^)[REGEX_QUOTE(their_last_name)](\\L|$)", "i")))
```

easy fix by just running names thru `REGEX_QUOTE` when generating the first/last name regex

## Changelog
:cl:
fix: Fixed voice of god just not working sometimes.
/:cl:
