### PR TITLE
Fixes cyborg tracking not always showing up

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -494,6 +494,14 @@
 		create_modularInterface()
 	modularInterface.imprint_id(name = newname)
 
+/mob/living/silicon/can_track(mob/living/user)
+	//if their camera is online, it's safe to assume they are in cameranets
+	//since it takes a while for camera vis to update, this lets us bypass that so AIs can always see their borgs,
+	//without making cameras constantly update every time a borg moves.
+	if(builtInCamera && builtInCamera.can_use())
+		return TRUE
+	return ..()
+
 /mob/living/silicon/get_access()
 	return REGION_ACCESS_ALL_STATION
 


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/82975

Silicons moving with their builtincamera doesnt automatically update the camera net, so for some time after borgs move, they wont show up to the AI to track. It's a minor but annoying issue that this fixes.

## Why It's Good For The Game

Fixes a minor issue with the new ai tracking stuff.

## Changelog

:cl:
fix: AIs can now track Silicon as long as their built-in camera is online.
/:cl: