### PR TITLE
Stray Cargo ghost announcements now target the pod

### DIFF
--- a/code/modules/events/stray_cargo.dm
+++ b/code/modules/events/stray_cargo.dm
@@ -104,7 +104,7 @@
 		crate.locked = FALSE //Unlock secure crates
 		crate.update_appearance()
 	var/obj/structure/closet/supplypod/pod = make_pod()
-	var/obj/effect/pod_landingzone/landing_marker = new(landing_zone, pod, crate)
+	new /obj/effect/pod_landingzone(landing_zone, pod, crate)
 	announce_to_ghosts(pod)
 
 ///Handles the creation of the pod, in case it needs to be modified beforehand


### PR DESCRIPTION

## About The Pull Request
fixes #10906 

Fixes Stray Cargo ghost announcements breaking after 3 seconds because the target landing zone designator gets removed after the pod lands, breaking the jump. It now insteads targets the pod, which works from announcement to post-landing. If a little weird looking.
## Why It's Good For The Game
Bug fixes
## Testing


<img width="157" height="120" alt="image" src="https://github.com/user-attachments/assets/59f3cd98-fc48-4c38-ac8c-37005e403efb" />

clicked immediately, went to the pod launch area and automatically followed the pod to the station.
left the pod and clicked the jump to button again, worked as intended.
## Changelog
:cl:
fix: fixed ghosts not being able to jump to Stray Cargo Pods after 3 seconds.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
