### PR TITLE
Disables wastes pins on Oshan station Z (also allows shooty near mining base)

### DIFF
--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -403,8 +403,9 @@
 
 		/area/lavaland/surface/outdoors,
 
-		/area/ocean/generated,
-		/area/ocean/generated_above,
+		/area/ocean, // uses Z-levels until Oshan mapping is fixed
+		// /area/ocean/generated,
+		// /area/ocean/generated_above,
 
 		/area/ruin,
 
@@ -419,7 +420,12 @@
 /obj/item/firing_pin/wastes/pin_auth(mob/living/user)
 	if(!istype(user) || is_type_in_list(get_area(user), blacklist))
 		return FALSE
-	if (is_type_in_list(get_area(user), wastes)|| SSticker.current_state == GAME_STATE_FINISHED) //now unlocks after game is over. have fun
+	if(SSticker.current_state == GAME_STATE_FINISHED) //now unlocks after game is over. have fun
+		return TRUE
+	if(is_type_in_list(get_area(user), wastes))
+		var/turf/userturf = get_turf(user)
+		if(istype(get_area(user), /area/ocean) && SSmapping.level_trait(userturf.z, ZTRAIT_STATION))
+			return FALSE // block Oshan main station Z
 		return TRUE
 	return FALSE
 


### PR DESCRIPTION
## About The Pull Request
Temporary fix until oshan areas are fixed. For reference, Icebox has `area/icemoon/surface/outdoors` which blocks wastes pins, allowing defining of blacklisted/whitelisted areas without using Z-levels, but Oshan mapping needs to be changed to follow suit. I'm no mapper, so for the time being, this is the Z-level based fix.

The use of `area/ocean/generated` basically allowed the use of wastes pins on the far exterior of the station, but not near the station, and also blocked their use near the exterior of the lavaland mining base (a nuisance because mobs can spawn pretty close to the outside of mining base). This fixes this issue by checking for the Z-level instead, and loosening the area requirement to just `area/ocean`.

## Why It's Good For The Game
Closes #9420
Fixes #9866 (will close manually)

## Testing

[OSHAN]
Wastes pin guns don't work on station Z, inside or outside anywhere.
They work anywhere on mining Z which isn't inside the mining base.
PKAs unaffected (including PK pistol and other derivatives from PKA without wastes pins)
For reference: Station Z is level 2, mining Z is level 3.

Shouldn't affect other maps.

## Changelog
:cl: Lawlolawl
balance: Disabled wastes pins on Oshan station Z, completely (even far away from station exterior).
fix: Allowed shooting of wastes pin weapons around the exterior of the Oshan mining base (previously blocked shooting when too close).
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
