### PR TITLE
Adds ponies to possible wabbajack animals

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1559,6 +1559,8 @@
 				/mob/living/simple_animal/hostile/megafauna/dragon/lesser,
 				/mob/living/simple_animal/pet/cat,
 				/mob/living/simple_animal/pet/cat/cak,
+				/mob/living/basic/pony
+				/mob/living/basic/pony/syndicate
 			)
 			new_mob = new picked_animal(loc)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1559,8 +1559,8 @@
 				/mob/living/simple_animal/hostile/megafauna/dragon/lesser,
 				/mob/living/simple_animal/pet/cat,
 				/mob/living/simple_animal/pet/cat/cak,
-				/mob/living/basic/pony
-				/mob/living/basic/pony/syndicate
+				/mob/living/basic/pony,
+				/mob/living/basic/pony/syndicate,
 			)
 			new_mob = new picked_animal(loc)
 


### PR DESCRIPTION

## About The Pull Request
Adds /mob/living/basic/pony to possible wabbajack animals.


## Why It's Good For The Game
Horse.
I mean, you can change spessmen into butterflies, why not horsies?


## Testing
## Changelog
:cl: CanadianZ
Add: Adds ponies and syndicate ponies to the list of possible wabbajack animals
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
