### PR TITLE
Removes 2 steps from the Repair robotic limbs surgery

### DIFF
--- a/monkestation/code/modules/surgery/robot_healing.dm
+++ b/monkestation/code/modules/surgery/robot_healing.dm
@@ -6,8 +6,6 @@
 /datum/surgery/robot_healing
 	steps = list(
 		/datum/surgery_step/mechanic_open,
-		/datum/surgery_step/pry_off_plating,
-		/datum/surgery_step/cut_wires,
 		/datum/surgery_step/robot_heal,
 		/datum/surgery_step/mechanic_close,
 	)
@@ -28,8 +26,6 @@
 	if(healing_step_type)
 		steps = list(
 			/datum/surgery_step/mechanic_open,
-			/datum/surgery_step/pry_off_plating,
-			/datum/surgery_step/cut_wires,
 			healing_step_type,
 			/datum/surgery_step/mechanic_close,
 		)


### PR DESCRIPTION

## About The Pull Request
Balance PR time, removes the crowbar and wirecutter steps from the robotic tend wounds surgery. making it simpler and a little faster. The surgery is now cut down to screwdriver, crowbar/wirecutters (repeated), screwdriver.
## Why It's Good For The Game
wound tending is the most common surgery type, and on humans, its also only three steps. and I dont think anyone has picked this over going at the patient with a welder/some cable and their numpad, simply due to the fact its faster, easier, and the resources consumed doing so are easily replaced at a welding fuel tank or autolathe. (welder and numpad is likely still faster, but thats a topic to inspect another time.)
## Testing
Tested locally, basic and max tier wound tending both only had 3 steps.
## Changelog
:cl:
balance: removed 2 steps from robotic wound tending.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
