### PR TITLE
add traffic cone hat to monke coin store

### DIFF
--- a/monkestation/code/modules/store/store_items/head.dm
+++ b/monkestation/code/modules/store/store_items/head.dm
@@ -203,6 +203,11 @@ GLOBAL_LIST_INIT(store_head, generate_store_items(/datum/store_item/head))
 	item_path = /obj/item/clothing/head/hats/fez
 	item_cost = 5000
 
+/datum/store_item/head/warning_cone
+	name = "Warning Cone"
+	item_path = /obj/item/clothing/head/cone
+	item_cost = 1000
+
 /*
 *	HALLOWEEN
 */


### PR DESCRIPTION
## About The Pull Request
Adds the traffic cone hat to the monkecoin store, for 1k

## Why It's Good For The Game
Someone asked me to do this

## Changelog

:cl: Mantle
add: Traffic Cone Hat added to monkecoin store
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
