### PR TITLE
NTNet relay always processes

### DIFF
--- a/code/modules/NTNet/relays.dm
+++ b/code/modules/NTNet/relays.dm
@@ -97,8 +97,6 @@
 		set_dos_failure(FALSE)
 		update_appearance()
 		SSmodular_computers.add_log("Quantum relay switched from overload recovery mode to normal operation mode.")
-	if(dos_overload == 0)
-		end_processing() //my job here is done.
 
 /obj/machinery/ntnet_relay/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -56,7 +56,7 @@
 			if(target)
 				executed = TRUE
 				target.dos_sources.Add(src)
-				target.begin_processing() //target will handle stopping processing itself
+				target.begin_processing() //target BETTER FUCKING BE PROCESSING OR I SWEAR TO GOD
 				if(SSmodular_computers.intrusion_detection_enabled)
 					SSmodular_computers.add_log("IDS WARNING - Excess traffic flood targeting relay [target.uid] detected from device: [computer.name]")
 					SSmodular_computers.intrusion_detection_alarm = TRUE


### PR DESCRIPTION

## About The Pull Request
Makes the NTNet relay never stop processing, so that it wont INTAKE AN INFINITE AMOUNT OF GQ
## Why It's Good For The Game
Makes the thing actually work.
## Testing
## Changelog
:cl:
code: NTNet relays never stop processing, making them more likely to Actually Get DDoSed Properly now.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
