### PR TITLE
HIT THE DECK! (flashbang nerf kinda)

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -58,7 +58,7 @@
 			living_mob.Paralyze(5)
 			living_mob.Knockdown(30)
 		if(hit_the_deck)
-			living_mob.soundbang_act(1, max(200 / max(1, distance) * 0.1, 60), rand(0, 2))
+			living_mob.soundbang_act(1, max(200 / max(1, distance) * 0.1, 60), rand(0, 2), 5)
 		else
 			living_mob.soundbang_act(1, max(200 / max(1, distance), 60), rand(0, 5))
 


### PR DESCRIPTION
## About The Pull Request
flashbang's bang effect is weakened on those laying down causing only 1/10th of the normal stun effect. if you are laying down with your face to the ground you won't get hit by the flash of flashbangs.

## Why It's Good For The Game
makes flashbang spam a bit weaker and flashbangs overall less of a gear check. granted you are laying down and still kinda fucked but less fucked.

## Changelog

:cl:
balance: flashbang's bang effect is weakened on those laying down causing only 1/10th of the normal stun effect. if you are laying down with your face to the ground you won't get hit by the flash of flashbangs.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

