### PR TITLE
[BALANCE] Gives changeling armor flashbang & pepperspray protection. Adjusts the costs of a couple powers. 

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -169,7 +169,7 @@
 	helptext = "We may retract our armblade in the same manner as we form it. Cannot be used while in lesser form."
 	button_icon_state = "armblade"
 	chemical_cost = 20
-	dna_cost = 2
+	dna_cost = 1
 	req_human = TRUE
 	weapon_type = /obj/item/melee/arm_blade
 	weapon_name_simple = "blade"
@@ -519,11 +519,11 @@
 \***************************************/
 /datum/action/changeling/suit/armor
 	name = "Chitinous Armor"
-	desc = "We turn our skin into tough chitin to protect us from damage. Costs 20 chemicals."
+	desc = "We turn our skin into tough chitin to protect us from damage, as well as pepperspray and flashbangs. Costs 20 chemicals."
 	helptext = "Upkeep of the armor requires a low expenditure of chemicals. The armor provides decent protection against brute force and energy weapons. Cannot be used in lesser form."
 	button_icon_state = "chitinous_armor"
 	chemical_cost = 20
-	dna_cost = 1
+	dna_cost = 2
 	req_human = TRUE
 	recharge_slowdown = 0.125
 	weird = TRUE
@@ -564,13 +564,19 @@
 
 /obj/item/clothing/head/helmet/changeling
 	name = "chitinous mass"
-	desc = "A tough, hard covering of black chitin with transparent chitin in front."
+	desc = "A tough, hard covering of black chitin with transparent chitin in front. It will shield you from the effects of pepperspray and flashbangs."
 	icon_state = "lingarmorhelmet"
 	inhand_icon_state = null
 	item_flags = DROPDEL
 	armor_type = /datum/armor/helmet_changeling
 	flags_inv = HIDEEARS|HIDEHAIR|HIDEEYES|HIDEFACIALHAIR|HIDEFACE|HIDESNOUT
+	flags_cover = PEPPERPROOF
+	flash_protect = FLASH_PROTECTION_WELDER
 	resistance_flags = FLAMMABLE //MONKESTATION ADDITION
+
+/obj/item/clothing/head/helmet/changeling/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/wearertargeting/earprotection, list(ITEM_SLOT_HEAD))
 
 /datum/armor/helmet_changeling
 	melee = 40


### PR DESCRIPTION

## About The Pull Request

Changeling armor (specifically the helmet) now gives you flashbang protection (including tier 2 flash protection) and pepperspray protection.

The changeling armor ability now costs 2 dna points instead of 1.

The changeling armblade ability now costs 1 dna point instead of 2. 

## Why It's Good For The Game

Changeling as an antagonist actually has no built-in sources of flashbang or pepper protection (they have flash prot with augmented eyesight, but not bang)- while I think this is fine for _most_ antagonists as they are supposed to be 'just a guy' with special gear/spells/abilities whatever (but still ultimately human), changelings are _not_ just a guy. They are supposed to be The Thing from Space, and part of their gimmick is being able to rely entirely on their built in abilities for strength, as opposed to relying on gear- so having to rely on gear for protection from 2 pretty accessible security stuns doesn't really make sense. 

I slightly increased the dna cost of the armor ability because 1 is kinda crazy low for how good it is - especially since armor will be affecting ranged stamina weapons soon (https://github.com/Monkestation/Monkestation2.0/pull/9849), it's quite strong armor and now also gives extra resistance to more stuns- so made it a little more expensive. 

I slightly decreased the dna cost of the armblade ability because 2 is, in my opinion, pretty expensive for how good the weapon actually is- yes it's undroppable, but it's only 25 damage, has no blocking, makes you hyper valid, and doesn't even have armor penetration. Armblades are kinda the quintessential changeling weapon so I want them to be more accessible. 

These 2 adjustments also means the classic armor + blade ling combo is still the same price as before, when combined. 

## Testing

Tested on localhost - I could not flashbang, flash, or pepperspray a chitin ling. 

## Changelog
:cl:
balance: Ling's chitin armor (specifically the helmet) now protects from flashes, flashbangs, and pepperspray.
balance: Ling's chitin armor ability cost increased from 1 dna point to 2.
balance: Ling's armblade ability cost decreased from 2 dna points to 1. 
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
