### PR TITLE
replace flowerpots with tables in kilo AI upload

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -12586,7 +12586,8 @@
 /area/station/medical/chemistry)
 "dTT" = (
 /obj/structure/sign/poster/contraband/self_ai_liberation/directional/west,
-/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/table,
 /turf/open/floor/circuit,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "dTW" = (
@@ -53551,7 +53552,6 @@
 "qHT" = (
 /obj/structure/table,
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/spawner/random/aimodule/neutral,
 /obj/machinery/door/window{
 	base_state = "right";
@@ -55495,7 +55495,6 @@
 /area/station/cargo/sorting)
 "rmL" = (
 /obj/structure/table,
-/obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/effect/spawner/random/aimodule/harmful,
 /obj/machinery/door/window/brigdoor/left/directional/south{
@@ -76664,7 +76663,8 @@
 	name = "upload camera";
 	network = list("aiupload")
 	},
-/obj/structure/table/reinforced,
+/obj/structure/window/reinforced/spawner/directional/south,
+/obj/structure/table,
 /turf/open/floor/circuit/red,
 /area/station/ai_monitored/turret_protected/ai_upload)
 "xWq" = (


### PR DESCRIPTION

## About The Pull Request

Small change tweaking the setup in the AI upload for Kilo as an attempted fix of https://github.com/Monkestation/Monkestation2.0/issues/10922
## Why It's Good For The Game

This should ideally prevent cyborgs from late-joining Kilo in positions where they're stuck.
## Testing

Spawned a few times with success so far, but not enough to reliably know it won't happen. Will be testing it out more tonight. For now I gotta run :p

<img width="480" height="589" alt="image" src="https://github.com/user-attachments/assets/04accdef-f383-4f14-81bd-6ee855f93e36" />

The new setup (with Gary being attacked of course)
## Changelog
:cl:
map: tweaked AI upload room in kilo to fix borg spawns
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
