### PR TITLE
slashers do not need to spawn 5 morbillion blood particles per hit

### DIFF
--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -269,8 +269,7 @@
 	return blood_data
 */
 
-/mob/living/proc/get_blood_type()
-	RETURN_TYPE(/datum/blood_type)
+/mob/living/proc/get_blood_type() as /datum/blood_type
 	if(HAS_TRAIT(src, TRAIT_NOBLOOD))
 		return null
 	return GLOB.blood_types[/datum/blood_type/animal]
@@ -339,14 +338,17 @@
  * Helper proc for throwing blood particles around, similar to the spray_blood proc.
  */
 /mob/living/proc/blood_particles(amount = rand(1, 3), angle = rand(0,360), min_deviation = -30, max_deviation = 30, min_pixel_z = 0, max_pixel_z = 6)
-	if(QDELETED(src) || !isturf(loc) || QDELING(loc) || !blood_volume || HAS_TRAIT(src, TRAIT_NOBLOOD))
+	if(QDELETED(src) || !isturf(loc) || !blood_volume || HAS_TRAIT(src, TRAIT_NOBLOOD))
 		return
+	var/list/blood_dna = get_blood_dna_list()
+	var/blood_color = get_blood_type()?.color
 	for(var/i in 1 to amount)
 		var/obj/effect/decal/cleanable/blood/particle/droplet = new(loc)
 		if(QDELETED(droplet)) // if they're deleting upon init, let's not waste any more time, any others will prolly just do the same thing
 			return
-		droplet.color = get_blood_type()?.color
-		droplet.add_mob_blood(src)
+		droplet.color = blood_color
+		if(blood_dna)
+			droplet.add_blood_DNA(blood_dna)
 		droplet.pixel_z = rand(min_pixel_z, max_pixel_z)
 		droplet.start_movement(angle + rand(min_deviation, max_deviation))
 

--- a/monkestation/code/modules/blood_datum/forensics_helpers.dm
+++ b/monkestation/code/modules/blood_datum/forensics_helpers.dm
@@ -8,9 +8,10 @@
 
 	var/list/colors = list()
 	var/list/all_dna = GET_ATOM_BLOOD_DNA(src)
-	for(var/dna_sample in all_dna)
-		colors += GLOB.blood_types[all_dna[dna_sample]]?.color
-	list_clear_nulls(colors)
+	for(var/dna_sample, dna_type in all_dna)
+		var/blood_color = GLOB.blood_types[dna_type]?.color
+		if(blood_color)
+			colors += blood_color
 	var/final_color = COLOR_BLOOD
 	if(length(colors))
 		final_color = pop(colors)
@@ -34,10 +35,8 @@
 	if(dried)
 		return TRUE
 	// Imperfect, ends up with some blood types being double-set-up, but harmless (for now)
-	for(var/new_blood in blood_DNA_to_add)
-		var/datum/blood_type/blood = GLOB.blood_types[blood_DNA_to_add[new_blood]]
-		if(!blood)
-			continue
-		blood.set_up_blood(src, first_dna == 0)
+	for(var/new_blood, blood_type in blood_DNA_to_add)
+		var/datum/blood_type/blood = GLOB.blood_types[blood_type]
+		blood?.set_up_blood(src, first_dna == 0)
 	update_appearance()
 	return TRUE

--- a/monkestation/code/modules/blood_for_the_blood_gods/slasher/slasher_datum.dm
+++ b/monkestation/code/modules/blood_for_the_blood_gods/slasher/slasher_datum.dm
@@ -270,9 +270,7 @@
 		held_force = held_item.force
 
 	increase_fear(attacked_mob, held_force / 3)
-
-	for(var/i = 1 to (held_force / 3))
-		attacked_mob.blood_particles(2, max_deviation = rand(-120, 120), min_pixel_z = rand(-4, 12), max_pixel_z = rand(-4, 12))
+	attacked_mob.blood_particles(5, max_deviation = rand(-120, 120), min_pixel_z = rand(-4, 12), max_pixel_z = rand(-4, 12))
 
 /datum/antagonist/slasher/proc/item_pickup(datum/input_source, obj/item/source)
 	SIGNAL_HANDLER


### PR DESCRIPTION

## About The Pull Request

this just makes it so slashers spawn 5 blood particles each hit, rather than a shitload that scales with damage.

also optimized some blood-related functions while I was there.

## Why It's Good For The Game

this is not good for the server's performance:

<img width="659" height="531" alt="2026-01-13 (1768355124) ~ dreamseeker" src="https://github.com/user-attachments/assets/168289bc-fa14-4acc-8dea-8f35cdaf31a5" />

## Changelog
:cl:
fix: Slightly optimized some blood-related code.
qol: Slashers no longer spawn a morbillion blood particles (they still spawn SOME) each hit, hopefully avoiding grinding the server to a halt.
/:cl: