### PR TITLE
Ports #94272 (Robot wabbajack fix)

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1473,12 +1473,12 @@
 			var/static/list/robot_options = list(
 				/mob/living/silicon/robot = 200,
 				/mob/living/basic/drone/polymorphed = 200,
-				/mob/living/silicon/robot/model/syndicate = 1,
-				/mob/living/silicon/robot/model/syndicate/medical = 1,
-				/mob/living/silicon/robot/model/syndicate/saboteur = 1,
+				/mob/living/silicon/robot/model/syndicate = 100,
+				/mob/living/silicon/robot/model/syndicate/medical = 100,
+				/mob/living/silicon/robot/model/syndicate/saboteur = 100,
 			)
 
-			var/picked_robot = pick(robot_options)
+			var/picked_robot = pick_weight(robot_options)
 			new_mob = new picked_robot(loc)
 			if(issilicon(new_mob))
 				var/mob/living/silicon/robot/created_robot = new_mob


### PR DESCRIPTION

## About The Pull Request

Ports:
- https://github.com/tgstation/tgstation/pull/94272

Basically all the same arguments apply from that PR, but to a much lesser degree because the list still only has 5 entries instead of TG's 16. Syndi borgs are a bit less common and normal borgs are a bit more now.

## Why It's Good For The Game

The robot weights on robot wabbajack are now actually weighted

## Testing

I spawned in, wabbajacked 4 things, forgot to take a screenshot and started bashing my head against a brick wall

## Changelog

:cl:
fix: the robot wabbajack list is actually weighted now as it was supposed to be
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
