### PR TITLE
Oshan floor under medical

### DIFF
--- a/_maps/map_files/Oshan/Oshan.dmm
+++ b/_maps/map_files/Oshan/Oshan.dmm
@@ -13212,16 +13212,6 @@
 /obj/effect/landmark/start/blueshield,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/blueshield)
-"ehT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "ehW" = (
 /obj/effect/spawner/random/trash,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13492,17 +13482,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/security/medical)
 "enT" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/line{
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/turf_decal/tile/orange/opposingcorners{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/area/station/medical/chemistry)
 "eoC" = (
 /obj/effect/spawner/random/trash/graffiti,
 /obj/effect/decal/cleanable/dirt,
@@ -22634,15 +22620,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/security/office)
-"hiO" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/landmark/start/chemist,
-/obj/effect/turf_decal/tile/orange/opposingcorners{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/chemistry)
 "hiP" = (
 /obj/structure/table/reinforced,
 /obj/item/multitool,
@@ -24795,16 +24772,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"hQE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/obj/structure/drain,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
 "hQG" = (
 /obj/effect/turf_decal/trimline/white/line{
 	dir = 1;
@@ -25054,6 +25021,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
+"hVB" = (
+/obj/effect/turf_decal/tile/orange/opposingcorners{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/pharmacy)
 "hVE" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 8
@@ -41294,9 +41270,15 @@
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "ngR" = (
-/obj/effect/landmark/start/chief_medical_officer,
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/cmo)
+/obj/effect/turf_decal/tile/orange/opposingcorners{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/pharmacy)
 "ngS" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/table/reinforced,
@@ -57591,6 +57573,18 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"spD" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "spF" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
@@ -64557,14 +64551,6 @@
 /obj/machinery/shower/directional/north,
 /turf/open/ballpit,
 /area/station/cargo/miningdock/cafeteria)
-"uvX" = (
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/effect/turf_decal/tile/orange/opposingcorners{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/textured,
-/area/station/medical/chemistry)
 "uwa" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/clothing/costume,
@@ -66106,6 +66092,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics)
+"uSK" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/arrow_cw{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "uSL" = (
 /obj/structure/sign/poster/quirk/service_logo,
 /turf/closed/wall,
@@ -67704,14 +67702,14 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/miningoffice)
 "vrM" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/chair/office/tactical{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/arrow_ccw{
-	dir = 8
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/medbay/central)
+/obj/effect/landmark/start/chief_medical_officer,
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/cmo)
 "vrP" = (
 /turf/open/floor/plating/ocean/rock,
 /area/ocean)
@@ -68782,6 +68780,16 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/lobby)
+"vLQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/obj/structure/drain,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/medbay/central)
 "vLT" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -68989,16 +68997,6 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/hallway/primary/central)
-"vPq" = (
-/obj/effect/turf_decal/tile/orange/opposingcorners{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/iron/white/textured,
-/area/station/medical/pharmacy)
 "vPv" = (
 /obj/effect/turf_decal/trimline/hot_pink/filled/line{
 	dir = 8
@@ -69377,14 +69375,19 @@
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/security/armory)
 "vWl" = (
-/obj/effect/turf_decal/tile/orange/opposingcorners{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	invisibility = 101
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 1
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/white/textured,
-/area/station/medical/pharmacy)
+/area/station/medical/medbay/central)
 "vWn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -69761,7 +69764,6 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wbO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
@@ -73057,6 +73059,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
+"xfP" = (
+/obj/effect/turf_decal/tile/blue/opposingcorners,
+/obj/effect/landmark/start/chemist,
+/obj/effect/turf_decal/tile/orange/opposingcorners{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white/textured,
+/area/station/medical/chemistry)
 "xfX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -74576,14 +74587,12 @@
 /turf/open/floor/carpet/grimey,
 /area/station/service/theater/abandoned)
 "xBi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/arrow_cw{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
 	},
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/central)
@@ -75386,17 +75395,13 @@
 /turf/open/floor/iron,
 /area/station/maintenance/port/central)
 "xOW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	invisibility = 101
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/arrow_ccw{
+	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/central)
 "xPo" = (
@@ -100127,9 +100132,9 @@ ogc
 wAW
 iwa
 iwa
-hiO
+xfP
 xgR
-uvX
+enT
 hDo
 rWG
 iXT
@@ -101915,7 +101920,7 @@ kjb
 bfx
 iXL
 cCI
-ngR
+lTb
 aBy
 wil
 kjQ
@@ -102432,7 +102437,7 @@ tGx
 bfx
 rZS
 eVl
-aub
+vrM
 wdj
 bCM
 sXH
@@ -102696,11 +102701,11 @@ cUL
 vIn
 vwx
 lSL
-xOW
+vWl
 jor
 kQX
-vWl
-vPq
+hVB
+ngR
 kQX
 aot
 leD
@@ -103210,7 +103215,7 @@ nFI
 cek
 nFI
 nzl
-xOW
+vWl
 uNc
 kQX
 uxf
@@ -104244,9 +104249,9 @@ sKJ
 wZF
 wGx
 pzd
-ehT
+xBi
+xOW
 wbO
-vrM
 rjO
 srT
 fUj
@@ -105786,8 +105791,8 @@ hCs
 mZV
 wAY
 fiV
-hQE
-xBi
+vLQ
+uSK
 aTg
 uKs
 pgJ
@@ -107578,7 +107583,7 @@ hSm
 oYH
 nxY
 awg
-enT
+spD
 pIQ
 gTr
 gTr


### PR DESCRIPTION

## About The Pull Request
- Fixes the disconnected APC's in medical.
- Adds a air alarm to pharmacy
- Chemistry is now behind chemistry access.
- Pathology has less confusing wiring.
- Cleans up distro/power cabling.
## Why It's Good For The Game
## Testing
## Changelog
:cl:
map: Oshan medical has connected power.
map: Oshan pharmacy has a air alarm now
map: Oshan chemistry is now accessed by chemistry, not pharmacy
map: Oshan medical department had its distro/power cabling cleaned up.
map: Oshan pathology given more standard equipment
map: Oshan CMO's no longer shall live/spawn in walls
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
