### PR TITLE
fix awakened dragon not properly giving prefixes

### DIFF
--- a/monkestation/code/modules/martial_arts/awakened_dragon.dm
+++ b/monkestation/code/modules/martial_arts/awakened_dragon.dm
@@ -47,7 +47,7 @@
 /datum/martial_art/the_sleeping_carp/awakened_dragon/teach(mob/living/carbon/human/target, make_temporary)
 	. = ..()
 	target.physiology.stamina_mod *= 0.7
-	if(findtext_char(target.real_name, title) == 1)
+	if(title && findtext_char(target.real_name, title) == 1)
 		return
 	original_name = target.real_name
 	if(QDELETED(original_body))


### PR DESCRIPTION

## About The Pull Request

oopsie

## Testing

<img width="1727" height="753" alt="image" src="https://github.com/user-attachments/assets/ab4f4657-fd77-4737-9826-e62e9a9304f2" />


## Changelog
:cl:
fix: Fixed awakened dragon not properly giving the name prefix.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
