### PR TITLE
reduces the chance of dangerous unrestricted fluid anomalies occuring

### DIFF
--- a/monkestation/code/game/objects/effects/anomalies/anomalies_fluid.dm
+++ b/monkestation/code/game/objects/effects/anomalies/anomalies_fluid.dm
@@ -11,7 +11,7 @@
 
 /obj/effect/anomaly/fluid/Initialize(mapload, new_lifespan)
 	. = ..()
-	if(prob(10))
+	if(prob(5))
 		dangerous = TRUE //Unrestricts the reagent choice and increases fluid amounts
 
 	for(var/i = 1, i <= rand(1,5), i++) //Between 1 and 5 random chemicals


### PR DESCRIPTION

## About The Pull Request
title. drops 10% to 5% for fluid anomalies grabbing a reagent regardless of blacklist.

## Why It's Good For The Game
less chance for instant death floods.

## Testing

## Changelog

:cl:
balance: reduces the chance of dangerous unrestricted fluid anomalies occuring
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

