### PR TITLE
door buttons now drop all their parts when broken

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -190,7 +190,7 @@
 	if(!initialized_button)
 		setup_device()
 	add_fingerprint(user)
-	play_click_sound("button")
+	play_click_sound(SFX_BUTTON)
 	if(panel_open)
 		if(device || board)
 			if(device)


### PR DESCRIPTION

## About The Pull Request
Buttons (like the shutter buttons) now drop their parts on the ground when broken
## Why It's Good For The Game
They didnt drop anything before, making it really annoying to fix them
## Changelog
Buttons drop all their parts when broken
:cl:
qol: Buttons drop all their parts when broken
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
