### PR TITLE
Removes instability category from seed extractors

### DIFF
--- a/tgui/packages/tgui/interfaces/SeedExtractor.tsx
+++ b/tgui/packages/tgui/interfaces/SeedExtractor.tsx
@@ -39,7 +39,6 @@ type SeedData = {
   production: number;
   yield: number;
   potency: number;
-  instability: number;
   icon: string;
   icon_state: string;
   volume_mod: number;
@@ -129,20 +128,6 @@ export const SeedExtractor = (props) => {
                     onClick={(e) => setSortField('yield')}
                   >
                     YLD
-                  </Box>
-                </Tooltip>
-              </Table.Cell>
-              <Table.Cell collapsing p={1}>
-                <Tooltip
-                  content={
-                    'Instability: The likelihood of the plant to randomize stats or mutate. Affects quality of resulting food & drinks.'
-                  }
-                >
-                  <Box
-                    style={{ cursor: 'pointer' }}
-                    onClick={(e) => setSortField('instability')}
-                  >
-                    INS
                   </Box>
                 </Tooltip>
               </Table.Cell>
@@ -287,9 +272,6 @@ export const SeedExtractor = (props) => {
                   </Table.Cell>
                   <Table.Cell py={0.5} px={1} collapsing>
                     <Level value={item.yield} max={10} />
-                  </Table.Cell>
-                  <Table.Cell py={0.5} px={1} collapsing>
-                    <Level value={item.instability} max={100} reverse />
                   </Table.Cell>
                   <Table.Cell py={0.5} px={1} collapsing>
                     <Level value={item.endurance} max={100} />


### PR DESCRIPTION

## About The Pull Request
Removes instability category from seed extractors
## Why It's Good For The Game
Ill be frank Im not a botany nerd so someone feel free to correct me if Im wrong here but I dont know if this stat exists and never seen a value in it.
So remove it from tgui.
If Im nuking somehting bad uh
Yell please
## Testing
<img width="791" height="129" alt="image" src="https://github.com/user-attachments/assets/336c74b7-9315-42b1-8df5-6ef07e26572e" />

## Changelog
:cl:
del: Removed Instability from seed extractors
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
