### PR TITLE
[Bounty(notided)] Doubles apocalypse rune time/ties it to shuttle refueling

### DIFF
--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -287,8 +287,9 @@
 		return
 
 	if(ispath(rune_to_scribe, /obj/effect/rune/apocalypse))
-		if((world.time - SSticker.round_start_time) <= 6000)
-			var/wait = 6000 - (world.time - SSticker.round_start_time)
+		var/shuttle_refuel_delay = CONFIG_GET(number/shuttle_refuel_delay)
+		if(world.time - SSticker.round_start_time < shuttle_refuel_delay)
+			var/wait = shuttle_refuel_delay - (world.time - SSticker.round_start_time)
 			to_chat(cultist, span_cultitalic("The veil is not yet weak enough for this rune - it will be available in [DisplayTimeText(wait)]."))
 			return
 		if(!check_if_in_ritual_site(cultist, user_team, TRUE))


### PR DESCRIPTION

## About The Pull Request
apocalypserune timer is now as long as it takes the shuttle to refuel in config, which is 20 minutes up from 10 minutes.

## Why It's Good For The Game
apocalypse rune early on is funny but a bit goofy, considering it scales on how little cult there is and how much crew there is, using it this early  makes it absolutely insane making its effects cover the entire station and really screw the crew up.
The description of the rune is also "a harbinger of the end times. Grows in strength with the cult's desperation - but at the risk of... side effects."
Doesn't really make sense for the cult to be throwing these out off the bat, shuttle timer at least comes with the downside of crew being able to escape from all the messed up effects. 

Overall makes it a bit lessed fucked and a bit more sense

## Testing
Tested with cultist datum on local

## Changelog

:cl:
balance: apocalypse rune can not be used until shuttle can be called
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

