### PR TITLE
Fixes accesses on Theseus for NTR/BSO

### DIFF
--- a/_maps/map_files/Theseus/Theseus.dmm
+++ b/_maps/map_files/Theseus/Theseus.dmm
@@ -18851,6 +18851,7 @@
 	name = "Blueshield's Office"
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
+/obj/effect/mapping_helpers/airlock/access/any/command/nt_rep,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/blueshield)
 "fGn" = (
@@ -63681,6 +63682,7 @@
 	},
 /obj/machinery/duct,
 /obj/effect/mapping_helpers/airlock/access/any/command/nt_rep,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/nt_rep)
 "sCg" = (
@@ -74157,6 +74159,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/any/command/nt_rep,
 /obj/effect/landmark/navigate_destination,
+/obj/effect/mapping_helpers/airlock/access/any/command/blueshield,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/nt_rep)
 "vxI" = (


### PR DESCRIPTION
## About The Pull Request

I had this sitting as uncommitted on my github desktop for a long ass time so here you go

Nanotrasen Representative and Blueshield Officer are supposed to be able to access eachother's offices, Theseus doesn't follow that convention (which I assume I accidentally changed, so I'm fixing my own bug)

## Why It's Good For The Game

Fix.

## Changelog

:cl:
fix: [Theseus] NT Rep & BSO can now access eachother's offices again.
/:cl: