### PR TITLE
quick ERT fix

### DIFF
--- a/monkestation/code/modules/ERT/ERT_outfits.dm
+++ b/monkestation/code/modules/ERT/ERT_outfits.dm
@@ -159,7 +159,7 @@
 
 /datum/antagonist/ert/generic/medical/blue
 	name = "Code Blue Medical Response Officer"
-	outfit = /datum/outfit/centcom/ert/generic/medical
+	outfit = /datum/outfit/centcom/ert/generic/medical/blue
 
 /datum/outfit/centcom/ert/generic/medical/blue
 	name = "Code Blue Medical Response Officer"

--- a/monkestation/code/modules/ERT/equipment/ERT_spacesuits.dm
+++ b/monkestation/code/modules/ERT/equipment/ERT_spacesuits.dm
@@ -72,6 +72,7 @@
 	max_integrity = 300
 	armor_type = /datum/armor/ert
 	resistance_flags = ACID_PROOF | FIRE_PROOF
+	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	//helmet light
 	actions_types = list(/datum/action/item_action/toggle_helmet_light)
 	light_system = OVERLAY_LIGHT_DIRECTIONAL


### PR DESCRIPTION
fixes ERT helmets not having the right heat protection and code blue medical officers spawning with a code green outfit.
## Changelog

:cl:
fix: fixed ERT space suit helmets not having the right heat protection.
fix: fixed code blue medical officers spawning with a code green outfit.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

