### PR TITLE
fixes a double genetics windoor on pubby

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -19020,11 +19020,6 @@
 	pixel_x = -2;
 	pixel_y = 6
 	},
-/obj/machinery/door/window/left/directional/west{
-	dir = 3;
-	name = "Genetics Desk";
-	req_access = list("genetics")
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 1;
 	id = "rdgene";


### PR DESCRIPTION

## About The Pull Request
check title

## Why It's Good For The Game
bug fix

## Testing

## Changelog

:cl:
map: fixed a double placed genetics windoor on pubby station.
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

