### PR TITLE
Heretics can no longer research blade upgrades of paths other than their main one + bug fixes

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -72,6 +72,7 @@
 
 
 // Heretic path defines.
+#define PATH_ANY "Any Path"
 #define PATH_START "Start Path"
 #define PATH_SIDE "Side Path"
 #define PATH_ASH "Ash Path"

--- a/code/modules/antagonists/heretic/heretic_antag.dm
+++ b/code/modules/antagonists/heretic/heretic_antag.dm
@@ -654,12 +654,18 @@ monkestation end */
 /datum/antagonist/heretic/proc/get_researchable_knowledge()
 	var/list/researchable_knowledge = list()
 	var/list/banned_knowledge = list()
+	var/list/blocked_knowledge = list()
 	for(var/knowledge_index in researched_knowledge)
 		var/datum/heretic_knowledge/knowledge = researched_knowledge[knowledge_index]
 		researchable_knowledge |= knowledge.next_knowledge
 		banned_knowledge |= knowledge.banned_knowledge
 		banned_knowledge |= knowledge.type
 	researchable_knowledge -= banned_knowledge
+	for(var/blocked_knowledge_index in 1 to length(researchable_knowledge))
+		var/datum/heretic_knowledge/knowledge_to_checck = researchable_knowledge[blocked_knowledge_index]
+		if(knowledge_to_checck.required_path != PATH_ANY && knowledge_to_checck.required_path != heretic_path)
+			blocked_knowledge |= knowledge_to_checck
+	researchable_knowledge -= blocked_knowledge
 	return researchable_knowledge
 
 /**

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -40,6 +40,8 @@
 	var/route
 	///Determines what kind of monster ghosts will ignore from here on out. Defaults to POLL_IGNORE_HERETIC_MONSTER, but we define other types of monsters for more granularity.
 	var/poll_ignore_define = POLL_IGNORE_HERETIC_MONSTER
+	///What path is required to research this knowledge. used to blacklist blade upgrades that are not of the main path the heretic has selected from being added to the research list
+	var/required_path = PATH_ANY
 
 /datum/heretic_knowledge/New()
 	if(!mutually_exclusive)

--- a/code/modules/antagonists/heretic/knowledge/ash_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/ash_lore.dm
@@ -149,6 +149,7 @@
 		His city, the people he swore to watch... and watch he did, as they all burnt to cinders."
 	next_knowledge = list(/datum/heretic_knowledge/spell/flame_birth)
 	route = PATH_ASH
+	required_path = PATH_ASH
 
 /datum/heretic_knowledge/blade_upgrade/ash/do_melee_effects(mob/living/source, mob/living/target, obj/item/melee/sickly_blade/blade)
 	if(source == target)

--- a/code/modules/antagonists/heretic/knowledge/blade_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/blade_lore.dm
@@ -313,6 +313,7 @@
 		a flurry of blades, neither hitting their mark, for the Champion was indomitable."
 	next_knowledge = list(/datum/heretic_knowledge/spell/furious_steel)
 	route = PATH_BLADE
+	required_path = PATH_BLADE
 	/// How much force do we apply to the offhand?
 	var/offand_force_decrement = 0
 	/// How much force was the last weapon we offhanded with? If it's different, we need to re-calculate the decrement

--- a/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/cosmic_lore.dm
@@ -134,6 +134,7 @@
 		The blades now glistened with fragmented power. I fell to the ground and wept at the beast's feet."
 	next_knowledge = list(/datum/heretic_knowledge/spell/cosmic_expansion)
 	route = PATH_COSMIC
+	required_path = PATH_COSMIC
 	/// Storage for the second target.
 	var/datum/weakref/second_target
 	/// Storage for the third target.

--- a/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/flesh_lore.dm
@@ -291,6 +291,7 @@
 		I finally began to understand. And then, blood rained from the heavens."
 	next_knowledge = list(/datum/heretic_knowledge/summon/stalker)
 	route = PATH_FLESH
+	required_path = PATH_FLESH
 	///What type of wound do we apply on hit
 	var/wound_type = /datum/wound/slash/flesh/severe
 

--- a/code/modules/antagonists/heretic/knowledge/knock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/knock_lore.dm
@@ -171,6 +171,7 @@
 	gain_text = "The power of my patron courses through my blade, willing their very flesh to part."
 	next_knowledge = list(/datum/heretic_knowledge/spell/caretaker_refuge)
 	route = PATH_KNOCK
+	required_path = PATH_KNOCK
 	wound_type = /datum/wound/slash/flesh/critical
 	var/chance = 35
 

--- a/code/modules/antagonists/heretic/knowledge/moon_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/moon_lore.dm
@@ -149,6 +149,7 @@
 	gain_text = "His wit was sharp as a blade, cutting through the lie to bring us joy."
 	next_knowledge = list(/datum/heretic_knowledge/spell/moon_ringleader)
 	route = PATH_MOON
+	required_path = PATH_MOON
 
 /datum/heretic_knowledge/blade_upgrade/moon/do_melee_effects(mob/living/source, mob/living/target, obj/item/melee/sickly_blade/blade)
 	if(source == target)

--- a/code/modules/antagonists/heretic/knowledge/rust_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/rust_lore.dm
@@ -191,6 +191,7 @@
 		The heavy rust weights it down. You stare deeply into it. The Rusted Hills call for you, now."
 	next_knowledge = list(/datum/heretic_knowledge/spell/entropic_plume)
 	route = PATH_RUST
+	required_path = PATH_RUST
 
 /datum/heretic_knowledge/blade_upgrade/rust/do_melee_effects(mob/living/source, mob/living/target, obj/item/melee/sickly_blade/blade)
 	// No user == target check here, cause it's technically good for the heretic?

--- a/code/modules/antagonists/heretic/knowledge/void_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/void_lore.dm
@@ -161,6 +161,7 @@
 	gain_text = "Fleeting memories, fleeting feet. I mark my way with frozen blood upon the snow. Covered and forgotten."
 	next_knowledge = list(/datum/heretic_knowledge/spell/void_pull)
 	route = PATH_VOID
+	required_path = PATH_VOID
 
 /datum/heretic_knowledge/blade_upgrade/void/do_melee_effects(mob/living/source, mob/living/target, obj/item/melee/sickly_blade/blade)
 	if(source == target)

--- a/code/modules/events/space_vines/vine_structure.dm
+++ b/code/modules/events/space_vines/vine_structure.dm
@@ -28,6 +28,11 @@
 	/// The kudzu blocks light on default once it grows
 	var/light_state = BLOCK_LIGHT
 
+GLOBAL_LIST_INIT(spacevine_tile_spread_blacklist, list(
+	/turf/open/floor/plating/ocean,
+	/turf/open/space,
+))
+
 /obj/structure/spacevine/Initialize(mapload)
 	. = ..()
 	//MONKESTATION EDIT START
@@ -167,7 +172,7 @@
 	if(!istype(stepturf))
 		return
 
-	if(!isspaceturf(stepturf) && stepturf.Enter(src))
+	if(!(stepturf.type in GLOB.spacevine_tile_spread_blacklist) && stepturf.Enter(src))
 		var/obj/structure/spacevine/spot_taken = locate() in stepturf //Locates any vine on target turf. Calls that vine "spot_taken".
 		var/datum/spacevine_mutation/vine_eating/eating = locate() in mutations //Locates the vine eating trait in our own seed and calls it E.
 		if(!spot_taken || (eating && (spot_taken && !spot_taken.mutations?.Find(eating)))) //Proceed if there isn't a vine on the target turf, OR we have vine eater AND target vine is from our seed and doesn't. Vines from other seeds are eaten regardless.

--- a/code/modules/hydroponics/grown/weeds/kudzu.dm
+++ b/code/modules/hydroponics/grown/weeds/kudzu.dm
@@ -29,7 +29,7 @@
 	return BRUTELOSS
 
 /obj/item/seeds/kudzu/proc/plant(mob/user)
-	if(isspaceturf(user.loc))
+	if(user.loc.type in GLOB.spacevine_tile_spread_blacklist)
 		return
 	if(!isturf(user.loc))
 		to_chat(user, span_warning("You need more space to plant [src]."))
@@ -45,7 +45,7 @@
 
 /obj/item/seeds/kudzu/attack_self(mob/user)
 	user.visible_message(span_danger("[user] begins throwing seeds on the ground..."))
-	if(do_after(user, 5 SECONDS, target = user.drop_location(), progress = TRUE))
+	if(do_after(user, 5 SECONDS, target = user.drop_location(), progress = TRUE) && !(user.loc.type in GLOB.spacevine_tile_spread_blacklist))
 		plant(user)
 		to_chat(user, span_notice("You plant the kudzu. You monster."))
 

--- a/monkestation/code/game/objects/effects/anomalies/anomalies_lifebringer.dm
+++ b/monkestation/code/game/objects/effects/anomalies/anomalies_lifebringer.dm
@@ -28,7 +28,9 @@
 	pet_type_cache -= list(/mob/living/basic/pet/penguin, //Removing the risky and broken ones.
 		/mob/living/basic/pet/dog/corgi/narsie,
 		/mob/living/basic/pet/dog,
-		/mob/living/basic/pet/fox
+		/mob/living/basic/pet/fox,
+		/mob/living/basic/pet/slime,
+		/mob/living/basic/pet/spider,
 		)
 
 /obj/effect/anomaly/lifebringer/anomalyEffect(seconds_per_tick)


### PR DESCRIPTION
## About The Pull Request

Fixes #11065
Fixes #11096
Heretics can longer research blade upgrades from paths other than their main one, preventing themselves from soft locking out of being able to ascend, because researching a different blade upgrade wont give you the next required research

Kudzu can no longer grow on oshan floor -> it cant grow in space, oshan floor is the space equivalent of Oshan
Planting kudzu will now check that you can plant it on your tile before the doafter, saving you from waiting there for 5 seconds to find out you cant plant it there.
## Why It's Good For The Game
Bug fixes good, softlocks bad
Technically the kudzu and heretic stuff are both balance changes, but fighting Kudzu in space is not fun, neither is fighting kudzu in the infinite expanse of the sea

Heretics not being able to research other blade upgrades is also technically a balance change, but you can only research one of them anyhow and usually the other blade upgrades aren't terribly strong unless you are going down that path in the first place

## Testing
Heretic stuff
researched everything except main path's blade upgrade, was unable to research other path's upgrades
## Changelog
:cl:
balance: Kudzu can no longer be planted on Oshan's sea floor
fix: Heretics can no longer research blade upgrades from paths other than their main path (You already couldnt research more than one), this prevents a softlock
fix: Lifebringer anomalies will no longer spawn broken mobs
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
