### PR TITLE
The DDoS Update (actually a fix)

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2719,10 +2719,11 @@
 /turf/open/floor/iron/dark,
 /area/centcom/central_command_areas/briefing)
 "ahp" = (
-/obj/machinery/ntnet_relay{
+/obj/structure/fluff{
+	desc = "A very complex router and transmitter capable of connecting electronic devices together. Did Ook somehow steal this hunk of junk from NT or something??";
 	name = "Ook's Modem";
-	is_operational = 0;
-	desc = "A very complex router and transmitter capable of connecting electronic devices together. Did Ook somehow steal this hunk of junk from NT or something??"
+	icon = 'icons/obj/machines/telecomms.dmi';
+	icon_state = "bus"
 	},
 /turf/open/misc/grass,
 /area/centcom/central_command_areas/admin)

--- a/code/modules/NTNet/relays.dm
+++ b/code/modules/NTNet/relays.dm
@@ -97,7 +97,8 @@
 		set_dos_failure(FALSE)
 		update_appearance()
 		SSmodular_computers.add_log("Quantum relay switched from overload recovery mode to normal operation mode.")
-	return ..()
+	if(dos_overload == 0)
+		end_processing() //my job here is done.
 
 /obj/machinery/ntnet_relay/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -56,6 +56,7 @@
 			if(target)
 				executed = TRUE
 				target.dos_sources.Add(src)
+				target.begin_processing() //target will handle stopping processing itself
 				if(SSmodular_computers.intrusion_detection_enabled)
 					SSmodular_computers.add_log("IDS WARNING - Excess traffic flood targeting relay [target.uid] detected from device: [computer.name]")
 					SSmodular_computers.intrusion_detection_alarm = TRUE


### PR DESCRIPTION
## About The Pull Request
So. The NTNet relay has a function where if a traitor hits it with a DoS hard enough, itll crash and stop NTNet for a while or until a sigtech comes and presses the reboot button.

Unfortunately, the machine called parent, which returns PROCESS_KILL, which makes it so it cant decay its buffer, or even die upon being fully DDoSed.
This fixes it by making DoS generator make the relay start processing, and the relay stop processing once it has no buffer.
Additionally, removes Ook's modem and replaces it with an nearly identical fluff object so that Wirecarp and DoS Generator arent hit with a useless relay.

Fixes #10703
## Why It's Good For The Game
Now you can see this screen again. Bug fixes good. Make the science team mad :)

<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/ca535aac-e87f-4c8f-91a6-093907ba5de3" />

## Testing
See above.
## Changelog
:cl:
fix: NTNet relays can be DDoSed properly again.
map: Ook's modem is now a fluff object, and wont show on DoS generator or Wirecarp as a useless endpoint as such.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
