### PR TITLE
Re-adds pain medication to medkits.

### DIFF
--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -99,7 +99,7 @@
 		/obj/item/stack/medical/suture = 2,
 		/obj/item/stack/medical/mesh = 2,
 		/obj/item/reagent_containers/hypospray/medipen = 1,
-		/obj/item/healthanalyzer/simple = 1,
+		/obj/item/reagent_containers/hypospray/medipen/morphine = 1,
 	)
 	generate_items_inside(items_inside,src)
 
@@ -187,7 +187,7 @@
 		/obj/item/reagent_containers/pill/patch/aiuri = 3,
 		/obj/item/reagent_containers/spray/hercuri = 1,
 		/obj/item/reagent_containers/hypospray/medipen/oxandrolone = 1,
-		/obj/item/reagent_containers/hypospray/medipen = 1)
+		/obj/item/reagent_containers/hypospray/medipen/burn_painkiller = 1)
 	generate_items_inside(items_inside,src)
 
 /obj/item/storage/medkit/toxin
@@ -262,7 +262,7 @@
 		/obj/item/stack/medical/gauze = 1,
 		/obj/item/storage/pill_bottle/probital = 1,
 		/obj/item/reagent_containers/hypospray/medipen/salacid = 1,
-		/obj/item/healthanalyzer/simple = 1,
+		/obj/item/reagent_containers/hypospray/medipen/brute_painkiller = 1,
 		)
 	generate_items_inside(items_inside,src)
 


### PR DESCRIPTION

## About The Pull Request

Re-adds pain medication to medkits

## Why It's Good For The Game

They were PR'd out because "pain is not as prevelant anymore". it defenitely is. you can get killed by 2 zaps because you'll get perma-stunned by paincrit and then suffocate to death. If you wanna go by that logic just remove pain entirely.

## Testing

I localhosted. Works.

## Changelog

Re-adds pain medication

:cl:
add: Pain medication to medkits.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
