### PR TITLE
adds an admin button in the Secrets panel to lobotomize Poly

### DIFF
--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -633,7 +633,7 @@ monkestation end */
 			message_admins("[key_name_admin(holder)] healed everyone.")
 			log_admin("[key_name(holder)] healed everyone.")
 
-		if("lobotimize_the_bird")
+		if("lobotomize_the_bird")
 			var/choice = tgui_alert(usr, "Would you like to lobotomize Poly? This will kill them, and clear ALL saved phrases!", "i have to water the shitbird wait a minute", list("Yes", "No"))
 			if(choice != "Yes")
 				return

--- a/tgui/packages/tgui/interfaces/Secrets.jsx
+++ b/tgui/packages/tgui/interfaces/Secrets.jsx
@@ -94,7 +94,7 @@ const HelpfulTab = (props) => {
               lineHeight={lineHeightNormal}
               width={buttonWidthNormal}
               content="Lobotomize Poly"
-              onClick={() => act('lobotimize_the_bird')}
+              onClick={() => act('lobotomize_the_bird')}
             />
           </Stack.Item>
           <Stack.Item>


### PR DESCRIPTION

## About The Pull Request

this adds a new button to the secrets panel, "Lobotomize Poly"

it evaporates poly from the world (complete with a fancy BSA effect) and wipes their memory/save files.

basically you use this when poly has something in their saved phrases they really shouldn't be saying.

## Why It's Good For The Game

so you don't need to rely on a maintainer or sysadmin to clean things up when poly decides to get racist

## Testing

https://github.com/user-attachments/assets/b640920c-5397-480e-8912-89d4af4a93af

## Changelog
:cl:
admin: Added an admin button in the Secrets panel to lobotomize Poly.
/:cl:
## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
