### PR TITLE
Prioritize ling husk over burn husk for advanced health analyzers

### DIFF
--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -164,10 +164,10 @@
 	// Husk detection
 	if(HAS_TRAIT(target, TRAIT_HUSK))
 		if(advanced)
-			if(HAS_TRAIT_FROM(target, TRAIT_HUSK, BURN))
-				render_list += "<span class='alert ml-1'>Subject has been husked by [conditional_tooltip("severe burns", "Tend burns and apply a de-husking agent, such as [/datum/reagent/medicine/c2/synthflesh::name].", tochat)].</span><br>"
-			else if (HAS_TRAIT_FROM(target, TRAIT_HUSK, CHANGELING_DRAIN))
+			if (HAS_TRAIT_FROM(target, TRAIT_HUSK, CHANGELING_DRAIN))
 				render_list += "<span class='alert ml-1'>Subject has been husked by [conditional_tooltip("desiccation", "Irreparable. Under normal circumstances, revival can only proceed via brain transplant or special surgies.", tochat)].</span><br>"
+			else if(HAS_TRAIT_FROM(target, TRAIT_HUSK, BURN))
+				render_list += "<span class='alert ml-1'>Subject has been husked by [conditional_tooltip("severe burns", "Tend burns and apply a de-husking agent, such as [/datum/reagent/medicine/c2/synthflesh::name].", tochat)].</span><br>"
 			else
 				render_list += "<span class='alert ml-1'>Subject has been husked by mysterious causes.</span>\n"
 


### PR DESCRIPTION

## About The Pull Request
switches the order of husks displayed by the advanced health analyzer, ling husk now takes priority over burn husk.
## Why It's Good For The Game
Currently if a ling desiccates a corpse, and then that corpse lights on fire and husks, it will display as a burn husk. This gives a false illusion to medbay that the corpse is fixable via synthflesh when it is not. Now prioritizes displaying ling husk over burn husk to prevent this.
## Testing
Tested on a local host, desiccated a corpse and then burnt it. Displayed desiccation the whole time.
## Changelog
:cl: Cujo
add: Ling husk now takes priority over burn husk for advanced health analyzers
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
