### PR TITLE
Fixes mining MODsuit suit storage

### DIFF
--- a/code/modules/mod/mod_theme.dm
+++ b/code/modules/mod/mod_theme.dm
@@ -376,7 +376,7 @@
 		),
 	)
 
-/datum/mod_theme/loader/New()
+/datum/mod_theme/mining/New()
 	.=..()
 	allowed_suit_storage = GLOB.mining_suit_allowed
 


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/85342

## Testing

<img width="546" height="841" alt="2025-12-07 (1765155362) ~ dreamseeker" src="https://github.com/user-attachments/assets/97205376-9b13-4061-900e-e90d9f11497b" />


## Changelog
:cl: Absolucy, SmArtKar
fix: Mining MODsuits now can store everything that explorer suits can
/:cl:
