### PR TITLE
Adds the (actual) cassette tape to loadouts

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -1,6 +1,6 @@
 /obj/item/taperecorder
 	name = "universal recorder"
-	desc = "A device that can record to cassette tapes, and play them. It automatically translates the content in playback."
+	desc = "A device that can record to magnetic tapes, and play them. It automatically translates the content in playback."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "taperecorder_empty"
 	inhand_icon_state = "analyzer"

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -1,6 +1,6 @@
 /obj/item/taperecorder
 	name = "universal recorder"
-	desc = "A device that can record to magnetic tapes, and play them. It automatically translates the content in playback."
+	desc = "A device that can record to recording tapes, and play them. It automatically translates the content in playback."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "taperecorder_empty"
 	inhand_icon_state = "analyzer"
@@ -366,7 +366,7 @@
 	starting_tape_type = null
 
 /obj/item/tape
-	name = "tape"
+	name = "recording tape"
 	desc = "A magnetic tape that can hold up to ten minutes of content on either side."
 	icon_state = "tape_white"
 	icon = 'icons/obj/device.dmi'

--- a/monkestation/code/modules/blueshift/structures/fluff.dm
+++ b/monkestation/code/modules/blueshift/structures/fluff.dm
@@ -10,7 +10,7 @@
 /* ----------------- Lore ----------------- */
 //Tape subtype for adding ruin lore -- the variables below are the ones you need to change
 /obj/item/tape/ruins
-	name = "tape"
+	name = "recording tape"
 	desc = "A magnetic tape that can hold up to ten minutes of content on either side."
 	icon_state = "tape_white"   //Options are white, blue, red, yellow, purple, greyscale, or you can chose one randomly (see tape/ruins/random below)
 

--- a/monkestation/code/modules/loadouts/items/pocket.dm
+++ b/monkestation/code/modules/loadouts/items/pocket.dm
@@ -148,7 +148,7 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 	item_path = /obj/item/taperecorder
 
 /datum/loadout_item/pocket_items/tape
-	name = "Spare Cassette Tape"
+	name = "Spare Magnetic Tape"
 	item_path = /obj/item/tape/random
 
 /datum/loadout_item/pocket_items/newspaper

--- a/monkestation/code/modules/loadouts/items/pocket.dm
+++ b/monkestation/code/modules/loadouts/items/pocket.dm
@@ -148,7 +148,7 @@ GLOBAL_LIST_INIT(loadout_pocket_items, generate_loadout_items(/datum/loadout_ite
 	item_path = /obj/item/taperecorder
 
 /datum/loadout_item/pocket_items/tape
-	name = "Spare Magnetic Tape"
+	name = "Spare Recording Tape"
 	item_path = /obj/item/tape/random
 
 /datum/loadout_item/pocket_items/newspaper

--- a/monkestation/code/modules/loadouts/items/toys.dm
+++ b/monkestation/code/modules/loadouts/items/toys.dm
@@ -123,6 +123,10 @@ GLOBAL_LIST_INIT(loadout_toys, generate_loadout_items(/datum/loadout_item/toys))
 	name = "Walkman"
 	item_path = /obj/item/walkman
 
+/datum/loadout_item/toys/cassette_tape
+	name = "Spare Cassette Tape"
+	item_path = /obj/item/cassette_tape/random
+
 /datum/loadout_item/toys/monkey_pen
 	name = "Monkey Pen"
 	item_path = /obj/item/pen/monkey

--- a/monkestation/code/modules/store/store_items/pocket.dm
+++ b/monkestation/code/modules/store/store_items/pocket.dm
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(store_pockets, generate_store_items(/datum/store_item/pocket))
 	item_cost = 3000
 
 /datum/store_item/pocket/tape
-	name = "Spare Magnetic Tape"
+	name = "Spare Recording Tape"
 	item_path = /obj/item/tape/random
 	item_cost = 2500
 

--- a/monkestation/code/modules/store/store_items/pocket.dm
+++ b/monkestation/code/modules/store/store_items/pocket.dm
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(store_pockets, generate_store_items(/datum/store_item/pocket))
 	item_cost = 3000
 
 /datum/store_item/pocket/tape
-	name = "Spare Cassette Tape"
+	name = "Spare Magnetic Tape"
 	item_path = /obj/item/tape/random
 	item_cost = 2500
 

--- a/monkestation/code/modules/store/store_items/toys.dm
+++ b/monkestation/code/modules/store/store_items/toys.dm
@@ -14,6 +14,11 @@ GLOBAL_LIST_INIT(store_toys, generate_store_items(/datum/store_item/toys))
 	name = "Walkman"
 	item_path = /obj/item/walkman
 
+/datum/store_item/toys/walkman
+	item_cost = 350
+	name = "Spare Cassette Tape"
+	item_path = /obj/item/cassette_tape/random
+
 /datum/store_item/toys/card_deck
 	item_cost = 2500
 	name = "Playing Card Deck"


### PR DESCRIPTION
## About The Pull Request
- Renames current (fake) cassette tape shop item to recording tape
- Adds the (actual) random cassette tape thats playable by walkmans
## Why It's Good For The Game
Refund my 2500 monkecoin please.
## Testing
## Changelog
:cl:
add: adds the (actual) cassette tapes to loadout
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
