### PR TITLE
Fire is now a valid alarm clock.

### DIFF
--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -124,6 +124,7 @@
 		owner.clear_alert(ALERT_FIRE)
 	else if(!was_on_fire && owner.on_fire)
 		owner.throw_alert(ALERT_FIRE, /atom/movable/screen/alert/fire)
+		owner.SetSleeping(-1) //FIRE!!!!!
 	owner.update_appearance(UPDATE_OVERLAYS)
 	update_particles()
 


### PR DESCRIPTION
## About The Pull Request

Catching fire will now remove sleep stacks (but not unconscious ones, if you were knocked out)

## Why It's Good For The Game

Interesting alarm clock you have there.

## Testing

Set myself on fire with VV while I was sleeping, woke up.

## Changelog

:cl:
balance: Catching fire now wakes you up.
/:cl: