### PR TITLE
Removes the holopay range limit

### DIFF
--- a/code/modules/economy/holopay.dm
+++ b/code/modules/economy/holopay.dm
@@ -10,8 +10,6 @@
 	layer = FLY_LAYER
 	/// ID linked to the holopay
 	var/obj/item/card/id/linked_card
-	/// Max range at which the hologram can be projected before it deletes
-	var/max_holo_range = 15
 	/// The holopay shop icon displayed in the UI
 	var/shop_logo = "donate"
 	/// Replaces the "pay whatever" functionality with a set amount when non-zero.
@@ -205,34 +203,7 @@
 	add_atom_colour("#77abff", FIXED_COLOUR_PRIORITY)
 	set_light(2)
 	visible_message(span_notice("A holographic pay stand appears."))
-	/// Start checking if the source projection is in range
-	track(linked_card)
 	return TRUE
-
-/obj/structure/holopay/proc/track(atom/movable/thing)
-	RegisterSignal(thing, COMSIG_MOVABLE_MOVED, PROC_REF(handle_move))
-	var/list/locations = get_nested_locs(thing, include_turf = FALSE)
-	for(var/atom/movable/location in locations)
-		RegisterSignal(location, COMSIG_MOVABLE_MOVED, PROC_REF(handle_move))
-
-/obj/structure/holopay/proc/untrack(atom/movable/thing)
-	UnregisterSignal(thing, COMSIG_MOVABLE_MOVED)
-	var/list/locations = get_nested_locs(thing, include_turf = FALSE)
-	for(var/atom/movable/location in locations)
-		UnregisterSignal(location, COMSIG_MOVABLE_MOVED)
-
-/**
- * A periodic check to see if the projecting card is nearby.
- * Deletes the holopay if not.
- */
-/obj/structure/holopay/proc/handle_move(atom/movable/source, atom/old_loc, dir, forced, list/old_locs)
-	if(ismovable(old_loc))
-		untrack(old_loc)
-	if(!IN_GIVEN_RANGE(src, linked_card, max_holo_range))
-		dissipate()
-		return
-	if(ismovable(source.loc))
-		track(source.loc)
 
 /**
  * Creates holopay vanishing effects.


### PR DESCRIPTION

## About The Pull Request
Title

## Why It's Good For The Game
Holopay if you don't know is the cool little paystand/cash register your ID can project, its literally never used although its pretty cool.
Current it automatically disappears if you go more than 4 tiles away which makes it pretty much unusuable, even within vacant commissary if you take a few steps it'll just disappear and you gotta place it back, chefs, or anyone else with a bigger zone have it even worse.
There isn't any real reason I can think of for it to have a range limit, its a 15 integ structure with pass through and appears below people and you can only have one at a time.

This change should allow people to actually use the holopay feature without being almost completely unable to move. Letting chefs actually have a stand and access their freezer, or other people have one outside their department for various purposes

## Testing
Tested, spawned holopay with ID, went far, placed new one etc

## Changelog

:cl:
qol: holopay no longer has a range limit
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

