### PR TITLE
nerfs oil extract explosions

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -441,7 +441,7 @@
 			user.visible_message(span_warning("[user]'s skin starts pulsing and glowing ominously..."), span_userdanger("You feel unstable..."))
 			if(do_after(user, 6 SECONDS, target = user))
 				to_chat(user, span_userdanger("You explode!"))
-				explosion(user, devastation_range = 0, heavy_impact_range = 1, light_impact_range = 3, explosion_cause = src)
+				explosion(user, devastation_range = 1, heavy_impact_range = 3, light_impact_range = 6, explosion_cause = src)
 				user.investigate_log("has been gibbed by an oil slime extract explosion.", INVESTIGATE_DEATHS)
 				user.gib()
 				return


### PR DESCRIPTION

## About The Pull Request
title

## Why It's Good For The Game
mass producable items shouldn't be stronger than Syndicate minibombs.

## Testing

## Changelog

:cl:
balance: lessened the explosion effect of oil extracts.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

