### PR TITLE
Fix displayed message when choking is cleared by heimlich

### DIFF
--- a/code/datums/status_effects/debuffs/choke.dm
+++ b/code/datums/status_effects/debuffs/choke.dm
@@ -210,7 +210,7 @@
 	aggressor.stop_pulling()
 
 	var/atom/movable/choking_on = choking_on_ref?.resolve()
-	owner.visible_message(span_green("[victim] vomits up \the[choking_on]. [victim.p_theyre()] gonna make it!"), \
+	owner.visible_message(span_green("[victim] vomits up [choking_on]. [victim.p_theyre()] gonna make it!"), \
 			span_green("You vomit up that accursed blockage. YOU CAN BREATHE! The broken chest is a hell of a price to pay."))
 	if(iscarbon(victim))
 		var/mob/living/carbon/carbon_victim = victim

--- a/code/datums/status_effects/debuffs/choke.dm
+++ b/code/datums/status_effects/debuffs/choke.dm
@@ -210,7 +210,7 @@
 	aggressor.stop_pulling()
 
 	var/atom/movable/choking_on = choking_on_ref?.resolve()
-	owner.visible_message(span_green("[victim] vomits up [choking_on]. [victim.p_theyre()] gonna make it!"), \
+	owner.visible_message(span_green("[victim] vomits up \the [choking_on]. [victim.p_theyre()] gonna make it!"), \
 			span_green("You vomit up that accursed blockage. YOU CAN BREATHE! The broken chest is a hell of a price to pay."))
 	if(iscarbon(victim))
 		var/mob/living/carbon/carbon_victim = victim


### PR DESCRIPTION

## About The Pull Request
Adds a space after \the in the displayed message when choking is cleared by the heimlich.

If there's a way to uppercase the start of the second sentence let me know
## Why It's Good For The Game
Fixes a weirdly displayed message when choking is cleared by the heimlich
## Testing
before
<img width="499" height="24" alt="before" src="https://github.com/user-attachments/assets/5d8d0c5a-f765-459a-89f5-7dab4382d8b1" />
after
![after](https://github.com/user-attachments/assets/003de21d-a50a-4be9-a91d-2313b2f1a469)
## Changelog
:cl: Cujo
fix: Fixes displayed message when choking is cleared by the heimlich
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
