### PR TITLE
Re-adds healing items to wall mounted medical biogenerator

### DIFF
--- a/monkestation/code/modules/blueshift/designs/deforest.dm
+++ b/monkestation/code/modules/blueshift/designs/deforest.dm
@@ -119,6 +119,17 @@
 		RND_CATEGORY_DEFOREST_BLOOD,
 	)
 
+/datum/design/organic_printer_balm
+	name = "Red Sun Balm"
+	id = "organic_sun_balm"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 50)
+	build_path = /obj/item/stack/medical/ointment/red_sun
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_DEFOREST_MEDICAL,
+	)
+
 /datum/design/organic_printer_gauze
 	name = "medical gauze"
 	id = "medical_gauze"
@@ -136,6 +147,28 @@
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 50)
 	build_path = /obj/item/stack/medical/gauze/sterilized
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_DEFOREST_MEDICAL,
+	)
+
+/datum/design/organic_printer_ointment
+	name = "Ointment"
+	id = "organic_ointment"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 25)
+	build_path = /obj/item/stack/medical/ointment
+	category = list(
+		RND_CATEGORY_INITIAL,
+		RND_CATEGORY_DEFOREST_MEDICAL,
+	)
+
+/datum/design/organic_printer_bruise_pack
+	name = "Bruise Packs"
+	id = "organic_bruise_packs"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass = 25)
+	build_path = /obj/item/stack/medical/bruise_pack
 	category = list(
 		RND_CATEGORY_INITIAL,
 		RND_CATEGORY_DEFOREST_MEDICAL,


### PR DESCRIPTION

## About The Pull Request
Re-adds red sun balm, ointment, and bruise packs to the wall mounted medstation.

## Why It's Good For The Game
They were replaced with some medkits in one PR, and then those medkits were removed from the game without giving the medstations their old healing items back. This was an oversight.

Fixes https://github.com/Monkestation/Monkestation2.0/issues/9994

## Testing
## Changelog
:cl:
fix: Wall mounted medstation has healing items again.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
