### PR TITLE
Plexora kick changes + why are we using LOWER_TEXT on a client key for prefs

### DIFF
--- a/code/controllers/subsystem/plexora/topics.dm
+++ b/code/controllers/subsystem/plexora/topics.dm
@@ -526,6 +526,7 @@
 	var/ckey = input["ckey"]
 	var/reason = input["reason"]
 	var/kicker = input["admin_ckey"]
+	var/clear_prefs_cache = input["clear_prefs_cache"]
 
 	if(!ckey || !kicker)
 		return list("error" = PLEXORA_ERROR_BAD_PARAM, "param" = "ckey/admin_ckey", "reason" = "missing required parameter")
@@ -544,6 +545,8 @@
 	qdel(client)
 	log_admin("Discord: [key_name(mockadmin)] has kicked [key_name(client)] from the server! Reason: [reason]")
 	message_admins("Discord: [key_name_admin(mockadmin)] has kicked [key_name_admin(client)] from the server! Reason: [reason]")
+	if (clear_prefs_cache)
+		GLOB.preferences_datums -= ckey
 
 /datum/world_topic/plx_ticketaction
 	keyword = "PLX_ticketaction"

--- a/monkestation/code/modules/blueshift/optin/mind.dm
+++ b/monkestation/code/modules/blueshift/optin/mind.dm
@@ -47,7 +47,7 @@ GLOBAL_LIST_INIT(optin_forcing_on_spawn_antag_categories, list(
 		mind.opt_in_initialized = TRUE
 
 /// Refreshes our ideal/on spawn antag opt in level by accessing preferences.
-/datum/mind/proc/update_opt_in(datum/preferences/preference_instance = GLOB.preferences_datums[LOWER_TEXT(key)])
+/datum/mind/proc/update_opt_in(datum/preferences/preference_instance = GLOB.preferences_datums[ckey(key)])
 	if (isnull(preference_instance))
 		return
 
@@ -60,7 +60,7 @@ GLOBAL_LIST_INIT(optin_forcing_on_spawn_antag_categories, list(
 
 /// Sends a bold message to our holder, telling them if their optin setting has been set to a minimum due to their antag preferences.
 /datum/mind/proc/send_antag_optin_reminder()
-	var/datum/preferences/preference_instance = GLOB.preferences_datums[LOWER_TEXT(key)]
+	var/datum/preferences/preference_instance = GLOB.preferences_datums[ckey(key)]
 	var/client/our_client = preference_instance?.parent // that moment when /mind doesnt have a ref to client :)
 	if (our_client)
 		var/antag_level = get_antag_opt_in_level()
@@ -84,7 +84,7 @@ GLOBAL_LIST_INIT(optin_forcing_on_spawn_antag_categories, list(
 	if (on_spawn_antag_opt_in_level > OPT_IN_NOT_TARGET)
 		return on_spawn_antag_opt_in_level
 
-	var/datum/preferences/preference_instance = GLOB.preferences_datums[LOWER_TEXT(key)]
+	var/datum/preferences/preference_instance = GLOB.preferences_datums[ckey(key)]
 	if (!isnull(preference_instance))
 		for (var/antag_category in GLOB.optin_forcing_midround_antag_categories)
 			if (antag_category in preference_instance.be_special)


### PR DESCRIPTION

## About The Pull Request
uueuguruhgrhurgr

## Changelog
:cl:
fix: Probably fixed some obscure issue with preferences not loading for some people
add: clear_prefs_cache for Kick topic
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
