### PR TITLE
Prevent stationwide blackout and disable telecomms from being discounted

### DIFF
--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -106,6 +106,7 @@
 	limited_stock = 1
 	cost = 4
 	restricted = TRUE
+	cant_discount = TRUE
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/stealthy_tools/telecomm_blackout/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)
@@ -121,6 +122,7 @@
 	limited_stock = 1
 	cost = 6
 	restricted = TRUE
+	cant_discount = TRUE
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
 
 /datum/uplink_item/stealthy_tools/blackout/spawn_item(spawn_path, mob/user, datum/uplink_handler/uplink_handler, atom/movable/source)


### PR DESCRIPTION

## About The Pull Request

this simply makes it so Disable Telecomms and Trigger Stationwide Blackout can't be discounted, as discounts bypass the usual limited stock.

## Why It's Good For The Game

Because 15 grid checks or ion storms bc someone got a discount isn't very fun tbh.

## Changelog
:cl:
balance: "Disable Telecomms" and "Trigger Stationwide Blackout" can no longer be discounted in the traitor uplink.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
