### PR TITLE
adds `CHECK_TICK` to credits subsystem init

### DIFF
--- a/monkestation/code/modules/and_roll_credits/credits_subsystem.dm
+++ b/monkestation/code/modules/and_roll_credits/credits_subsystem.dm
@@ -110,6 +110,7 @@ SUBSYSTEM_DEF(credits)
 		appearance.maptext_y = -12
 		appearance.maptext = "<center>[ckey]</center>"
 		contributer_pref_images += appearance
+		CHECK_TICK
 
 	for(var/ckey in GLOB.admin_datums)
 		var/datum/client_interface/interface = new(ckey(ckey))
@@ -122,6 +123,7 @@ SUBSYSTEM_DEF(credits)
 		appearance.maptext_y = -12
 		appearance.maptext = "<center>[ckey]</center>"
 		admin_pref_images += appearance
+		CHECK_TICK
 
 /datum/controller/subsystem/credits/proc/finalize_name()
 	if(customized_name)


### PR DESCRIPTION
this adds `CHECK_TICK` to the credits subsystem init, hopefully reducing the player-side freezing when it inits.