### PR TITLE
Fixes Theseus engi lobby missing construction access

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -8028,6 +8028,9 @@
 /obj/machinery/light_switch/directional/south{
 	pixel_x = 8
 	},
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/iron,
 /area/station/engineering/engine_smes)
 "cuy" = (
@@ -22463,13 +22466,6 @@
 	dir = 1
 	},
 /obj/machinery/light/small/directional/north,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow{
-	pixel_y = 5
-	},
-/obj/item/clothing/gloves/color/yellow{
-	pixel_y = 9
-	},
 /turf/open/floor/iron,
 /area/station/engineering/hallway)
 "gJs" = (
@@ -55908,6 +55904,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "qrn" = (
@@ -71475,6 +71472,7 @@
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "uLX" = (


### PR DESCRIPTION
## About The Pull Request

Same as #10276.
Additional change: shifted 3 sets of insuls to the SMES room so parameds/engisec or plain tiders can't take insuls from engi easily (1 airlock of tiding). See image:
<img width="943" height="736" alt="image" src="https://github.com/user-attachments/assets/063db166-c659-4af1-8b0b-e76c3fa18352" />


## Changelog
:cl: Lawlolawl
fix: Fixed Theseus engi lobby airlocks missing construction access. 3 insuls have been shifted to the smes room so they are harder for tiders to take.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
