### PR TITLE
Adds multiver to new paramed injector

### DIFF
--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -11,8 +11,7 @@
 #define PARAMEDIC_MEDICAL_REAGENTS list(\
 		/datum/reagent/medicine/epinephrine,\
 		/datum/reagent/toxin/formaldehyde,\
-		/datum/reagent/medicine/c2/aiuri,\
-		/datum/reagent/medicine/c2/libital\
+		/datum/reagent/medicine/c2/multiver\
 	)
 #define EXPANDED_MEDICAL_REAGENTS list(\
 		/datum/reagent/medicine/haloperidol,\


### PR DESCRIPTION
ill test if i can, but that's a matter of if that whole memory buf with webview 2 under wine is fixed
## About The Pull Request

simply adds multiver to the new paramed hypospray list

## Why It's Good For The Game

~~mostly as parity as to what it could heal before, might instead swap it for just multiver~~
epi isnt able to purge chems on its own, this helps the new injector fit the role of stabilizer

## Testing

i have zero clue how to test this on a steamdeck, but its just one line, should be fine

## Changelog
adds multiver to paramedic borghypo

:cl:
add: Paramedic implants new hypo now includes Multiver
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
