### PR TITLE
Removes incorrectly pathed lionhunter rifle code

### DIFF
--- a/code/modules/antagonists/heretic/items/hunter_rifle.dm
+++ b/code/modules/antagonists/heretic/items/hunter_rifle.dm
@@ -14,9 +14,6 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/boltaction/lionhunter
 	fire_sound = 'sound/weapons/gun/sniper/shot.ogg'
 
-/obj/item/gun/ballistic/rifle/boltaction/lionhunter/give_manufacturer_examine()
-	return
-
 /obj/item/gun/ballistic/rifle/lionhunter/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/scope, range_modifier = 3.2)


### PR DESCRIPTION

## About The Pull Request
There was code to remove the manufacturer on the lionhunter, but it pathed to rifle/boltaction/lionhunter, whereas the lionhunter is rifle/lionhunter. the lionhunter itself already doesnt have an examine compared to the nagant of its parent type, so this doesnt seem necessary.
## Why It's Good For The Game
1 less useless gun on the centcom printer list
## Testing
None
## Changelog
:cl:
code: Minor housekeeping with lionhunter rifle code
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
