### PR TITLE
Adds liquid barriers to Theseus xenobio

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -14762,6 +14762,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology/hallway)
 "erH" = (
@@ -38854,6 +38855,7 @@
 /obj/machinery/duct,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology/hallway)
 "lpm" = (
@@ -44478,6 +44480,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "mWQ" = (
@@ -54125,6 +54128,7 @@
 	id = "xenosecure";
 	name = "Secure Pen Shutters"
 	},
+/obj/structure/liquid_barrier,
 /turf/open/floor/engine,
 /area/station/science/xenobiology/cell)
 "pUt" = (
@@ -58754,6 +58758,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "rhR" = (
@@ -63585,6 +63590,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/mapping_helpers/airlock/access/all/science/xenobio,
+/obj/structure/liquid_barrier,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology/hallway)
 "sBG" = (


### PR DESCRIPTION

## About The Pull Request

this simply adds liquid barriers under the doors to Theseus's xenobio, consistent with other maps.

## Why It's Good For The Game

because this is not good for the server's performance, or anyone's eyes:

<img width="1528" height="1349" alt="2026-01-06 (1767731494) ~ dreamseeker" src="https://github.com/user-attachments/assets/c0e3256d-9c5d-49ee-b2fc-4f4b29e139f2" />

## Changelog
:cl:
map: Added liquid barriers under the xenobio doors on Theseus.
/:cl: