### PR TITLE
Adds holopads to most syndicate/pirate bases and ships

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -24714,6 +24714,12 @@
 /obj/structure/flora/bush/flowers_yw/style_3,
 /turf/open/misc/grass,
 /area/centcom)
+"jsJ" = (
+/obj/machinery/holopad/secure/hacked{
+	layer = 2.6
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/cruiser_dock)
 "jth" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
@@ -26682,6 +26688,13 @@
 	},
 /turf/open/floor/plastic,
 /area/centcom/central_command_areas/admin)
+"mSk" = (
+/obj/effect/turf_decal/siding/red{
+	dir = 4
+	},
+/obj/machinery/holopad/secure/hacked,
+/turf/open/floor/iron/dark/textured_large,
+/area/centcom/syndicate_mothership/control)
 "mTh" = (
 /obj/structure/sign{
 	name = "wall";
@@ -30110,6 +30123,10 @@
 	},
 /turf/open/floor/iron/white/diagonal,
 /area/centcom/central_command_areas/kitchen)
+"sNe" = (
+/obj/machinery/holopad/secure/hacked,
+/turf/open/floor/mineral/plastitanium/red,
+/area/centcom/syndicate_mothership/control)
 "sNI" = (
 /obj/item/food/grown/banana/bunch,
 /turf/open/floor/mineral/bananium,
@@ -31496,6 +31513,16 @@
 	dir = 8
 	},
 /area/centcom/central_command_areas/evacuation)
+"vpg" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/orange/hidden/layer5,
+/obj/machinery/holopad/secure/hacked{
+	layer = 2.6
+	},
+/turf/open/floor/catwalk_floor/iron_smooth,
+/area/centcom/syndicate_mothership/control)
 "vrG" = (
 /obj/effect/turf_decal/tile/dark/opposingcorners,
 /obj/structure/railing/wood{
@@ -37112,7 +37139,7 @@ aku
 aku
 aku
 aQr
-axU
+sNe
 aoa
 aNw
 azL
@@ -40189,7 +40216,7 @@ aVK
 aVK
 aIY
 aFr
-anS
+vpg
 anS
 anS
 aYh
@@ -48679,7 +48706,7 @@ aVK
 aVK
 aDm
 aBV
-aBV
+mSk
 aBV
 aSG
 aSr
@@ -85776,7 +85803,7 @@ bnQ
 bBh
 bBh
 jce
-iDX
+jsJ
 rXO
 eAb
 iDX

--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -201,6 +201,7 @@
 	dir = 10
 	},
 /obj/structure/cable,
+/obj/machinery/holopad/secure/hacked,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/bridge)
 "ax" = (
@@ -515,6 +516,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/holopad/secure/hacked,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/eva)
 "bl" = (

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -866,6 +866,12 @@
 /obj/item/storage/backpack/duffelbag/syndie/surgery,
 /turf/open/floor/iron/white/side,
 /area/shuttle/syndicate/medical)
+"zr" = (
+/obj/machinery/holopad/secure/hacked{
+	layer = 2.6
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/shuttle/syndicate/hallway)
 "zL" = (
 /obj/machinery/status_display/evac{
 	pixel_x = -32
@@ -1335,7 +1341,7 @@ ap
 lm
 aD
 ak
-ak
+zr
 ak
 aD
 Tu

--- a/_maps/shuttles/nova/goldeneye_cruiser.dmm
+++ b/_maps/shuttles/nova/goldeneye_cruiser.dmm
@@ -569,6 +569,10 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/shuttle/syndicate/cruiser/brig)
+"Cg" = (
+/obj/machinery/holopad/secure/hacked,
+/turf/open/floor/iron/smooth_large,
+/area/shuttle/syndicate/cruiser/bridge)
 "CH" = (
 /turf/open/floor/iron/smooth_large,
 /area/shuttle/syndicate/cruiser/hallway)
@@ -1072,7 +1076,7 @@ zL
 mP
 Re
 cl
-Yk
+Cg
 Yk
 Yk
 Yk

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -937,6 +937,11 @@
 	},
 /turf/open/floor/pod/light,
 /area/shuttle/pirate)
+"Mx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/holopad/secure/hacked,
+/turf/open/floor/pod/dark,
+/area/shuttle/pirate)
 "Ni" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
@@ -1159,7 +1164,7 @@ am
 au
 bm
 by
-bm
+Mx
 mU
 aL
 bP

--- a/_maps/shuttles/pirate_dutchman.dmm
+++ b/_maps/shuttles/pirate_dutchman.dmm
@@ -289,6 +289,10 @@
 	},
 /turf/open/floor/wood/airless,
 /area/shuttle/pirate/flying_dutchman)
+"gn" = (
+/obj/machinery/holopad/secure/hacked,
+/turf/open/floor/wood/airless,
+/area/shuttle/pirate/flying_dutchman)
 "gq" = (
 /obj/machinery/computer/shuttle/pirate{
 	dir = 1
@@ -1249,7 +1253,7 @@ fW
 St
 Da
 da
-WB
+gn
 WB
 RQ
 eG

--- a/_maps/shuttles/pirate_ex_interdyne.dmm
+++ b/_maps/shuttles/pirate_ex_interdyne.dmm
@@ -548,6 +548,7 @@
 /area/shuttle/pirate)
 "ua" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden,
+/obj/machinery/holopad/secure/hacked,
 /turf/open/floor/iron/dark,
 /area/shuttle/pirate)
 "vz" = (

--- a/_maps/shuttles/pirate_geode.dmm
+++ b/_maps/shuttles/pirate_geode.dmm
@@ -380,6 +380,17 @@
 /obj/effect/mapping_helpers/airlock/access/any/syndicate,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
+"uB" = (
+/obj/effect/turf_decal/lunar_sand/plating,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/holopad/secure/hacked,
+/turf/open/floor/plating,
+/area/shuttle/pirate)
 "uH" = (
 /obj/effect/turf_decal/lunar_sand/plating,
 /obj/effect/turf_decal/weather/dirt{
@@ -1247,7 +1258,7 @@ qO
 kx
 GQ
 pC
-iu
+uB
 pC
 GQ
 pC

--- a/_maps/shuttles/pirate_grey.dmm
+++ b/_maps/shuttles/pirate_grey.dmm
@@ -220,6 +220,7 @@
 /area/shuttle/pirate)
 "ie" = (
 /obj/structure/cable,
+/obj/machinery/holopad/secure/hacked,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "it" = (

--- a/_maps/shuttles/pirate_irs.dmm
+++ b/_maps/shuttles/pirate_irs.dmm
@@ -1765,6 +1765,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/dark,
+/obj/machinery/holopad/secure/hacked,
 /turf/open/floor/glass,
 /area/shuttle/pirate)
 "TA" = (

--- a/_maps/shuttles/pirate_silverscale.dmm
+++ b/_maps/shuttles/pirate_silverscale.dmm
@@ -566,6 +566,10 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/pirate)
+"EU" = (
+/obj/machinery/holopad/secure/hacked,
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/pirate)
 "Gr" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 8
@@ -1224,7 +1228,7 @@ xs
 Ai
 am
 am
-am
+EU
 am
 am
 Ai

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -84,6 +84,9 @@ Possible to do for anyone motivated enough:
 	var/ringing = FALSE
 	var/offset = FALSE
 	var/on_network = TRUE
+	/// If set, only other holopads with the same "key" will be able to start a call with this holopad.
+	/// However, they can still START outgoing calls to key-less holopads.
+	var/key
 	/// For pads in secure areas; do not allow forced connecting
 	var/secure = FALSE
 	/// If we are currently calling another holopad
@@ -119,6 +122,7 @@ Possible to do for anyone motivated enough:
 	name = "hacked holopad"
 	desc = "It's a floor-mounted device for projecting holographic images. This one will refuse to auto-connect incoming calls."
 	req_access = list(ACCESS_SYNDICATE)
+	key = "syndicate"
 
 /obj/machinery/holopad/tutorial
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
@@ -334,10 +338,11 @@ Possible to do for anyone motivated enough:
 				return
 			if(usr.loc == loc)
 				var/list/callnames = list()
-				for(var/I in holopads)
-					var/area/A = get_area(I)
-					if(A)
-						LAZYADD(callnames[A], I)
+				for(var/obj/machinery/holopad/holopad as anything in holopads)
+					var/area/holopad_area = get_area(holopad)
+					if(!holopad_area || !can_call_to(holopad))
+						continue
+					LAZYADD(callnames[holopad_area], holopad)
 				callnames -= get_area(src)
 				var/result = tgui_input_list(usr, "Choose an area to call", "Holocall", sort_names(callnames))
 				if(isnull(result))
@@ -647,14 +652,20 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	SetLightsAndPower()
 	return TRUE
 
+/obj/machinery/holopad/proc/can_call_to(obj/machinery/holopad/other)
+	if(QDELETED(other))
+		return FALSE
+	if(other.key && key != other.key)
+		return FALSE
+	return TRUE
+
 //Try to transfer hologram to another pad that can project on T
 /obj/machinery/holopad/proc/transfer_to_nearby_pad(turf/T, datum/holo_owner)
 	var/obj/effect/overlay/holo_pad_hologram/h = masters[holo_owner]
 	if(!h || h.HC) //Holocalls can't change source.
 		return FALSE
-	for(var/pad in holopads)
-		var/obj/machinery/holopad/another = pad
-		if(another == src)
+	for(var/obj/machinery/holopad/another as anything in holopads)
+		if(another == src || !can_call_to(another))
 			continue
 		if(another.validate_location(T))
 			unset_holo(holo_owner)


### PR DESCRIPTION
## About The Pull Request

This adds holopads to most syndicate bases/ships and pirate ships.

These holopads are considered "hacked", and they will not show up as an option when attempting to call from a normal holopad.
However, hacked holopads _can_ make outgoing calls to both hacked and normal holopads.

## Why It's Good For The Game

Allows for potentially interesting RP/gimmicks - pirates trying to make some sort of deal with the station, for example.

## Testing

<img width="598" height="413" alt="2025-12-13 (1765667122) ~ dreamseeker" src="https://github.com/user-attachments/assets/4476acf6-ee4b-4c5d-9bd6-f18fa569a633" />
<img width="790" height="688" alt="2025-12-13 (1765667145) ~ dreamseeker" src="https://github.com/user-attachments/assets/639207b3-873d-49d3-98eb-b4e98a7dbfae" />
<img width="404" height="453" alt="2025-12-13 (1765667213) ~ dreamseeker" src="https://github.com/user-attachments/assets/a90169ad-60a0-4e49-aae5-0a6f1f197e23" />


## Changelog
:cl:
map: Added "hacked" holopads to most syndicate/pirate bases and ships, allowing them to call the station if they so desire.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
