### PR TITLE
handheld crew monitor designs now print the correct monitors

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -196,7 +196,7 @@
 		/datum/material/uranium = HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/diamond = HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/bluespace = HALF_SHEET_MATERIAL_AMOUNT,)
-	build_path = /obj/item/sensor_device
+	build_path = /obj/item/sensor_device/security
 	category = list(
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL + RND_SUBCATEGORY_EQUIPMENT_SECURITY
 	)
@@ -214,7 +214,7 @@
 		/datum/material/uranium = HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/diamond = HALF_SHEET_MATERIAL_AMOUNT,
 		/datum/material/bluespace = HALF_SHEET_MATERIAL_AMOUNT,)
-	build_path = /obj/item/sensor_device
+	build_path = /obj/item/sensor_device/command
 	category = list(
 		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_MEDICAL + RND_SUBCATEGORY_EQUIPMENT_SECURITY
 	)


### PR DESCRIPTION

## About The Pull Request
they all printed the same item, despite there being 3 distinct items specified in name.
## Why It's Good For The Game
get what you paid for
## Testing
locally tested, got all 3 with the unique sprites, names, and functions.
## Changelog
:cl:
fix: handheld crew monitor designs no longer print the same thing.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
