### PR TITLE
bandolier buff

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -772,12 +772,16 @@
 
 /obj/item/storage/belt/bandolier/Initialize(mapload)
 	. = ..()
-	atom_storage.max_slots = 18
-	atom_storage.max_total_storage = 18
+	atom_storage.max_slots = 28
+	atom_storage.max_total_storage = 28
 	atom_storage.numerical_stacking = TRUE
+	atom_storage.allow_quick_gather = TRUE
+	atom_storage.allow_quick_empty = TRUE
+
 	atom_storage.set_holdable(list(
 		/obj/item/ammo_casing/a762,
 		/obj/item/ammo_casing/shotgun,
+		/obj/item/ammo_casing/a357,
 	))
 
 /obj/item/storage/belt/fannypack


### PR DESCRIPTION

## About The Pull Request
gives bandoliers quick gather and quick empty. they can hold 10 more ammo casings and can now hold .357 rounds.

## Why It's Good For The Game
i rarely see bandoliers used to this should make it a bit more useful.


## Changelog

:cl:
qol: gave bandoliers quick gather and quick empty like most storage bags.
balance: bandoliers can hold 10 more ammo casings. 18 to 28.
balance: bandoliers can hold .357 rounds.
balance
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

