### PR TITLE
Fix Revelation Obfuscation Name

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosRevelation.tsx
+++ b/tgui/packages/tgui/interfaces/NtosRevelation.tsx
@@ -1,7 +1,8 @@
-import { Section, Button, LabeledList } from '../components';
+import { Button, LabeledList, Section } from 'tgui-core/components';
+import type { BooleanLike } from 'tgui-core/react';
+
 import { useBackend } from '../backend';
 import { NtosWindow } from '../layouts';
-import { BooleanLike } from 'common/react';
 
 type Data = {
   armed: BooleanLike;
@@ -17,7 +18,7 @@ export const NtosRevelation = (props) => {
         <Section>
           <Button.Input
             fluid
-            content="Obfuscate Name..."
+            buttonText="Obfuscate Name..."
             onCommit={(value) =>
               act('PRG_obfuscate', {
                 new_name: value,


### PR DESCRIPTION
## About The Pull Request
I have no idea what im doing. I just stole what the current TGstation file for it is [currently](https://github.com/tgstation/tgstation/blob/09ae25cf9e340d9ec8a95ed09189d80552111d1c/tgui/packages/tgui/interfaces/NtosRevelation.tsx#L21)
## Why It's Good For The Game
Lets me do funny
## Testing

<img width="400" height="250" alt="image" src="https://github.com/user-attachments/assets/e434de29-607a-461e-9577-aa15cb1c68c9" />

<img width="400" height="500" alt="image" src="https://github.com/user-attachments/assets/483e366c-25cd-4325-9dab-13edfb3c7946" />

Woah whats up with this one. Snip and sketch fucked up.

## Changelog
:cl:
fix: Revelation can (hopefully) now can have a fake name again.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
