### PR TITLE
[OSHAN][MAPPING] Minor fixes/changes to medical, atmos, and the library

### DIFF
--- a/_maps/map_files/Oshan/Oshan.dmm
+++ b/_maps/map_files/Oshan/Oshan.dmm
@@ -19389,10 +19389,8 @@
 /turf/open/floor/iron/white/textured,
 /area/station/medical/medbay/central)
 "fXm" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/yellow/visible,
 /obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "fXB" = (
@@ -27593,6 +27591,10 @@
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/science/lobby)
+"iDm" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos)
 "iDn" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/assistant,
@@ -33585,7 +33587,9 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
 "kyU" = (
@@ -35443,6 +35447,9 @@
 /obj/machinery/air_sensor/oxygen_tank,
 /obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
+	},
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "kXa" = (
@@ -49321,6 +49328,9 @@
 /obj/machinery/air_sensor/nitrogen_tank,
 /obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/siding/thinplating_new/dark,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
+	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
 "phT" = (
@@ -53097,7 +53107,9 @@
 /obj/effect/turf_decal/siding/thinplating_new/dark{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 4
+	},
 /turf/open/floor/engine/o2,
 /area/station/engineering/atmos)
 "qqB" = (
@@ -69205,10 +69217,8 @@
 /turf/open/floor/iron/dark/diagonal,
 /area/station/cargo/lobby)
 "vmw" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
 /obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "vmz" = (
@@ -126002,9 +126012,9 @@ hMv
 meJ
 meJ
 meJ
-meJ
-meJ
 lGC
+meJ
+meJ
 hXv
 wWl
 uJA
@@ -126259,9 +126269,9 @@ vmk
 meJ
 meJ
 sks
-sks
-sks
 hBv
+iDm
+iDm
 bPz
 lWU
 qUn


### PR DESCRIPTION


## About The Pull Request

Atmos:
Nitrogen and Oxygen tanks have manifold under the glass instead of behind (easier to get valves and pumps on)
Waste Line vent moved farther away from window to prevent destruction of glass when venting 

Library:
moves a thing to add Skillsoft chamber (job chip implanter)

Medbay:
Fixes disposal net to properly remove waste from the department
removes lone operating computer 

:cl:
\
map: Minor oshan fixes to atmos, library, and med
/:cl:
