### PR TITLE
reverts some fun removal (you can properly eat the SM with matter eater again)

### DIFF
--- a/monkestation/code/datums/mutations/matter_eater.dm
+++ b/monkestation/code/datums/mutations/matter_eater.dm
@@ -510,12 +510,6 @@
 		to_chat(hungry_boy, span_danger("You were interrupted before you could eat [src]!"))
 		return EAT_FAILED
 
-	if(!HAS_TRAIT(hungry_boy, TRAIT_SHOCKIMMUNE))
-		hungry_boy.visible_message(span_warning("[hungry_boy]'s body flashes and burns up from inside in blazing light!"))
-		hungry_boy.investigate_log("has been dusted by attempting to eat a supermatter.", INVESTIGATE_DEATHS)
-		hungry_boy.dust(TRUE, TRUE)
-		return EAT_FAILED
-
 	hungry_boy.visible_message(span_danger("[hungry_boy] consumes [src] whole, how is that even possible?"))
 	return EAT_SUCCESS
 


### PR DESCRIPTION
## About The Pull Request

reverts a stupid-ass change made in https://github.com/Monkestation/Monkestation2.0/pull/10241 that made it so you needed insulated or nerve grounding to do so. this was not documented anywhere - "which requires another mutation/trait to work" is not a helpful description on what's needed in the slightest, I needed to code dive to figure out what it was.

## Why It's Good For The Game

it was fun removal to do this.
if people are abusing it, **that's an admin issue.**

## Changelog
:cl:
qol: You can properly eat the supermatter with Matter Eater again.
/:cl:
