### PR TITLE
Maybe stops needless stamina process calls

### DIFF
--- a/monkestation/code/datums/stamina_container.dm
+++ b/monkestation/code/datums/stamina_container.dm
@@ -76,6 +76,7 @@
 
 	if(current == maximum)
 		process_stamina = FALSE
+		update_process()
 
 	if(should_notify_parent)
 		parent.on_stamina_update()
@@ -114,6 +115,7 @@
 	if(modify < 0)
 		pause(STAMINA_REGEN_TIME)
 	update()
+	update_process()
 	return modify
 
 /// Revitalize the stamina to the maximum this container can have.
@@ -135,6 +137,7 @@
 	if(modify < 0)
 		pause(STAMINA_REGEN_TIME)
 	update()
+	update_process()
 	return modify
 
 /// Signal handler for COMSIG_MOVABLE_MOVED to ensure that update_process() gets called whenever moving to/from nullspace.
@@ -146,6 +149,8 @@
 /// Returns if the container should currently be processing or not.
 /datum/stamina_container/proc/should_process()
 	SHOULD_BE_PURE(TRUE)
+	if(!process_stamina)
+		return FALSE
 	if(QDELETED(parent) || isnull(parent.loc))
 		return FALSE
 	if(!parent.uses_stamina)


### PR DESCRIPTION
## About The Pull Request

This is experimental and I'm not entirely sure if it'll work. I tried sprinting around, batoning myself and others, and it seems to work fine dot dot dot question mark.

## Why It's Good For The Game

3 minutes into the round on local there's 1 client (me), 563 mobs, and 119k proc calls to stamina update. Why do we need to update stamina 119k times? Who was stunned?

This should help with proc overhead and not have a list of 563 mobs in SSstamina processing every 10 game ticks.

## Changelog

Nothing directly player-facing, though I'd assume stamina would be less susceptible to lag under heavy loads since it no longer has to update 563 mobs and freezing partially for the MC tick check.