### PR TITLE
Assembler assorted fixes

### DIFF
--- a/monkestation/code/modules/factory_type_beat/machinery/assembler.dm
+++ b/monkestation/code/modules/factory_type_beat/machinery/assembler.dm
@@ -208,21 +208,19 @@
 		start_craft()
 
 /obj/machinery/assembler/proc/consume_stack(obj/item/Type, amount)
-	var left = amount
+	var/left = amount
 	for(var/obj/item/item as anything in crafting_inventory)
 		if(isstack(item) && istype(item, Type))
 			var/obj/item/stack/stack = item
-			if(stack.amount == left)
-				crafting_inventory -= item
-				qdel(item)
-				break
-			else if(stack.amount > left)
-				stack.amount -= left
-				break
-			else if(stack.amount < left)
+			if(left >= stack.amount)
 				left -= stack.amount
+				stack.use(stack.amount)
 				crafting_inventory -= item
-				qdel(item)
+				if(left == 0)
+					return
+			else
+				stack.use(left)
+				return
 
 /obj/machinery/assembler/proc/start_craft()
 	if(crafting)
@@ -249,7 +247,7 @@
 			consume_stack(req, requirements[req])
 			continue
 		else
-			var left = requirements[req]
+			var/left = requirements[req]
 			for(var/obj/item/item as anything in crafting_inventory)
 				if(!istype(item, req))
 					continue


### PR DESCRIPTION
## About The Pull Request
Fixed issue with assemblers able to use same atoms for crafting while they stacked on the same tile.
Fixed issue where assembler would consume more items than required.
Assembler will now wait ongoing craft before emptying it's content, if you change recipe during crafting
## Why It's Good For The Game
bugfix
## Testing

https://github.com/user-attachments/assets/f6fbbfdc-aa54-4533-8427-a58d797bed97


## Changelog
:cl:
fix: Assembler will how use proper amount of items for crafting
fix: Fixed assembler stack exploit
fix: Fixed assembler free craft exploit
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
