### PR TITLE
fixes nightmares reviving in 2 seconds

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -1,4 +1,4 @@
-#define HEART_RESPAWN_THRESHHOLD 40
+#define HEART_RESPAWN_THRESHHOLD 30 SECONDS
 #define HEART_SPECIAL_SHADOWIFY 2
 ///cooldown between charges of the projectile absorb
 #define DARKSPAWN_REFLECT_COOLDOWN 15 SECONDS


### PR DESCRIPTION

## About The Pull Request
the threshold never had seconds applied to it and it since it increments by seconds the timer was off by a decimal point.
## Why It's Good For The Game
bug fix

## Changelog

:cl:
fix: fixed the nightmare revive timer being off by a decimal point.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

