### PR TITLE
fix syndie lavaland base causing unit tests to fail

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -4293,8 +4293,6 @@
 "XU" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/firealarm/directional/west,
-/obj/machinery/light/small/directional/west,
-/obj/machinery/firealarm/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer4{
 	dir = 9
 	},


### PR DESCRIPTION

## About The Pull Request

```
[19:20:07] Runtime in code/modules/power/lighting/light.dm,109: Conflicting double stacked light /obj/machinery/light/small/directional/west found at Syndicate Lavaland Cargo Bay (127,135,5)
  proc name:  stack trace (/proc/_stack_trace)
  src: null
  call stack:
   stack trace("Conflicting double stacked lig...", "code/modules/power/lighting/li...", 109)
  the light fixture (/obj/machinery/light/small/directional/west): Initialize(1)
  Atoms (/datum/controller/subsystem/atoms): InitAtom(the light fixture (/obj/machinery/light/small/directional/west), 0, /list (/list))
  Atoms (/datum/controller/subsystem/atoms): CreateAtoms(null, null, "subsystem init 1")
  Atoms (/datum/controller/subsystem/atoms): InitializeAtoms(null, null)
  Atoms (/datum/controller/subsystem/atoms): Initialize()
  Master (/datum/controller/master): init subsystem(Atoms (/datum/controller/subsystem/atoms))
  Master (/datum/controller/master): Initialize(10, 0, 1)

```

turns out there was a stacked lightbulb (and fire alarm) in the syndie lavaland base, leading to unit test failures. this should fix that.

## Why It's Good For The Game
## Changelog
:cl:
map: Fixed a spot on the Syndicate lavaland base that had two lightbulbs and fire alarms stacked on the same tile.
/:cl: