### PR TITLE
Makes brain surgery automatically repeat on success and stop when fully healed

### DIFF
--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -39,6 +39,13 @@
 	)
 	display_pain(target, "Your head pounds with unimaginable pain!")
 
+/datum/surgery_step/fix_brain/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
+	if(!..())
+		return
+	while(target.get_organ_loss(ORGAN_SLOT_BRAIN))
+		if(!..())
+			break
+
 /datum/surgery_step/fix_brain/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
 	display_results(
 		user,


### PR DESCRIPTION

## About The Pull Request
Makes brain surgery automatically repeat on success
## Why It's Good For The Game
Right now brain surgery only automatically repeats on failure, stopping at a single success. Since the brain has 200 health and heals 50 per fix, it is nice to automatically repeat it to signal that it requires multiple fixes to fully heal. Additionally, it will stop repeating when the brain is fully healed.
## Testing
Tested on a localhost, brain surgery repeats on success and stops when brain damage is zero.
## Changelog
:cl: Cujo
fix: Makes brain surgery automatically repeat on success and stop when brain damage equals zero
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
