### PR TITLE
Junkie Trait harshness reduced

### DIFF
--- a/code/datums/quirks/negative_quirks/junkie.dm
+++ b/code/datums/quirks/negative_quirks/junkie.dm
@@ -17,7 +17,7 @@
 	var/where_accessory //! where the accessory spawned
 	var/obj/item/accessory_type //! If this is null, an accessory won't be spawned.
 	var/drug_flavour_text = "Better hope you don't run out..."
-	var/process_interval = 240 SECONDS //! how frequently the quirk processes (This was set at 30 seconds, which caused you to hit high withdrawal WAY TOO QUICKLY)
+	var/process_interval = 120 SECONDS //! how frequently the quirk processes (This was set at 30 seconds, which caused you to hit high withdrawal WAY TOO QUICKLY)
 	COOLDOWN_DECLARE(next_process) //! ticker for processing
 
 /datum/quirk/item_quirk/junkie/add_unique(client/client_source)


### PR DESCRIPTION
## About The Pull Request

Moves the process timer for the Junkie trait to 4 minutes instead of 30 seconds, increasing the time it takes to get full withdrawal symptoms (if you roll something like meth for this, you are essentially braindead 20 minutes in without intervention)

## Why It's Good For The Game

Makes the perk more usable.

## Testing

Number change!

## Changelog
:cl:
balance: Changed the process time from 30 seconds to 2 minutes for the Junkie quirk, reducing how quickly you go through withdrawal stages.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
