### PR TITLE
Remove stamina damage from baseball bats

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -838,9 +838,6 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	var/relative_direction = get_cardinal_dir(src, target)
 	var/atom/throw_target = get_edge_target_turf(target, relative_direction)
 	. = ..()
-	if(iscarbon(target))
-		var/mob/living/carbon/carbon_target = target
-		carbon_target.stamina.adjust(-force * 2)
 
 	if(homerun_ready)
 		user.visible_message(span_userdanger("It's a home run!"))


### PR DESCRIPTION

## About The Pull Request
Remove stamina damage from baseball bats

## Why It's Good For The Game
Baseball bats are pretty insane currently doing 24 stamina damage a hit stam critting in roughly 5 hits, with normal attack cooldown(compared to batons) and their knockback + chance to knockdown this is honestly just OP, really fun to use but not good for balance or fun to fight against, baseball bats are cheap and stamina damage ignores armor letting anyone quickly craft a really strong weapon being able to drop anyone the same unless they kill you first.
baseball bats are already solid weapons without stam crit as well due to their knockback doesn't kill them to not have it, could see a small damage increase but thats it.

## Testing
tested by hitting things, bats work without these 3 lines yes
## Changelog

:cl:
balance: baseball bats no longer do stam damage
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

