### PR TITLE
Filter blood works on species w/o blood again

### DIFF
--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -9,11 +9,6 @@
 		/datum/surgery_step/close,
 	)
 
-/datum/surgery/blood_filter/can_start(mob/user, mob/living/carbon/target)
-	if(HAS_TRAIT(target, TRAIT_NOBLOOD)) // MONKESTATION EDIT: You can't filter the blood of people without blood. Duh.
-		return FALSE
-	return ..()
-
 /* monke edit: replaced for toxin healing support
 /datum/surgery_step/filter_blood/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	if(!..())


### PR DESCRIPTION
## About The Pull Request

If a bloodless species get chemicals in their system that works without having to process, it becomes totally unremovable. This fixes that, because it's annoying AF!

## Changelog

:cl:
fix: Bloodless species can get chemicals removed from their 'blood' again.
/:cl: