### PR TITLE
Fixes light boxes not storing lights

### DIFF
--- a/code/game/objects/items/storage/boxes/service_boxes.dm
+++ b/code/game/objects/items/storage/boxes/service_boxes.dm
@@ -167,7 +167,7 @@
 	desc = "A completely randomized and wacky box of long balloons, harvested straight from balloon farms on the clown planet."
 	illustration = "balloon"
 
-/obj/item/storage/box/lights/Initialize(mapload)
+/obj/item/storage/box/balloons/Initialize(mapload)
 	. = ..()
 	atom_storage.max_slots = 24
 	atom_storage.set_holdable(list(/obj/item/toy/balloon/long))


### PR DESCRIPTION

## About The Pull Request
Fixes a typo where box/lights/Initialize was overridden by box/balloons/Initialize, resulting in the light box storage datum only storing balloons.

## Why It's Good For The Game
Fixes #9922

## Testing
Yes.

## Changelog
:cl: Lawlolawl
fix: Fixed lights not being able to be placed back into box of replacement lights.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
