### PR TITLE
Adds a smoker variant of slime lungs

### DIFF
--- a/code/datums/quirks/negative_quirks/junkie.dm
+++ b/code/datums/quirks/negative_quirks/junkie.dm
@@ -126,6 +126,8 @@
 			smoker_lungs = /obj/item/organ/internal/lungs/plasmaman/plasmaman_smoker
 		else if(isethereal(carbon_holder))
 			smoker_lungs = /obj/item/organ/internal/lungs/ethereal/ethereal_smoker
+		else if(isoozeling(carbon_holder))
+			smoker_lungs = /obj/item/organ/internal/lungs/slime/slime_smoker
 		else
 			smoker_lungs = /obj/item/organ/internal/lungs/smoker_lungs
 	if(!isnull(smoker_lungs))

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -954,6 +954,14 @@
 		var/plasma_pp = breath.get_breath_partial_pressure(breath.gases[/datum/gas/plasma][MOLES])
 		breather_slime.blood_volume += (0.2 * plasma_pp) // 10/s when breathing literally nothing but plasma, which will suffocate you.
 
+/obj/item/organ/internal/lungs/slime/slime_smoker
+	name = "smoker vacuole"
+	desc = "A large organelle designed to store oxygen and other important gasses. It loosk discolored, from smoking a lot."
+	icon_state = "lungs_smoker"
+
+	maxHealth = SMOKER_ORGAN_HEALTH
+	healing_factor = SMOKER_LUNG_HEALING
+
 /obj/item/organ/internal/lungs/oni
 	name = "oni lungs"
 	desc = "The lungs of an oni, resistant to heat and able to produce small amounts of flame to be expelled through the mouth."


### PR DESCRIPTION

## About The Pull Request

this adds a `slime_smoker` subtype of slime lungs, which just has the smoker lungs sprite and the reduced health.

this prevents oozelings from getting normal non-slime lungs via the smoker quirk.

## Why It's Good For The Game

fixes a potential exploit, and makes things behave as expected

## Changelog
:cl:
fix: Being an oozeling with the Smoker quirk no longer makes you immune to water vapor, or removes your ability to gain blood from plasma.
/:cl: