### PR TITLE
Add classic Play-Internet-Sound

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -287,7 +287,7 @@ ADMIN_VERB(play_web_sound, R_SOUND, FALSE, "Play Internet Sound", "Play a given 
 ADMIN_VERB_CUSTOM_EXIST_CHECK(play_web_sound_classic)
 	return !!CONFIG_GET(string/invoke_youtubedl)
 
-ADMIN_VERB(play_web_sound_classic, R_SOUND, FALSE, "Play Internet Sound", "Play a given internet sound to all players.", ADMIN_CATEGORY_FUN)
+ADMIN_VERB(play_web_sound_classic, R_SOUND, FALSE, "Play Internet Sound Classic", "Play a given internet sound to all players.", ADMIN_CATEGORY_FUN)
 	if(GLOB.dj_booth?.broadcasting)
 		var/prompt = tgui_alert(
 			user,


### PR DESCRIPTION

## About The Pull Request

Adds the classic Play Internet Sound verb, because sometimes I just don't fucking trust Floxy to play my music, and would rather have all clients play a direct audio url.


## Testing
Works the same as before
## Changelog
:cl:
add: Play-internet-sound-classic verb
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [ ] You documented all of your changes.
