### PR TITLE
Add some visible messages clarifying the cause of oozeling limb retraction

### DIFF
--- a/monkestation/code/modules/surgery/organs/internal/heart.dm
+++ b/monkestation/code/modules/surgery/organs/internal/heart.dm
@@ -92,7 +92,10 @@
 		if(!QDELETED(organ))
 			organ.forceMove(body.drop_location())
 	consumed_limb.drop_limb()
-	to_chat(body, span_userdanger("Your [consumed_limb] is drawn back into your body, unable to maintain its shape!"))
+	body.visible_message(
+		span_danger("[body]'s [consumed_limb] rapidly loses its shape, painfully being drawn back into [body.p_their()] body!"),
+		span_userdanger("Your [consumed_limb] is drawn back into your body, unable to maintain its shape!")
+	)
 	qdel(consumed_limb)
 	body.blood_volume += 20
 
@@ -199,6 +202,10 @@
 	var/brute = selected_limb.brute_dam
 	var/burn = selected_limb.burn_dam
 	selected_limb.drop_limb()
+	user.visible_message(
+		span_warning("[user]'s [selected_limb] is retracted into [user.p_their()] body with a quick, deliberate motion!"),
+		span_notice("You retract your [selected_limb] back into your body."),
+	)
 	qdel(selected_limb)
 	chest?.receive_damage(brute, burn, forced = TRUE, wound_bonus = CANT_WOUND)
 	user.blood_volume += 20


### PR DESCRIPTION
## About The Pull Request

this adds visible messages when an oozeling limbs retract - whether intentionally or via blood loss.

hopefully this is minor enough to be fine during the freeze.

Losing a limb due to blood loss:
> Shion Rosenthal's oozeling right arm rapidly loses its shape, painfully being drawn back into her body!

Retracting a limb:
> Shion Rosenthal's oozeling right arm is retracted into her body with a quick, deliberate motion!

## Why It's Good For The Game

Makes some situations less confusing

## Testing
## Changelog
:cl:
qol: Added some visible messages allowing people to distinguish if an oozeling manually retracted their limb, or if their limb has retracted due to low blood.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
