### PR TITLE
pain datum deletes itself on creation (temporary measure to disable pain)

### DIFF
--- a/monkestation/code/modules/can_spessmen_feel_pain/pain/_base.dm
+++ b/monkestation/code/modules/can_spessmen_feel_pain/pain/_base.dm
@@ -42,26 +42,26 @@
 	qdel(src) // temporary measure to disable pain - snk 12/21/2025
 	return null
 
-	parent = new_parent
+// 	parent = new_parent
 
-	body_zones = list()
-	for(var/obj/item/bodypart/parent_bodypart as anything in parent.bodyparts)
-		add_bodypart(parent, parent_bodypart, TRUE)
+// 	body_zones = list()
+// 	for(var/obj/item/bodypart/parent_bodypart as anything in parent.bodyparts)
+// 		add_bodypart(parent, parent_bodypart, TRUE)
 
-	if(!length(body_zones))
-		stack_trace("Pain datum failed to find any body_zones to track!")
-		qdel(src) // If we have no bodyparts, delete us
-		return
+// 	if(!length(body_zones))
+// 		stack_trace("Pain datum failed to find any body_zones to track!")
+// 		qdel(src) // If we have no bodyparts, delete us
+// 		return
 
-	register_pain_signals()
-	base_pain_decay = natural_pain_decay
+// 	register_pain_signals()
+// 	base_pain_decay = natural_pain_decay
 
-	addtimer(CALLBACK(src, PROC_REF(start_pain_processing), 1))
+// 	addtimer(CALLBACK(src, PROC_REF(start_pain_processing), 1))
 
-#ifdef TESTING
-	if(new_parent.z && !is_station_level(new_parent.z))
-		print_debug_messages = FALSE
-#endif
+// #ifdef TESTING
+// 	if(new_parent.z && !is_station_level(new_parent.z))
+// 		print_debug_messages = FALSE
+// #endif
 
 /datum/pain/Destroy()
 	body_zones = null


### PR DESCRIPTION
## About The Pull Request
temporary measure to disable pain while i figure out what to do with it.
## Why It's Good For The Game
pain as a system has been slowly getting disabled in steps since it was added.
## Testing

## Changelog

:cl:
removal: disabled pain temporarily. 
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

