### PR TITLE
Fix robotact not printing your name

### DIFF
--- a/code/modules/modular_computers/file_system/programs/robotact.dm
+++ b/code/modules/modular_computers/file_system/programs/robotact.dm
@@ -34,7 +34,7 @@
 
 	var/mob/living/silicon/robot/cyborg = tablet.silicon_owner
 
-	data["name"] = cyborg.name
+	data["borgName"] = cyborg.name
 	data["designation"] = cyborg.model
 	data["masterAI"] = cyborg.connected_ai //Master AI
 	data["MasterAI_connected"] = !!cyborg.connected_ai //Need a bool for this on the other side


### PR DESCRIPTION
## About The Pull Request
robotact data had it under "name" but the jsx portion wanted it under "borgName", so the UI would search for nonexistant data, and the code would provide unused data.
## Why It's Good For The Game
sure, its fluff, but its also broken! bugfix good!
## Testing

<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/bc03ca98-2a1b-40e4-91c3-34ba25890145" />

Looks like it works to me, bossmaam.

## Changelog
:cl:
fix: RoboTact for cyborgs now prints their name again.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
