### PR TITLE
[s] Adds NaN check to regular(non-tgui) tgui_input_number windows, and validation to chunked payloads.

### DIFF
--- a/code/modules/tgui/tgui_window.dm
+++ b/code/modules/tgui/tgui_window.dm
@@ -468,6 +468,9 @@
 		var/message_type = payload["type"]
 		var/final_payload = chunks.Join()
 		remove_oversized_payload(payload_id)
+		if (!rustg_json_is_valid(final_payload))
+			log_tgui(usr, "Error: Invalid JSON")
+			return
 		on_message(message_type, json_decode(final_payload), list("type" = message_type, "payload" = final_payload, "tgui" = TRUE, "window_id" = id))
 	else
 		payload["timeout"] = addtimer(CALLBACK(src, PROC_REF(remove_oversized_payload), payload_id), 1 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE|TIMER_STOPPABLE)

--- a/code/modules/tgui_input/number.dm
+++ b/code/modules/tgui_input/number.dm
@@ -31,6 +31,8 @@
 	// Client does NOT have tgui_input on: Returns regular input
 	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
 		var/input_number = input(user, message, title, default) as null|num
+		if(isnan(input_number))
+			CRASH("A non number was input into non-tgui number input by [user]")
 		return clamp(round_value ? round(input_number) : input_number, min_value, max_value)
 	var/datum/tgui_input_number/number_input = new(user, message, title, default, max_value, min_value, timeout, round_value, ui_state)
 	number_input.ui_interact(user)


### PR DESCRIPTION
## About The Pull Request
It's possible to pass `NaN` to regular input window by using a hidden command/verb `.prompt`.
And, well, passing `NaN` to `clamp` just returns `NaN`.
This means that any `tgui_input_number` (with tgui-input preference disabled) can return `NaN`. 

`tgui_Topic` already performs `rustg_json_is_valid` check to prevent passing `NaN` in payload, but by using chunked payloads you can just bypass it.

<details>
<summary><b>As for why [s]:</b></summary>

<img width="634" height="291" alt="dreamseeker_3phdvucCC0" src="https://github.com/user-attachments/assets/ac6a5c36-9ee5-47fd-8558-2100679b3286" />

</details>

## Why It's Good For The Game
Me no like exploits.

## Testing
Sure did!

## Changelog

Not player-facing.

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
