### PR TITLE
Prevent Gary from wandering to people in the supermatter room

### DIFF
--- a/monkestation/code/modules/ranching/chickens/ai/gary/gary_behaviours.dm
+++ b/monkestation/code/modules/ranching/chickens/ai/gary/gary_behaviours.dm
@@ -190,6 +190,9 @@
 			continue
 		if(!(mob.z in SSmapping.levels_by_trait(ZTRAIT_STATION)))
 			continue
+		var/area/mob_area = get_area(mob)
+		if(istype(mob_area, /area/station/engineering/supermatter))
+			continue
 		mobs += mob
 
 	controller.blackboard[BB_TRAVEL_DESTINATION] = (length(mobs) > 0) ? pick(mobs) : null //pick() cries if theres nothing in the list.


### PR DESCRIPTION

## About The Pull Request

this makes it so Gary (the crow) won't try to wander to people in the SM room, which can and will result in premature SM starts.

## Why It's Good For The Game

stupid crow stop trying to delam the SM

## Changelog
:cl:
qol: Gary should no longer randomly wander into the supermatter at roundstart.
/:cl: