### PR TITLE
Fixes space heater deconstruction generating cells

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -138,7 +138,7 @@
 #define SOUND_ENVIRONMENT_DIZZY 24
 #define SOUND_ENVIRONMENT_PSYCHOTIC 25
 //If we ever make custom ones add them here
-#define SOUND_ENVIROMENT_PHASED list(1.8, 0.5, -1000, -4000, 0, 5, 0.1, 1, -15500, 0.007, 2000, 0.05, 0.25, 1, 1.18, 0.348, -5, 2000, 250, 0, 3, 100, 63)
+#define SOUND_ENVIRONMENT_PHASED list(1.8, 0.5, -1000, -4000, 0, 5, 0.1, 1, -15500, 0.007, 2000, 0.05, 0.25, 1, 1.18, 0.348, -5, 2000, 250, 0, 3, 100, 63)
 
 //"sound areas": easy way of keeping different types of areas consistent.
 #define SOUND_AREA_STANDARD_STATION SOUND_ENVIRONMENT_HANGAR

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -74,11 +74,14 @@
 
 /obj/machinery/space_heater/Destroy()
 	SSair.stop_processing_machine(src)
-	return..()
+	return ..()
 
 /obj/machinery/space_heater/on_construction()
 	set_panel_open(TRUE)
+	src.contents -= cell // heater starts with a cell for Initialize(), we remove it for constructed heaters
 	cell = null
+	QDEL_NULL(cell)
+
 
 /obj/machinery/space_heater/on_deconstruction()
 	if(cell)
@@ -131,12 +134,12 @@
 			update_appearance()
 		return
 
-	var/datum/gas_mixture/enviroment = local_turf.return_air()
+	var/datum/gas_mixture/environment = local_turf.return_air()
 
 	var/new_mode = HEATER_MODE_STANDBY
-	if(set_mode != HEATER_MODE_COOL && enviroment.temperature < target_temperature - temperature_tolerance)
+	if(set_mode != HEATER_MODE_COOL && environment.temperature < target_temperature - temperature_tolerance)
 		new_mode = HEATER_MODE_HEAT
-	else if(set_mode != HEATER_MODE_HEAT && enviroment.temperature > target_temperature + temperature_tolerance)
+	else if(set_mode != HEATER_MODE_HEAT && environment.temperature > target_temperature + temperature_tolerance)
 		new_mode = HEATER_MODE_COOL
 
 	if(mode != new_mode)
@@ -147,7 +150,7 @@
 		return
 
 	var/list/turfs = (local_turf.atmos_adjacent_turfs || list()) + local_turf
-	var/required_energy = abs(enviroment.temperature - target_temperature) * enviroment.heat_capacity()
+	var/required_energy = abs(environment.temperature - target_temperature) * environment.heat_capacity()
 	required_energy = min(required_energy, heating_energy, (cell.charge * efficiency) / length(turfs))
 	if(required_energy < 1)
 		return
@@ -249,8 +252,8 @@
 	var/turf/local_turf = get_turf(loc)
 	var/current_temperature
 	if(istype(local_turf))
-		var/datum/gas_mixture/enviroment = local_turf.return_air()
-		current_temperature = enviroment.temperature
+		var/datum/gas_mixture/environment = local_turf.return_air()
+		current_temperature = environment.temperature
 	else if(isturf(local_turf))
 		current_temperature = local_turf.temperature
 	if(isnull(current_temperature))
@@ -418,7 +421,6 @@
 		beaker?.forceMove(drop_location())
 		beaker = null
 	var/static/bonus_junk = list(
-		/obj/item/stack/cable_coil = 2,
 		/obj/item/stack/sheet/glass = 2,
 		/obj/item/stack/sheet/iron = 2,
 		/obj/item/thermometer = 1

--- a/code/modules/antagonists/changeling/powers/darkness_adaptation.dm
+++ b/code/modules/antagonists/changeling/powers/darkness_adaptation.dm
@@ -1,7 +1,7 @@
 /datum/action/changeling/darkness_adaptation
 	name = "Darkness Adaptation"
 	desc = "Our skin pigmentation and eyes rapidly change to suit the darkness. Requires 10 available chemicals and slightly slows down chemical regeneration." // monkestation edit
-	helptext = "Makes us translucent. Works best in dark enviroments and garments. Makes our eyes more sensitive to flashes." // monkestation edit
+	helptext = "Makes us translucent. Works best in dark environments and garments. Makes our eyes more sensitive to flashes." // monkestation edit
 	button_icon_state = "darkness_adaptation"
 	dna_cost = 2
 	chemical_cost = 10

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -459,7 +459,7 @@
  * Called by wrench_act() before deconstruct()
  * Arguments:
  * * mob_user - the mob doing the act
- * * pressures - it can be passed on from wrench_act(), it's the pressure difference between the enviroment pressure and the pipe internal pressure
+ * * pressures - it can be passed on from wrench_act(), it's the pressure difference between the environment pressure and the pipe internal pressure
  */
 /obj/machinery/atmospherics/proc/unsafe_pressure_release(mob/user, pressures = null)
 	if(!user)

--- a/code/modules/atmospherics/machinery/portable/scrubber.dm
+++ b/code/modules/atmospherics/machinery/portable/scrubber.dm
@@ -9,7 +9,7 @@
 	var/on = FALSE
 	///the rate the machine will scrub air
 	var/volume_rate = 1000
-	///Multiplier with ONE_ATMOSPHERE, if the enviroment pressure is higher than that, the scrubber won't work
+	///Multiplier with ONE_ATMOSPHERE, if the environment pressure is higher than that, the scrubber won't work
 	var/overpressure_m = 80
 	///Should the machine use overlay in update_overlays() when open/close?
 	var/use_overlays = TRUE

--- a/code/modules/explorer_drone/scanner_array.dm
+++ b/code/modules/explorer_drone/scanner_array.dm
@@ -194,7 +194,7 @@ GLOBAL_LIST_INIT(scan_conditions,init_scan_conditions())
 	name = "Scanner array"
 	icon = 'icons/obj/exploration.dmi'
 	icon_state = "scanner_off"
-	desc = "Sophisticated scanning array. Easily influenced by enviroment."
+	desc = "Sophisticated scanning array. Easily influenced by environment."
 
 /obj/machinery/exoscanner/Initialize(mapload)
 	. = ..()

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -188,7 +188,7 @@
 
 /turf/open/floor/holofloor/dark
 	icon_state = "darkfull"
-	desc = "The surrounding enviroment is so dark you can hardly see yourself."
+	desc = "The surrounding environment is so dark you can hardly see yourself."
 
 /turf/open/floor/holofloor/stairs
 	name = "stairs"

--- a/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spiders.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spiders.dm
@@ -424,7 +424,7 @@
 /**
  * ### Scrawny Hunter Spider
  *
- * A hunter spider that trades damage for health, unable to smash enviroments.
+ * A hunter spider that trades damage for health, unable to smash environments.
  * Used as a minor threat in abandoned places, such as areas in maintenance or a ruin.
  */
 /mob/living/basic/spider/giant/hunter/scrawny
@@ -440,7 +440,7 @@
 /**
  * ### Scrawny Tarantula
  *
- * A weaker version of the Tarantula, unable to smash enviroments.
+ * A weaker version of the Tarantula, unable to smash environments.
  * Used as a moderately strong but slow threat in abandoned places, such as areas in maintenance or a ruin.
  */
 /mob/living/basic/spider/giant/tarantula/scrawny
@@ -456,7 +456,7 @@
 /**
  * ### Scrawny Nurse Spider
  *
- * A weaker version of the nurse spider with reduced health, unable to smash enviroments.
+ * A weaker version of the nurse spider with reduced health, unable to smash environments.
  * Mainly used as a weak threat in abandoned places, such as areas in maintenance or a ruin.
  * In the future we should give this AI so that it actually heals its teammates.
  */

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -716,7 +716,7 @@
 
 	invisible_man.update_body()
 	invisible_man.remove_from_all_data_huds()
-	invisible_man.sound_environment_override = SOUND_ENVIROMENT_PHASED
+	invisible_man.sound_environment_override = SOUND_ENVIRONMENT_PHASED
 
 /datum/reagent/drug/saturnx/on_mob_end_metabolize(mob/living/carbon/invisible_man)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -309,7 +309,7 @@
 
 /obj/item/reagent_containers/hypospray/medipen/survival/luxury
 	name = "luxury medipen"
-	desc = "Cutting edge bluespace technology allowed Nanotrasen to compact 70u of volume into a single medipen. Contains rare and powerful chemicals used to aid in exploration of very hard enviroments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE."
+	desc = "Cutting edge bluespace technology allowed Nanotrasen to compact 70u of volume into a single medipen. Contains rare and powerful chemicals used to aid in exploration of very hard environments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE."
 	icon_state = "luxpen"
 	inhand_icon_state = "atropen"
 	base_icon_state = "luxpen"
@@ -429,7 +429,7 @@
 
 /obj/item/reagent_containers/hypospray/medipen/survival/luxury/oozeling //oozeling safe version of the luxury pen!
 	name = "luxury oozeling medipen"
-	desc = "Even more cutting edge bluespace technology allowed Nanotrasen to compact 90u of volume into a single medipen. Contains rare and powerful chemicals that are also oozeling safe! Used to aid in exploration of very harsh enviroments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE. <b> EXTRA WARNING : UNSAFE FOR NON OOZELING LIFE </b>"
+	desc = "Even more cutting edge bluespace technology allowed Nanotrasen to compact 90u of volume into a single medipen. Contains rare and powerful chemicals that are also oozeling safe! Used to aid in exploration of very harsh environments. WARNING: DO NOT MIX WITH EPINEPHRINE OR ATROPINE. <b> EXTRA WARNING : UNSAFE FOR NON OOZELING LIFE </b>"
 	icon_state = "luxpen"
 	inhand_icon_state = "atropen"
 	base_icon_state = "luxpen"

--- a/monkestation/code/modules/a_ship_in_need_of_breaking/ships.dm
+++ b/monkestation/code/modules/a_ship_in_need_of_breaking/ships.dm
@@ -44,7 +44,7 @@
 /datum/map_template/shipbreaker/mcsloop
 	name = "McSteal Sloop"
 	template_id = "McSloop"
-	description = "Little more then a expanded escape pod. Contains enough to survive and thrive on dangerous enviroments."
+	description = "Little more then a expanded escape pod. Contains enough to survive and thrive on dangerous environments."
 	mappath = "_maps/~monkestation/shipbreaking/mcsteal_sloop.dmm"
 
 /*

--- a/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/utility.dm
@@ -80,16 +80,16 @@
 	if (!istype(turf))
 		return
 
-	var/datum/gas_mixture/enviroment = turf.return_air()
-	if (host_mob.bodytemperature < enviroment.temperature) // sadly our bitcoin mining operations just aren't cool enough
+	var/datum/gas_mixture/environment = turf.return_air()
+	if (host_mob.bodytemperature < environment.temperature) // sadly our bitcoin mining operations just aren't cool enough
 		return
 
-	var/difference = host_mob.bodytemperature - enviroment.temperature
-	var/heat_capacity = enviroment.heat_capacity()
+	var/difference = host_mob.bodytemperature - environment.temperature
+	var/heat_capacity = environment.heat_capacity()
 	var/required_energy = difference * heat_capacity
 	var/delta_temperature = min(required_energy, research_speed * 500) / heat_capacity
 
-	enviroment.temperature += delta_temperature
+	environment.temperature += delta_temperature
 	turf.air_update_turf()
 
 /datum/nanite_program/research/enable_passive_effect()

--- a/monkestation/code/modules/surgery/organs/external/ethereal_accessories.dm
+++ b/monkestation/code/modules/surgery/organs/external/ethereal_accessories.dm
@@ -1,6 +1,6 @@
 /obj/item/organ/external/ethereal_horns
 	name = "ethereal horns"
-	desc = "These seemingly decorative horns are actually sensory organs, albiet somewhat vegistal ones in their current enviroment, for detecting nearby electromagnetic fields. They are also extremely sensitive, a fact that which whatever poor ethereal you took these from is probably heavily aware of."
+	desc = "These seemingly decorative horns are actually sensory organs, albiet somewhat vegistal ones in their current environment, for detecting nearby electromagnetic fields. They are also extremely sensitive, a fact that which whatever poor ethereal you took these from is probably heavily aware of."
 	icon_state = "ethereal_horns"
 	icon = 'monkestation/icons/obj/medical/organs/organs.dmi'
 


### PR DESCRIPTION

## About The Pull Request
Fixes space heater deconstruction generating cells.
Also fixes extra cable coil generation during deconstruction of improvised chem heaters (as a result of cable coil stack changes, it spawned a full cable coil stack of 30 along with extra cable from the space heater, in great excess of the 2 for the improvised heater craft and 3 for the space heater machine design). Now, only the cable from the space heater machine design is spawned upon deconstruction. The issue was caused by cable stacks reverting to a default of 30 instead of 1.
Also cleans up typos of the word "environment" from "enviroment".

[Relevant /tg PR](https://github.com/tgstation/tgstation/pull/77992)

## Why It's Good For The Game

Fixes #9956

## Testing
Disassembled & reassembled space heaters and improvised chem heaters.
No issues after replacing typo.

## Changelog
:cl: Lawlolawl
fix: Fixed space heater deconstruction generating power cells, as well as improvised chem heater deconstruction generating cable coils.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
