### PR TITLE
Change blood filter whitelist to blacklist

### DIFF
--- a/code/modules/surgery/blood_filter.dm
+++ b/code/modules/surgery/blood_filter.dm
@@ -21,22 +21,22 @@ monke end */
 /**
  * Checks if the mob contains chems we can filter
  *
- * If the blood filter's whitelist is empty this checks if the mob contains any chems
- * If the whitelist contains chems it checks if any chems in the mob match chems in the whitelist
+ * If the blood filter's blacklist is not empty this checks that the mob contains any chems not in the blacklist
+ * Otherwise, if the blacklist is empty this always returns true
  *
  * Arguments:
  * * target - The mob to check the chems of
- * * bloodfilter - The blood filter to check the whitelist of
+ * * bloodfilter - The blood filter to check the blacklist of
  */
 /datum/surgery_step/filter_blood/proc/has_filterable_chems(mob/living/carbon/target, obj/item/blood_filter/bloodfilter)
 	if(!length(target.reagents?.reagent_list))
 		return FALSE
 
-	if(!length(bloodfilter.whitelist))
+	if(!length(bloodfilter.blacklist))
 		return TRUE
 
 	for(var/datum/reagent/chem as anything in target.reagents.reagent_list)
-		if(chem.type in bloodfilter.whitelist)
+		if(!(chem.type in bloodfilter.blacklist))
 			return TRUE
 
 	return FALSE

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -583,7 +583,7 @@
 	tool_behaviour = TOOL_BLOODFILTER
 	toolspeed = 1
 	/// Assoc list of chem ids to names, used for deciding which chems to filter when used for surgery
-	var/list/whitelist = list()
+	var/list/blacklist = list()
 
 /obj/item/blood_filter/get_surgery_tool_overlay(tray_extended)
 	return "filter"
@@ -597,9 +597,9 @@
 /obj/item/blood_filter/ui_data(mob/user)
 	var/list/data = list()
 	var/list/chem_names = list()
-	for(var/key in whitelist)
-		chem_names += whitelist[key]
-	data["whitelist"] = chem_names
+	for(var/key in blacklist)
+		chem_names += blacklist[key]
+	data["blacklist"] = chem_names
 	return data
 
 /obj/item/blood_filter/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
@@ -609,7 +609,7 @@
 	. = TRUE
 	switch(action)
 		if("add")
-			var/selected_reagent = tgui_input_list(usr, "Select reagent to filter", "Whitelist reagent", GLOB.chemical_name_list)
+			var/selected_reagent = tgui_input_list(usr, "Select reagent to filter", "Blacklist reagent", GLOB.chemical_name_list)
 			if(!selected_reagent)
 				return TRUE
 
@@ -617,12 +617,12 @@
 			if(!chem_id)
 				return TRUE
 
-			if(!(chem_id in whitelist))
-				whitelist[chem_id] = selected_reagent
+			if(!(chem_id in blacklist))
+				blacklist[chem_id] = selected_reagent
 
 
 
 		if("remove")
 			var/chem_name = params["reagent"]
 			var/chem_id = get_chem_id(chem_name)
-			whitelist -= chem_id
+			blacklist -= chem_id

--- a/monkestation/code/modules/surgery/blood_filter.dm
+++ b/monkestation/code/modules/surgery/blood_filter.dm
@@ -31,7 +31,7 @@
 	var/obj/item/blood_filter/bloodfilter = tool
 	if(target.reagents?.total_volume)
 		for(var/datum/reagent/chem as anything in target.reagents.reagent_list)
-			if(!length(bloodfilter.whitelist) || (chem.type in bloodfilter.whitelist))
+			if(!length(bloodfilter.blacklist) || !(chem.type in bloodfilter.blacklist))
 				var/purge_amt = (chem.volume <= 2) ? chem.volume : min(chem.volume * chem_purge_factor, 10)
 				target.reagents.remove_reagent(chem.type, purge_amt)
 	var/tox_loss = target.getToxLoss()

--- a/tgui/packages/tgui/interfaces/BloodFilter.tsx
+++ b/tgui/packages/tgui/interfaces/BloodFilter.tsx
@@ -4,12 +4,12 @@ import { Window } from '../layouts';
 import { ChemFilterPane } from './ChemFilter';
 
 type Data = {
-  whitelist: string[];
+  blacklist: string[];
 };
 
 export const BloodFilter = (props) => {
   const { data } = useBackend<Data>();
-  const { whitelist = [] } = data;
+  const { blacklist = [] } = data;
 
   return (
     <Window width={500} height={300}>
@@ -17,8 +17,8 @@ export const BloodFilter = (props) => {
         <Stack>
           <Stack.Item grow>
             <ChemFilterPane
-              title="Whitelist"
-              list={whitelist}
+              title="Blacklist"
+              list={blacklist}
               buttonColor="green"
             />
           </Stack.Item>


### PR DESCRIPTION

## About The Pull Request
Changes the blood filter whitelist option into a blacklist.
## Why It's Good For The Game
The blood filter has a whitelist option but in practice this is not very useful. If someone has a large number of toxic chems but a few good chems you would have to type out every single bad chem in order to keep the good chems. Now, you can simply type the good chems and it will keep them whilst removing every other chem. Saves a lot of clicks and helps keep patients with good chems rather than just filtering everything.
## Testing
Tested in a local host, blood filter acts as a blacklist.
## Changelog
:cl: Cujo
qol: Changes the blood filter whitelist into a blacklist
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
