### PR TITLE
Fixes Oshan confessional

### DIFF
--- a/_maps/map_files/Oshan/Oshan.dmm
+++ b/_maps/map_files/Oshan/Oshan.dmm
@@ -3053,7 +3053,7 @@
 /obj/item/clothing/under/misc/burial,
 /obj/item/clothing/under/misc/burial,
 /obj/item/clothing/under/misc/burial,
-/obj/item/radio/intercom/chapel/directional/west,
+/obj/item/radio/intercom/directional/west,
 /obj/item/reagent_containers/cup/glass/bottle/wine/unlabeled,
 /obj/item/reagent_containers/cup/glass/bottle/wine/unlabeled,
 /obj/item/reagent_containers/cup/glass/bottle/wine/unlabeled,
@@ -6571,6 +6571,7 @@
 /area/station/maintenance/abandon_cafeteria)
 "ceK" = (
 /obj/machinery/light/small/directional/south,
+/obj/item/radio/intercom/chapel/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
 "ceU" = (
@@ -64576,7 +64577,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/warning{
 	dir = 10
 	},
-/obj/item/radio/intercom/chapel/directional/west,
+/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/secondary/entry)
 "uzc" = (


### PR DESCRIPTION

## About The Pull Request
There was a confessional intercom at arrivals, and the confessional in the chapel wasnt in the chaplains confessional room.
## Why It's Good For The Game
map fix.
## Testing
none:tm:
## Changelog
:cl:
map: fixed confessional intercoms on Oshan
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
