### PR TITLE
Fixes labeler losing labels on chemnade assembly/disassembly, or name updates in general

### DIFF
--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -231,6 +231,7 @@
 	RegisterSignal(sticking_to, COMSIG_ATOM_ITEM_INTERACTION, PROC_REF(interacted_with))
 	RegisterSignal(sticking_to, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
 	RegisterSignals(sticking_to, list(SIGNAL_ADDTRAIT(TRAIT_WAS_RENAMED), SIGNAL_REMOVETRAIT(TRAIT_WAS_RENAMED)), PROC_REF(reapply))
+	RegisterSignal(sticking_to, COMSIG_ATOM_UPDATE_NAME, PROC_REF(reapply))
 	RegisterSignal(sticking_to, COMSIG_QDELETING, PROC_REF(clear_stick_to))
 	apply_label()
 


### PR DESCRIPTION

## About The Pull Request

Labels now register when the item they're attached to has its name updated, to re-append the label to the end of the item's name. Otherwise the label is perceived as "missing" (the item's name just hasn't had the label re-appended).

## Why It's Good For The Game

Fixes #9950
Closes #8425 (unable to reproduce after fix, labels remained after > 10 min, lack of duplicate issues reported)

## Testing

Labels were retained (or rather, the label string was consistently appended upon chemnade stage changes).
Pill bottles retained labels with no issues observed.

## Changelog
:cl: Lawlolawl
fix: Fixed chemnades losing labels during assembly/disassembly steps. In general, hand labeler labels should have their label added to the end of an item's new name every time it is updated.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
