### PR TITLE
[PORT] fixes seed ruin logic preventing forced ruins from spawning when budget is zero

### DIFF
--- a/code/modules/mapping/ruins.dm
+++ b/code/modules/mapping/ruins.dm
@@ -111,7 +111,7 @@
 		if(R.unpickable)
 			continue
 		ruins_available[R] = R.placement_weight
-	while((budget > 0 || mineral_budget > 0) && (ruins_available.len || forced_ruins.len))
+	while(((budget > 0 || mineral_budget > 0) && ruins_available.len) || forced_ruins.len)
 		var/datum/map_template/ruin/current_pick
 		var/forced = FALSE
 		var/forced_z //If set we won't pick z level and use this one instead.


### PR DESCRIPTION

## About The Pull Request

ports the following PRs:
- https://github.com/tgstation/tgstation/pull/87207 (just the `ruins.dm` part)
- https://github.com/tgstation/tgstation/pull/87910

## Changelog
:cl: Absolucy, Majkl-J
fix: Ruins will now correctly spawn their tied ruins in.
/:cl: