### PR TITLE
stationary modular computers can now have their batteries replaced

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -829,8 +829,6 @@
 		return ITEM_INTERACT_SUCCESS
 
 	if(istype(tool, /obj/item/stock_parts/power_store/cell))
-		if(ismachinery(loc))
-			return ITEM_INTERACT_BLOCKING
 		if(internal_cell)
 			to_chat(user, span_warning("You try to connect \the [tool] to \the [src], but its connectors are occupied."))
 			return ITEM_INTERACT_BLOCKING

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -159,6 +159,9 @@
 /obj/machinery/modular_computer/screwdriver_act(mob/user, obj/item/tool)
 	return CPU_INTERACTABLE(user) ? cpu.screwdriver_act(user, tool) : ..()
 
+/obj/machinery/modular_computer/screwdriver_act_secondary(mob/user, obj/item/tool)
+	return CPU_INTERACTABLE(user) ? cpu.screwdriver_act_secondary(user, tool) : ..()
+
 /obj/machinery/modular_computer/wrench_act_secondary(mob/user, obj/item/tool)
 	return CPU_INTERACTABLE(user) ? cpu.wrench_act_secondary(user, tool) : ..()
 


### PR DESCRIPTION

## About The Pull Request

adds modular computer right click screwdriver interaction to stationary modular computers, like the civilian console

removes the check in computer.dm that disallows stationary computers from having batteries inserted
## Why It's Good For The Game

https://github.com/Monkestation/Monkestation2.0/issues/10828 directly approaches this issue stated here, allowing batteries to be ejected and replaced in all machine console derivatives, whether machinery or item based
## Testing

https://github.com/user-attachments/assets/e399d63f-8b2b-4234-8c49-3be60f6360f0
## Changelog
:cl: cam_dev
add: right-click screwdriver interaction to machinery based modular computers (such as civilian console and cargo chat console)
del: check blocking machinery-based modular computers from having batteries inserted
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
