### PR TITLE
Curator language continues through bodies

### DIFF
--- a/code/__DEFINES/language.dm
+++ b/code/__DEFINES/language.dm
@@ -24,7 +24,6 @@
 #define LANGUAGE_APHASIA "aphasia"
 #define LANGUAGE_CTF "ctf"
 #define LANGUAGE_CULTIST "cultist"
-#define LANGUAGE_CURATOR "curator"
 #define LANGUAGE_GLAND "gland"
 #define LANGUAGE_HAT "hat"
 #define LANGUAGE_QUIRK "quirk"

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -71,5 +71,5 @@
 	if(visualsOnly)
 		return
 
-	translator.grant_all_languages(source = LANGUAGE_CURATOR)
+	translator.grant_all_languages(source = LANGUAGE_MIND)
 	translator.remove_blocked_language(GLOB.all_languages, source=LANGUAGE_ALL)


### PR DESCRIPTION
## About The Pull Request

Curators being transformed into another mob now keeps their languages

## Why It's Good For The Game

A Curator turning into a Xenomorph or Cyborg and losing all their languages is quite lame, moreso if they turn back human and it's just gone forever.

## Testing

Ate a Roburger, kept my languages.

## Changelog

:cl:
qol: Curators now keep languages through body transformations.
/:cl: