### PR TITLE
makes the chameleon syndicate body armor lockable + fixes locking the chameleon backpack

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -861,8 +861,7 @@
 	name = "backpack"
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-// MONKESTATION ADDITION START
-/obj/item/storage/backpack/chameleon/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+/obj/item/storage/backpack/chameleon/item_interaction(mob/living/user, obj/item/attacking_item, list/modifiers)
 	if(attacking_item.tool_behaviour != TOOL_MULTITOOL)
 		return ..()
 
@@ -876,7 +875,7 @@
 		actions -= chameleon_action
 		chameleon_action.Remove(user)
 		log_game("[key_name(user)] has locked the disguise of the chameleon backpack ([name]) with [attacking_item]")
-// MONKESTATION ADDITION END
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/storage/backpack/chameleon/Initialize(mapload)
 	. = ..()

--- a/monkestation/code/modules/clothing/suits/costume.dm
+++ b/monkestation/code/modules/clothing/suits/costume.dm
@@ -184,7 +184,7 @@
 
 	create_storage(storage_type = /datum/storage/pockets)
 
-/obj/item/clothing/suit/chameleon/syndie_armor/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+/obj/item/clothing/suit/chameleon/syndie_armor/item_interaction(mob/living/user, obj/item/attacking_item, list/modifiers)
 	if(attacking_item.tool_behaviour != TOOL_MULTITOOL)
 		return ..()
 
@@ -192,12 +192,13 @@
 		chameleon_action.hidden = FALSE
 		actions += chameleon_action
 		chameleon_action.Grant(user)
-		log_game("[key_name(user)] has removed the disguise lock on the chameleon backpack ([name]) with [attacking_item]")
+		log_game("[key_name(user)] has removed the disguise lock on the chameleon body armor ([name]) with [attacking_item]")
 	else
 		chameleon_action.hidden = TRUE
 		actions -= chameleon_action
 		chameleon_action.Remove(user)
-		log_game("[key_name(user)] has locked the disguise of the chameleon backpack ([name]) with [attacking_item]")
+		log_game("[key_name(user)] has locked the disguise of the chameleon body armor ([name]) with [attacking_item]")
+	return ITEM_INTERACT_SUCCESS
 
 /obj/item/clothing/suit/infinity_jacket
 	name = "infinity jersey"


### PR DESCRIPTION
## About The Pull Request
title
## Why It's Good For The Game
bug fix
## Changelog

:cl:
fix: chameleon syndicate body armor can be locked with a multitool like other chameleon clothing items.
fix: fixed chameleon backpacks not being able to have their disguise locked.
/:cl:


