### PR TITLE
NT CIMS is scrollable

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosSupermatter.tsx
+++ b/tgui/packages/tgui/interfaces/NtosSupermatter.tsx
@@ -26,6 +26,8 @@ export const NtosSupermatter = (props) => {
         ) : (
           <Section
             title="Detected Supermatters"
+            height="100%"
+            overflowY="auto"
             buttons={
               <Button
                 icon="sync"


### PR DESCRIPTION
## About The Pull Request

NT CIMS is scrollable if there's too many SM's to fit on-screen.

## Why It's Good For The Game

Closes #10199 for the guy who manages it.

## Testing

<img width="695" height="376" alt="image" src="https://github.com/user-attachments/assets/fbe586c9-ceca-437e-8dbb-c544a6b69f26" />

<img width="697" height="294" alt="image" src="https://github.com/user-attachments/assets/6c1c9c21-28d9-44f8-8f9c-4e5cd785b101" />

## Changelog

:cl:
fix: NT CIMS is scrollable if you have enough supermatters.
/:cl: