### PR TITLE
[PORT] [QOL] Makes windoors stay open for longer

### DIFF
--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -117,9 +117,9 @@
 		return
 	autoclose = TRUE
 	if(check_access(null))
-		sleep(5 SECONDS)
+		sleep(8 SECONDS)
 	else //secure doors close faster
-		sleep(2 SECONDS)
+		sleep(5 SECONDS)
 	if(!density && autoclose) //did someone change state while we slept?
 		close()
 


### PR DESCRIPTION

## About The Pull Request

Port of https://github.com/tgstation/tgstation/pull/84456

Makes windoors stay open for 8 seconds instead of 5. Makes secure windoors stay open for 5 seconds instead of 2.

## Why It's Good For The Game

DOOR STUCK, DOOR STUCK- PLEASE- I BEG YOU!!

## Testing
https://github.com/user-attachments/assets/e2295dc3-829a-4b99-be17-a395b9020537

## Changelog
:cl: grungussuss, JupiterJaeden
qol: Windoors now stay open for 8 seconds instead of 5.
qol: Secure windoors now stay open for 5 seconds instead of 2.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
