### PR TITLE
Removes the borer's infinite chain stun.

### DIFF
--- a/monkestation/code/modules/antagonists/borers/code/abilities/force_speech.dm
+++ b/monkestation/code/modules/antagonists/borers/code/abilities/force_speech.dm
@@ -1,7 +1,7 @@
 /datum/action/cooldown/borer/force_speak
 	name = "Force Host Speak"
 	cooldown_time = 25 SECONDS
-	willing_cooldown_time = 5 SECONDS
+	var/willing_cooldown_time = 5 SECONDS
 	button_icon_state = "speak"
 	requires_host = TRUE
 	sugar_restricted = TRUE


### PR DESCRIPTION

## About The Pull Request
Borers can no longer force you to 'surrender' 'faint' or 'collapse'
Force host speak cooldown lowered to 25 seconds
## Why It's Good For The Game
By chaining "Incite Fear" And one of the hard self stun emotes you can put someone into a infinite chain stun with little/no counterplay. Or ability to scream for help. Isn't that so engaging?

I'll be frank I am one of the biggest users of said method but It's defiantly isn't the healthiest.
## Testing
<img width="637" height="143" alt="Screenshot 2026-03-07 223224" src="https://github.com/user-attachments/assets/684aeebd-255f-494b-a76c-a521fb87d9c1" />

## Changelog
:cl:
balance: Borers can no longer force people to preform self stunning emotes such as 'collaspe' 'surrender' and 'faint'
balance: Force host speak cooldown has been lowered (30 -> 25 seconds)
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
