### PR TITLE
Changes the vendozer recipe a bit, fixes a vendozer bug, and fixes a typo.

### DIFF
--- a/code/datums/components/crafting/makeshift_mechs.dm
+++ b/code/datums/components/crafting/makeshift_mechs.dm
@@ -139,7 +139,7 @@
 	category = CAT_ROBOT
 
 /datum/crafting_recipe/peashooter_breech
-	name = "Peahooter Breech"
+	name = "Peashooter Breech"
 	result = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/peashooter
 	reqs = list(/obj/item/pipe = 2,
 		/obj/item/stock_parts/manipulator = 1,

--- a/code/datums/components/crafting/robot.dm
+++ b/code/datums/components/crafting/robot.dm
@@ -241,66 +241,72 @@
 
 /datum/crafting_recipe/vendozer_fl
 	name = "Vendozer Front Left Armor Parts"
+	desc = "Giant shitty armor for something... Crafted with the parts of a YouTool and SecDrobe." //the vending refills dont have unique names, so we have to do this.
 	always_available = FALSE
 	result = /obj/item/mecha_parts/part/vendozer_fl
 	tool_behaviors = list(TOOL_WELDER, TOOL_SCREWDRIVER, TOOL_WIRECUTTER, TOOL_WRENCH, TOOL_CROWBAR)
 	time = 10 SECONDS
-	machinery = list(/obj/machinery/vending/tool  = CRAFTING_MACHINERY_CONSUME,/obj/machinery/vending/wardrobe/sec_wardrobe = CRAFTING_MACHINERY_CONSUME)
 	reqs = list(
 		/obj/item/stack/sheet/mineral/wood = 10,
-		/obj/item/stack/sheet/iron = 10,
+		/obj/item/stack/sheet/iron = 20,
 		/obj/item/pipe = 6,
-		/obj/item/stack/cable_coil = 30,
+		/obj/item/stack/cable_coil = 40,
+		/obj/item/vending_refill/youtool = 1,
+		/obj/item/vending_refill/wardrobe/sec_wardrobe = 1,
 	)
 	category = CAT_ROBOT
 
 /datum/crafting_recipe/vendozer_fr
 	name = "Vendozer Front Right Armor Parts"
+	desc = "Giant shitty armor for something... Crafted with the parts of a Robust Softdrinks."
 	always_available = FALSE
 	result = /obj/item/mecha_parts/part/vendozer_fr
 	tool_behaviors = list(TOOL_WELDER, TOOL_SCREWDRIVER, TOOL_WIRECUTTER, TOOL_WRENCH, TOOL_CROWBAR)
 	time = 10 SECONDS
-	machinery = list(/obj/machinery/vending/cola = CRAFTING_MACHINERY_CONSUME)
 	reqs = list(
 		/obj/item/stack/sheet/mineral/wood = 10,
 		/obj/item/stack/sheet/plasteel = 5,
 		/obj/item/pipe = 6,
-		/obj/item/stack/cable_coil = 30,
+		/obj/item/stack/cable_coil = 35,
 		/obj/item/toy/crayon/spraycan = 1,
+		/obj/item/vending_refill/cola = 1,
+		/obj/item/stack/sheet/iron = 5,
 	)
 	category = CAT_ROBOT
 
 /datum/crafting_recipe/vendozer_bl
 	name = "Vendozer Back Left Armor Parts"
+	desc = "Giant shitty armor for something... Crafted with the parts of a NanoDrug Plus."
 	always_available = FALSE
 	result = /obj/item/mecha_parts/part/vendozer_bl
 	tool_behaviors = list(TOOL_WELDER, TOOL_SCREWDRIVER, TOOL_WIRECUTTER, TOOL_WRENCH, TOOL_CROWBAR)
 	time = 10 SECONDS
-	machinery = list(/obj/machinery/vending/drugs = CRAFTING_MACHINERY_CONSUME)
 	reqs = list(
 		/obj/item/stack/sheet/mineral/wood = 10,
-		/obj/item/stack/sheet/iron = 10,
-		/obj/item/stack/cable_coil = 45,
+		/obj/item/stack/sheet/iron = 15,
+		/obj/item/stack/cable_coil = 50,
 		/obj/item/extinguisher = 2,
 		/obj/item/stack/sticky_tape = 5,
 		/obj/item/light/tube = 1,
+		/obj/item/vending_refill/drugs = 1,
 	)
 	category = CAT_ROBOT
 
 /datum/crafting_recipe/vendozer_br
 	name = "Vendozer Back Right Armor Parts"
+	desc = "Giant shitty armor for something... Crafted with the parts of a Getmore Chocolate Corp vendor."
 	always_available = FALSE
 	result = /obj/item/mecha_parts/part/vendozer_br
 	tool_behaviors = list(TOOL_WELDER, TOOL_SCREWDRIVER, TOOL_WIRECUTTER, TOOL_WRENCH, TOOL_CROWBAR)
 	time = 10 SECONDS
-	machinery = list(/obj/machinery/vending/snack = CRAFTING_MACHINERY_CONSUME)
 	reqs = list(
 		/obj/item/stack/sheet/mineral/wood = 10,
-		/obj/item/stack/sheet/iron = 10,
-		/obj/item/stack/cable_coil = 15,
+		/obj/item/stack/sheet/iron = 15,
+		/obj/item/stack/cable_coil = 20,
 		/obj/item/extinguisher = 2,
 		/obj/item/stack/sticky_tape = 5,
 		/obj/item/light/tube = 1,
+		/obj/item/vending_refill/snack = 1,
 	)
 	category = CAT_ROBOT
 

--- a/code/modules/vehicles/mecha/combat/vendozer.dm
+++ b/code/modules/vehicles/mecha/combat/vendozer.dm
@@ -13,7 +13,7 @@
 	force = 60 // dont get hit
 	internal_damage_threshold = 18
 	wreckage = null
-	mech_type = EXOSUIT_MODULE_TANK
+	mech_type = (EXOSUIT_MODULE_TANK | EXOSUIT_MODULE_TRASHTANK ) // trashtank because it comes with a pipegun you cant replace if its just tank
 	mecha_flags = OMNIDIRECTIONAL_ATTACKS
 	bumpsmash = TRUE
 	var/crushdmglower = 10


### PR DESCRIPTION

## About The Pull Request
1. The Vendozer recipe:
The recipe calls upon a vending machine as machinery to be consumed, however, this does not support subtypes, so if you have a getmore vendor that isnt red, your just fucked. The recipe is changed to remove the vending machines, and in place add the resupply of the removed vending machine, +5 iron, and +5 cable.
2. Vendozer bug:
The vendozer spawns with a pipegun breech, but the breech is a EXOSUIT_MODULE_TRASHTANK, whereas the vendozer is EXOSUIT_MODULE_TANK, this means that when you remove the pipegun, you cannot readd it. This replaces the vendozer type from EXOSUIT_MODULE_TANK to (EXOSUIT_MODULE_TANK | EXOSUIT_MODULE_TRASHTANK), permitting its previous "selection" (you cant really make any of it anyways) of weapons, and the pipegun, this adds the consequence of other trashtank weapons being valid for vendozer utilization.
3. Typo:
the peashooter breech was called peahooter in crafting. this has been rectified.
## Why It's Good For The Game
1. QOL
2. Bugfix
3. Typo
## Testing
Tested locally, built a vendozer over 30 minutes (wow thats long) with as little admin spawning as possible, managed to suceed.
## Changelog
:cl:
balance: Vendozer recipes that called for a vending machine now call for that machines resupply, 5 iron, and 5 cable.
balance: Vendozers can now carry trashtank weapons (this is also a bugfix, since it spawned with one that, when removed, cannot be readded.)
spellcheck: fixed a typo on the peashooter breech recipe.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
