### PR TITLE
hacked/glitched digicoat fixes

### DIFF
--- a/monkestation/code/modules/clothing/~donator/clothing.dm
+++ b/monkestation/code/modules/clothing/~donator/clothing.dm
@@ -1342,8 +1342,15 @@
 	worn_icon = 'monkestation/icons/donator/mob/clothing/suit.dmi'
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
 
-//Donation reward for Razurath
+//Public version of Razurath's donation reward
 /obj/item/clothing/suit/toggle/digicoat/glitched
+	name = "glitched digicoat"
+	desc = "Glitched images display across the back. Cool!"
+	base_icon_state = "digicoat_glitched"
+	icon_state = "digicoat_glitched"
+
+//Donation reward for Razurath
+/obj/item/clothing/suit/toggle/digicoat/hacked
 	name = "hacked digicoat"
 	desc = "Glitched images display across the back. Cool!"
 	base_icon_state = "digicoat_glitched"

--- a/monkestation/code/modules/loadouts/donator/personal.dm
+++ b/monkestation/code/modules/loadouts/donator/personal.dm
@@ -541,9 +541,9 @@
 	donator_only = TRUE
 	requires_purchase = FALSE
 
-/datum/loadout_item/suit/digicoat_glitched
-	name = "Glitched Digicoat"
-	item_path = /obj/item/clothing/suit/toggle/digicoat/glitched
+/datum/loadout_item/suit/digicoat_hacked
+	name = "Hacked Digicoat"
+	item_path = /obj/item/clothing/suit/toggle/digicoat/hacked
 	donator_only = TRUE
 	requires_purchase = FALSE
 

--- a/monkestation/code/modules/loadouts/items/suits.dm
+++ b/monkestation/code/modules/loadouts/items/suits.dm
@@ -722,7 +722,7 @@ GLOBAL_LIST_INIT(loadout_exosuits, generate_loadout_items(/datum/loadout_item/su
 	restricted_roles = list(JOB_CARGO_TECHNICIAN, JOB_SHAFT_MINER, JOB_QUARTERMASTER)
 	requires_purchase = FALSE
 
-/datum/loadout_item/suit/digicoat_glitched //Public donator reward for Razurath.
+/datum/loadout_item/suit/digicoat_glitched //Purchasable version of Razurath's donator reward.
 	name = "Glitched Digicoat"
 	item_path = /obj/item/clothing/suit/toggle/digicoat/glitched
 


### PR DESCRIPTION

## About The Pull Request

small bugfix PR that allows for the glitched digicoat purchasable in the loadout store to be visible by making it a separate item from the donator version. these use the same sprites and are functionally identical but have been renamed for clarity

renames the donator version in the loadout to hacked digicoat, like it says in-game

renames the purchasable digicoat to glitched digicoat in-game, like it says in the loadout store
## Why It's Good For The Game

I saw a comment in the discord mourning the loss of their 7500 monkecoins to this bug back in August of 2024. How many monkecoins have fallen to this bug since then? Well I say, free the spent monkecoins! Release the glitched digicoats!
## Testing

<img width="1059" height="458" alt="image" src="https://github.com/user-attachments/assets/5f910c37-1176-4cf8-b19b-67784582383a" />

<img width="651" height="237" alt="image" src="https://github.com/user-attachments/assets/1d53b9d2-d9a4-4b83-aab8-fc4ee68f3927" />

Sadly, I can't test to see if the glitched digicoat properly shows up in the loadout menu on a private test, this will need to be TM'd first.
## Changelog
:cl:
add: duplicated the hacked digicoat to separate the donator and non-donator version
qol: changed name of donator digicoat to hacked digicoat in loadout to match in-game name
qol: changed name of loadout store digicoat to glitched digicoat in-game to match store name
fix: glitched digicoat not appearing in loadout after purchase (hopefully)
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
