### PR TITLE
security (but not sechudsunglasses) sunglasses now have sunglasses' description.

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -190,14 +190,14 @@
 	glass_colour_type = /datum/client_colour/glass_colour/darkred
 
 /obj/item/clothing/glasses/hud/security/sunglasses/normal /// Monkestation edit : Adding some substance to the detective role
-	name = "sunglasses"
-	desc = "N/A"
-	icon_state = "sun"
-	inhand_icon_state = "sunglasses"
+	name = /obj/item/clothing/glasses/sunglasses::name
+	desc = /obj/item/clothing/glasses/sunglasses::desc
+	icon_state = /obj/item/clothing/glasses/sunglasses::icon_state
+	inhand_icon_state = /obj/item/clothing/glasses/sunglasses::inhand_icon_state
 	flash_protect = FLASH_PROTECTION_FLASH
 	tint = 1
 	glass_colour_type = /datum/client_colour/glass_colour/gray
-	dog_fashion = /datum/dog_fashion/head
+	dog_fashion = /obj/item/clothing/glasses/sunglasses::dog_fashion
 
 /obj/item/clothing/glasses/hud/security/night
 	name = "night vision security HUD"


### PR DESCRIPTION
## About The Pull Request

very small PR that makes security non-secglasses sunglasses steal the sunglasses description
this is the parent type to spyglasses so this will ensure they don't fall out of date.

## Testing

<img width="81" height="83" alt="image" src="https://github.com/user-attachments/assets/ada81d2d-6892-4bba-bd39-17a75beba9de" />

No changelog.