### PR TITLE
explorer and shaft miner alt job names

### DIFF
--- a/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
+++ b/monkestation/code/modules/client/preferences/alt_jobs/titles.dm
@@ -375,6 +375,7 @@
 		"Spelunker",
 		"Drill Technician",
 		"Prospector",
+		"Big Game Hunter",
 	)
 
 /datum/job/station_engineer

--- a/monkestation/code/modules/jobs/job_types/explorer.dm
+++ b/monkestation/code/modules/jobs/job_types/explorer.dm
@@ -34,6 +34,9 @@
 		"Explorer",
 		"Expeditionist",
 		"Scavenger",
+		"Astronaut",
+		"Asteroid Miner",
+		"Space Miner",
 	)
 	rpg_title = "Adventurer"
 	job_flags = STATION_JOB_FLAGS | JOB_CANNOT_BE_TARGET | JOB_NO_PLANETARY

--- a/tgui/packages/tgui/interfaces/common/JobToIcon.ts
+++ b/tgui/packages/tgui/interfaces/common/JobToIcon.ts
@@ -146,6 +146,9 @@ const ALTTITLES = {
   // Explorer - rocket
   Expeditionist: BASEICONS.Explorer,
   Scavenger: BASEICONS.Explorer,
+  Astronaut: BASEICONS.Explorer,
+  'Space Miner': BASEICONS.Explorer,
+  'Asteroid Miner': BASEICONS.Explorer,
   // Chaplain - cross
   Priest: BASEICONS.Chaplain,
   Preacher: BASEICONS.Chaplain,
@@ -304,6 +307,7 @@ const ALTTITLES = {
   Spelunker: BASEICONS['Shaft Miner'],
   'Drill Technician': BASEICONS['Shaft Miner'],
   Prospector: BASEICONS['Shaft Miner'],
+  'Big Game Hunter': BASEICONS['Shaft Miner'],
   // Station Engineer - gears
   'Emergency Damage Control Technician': BASEICONS['Station Engineer'],
   Electrician: BASEICONS['Station Engineer'],


### PR DESCRIPTION

## About The Pull Request
Adds titles "Astronaut" "Space Miner" "Asteroid Miner" For the explorer job and title "Big Game Hunter" for the shaft miner job.
## Why It's Good For The Game
More names for a job that only just got alt names a month ago and one title i think is funny


## Testing
It worked on local host

<img width="265" height="158" alt="jW4Di1F5dz" src="https://github.com/user-attachments/assets/e5620f8f-4bec-4c8a-8e52-b325e1fa4437" />

<img width="269" height="61" alt="94g0WId8S3" src="https://github.com/user-attachments/assets/18aa7b46-f59d-4ab9-9313-fab3800ca70f" />
<img width="582" height="94" alt="image" src="https://github.com/user-attachments/assets/e3db03a9-d075-46e7-9606-c70f77d8c1c1" />

## Changelog
:cl:
add: 3 alternative job titles for Explorer and 1 for Shaft Miner 
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
