### PR TITLE
Buffs Paramedic arm some

### DIFF
--- a/code/game/objects/items/robot/items/hypo.dm
+++ b/code/game/objects/items/robot/items/hypo.dm
@@ -10,7 +10,9 @@
 	)
 #define PARAMEDIC_MEDICAL_REAGENTS list(\
 		/datum/reagent/medicine/epinephrine,\
-		/datum/reagent/toxin/formaldehyde\
+		/datum/reagent/toxin/formaldehyde,\
+		/datum/reagent/medicine/ammoniated_mercury,\
+		/datum/reagent/medicine/painkiller/morphine\
 	)
 #define EXPANDED_MEDICAL_REAGENTS list(\
 		/datum/reagent/medicine/haloperidol,\
@@ -274,7 +276,7 @@
 	name = "emergency paramedic hypospray"
 	desc = "A cut-down version of the cyborg's chemical synthesizer and injection system for paramedics able to fit into implants."
 	possible_transfer_amounts = list(1, 5)
-	max_volume_per_reagent = 5
+	max_volume_per_reagent = 10
 	default_reagent_types = PARAMEDIC_MEDICAL_REAGENTS
 	bypass_protection = TRUE
 
@@ -282,7 +284,7 @@
 	for(var/reagent in reagents_to_regen)
 		var/datum/reagent/reagent_to_regen = reagent
 		if(!stored_reagents.has_reagent(reagent_to_regen, max_volume_per_reagent))
-			stored_reagents.add_reagent(reagent_to_regen, 1, reagtemp = dispensed_temperature, no_react = TRUE)
+			stored_reagents.add_reagent(reagent_to_regen, 2, reagtemp = dispensed_temperature, no_react = TRUE)
 
 /// Peacekeeper hypospray
 /obj/item/reagent_containers/borghypo/peace


### PR DESCRIPTION
## About The Pull Request
- Paramedic arm now has 10 units of each reagent
- Paramedic arm now produces 2 units
- Paramedic arm now has morphine and ammoniated mercury
## Why It's Good For The Game
Paramedic arm had its Medi beam replaced with a cheap hypo, which while fair... it's a bit under loved and arguably worse than just caring a epi pen. (Less epi, have to toggle to not deal toxin damage via Formaldehyde, and no Sanguirite)
So to help give it some love here's my proposed changes.
## Two new chemicals
Morphine and Ammoniated mercury.
For being a paramedic arm and not have ammoniated mercury , it is one of the two chemicals paramedics are actually given.
Morphine is to give some form of painkiller, as pain crit while rare is very real when present.

## Reagent changes.
5 Units with a recharge rate of 1 is depressing, 5 units of epi is less than actual epi pen and makes it fail to fill the emergency part of emergency hypo. Stabilizing frequenting or more than one person feels frustrating. Boosting its capacity alongside it's recharge rate helps keeps it active but still much less than a borg hypo. Alongside the exclusive chems pushing it further into a niche.
## Testing
## Changelog
:cl:
add: Added Morphine and ammoniated mercury to emergency hypo spray
balance: Emergency Hypo spray 5 > 10 capacity
balance: Emergency Hypo spray 1 > 2 recharge rate
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
