### PR TITLE
Adds a character preference to give MODlink scryers a default label

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -355,7 +355,7 @@
 		humanspawned.equip_in_one_of_slots(silly_little_scarf, slots, qdel_on_fail = FALSE)
 
 	var/obj/item/clothing/neck/link_scryer/loaded/new_scryer = new(spawned)
-	new_scryer.label = spawned.name
+	new_scryer.label = player_client?.prefs?.read_preference(/datum/preference/text/default_scryer_label) || spawned.real_name
 	new_scryer.update_name()
 
 	spawned.equip_to_slot_or_del(new_scryer, ITEM_SLOT_NECK, initial = FALSE)

--- a/code/modules/client/preferences/default_scryer_label.dm
+++ b/code/modules/client/preferences/default_scryer_label.dm
@@ -1,0 +1,19 @@
+/datum/preference/text/default_scryer_label
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_key = "default_scryer_label"
+	savefile_identifier = PREFERENCE_CHARACTER
+	maximum_value_length = MAX_NAME_LEN
+
+/datum/preference/text/default_scryer_label/is_valid(value)
+	if(!value)
+		return TRUE
+	if(!istext(value))
+		return FALSE
+	if(length_char(value) > maximum_value_length)
+		return FALSE
+	if(!reject_bad_text(value))
+		return FALSE
+	return TRUE
+
+/datum/preference/text/default_scryer_label/apply_to_human(mob/living/carbon/human/target, value)
+	return

--- a/monkestation/code/modules/loadouts/items/neck.dm
+++ b/monkestation/code/modules/loadouts/items/neck.dm
@@ -207,6 +207,16 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 	name = "MODlink Scryer"
 	item_path = /obj/item/clothing/neck/link_scryer/loaded
 
+/datum/loadout_item/neck/modlink/post_equip_item(datum/preferences/preference_source, mob/living/carbon/human/equipper)
+	. = ..()
+	var/label = preference_source?.read_preference(/datum/preference/text/default_scryer_label)
+	if(!label)
+		return
+	var/obj/item/clothing/neck/link_scryer/scryer = locate(item_path) in equipper.get_equipped_items()
+	if(scryer)
+		scryer.label = label
+		scryer.update_name()
+
 /*
 *	DONATOR
 */

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3771,6 +3771,7 @@
 #include "code\modules\client\preferences\broadcast_login_logout.dm"
 #include "code\modules\client\preferences\clothing.dm"
 #include "code\modules\client\preferences\credits.dm"
+#include "code\modules\client\preferences\default_scryer_label.dm"
 #include "code\modules\client\preferences\flash_visuals.dm"
 #include "code\modules\client\preferences\food_allergy.dm"
 #include "code\modules\client\preferences\fov_darkness.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/scryer.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/scryer.tsx
@@ -1,0 +1,8 @@
+import { Feature, FeatureShortTextInput } from '../base';
+
+export const default_scryer_label: Feature<string> = {
+  name: 'Default Scryer Label',
+  description:
+    'Default label to use for whenever you spawn with a MODlink scryer - either from loadout or a station trait.',
+  component: FeatureShortTextInput,
+};


### PR DESCRIPTION

## About The Pull Request

exactly what it says on the tin.

## Why It's Good For The Game

makes things more convenient :D

## Testing

<img width="378" height="387" alt="2025-12-22 (1766444708) ~ dreamseeker" src="https://github.com/user-attachments/assets/53d7e19a-5180-4485-9868-6e884a76d3d4" />

## Changelog
:cl:
add: Added a new "Default Scryer Label" character preference, which will set the default label of a MODlink scryer if you spawn with one, either via loadout or the station trait.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
