### PR TITLE
Fixed the Tin Man and Prosthetic Organ quirks being copied to oozelings when they revive

### DIFF
--- a/monkestation/code/modules/surgery/organs/internal/brain.dm
+++ b/monkestation/code/modules/surgery/organs/internal/brain.dm
@@ -88,11 +88,14 @@ GLOBAL_LIST_EMPTY_TYPED(dead_oozeling_cores, /obj/item/organ/internal/brain/slim
 	))
 	/// Quirks that should just be completely skipped.
 	var/static/list/skip_quirks = typecacheof(list(
+		/datum/quirk/cybernetics_quirk,
 		/datum/quirk/drg_callout, // skillchips are in the brain anyways
+		/datum/quirk/item_quirk/food_allergic,
 		/datum/quirk/prosthetic_limb,
+		/datum/quirk/prosthetic_organ,
 		/datum/quirk/quadruple_amputee,
 		/datum/quirk/stowaway,
-		/datum/quirk/cybernetics_quirk,
+		/datum/quirk/tin_man,
 	))
 
 	var/rebuilt = TRUE


### PR DESCRIPTION

## About The Pull Request

this adds Tin Man and Prosthetic Organ to the oozeling core "skip_quirks" list

oozelings cannot normally select these quirks anyways, so this only matters whenever someone becomes an oozeling via xenobio and such - and if they get revived from a core, they get stuck as a nugget due to being unable to regen limbs.

## Why It's Good For The Game

bugfix

## Changelog
:cl:
fix: Fixed the Tin Man and Prosthetic Organ quirks being copied to oozelings when they revive.
/:cl: