### PR TITLE
Chem scanning removes achievements from maint pills

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_medical.dm
+++ b/code/__DEFINES/dcs/signals/signals_medical.dm
@@ -20,3 +20,6 @@
 #define COMSIG_SURGERY_STARTING "surgery_starting"
 	#define COMPONENT_CANCEL_SURGERY (1<<0)
 	#define COMPONENT_FORCE_SURGERY (1<<1)
+
+/// From /obj/item/ph_meter/interact_with_atom(): (atom/source, mob/user)
+#define COMSIG_ON_REAGENT_SCAN "on_reagent_scan"

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -165,7 +165,7 @@
 	else if(!ismob(scanned_atom))
 
 		log_entry_data[DETSCAN_CATEGORY_FINGERS] = GET_ATOM_FINGERPRINTS(scanned_atom)
-
+		SEND_SIGNAL(scanned_atom, COMSIG_ON_REAGENT_SCAN, user)
 		// Only get reagents from non-mobs.
 		for(var/datum/reagent/present_reagent as anything in scanned_atom.reagents?.reagent_list)
 			LAZYADD(log_entry_data[DETSCAN_CATEGORY_DRINK], list(present_reagent.name = present_reagent.volume))

--- a/code/modules/reagents/chemistry/items.dm
+++ b/code/modules/reagents/chemistry/items.dm
@@ -134,6 +134,7 @@
 			out_message += "<b>Analysis:</b> [reagent.description]\n"
 	to_chat(user, boxed_message(span_notice("[out_message.Join()]")))
 	desc = "An electrode attached to a small circuit box that will display details of a solution. Can be toggled to provide a description of each of the reagents. The screen currently displays detected vol: [round(cont.volume, 0.01)] detected pH:[round(cont.reagents.ph, 0.1)]."
+	SEND_SIGNAL(interacting_with, COMSIG_ON_REAGENT_SCAN, user)
 	return ITEM_INTERACT_SUCCESS
 
 /obj/item/burner

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -275,8 +275,15 @@
 	name = "maintenance pill"
 	desc = "A strange pill found in the depths of maintenance."
 	icon_state = "pill21"
-	var/static/list/descs = list("Your feeling is telling you no, but...","Drugs are expensive, you can't afford not to eat any pills that you find."\
-	, "Surely, there's no way this could go bad.", "Winners don't do dr- oh what the heck!", "Free pills? At no cost, how could I lose?")
+	///Boolean on whether this will count towards your achievement score if you consume it.
+	var/count_towards_achievement = FALSE
+	var/static/list/descs = list(
+		"Your feeling is telling you no, but...",
+		"Drugs are expensive, you can't afford not to eat any pills that you find.",
+		"Surely, there's no way this could go bad.",
+		"Winners don't do dr- oh what the heck!",
+		"Free pills? At no cost, how could I lose?",
+	)
 
 /obj/item/reagent_containers/pill/maintenance/Initialize(mapload)
 	//monkestation edit on next line: replaced get_random_reagent_id_unrestricted() with pick_weight(GLOB.weighted_random_reagents)
@@ -307,10 +314,22 @@
 	else
 		icon_state = "pill[rand(1,21)]"
 
-/obj/item/reagent_containers/pill/maintenance/achievement/on_consumption(mob/M, mob/user)
+/obj/item/reagent_containers/pill/maintenance/on_consumption(mob/person_eating, mob/person_that_fed_us)
 	. = ..()
+	if(count_towards_achievement)
+		person_eating.client?.give_award(/datum/award/score/maintenance_pill, person_eating)
 
-	M.client?.give_award(/datum/award/score/maintenance_pill, M)
+/obj/item/reagent_containers/pill/maintenance/achievement
+	count_towards_achievement = TRUE
+
+/obj/item/reagent_containers/pill/maintenance/achievement/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_ON_REAGENT_SCAN, PROC_REF(on_chemical_scan))
+
+///called when we are chemically scanned.
+/obj/item/reagent_containers/pill/maintenance/achievement/proc/on_chemical_scan(atom/source, mob/user)
+	SIGNAL_HANDLER
+	count_towards_achievement = FALSE
 
 /obj/item/reagent_containers/pill/potassiodide
 	name = "potassium iodide pill"


### PR DESCRIPTION
## About The Pull Request

Chem scanning a maint pill now removes the achievement for eating it.

## Why It's Good For The Game

cheater.

## Testing

<img width="480" height="299" alt="image" src="https://github.com/user-attachments/assets/889be093-6871-4c61-a92d-c210acba9344" />

<img width="628" height="393" alt="image" src="https://github.com/user-attachments/assets/afab8083-cc3e-4ff2-9f19-93a788b5fb65" />


## Changelog

:cl:
fix: Chem scanning a maintenance pill removes the achievement value.
/:cl: