### PR TITLE
Actualizer only kicks in if done via timer

### DIFF
--- a/monkestation/code/game/machinery/bomb_actualizer.dm
+++ b/monkestation/code/game/machinery/bomb_actualizer.dm
@@ -57,7 +57,6 @@
 
 /obj/machinery/bomb_actualizer/Initialize(mapload)
 	. = ..()
-	RegisterSignal(src, COMSIG_ATOM_INTERNAL_EXPLOSION, PROC_REF(modify_explosion))
 	radio = new(src)
 	radio.keyslot = new radio_key
 	radio.set_listening(FALSE)
@@ -184,28 +183,25 @@
 			stage++
 
 	if(active && (timer <= world.time))
+		RegisterSignal(src, COMSIG_ATOM_INTERNAL_EXPLOSION, PROC_REF(modify_explosion))
 		playsound(loc, youdied, 100, FALSE, 45)
 		active = FALSE
 		stage = 0
 		update_appearance()
 		inserted_bomb.toggle_valve(tank_to_target)
 
-
 /obj/machinery/bomb_actualizer/proc/seconds_remaining()
 	if(active)
 		. = max(0, round(timer - world.time) / 10)
-
 	else
 		. = 420
 
-
-
-	/**
-	* catches the parameters of the TTV's explosion as it happens internally,
-	* cancels the explosion and then re-triggers it to happen with modified perameters (such as maxcap = false)
-	* while REDUCING the theoretical size by actualizer multiplier
-	* (actualizer_multiplier 0.25 would mean the 200 size theoretical bomb is only 12 + (200*0.25) in size )
-	*/
+/**
+ * catches the parameters of the TTV's explosion as it happens internally,
+ * cancels the explosion and then re-triggers it to happen with modified perameters (such as maxcap = false)
+ * while REDUCING the theoretical size by actualizer multiplier
+ * (actualizer_multiplier 0.25 would mean the 200 size theoretical bomb is only 12 + (200*0.25) in size )
+ */
 /obj/machinery/bomb_actualizer/proc/modify_explosion(atom/source, list/arguments)
 	SIGNAL_HANDLER
 	if(!exploded)


### PR DESCRIPTION
## About The Pull Request

setting off a bomb while inside of an actualizer will not apply actualizer effects onto it, so only the actualizer's timer going off can set it off.

You can put a TTV in an actualizer and blow it up if people are starting to destroy it, it just won't bypass the maxcap anymore. Best of both worlds, I think.

## Why It's Good For The Game

Exploit fix while making a part of it a feature.

## Changelog

:cl:
fix: Setting off a TTV in a bomb actualizer will no longer get the effects of being actualized.
/:cl: