### PR TITLE
Monkeys can no longer break out of monkey prison

### DIFF
--- a/monkestation/code/modules/slimecore/corral/machines/corral_corner.dm
+++ b/monkestation/code/modules/slimecore/corral/machines/corral_corner.dm
@@ -169,11 +169,7 @@
 	. = ..()
 	if(mover.pulledby)
 		return TRUE
-	if(isliving(mover))
-		var/mob/living/movee = mover
-		if(movee.mind)
-			return TRUE
-	if((istype(mover, /mob/living/basic/slime) || ismonkey(mover) || istype(mover, /mob/living/basic/cockroach) || istype(mover, /mob/living/basic/xenofauna)) && !HAS_TRAIT(mover, VACPACK_THROW))
+	if((istype(mover, /mob/living/basic/slime) || ismonkeybasic(mover) || istype(mover, /mob/living/basic/cockroach) || istype(mover, /mob/living/basic/xenofauna)) && !HAS_TRAIT(mover, VACPACK_THROW))
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Fixes xenobio monkeys being able to walk out of the pens, by making the pens not block anyone with a mind from walking through. This should also prevent this from happening with any future monkey based races
## Why It's Good For The Game

Bug fix good
fixes: #11050
fixes #11062
fixes #11060
## Testing
Sentient mobs are able to freely walk through regardless of race
Build mode was unable to throw monkeys through, if they weren't sentient. 

## Changelog

:cl: Mantle
fix: Monkeys can no longer break out of xenobio pens
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
