### PR TITLE
Allow revived lavaland elites to speak

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -59,12 +59,8 @@
 		var/obj/vehicle/sealed/mecha/M = target
 		M.take_damage(50, BRUTE, MELEE, 1)
 
-//Elites can't talk (normally)!
-/mob/living/simple_animal/hostile/asteroid/elite/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null, filterproof = null, message_range = 7, datum/saymode/saymode = null)
-	if(can_talk)
-		. = ..()
-		return TRUE
-	return FALSE
+/mob/living/simple_animal/hostile/asteroid/elite/can_speak(allow_mimes)
+	return can_talk
 
 /*Basic setup for elite attacks, based on Whoneedspace's megafauna attack setup.
 While using this makes the system rely on OnFire, it still gives options for timers not tied to OnFire, and it makes using attacks consistent accross the board for player-controlled elites.*/
@@ -385,20 +381,21 @@ While using this makes the system rely on OnFire, it still gives options for tim
 	if(!istype(interacting_with, /mob/living/simple_animal/hostile/asteroid/elite))
 		return NONE
 
-	var/mob/living/simple_animal/hostile/asteroid/elite/E = interacting_with
-	if(E.stat != DEAD || E.sentience_type != SENTIENCE_BOSS) //MONKESTATION EDIT: removed || !E.key
-		user.visible_message(span_notice("It appears [E] is unable to be revived right now. Perhaps try again later."))
+	var/mob/living/simple_animal/hostile/asteroid/elite/elite = interacting_with
+	if(elite.stat != DEAD || elite.sentience_type != SENTIENCE_BOSS)
+		user.visible_message(span_notice("It appears [elite] is unable to be revived right now. Perhaps try again later."))
 		return ITEM_INTERACT_BLOCKING
-	E.faction = list("[REF(user)]")
-	E.revive(HEAL_ALL)
-	user.visible_message(span_notice("[user] stabs [E] with [src], reviving it."))
-	E.playsound_local(get_turf(E), 'sound/effects/magic.ogg', 40, 0)
-	to_chat(E, "<span class='userdanger'>You have been revived by [user]. While you can't speak to them, you owe [user] a great debt.  Assist [user.p_them()] in achieving [user.p_their()] goals, regardless of risk.</span>")
-	to_chat(E, "<span class='big bold'>Note that you now share the loyalties of [user].  You are expected not to intentionally sabotage their faction unless commanded to!</span>")
-	E.maxHealth = E.maxHealth * 0.4
-	E.health = E.maxHealth
-	E.desc = "[E.desc] However, this one appears to be less wild in nature, and calmer around people."
-	E.sentience_type = SENTIENCE_ORGANIC
+	elite.faction = list("[REF(user)]")
+	elite.revive(HEAL_ALL)
+	user.visible_message(span_notice("[user] stabs [elite] with [src], reviving it."))
+	elite.playsound_local(get_turf(elite), 'sound/effects/magic.ogg', vol = 40, vary = FALSE)
+	to_chat(elite, span_userdanger("You have been revived by [user.real_name]. You owe them [user.p_them()] a great debt, assist [user.p_them()] in achieving [user.p_their()] goals, regardless of risk."))
+	to_chat(elite, span_boldbig("Note that you now share the loyalties of [user.real_name].  You are expected not to intentionally sabotage their faction unless commanded to!"))
+	elite.maxHealth *= 0.4
+	elite.health = elite.maxHealth
+	elite.desc = "[elite.desc] However, this one appears to be less wild in nature, and calmer around people."
+	elite.sentience_type = SENTIENCE_ORGANIC
+	elite.can_talk = TRUE
 	qdel(src)
 	return ITEM_INTERACT_SUCCESS
 


### PR DESCRIPTION
## About The Pull Request

this makes it so reviving a lavaland elite with the tumro shard allows them to talk.

also slightly cleaned up some code

Closes https://github.com/Monkestation/Monkestation2.0/issues/9823
Closes https://github.com/Monkestation/Monkestation2.0/issues/9428

## Why It's Good For The Game

this confuses people quite a bit, and allows for them to at least attempt to RP.

## Changelog
:cl:
qol: Revived lavaland elites (as in, a sentient lavaland elite that is revived after being defeated) can now speak.
/:cl:
