### PR TITLE
[BALANCE] Gives commando operatives microbomb implants by default + allows recalling the automatic shuttle after nuke is disarmed.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_bomb/commando_nuke.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_bomb/commando_nuke.dm
@@ -172,7 +172,6 @@
 		)
 		if(SSsecurity_level.get_current_level_as_number() == SEC_LEVEL_DELTA)
 			SSsecurity_level.set_level(SEC_LEVEL_RED)
-		SSshuttle.admin_emergency_no_recall = TRUE
 		if(!EMERGENCY_AT_LEAST_DOCKED)
 			SSshuttle.emergency.request()
 	return ..()

--- a/code/modules/antagonists/nukeop/outfits.dm
+++ b/code/modules/antagonists/nukeop/outfits.dm
@@ -217,8 +217,6 @@
 
 	uplink_type = null
 
-	implant_explosive_implant = FALSE
-
 /datum/outfit/syndicate/commando/plasmaman
 	name = "Syndicate Commando Operative (Plasmaman)"
 	head = /obj/item/clothing/head/helmet/space/plasmaman/syndie


### PR DESCRIPTION

## About The Pull Request

See title or changelog.

## Why It's Good For The Game

I honestly have no idea why they didn't have microbombs by default anyways - as far as I can tell there's no good balance reason for this. Crew don't need to get their hands on all the juicy operative gear, and besides, nukies blowing up is thematic. They also still start with atropine pens so, you can still prevent fellow operatives blowing up by atropine penning them. 

Occasionally commando ops get rolled without doing too much damage and the rest of the people in the round may want to keep playing - allowing the shuttle to be recalled is a good way to allow this to happen if the command in the round decide the situation is salvageable. 

## Testing

Tested on localhost - spawned myself in as a commando op, had a microbomb. Brought nuke to station, armed nuke, destroyed it, shuttle was still auto called but I was able to recall it. 

## Changelog
:cl:
balance: Commando operatives now start with syndicate microbomb implants, like normal nuclear operatives.
balance: Disarming/destroying the commando operative nuke still automatically calls the shuttle, but the shuttle is now recallable if command so desires. 
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
