### PR TITLE
Corrects the emergency medical bed's drop stack

### DIFF
--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -94,7 +94,7 @@
 	icon_state = "emerg_down"
 	base_icon_state = "emerg"
 	build_stack_type = /obj/item/stack/sheet/iron
-	build_stack_amount = 2
+	build_stack_amount = 1
 	foldable_type = /obj/item/emergency_bed
 
 /obj/structure/bed/medical/Initialize(mapload)


### PR DESCRIPTION
## About The Pull Request

Fixes #10117 

Changes the emergency rolling bed (`/obj/structure/bed/medical/emergency`) drop stack to 1 iron sheet, instead of titanium (which was being pulled from `/obj/structure/bed/medical`), since its techfab recipe is 1.5 iron. Huge server-demolishing overlook!

## Why It's Good For The Game

Less inconsistency.

## Testing

i promise it works
<img width="486" height="181" alt="image" src="https://github.com/user-attachments/assets/d5b964ef-9fc1-4af0-8c1e-f3307f278a3d" />

## Changelog
:cl:Chelxox
fix: Fixed the emergency rolling bed's drop stack, now dropping 1 sheet of iron instead of titanium.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
