### PR TITLE
Gives nanite programmers a GPS signal similar to comms consoles

### DIFF
--- a/monkestation/code/modules/research/nanites/nanite_cloud_controller.dm
+++ b/monkestation/code/modules/research/nanites/nanite_cloud_controller.dm
@@ -29,6 +29,7 @@
 	. = ..()
 	become_hearing_sensitive(trait_source = ROUNDSTART_TRAIT)
 	linked_techweb = SSresearch.science_tech
+	AddComponent(/datum/component/gps, "Nanite Synchronization Signal")
 
 /obj/machinery/computer/nanite_cloud_controller/Destroy()
 	QDEL_LIST(cloud_backups) //rip backups


### PR DESCRIPTION

## About The Pull Request

similar to comms consoles, this gives nanite cloud controllers a GPS signal, called "Nanite Synchronization Signal" (please give me ideas for better names)

## Why It's Good For The Game

because hidden nanite clouds are bullshit ngl

## Testing
## Changelog
:cl:
add: Nanite programmers now have a GPS signal, named "Nanite Synchronization Signal".
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
