### PR TITLE
paycheck_department properly updates on job change

### DIFF
--- a/code/controllers/subsystem/id_access.dm
+++ b/code/controllers/subsystem/id_access.dm
@@ -500,7 +500,7 @@ SUBSYSTEM_DEF(id_access)
 	id_card.add_wildcards(trim.wildcard_access, mode = TRY_ADD_ALL)
 	if(istype(trim, /datum/id_trim/job))
 		var/datum/id_trim/job/job_trim = trim // Here is where we update a player's paycheck department for the purposes of discounts/paychecks.
-		id_card.registered_account.account_job.paycheck_department = job_trim.job.paycheck_department
+		id_card.registered_account.account_job = job_trim.job
 
 /**
  * Tallies up all accesses the card has that have flags greater than or equal to the access_flag supplied.


### PR DESCRIPTION
## About The Pull Request

Adding job access in the HoP's console (``add_trim_access_to_card`` proc) changes the payment department of EVERYONE of that job, because we assign all players via one job datum using ``SStype_occupations`` (through ``get_job_type``), so everyone's bank account stores the same job datum as everyone else of their job.

To fix this, we are simply going to update the job of the bank account to the new one, rather than change the paycheck department. This will keep it in-sync with the current system while fixing the bug.

## Why It's Good For The Game

Fixes https://github.com/Monkestation/Monkestation2.0/issues/10357
Fixes https://github.com/Monkestation/Monkestation2.0/issues/10203

## Testing

Messed around with 2 Engineer cards and it was working as it's supposed to.

## Changelog

:cl:
fix: Changing the job of one person from one job position to another won't set EVERYONE ELSE of the old job's paycheck department to the new one.
/:cl: