### PR TITLE
fixes the apc control console

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -2149,6 +2149,12 @@
 /obj/machinery/quantum_server,
 /turf/open/floor/iron,
 /area/station/bitrunning/den)
+"yx" = (
+/obj/machinery/computer/apc_control{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "yA" = (
 /obj/docking_port/stationary/laborcamp_home{
 	dir = 8
@@ -7245,7 +7251,7 @@ aa
 aa
 aj
 al
-aA
+yx
 aj
 WT
 aj

--- a/code/game/machinery/computer/apc_control.dm
+++ b/code/game/machinery/computer/apc_control.dm
@@ -6,26 +6,33 @@
 	req_access = list(ACCESS_CE)
 	circuit = /obj/item/circuitboard/computer/apc_control
 	light_color = LIGHT_COLOR_DIM_YELLOW
-	var/obj/machinery/power/apc/active_apc //The APC we're using right now
+	///The APC we're remotely connected to right now
+	var/obj/machinery/power/apc/active_apc
+	///Whether actions are being logged to the console's logs or not
 	var/should_log = TRUE
+	///Whether the console is currently being restored from an emagged state
 	var/restoring = FALSE
-	var/list/logs
+	///List of logs containing events like logins/logoffs, APC access and manipulation, checking the APC/logs tabs and restoring logging after an emag
+	var/list/logs = list()
+	///Tracks the current logged-in user's ID card's name and assignment
 	var/auth_id = "\[NULL\]:"
+	///Whether the computer is on a station-level; set in Initialize() for use in checking APCs
+	var/is_on_station = TRUE
 
 /obj/machinery/computer/apc_control/Initialize(mapload, obj/item/circuitboard/C)
 	. = ..()
-	logs = list()
+	is_on_station = is_station_level(z)
 
 /obj/machinery/computer/apc_control/on_set_machine_stat(old_value)
 	. = ..()
-	if(machine_stat)
+	if(machine_stat && active_apc)
 		disconnect_apc()
 
 /obj/machinery/computer/apc_control/attack_ai(mob/user)
 	if(!isAdminGhostAI(user))
 		to_chat(user,span_warning("[src] does not support AI control.")) //You already have APC access, cheater!
 		return
-	..()
+	return ..()
 
 /obj/machinery/computer/apc_control/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(obj_flags & EMAGGED)
@@ -37,11 +44,13 @@
 	playsound(src, SFX_SPARKS, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	return TRUE
 
+///Creates a log entry in the console with a timestamp, current login ID data and the text provided in log_text
 /obj/machinery/computer/apc_control/proc/log_activity(log_text)
 	if(!should_log)
 		return
 	LAZYADD(logs, "([station_time_timestamp()]): [auth_id] [log_text]")
 
+///Resets the console's emagged state and re-enables logging of activity
 /obj/machinery/computer/apc_control/proc/restore_comp(mob/user)
 	obj_flags &= ~EMAGGED
 	should_log = TRUE
@@ -49,6 +58,7 @@
 	log_activity("-=- Logging restored to full functionality at this point -=-")
 	restoring = FALSE
 
+///Initiates remote access to the APC
 /obj/machinery/computer/apc_control/proc/connect_apc(obj/machinery/power/apc/apc, mob/user)
 	if(isnull(apc))
 		return
@@ -62,17 +72,37 @@
 	user.log_message("remotely accessed [apc] from [src].", LOG_GAME)
 	log_activity("[auth_id] remotely accessed APC in [get_area_name(apc.area, TRUE)]")
 	active_apc = apc
+	RegisterSignal(active_apc, COMSIG_QDELETING, PROC_REF(on_apc_destroyed))
 
-/obj/machinery/computer/apc_control/proc/disconnect_apc()
-	// check if apc exists and is not controlled by anyone
-	if(QDELETED(active_apc))
-		return
+///Disconnects the computer from the accessed APC upon its destruction
+/obj/machinery/computer/apc_control/proc/on_apc_destroyed(datum/source)
+	SIGNAL_HANDLER
+	disconnect_apc(TRUE) //to prevent the APC from trying to speak while being qdel'd
+
+/**
+ * Disconnect from the APC we're currently in remote access with
+ * arguments:
+ * mute - whether the APC should announce the disconnection locally, passed into apc's disconnect_remote_access()
+ */
+/obj/machinery/computer/apc_control/proc/disconnect_apc(mute = FALSE)
+	UnregisterSignal(active_apc, COMSIG_QDELETING)
 	if(active_apc.remote_control_user)
-		active_apc.disconnect_remote_access()
+		active_apc.disconnect_remote_access(mute)
 	active_apc = null
 
-/obj/machinery/computer/apc_control/proc/check_apc(obj/machinery/power/apc/APC)
-	return APC.z == z && !APC.malfhack && !APC.aidisabled && !(APC.obj_flags & EMAGGED) && !APC.machine_stat && !istype(APC.area, /area/station/ai_monitored)
+/**
+* Checks for whether the APC provided is eligible for access and being listed in the APC list.
+* The APC has to:
+* - be on a station z-level if the computer is station-side or be on the same z-level as the computer if otherwise (away subtype, charlie station)
+* - be not hacked by a malf AI
+* - have AI control enabled
+* - be not emagged
+* - be working
+* - not be an AI monitored area (AI sat areas and AI upload)
+*/
+
+/obj/machinery/computer/apc_control/proc/check_apc(obj/machinery/power/apc/checked_apc)
+	return (is_on_station ? is_station_level(checked_apc.z) : checked_apc.z == z) && !checked_apc.malfhack && !checked_apc.aidisabled && !(checked_apc.obj_flags & EMAGGED) && !checked_apc.machine_stat && !istype(checked_apc.area, /area/station/ai_monitored)
 
 /obj/machinery/computer/apc_control/ui_interact(mob/user, datum/tgui/ui)
 	. = ..()
@@ -94,7 +124,7 @@
 	for(var/entry in logs)
 		data["logs"] += list(list("entry" = entry))
 
-	for(var/obj/machinery/power/apc/apc as anything in SSmachines.get_machines_by_type(/obj/machinery/power/apc))
+	for(var/obj/machinery/power/apc/apc as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/power/apc))
 		if(check_apc(apc))
 			var/has_cell = (apc.cell) ? TRUE : FALSE
 			data["apcs"] += list(list(
@@ -118,6 +148,7 @@
 	if(.)
 		return
 
+	var/mob/living/user = ui.user
 	switch(action)
 		if("log-in")
 			if(obj_flags & EMAGGED)
@@ -125,18 +156,17 @@
 				auth_id = "Unknown (Unknown):"
 				log_activity("[auth_id] logged in to the terminal")
 				return
-			var/mob/living/operator = usr
-			if(!istype(operator))
+			if(!istype(user))
 				return
-			var/obj/item/card/id/ID = operator.get_idcard(TRUE)
-			if(ID && istype(ID))
-				if(check_access(ID))
+			var/obj/item/card/id/user_id_card = user.get_idcard(TRUE)
+			if(istype(user_id_card))
+				if(check_access(user_id_card))
 					authenticated = TRUE
-					auth_id = "[ID.registered_name] ([ID.assignment]):"
+					auth_id = "[user_id_card.registered_name] ([user_id_card.assignment]):"
 					log_activity("[auth_id] logged in to the terminal")
 					playsound(src, 'sound/machines/terminal_on.ogg', 50, FALSE)
 				else
-					auth_id = "[ID.registered_name] ([ID.assignment]):"
+					auth_id = "[user_id_card.registered_name] ([user_id_card.assignment]):"
 					log_activity("[auth_id] attempted to log into the terminal")
 					playsound(src, 'sound/machines/terminal_error.ogg', 50, FALSE)
 					say("ID rejected, access denied!")
@@ -150,15 +180,18 @@
 			auth_id = "\[NULL\]"
 		if("toggle-logs")
 			should_log = !should_log
-			usr.log_message("set the logs of [src] [should_log ? "On" : "Off"].", LOG_GAME)
+			user.log_message("set the logs of [src] [should_log ? "On" : "Off"].", LOG_GAME)
 		if("restore-console")
 			restoring = TRUE
-			addtimer(CALLBACK(src, PROC_REF(restore_comp)), rand(3,5) * 9 SECONDS)
+			addtimer(CALLBACK(src, PROC_REF(restore_comp), user), rand(3,5) * 9 SECONDS)
 		if("access-apc")
 			var/ref = params["ref"]
 			playsound(src, SFX_TERMINAL_TYPE, 50, FALSE)
-			var/obj/machinery/power/apc/APC = locate(ref) in SSmachines.get_machines_by_type(/obj/machinery/power/apc)
-			connect_apc(APC, usr)
+			var/obj/machinery/power/apc/remote_target = locate(ref) in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/power/apc)
+			if(!remote_target || !check_apc(remote_target))
+				return
+			connect_apc(remote_target, user)
+			return TRUE
 		if("check-logs")
 			log_activity("Checked Logs")
 		if("check-apcs")
@@ -167,17 +200,23 @@
 			var/ref = params["ref"]
 			var/type = params["type"]
 			var/value = params["value"]
-			var/obj/machinery/power/apc/target = locate(ref) in SSmachines.get_machines_by_type(/obj/machinery/power/apc)
-			if(!target)
+			var/obj/machinery/power/apc/target = locate(ref) in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/power/apc)
+			if(!target || !check_apc(target))
 				return
 
 			value = target.setsubsystem(text2num(value))
 			switch(type) // Sanity check
-				if("equipment", "lighting", "environ")
-					target.vars[type] = value
+				if("equipment")
+					target.equipment = value
+				if("lighting")
+					target.lighting = value
+				if("environ")
+					target.environ = value
+				if(null)
+					return
 				else
-					message_admins("Warning: possible href exploit by [key_name(usr)] - attempted to set [html_encode(type)] on [target] to [html_encode(value)]")
-					usr.log_message("possibly trying to href exploit - attempted to set [html_encode(type)] on [target] to [html_encode(value)]", LOG_ADMIN)
+					message_admins("Warning: possible href exploit by [key_name(user)] - attempted to set [html_encode(type)] on [target] to [html_encode(value)]")
+					user.log_message("possibly trying to href exploit - attempted to set [html_encode(type)] on [target] to [html_encode(value)]", LOG_ADMIN)
 					return
 
 			target.update_appearance()
@@ -193,15 +232,21 @@
 				if(3)
 					setTo = "Auto On"
 			log_activity("Set APC [target.area.name] [type] to [setTo]")
-			usr.log_message("set APC [target.area.name] [type] to [setTo]]", LOG_GAME)
+			user.log_message("set APC [target.area.name] [type] to [setTo]]", LOG_GAME)
 		if("breaker")
 			var/ref = params["ref"]
-			var/obj/machinery/power/apc/target = locate(ref) in SSmachines.get_machines_by_type(/obj/machinery/power/apc)
-			target.toggle_breaker(usr)
-			var/setTo = target.operating ? "On" : "Off"
-			log_activity("Turned APC [target.area.name]'s breaker [setTo]")
+			var/obj/machinery/power/apc/breaker_target = locate(ref) in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/power/apc)
+			if(!breaker_target || !check_apc(breaker_target))
+				return
+			breaker_target.toggle_breaker(user)
+			var/setTo = breaker_target.operating ? "On" : "Off"
+			log_activity("Turned APC [breaker_target.area.name]'s breaker [setTo]")
+			return TRUE
 
 /obj/machinery/computer/apc_control/ui_close(mob/user)
 	. = ..()
 	if(active_apc)
 		disconnect_apc()
+
+/obj/machinery/computer/apc_control/away
+	req_access = list(ACCESS_AWAY_ENGINEERING)

--- a/tgui/packages/tgui/interfaces/ApcControl.tsx
+++ b/tgui/packages/tgui/interfaces/ApcControl.tsx
@@ -10,8 +10,8 @@ import {
   Stack,
   Table,
   Tabs,
-} from '../components';
-import type { BooleanLike } from 'common/react';
+} from 'tgui-core/components';
+import type { BooleanLike } from 'tgui-core/react';
 
 import { useBackend } from '../backend';
 import { Window } from '../layouts';


### PR DESCRIPTION
## About The Pull Request
ports: https://github.com/tgstation/tgstation/pull/87502

## Why It's Good For The Game
bug fixes
fixes: https://github.com/Monkestation/Monkestation2.0/issues/10404
fixes: https://github.com/Monkestation/Monkestation2.0/issues/10355

## Testing
tested on local

## Changelog

:cl: Sealed101, SirNightKnight
fix: fixed APC control console found in CE office only accessing APCs on its z-level.
fix: fixed restoring an emagged APC control console potentially leaving the console in a forever state of restoring.

fix: fixed the APC control console UI not loading correctly.

map: added an APC control console to runtime station engineering.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

