### PR TITLE
blacklists heretic paintings from gifts

### DIFF
--- a/code/game/objects/items/gift.dm
+++ b/code/game/objects/items/gift.dm
@@ -119,7 +119,7 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 		var/list/gift_types_list = subtypesof(/obj/item)
 		for(var/V in gift_types_list)
 			var/obj/item/I = V
-			if((!initial(I.icon_state)) || (!initial(I.inhand_icon_state)) || (initial(I.item_flags) & ABSTRACT))
+			if((!initial(I.icon_state)) || (!initial(I.inhand_icon_state)) || (initial(I.item_flags) & (ABSTRACT | DROPDEL)))
 				gift_types_list -= V
 		// List of items we want to block the anything-gift from spawning. Reasons for blocking
 		// these vary, but usually come down to keeping the server (and game clients) stable.
@@ -149,6 +149,11 @@ GLOBAL_LIST_EMPTY(possible_gifts)
 
 			// causes too many issues
 			/obj/structure/sign/painting/eldritch,
+
+			// abstract items that shouldn't be gotten anyways
+			/obj/item/clothing/head/chameleon/drone,
+			/obj/item/clothing/mask/chameleon/drone,
+			/obj/item/clothing/neck/necklace/ashwalker/cursed,
 
 			//A list of every debug item I could find. I compiled a list of every item in the possible gifts list
 			//and ran a keyword search through the list. Hopefully, this grabbed most, if not all, of the items.


### PR DESCRIPTION
## About The Pull Request

this blacklists all subtypes of `/obj/structure/sign/painting/eldritch` from gifts.

also blacklists DROPDEL and a couple of other abstract items, bc they typically just bug the player in a way that requires an admin to fix it.

## Why It's Good For The Game

infinite brain trauma works bc haha funny gift is not fun...

## Changelog
:cl:
del: You can no longer get those annoying heretic paintings from gifts.
fix: Fixed getting certain buggy items from christmas gifts that would require an admin to fix you.
/:cl: