### PR TITLE
draconic and ash tongue are closer

### DIFF
--- a/code/modules/language/ashtongue.dm
+++ b/code/modules/language/ashtongue.dm
@@ -38,5 +38,5 @@
 	default_priority = 90
 
 	mutual_understanding = list(
-		/datum/language/draconic = 45,
+		/datum/language/draconic = 80,
 	)

--- a/code/modules/language/draconic.dm
+++ b/code/modules/language/draconic.dm
@@ -22,5 +22,5 @@
 	default_priority = 90
 
 	mutual_understanding = list(
-		/datum/language/ashtongue = 45,
+		/datum/language/ashtongue = 80,
 	)


### PR DESCRIPTION
## About The Pull Request

I don't like the ash walker language in general as it feels kinda pointless, but it kinda makes sense for them to be sorta dialects of eachother, so making them understand more of the other and miss the words with heavy accents makes sense I think. Think of it like France French vs Quebec French, if anything.

## Testing

From the POV of a station-side lizard

<img width="595" height="44" alt="image" src="https://github.com/user-attachments/assets/acf3102c-e50c-4653-8411-d4fbdf1b2b04" />

## Changelog

:cl:
balance: Ash Walkers and Lizards understand eachother better.
/:cl: