### PR TITLE
Changes Oshan medical protolathe to techfab

### DIFF
--- a/_maps/map_files/Oshan/Oshan.dmm
+++ b/_maps/map_files/Oshan/Oshan.dmm
@@ -75986,7 +75986,7 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "yaE" = (
-/obj/machinery/rnd/production/protolathe/department/medical,
+/obj/machinery/rnd/production/techfab/department/medical,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/storage)
 "yaF" = (


### PR DESCRIPTION

## About The Pull Request
Oshan medbay is currently using a medical protolathe, every other map uses a medical techfab. This changes it to that.
## Why It's Good For The Game
Oshan medical is using a protolathe which does not allow the printing of computer or machine boards. Swaps it to a techfab which has computer and machine boards. Additionally every other map uses techfabs for medical/service/security/cargo, and protolathes for engie/sci, so this keeps it consistent.
## Testing
tested on a local host, seems to be all good with ore silo n stuff
## Changelog
:cl: Cujo
fix: Changed Oshan medical protolathe to techfab. Now allows printing of computer and machine boards.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
