### PR TITLE
Fixes food items with no reagents not being able to be eaten

### DIFF
--- a/code/datums/components/food/edible.dm
+++ b/code/datums/components/food/edible.dm
@@ -457,7 +457,7 @@ Behavior that's still missing from this component that original food items had t
 
 	if(!owner?.reagents)
 		stack_trace("[eater] failed to bite [owner], because [owner] had no reagents.")
-		// Allow eating to proceed even if there are no reagents left in the food
+		return FALSE
 
 	if(eater.satiety > -200)
 		eater.adjust_satiety(-junkiness)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #10493 

Previously, food items with no reagents couldn't be eaten whatsoever. Following @MissClassyPineapple's reproduction,

> **MissClassyPineapple**
> Recreated and further details found.
> The reason that you're unable to eat certain foods is that food without reagents are unable to be eaten. This includes food where the reagents have been removed, e.g. via the comically large straw.
> A funny thing to note is that readding reagents will make the food eatable again.

... this PR fixes this, making it so food items depleted of their reagents can still be eaten, although, because they hold no nutritious value, they won't satiate the user's hunger, instead displaying a warning in chat as shown in testing.

Also, food items with no reagents were supposed to be deleted after one bite. This fixes that as well, making it so reagentless food still follows normal bite progression, but doesn't provide the user with any reagents, since it has none.

## Why It's Good For The Game

Trying to eat a food item that had no reagent would confuse some players, leading them to believe it was a bug, when it was an overlook at best. This PR in-*characterizes* non-nutritious food items.

## Testing

<img width="490" height="37" alt="image" src="https://github.com/user-attachments/assets/e9586a66-dfec-436a-b973-d791ad2cc995" />

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:Chelxox
fix: Food items with no reagents can now be eaten, although won't provide the eater with any sort of nutrition.
add: Adds a chat warning if user eats reagentless (otherwise non-nutritive) food.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
