### PR TITLE
ED209s can't use space helmets & fixes lung stirfry

### DIFF
--- a/code/datums/components/crafting/robot.dm
+++ b/code/datums/components/crafting/robot.dm
@@ -16,6 +16,10 @@
 	time = 6 SECONDS
 	category = CAT_ROBOT
 
+/datum/crafting_recipe/ed209/New()
+	. = ..()
+	blacklist |= typesof(/obj/item/clothing/head/helmet/space)
+
 /datum/crafting_recipe/secbot
 	name = "Secbot"
 	result = /mob/living/simple_animal/bot/secbot

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
@@ -28,12 +28,12 @@
 		/obj/item/organ/internal/lungs = 1,
 		/obj/item/reagent_containers/cup/bowl = 1,
 	)
-	blacklist = list(
-		/obj/item/organ/internal/lungs/cybernetic,
-	)
-
 	result = /obj/item/food/shredded_lungs
 	category = CAT_LIZARD
+
+/datum/crafting_recipe/food/shredded_lungs/New()
+	. = ..()
+	blacklist |= typesof(/obj/item/organ/internal/lungs/cybernetic)
 
 /datum/crafting_recipe/food/tsatsikh
 	name = "Tsatsikh"


### PR DESCRIPTION
## About The Pull Request

Space helmets can't be used for ED209's and upgraded cybernetics can't be used for lung stirfry (it wasn't using typesof) which I noticed while working on ED209 exclusions.

## Why It's Good For The Game

Closes https://github.com/Monkestation/Monkestation2.0/issues/10093

Fixes using cybernetic lungs in a recipe that specifically excludes cybernetic lungs.

## Testing

I did.

## Changelog

:cl:
fix: ED209's no longer take space helmets to craft.
fix: Lung stirfry no longer takes cybernetic lungs to craft.
/:cl: