### PR TITLE
Fix allowing sign language when handcuffed

### DIFF
--- a/code/datums/components/sign_language.dm
+++ b/code/datums/components/sign_language.dm
@@ -180,7 +180,7 @@
 		busy_hands++
 
 	// Handcuffed or otherwise restrained - can't talk
-	if(HAS_TRAIT(src, TRAIT_RESTRAINED))
+	if(HAS_TRAIT(usr, TRAIT_RESTRAINED))
 		return SIGN_CUFFED
 	// Some other trait preventing us from using our hands now
 	else if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED) || HAS_TRAIT(src, TRAIT_EMOTEMUTE))

--- a/code/datums/components/sign_language.dm
+++ b/code/datums/components/sign_language.dm
@@ -180,10 +180,10 @@
 		busy_hands++
 
 	// Handcuffed or otherwise restrained - can't talk
-	if(HAS_TRAIT(usr, TRAIT_RESTRAINED))
+	if(HAS_TRAIT(carbon_parent, TRAIT_RESTRAINED))
 		return SIGN_CUFFED
 	// Some other trait preventing us from using our hands now
-	else if(HAS_TRAIT(src, TRAIT_HANDS_BLOCKED) || HAS_TRAIT(src, TRAIT_EMOTEMUTE))
+	else if(HAS_TRAIT(carbon_parent, TRAIT_HANDS_BLOCKED) || HAS_TRAIT(carbon_parent, TRAIT_EMOTEMUTE))
 		return SIGN_TRAIT_BLOCKED
 
 	// Okay let's compare the total hands to the number of busy hands


### PR DESCRIPTION
## About The Pull Request
Fixes a bug allowing sign language to be used while having TRAIT_RESTRAINED, TRAIT_HANDS_BLOCKED, or TRAIT_EMOTEMUTE
## Why It's Good For The Game
To be honest I'm not sure that entirely preventing someone from using sign language while cuffed is a great idea, but it was broken in the code and now properly stops you. 

Also fixes signing not being blocked by TRAIT_HANDS_BLOCKED (Prevents signing on stasis beds and mechs) and TRAIT_EMOTEMUTE
## Testing

https://github.com/user-attachments/assets/ff4602cb-870e-4556-b2c3-e847a4494632
## Changelog
:cl: Cujo
fix: Fixed being able to use sign language while handcuffed, on a stasis bed, or in mechs
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
