### PR TITLE
[opening new pr with new branch name]

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -583,7 +583,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_COMBAT
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY // monkestation edit
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/design/cyberimp_thermals
 	name = "Thermal Eyes"
@@ -603,7 +603,7 @@
 	category = list(
 		RND_CATEGORY_CYBERNETICS + RND_SUBCATEGORY_CYBERNETICS_ORGANS_COMBAT
 	)
-	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SECURITY // monkestation edit
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL
 
 /datum/design/cyberimp_antidrop
 	name = "Anti-Drop Implant"


### PR DESCRIPTION

## About The Pull Request

exactly what it says on the tin: removes thermal and x-ray eyes from the sec techfab

medical techfab and the exofab can still print them. just not the security techfab.

## Why It's Good For The Game

it feels like cybernetics have caused security to become _overwelmingly_ oppressive to antags when combined with other recent balance changes - and a big part of this is everyone and their mother getting x-ray eyes implanted, completely ruining any antags chance of having secret bases of whatever.

while this doesn't make it _impossible_ for sec to get them, it does mean they can't just have the brig phys give them all the powergame eyes without even leaving the brig.

## Changelog
:cl:
balance: The Security techfab can no longer print Thermal Eyes or X-ray Eyes.
/:cl: