### PR TITLE
Nerfs scatter laser shells

### DIFF
--- a/code/datums/components/crafting/weapon_ammo.dm
+++ b/code/datums/components/crafting/weapon_ammo.dm
@@ -102,18 +102,6 @@
 	time = 1.2 SECONDS
 	category = CAT_WEAPON_AMMO
 
-/datum/crafting_recipe/laserslug
-	name = "Scatter Laser Shell"
-	result = /obj/item/ammo_casing/shotgun/laserslug
-	reqs = list(
-		/obj/item/ammo_casing/shotgun/techshell = 1,
-		/obj/item/stock_parts/capacitor/adv = 1,
-		/obj/item/stock_parts/micro_laser/high = 1,
-	)
-	tool_behaviors = list(TOOL_SCREWDRIVER)
-	time = 0.5 SECONDS
-	category = CAT_WEAPON_AMMO
-
 /datum/crafting_recipe/trashball
 	name = "Trashball"
 	always_available = FALSE

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -188,14 +188,23 @@
 	variance = 35
 	can_be_printed = FALSE
 
-/obj/item/ammo_casing/shotgun/laserslug
+/obj/item/ammo_casing/shotgun/scatterlaser
 	name = "scatter laser shell"
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
 	icon_state = "lshell"
-	projectile_type = /obj/projectile/beam/weak
+	projectile_type = /obj/projectile/beam/scatter
 	pellets = 6
 	variance = 35
 	can_be_printed = FALSE
+
+/obj/item/ammo_casing/shotgun/scatterlaser/emp_act(severity)
+	. = ..()
+	if(isnull(loaded_projectile) || !prob(40/severity))
+		return
+	name = "malfunctioning laser shell"
+	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package. The capacitor powering this assembly appears to be smoking."
+	projectile_type = /obj/projectile/beam/scatter/pathetic
+	loaded_projectile = new projectile_type(src)
 
 /obj/item/ammo_casing/shotgun/techshell
 	name = "unloaded technological shell"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -128,7 +128,18 @@
 /obj/projectile/beam/scatter
 	name = "laser pellet"
 	icon_state = "scatterlaser"
-	damage = 5
+	damage = 7.5
+	wound_bonus = 5
+	bare_wound_bonus = 5
+	wound_falloff_tile = -2.5
+
+/obj/projectile/beam/scatter/pathetic
+	name = "extremely weak laser pellet"
+	damage = 1
+	wound_bonus = 0
+	color = "#dbc11d"
+	hitsound = 'sound/items/bikehorn.ogg' //honk
+	hitsound_wall = 'sound/items/bikehorn.ogg'
 
 /obj/projectile/beam/xray
 	name = "\improper X-ray beam"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -374,6 +374,20 @@
 	)
 	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
 
+/datum/design/lasershell
+	name = "Scatter Laser Shotgun Shell (Lethal)"
+	desc = "A high-tech shotgun shell which houses an internal capacitor and laser focusing crystal inside of a shell casing. \
+		Able to be fired from conventional ballistic shotguns with minimal rifling degradation. Also leaves most targets covered \
+		in grotesque burns."
+	id = "lasershell"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/glass = SMALL_MATERIAL_AMOUNT * 2, /datum/material/gold = HALF_SHEET_MATERIAL_AMOUNT)
+	build_path = /obj/item/ammo_casing/shotgun/scatterlaser
+	category = list(
+		RND_CATEGORY_WEAPONS + RND_SUBCATEGORY_WEAPONS_AMMO
+	)
+	departmental_flags = DEPARTMENT_BITFLAG_SECURITY
+
 /datum/design/techshell
 	name = "Unloaded Technological Shotshell"
 	desc = "A high-tech shotgun shell which can be crafted into more advanced shells to produce unique effects. \

--- a/code/modules/research/techweb/security_nodes.dm
+++ b/code/modules/research/techweb/security_nodes.dm
@@ -25,6 +25,7 @@
 		"pin_testing",
 		"tele_shield",
 		"mag_autorifle_rub", //monkestation edit: autorifles
+		"lasershell",
 	)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = TECHWEB_TIER_4_POINTS)
 	discount_experiments = list(/datum/experiment/ordnance/explosive/pressurebomb = TECHWEB_TIER_2_POINTS)


### PR DESCRIPTION

## About The Pull Request
Semi-Port of https://github.com/tgstation/tgstation/pull/78927
doesn't include damage falloff

## Why It's Good For The Game
Scatter laser shells are currently a insane 15 damage a laser with 6 lasers in each shot for 90 damage. And they usually do burn wounds which multiple burn damage taken coming out to a total of slightly more 1 hit critting a lot of the time and 2 hitting even with great armor
This is absolutely insane and just shouldn't be.
This brings it to 7.5 damage * 6 shots for 45 damage compared to buckshots 48, usually coming out to be slightly more with burn wounds, and gives it a weakness to emps as well as making it printable when researched in weapon dev tech.
Bringing it to a much more reasonable amount of damage overall while still keeping it a respectable choice with its ability to shoot through glass and do anything other laser projectiles can do.

## Testing
spawned and used, checked research tree and tested

## Changelog

:cl:
balance: Scatter laser shells actually utilize the real scatter laser beam. Doing 45 damage per shot rather than 90
feature: EMPs can potentially damage scatter laser shells.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

