### PR TITLE
security officers spawn with armor vest and helmet instead of dusters

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -79,8 +79,6 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	var/accessory = null
 	var/list/dep_trim = null
 	var/destination = null
-	var/suit = null //monkestation edit: add departmental sec outfits
-	var/head = null //monkestation edit: add departmental sec outfits
 
 	switch(department)
 		if(SEC_DEPT_SUPPLY)
@@ -88,29 +86,21 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 			dep_trim = /datum/id_trim/job/security_officer/supply
 			destination = /area/station/security/checkpoint/supply
 			accessory = /obj/item/clothing/accessory/armband/cargo
-			suit = /obj/item/clothing/suit/armor/secduster/cargo //monkestation edit: add departmental sec outfits
-			head = /obj/item/clothing/head/helmet/hat/cowboy/cargo//monkestation edit: add departmental sec outfits
 		if(SEC_DEPT_ENGINEERING)
 			ears = /obj/item/radio/headset/headset_sec/alt/department/engi
 			dep_trim = /datum/id_trim/job/security_officer/engineering
 			destination = /area/station/security/checkpoint/engineering
 			accessory = /obj/item/clothing/accessory/armband/engine
-			suit = /obj/item/clothing/suit/armor/secduster/engineering //monkestation edit: add departmental sec outfits
-			head = /obj/item/clothing/head/helmet/hat/cowboy/engineering //monkestation edit: add departmental sec outfits
 		if(SEC_DEPT_MEDICAL)
 			ears = /obj/item/radio/headset/headset_sec/alt/department/med
 			dep_trim = /datum/id_trim/job/security_officer/medical
 			destination = /area/station/security/checkpoint/medical
 			accessory = /obj/item/clothing/accessory/armband/medblue
-			suit = /obj/item/clothing/suit/armor/secduster/medical //monkestation edit: add departmental sec outfits
-			head = /obj/item/clothing/head/helmet/hat/cowboy/medical //monkestation edit: add departmental sec outfits
 		if(SEC_DEPT_SCIENCE)
 			ears = /obj/item/radio/headset/headset_sec/alt/department/sci
 			dep_trim = /datum/id_trim/job/security_officer/science
 			destination = /area/station/security/checkpoint/science
 			accessory = /obj/item/clothing/accessory/armband/science
-			suit = /obj/item/clothing/suit/armor/secduster/science//monkestation edit: add departmental sec outfits
-			head = /obj/item/clothing/head/helmet/hat/cowboy/science//monkestation edit: add departmental sec outfits
 
 	if(accessory)
 		var/obj/item/clothing/under/worn_under = spawning.w_uniform
@@ -120,17 +110,6 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 		if(spawning.ears)
 			qdel(spawning.ears)
 		spawning.equip_to_slot_or_del(new ears(spawning),ITEM_SLOT_EARS)
-
-	//monkestation edit start: add dept sec outfitsif(suit)
-	if(suit)
-		if(spawning.wear_suit)
-			qdel(spawning.wear_suit)
-		spawning.equip_to_slot_or_del(new suit(spawning),ITEM_SLOT_OCLOTHING)
-	if(head)
-		if(spawning.head && !isplasmaman(spawning))
-			qdel(spawning.head)
-		spawning.equip_to_slot_or_del(new head(spawning),ITEM_SLOT_HEAD)
-	//monkestation edit end
 
 	// If there's a departmental sec trim to apply to the card, overwrite.
 	if(dep_trim)
@@ -220,8 +199,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 
 	id_trim = /datum/id_trim/job/security_officer
 	uniform = /obj/item/clothing/under/rank/security/officer
-	head = /obj/item/clothing/head/helmet/hat/cowboy //monkestation edit: cowboy sec
-	suit = /obj/item/clothing/suit/armor/secduster //monkestation edit: cowboy sec
+	suit = /obj/item/clothing/suit/armor/vest/alt/sec
 	backpack_contents = list(
 		/obj/item/evidencebag = 1,
 		/obj/item/security_voucher/primary, //monkestation edit: Voucher sec
@@ -230,6 +208,7 @@ GLOBAL_LIST_EMPTY(security_officer_distribution)
 	belt = /obj/item/modular_computer/pda/security
 	ears = /obj/item/radio/headset/headset_sec/alt
 	gloves = /obj/item/clothing/gloves/color/black/security
+	head = /obj/item/clothing/head/helmet/sec
 	shoes = /obj/item/clothing/shoes/jackboots/sec
 	l_pocket = /obj/item/assembly/flash/handheld
 	r_pocket = /obj/item/restraints/handcuffs


### PR DESCRIPTION
## About The Pull Request

reverts change made in this commit https://github.com/Monkestation/Monkestation2.0/commit/ec345b2c0e14d4f5ccae0122749f6434317fdd62

## Why It's Good For The Game

literally 90% of officers discard duster and hat upon arrival and not like they fit the theme because paco isnt the only roundstart gun now
dusters can still be purchased in sec wardrobe so nothing is really lost (besides your money)
armbands are still there

## Testing

joined as officer on localhost helmet and armor were workin fine

## Changelog

:cl:
add: Security officer spawn with armor vest and helmet instead of dusters once again
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
