### PR TITLE
Make Oshan hotspots try to drift past walls if they can.

### DIFF
--- a/monkestation/code/modules/ocean_content/hotspot/hotspot.dm
+++ b/monkestation/code/modules/ocean_content/hotspot/hotspot.dm
@@ -49,6 +49,16 @@
 		drift_direction = turn(drift_direction, 180)
 		return
 
+	// if we drift into a wall or groundless, try to keep going ahead until we hit a normal open turf, up to 3 times.
+	if(!force)
+		var/safety = 3
+		while((destination.density || isgroundlessturf(destination)) && safety > 0)
+			safety--
+			var/new_destination = get_step(destination, drift_direction)
+			if(!new_destination || is_edge_or_blacklist(new_destination))
+				break
+			destination = new_destination
+
 	center.relocate(destination.x, destination.y, destination.z)
 
 	///if we are end of round or pre round no point in checking vents or dousing rods. As latter there will never be any and former doesn't matter as rounds over.


### PR DESCRIPTION
## About The Pull Request

this makes it so that when an oshan hotspot drifts, if the destination is a closed/groundless turf, it will try up to 3 times in the same direction until it hits an open turf.

## Why It's Good For The Game

trying to pin a hotspot that's in a fucking r-wall sucks

## Testing

tested locally, seems to work. stomped a hotspot around and it seemed to go past walls.

## Changelog
:cl:
qol: Oshan hotspots will now try to go a few extra steps if they drift into a wall, to hopefully avoid them being stuck in a wall.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
