### PR TITLE
Removes anti-grief span_adminhelp warning for servant golems on spawn

### DIFF
--- a/code/modules/mob_spawn/ghost_roles/golem_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/golem_roles.dm
@@ -25,6 +25,7 @@
 	if(creator)
 		name = "inert servant golem shell"
 		prompt_name = "servant golem"
+		dont_be_a_shit = FALSE // if creator is antag, you are allowed to assist
 	if(species) //spawners list uses object name to register so this goes before ..()
 		name += " ([initial(species.prefix)])"
 		mob_species = species


### PR DESCRIPTION

## About The Pull Request
Servant golems no longer get the (conflicting) warning against griefing as they follow the will of their master. Prevents confusion if an antag/cultist/etc. xenobio makes shells for mischief.

Admin-spawned servant golem shells via game panel do NOT have creators and behave as free golems, despite initially spawned using `/obj/effect/mob_spawn/ghost_role/human/golem/servant` as the `creator` var is empty. The proc is basically identical anyway as most of the implementation is handled in `/obj/effect/mob_spawn/ghost_role/human/golem`.

## Why It's Good For The Game

Fixes #9809

## Testing
BEFORE: Receives warning despite being a servant
<img width="636" height="213" alt="golem1" src="https://github.com/user-attachments/assets/4c3c02a6-b71f-4af6-8588-910a810a3226" />

AFTER:
No warning as servant
<img width="624" height="198" alt="golem2" src="https://github.com/user-attachments/assets/f066cc18-bb22-4871-b354-fdfe6e272889" />

Free golems still get warnings:
<img width="633" height="158" alt="fgolem1" src="https://github.com/user-attachments/assets/01ea0442-5afc-445e-92f4-205203992d7b" />

<img width="639" height="340" alt="fgolem2" src="https://github.com/user-attachments/assets/97e21067-8e7b-4ce0-83ae-bc289f92b828" />

Golems with golems as masters do not get warnings (recursive golem factory):
<img width="636" height="152" alt="recgolem" src="https://github.com/user-attachments/assets/647a4c6a-a7b0-4bcf-8879-678e056fd6d7" />


## Changelog
:cl: Lawlolawl
del: Removed anti-grief warning for servant golems on spawn, as they follow the will of their creators. Non-antag creators are still liable for bwoinking if you use your golems for mischief! Warnings still remain for free golems.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
