### PR TITLE
Ports melee_cooldown_time now defaults to zero

### DIFF
--- a/code/datums/actions/cooldown_action.dm
+++ b/code/datums/actions/cooldown_action.dm
@@ -11,8 +11,8 @@
 	var/panel
 	/// The default cooldown applied when StartCooldown() is called
 	var/cooldown_time = 0
-	/// The default melee cooldown applied after the ability ends
-	var/melee_cooldown_time
+	/// The default melee cooldown applied after the ability ends. If set to null, copies cooldown_time.
+	var/melee_cooldown_time = 0
 	/// The actual next time the owner of this action can melee
 	var/next_melee_use_time = 0
 	/// Whether or not you want the cooldown for the ability to display in text form

--- a/code/modules/mob/living/basic/clown/clown.dm
+++ b/code/modules/mob/living/basic/clown/clown.dm
@@ -469,7 +469,6 @@
 	button_icon = 'icons/mob/actions/actions_animal.dmi'
 	button_icon_state = "regurgitate"
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_INCAPACITATED
-	melee_cooldown_time = 0 SECONDS
 	click_to_activate = TRUE
 
 /datum/action/cooldown/regurgitate/set_click_ability(mob/on_who)

--- a/code/modules/mob/living/basic/guardian/guardian_types/explosive.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/explosive.dm
@@ -35,7 +35,6 @@
 	button_icon = 'icons/mob/actions/actions_spells.dmi'
 	button_icon_state = "smoke"
 	cooldown_time = 20 SECONDS
-	melee_cooldown_time = 0 SECONDS
 	background_icon = 'icons/hud/guardian.dmi'
 	background_icon_state = "base"
 	/// After this amount of time passses, bomb deactivates.

--- a/code/modules/mob/living/basic/guardian/guardian_types/gaseous.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/gaseous.dm
@@ -77,7 +77,6 @@
 	button_icon = 'icons/mob/actions/actions_spells.dmi'
 	button_icon_state = "smoke"
 	cooldown_time = 0 SECONDS // We're here for the interface not the cooldown
-	melee_cooldown_time = 0 SECONDS
 	click_to_activate = FALSE
 	/// Gas being expelled.
 	var/active_gas = null

--- a/code/modules/mob/living/basic/icemoon/ice_demon/ice_demon_abilities.dm
+++ b/code/modules/mob/living/basic/icemoon/ice_demon/ice_demon_abilities.dm
@@ -14,7 +14,6 @@
 	button_icon = 'icons/obj/ore.dmi'
 	button_icon_state = "bluespace_crystal"
 	cooldown_time = 3 SECONDS
-	melee_cooldown_time = 0 SECONDS
 	///time delay before teleport
 	var/time_delay = 0.5 SECONDS
 
@@ -38,7 +37,6 @@
 	button_icon_state = "ice_turf-6"
 	cooldown_time = 2 SECONDS
 	click_to_activate = FALSE
-	melee_cooldown_time = 0 SECONDS
 	///perimeter we will spawn the iced floors on
 	var/radius = 1
 	///intervals we will spawn the ice floors in

--- a/code/modules/mob/living/basic/icemoon/ice_whelp/ice_whelp_abilities.dm
+++ b/code/modules/mob/living/basic/icemoon/ice_whelp/ice_whelp_abilities.dm
@@ -5,7 +5,6 @@
 	button_icon = 'icons/effects/magic.dmi'
 	button_icon_state = "fireball"
 	cooldown_time = 3 SECONDS
-	melee_cooldown_time = 0 SECONDS
 	fire_range = 4
 	fire_damage = 10
 
@@ -26,7 +25,6 @@
 	button_icon = 'icons/effects/fire.dmi'
 	button_icon_state = "light"
 	cooldown_time = 4 SECONDS
-	melee_cooldown_time = 0 SECONDS
 	click_to_activate = FALSE
 	fire_range = 6
 

--- a/code/modules/mob/living/basic/jungle/mega_arachnid/mega_arachnid_abilities.dm
+++ b/code/modules/mob/living/basic/jungle/mega_arachnid/mega_arachnid_abilities.dm
@@ -43,7 +43,6 @@
 	button_icon_state = "default"
 	desc = "Secrete a slippery acid!"
 	cooldown_time = 15 SECONDS
-	melee_cooldown_time = 0 SECONDS
 	click_to_activate = FALSE
 
 /datum/action/cooldown/mob_cooldown/secrete_acid/Activate(atom/target_atom)

--- a/code/modules/mob/living/basic/jungle/seedling/seedling.dm
+++ b/code/modules/mob/living/basic/jungle/seedling/seedling.dm
@@ -239,7 +239,6 @@
 	default_projectile_spread = 10
 	shot_count = 10
 	shot_delay = 0.2 SECONDS
-	melee_cooldown_time = 0 SECONDS
 	shared_cooldown = NONE
 	///how long we must charge up before firing off
 	var/charge_up_timer = 3 SECONDS

--- a/code/modules/mob/living/basic/lavaland/mook/mook_abilities.dm
+++ b/code/modules/mob/living/basic/lavaland/mook/mook_abilities.dm
@@ -29,7 +29,6 @@
 	desc = "Leap towards the enemy!"
 	cooldown_time = 7 SECONDS
 	shared_cooldown = NONE
-	melee_cooldown_time = 0 SECONDS
 	///telegraph time before jumping
 	var/wind_up_time = 2 SECONDS
 	///intervals between each of our attacks
@@ -92,7 +91,6 @@
 	desc = "Soar high in the air!"
 	cooldown_time = 14 SECONDS
 	shared_cooldown = NONE
-	melee_cooldown_time = 0 SECONDS
 	click_to_activate = FALSE
 
 /datum/action/cooldown/mob_cooldown/mook_ability/mook_jump/Activate(atom/target)

--- a/code/modules/mob/living/basic/lavaland/watcher/watcher_gaze.dm
+++ b/code/modules/mob/living/basic/lavaland/watcher/watcher_gaze.dm
@@ -11,7 +11,6 @@
 	cooldown_time = 20 SECONDS
 	click_to_activate = FALSE
 	shared_cooldown = NONE
-	melee_cooldown_time = 0 SECONDS
 	/// At what range do we check for vision?
 	var/effect_radius = 7
 	/// How long does it take to play our various animation stages

--- a/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
+++ b/code/modules/mob/living/basic/space_fauna/regal_rat/regal_rat_actions.dm
@@ -7,7 +7,6 @@
 	desc = "Corrupts this area to be more suitable for your rat army."
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_INCAPACITATED|AB_CHECK_OPEN_TURF // monkestation edit: add AB_CHECK_OPEN_TURF
 	cooldown_time = 6 SECONDS
-	melee_cooldown_time = 0 SECONDS
 	button_icon = 'icons/mob/actions/actions_animal.dmi'
 	background_icon_state = "bg_clock"
 	overlay_icon_state = "bg_clock_border"
@@ -45,7 +44,6 @@
 	background_icon_state = "bg_clock"
 	overlay_icon_state = "bg_clock_border"
 	cooldown_time = 8 SECONDS
-	melee_cooldown_time = 0 SECONDS
 	shared_cooldown = NONE
 	/// How close does something need to be for us to recruit it?
 	var/range = 5

--- a/code/modules/mob/living/basic/space_fauna/space_dragon/dragon_breath.dm
+++ b/code/modules/mob/living/basic/space_fauna/space_dragon/dragon_breath.dm
@@ -6,7 +6,6 @@
 	fire_range = 20
 	fire_temperature = 700 // Even hotter than a megafauna for some reason
 	shared_cooldown = NONE
-	melee_cooldown_time = 0 SECONDS
 
 /datum/action/cooldown/mob_cooldown/fire_breath/carp/on_burn_mob(mob/living/barbecued, mob/living/source)
 	if (!source.faction_check_atom(barbecued))

--- a/code/modules/mob/living/basic/space_fauna/wumborian_fugu/inflation.dm
+++ b/code/modules/mob/living/basic/space_fauna/wumborian_fugu/inflation.dm
@@ -11,7 +11,6 @@
 	background_icon_state = "bg_fugu"
 	overlay_icon_state = "bg_fugu_border"
 	cooldown_time = 16 SECONDS
-	melee_cooldown_time = 0 SECONDS
 
 /datum/action/cooldown/fugu_expand/IsAvailable(feedback)
 	. = ..()

--- a/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/adult/alien_powers.dm
@@ -14,7 +14,6 @@ Doesn't work on other aliens/AI.*/
 	button_icon = 'icons/mob/actions/actions_xeno.dmi'
 	button_icon_state = "spell_default"
 	check_flags = AB_CHECK_IMMOBILE | AB_CHECK_CONSCIOUS | AB_CHECK_INCAPACITATED
-	melee_cooldown_time = 0 SECONDS
 
 	/// How much plasma this action uses.
 	var/plasma_cost = 0

--- a/code/modules/mob/living/simple_animal/bot/bot_announcement.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot_announcement.dm
@@ -7,7 +7,6 @@
 	button_icon = 'icons/mob/actions/actions_AI.dmi'
 	button_icon_state = "intercom"
 	cooldown_time = 10 SECONDS
-	melee_cooldown_time = 0 SECONDS
 	/// List of strings to sound effects corresponding to automated messages we can play
 	var/list/automated_announcements
 

--- a/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vatbeast.dm
@@ -53,7 +53,6 @@
 	button_icon_state = "tentacle_slap"
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_INCAPACITATED
 	cooldown_time = 12 SECONDS
-	melee_cooldown_time = 0 SECONDS
 	click_to_activate = TRUE
 	ranged_mousepointer = 'icons/effects/mouse_pointers/supplypod_target.dmi'
 

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -50,7 +50,6 @@
 	active_overlay_icon_state = "bg_spell_border_active_red"
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_PHASED
 	panel = "Spells"
-	melee_cooldown_time = 0 SECONDS
 
 	/// The sound played on cast.
 	var/sound = null


### PR DESCRIPTION

## About The Pull Request
Port of https://github.com/tgstation/tgstation/pull/87599
melee_cooldown_time now defaults to zero instead of being null.

## Why It's Good For The Game
Is usually overridden, but when coder forgets to override it causes janky feeling combat. (Like venus flytrap not being able to attack while tangle is on cooldown.)

## Testing
## Changelog
:cl:
refactor: Actions will no longer by default apply a melee cooldown equal to action cooldown.
fix: Fixed various abilities causing melee jank, most noticeably venus man eaters
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
