### PR TITLE
stowaways no longer announce their latejoin arrival

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -268,6 +268,8 @@
 		return
 	if(!(character.mind.assigned_role.job_flags & JOB_ANNOUNCE_ARRIVAL))
 		return
+	if(HAS_TRAIT(character, TRAIT_STOWAWAY))
+		return
 
 	var/obj/machinery/announcement_system/announcer
 	var/list/available_machines = list()


### PR DESCRIPTION

## About The Pull Request

pretty simple check to block the announcer from being called if the player has the stowaway trait
## Why It's Good For The Game

Stowaways aren't in the system and aren't hired by Nanotrasen. They've illicitly boarded the station by whatever means the player ascertains. It doesn't make sense their arrival would be announced, since emerging from a locker means they've probably been sleeping in it all shift anyways.
## Testing

Tested it on a private server on MetaStation, mostly because I forgot to switch back to Runtime. Announcement didn't go off after bumming around in a locker for five minutes, while it instantly greeted me at the arrival shuttle when switching to a hired character.
## Changelog
:cl:
add: check on player arrival that stops announcement board if player is a stowaway
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
