### PR TITLE
Adds missing robotic repair toolbox to tramstation medical

### DIFF
--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -65141,6 +65141,7 @@
 	name = "Secure Medical Storage";
 	req_access = list("medical")
 	},
+/obj/item/storage/toolbox/electrical/medical,
 /obj/item/clothing/glasses/blindfold,
 /obj/item/clothing/glasses/blindfold,
 /obj/item/clothing/ears/earmuffs,


### PR DESCRIPTION

## About The Pull Request
adds the new robotic repair toolbox to tramstation medical as it was missing
## Why It's Good For The Game
every other map has it, tram should too
## Testing
tested on a local host nothing blew up the toolbox is there
## Changelog
:cl: Cujo
add: Adds missing robotic repair toolbox to tramstation medical
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
