### PR TITLE
Disables the Nosferatu bloodsucker clan

### DIFF
--- a/monkestation/code/modules/bloodsuckers/clans/nosferatu.dm
+++ b/monkestation/code/modules/bloodsuckers/clans/nosferatu.dm
@@ -10,6 +10,7 @@
 		lose your Masquerade ability, but gain the ability to Ventcrawl even while clothed."
 	blood_drink_type = BLOODSUCKER_DRINK_INHUMANELY
 	banned_powers = list(/datum/action/cooldown/bloodsucker/masquerade, /datum/action/cooldown/bloodsucker/veil)
+	joinable_clan = FALSE
 
 /datum/bloodsucker_clan/nosferatu/New(datum/antagonist/bloodsucker/owner_datum)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

simple removes the Nosferatu clan from the list of joinable clans. that's all there is to it.

## Why It's Good For The Game

- clothed ventcrawling is super OP
  - speedrunning the armory is fun for nobody but them
  - removing it kind of nukes their whole gimmick, too, so... why keep them?
- only downside is like a mood debuff
- they make other clans irrelevant - they're basically Caitiff but better, Malkavian's portals are shit compared to just ventcrawling, etc etc,.

the vampire rework will save us all, trust me.

## Changelog
:cl:
del: Bloodsuckers can no longer choose the Nosferatu clan.
/:cl: