### PR TITLE
[OSHAN][MAPPING] Reworks Medical Department

### DIFF
--- a/_maps/map_files/Oshan/Oshan.dmm
+++ b/_maps/map_files/Oshan/Oshan.dmm
@@ -23691,9 +23691,12 @@
 	req_access = list("medical");
 	name = "First Aid Supplies"
 	},
-/obj/item/storage/medkit,
 /obj/item/storage/medkit/fire,
 /obj/item/storage/medkit/fire,
+/obj/item/storage/medkit/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/storage)
 "hBM" = (
@@ -27780,6 +27783,10 @@
 	pixel_y = 14;
 	pixel_x = -9
 	},
+/obj/item/cane/crutch,
+/obj/item/cane/crutch,
+/obj/item/cane/white,
+/obj/item/cane/white,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/storage)
 "iUi" = (
@@ -51776,9 +51783,12 @@
 "qvQ" = (
 /obj/structure/rack,
 /obj/structure/window/spawner/directional/west,
-/obj/item/storage/medkit,
 /obj/item/storage/medkit/toxin,
 /obj/item/storage/medkit/toxin,
+/obj/item/storage/medkit/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/storage)
 "qvS" = (
@@ -52593,10 +52603,13 @@
 "qLj" = (
 /obj/structure/rack,
 /obj/structure/window/spawner/directional/west,
-/obj/item/storage/medkit,
 /obj/item/storage/medkit/o2,
 /obj/item/storage/medkit/o2,
 /obj/item/gun/syringe,
+/obj/item/storage/medkit/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/storage)
 "qLC" = (
@@ -60396,9 +60409,12 @@
 	name = "First Aid Supplies";
 	req_access = list("medical")
 	},
-/obj/item/storage/medkit,
 /obj/item/storage/medkit/brute,
 /obj/item/storage/medkit/brute,
+/obj/item/storage/medkit/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/storage)
 "tiI" = (


### PR DESCRIPTION
## About The Pull Request
 reworks the medical department to be a little less ass to navigate and use (image used not final depiction check below for up to date images)
 
<img width="1281" height="734" alt="image" src="https://github.com/user-attachments/assets/e5185551-b5c7-481f-be27-7036d4209939" />

big changes:
proper chemistry room medical and chem can use 
unifies the department hallways into a unified hall connecting all sub departments
moves sub departments around 
preps medical for proper mail sorting and disposals
[experi] cooks and chaplains can access a bit more of medical to get to morgue (central lobby, treatment center, morgue)
--can help or hinder with dealing with departed bodies 

minor changes
 fixes access on nt rep and BlueShield doors
 

## Why It's Good For The Game

originally hated the layout but looking deeper under the hood there is still a lot of oshan problems to fix. going department by department basis for reworks helps dealing with problems mapwise while isolating new issues from sweeping changes 

## Testing
## Changelog
:cl:

map: [oshan] Reworks Medical Department Layout
map: [oshan] Proper Chemistry room
map: [oshan] Fixes Access For NTrep and Blueshield doors
map: [oshan] Chefs and Chaplains Medical Front Door Access for Morgue
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
