### PR TITLE
Emoting now results in an attack cooldown, with exceptions

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -338,7 +338,7 @@
 
 /mob/proc/dance_flip()
 	if(dir == WEST)
-		emote("flip")
+		emote("flip", prevent_attack = FALSE)
 
 /obj/machinery/dance_machine/disco/proc/dance3(mob/living/M)
 	var/matrix/initial_matrix = matrix(M.transform)

--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -93,7 +93,7 @@
 			if(user.is_holding(src))
 				randdir = pick(GLOB.alldirs)
 				user.Move(get_step(user, randdir),randdir)
-				user.emote("spin")
+				user.emote("spin", prevent_attack = FALSE)
 				if (i == 3 && myhead)
 					myhead.drop_limb()
 				sleep(0.3 SECONDS)


### PR DESCRIPTION
## About The Pull Request / Why It's Good For The Game
Addresses some concerns of #9277 regarding use of emotes during combat. This is a more fundamental fix to emote abuse during combat. While currently not a major issue, in the future some new emote or niche interaction could be used in conjunction with emotes to obtain an unfair advantage in combat through emote spam. This addresses that by adding a `CLICK_CD_MELEE` (0.8s) after emoting to nerf emote use during combat. This prevents most things like picking up of items, shooting weapons or using melee weapons immediately after emoting.

## Testing
Tested with most of the emotes (I was lazy and skipped some of the silicon/IPC specific ones), and all of the action related emotes. In particular, given the mechanics of specific emotes such as *kiss, *slap, and *shoesteal, they are exempt from the cooldown. *Kiss in particular is needed to use the syndi lipstick. Deswords have been given an exemption within their own file, under the `dance_flip()` proc which it specifically uses.

Current issues:
Full auto weapons bypass the cooldown entirely as the `full_auto` datum uses raw mousedown input. I will try and work on a fix which allows full auto firing to be paused / stopped.

~~Balance wise, should *cry result in the cooldown as well? As pepperspray / swat nades use them~~
TO ADD TO EXEMPTIONS: North star, custom *me emotes, mimery finger guns (not sure, I don't play mime, will check), forced emotes (pain, VOG, etc), *cry (pepperspray), mining style meter interactions

## Changelog
:cl: Lawlolawl
balance: Emoting now prevents attacking to discourage emote spam during combat. In-hand use of items still work, however, such as quantum spin inverters and bladebreaking. Deswords and syndi lipstick which mechanically involve emoting are exempt.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [ ] You documented all of your changes.
