### PR TITLE
Fixes ashstorms being able to be resisted by partial insulation

### DIFF
--- a/code/datums/weather/weather_types/ash_storm.dm
+++ b/code/datums/weather/weather_types/ash_storm.dm
@@ -66,7 +66,7 @@
 	if(!. || !ishuman(mob_to_check))
 		return
 	var/mob/living/carbon/human/human_to_check = mob_to_check
-	if(human_to_check.get_insulation(FIRE_IMMUNITY_MAX_TEMP_PROTECT) >= 0.9) //potentially broken
+	if(human_to_check.get_insulation(FIRE_IMMUNITY_MAX_TEMP_PROTECT) == 1)
 		return FALSE
 
 /datum/weather/ash_storm/weather_act(mob/living/victim)


### PR DESCRIPTION

## About The Pull Request

- Ashstorms no longer only need 90% of insulation to resist ashstorms
- Fixes #7647

## Why It's Good For The Game

> Ashstorms no longer only need 90% of insulation to resist ashstorms
- Ashstorms should need full insulation in order to be resisted, this pretty much only affects wintercoats and all other clothing is unaffected

## Testing

<img width="1600" height="857" alt="image" src="https://github.com/user-attachments/assets/326071b1-ee9a-4e8e-adc0-1d307f8620f4" />

## Changelog

:cl:
fix: wintercoats no longer resist ashstorms
/:cl:

## Pre-Merge Checklist
- [X] You tested this on a local server.
- [X] This code did not runtime during testing.
- [X] You documented all of your changes.
