### PR TITLE
Allows deaf people to see emotes in runechat

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -352,7 +352,7 @@
 	for(var/mob/M in hearers)
 		if(push_appearance)
 			M << output(push_appearance, "push_appearance_placeholder_id")
-		if(audible_message_flags & EMOTE_MESSAGE && runechat_prefs_check(M, audible_message_flags) && M.can_hear())
+		if(audible_message_flags & EMOTE_MESSAGE && runechat_prefs_check(M, audible_message_flags))
 			M.create_chat_message(src, raw_message = raw_msg, runechat_flags = audible_message_flags)
 		M.show_message(message, MSG_AUDIBLE, deaf_message, MSG_VISUAL)
 


### PR DESCRIPTION

## About The Pull Request
Removes can_hear() from the thing that displays emotes in runechat
## Why It's Good For The Game
Currently when you are deaf you cannot see any emotes (except for dancing?) in runechat. This is quite obviously annoying as every emote requires you to read chat specifically to see it. Whether or not you can actually 'hear' the emote, it will now show in runechat. All emotes were previously written in chat, so no extra information is being given to deaf users. 
## Testing
![jumps!](https://github.com/user-attachments/assets/85edc938-e9af-445a-b916-3af5c2a3bb4a)
## Changelog
:cl: Cujo
add: Allows deaf people to see emotes in runechat
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
