### PR TITLE
Fixes invisible helio weight machines

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -4268,7 +4268,7 @@
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "ayQ" = (
-/obj/structure/weightmachine,
+/obj/structure/weightmachine/stacklifter,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "ayR" = (
@@ -58740,7 +58740,7 @@
 /turf/open/floor/iron/dark/smooth_corner,
 /area/station/ai_monitored/turret_protected/ai)
 "pkx" = (
-/obj/structure/weightmachine,
+/obj/structure/weightmachine/stacklifter,
 /turf/open/misc/asteroid,
 /area/station/security/prison/rec)
 "pkB" = (


### PR DESCRIPTION
## About The Pull Request

When porting Helio no one updated the path for weightmachines, because on TG the "stacklifter" is the base path, and the subtype got removed.

## Why It's Good For The Game

Closes https://github.com/Monkestation/Monkestation2.0/issues/9868
Closes https://github.com/Monkestation/Monkestation2.0/issues/9023

## Changelog

:cl:
fix: Heliostation's weight machines are now visible.
/:cl: