### PR TITLE
Fixes arachnids having a tackling attack bonus

### DIFF
--- a/code/datums/components/tackle.dm
+++ b/code/datums/components/tackle.dm
@@ -348,7 +348,8 @@
 		if(!istype(sacker_moth_wing) || sacker_moth_wing.burnt)
 			attack_mod -= 2
 	var/obj/item/organ/external/wings/sacker_wing = sacker.get_organ_slot(ORGAN_SLOT_EXTERNAL_WINGS)
-	if(sacker_wing)
+//	if(sacker_wing) // MONKESTATION EDIT OLD -- Arachnids use the external wing slot aswell, so we have to check for actual wings
+	if(sacker_wing && istype(sacker_wing)) // MONKESTATION EDIT NEW
 		attack_mod += 2
 
 	if(ishuman(target))


### PR DESCRIPTION

## About The Pull Request

- Removes the tackling attack bonus from arachnids

## Why It's Good For The Game

> Removes the tackling attack bonus from arachnids
- They weren't intended to have it, they had it due to their cosmetic appendages taking the same slot as moth wings

## Testing

Tested and farmed locally, non-GMO
Tackled as a moth, spider, h*man and tis bout it

## Changelog

:cl:
fix: arachnids no longer get a tackle attack buff due to their appendages
/:cl:

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
