### PR TITLE
Mime abilities work while non-human

### DIFF
--- a/code/modules/spells/spell_types/conjure/invisible_chair.dm
+++ b/code/modules/spells/spell_types/conjure/invisible_chair.dm
@@ -15,7 +15,7 @@
 	invocation_self_message = span_notice("You conjure an invisible chair and sit down.")
 	invocation_type = INVOCATION_EMOTE
 
-	spell_requirements = SPELL_REQUIRES_HUMAN|SPELL_REQUIRES_MIME_VOW
+	spell_requirements = SPELL_REQUIRES_MIME_VOW
 	antimagic_flags = NONE
 	spell_max_level = 1
 

--- a/code/modules/spells/spell_types/conjure/invisible_wall.dm
+++ b/code/modules/spells/spell_types/conjure/invisible_wall.dm
@@ -15,7 +15,7 @@
 	invocation_self_message = span_notice("You form a wall in front of yourself.")
 	invocation_type = INVOCATION_EMOTE
 
-	spell_requirements = SPELL_REQUIRES_HUMAN|SPELL_REQUIRES_MIME_VOW
+	spell_requirements = SPELL_REQUIRES_MIME_VOW
 	antimagic_flags = NONE
 	spell_max_level = 1
 

--- a/code/modules/spells/spell_types/conjure_item/invisible_box.dm
+++ b/code/modules/spells/spell_types/conjure_item/invisible_box.dm
@@ -17,7 +17,7 @@
 	invocation_self_message = span_notice("You conjure up an invisible box, large enough to store a few things.")
 	invocation_type = INVOCATION_EMOTE
 
-	spell_requirements = SPELL_REQUIRES_HUMAN|SPELL_REQUIRES_MIME_VOW
+	spell_requirements = SPELL_REQUIRES_MIME_VOW
 	antimagic_flags = NONE
 	spell_max_level = 1
 


### PR DESCRIPTION
## About The Pull Request

Mimes being transformed into other mobs carry their abilities & vow, but not the ability to use their Mime spells. I thought it was sad, so I'm removing it.

## Changelog

:cl:
balance: Mimes can use their spells while non-human (if they were transformed into something else)
/:cl: