### PR TITLE
Fixes Oshan engi lobby missing construction access

### DIFF
--- a/_maps/map_files/Oshan/Oshan.dmm
+++ b/_maps/map_files/Oshan/Oshan.dmm
@@ -8596,7 +8596,6 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Lobby"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
@@ -8610,6 +8609,8 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "engie"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/lobby)
 "cQP" = (
@@ -47954,7 +47955,6 @@
 	dir = 4;
 	invisibility = 101
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 8
 	},
@@ -47972,6 +47972,8 @@
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Lobby"
 	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
 /turf/open/floor/iron/dark/textured,
 /area/station/engineering/lobby)
 "poN" = (


### PR DESCRIPTION
## About The Pull Request
Replace access requirements for Oshan engi lobby door from requiring all: engi general to any: engi general OR construction.
## Why It's Good For The Game
Consistency for construction access across all maps, which is supposed to allow entry for those with only construction access. This is consistent with the actual lathe room having any access for engi general + construction. The mapper stated they didn't like parameds walking in but this also affects other jobs like engisec and RD who also have construction but NOT engi general access.

I will also no longer have to type out a lengthy explanation in LOOC when telling the hop why I need engi general access despite already having construction access.

Snippet from access.dm highlighting the purpose of the construction access:
```
/// Access to "construction" areas of the station. However, in mapping, it's used to 
///    get access to the front door and lathe room of the engineering department. <<<
#define ACCESS_CONSTRUCTION "construction"
```
Closes #8610

## Testing

Localhost test with an ID with construction access and not engineering general.
## Changelog
:cl: Lawlolawl
fix: Fixed Oshan engi lobby missing construction access. Parameds, engisec and RD can finally open the door.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
