### PR TITLE
Autopsy scanners can now fit in medkits

### DIFF
--- a/code/game/objects/items/storage/medkit.dm
+++ b/code/game/objects/items/storage/medkit.dm
@@ -76,6 +76,7 @@
 		/obj/item/device/antibody_scanner, //monkestation addition
 		/obj/item/reagent_containers/cup/tube,
 		/obj/item/surgical_processor,
+		/obj/item/autopsy_scanner,
 	)
 
 /obj/item/storage/medkit/Initialize(mapload)


### PR DESCRIPTION

## About The Pull Request
Adds autopsy scanners to the medkit whitelist. Health analyzers and patho analyzers can fit, why not this?
## Why It's Good For The Game
Consistency, i like it.
## Testing


<img width="457" height="132" alt="image" src="https://github.com/user-attachments/assets/b6a3e61f-efdc-462e-87c0-655eabd42d71" />

## Changelog
:cl:
add: Autopsy scanners now fit in medkits.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
