### PR TITLE
nanites and borer force speech can't make you piss yourself

### DIFF
--- a/monkestation/code/modules/antagonists/borers/code/abilities/force_speech.dm
+++ b/monkestation/code/modules/antagonists/borers/code/abilities/force_speech.dm
@@ -12,6 +12,7 @@
 		"*surrender",
 		"*collapse",
 		"*faint",
+		"*piss",
 	)
 
 /datum/action/cooldown/borer/force_speak/Trigger(trigger_flags, atom/target)

--- a/monkestation/code/modules/research/nanites/nanite_programs/suppression.dm
+++ b/monkestation/code/modules/research/nanites/nanite_programs/suppression.dm
@@ -148,6 +148,7 @@
 		"*surrender",
 		"*collapse",
 		"*faint",
+		"*piss",
 	)
 
 /datum/nanite_program/comm/speech/register_extra_settings()


### PR DESCRIPTION

## About The Pull Request
title
## Why It's Good For The Game
pissing sets you to wanted automatically and this change was requested by admins

## Changelog

:cl:
balance: nanites and borer force speech can't make you piss yourself.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

