### PR TITLE
fix Default Scryer Label option not applying if you spawn with a case

### DIFF
--- a/monkestation/code/modules/loadouts/items/neck.dm
+++ b/monkestation/code/modules/loadouts/items/neck.dm
@@ -209,7 +209,7 @@ GLOBAL_LIST_INIT(loadout_necks, generate_loadout_items(/datum/loadout_item/neck)
 
 /datum/loadout_item/neck/modlink/post_equip_item(datum/preferences/preference_source, mob/living/carbon/human/equipper)
 	. = ..()
-	var/obj/item/clothing/neck/link_scryer/scryer = locate(item_path) in equipper.get_equipped_items()
+	var/obj/item/clothing/neck/link_scryer/scryer = locate(item_path) in equipper.get_all_gear()
 	if(!scryer)
 		return
 	scryer.set_ringtone(preference_source.read_preference(/datum/preference/choiced/call_ringtone))


### PR DESCRIPTION
## Changelog
:cl:
fix: Fixed the Default Scryer Label option not applying if you spawn with a case.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
