### PR TITLE
Fix the wiremod module duplicator using 100x more glass than it should

### DIFF
--- a/code/modules/wiremod/core/component_printer.dm
+++ b/code/modules/wiremod/core/component_printer.dm
@@ -305,7 +305,7 @@
 
 	var/list/scanned_designs = list()
 
-	var/cost_per_component = 1000
+	var/cost_per_component = SHEET_MATERIAL_AMOUNT / 10
 
 	var/efficiency_coeff = 1
 


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/9619

this is the same value that tg uses upstream

## Testing
## Changelog
:cl:
fix: The wiremod module duplicator no longer uses 100 times more glass than it should.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
