### PR TITLE
Fixes iron dupe with modular_computer disassembly

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -886,7 +886,8 @@
 	if (!disassembled)
 		physical.visible_message(span_notice("\The [src] breaks apart!"))
 	new /obj/item/stack/sheet/iron(droploc, steel_sheet_cost * (disassembled ? 1 : 0.5))
-	relay_qdel()
+	relay_qdel() // Needed for /obj/item/modular_computer/processor/relay_qdel()
+	qdel(src)
 
 // Ejects the inserted intellicard, if one exists. Used when the computer is deconstructed.
 /obj/item/modular_computer/proc/eject_aicard()


### PR DESCRIPTION
## About The Pull Request
`modular_computers` were not deleted upon disassembly. So infinite iron duping (but not power cells)

## Why It's Good For The Game

@Absolucy Easily accessible dupe exploit which can be done with just a wrench and your spawn PDA, high priority for fixing

Casualty of #8243

Fixes #9653 
## Testing
Yes.

## Changelog
:cl: Lawlolawl
fix: Fixed pda disassembly iron duping.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
