### PR TITLE
[QOL] Updated cooking recipe step for clarity when no reaction/processing needed

### DIFF
--- a/code/datums/components/crafting/crafting.dm
+++ b/code/datums/components/crafting/crafting.dm
@@ -610,6 +610,9 @@
 			stack_trace("Invalid reaction found in recipe code! ([recipe.reaction])")
 	else if(!isnull(recipe.reaction))
 		stack_trace("Invalid reaction found in recipe code! ([recipe.reaction])")
+	else if(mode && !data["steps"]) // For cooking recipes, if it's a simple craft with no reaction steps required
+		data["steps"] = list()
+		data["steps"] += "No further reaction needed, and can be crafted from separate reagent containers and ingredients."
 
 	return data
 


### PR DESCRIPTION

## About The Pull Request
QOL fix because people don't know how to make rice dough. If no cooking steps are needed, the recipe explicitly states so under "steps", so just click the craft button!
## Why It's Good For The Game

Fixes #9547
Fixes #9808

## Testing
BEFORE:
<img width="709" height="326" alt="QOL_NO MIXING" src="https://github.com/user-attachments/assets/6c0cbc21-efc2-4119-bf62-08392094ea5c" />

AFTER:
<img width="864" height="806" alt="image" src="https://github.com/user-attachments/assets/36b88479-0878-4cf9-a09b-f18aef0c0ea0" />
## Changelog
:cl: Lawlolawl
qol: Updated cooking recipe step for clarity when no reaction/processing needed. Rice dough ingredients do NOT need to be mixed, people!
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
