### PR TITLE
Nanite adjustments

### DIFF
--- a/monkestation/code/modules/datums/components/nanites.dm
+++ b/monkestation/code/modules/datums/components/nanites.dm
@@ -111,6 +111,8 @@
 		adjust_nanites(null, amount) //just add to the nanite volume
 
 /datum/component/nanites/process(seconds_per_tick)
+	if(QDELETED(src))
+		return PROCESS_KILL
 	if(!HAS_TRAIT(host_mob, TRAIT_STASIS))
 		adjust_nanites(null, (regen_rate + (SSresearch.science_tech.researched_nodes["nanite_harmonic"] ? HARMONIC_REGEN_BOOST : 0)) * seconds_per_tick)
 		add_research()

--- a/monkestation/code/modules/research/nanites/nanite_programs/weapon.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/weapon.dm
@@ -63,6 +63,9 @@
 	use_rate = 10
 	rogue_types = list(/datum/nanite_program/glitch)
 
+/datum/nanite_program/meltdown/consume_nanites(amount, force)
+	. = ..(amount, force = TRUE)
+
 /datum/nanite_program/meltdown/active_effect()
 	host_mob.adjustFireLoss(3.5)
 


### PR DESCRIPTION

## About The Pull Request
- Meltdown program ignores safety threshold when activating
## Why It's Good For The Game
For a program that's supposed to set the safety threshold to 0, it still checks the threshold when initially activating. This should make it more consistent.
When nanites are deleted process() consistently runtimes. Not sure why the STOP_PROCESSING in Destroy() isn't working.
## Testing
## Changelog
:cl:
balance: meltdown nanite program ignores safety threshold when activating
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
