### PR TITLE
Move join_game to its own verb

### DIFF
--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -230,7 +230,6 @@
 
 	new_player.join_game(TRUE, params)
 
-
 /atom/movable/screen/lobby/button/join/proc/show_join_button()
 	SIGNAL_HANDLER
 	set_button_status(TRUE)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -108,7 +108,7 @@
 			to_chat(src, span_notice("You have been added to the queue to join the game. Your position in queue is [SSticker.queued_players.len]."))
 		return
 
-	if (from_lobby_menu)
+	if(from_lobby_menu)
 		if(!LAZYACCESS(params2list(params), CTRL_CLICK))
 			GLOB.latejoin_menu.ui_interact(src)
 		else


### PR DESCRIPTION
## About The Pull Request

Moves the join game button functionality to it's own verb that is on mob/dead/new_player, like with the Observe verb.

## Why It's Good For The Game

Possibly fixes an issue for some linux users where they cannot interact with the lobby menu, but can interact with everything else. 

## Testing

https://github.com/user-attachments/assets/513a044c-c33d-40a2-8a66-41760db0d166

## Changelog
:cl:
code: moved "Join Game" button functionality to its own proc
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
