### PR TITLE
Fixes non darkspawn being able to use the darkspawn cams console

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -128,6 +128,11 @@
 		return FALSE
 	return ..()
 
+/obj/machinery/computer/camera_advanced/darkspawn/can_use(mob/user)
+	if(!IS_DARKSPAWN(user))
+		return FALSE
+	return ..()
+
 /obj/machinery/computer/camera_advanced/attack_hand(mob/user, list/modifiers)
 	. = ..()
 	if(.)

--- a/code/modules/antagonists/darkspawn/darkspawn_objects/veil_camera.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_objects/veil_camera.dm
@@ -112,10 +112,3 @@ GLOBAL_DATUM_INIT(thrallnet, /datum/cameranet/darkspawn, new)
 /obj/machinery/camera/darkspawn/update_overlays()
 	. = ..()
 	. += emissive_appearance(icon, "[icon_state]_emissive", src)
-/obj/machinery/computer/camera_advanced/darkspawn/attack_hand(mob/user, list/modifiers)
-	. = ..()
-	if(!.)
-		return
-	if(!IS_TEAM_DARKSPAWN(user))
-		return FALSE
-	return TRUE


### PR DESCRIPTION

## About The Pull Request

fixes https://github.com/Monkestation/Monkestation2.0/issues/10062

## Why It's Good For The Game

Bugfix

## Testing

Used camera as darkspawn, it worked. Used camera as non darkspawn, didnt work.

## Changelog
:cl:
fix: Non-darkspawn are not able to use the darkspawn cams console anymore.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
