### PR TITLE
pAIs recursively check for a mob

### DIFF
--- a/code/modules/pai/door_jack.dm
+++ b/code/modules/pai/door_jack.dm
@@ -35,8 +35,8 @@
 /mob/living/silicon/pai/proc/extend_cable()
 	QDEL_NULL(hacking_cable) //clear any old cables
 	hacking_cable = new
-	var/mob/living/carbon/hacker = get_holder()
-	if(iscarbon(hacker) && hacker.put_in_hands(hacking_cable)) //important to double check since get_holder can return non-null values that aren't carbons.
+	var/mob/living/hacker = get_holder()
+	if(isliving(hacker) && hacker.put_in_hands(hacking_cable)) //important to double check since get_holder can return non-null values that aren't carbons.
 		hacker.visible_message(span_notice("A port on [src] opens to reveal a cable, which [hacker] quickly grabs."), span_notice("A port on [src] opens to reveal a cable, which you quickly grab."), span_hear("You hear the soft click of a plastic component and manage to catch the falling cable."))
 		track_pai()
 		track_thing(hacking_cable)

--- a/code/modules/pai/pai.dm
+++ b/code/modules/pai/pai.dm
@@ -293,12 +293,8 @@
  * 	or FALSE if the pAI is not being carried.
  */
 /mob/living/silicon/pai/proc/get_holder()
-	var/mob/living/carbon/holder
-	if(!holoform && iscarbon(card.loc))
-		holder = card.loc
-	if(holoform && ispickedupmob(loc) && iscarbon(loc.loc))
-		holder = loc.loc
-	if(!holder || !iscarbon(holder))
+	var/mob/holder = recursive_loc_check(card, /mob)
+	if(isnull(holder))
 		return FALSE
 	return holder
 

--- a/code/modules/pai/software.dm
+++ b/code/modules/pai/software.dm
@@ -160,8 +160,11 @@
 		to_chat(src, span_syndradio("You are not at liberty to do this! All agents are clandestine."))
 		return FALSE
 	var/mob/living/carbon/holder = get_holder()
-	if(!iscarbon(holder))
+	if(isnull(holder))
 		balloon_alert(src, "not being carried")
+		return FALSE
+	if(!iscarbon(holder))
+		balloon_alert(src, "no dna detected!")
 		return FALSE
 	balloon_alert(src, "requesting dna sample")
 	if(tgui_alert(holder, "[src] is requesting a DNA sample from you. Will you allow it to confirm your identity?", "Checking DNA", list("Yes", "No")) != "Yes")


### PR DESCRIPTION
## About The Pull Request

Fixes pAI abilities that require being on a mob but aren't considered "on a mob" because they are in a PDA on a mob, by recursively checking for one.

## Why It's Good For The Game

Fixes host scan/door jack/dna request while in a PDA as a pAI.

## Testing

i did

## Changelog

:cl:
fix: pAIs in a PDA can now use abilities that rely on being carried.
/:cl: