### PR TITLE
fix BCI keyboards and thought listeners html encoding input

### DIFF
--- a/code/modules/wiremod/components/admin/input_request.dm
+++ b/code/modules/wiremod/components/admin/input_request.dm
@@ -59,8 +59,8 @@
 	var/new_option = input_options.value
 	switch(new_option)
 		if(COMP_INPUT_STRING)
-			var/player_input = tgui_input_text(player, "Input a value", "Input value")
-			if(isnull(player_input))
+			var/player_input = trimtext(tgui_input_text(player, "Input a value", "Input value", encode = FALSE))
+			if(!length(player_input))
 				return
 			input_response.set_output(player_input)
 		if(COMP_INPUT_NUMBER)

--- a/code/modules/wiremod/components/bci/thought_listener.dm
+++ b/code/modules/wiremod/components/bci/thought_listener.dm
@@ -56,7 +56,8 @@
 	ready = FALSE
 
 /obj/item/circuit_component/thought_listener/proc/thought_listen(mob/living/owner)
-	var/message = tgui_input_text(owner, input_desc.value ? input_desc.value : "", input_name.value ? input_name.value : "Thought Listener", "")
-	output.set_output(message)
-	trigger_output.set_output(COMPONENT_SIGNAL)
+	var/message = trimtext(tgui_input_text(owner, input_desc.value ? input_desc.value : "", input_name.value ? input_name.value : "Thought Listener", "", encode = FALSE))
+	if(length(message))
+		output.set_output(message)
+		trigger_output.set_output(COMPONENT_SIGNAL)
 	ready = TRUE

--- a/code/modules/wiremod/shell/keyboard.dm
+++ b/code/modules/wiremod/shell/keyboard.dm
@@ -48,9 +48,10 @@
 		to_chat(user, span_warning("You start mashing keys at random!"))
 		return
 
-	var/message = tgui_input_text(user, "Input your text", "Keyboard")
-	entity.set_output(user)
-	output.set_output(message)
-	signal.set_output(COMPONENT_SIGNAL)
+	var/message = trimtext(tgui_input_text(user, "Input your text", "Keyboard", encode = FALSE))
+	if(length(message))
+		entity.set_output(user)
+		output.set_output(message)
+		signal.set_output(COMPONENT_SIGNAL)
 
 


### PR DESCRIPTION
## About The Pull Request

this makes it so BCI keyboards, thought listeners, and the admin-only input request will not html encode their text input. they will trim it tho.

in additional, keyboards and thought listeners won't send a signal if you don't input anything.

## Why It's Good For The Game

because having `Ain't that neat` become `Ain&#39;t that neat?` is annoying.

## Testing

<img width="481" height="46" alt="image" src="https://github.com/user-attachments/assets/a3683720-2f31-4977-9dfd-40b2d226f533" />


## Changelog
:cl:
fix: Fixed BCI keyboards and thought listeners html encoding text input.
fix: Fixed BCI keyboards and thought listeners sending a signal if you don't actually type anything in.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
