### PR TITLE
Adds ignored_mob to audible_message, fix prude showing emotes again

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -344,22 +344,23 @@
 /atom/proc/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, audible_message_flags = NONE, atom/push_appearance, list/ignored_mobs)
 	if(!isnull(push_appearance) && !isatom(push_appearance))
 		stack_trace("push_appearance must be an atom, but got [push_appearance] instead")
+	var/list/hearers = get_hearers_in_range(hearing_distance, src) //caches the hearers and then removes ignored mobs.
+	if(isnull(hearers))
+		return
 	if(!islist(ignored_mobs))
 		ignored_mobs = list(ignored_mobs)
-	var/list/hearers = get_hearers_in_range(hearing_distance, src) //caches the hearers and then removes ignored mobs.
-	if(hearers)
-		hearers -= ignored_mobs
-		if(self_message)
-			hearers -= src
-		var/raw_msg = message
-		if(audible_message_flags & EMOTE_MESSAGE)
-			message = "<span class='emote'><b>[src]</b> [message]</span>"
-		for(var/mob/M in hearers)
-			if(push_appearance)
-				M << output(push_appearance, "push_appearance_placeholder_id")
-			if(audible_message_flags & EMOTE_MESSAGE && runechat_prefs_check(M, audible_message_flags))
-				M.create_chat_message(src, raw_message = raw_msg, runechat_flags = audible_message_flags)
-			M.show_message(message, MSG_AUDIBLE, deaf_message, MSG_VISUAL)
+	hearers -= ignored_mobs
+	if(self_message)
+		hearers -= src
+	var/raw_msg = message
+	if(audible_message_flags & EMOTE_MESSAGE)
+		message = "<span class='emote'><b>[src]</b> [message]</span>"
+	for(var/mob/M in hearers)
+		if(push_appearance)
+			M << output(push_appearance, "push_appearance_placeholder_id")
+		if(audible_message_flags & EMOTE_MESSAGE && runechat_prefs_check(M, audible_message_flags))
+			M.create_chat_message(src, raw_message = raw_msg, runechat_flags = audible_message_flags)
+		M.show_message(message, MSG_AUDIBLE, deaf_message, MSG_VISUAL)
 
 /**
  * Show a message to all mobs in earshot of this one

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -341,21 +341,25 @@
  * * hearing_distance (optional) is the range, how many tiles away the message can be heard.
  * * push_appearance (optional) pushes an atom's appearance to all viewing mobs, for use with <img src='\ref[thing]'>
  */
-/atom/proc/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, audible_message_flags = NONE, atom/push_appearance)
+/atom/proc/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, audible_message_flags = NONE, atom/push_appearance, list/ignored_mobs)
 	if(!isnull(push_appearance) && !isatom(push_appearance))
 		stack_trace("push_appearance must be an atom, but got [push_appearance] instead")
-	var/list/hearers = get_hearers_in_view(hearing_distance, src)
-	if(self_message)
-		hearers -= src
-	var/raw_msg = message
-	if(audible_message_flags & EMOTE_MESSAGE)
-		message = "<span class='emote'><b>[src]</b> [message]</span>"
-	for(var/mob/M in hearers)
-		if(push_appearance)
-			M << output(push_appearance, "push_appearance_placeholder_id")
-		if(audible_message_flags & EMOTE_MESSAGE && runechat_prefs_check(M, audible_message_flags))
-			M.create_chat_message(src, raw_message = raw_msg, runechat_flags = audible_message_flags)
-		M.show_message(message, MSG_AUDIBLE, deaf_message, MSG_VISUAL)
+	if(!islist(ignored_mobs))
+		ignored_mobs = list(ignored_mobs)
+	var/list/hearers = get_hearers_in_range(hearing_distance, src) //caches the hearers and then removes ignored mobs.
+	if(hearers)
+		hearers -= ignored_mobs
+		if(self_message)
+			hearers -= src
+		var/raw_msg = message
+		if(audible_message_flags & EMOTE_MESSAGE)
+			message = "<span class='emote'><b>[src]</b> [message]</span>"
+		for(var/mob/M in hearers)
+			if(push_appearance)
+				M << output(push_appearance, "push_appearance_placeholder_id")
+			if(audible_message_flags & EMOTE_MESSAGE && runechat_prefs_check(M, audible_message_flags))
+				M.create_chat_message(src, raw_message = raw_msg, runechat_flags = audible_message_flags)
+			M.show_message(message, MSG_AUDIBLE, deaf_message, MSG_VISUAL)
 
 /**
  * Show a message to all mobs in earshot of this one
@@ -369,7 +373,7 @@
  * * hearing_distance (optional) is the range, how many tiles away the message can be heard.
  * * push_appearance (optional) pushes an atom's appearance to all viewing mobs, for use with <img src='\ref[thing]'>
  */
-/mob/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, audible_message_flags = NONE, atom/push_appearance)
+/mob/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, audible_message_flags = NONE, atom/push_appearance, list/ignored_mobs)
 	. = ..()
 	if(self_message)
 		show_message(self_message, MSG_AUDIBLE, deaf_message, MSG_VISUAL)

--- a/monkestation/code/modules/surgery/organs/internal/butts.dm
+++ b/monkestation/code/modules/surgery/organs/internal/butts.dm
@@ -188,8 +188,8 @@
 										"gets real close to [Targeted]'s face and cuts the cheese!")]", ignored_mobs = ignored_mobs)
 			hit_target = TRUE
 			break
-	if(!hit_target && !user.client?.prefs?.read_preference(/datum/preference/toggle/prude_mode))
-		user.audible_message("[pick(world.file2list("strings/farts.txt"))]", audible_message_flags = list(CHATMESSAGE_EMOTE = TRUE))
+	if(!hit_target)
+		user.audible_message("[pick(world.file2list("strings/farts.txt"))]", audible_message_flags = list(CHATMESSAGE_EMOTE = TRUE), ignored_mobs = ignored_mobs)
 
 	if(superfart_armed)
 		to_chat(user, span_notice("You decide to disarm your ass by farting slowly. Thank god."))


### PR DESCRIPTION

## About The Pull Request
Adds ignored_mob to audible_message, and adds ignored_mob to prude messages which ignore showing emotes to anyone with prude mode enabled

reverts https://github.com/Monkestation/Monkestation2.0/pull/11008 cause i am stupid

i love git
## Why It's Good For The Game
visible_message has ignored_mob as a list of mobs to ignore, now audible_message does so similarly. also stops fart emotes and such from showing to people with prude mode enabled
## Testing
ive had to do this like 4 times now it probably works 
## Changelog
:cl: Cujo
add: Adds ignored_mob to audible_message
fix: Actually fixes prude mode showing fart emotes in runechat
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
