### PR TITLE
Expands Tram Slum Bar

### DIFF
--- a/_maps/~monkestation/RandomBars/Tram/tram_slum_bar.dmm
+++ b/_maps/~monkestation/RandomBars/Tram/tram_slum_bar.dmm
@@ -471,6 +471,7 @@
 /area/station/service/kitchen)
 "rf" = (
 /obj/structure/bonfire/prelit,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/stone,
 /area/station/commons/lounge)
 "rm" = (
@@ -857,7 +858,6 @@
 /turf/open/floor/wood/tile,
 /area/station/service/theater)
 "HQ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/chair/greyscale{
 	dir = 8;
 	pixel_x = 4
@@ -1351,7 +1351,7 @@ nk
 nk
 nk
 nk
-QC
+nk
 QC
 QC
 QC
@@ -1376,9 +1376,9 @@ nk
 qi
 iF
 GW
+iY
 rf
 nk
-QC
 QC
 QC
 QC
@@ -1403,9 +1403,9 @@ nk
 iY
 dN
 nq
+dN
 HQ
 nk
-QC
 QC
 QC
 QC


### PR DESCRIPTION

## About The Pull Request
Noticed during a delayed reboot that there was some space tiles here. Expanded the lounge a little bit to resolve that.
<img width="652" height="480" alt="image" src="https://github.com/user-attachments/assets/c9fcda06-4e8d-4bc8-bcc7-d4085c125443" />
## Why It's Good For The Game
Bug Fix
## Testing
None:tm:
## Changelog
:cl:
fix: fixed some space leaking through on the Tram Slum Bar.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
