### PR TITLE
Interaction Comps now check for nodrop

### DIFF
--- a/monkestation/code/modules/mech_comp/objects/interactor.dm
+++ b/monkestation/code/modules/mech_comp/objects/interactor.dm
@@ -220,6 +220,9 @@
 	if(!can_interact_with(weapon))
 		balloon_alert(user, "[weapon] is incompatible!")
 		return
+	if(HAS_TRAIT(weapon, TRAIT_NODROP))
+		to_chat(user, "[weapon] is stuck to you!")
+		return
 	else if(check_restrictions(items = TRUE))
 		balloon_alert(user, "holding items is disabled!")
 		return


### PR DESCRIPTION

## About The Pull Request
can no longer put no drop items into interaction comps

fixes https://github.com/Monkestation/Monkestation2.0/issues/10866

## Why It's Good For The Game
bug bad

## Testing
tested with glue on items and interaction comp

## Changelog

:cl:
fix: interaction comps now check for nodrop
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

