### PR TITLE
Fix Plasma Fixation killing oozelings

### DIFF
--- a/monkestation/code/modules/virology/disease/symtoms/helpful/plasma_heal.dm
+++ b/monkestation/code/modules/virology/disease/symtoms/helpful/plasma_heal.dm
@@ -95,13 +95,16 @@
 		if(prob(5))
 			to_chat(M, span_notice("You feel warmer."))
 
-
-	M.adjustToxLoss(-heal_amt)
+	var/should_update = M.adjustToxLoss(-heal_amt, forced = TRUE, updating_health = FALSE)
 
 	if(M.getBruteLoss_nonProsthetic() > 0 || M.getFireLoss_nonProsthetic() > 0)
-		M.heal_overall_damage(brute = heal_amt, burn = heal_amt, required_bodytype = BODYTYPE_ORGANIC)
+		M.heal_overall_damage(brute = heal_amt, burn = heal_amt, required_bodytype = BODYTYPE_ORGANIC, updating_health = FALSE)
+		should_update = TRUE
 		if(prob(5))
 			to_chat(M, span_notice("The pain from your wounds fades rapidly."))
+
+	if(should_update)
+		M.updatehealth()
 	return TRUE
 
 ///Plasma End


### PR DESCRIPTION
## About The Pull Request

Oozelings _already_ can breathe plasma to heal toxins and restore blood level, so it makes no sense that a symptom that heals from plasma would hurt beings that can already breathe plasma???

also very slight code optimization

## Why It's Good For The Game

just makes sense tbh

## Changelog
:cl:
fix: Plasma Fixation no longer kills oozelings... why did something that healed from breathing plasma hurt people who could already heal from breathing plasma anyways?
/:cl:
