### PR TITLE
fixes teleporting dissconnecting mobs from what they are buckled to

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -87,6 +87,23 @@
 
 	SEND_SIGNAL(teleatom, COMSIG_MOVABLE_POST_TELEPORT)
 
+		//We need to be sure that the buckled mobs can teleport too
+	if(teleatom.has_buckled_mobs())
+		for(var/mob/living/rider in teleatom.buckled_mobs)
+			//just in case it fails, but the mob gets unbuckled anyways even if it passes
+			teleatom.unbuckle_mob(rider, TRUE, FALSE)
+
+			var/rider_success = do_teleport(rider, destturf, precision, channel=channel, no_effects=TRUE)
+			if(!rider_success)
+				continue
+
+			if(get_turf(rider) != destturf) //precision made them teleport somewhere else
+				to_chat(rider, span_warning("As you reorient your senses, you realize you aren't riding [teleatom] anymore!"))
+				continue
+
+			// [mob/living].forceMove() forces mobs to unbuckle, so we need to buckle them again
+			teleatom.buckle_mob(rider, force=TRUE)
+
 	return TRUE
 
 /proc/tele_play_specials(atom/movable/teleatom, atom/location, datum/effect_system/effect, sound)


### PR DESCRIPTION
## About The Pull Request
ever shoved a person on a roller bed into a portal and realize they are just floating there quantum entangled to the bed? well this fixes that. fix taken from TG.

## Why It's Good For The Game
bug fix.

## Changelog

:cl:
fix: fixed teleporting disconnecting mobs from what they are buckled to.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

