### PR TITLE
Fart emote no longer displays in runechat if you have prude mode enabled

### DIFF
--- a/monkestation/code/modules/surgery/organs/internal/butts.dm
+++ b/monkestation/code/modules/surgery/organs/internal/butts.dm
@@ -188,7 +188,7 @@
 										"gets real close to [Targeted]'s face and cuts the cheese!")]", ignored_mobs = ignored_mobs)
 			hit_target = TRUE
 			break
-	if(!hit_target)
+	if(!hit_target && !user.client?.prefs?.read_preference(/datum/preference/toggle/prude_mode))
 		user.audible_message("[pick(world.file2list("strings/farts.txt"))]", audible_message_flags = list(CHATMESSAGE_EMOTE = TRUE))
 
 	if(superfart_armed)


### PR DESCRIPTION

## About The Pull Request
before displaying fart emotes check if someone has prude mode enabled. if they do then don't display the message
## Why It's Good For The Game
worlds biggest fart emote hater here. if you have prude mode enabled you probably don't want to see fart emotes in runechat. the message doesn't even display in chat, it's only in runechat so it was weird that it displayed at all. shouldn't change anything else probably.
## Testing
tested on a localhost, effects same with prude mode disabled and hides messages with prude mode enabled.
## Changelog
:cl: Cujo
fix: Prude mode now stops fart emotes from displaying in runechat
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
