### PR TITLE
Increases reload time on nukie shuttle turret

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -831,7 +831,7 @@ DEFINE_BITFIELD(turret_flags, list(
 
 /obj/machinery/porta_turret/syndicate/shuttle
 	scan_range = 9
-	shot_delay = 3
+	shot_delay = 4.5
 	stun_projectile = /obj/projectile/bullet/p50/penetrator/shuttle
 	lethal_projectile = /obj/projectile/bullet/p50/penetrator/shuttle
 	lethal_projectile_sound = 'sound/weapons/gun/smg/shot.ogg'


### PR DESCRIPTION
Basically for balance and issue #7577
## About The Pull Request
Increases reload from 3 seconds to 4.5

## Why It's Good For The Game
No more mowing all of sec down in 5 seconds

## Testing
- [ x] Doesn't break anything 


## Changelog
:cl: Mushy


balance: Nukie turret reload from 3 -> 4.5 seconds
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
