### PR TITLE
possibly improves liquid subsystem performance

### DIFF
--- a/monkestation/code/modules/liquids/liquid_groups.dm
+++ b/monkestation/code/modules/liquids/liquid_groups.dm
@@ -232,7 +232,6 @@ GLOBAL_VAR_INIT(liquid_debug_colors, FALSE)
 
 	if(from_SS)
 		total_reagent_volume = reagents.total_volume
-		reagents.handle_reactions()
 
 		if(!total_reagent_volume || !members)
 			return
@@ -264,7 +263,7 @@ GLOBAL_VAR_INIT(liquid_debug_colors, FALSE)
 
 /datum/liquid_group/proc/cleanse_members()
 	for(var/turf/listed_turf as anything in members)
-		if(isclosedturf(listed_turf))
+		if(isclosedturf(listed_turf) || isgroundlessturf(listed_turf))
 			remove_from_group(listed_turf)
 			qdel(listed_turf.liquids)
 


### PR DESCRIPTION
in theory we prolly don't need to run `reagents.handle_reactions()` every process. 

<img width="746" height="298" alt="image" src="https://github.com/user-attachments/assets/1203461d-bdb8-4ace-8d40-50d6c45f3ca0" />

also made it so `cleanse_members` also cleanses liquids from groundless turfs.