### PR TITLE
wall mounted chargers no longer charging around 800 times faster than a regular charger

### DIFF
--- a/monkestation/code/modules/blueshift/appliances/colony.dm
+++ b/monkestation/code/modules/blueshift/appliances/colony.dm
@@ -510,10 +510,6 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/cell_charger_multi/wall_mounted, 29)
 	if(disassembled)
 		new repacked_type(drop_location())
 
-/obj/machinery/cell_charger_multi/wall_mounted/RefreshParts()
-	. = ..()
-	charge_rate = 900 KW // Nuh uh!
-
 // Item for creating the arc furnace or carrying it around
 
 /obj/item/wallframe/cell_charger_multi


### PR DESCRIPTION

## About The Pull Request
Wall mounted wall chargers no longer work off of a set constant regardless of parts
## Why It's Good For The Game
closes: #9676 
## Testing
## Changelog
:cl:
fix: Wall mounted wall chargers now charge at normal rates
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
