### PR TITLE
Aux base construction console fix

### DIFF
--- a/code/game/objects/structures/construction_console/construction_actions.dm
+++ b/code/game/objects/structures/construction_console/construction_actions.dm
@@ -56,6 +56,7 @@
 			rcd_target = S //If we don't break out of this loop we'll get the last placed thing
 	owner.changeNext_move(CLICK_CD_RANGE)
 	check_rcd()
+	base_console.internal_rcd.mode = base_console.internal_rcd.construction_mode
 	base_console.internal_rcd.rcd_create(rcd_target, owner) //Activate the RCD and force it to work remotely!
 	playsound(target_turf, 'sound/items/deconstruct.ogg', 60, TRUE)
 

--- a/code/game/objects/structures/construction_console/construction_console.dm
+++ b/code/game/objects/structures/construction_console/construction_console.dm
@@ -65,10 +65,11 @@
 	eyeobj.origin = src
 	return TRUE
 
-/obj/machinery/computer/camera_advanced/base_construction/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+/obj/machinery/computer/camera_advanced/base_construction/item_interaction(mob/living/user, obj/item/interacting_item, list/modifiers)
 	//If we have an internal RCD, we can refill it by slapping the console with some materials
-	if(internal_rcd && (istype(attacking_item, /obj/item/rcd_ammo) || istype(attacking_item, /obj/item/stack/sheet)))
-		internal_rcd.attackby(attacking_item, user, modifiers, attack_modifiers)
+	if(internal_rcd && (istype(interacting_item, /obj/item/rcd_ammo) || istype(interacting_item, /obj/item/stack/sheet)))
+		internal_rcd.item_interaction(user, interacting_item, modifiers)
+		return ITEM_INTERACT_SUCCESS
 	else
 		return ..()
 


### PR DESCRIPTION

## About The Pull Request
Fixes the inability to build selected structures and restocking the console.
## Why It's Good For The Game
Fixes #8723 
## Testing
It built the thing and ate the sheet.
## Changelog
:cl: EssentialTomato
fix: Aux base construction console now builds selected structures instead of just walls.
fix: Aux base construction console can be restocked again.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
