### PR TITLE
fixes CALL_RINGTONE_DOOMSGATE showing instead of At Dooms Gate

### DIFF
--- a/code/modules/client/preferences/scryer.dm
+++ b/code/modules/client/preferences/scryer.dm
@@ -51,7 +51,7 @@ GLOBAL_LIST_INIT(call_ringtones, list(
 	CALL_RINGTONE_ULTIMATUM = list('sound/machines/call_ringtones/grinch_ultimatum.ogg', 30 SECONDS),
 	CALL_RINGTONE_TENNABOARD = list('sound/machines/call_ringtones/TennaBoardIntro.ogg', 21 SECONDS),
 	CALL_RINGTONE_BADPIGGIES = list('sound/machines/call_ringtones/BadPiggies.ogg', 27.7 SECONDS),
-	CALL_RINGTONE_DOOMSGATE = list('sound/machines/call_ringtones/AtDoomsGate.ogg', 26.2 SECONDS),
+	CALL_RINGTONE_DOOMGATE = list('sound/machines/call_ringtones/AtDoomsGate.ogg', 26.2 SECONDS),
 	CALL_RINGTONE_TEACHFISH = list('sound/machines/call_ringtones/TeachAFishToMan.ogg', 26.8 SECONDS),
 	CALL_RINGTONE_RUNNINGOUT = list('sound/machines/call_ringtones/RunningOut.ogg', 14.8 SECONDS),
 	CALL_RINGTONE_MEGALO = list('sound/machines/call_ringtones/megalovania.ogg', 16.8 SECONDS),


### PR DESCRIPTION

## About The Pull Request
someone messed up spelling and so it showed wrong
## Why It's Good For The Game
bugfix, speedmerge now or i blow up a moth
## Testing
yeeeeop
## Changelog
:cl:
spellcheck: At Dooms Gate is shown instead of CALL_RINGTONE_DOOMSGATE for scryer ringtones
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
