### PR TITLE
[insert color here]TIDE WORLDWIDE

### DIFF
--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -86,7 +86,7 @@ Assistant
 		H.update_worn_undersuit()
 
 /proc/get_configured_colored_assistant_type()
-	return CONFIG_GET(flag/grey_assistants) ? /datum/colored_assistant/grey : /datum/colored_assistant/random
+	return CONFIG_GET(flag/grey_assistants) ? /datum/colored_assistant/grey : /datum/colored_assistant/solid
 
 /// Defines a style of jumpsuit/jumpskirt for assistants.
 /// Jumpsuit and jumpskirt lists should match in colors, as they are used interchangably.
@@ -97,10 +97,6 @@ Assistant
 /datum/colored_assistant/grey
 	jumpsuits = list(/obj/item/clothing/under/color/grey)
 	jumpskirts = list(/obj/item/clothing/under/color/jumpskirt/grey)
-
-/datum/colored_assistant/random
-	jumpsuits = list(/obj/item/clothing/under/color/random)
-	jumpskirts = list(/obj/item/clothing/under/color/jumpskirt/random)
 
 /datum/colored_assistant/christmas
 	jumpsuits = list(


### PR DESCRIPTION
## About The Pull Request
removes random assistant colors, assistants will always be the same color or palette during the colored assistants station trait

## Why It's Good For The Game
the tide is one

## Testing

## Changelog

:cl:
del: removed random assistant colors, assistants will always be the same color or palette during the colored assistants station trait.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

