### PR TITLE
stop microphone components from spamming logs

### DIFF
--- a/monkestation/code/modules/mech_comp/objects/messages/microphone.dm
+++ b/monkestation/code/modules/mech_comp/objects/messages/microphone.dm
@@ -16,7 +16,7 @@
 
 /obj/item/mcobject/messaging/microphone/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, list/message_mods, message_range)
 	. = ..()
-	if(!anchored)
+	if(!anchored || istype(speaker, /obj/item/mcobject))
 		return
 	fire("[relay_speaker ? "[speaker.GetVoice()]:" : ""][html_decode(raw_message)]")
 


### PR DESCRIPTION

## Changelog
:cl:
admin: Microphone mechcomp components no longer spam logs with everything they hear.
/:cl: