### PR TITLE
makes the captain's aid toy a small item

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -360,6 +360,7 @@
 	icon = 'icons/obj/toys/toy.dmi'
 	icon_state = "captainsaid_off"
 	custom_price = PAYCHECK_COMMAND * 1.25
+	w_class = WEIGHT_CLASS_SMALL
 
 	/// List of modes it can cycle through
 	var/list/modes = list(


### PR DESCRIPTION

## About The Pull Request
title

## Why It's Good For The Game
makes it pocketable so its easier to carry. qol  of life really. if you're reading this force every captain to carry one i swear to god most cant tell ship directions to save their life.

## Testing

## Changelog

:cl:
qol: made the captain's aid toy a small item.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

