### PR TITLE
Cargo can print the BRM

### DIFF
--- a/monkestation/code/modules/factory_type_beat/designs.dm
+++ b/monkestation/code/modules/factory_type_beat/designs.dm
@@ -143,6 +143,7 @@
 /datum/design/board/brm
 	name = "Boulder Retrieval Matrix Board"
 	id = "brm"
+	build_type = COLONY_FABRICATOR | AUTOLATHE | PROTOLATHE
 	materials = list(
 		/datum/material/glass = SHEET_MATERIAL_AMOUNT,
 	)


### PR DESCRIPTION
## About The Pull Request

Cargo can print every board except the retrieval matrix for some reason.

## Why It's Good For The Game

Let miners set up their boulders.

## Changelog

:cl:
fix: The boulder retrieval matrix board can be printed by cargo now.
/:cl: