### PR TITLE
github actions only fire when it's meaningful to do so

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -37,6 +37,7 @@ jobs:
     uses: ./.github/workflows/collect_data.yml
 
   compile_all_maps:
+    if: needs.collect_data.outputs.game_changes == 'true'
     name: Compile Maps
     needs: collect_data
     uses: ./.github/workflows/compile_all_maps.yml
@@ -44,6 +45,7 @@ jobs:
       max_required_byond_client: ${{ needs.collect_data.outputs.max_required_byond_client }}
 
   setup_build_artifacts:
+    if: needs.collect_data.outputs.game_changes == 'true'
     name: Setup build artifacts
     needs: collect_data
     uses: ./.github/workflows/setup_build_artifacts.yml
@@ -51,6 +53,7 @@ jobs:
       build_versions: ${{ needs.collect_data.outputs.required_build_versions }}
 
   run_all_tests:
+    if: needs.collect_data.outputs.game_changes == 'true'
     name: Integration Tests
     needs: [collect_data, setup_build_artifacts]
     uses: ./.github/workflows/perform_regular_version_tests.yml
@@ -59,7 +62,7 @@ jobs:
       max_required_byond_client: ${{ needs.collect_data.outputs.max_required_byond_client }}
 
   run_alternate_tests:
-    if: needs.collect_data.outputs.alternate_tests != '[]'
+    if: (needs.collect_data.outputs.game_changes == 'true') && (needs.collect_data.outputs.alternate_tests != '[]')
     name: Alternate Tests
     needs: [collect_data, setup_build_artifacts]
     uses: ./.github/workflows/perform_alternate_version_tests.yml
@@ -90,4 +93,4 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
-          allowed-skips: compare_screenshots
+          allowed-skips: compare_screenshots,compile_all_maps,run_all_tests,run_alternate_tests

--- a/.github/workflows/collect_data.yml
+++ b/.github/workflows/collect_data.yml
@@ -15,6 +15,9 @@ on:
       required_build_versions:
         description: "Build versions that need to be precompiled"
         value: ${{ jobs.collect_data.outputs.required_build_versions }}
+      game_changes:
+        description: "Whether game files were changed"
+        value: ${{ jobs.collect_data.outputs.game_changes }}
 
 jobs:
   collect_data:
@@ -25,6 +28,7 @@ jobs:
       alternate_tests: ${{ steps.alternate_test_finder.outputs.alternate_tests }}
       max_required_byond_client: ${{ steps.max_required_byond_client.outputs.max_required_byond_client }}
       required_build_versions: ${{ steps.setup_required_build_versions.outputs.required_build_versions }}
+      game_changes: ${{ steps.find_game_changes.outputs.all_changed_files != '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -66,3 +70,13 @@ jobs:
             ($alternate + $default) | map({major, minor}) | unique
           ')
           echo "required_build_versions=$REQUIRED_BUILD_VERSIONS" >> $GITHUB_OUTPUT
+
+      - name: Find game changes
+        id: find_game_changes
+        uses: tj-actions/changed-files@v47
+        with:
+          fetch_depth: 0
+          files_ignore: |
+            **/*.md
+            html/**
+            tgui/**

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
 	"editor.insertSpaces": false,
 	"gitlens.advanced.blame.customArguments": ["-w"],
 	"tgstationTestExplorer.project.resultsType": "json",
-	"[javascript][javascriptreact][typescript][typescriptreact][html][css][scss][json][jsonc][yaml]": {
+	"[javascript][javascriptreact][typescript][typescriptreact][html][css][scss][json][jsonc][yaml][github-actions-workflow]": {
 		"editor.rulers": [80],
 		"editor.defaultFormatter": "esbenp.prettier-vscode",
 		"editor.formatOnSave": true


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/94989

> This checks which files were modified in a PR and skips larger tests when it doesn't contain game files.

## Why It's Good For The Game
> I can make solely-TGUI PRs in peace without waiting on it to check if monkeys are doing their business and whatnot
> 
> Saves your runners for PRs that actually require them
## Changelog

no in-game changes at all