### PR TITLE
THE PROTOLATHE ATE THE NUKE DISK AND IT DISAPPEARED (clickbait PR title, it just got teleported to vault)

### DIFF
--- a/code/datums/components/material/material_container.dm
+++ b/code/datums/components/material/material_container.dm
@@ -307,7 +307,7 @@
 				continue
 			//item is either not allowed for redemption, or not in the allowed types, such as INDESTRUCTIBLE items
 			if((target_item.item_flags & NO_MAT_REDEMPTION) || (target_item.resistance_flags & INDESTRUCTIBLE) \
-					 || (allowed_item_typecache && !is_type_in_typecache(target_item, allowed_item_typecache)))
+					|| (allowed_item_typecache && !is_type_in_typecache(target_item, allowed_item_typecache)))
 				if(!(mat_container_flags & MATCONTAINER_SILENT) && i == 1) //count only child items the 1st time around
 					var/list/status_data = chat_msgs["[MATERIAL_INSERT_ITEM_FAILURE]"] || list()
 					var/list/item_data = status_data[target_item.name] || list()


### PR DESCRIPTION

## About The Pull Request & Why It's Good For The Game
Fixes an issue where indestructible items are forcemoved to the ore silo machine (in vault) when used on a protolathe. Caused by the port of tg's rework in #7461.
## Testing
Items are rejected (with regular text feedback), and remain in the same location (in hand or in the storage which was used to attack the protolathe). Regular material sheets are still filtered out and get placed from the storage item into the protolathe.
## Changelog
:cl: Lawlolawl
fix: Fixed indestructible items (nuke disk, hand tele etc.) teleporting to ore silo in vault when attempting to place them into a protolathe. No one was stupid enough to try it in the last 5 months since porting tg's rework, apparently.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
