### PR TITLE
admins are now the big brother of christmas (notifies admins what people get from presents)

### DIFF
--- a/code/game/objects/items/gift.dm
+++ b/code/game/objects/items/gift.dm
@@ -19,6 +19,7 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 	resistance_flags = FLAMMABLE
 
 	var/atom/contains_type
+	var/notify_admins = FALSE
 
 /obj/item/a_gift/Initialize(mapload)
 	. = ..()
@@ -44,19 +45,23 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 
 	qdel(src)
 
+	var/gift_name = contains_type::name
 	if(ispath(contains_type, /obj/item))
 		var/atom/I = new contains_type(get_turf(M))
 		if (!QDELETED(I)) //might contain something like metal rods that might merge with a stack on the ground
 			M.put_in_hands(I)
 			I.add_fingerprint(M)
 			I.AddComponent(/datum/component/gift_item, M) // monkestation edit: gift item info component
+			gift_name = I
 		else
 			M.visible_message(span_danger("Oh no! The present that [M] opened had nothing inside it!"))
 			return
 	else
 		new contains_type(M.drop_location(), M)
-	M.visible_message(span_notice("[M] unwraps \the [src], finding \a [contains_type::name] inside!"))
-	M.investigate_log("has unwrapped a present containing [contains_type].", INVESTIGATE_PRESENTS)
+	M.visible_message(span_notice("[M] unwraps \the [src], finding \a [gift_name] inside!"))
+	M.investigate_log("has unwrapped a present containing [gift_name] ([contains_type]).", INVESTIGATE_PRESENTS)
+	if(notify_admins)
+		message_admins("[ADMIN_LOOKUPFLW(M)] unwrapped a present containing <b>[gift_name]</b> <small>([contains_type])</small>")
 
 /obj/item/a_gift/proc/get_gift_type()
 	var/gift_type_list = list(/obj/item/sord,
@@ -107,6 +112,7 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 /obj/item/a_gift/anything
 	name = "christmas gift"
 	desc = "It could be anything!"
+	notify_admins = TRUE
 
 /obj/item/a_gift/anything/get_gift_type()
 	if(!GLOB.possible_gifts.len)


### PR DESCRIPTION
## About The Pull Request

this just adds an admin message when someone unwraps a present, saying who unwrapped what.

doesn't apply to "normal" presents that just give you a toy or something, only applies to the presents that can give you anything

## Why It's Good For The Game

so admins can mentally prepare when someone gets a damn instakill rifle

## Testing

<img width="1230" height="170" alt="2025-12-07 (1765143855) ~ dreamseeker" src="https://github.com/user-attachments/assets/617ccb1f-9d9a-4e12-97fe-246701d05cee" />

## Changelog
:cl:
admin: Added an admin notification for when people open christmas presents.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
