### PR TITLE
get_insulation() fix

### DIFF
--- a/monkestation/code/modules/temperature_overhaul/temperature_proc.dm
+++ b/monkestation/code/modules/temperature_overhaul/temperature_proc.dm
@@ -48,14 +48,17 @@
 		var/max_heat_protection_temperature = insulation[3]
 
 		var/valid = FALSE
+
+		// If we have both heat and cold protection values, check both
 		if(isnum(max_heat_protection_temperature) && isnum(min_cold_protection_temperature))
 			valid = max_heat_protection_temperature >= temperature && min_cold_protection_temperature <= temperature
-
-		else if (isnum(max_heat_protection_temperature))
-			valid = max_heat_protection_temperature >= temperature
-
-		else if (isnum(min_cold_protection_temperature))
-			valid = min_cold_protection_temperature <= temperature
+		// If we don't, do checks based on our body temperature
+		else if(temperature > standard_body_temperature)
+			if (isnum(max_heat_protection_temperature))
+				valid = max_heat_protection_temperature >= temperature
+		else
+			if (isnum(min_cold_protection_temperature))
+				valid = min_cold_protection_temperature <= temperature
 
 		if(valid)
 			thermal_protection_flags |= body_parts_covered
@@ -115,8 +118,6 @@
 		amount *= (1 - get_insulation(bodytemperature + amount))
 	if(amount == 0)
 		return FALSE
-	if(amount == 0)
-		return 0
 	amount = round(amount, 0.01)
 	min_temp = max(min_temp, TCMB)
 	max_temp = min(max_temp, 603.15)


### PR DESCRIPTION
## About The Pull Request

`get_insulation()` supposed to give you insulation based on your coverage and what temperature your clothes protect you against
currently because the check doesnt actually care about when you get cold or hot, items like wintercoat that do not have both values set, will make you get insulation against heat (so, winter coat makes you very fire resistant and immune to ash storms)
this fixes this by checking if the temperature is higher/lower than your standart and then does checks based on that

also removes check that already exists and does the same thing

alternative to #11152 (but both can be merged fine)

closes #7647 

## Why It's Good For The Game

i dont think winter coats should make you resistant to fire because you dont get cold...
bug fix

## Testing

values gotten from wintercoat
from *very* cold temperature
from `FIRE_IMMUNITY_MAX_TEMP_PROTECT` (ash storm and fire check) and minimum temperature coat protects against
additionally, atmos hardsuit fire immunity

## Changelog

:cl:
fix: fixed temperature insulation checks, stuff like winter coats should no longer make you immune to ash storms and protect from fire
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
