### PR TITLE
Adds an SMES for the SM emitters on Void Raptor

### DIFF
--- a/_maps/map_files/Voidraptor/VoidRaptor.dmm
+++ b/_maps/map_files/Voidraptor/VoidRaptor.dmm
@@ -2120,6 +2120,7 @@
 /obj/structure/reflector/single/anchored{
 	dir = 5
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/supermatter/room)
 "aEE" = (
@@ -11229,6 +11230,7 @@
 /obj/structure/reflector/single/anchored{
 	dir = 9
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/supermatter/room)
 "dqJ" = (
@@ -21096,6 +21098,7 @@
 /area/station/maintenance/department/medical/morgue)
 "gcY" = (
 /obj/structure/girder,
+/obj/structure/cable,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/supermatter/room)
 "gdk" = (


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/10116

<img width="1320" height="688" alt="2025-12-25 (1766682625) ~ strongdmm" src="https://github.com/user-attachments/assets/19589e62-ae91-4866-943d-a12ec416f4fb" />

## Why It's Good For The Game

consistency with other maps, and making void raptor slightly less horrible.

## Changelog
:cl:
map: Added a proper SMES for the SM emitters on Void Raptor.
/:cl:
