### PR TITLE
Removes OOC ban evasion

### DIFF
--- a/monkestation/code/modules/client/verbs/looc.dm
+++ b/monkestation/code/modules/client/verbs/looc.dm
@@ -79,23 +79,26 @@ GLOBAL_VAR_INIT(looc_allowed, TRUE)
 
 	var/list/hearers = list()
 	for(var/mob/hearer in get_hearers_in_view(9, mob))
-		var/client/client = hearer.client
-		if(QDELETED(client) || !CHECK_BITFIELD(client.prefs.chat_toggles, CHAT_OOC))
+		var/client/hearing_client = hearer.client
+		if(QDELETED(hearing_client) || !CHECK_BITFIELD(hearing_client.prefs.chat_toggles, CHAT_OOC))
 			continue
-		hearers[client] = TRUE
-		if((client in GLOB.admins) && is_admin_looc_omnipotent(client))
+		if(key in hearing_client.prefs.ignoring)
+			continue
+		hearers[hearing_client] = TRUE
+		//handled in the for() loop below.
+		if((hearing_client in GLOB.admins) && is_admin_looc_omnipotent(hearing_client))
 			continue
 		to_chat(hearer, span_looc("[span_prefix("LOOC:")] <EM>[span_name("[mob.name]")]:</EM> <span class='message linkify'>[msg]</span>"), type = MESSAGE_TYPE_LOOC, avoid_highlighting = (hearer == mob))
-		if(client.prefs.read_preference(/datum/preference/toggle/enable_runechat_looc))
+		if(hearing_client.prefs.read_preference(/datum/preference/toggle/enable_runechat_looc))
 			hearer.create_chat_message(mob, /datum/language/common, "\[LOOC: [raw_msg]\]", runechat_flags = LOOC_MESSAGE)
 
-	for(var/client/client in GLOB.admins)
-		if(!CHECK_BITFIELD(client.prefs.chat_toggles, CHAT_OOC) || !is_admin_looc_omnipotent(client))
+	for(var/client/admin_client in GLOB.admins)
+		if(!CHECK_BITFIELD(admin_client.prefs.chat_toggles, CHAT_OOC) || !is_admin_looc_omnipotent(admin_client))
 			continue
-		var/prefix = "[hearers[client] ? "" : "(R)"]LOOC"
-		if(client.prefs.read_preference(/datum/preference/toggle/enable_runechat_looc))
-			client.mob?.create_chat_message(mob, /datum/language/common, "\[LOOC: [raw_msg]\]", runechat_flags = LOOC_MESSAGE)
-		to_chat(client, span_looc("[span_prefix("[prefix]:")] <EM>[ADMIN_LOOKUPFLW(mob)]:</EM> <span class='message linkify'>[msg]</span>"), type = MESSAGE_TYPE_LOOC, avoid_highlighting = (client == src))
+		var/prefix = "[hearers[admin_client] ? "" : "(R)"]LOOC"
+		if(admin_client.prefs.read_preference(/datum/preference/toggle/enable_runechat_looc))
+			admin_client.mob?.create_chat_message(mob, /datum/language/common, "\[LOOC: [raw_msg]\]", runechat_flags = LOOC_MESSAGE)
+		to_chat(admin_client, span_looc("[span_prefix("[prefix]:")] <EM>[ADMIN_LOOKUPFLW(mob)]:</EM> <span class='message linkify'>[msg]</span>"), type = MESSAGE_TYPE_LOOC, avoid_highlighting = (admin_client == src))
 
 /// Logging for messages sent in LOOC
 /proc/log_looc(text, list/data)


### PR DESCRIPTION
## About The Pull Request

Ignoring people currently ignores them in deadchat and OOC, but not LOOC. This fixes that.

## Why It's Good For The Game

People muted you for a good reason, be muted.

## Testing

Ran it locally with 2 clients.

## Changelog

:cl:
fix: Ignoring someone from OOC/Dchat will now also ignore them in LOOC.
/:cl: