### PR TITLE
Gives Helio HoP their window

### DIFF
--- a/_maps/map_files/Heliostation/Heliostation.dmm
+++ b/_maps/map_files/Heliostation/Heliostation.dmm
@@ -62346,14 +62346,6 @@
 /obj/effect/landmark/navigate_destination/chapel,
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"qFw" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hopqueue";
-	name = "HoP Queue Shutters"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/hallway/secondary/command)
 "qFQ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light/small/directional/east,
@@ -118788,7 +118780,7 @@ wld
 rpX
 nGr
 fRz
-qFw
+oAm
 koK
 cOl
 nvp


### PR DESCRIPTION

## About The Pull Request


<img width="587" height="506" alt="image" src="https://github.com/user-attachments/assets/cd7d8d46-d7d9-453e-9349-431bb892fe43" />


prosper, stupid paperworker
## Why It's Good For The Game
fix
## Testing
None
## Changelog
:cl:
map: the HoP line on Helio has their windows actually exist in full
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
