### PR TITLE
AltClick is no longer called twice (also badges stay on rolldown)

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -125,8 +125,6 @@
 		if(istate & ISTATE_CONTROL)
 			CtrlClickOn(A)
 			return
-	else if(LAZYACCESS(modifiers, ALT_CLICK)) // monke edit: ensure alt-secondary works
-		AltClickSecondaryOn(A)
 	if(LAZYACCESS(modifiers, SHIFT_CLICK))
 		if(LAZYACCESS(modifiers, MIDDLE_CLICK))
 			ShiftMiddleClickOn(A)

--- a/monkestation/code/modules/clothing/under/accessories/badges.dm
+++ b/monkestation/code/modules/clothing/under/accessories/badges.dm
@@ -13,7 +13,7 @@
 	worn_icon = 'monkestation/icons/mob/clothing/accessories.dmi'
 	icon_state = "badge"
 	slot_flags = ITEM_SLOT_NECK
-	attachment_slot = CHEST
+	attachment_slot = NONE //can be worn while rolled down
 
 	///The access needed to change the stored name, not needed if no name is given.
 	var/access_required = ACCESS_CARGO


### PR DESCRIPTION
## About The Pull Request

Atomized from my Cargo Union work

Small PR; Badge doesn't fall off on adjusted suits, secondary alt click isn't called twice every time.

The secondary altclick stuff I assumed was for right click context menu mode users, however it doesn't work regardless. People using this mode have no way of secondary altclicking which is an issue but I really don't gaf about that setting and I hope it gets removed.

## Why It's Good For The Game

Badges falling off was a requested feature and also badges are gaining importance in the round so them not falling off would be nice.

AltClick fix is so badges don't stack balloon alerts on you every time you remove them.

## Testing

i did indeed.

## Changelog

:cl:
qol: Badges don't fall off when you roll down your shirt.
fix: Secondary AltClick doesn't get called twice every click.
/:cl: