### PR TITLE
Fixes Blueshift morgues

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -44458,12 +44458,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
 "iCM" = (
-/obj/structure/bodycontainer{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot_white,
 /obj/machinery/status_display/ai/directional/west,
 /obj/structure/window/spawner/directional/north,
+/obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "iCV" = (
@@ -77446,11 +77444,9 @@
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "oVo" = (
-/obj/structure/bodycontainer{
-	dir = 4
-	},
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/effect/turf_decal/bot_white,
+/obj/structure/bodycontainer/morgue,
 /turf/open/floor/iron/dark/small,
 /area/station/medical/morgue)
 "oVJ" = (


### PR DESCRIPTION

## About The Pull Request
There were 2 morgue trays in blueshift that didnt actually, work. Likely because we dont have locked morgue trays and just, didnt fix them when porting. Further testing required, im not sure if these are working themselves.
## Why It's Good For The Game
Map Fix
## Testing
None, to be done later.
## Changelog
:cl:
map: fixed broken morgue trays on Blueshift.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
