### PR TITLE
[EXPLOIT] [SPEEDMERGE] Fixes TK teleporting bags and equipment

### DIFF
--- a/code/datums/elements/attack_equip.dm
+++ b/code/datums/elements/attack_equip.dm
@@ -39,13 +39,12 @@
 		return
 	var/equip_time = attire.equip_delay_other
 
+	if(!user.Adjacent(sharp_dresser)) // Stop TK from moving item locations
+		return
+
 	attire.item_start_equip(sharp_dresser, attire, user)
 
 	if(!do_after(user, equip_time, sharp_dresser))
-		return
-
-	if(!user.Adjacent(sharp_dresser)) // Due to teleporting shenanigans
-		user.put_in_hands(attire)
 		return
 
 	user.temporarilyRemoveItemFromInventory(attire)


### PR DESCRIPTION
## About The Pull Request
Relevant [tg PR](https://github.com/tgstation/tgstation/pull/69560)
Basically the PR author decided moving the item grabbed by TK was a good idea. This change:
1. Checks for user adjacency to target BEFORE starting to attempt to equip the target with the do after
2. Does nothing when user is not adjacent so no funny teleporting occurs

This is a exploit because you just need a stripped body with a backpack on the floor and TK (admittedly harder to get now with the bloated mutation pool) to teleport backpacks in particular through rwindows and glass airlocks, making it possible to steal people's bags. Of course, this is also possible with other equippable gear, and this PR fixes all that too. (I just realized I forgot to test MODsuits and space suits but this should fix those too.)



## Why It's Good For The Game
Fixes #10419
Closes #4725 as it's stale and unreproducible as a bonus

## Testing
Main issue resolved.

While testing this, I also discovered that quick equipping by attacking someone with an item targeting the right body part doesn't work for satchel backpacks and toolbelts (along with possibly more equipment), even when targeting groin as the PR author intended, but that's a minor thing as you can still equip items onto people via the stripping menu.

## Changelog
:cl: Lawlolawl
fix: Fixed TK teleporting bags and equipment.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
