### PR TITLE
[BALANCE] [FIX] Fixes evil clones not having red eyes + removes experimental cloning pod board from cargo & techweb

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -211,6 +211,9 @@ GLOBAL_LIST_INIT(ai_employers, list(
 /// Checks if the given mob is a blood cultist
 #define IS_CULTIST(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/cult))
 
+///Checks if the given mob is an evil clone
+#define IS_EVIL_CLONE(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/evil_clone))
+
 /// Checks if the given mob is a nuclear operative
 #define IS_NUKE_OP(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/nukeop))
 

--- a/code/datums/elements/cult_eyes.dm
+++ b/code/datums/elements/cult_eyes.dm
@@ -22,7 +22,7 @@
 /datum/element/cult_eyes/proc/set_eyes(mob/living/target)
 	SIGNAL_HANDLER
 
-	if(!IS_CULTIST(target))
+	if(!IS_CULTIST(target) && !IS_EVIL_CLONE(target))
 		target.RemoveElement(/datum/element/cult_eyes)
 		return
 

--- a/monkestation/code/modules/cargo/crates/large.dm
+++ b/monkestation/code/modules/cargo/crates/large.dm
@@ -1,15 +1,3 @@
-/datum/supply_pack/medical/experimental_cloner
-	name = "Experimental Cloner Crate"
-	desc = "A complete circuitboard set to a Experimental Cloner Pod and Scanner. Caution: Highly Experimental"
-	cost = 5000
-	access = ACCESS_CARGO
-	contains = list(/obj/item/circuitboard/machine/clonepod/experimental,
-					/obj/item/circuitboard/machine/clonescanner,
-					/obj/item/circuitboard/computer/cloning)
-	crate_name = "Experimental Cloner Crate"
-	crate_type = /obj/structure/closet/crate/medical
-	dangerous = TRUE
-
 /datum/supply_pack/engine/tesla_gen
 	name = "Tesla Generator Crate"
 	desc = "The key to unlocking the power of the Tesla energy ball. Particle Accelerator not included."

--- a/monkestation/code/modules/research/designs/machine_designs.dm
+++ b/monkestation/code/modules/research/designs/machine_designs.dm
@@ -19,17 +19,6 @@
 	)
 	departmental_flags =  DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
 
-/datum/design/board/clonepod_experimental
-	name = "Experimental Clone Pod"
-	desc = "Allows for the construction of circuit boards used to build an Experimental Cloning Pod."
-	id = "clonepod_experimental"
-	build_path = /obj/item/circuitboard/machine/clonepod/experimental
-	category = list(
-		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_GENETICS
-	)
-	departmental_flags =  DEPARTMENT_BITFLAG_SCIENCE
-
-
 /datum/design/board/clonescanner	//hippie end, re-add cloning
 	name = "Cloning Scanner"
 	desc = "Allows for the construction of circuit boards used to build a Cloning Scanner."

--- a/monkestation/code/modules/research/techweb/all_nodes.dm
+++ b/monkestation/code/modules/research/techweb/all_nodes.dm
@@ -3,7 +3,7 @@
 	display_name = "Cloning"
 	description = "We have the technology to make him."
 	prereq_ids = list("biotech")
-	design_ids = list("clonecontrol", "clonepod", "clonescanner", "dnascanner", "dna_disk", "clonepod_experimental")
+	design_ids = list("clonecontrol", "clonepod", "clonescanner", "dnascanner", "dna_disk")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 	announce_channels = list(RADIO_CHANNEL_SCIENCE)
 


### PR DESCRIPTION

## About The Pull Request
Fixes: https://github.com/Monkestation/Monkestation2.0/issues/10041

Fixes evil clones not having glowy red eyes like they are supposed to, which was accidentally broken by this PR ~4 months ago: https://github.com/Monkestation/Monkestation2.0/pull/7427

Removes the experimental cloning pod from the techweb and cargo. 

## Why It's Good For The Game

Bug fix good.

The experimental cloning pod is meant to be traitor gear (which is why I let it have auto-processing enabled still on the previous PR where I removed that from normal cloning), I have no idea why it was hidden in a cargo order and the techweb. 
 
## Testing

Tested on localhost, gave myself evil clone datum and got those beautiful red eyes. Also double checked and yes the experimental cloner board is gone from RND and cargo.

## Changelog
:cl:
fix: Evil clones once again have red eyes like they are supposed to.
balance: Experimental cloning pod board is removed from cargo and the sci techweb. Still accessible via traitor uplink, as intended.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
