### PR TITLE
Replaces Blueshift's brig infirmary (empty) medkits with regular ones

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -38909,13 +38909,11 @@
 	},
 /obj/structure/rack,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/item/storage/medkit{
-	pixel_x = 0;
-	pixel_y = -6
-	},
-/obj/item/storage/medkit{
-	pixel_x = 0;
+/obj/item/storage/medkit/regular{
 	pixel_y = 2
+	},
+/obj/item/storage/medkit/regular{
+	pixel_y = -6
 	},
 /turf/open/floor/iron/white/corner{
 	dir = 8


### PR DESCRIPTION

## About The Pull Request

Fixes #10517 

Full medkits are marked as `/regular` at the end of their datums. Empty medkits aren't. Likely a confusion from the mapper (or whoever touched this last, I didn't check).

## Why It's Good For The Game

Pro-security propagandist PR. Brig phys has the additional supply they'd usually have on other stations now.

## Testing

Checks & changed files.

## Changelog
:cl:
fix: Blueshift's brig infirmary now has supplied medkits instead of empty ones.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
