### PR TITLE
[FIX] Fixes evil clones not having red eyes.

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -211,6 +211,9 @@ GLOBAL_LIST_INIT(ai_employers, list(
 /// Checks if the given mob is a blood cultist
 #define IS_CULTIST(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/cult))
 
+///Checks if the given mob is an evil clone
+#define IS_EVIL_CLONE(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/evil_clone))
+
 /// Checks if the given mob is a nuclear operative
 #define IS_NUKE_OP(mob) (mob?.mind?.has_antag_datum(/datum/antagonist/nukeop))
 

--- a/code/datums/elements/cult_eyes.dm
+++ b/code/datums/elements/cult_eyes.dm
@@ -22,7 +22,7 @@
 /datum/element/cult_eyes/proc/set_eyes(mob/living/target)
 	SIGNAL_HANDLER
 
-	if(!IS_CULTIST(target))
+	if(!IS_CULTIST(target) && !IS_EVIL_CLONE(target))
 		target.RemoveElement(/datum/element/cult_eyes)
 		return
 


### PR DESCRIPTION

## About The Pull Request

Fixes: https://github.com/Monkestation/Monkestation2.0/issues/10041

Fixes evil clones not having glowy red eyes like they are supposed to, which was accidentally broken by this PR ~4 months ago: https://github.com/Monkestation/Monkestation2.0/pull/7427

## Why It's Good For The Game

Bug fix good.

## Testing

Tested on localhost, gave myself evil clone datum and got those beautiful red eyes.

## Changelog
:cl:
fix: Evil clones once again have glowing red eyes like they are supposed to.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
