### PR TITLE
Silicon aren't affected by temp (back on my pAI shit)

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -513,3 +513,9 @@
 	law_list += laws.get_law_list(include_zeroth = TRUE, render_html = FALSE)
 	for(var/borg_laws in law_list)
 		. += borg_laws
+
+/mob/living/silicon/body_temperature_damage(datum/gas_mixture/environment, seconds_per_tick, times_fired)
+	return
+
+/mob/living/silicon/body_temperature_alerts()
+	return


### PR DESCRIPTION
## About The Pull Request

Let's not needlessly run through body temp code for borgs just to throw useless, bugged, alerts at them.

## Why It's Good For The Game

fix

## Changelog

:cl:
fix: Silicons no longer get a bugged cold/hot alert,
/:cl:
