### PR TITLE
Don't apply hard of hearing or temporary deafness to people who are permanently deaf

### DIFF
--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -87,6 +87,9 @@
 /obj/item/organ/internal/ears/proc/update_hearing_loss()
 	var/was_deaf = HAS_TRAIT_FROM(owner, TRAIT_DEAF, EAR_DAMAGE)
 	var/was_hoh = HAS_TRAIT_FROM(owner, TRAIT_HARD_OF_HEARING, EAR_DAMAGE)
+//if already deaf from quirks or genetics, don't apply trait_hard_of_hearing or trait_deaf
+	if(HAS_TRAIT_FROM(owner, TRAIT_DEAF, QUIRK_TRAIT) || HAS_TRAIT_FROM(owner, TRAIT_DEAF, GENETIC_MUTATION))
+		return
 
 	if (!deaf)
 		if (was_deaf)


### PR DESCRIPTION

## About The Pull Request
Adds a check to see if someone is genetically deaf or using the deaf quirk before applying the hard of hearing trait
## Why It's Good For The Game
Explosions and other ear damaging effects would still technically apply TRAIT_HARD_OF_HEARING or TRAIT_DEAF to people who are already deaf. While this doesn't actually do anything if you already deaf, it would still display on an advanced health analyzer that you were temporarily deaf or temporarily hard of hearing, when it is infact permanent. It will now no longer apply that trait and just tell you that you are either permanently or genetically deaf.
## Testing
Tested on a local host, with a couple explosions and with deaf quirk + genetics deafness, still applies ear damage (maybe shouldnt?) but displays correct message on advanced analyzer
## Changelog
:cl: Cujo
fix: No longer applies hard of hearing to people who are genetically deaf or using quirk trait
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
