### PR TITLE
Lets Mech Radios work without telecomms

### DIFF
--- a/code/modules/vehicles/mecha/equipment/tools/radio.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/radio.dm
@@ -47,4 +47,4 @@
 		qdel(src)
 
 /obj/item/radio/mech
-	subspace_transmission = TRUE
+	subspace_transmission = FALSE // works when telecomms dies, like a intercom, but mobile!


### PR DESCRIPTION

## About The Pull Request
Disables subspace transmission on mech radios, permitting them to send a signal with a delay if they cannot be serviced by telecomms. akin to Intercoms, but mobile! (also like the company import headset)
## Why It's Good For The Game
You are spending an equipment slot, which can be utilized for air tanks, RCS, repair droids, and more, for a radio, it should probably be a damn good radio instead of just another headset, the item you have a slot exclusively provided for as a humanoid, and given to you for free as a MMI/AI.
## Testing
Tested locally via var editing, worked communicating with someone using a station bounced radio
## Changelog
:cl:
balance: Exosuit Radios are no longer subspace transmission. (This means they work without telecomms like a Intercom.)
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
