### PR TITLE
Changes max inject of needles (Hypodermic Prickles) plant gene

### DIFF
--- a/code/modules/hydroponics/plant_genes.dm
+++ b/code/modules/hydroponics/plant_genes.dm
@@ -750,7 +750,7 @@
 	var/mob/living/living_target = target
 	var/obj/item/seeds/our_seed = our_plant.get_plant_seed()
 	if(living_target.reagents && living_target.can_inject())
-		var/injecting_amount = qp_sigmoid(2000, 840, our_seed.potency)
+		var/injecting_amount = qp_sigmoid(2000, 50, our_seed.potency)
 		//420 units at 2000 potency
 		//one 5% reagent would fill a standard plant completely at 2000 potency
 		our_plant.reagents.trans_to(living_target, injecting_amount, methods = INJECT)


### PR DESCRIPTION
## About The Pull Request
Changes the maximum injection of any plant with the hypodermic prickles gene to 50u, from 840u

## Why It's Good For The Game
People were debating this in ERDC and i think being able to inject 840u by throwing a plant at a person is probably a problem. 

## Testing
Number change

## Changelog
:cl: Mantle
balance: Hypodermic Prickles gene on plants can now only inject 50u, from 840u
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [ ] You documented all of your changes.
