### PR TITLE
Fix gauze displayed messages

### DIFF
--- a/code/game/objects/items/stacks/sheets/medical_stack/gauze.dm
+++ b/code/game/objects/items/stacks/sheets/medical_stack/gauze.dm
@@ -106,8 +106,9 @@
 		return
 
 	var/whose = helper == owner ? "your" : "[owner]'s"
+	var/theirs = helper == owner ? helper.p_their() : "[owner]'s"
 	helper.visible_message(
-		span_notice("[helper] starts carefully removing [current_gauze] from [whose] [plaintext_zone]."),
+		span_notice("[helper] starts carefully removing [current_gauze] from [theirs] [plaintext_zone]."),
 		span_notice("You start carefully removing [current_gauze] from [whose] [plaintext_zone]..."),
 		vision_distance = COMBAT_MESSAGE_RANGE,
 	)
@@ -119,10 +120,9 @@
 	if(!current_gauze)
 		return
 
-	var/theirs = helper == owner ? helper.p_their() : "[owner]'s"
 	helper.visible_message(
 		span_notice("[helper] finishes removing [current_gauze] from [theirs] [plaintext_zone]."),
-		span_notice("You finish removing [current_gauze] from [theirs] [plaintext_zone]."),
+		span_notice("You finish removing [current_gauze] from [whose] [plaintext_zone]."),
 		vision_distance = COMBAT_MESSAGE_RANGE,
 	)
 


### PR DESCRIPTION

## About The Pull Request
(Hopefully) fixes some of the messages displayed when applying gauze to yourself or if someone else was doing it to themself. 
## Why It's Good For The Game
Should correct some of the wrong messages displayed when using gauze on others or yourself. Should no longer say other people are applying/removing gauze to "your" head when they are doing it to themselves, etc.
## Testing
Tested on a local host, seems all the messages are good now.
## Changelog
:cl: Cujo
fix: Fix messages displayed when applying gauze 
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
