### PR TITLE
Contractors now get an immolation implant instead of an explosive implant

### DIFF
--- a/monkestation/code/modules/antagonists/contractor/datums/outfit.dm
+++ b/monkestation/code/modules/antagonists/contractor/datums/outfit.dm
@@ -24,7 +24,7 @@
 
 	implants = list(
 		/obj/item/implant/uplink/precharged,
-		/obj/item/implant/explosive,
+		/obj/item/implant/dust,
 	)
 
 	id_trim = /datum/id_trim/chameleon/contractor


### PR DESCRIPTION

## About The Pull Request

What it says on the tin. Removes the explosive implant, replaces it with an immolation implant. It cleanly disintegrates you and your equipment.

## Why It's Good For The Game

Currently, it is impossible to safely detain a contractor without getting injured, as such security is somewhat encouraged to kill contractors at a distance to force-detonate their explosive implant, despite being told to arrest them.
This PR is there to make contractors still have the ability to disintegrate themselves and their equipment, but now sec is able to arrest them without going deaf for 10 minutes, critting, or even losing a limb.

## Testing

Localhosted. Triggered a contractor event. Works fine.

## Changelog
:cl:
balance: Drifting Contractors now spawn with a self-immolation implant, instead of an explosive implant.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
