### PR TITLE
achoo

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -426,7 +426,7 @@
 		if(istype(disease, /datum/disease/acute))
 			var/datum/disease/acute/acute_disease = disease
 			acute_disease.Refresh_Acute()
-			if(!((disease.visibility_flags & HIDDEN_SCANNER) && (disease.disease_flags & DISEASE_ANALYZED) && !(disease.disease_flags & DISEASE_DORMANT)))
+			if(!(disease.visibility_flags & HIDDEN_SCANNER) && (disease.disease_flags & DISEASE_ANALYZED) && !(disease.disease_flags & DISEASE_DORMANT))
 				if(disease.severity == DISEASE_SEVERITY_POSITIVE || DISEASE_SEVERITY_NONTHREAT)
 					render_list += "<span class='info ml-1'><b>[acute_disease.origin] disease detected</b>\n\
 					<div class='ml-2'>Name: [acute_disease.real_name()].\nType: [disease.get_spread_string()].\nStage: [disease.stage]/[disease.max_stages].</div>\
@@ -437,7 +437,7 @@
 					</span>"
 
 		else
-			if(!((disease.visibility_flags & HIDDEN_SCANNER) && (disease.disease_flags & DISEASE_ANALYZED) && !(disease.disease_flags & DISEASE_DORMANT)))
+			if(!(disease.visibility_flags & HIDDEN_SCANNER) && (disease.disease_flags & DISEASE_ANALYZED) && !(disease.disease_flags & DISEASE_DORMANT))
 				render_list += "<span class='alert ml-1'><b>Warning: [disease.form] disease detected</b>\n\
 				<div class='ml-2'>Name: [disease.name].\nType: [disease.get_spread_string()].\nStage: [disease.stage]/[disease.max_stages].\nPossible Cure: [disease.cure_text]</div>\
 				</span>"

--- a/monkestation/code/modules/virology/disease/base_disease_folder/_base.dm
+++ b/monkestation/code/modules/virology/disease/base_disease_folder/_base.dm
@@ -146,7 +146,7 @@ GLOBAL_LIST_INIT(virusDB, list())
 
 	//Searing body temperatures cure diseases, on top of killing you.
 	if(mob.bodytemperature > max_bodytemperature)
-		cure(target = mob)
+		cure(add_resistance = FALSE, target = mob)
 		return
 
 	if(disease_flags & DISEASE_DORMANT)


### PR DESCRIPTION
## About The Pull Request
- Health analyzers flags for disease scans are now properly fixed
- Heat no longer generates antibodies
## Why It's Good For The Game
- A bug by a mistake on my part due to (). Fixing a issue
- Heating a disease out I agree has a place within curing. However the fact it instantly generates antibodies while being a round start option invalidates the normal cure process. This keeps it a niche for individuals/emergency curing but cant be carried over into a mass cure. Nor am I sure why it even would
## Testing
<img width="1413" height="722" alt="image" src="https://github.com/user-attachments/assets/e497464b-1009-4f5e-8b08-71f2aa2d7646" />
## Changelog
:cl:
balance: Heat Cures no longer generate antibodies
fix: Health analyzers no longer tell you the wrong diseases existances.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
