### PR TITLE
Silencing the evil snitch known as the announcer board for GOOD

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -322,7 +322,8 @@
 		if(SSshuttle.arrivals)
 			SSshuttle.arrivals.QueueAnnounce(humanc, chosen_rank)
 		else
-			announce_arrival(humanc, chosen_rank)
+			if(!HAS_TRAIT(character, TRAIT_STOWAWAY))
+				announce_arrival(humanc, chosen_rank)
 		AddEmploymentContract(humanc)
 
 		humanc.increment_scar_slot()


### PR DESCRIPTION

## About The Pull Request

Squashes another potential place where the devious announcement board can snitch on the poor _innocent_ stowaways!
## Why It's Good For The Game

Because I said that I fixed this from happening. AND THEN IT HAPPENED
## Testing

Tried it out on a private server. Begrudgingly sat about for TEN minutes without seeing a popup this time...
## Changelog
:cl:
add: another check to block stowaways from being snitched on by announcer
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
