### PR TITLE
Medical penlight now fits on ears

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -286,6 +286,7 @@
 	icon_state = "penlight"
 	inhand_icon_state = ""
 	worn_icon_state = "pen"
+	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_EARS
 	w_class = WEIGHT_CLASS_TINY
 	flags_1 = CONDUCT_1
 	light_outer_range = 2


### PR DESCRIPTION

## About The Pull Request
Allows medical penlights to be placed on the ear slot.
## Why It's Good For The Game
Regular pens can be placed on your ears, and the penlight is also a pen.
## Testing
tested on localhost, penlight fits on ears and still fits in belt slot.
## Changelog
:cl: Cujo
add: Medical penlight can now fit on ear slot
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
