### PR TITLE
CoPilot woke me up and told me to do this: slightly nerfs gripper gloves & slightly buffs gorilla's.

### DIFF
--- a/code/modules/clothing/gloves/tacklers.dm
+++ b/code/modules/clothing/gloves/tacklers.dm
@@ -21,7 +21,7 @@
 	/// See: [/datum/component/tackler/var/speed]
 	var/tackle_speed = 1
 	/// See: [/datum/component/tackler/var/skill_mod]
-	var/skill_mod = 1.5 //monkestation edit: 0 to 2
+	var/skill_mod = 1.5 //monkestation edit: 0 to 2 to 1.5
 
 /obj/item/clothing/gloves/tackler/Destroy()
 	tackler = null
@@ -66,7 +66,7 @@
 	tackle_stam_cost = 30
 	base_knockdown = 1.25 SECONDS
 	tackle_range = 5
-	skill_mod = 3
+	skill_mod = 3 // monkestation edit: 2 to 3, to compensate for the gripper buff
 
 
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT


### PR DESCRIPTION

## About The Pull Request

Fixes #10095 - [slight oversight on the coder's part](https://github.com/Monkestation/Monkestation2.0/pull/4721) when buffing the gripper gloves to the same status as the gorrila gloves, without buffing them along the way (since they're meant to be more powerful than the security-issued ones). Or someone else changed them back, I couldn't be assed to git blame it.

Gripper gloves' `skill_mod` was modified from `2` to `1.5`;
Gorilla gloves' `skill_mod` was modified from `2` to `3`.

## Why It's Good For The Game

On a server with more than 10 security slots, every pro-antagonist buff is valid!

## Testing

Refer to changed files.

## Changelog
:cl:Chelxox
balance: Gripper gloves & gorilla gloves properly balanced.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
