### PR TITLE
Ectoscopic Sniffer printing recipe

### DIFF
--- a/code/modules/research/designs/machine_designs.dm
+++ b/code/modules/research/designs/machine_designs.dm
@@ -1227,3 +1227,13 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
 
+/datum/design/board/ecto_sniffer
+	name = "Ectoscopic Sniffer Board"
+	desc = "The circuit board for an Ectoscopic Sniffer, the latest in Sci-Fi!"
+	id = "ecto_sniffer"
+	build_path = /obj/item/circuitboard/machine/ecto_sniffer
+	category = list(
+		RND_CATEGORY_MACHINE + RND_SUBCATEGORY_MACHINE_RESEARCH
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SCIENCE | DEPARTMENT_BITFLAG_ENGINEERING
+

--- a/code/modules/research/techweb/robo_nodes.dm
+++ b/code/modules/research/techweb/robo_nodes.dm
@@ -17,6 +17,7 @@
 	prereq_ids = list("neural_programming", "robotics", "cyborg")
 	design_ids = list(
 		"mmi_posi",
+		"ecto_sniffer",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_1_POINTS)
 


### PR DESCRIPTION
## About The Pull Request
You are all subject to my one day sprint of having ideas AND the will to code them.
Adds a recipe to print Ectoscopic Sniffers, the machines in Robotics that ghosts can click to say "hey, i want to play as a positronic." under Advanced Robotics.
## Why It's Good For The Game
Currently, theres only ever 1 sniffer on station usually, so in the event of it being destroyed, thats it, ghosts cant ask anymore. This adds a method to make more, for good or back alley maint lab nefarious purposes.
## Testing


<img width="670" height="600" alt="image" src="https://github.com/user-attachments/assets/ce9afb9e-0577-48b9-a498-7af6be1e2062" />


## Changelog
:cl:
add: Added a print recipe for the Ectoscopic Sniffer to the Advanced Robotics technode.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
