### PR TITLE
Prevent brains with souls from being deep fryed

### DIFF
--- a/monkestation/code/modules/brewin_and_chewin/chewing/fryer_overhaul.dm
+++ b/monkestation/code/modules/brewin_and_chewin/chewing/fryer_overhaul.dm
@@ -83,5 +83,11 @@
 		icon_state = "fryer_on"
 		frying = TRUE
 		for(var/obj/item/item as anything in basket.contents)
+			if(istype(item, /obj/item/organ/internal/brain))
+				var/obj/item/organ/internal/brain/brain = item
+				if((brain.brainmob && (brain.brainmob.client || brain.brainmob.get_ghost())) || brain.decoy_override)
+					visible_message(span_warning("\The [brain] falls out of \the [basket]!"))
+					brain.forceMove(drop_location())
+					continue
 			start_fry(item, user)
 		fry_loop.start()


### PR DESCRIPTION
## About The Pull Request

this makes it so brains with souls can't be deep fried. attempting to insert one into a deep fryer will just have it fall out of the basket.

soulless brains (if it says "This one is completely devoid of life." on examine) can still be deep fried, so deep fried Pun Pun brain is still on the menu.

## Why It's Good For The Game

simply gets rid of an effortless way to delete a brain from the round - if you wanna RR someone, then that should require proper RR methods, rather than just hopping the kitchen counter and being done with it in 15 seconds

brain cakes and actual food are still possible, and if you want to eat a brain, you should embrace your inner cannibal ramsey, dammit.

## Testing
## Changelog
:cl:
del: You can no longer deep fry brains, unless they're soulless (deep fried Pun Pun brain is still on the menu, don't worry).
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
