### PR TITLE
Fixes 4 UIs slightly

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -351,6 +351,7 @@ GLOBAL_DATUM_INIT(crewmonitor_command, /datum/crewmonitor/command, new)
 		JOB_ERT_DEATHSQUAD = 227,
 		JOB_NANOTRASEN_REPRESENTATIVE = 230,
 		JOB_BLUESHIELD = 231,
+		JOB_BRIDGE_ASSISTANT = 232,
 	)
 
 GLOBAL_DATUM_INIT(crewmonitor_security, /datum/crewmonitor/security, new)

--- a/tgui/packages/tgui/interfaces/LockedSafe.tsx
+++ b/tgui/packages/tgui/interfaces/LockedSafe.tsx
@@ -16,7 +16,7 @@ export const LockedSafe = (props) => {
   const { act, data } = useBackend<Data>();
   const { input_code, locked, lock_code } = data;
   return (
-    <Window width={300} height={400} theme="ntos">
+    <Window width={300} height={430} theme="ntos">
       <Window.Content>
         <Box m="6px">
           <Box mb="6px" className="NuclearBomb__displayBox">

--- a/tgui/packages/tgui/interfaces/NtosMain.tsx
+++ b/tgui/packages/tgui/interfaces/NtosMain.tsx
@@ -119,7 +119,7 @@ export const NtosMain = (props) => {
               <Button
                 icon="eject"
                 content="Eject ID"
-                disabled={!proposed_login.IDInserted}
+                disabled={!proposed_login.IDName}
                 onClick={() => act('PC_Eject_Disk', { name: 'ID' })}
               />
               {!!show_imprint && (

--- a/tgui/packages/tgui/interfaces/NtosNtRep.tsx
+++ b/tgui/packages/tgui/interfaces/NtosNtRep.tsx
@@ -120,7 +120,7 @@ export const NtosNtRepContent = (props) => {
               placeholder="Leave your review/thoughts/comments..."
               maxLength={max_length}
               value={comment}
-              onChange={(value) =>
+              onBlur={(value) =>
                 act('set_text', {
                   new_review: value,
                 })


### PR DESCRIPTION
## About The Pull Request

Command monitor now shows Bridge Assistant
Locked Safe now fits all buttons
PDA's Eject button now works
NT Rep's app no longer freezes from "too many inputs".

## Why It's Good For The Game

UI fixes

## Changelog

:cl:
fix: Fixed minor UI issues with PDA, NT Rep's app & Locked safes.
fix: Bridge Assistant now shows on the command monitor.
/:cl: