### PR TITLE
fix OOC pronouns not being underlined

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -996,6 +996,10 @@ em {
   border-bottom: 1px dashed;
 }
 
+.tooltip_alt {
+  border-bottom: 1px dashed;
+}
+
 .fieldset_legend {
   position: relative;
   max-width: 95%;

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -1000,6 +1000,10 @@ h2.alert {
   border-bottom: 1px dashed;
 }
 
+.tooltip_alt {
+  border-bottom: 1px dashed;
+}
+
 .fieldset_legend {
   background: hsl(0, 0%, 100%); // Chat background color
 


### PR DESCRIPTION
## Changelog
:cl:
fix: Ckeys with pronouns in OOC are now properly underlined again.
/:cl: