### PR TITLE
Removes unused tgui context

### DIFF
--- a/tgui/packages/common/redux.ts
+++ b/tgui/packages/common/redux.ts
@@ -194,23 +194,3 @@ export const createAction = <TAction extends string>(
 
   return actionCreator;
 };
-
-// Implementation specific
-// --------------------------------------------------------
-
-export const useDispatch = <TAction extends Action = AnyAction>(context: {
-  store: Store<unknown, TAction>;
-}): Dispatch<TAction> => {
-  return context?.store?.dispatch;
-};
-
-export const useSelector = <State, Selected>(
-  context: { store: Store<State, Action> },
-  selector: (state: State) => Selected,
-): Selected => {
-  if (!context) {
-    return {} as Selected;
-  }
-
-  return selector(context?.store?.getState());
-};

--- a/tgui/packages/tgui-panel/Panel.tsx
+++ b/tgui/packages/tgui-panel/Panel.tsx
@@ -14,13 +14,13 @@ import { PingIndicator } from './ping';
 import { ReconnectButton } from './reconnect';
 import { SettingsPanel, useSettings } from './settings';
 
-export const Panel = (props, context) => {
-  const audio = useAudio(context);
-  const settings = useSettings(context);
-  const game = useGame(context);
+export const Panel = (props) => {
+  const audio = useAudio();
+  const settings = useSettings();
+  const game = useGame();
   if (process.env.NODE_ENV !== 'production') {
     const { useDebug, KitchenSink } = require('tgui/debug');
-    const debug = useDebug(context);
+    const debug = useDebug();
     if (debug.kitchenSink) {
       return <KitchenSink panel />;
     }

--- a/tgui/packages/tgui-panel/audio/NowPlayingWidget.jsx
+++ b/tgui/packages/tgui-panel/audio/NowPlayingWidget.jsx
@@ -5,15 +5,15 @@
  */
 
 import { toFixed } from 'common/math';
-import { useDispatch, useSelector } from 'common/redux';
+import { useDispatch, useSelector } from 'tgui/backend';
 import { Button, Collapsible, Flex, Knob, Section } from 'tgui/components';
 import { useSettings } from '../settings';
 import { selectAudio } from './selectors';
 
-export const NowPlayingWidget = (props, context) => {
-  const audio = useSelector(context, selectAudio),
-    dispatch = useDispatch(context),
-    settings = useSettings(context),
+export const NowPlayingWidget = (props) => {
+  const audio = useSelector(selectAudio),
+    dispatch = useDispatch(),
+    settings = useSettings(),
     title = audio.meta?.title,
     URL = audio.meta?.link,
     Artist = audio.meta?.artist || 'Unknown Artist',

--- a/tgui/packages/tgui-panel/audio/hooks.ts
+++ b/tgui/packages/tgui-panel/audio/hooks.ts
@@ -4,12 +4,12 @@
  * @license MIT
  */
 
-import { useSelector, useDispatch } from 'common/redux';
+import { useSelector, useDispatch } from 'tgui/backend';
 import { selectAudio } from './selectors';
 
-export const useAudio = (context) => {
-  const state = useSelector(context, selectAudio);
-  const dispatch = useDispatch(context);
+export const useAudio = () => {
+  const state = useSelector(selectAudio);
+  const dispatch = useDispatch();
   return {
     ...state,
     toggle: () => dispatch({ type: 'audio/toggle' }),

--- a/tgui/packages/tgui-panel/chat/ChatPageSettings.jsx
+++ b/tgui/packages/tgui-panel/chat/ChatPageSettings.jsx
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { useDispatch, useSelector } from 'common/redux';
+import { useDispatch, useSelector } from 'tgui/backend';
 import {
   Button,
   Collapsible,
@@ -24,9 +24,9 @@ import {
 import { MESSAGE_TYPES } from './constants';
 import { selectCurrentChatPage } from './selectors';
 
-export const ChatPageSettings = (props, context) => {
-  const page = useSelector(context, selectCurrentChatPage);
-  const dispatch = useDispatch(context);
+export const ChatPageSettings = (props) => {
+  const page = useSelector(selectCurrentChatPage);
+  const dispatch = useDispatch();
   return (
     <Section>
       <Stack align="center">

--- a/tgui/packages/tgui-panel/chat/ChatTabs.jsx
+++ b/tgui/packages/tgui-panel/chat/ChatTabs.jsx
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { useDispatch, useSelector } from 'common/redux';
+import { useDispatch, useSelector } from 'tgui/backend';
 import { Box, Tabs, Flex, Button } from 'tgui/components';
 import { changeChatPage, addChatPage } from './actions';
 import { selectChatPages, selectCurrentChatPage } from './selectors';
@@ -25,10 +25,10 @@ const UnreadCountWidget = ({ value }) => (
   </Box>
 );
 
-export const ChatTabs = (props, context) => {
-  const pages = useSelector(context, selectChatPages);
-  const currentPage = useSelector(context, selectCurrentChatPage);
-  const dispatch = useDispatch(context);
+export const ChatTabs = (props) => {
+  const pages = useSelector(selectChatPages);
+  const currentPage = useSelector(selectCurrentChatPage);
+  const dispatch = useDispatch();
   return (
     <Flex align="center">
       <Flex.Item>

--- a/tgui/packages/tgui-panel/game/hooks.ts
+++ b/tgui/packages/tgui-panel/game/hooks.ts
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { useSelector } from 'common/redux';
+import { useSelector } from 'tgui/backend';
 import { selectGame } from './selectors';
 
-export const useGame = (context) => {
-  return useSelector(context, selectGame);
+export const useGame = () => {
+  return useSelector(selectGame);
 };

--- a/tgui/packages/tgui-panel/ping/PingIndicator.jsx
+++ b/tgui/packages/tgui-panel/ping/PingIndicator.jsx
@@ -6,12 +6,12 @@
 
 import { Color } from 'common/color';
 import { toFixed } from 'common/math';
-import { useSelector } from 'common/redux';
+import { useSelector } from 'tgui/backend';
 import { Box } from 'tgui/components';
 import { selectPing } from './selectors';
 
-export const PingIndicator = (props, context) => {
-  const ping = useSelector(context, selectPing);
+export const PingIndicator = (props) => {
+  const ping = useSelector(selectPing);
   const color = Color.lookup(ping.networkQuality, [
     new Color(220, 40, 40),
     new Color(220, 200, 40),

--- a/tgui/packages/tgui-panel/settings/SettingsPanel.jsx
+++ b/tgui/packages/tgui-panel/settings/SettingsPanel.jsx
@@ -7,7 +7,7 @@
 import { toFixed } from 'common/math';
 import { capitalize } from 'common/string';
 import { useLocalState } from 'tgui/backend';
-import { useDispatch, useSelector } from 'common/redux';
+import { useDispatch, useSelector } from 'tgui/backend';
 import {
   Box,
   Button,
@@ -47,9 +47,9 @@ import { importChatSettings } from './settingsImExport';
 import { reconnectWebsocket, disconnectWebsocket } from '../websocket';
 import { chatRenderer } from '../chat/renderer';
 
-export const SettingsPanel = (props, context) => {
-  const activeTab = useSelector(context, selectActiveTab);
-  const dispatch = useDispatch(context);
+export const SettingsPanel = (props) => {
+  const activeTab = useSelector(selectActiveTab);
+  const dispatch = useDispatch();
   return (
     <Stack fill>
       <Stack.Item>
@@ -84,12 +84,10 @@ export const SettingsPanel = (props, context) => {
   );
 };
 
-export const SettingsGeneral = (props, context) => {
-  const { theme, fontFamily, coloredNames, fontSize, lineHeight } = useSelector(
-    context,
-    selectSettings,
-  );
-  const dispatch = useDispatch(context);
+export const SettingsGeneral = (props) => {
+  const { theme, fontFamily, coloredNames, fontSize, lineHeight } =
+    useSelector(selectSettings);
+  const dispatch = useDispatch();
   const [freeFont, setFreeFont] = useLocalState('freeFont', false);
   const [editingPanes, setEditingPanes] = useLocalState('freeFont', false);
 
@@ -280,9 +278,9 @@ export const SettingsGeneral = (props, context) => {
   );
 };
 
-const TextHighlightSettings = (props, context) => {
-  const highlightSettings = useSelector(context, selectHighlightSettings);
-  const dispatch = useDispatch(context);
+const TextHighlightSettings = (props) => {
+  const highlightSettings = useSelector(selectHighlightSettings);
+  const dispatch = useDispatch();
   return (
     <Section fill scrollable height="250px">
       <Stack vertical>
@@ -326,10 +324,10 @@ const TextHighlightSettings = (props, context) => {
   );
 };
 
-const TextHighlightSetting = (props, context) => {
+const TextHighlightSetting = (props) => {
   const { id, ...rest } = props;
-  const highlightSettingById = useSelector(context, selectHighlightSettingById);
-  const dispatch = useDispatch(context);
+  const highlightSettingById = useSelector(selectHighlightSettingById);
+  const dispatch = useDispatch();
   const {
     enabled,
     highlightColor,
@@ -451,10 +449,10 @@ const TextHighlightSetting = (props, context) => {
   );
 };
 
-const ExperimentalSettings = (props, context) => {
+const ExperimentalSettings = (props) => {
   const { websocketEnabled, websocketServer, scrollTrackingTolerance } =
-    useSelector(context, selectSettings);
-  const dispatch = useDispatch(context);
+    useSelector(selectSettings);
+  const dispatch = useDispatch();
 
   return (
     <Section>
@@ -564,12 +562,10 @@ const LinkedToChat = () => (
   <NoticeBox color="red">Unlink Stat Panel from chat!</NoticeBox>
 );
 
-const SettingsStatPanel = (props, context) => {
-  const { statLinked, statFontSize, statTabsStyle } = useSelector(
-    context,
-    selectSettings,
-  );
-  const dispatch = useDispatch(context);
+const SettingsStatPanel = (props) => {
+  const { statLinked, statFontSize, statTabsStyle } =
+    useSelector(selectSettings);
+  const dispatch = useDispatch();
 
   return (
     <Section fill>

--- a/tgui/packages/tgui-panel/settings/hooks.ts
+++ b/tgui/packages/tgui-panel/settings/hooks.ts
@@ -4,13 +4,13 @@
  * @license MIT
  */
 
-import { useDispatch, useSelector } from 'common/redux';
+import { useDispatch, useSelector } from 'tgui/backend';
 import { updateSettings, toggleSettings } from './actions';
 import { selectSettings } from './selectors';
 
-export const useSettings = (context) => {
-  const settings = useSelector(context, selectSettings);
-  const dispatch = useDispatch(context);
+export const useSettings = () => {
+  const settings = useSelector(selectSettings);
+  const dispatch = useDispatch();
   return {
     ...settings,
     visible: settings.view.visible,

--- a/tgui/packages/tgui/backend.ts
+++ b/tgui/packages/tgui/backend.ts
@@ -533,3 +533,11 @@ export const useSharedState = <T>(
     },
   ];
 };
+
+export const useDispatch = () => {
+  return globalStore.dispatch;
+};
+
+export const useSelector = (selector: (state: any) => any) => {
+  return selector(globalStore?.getState());
+};

--- a/tgui/packages/tgui/debug/hooks.js
+++ b/tgui/packages/tgui/debug/hooks.js
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { useSelector } from 'common/redux';
+import { useSelector } from 'tgui/backend';
 import { selectDebug } from './selectors';
 
-export const useDebug = (context) => useSelector(context, selectDebug);
+export const useDebug = () => useSelector(selectDebug);

--- a/tgui/packages/tgui/interfaces/DiscordVerification.tsx
+++ b/tgui/packages/tgui/interfaces/DiscordVerification.tsx
@@ -24,7 +24,7 @@ interface DiscordVerificationData {
   };
 }
 
-export const DiscordVerification = (props, context) => {
+export const DiscordVerification = (props) => {
   const { data } = useBackend<DiscordVerificationData>();
   const { verification_code, discord_invite } = data;
 

--- a/tgui/packages/tgui/interfaces/ExosuitFabricator.tsx
+++ b/tgui/packages/tgui/interfaces/ExosuitFabricator.tsx
@@ -380,7 +380,7 @@ const QueueList = (props: QueueListProps) => {
   );
 };
 
-const Authorization = (props, context) => {
+const Authorization = (props) => {
   const { data } = useBackend<ExosuitFabricatorData>();
   const auth_override = data.authorization;
   const alert_level = data.alert_level;

--- a/tgui/packages/tgui/interfaces/Machining.tsx
+++ b/tgui/packages/tgui/interfaces/Machining.tsx
@@ -47,7 +47,7 @@ type Data = {
   atom_data: String[];
 };
 
-export const Machining = (props, context) => {
+export const Machining = (props) => {
   const [activeTab, setActiveTab] = useLocalState(
     'machiningTab',
     TAB_LIST[0].key,
@@ -169,7 +169,7 @@ export const Machining = (props, context) => {
   );
 };
 
-const MainRecipeScreen = (props, context) => {
+const MainRecipeScreen = (props) => {
   const { act, data } = useBackend<Data>();
   const { tab, searchText } = props;
   const { recipes, atom_data, busy } = data;

--- a/tgui/packages/tgui/interfaces/StackCraft.jsx
+++ b/tgui/packages/tgui/interfaces/StackCraft.jsx
@@ -23,7 +23,7 @@ export const StackCraft = () => {
   );
 };
 
-const Recipes = (props, context) => {
+const Recipes = (props) => {
   const { data } = useBackend();
   const { amount, recipes } = data;
   const [searchText, setSearchText] = useLocalState('searchText', '');
@@ -125,8 +125,8 @@ const calculateMultiplier = (recipe, amount) => {
   return Math.floor(amount / recipe.required_amount);
 };
 
-const Multipliers = (props, context) => {
-  const { act } = useBackend(context);
+const Multipliers = (props) => {
+  const { act } = useBackend();
 
   const { recipe, max_possible_multiplier } = props;
 
@@ -176,7 +176,7 @@ const Multipliers = (props, context) => {
   return <>{finalResult.map((x) => x)}</>;
 };
 
-const RecipeListBox = (props, context) => {
+const RecipeListBox = (props) => {
   const { recipes } = props;
 
   return Object.entries(recipes).map((entry) => {
@@ -204,8 +204,8 @@ const RecipeListBox = (props, context) => {
   });
 };
 
-const RecipeBox = (props, context) => {
-  const { act, data } = useBackend(context);
+const RecipeBox = (props) => {
+  const { act, data } = useBackend();
   const { amount } = data;
   const { title, recipe } = props;
   const { result_amount, required_amount, max_result_amount, ref, image } =

--- a/tgui/packages/tgui/stories/ImageButton.stories.js
+++ b/tgui/packages/tgui/stories/ImageButton.stories.js
@@ -38,7 +38,7 @@ const COLORS_SPECTRUM = [
 
 const COLORS_STATES = ['good', 'average', 'bad', 'black', 'white'];
 
-const Story = (props, context) => {
+const Story = (props) => {
   const [disabled, setDisabled] = useLocalState('disabled', false);
   const [onClick, setOnClick] = useLocalState('onClick', true);
   const [vertical1, setVertical1] = useLocalState('vertical1', true);


### PR DESCRIPTION
## About The Pull Request
This removes some unused references to context in tgui, which should have been removed near #2331
## Why It's Good For The Game
Moves you closer to react! This was unused anyways
## Testing
I ran this in F5, but it also has been on TG for over a year
## Changelog
Nothing player facing 
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
