### PR TITLE
Fixes explosive implants not working properly for 3 months

### DIFF
--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -129,13 +129,12 @@
 	if(imp_in && !imp_in.stat)
 		imp_in.visible_message(span_warning("[imp_in] doubles over in pain!"))
 		imp_in.Paralyze(14 SECONDS)
-	//total of 4 bomb beeps, and we've already beeped once
-	//for extra spice
-	var/beep_volume = 35
-	for(var/i in 1 to 3)
-		playsound(loc, 'sound/items/timer.ogg', beep_volume, FALSE)
+	for(var/index in 1 to 3) // Total of 4 bomb beeps, and we've already beeped once
+		//for extra spice
+		var/beep_volume = 30 + (5 * index)
+		playsound(loc, 'sound/items/timer.ogg', beep_volume, vary = FALSE)
 		sleep(delay * 0.25)
-		beep_volume += 5
+
 	explosion(src, devastation_range = explosion_devastate, heavy_impact_range = explosion_heavy, light_impact_range = explosion_light, flame_range = explosion_light, flash_range = explosion_light, explosion_cause = src)
 	if(imp_in)
 		imp_in.investigate_log("has been gibbed by an explosive implant.", INVESTIGATE_DEATHS)


### PR DESCRIPTION

## About The Pull Request

`if(delay <= delay)` moment, thats now fixed
Now explosive implants take time to explode if they aren''t the basic micro variety
Ports:
- https://github.com/tgstation/tgstation/pull/76173

## Why It's Good For The Game

> Now explosive implants take time to explode if they aren''t the basic micro variety
- Game working as intended is good yeah?

## Testing

I exploded a person with a microbomb and they exploded
I exploded a person with a macrobomb and they exploded (after 7 seconds)

## Changelog

:cl:
fix: macrobombs are no longer instant, this was broken for 3 months.
/:cl:

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [X] You documented all of your changes.
