### PR TITLE
Removes access lock on perma doors

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -52231,7 +52231,6 @@
 	name = "Permabrig Access"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/security/permabrig,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
 "mSK" = (
@@ -61378,7 +61377,6 @@
 	name = "Permabrig Access"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/access/any/security/permabrig,
 /turf/open/floor/iron/dark/textured,
 /area/station/security/prison)
 "qoh" = (


### PR DESCRIPTION
## About The Pull Request

Idk who added it and when, but these doors aren't supposed to be behind perma access

<img width="682" height="350" alt="image" src="https://github.com/user-attachments/assets/91562854-d238-45ec-b023-82fa29c38492" />

So this is a quick PR to remove them

## Why It's Good For The Game

Fixes https://github.com/Monkestation/Monkestation2.0/issues/8864

## Testing

## Changelog

:cl:
fix: Helio permabrig entrance doors have had their access fixed.
/:cl:
