### PR TITLE
Colony megacell moment

### DIFF
--- a/monkestation/code/modules/blueshift/cargo/flatpacks.dm
+++ b/monkestation/code/modules/blueshift/cargo/flatpacks.dm
@@ -52,7 +52,7 @@
 		/obj/item/flatpacked_machine/airlock_kit_manual,
 		/obj/item/wallframe/apc,
 		/obj/item/electronics/apc,
-		/obj/item/stock_parts/power_store/cell/high,
+		/obj/item/stock_parts/power_store/battery/high,
 	)
 	crate_name = "colonization kit crate"
 
@@ -119,7 +119,7 @@
 	new /obj/item/flatpacked_machine/airlock_kit_manual(src)
 	new /obj/item/wallframe/apc(src)
 	new /obj/item/electronics/apc(src)
-	new /obj/item/stock_parts/power_store/cell/high(src)
+	new /obj/item/stock_parts/power_store/battery/high(src)
 	new /obj/item/wallframe/frontier_medstation(src)
 	new /obj/item/screwdriver/omni_drill(src)
 	new /obj/item/multitool(src)

--- a/monkestation/code/modules/blueshift/designs/colony.dm
+++ b/monkestation/code/modules/blueshift/designs/colony.dm
@@ -216,6 +216,10 @@
 	. = ..()
 	build_type |= COLONY_FABRICATOR
 
+/datum/design/super_battery/New()
+	. = ..()
+	build_type |= COLONY_FABRICATOR
+
 /datum/design/adv_capacitor/New()
 	. = ..()
 	build_type |= COLONY_FABRICATOR


### PR DESCRIPTION

## About The Pull Request
Swaps the cells for megacells in colony kits and adds megacells to the fabricator.
## Why It's Good For The Game
It fix #10397 and let's colonists build more APCs.
## Changelog
:cl: EssentialTomato
fix: Swapped regular cells for megacells in colony kits.
fix: Added missing megacell design to the colony fabricators.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
