### PR TITLE
Cloning fix/qol.

### DIFF
--- a/monkestation/code/game/machinery/cloning.dm
+++ b/monkestation/code/game/machinery/cloning.dm
@@ -330,17 +330,12 @@
 
 /obj/machinery/clonepod/multitool_act(mob/living/user, obj/item/multitool/multi)
 	. = NONE
-	if(!(occupant || mess))
-		return
-
 	if(!istype(multi.buffer, /obj/machinery/computer/cloning))
 		multi.set_buffer(src)
 		to_chat(user, "<font color = #666633>-% Successfully stored [REF(multi.buffer)] [multi.buffer] in buffer %-</font color>")
 		return ITEM_INTERACT_SUCCESS
-
-	if(get_area(multi.buffer) != get_area(src))
-		to_chat(user, "<font color = #666633>-% Cannot link machines across power zones. Buffer cleared %-</font color>")
-		multi.set_buffer(null)
+	if(get_dist(src, multi.buffer) > 16)
+		to_chat(user, "<font color = #666633>-% Cannot link machines that far away. %-</font color>")
 		return ITEM_INTERACT_BLOCKING
 
 	to_chat(user, "<font color = #666633>-% Successfully linked [multi.buffer] with [src] %-</font color>")


### PR DESCRIPTION

## About The Pull Request
Instead of powerzones limiting clone pod/computer linking, it is now based off distance.

Clonepods can now be linked to cloning computers again. (Was borked from item interaction changes.)

## Why It's Good For The Game
Features working is good.

It's always felt weird to me that you can't link two machines a few tiles away from each other because of some arbitrary lines. It being based off of distance is better.

## Testing
## Changelog
:cl:
qol: Instead of powerzones limiting clone pod/computer linking, it is now based off distance.
fix: Clonepods can now be linked to cloning computers again.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
