### PR TITLE
nerfs the shamshir sabre

### DIFF
--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -32,6 +32,13 @@
 	access_view = ACCESS_WEAPONS
 	contains = list(/obj/item/gun/ballistic/revolver/c38/detective)
 
+/datum/supply_pack/goody/validhunting_sabre
+	name = "Authentic Shamshir Sabre"
+	desc = "Jealous of your local high ranking Nanotrasen official's officer sabre? You too can show your off your authority by larping as someone more important with this shoddy replica sabre."
+	cost = PAYCHECK_CREW * 4
+	access_view = ACCESS_WEAPONS
+	contains = list(/obj/item/storage/belt/sabre/cargo)
+
 /datum/supply_pack/goody/stingbang
 	name = "Stingbang Single-Pack"
 	desc = "Contains one \"stingbang\" grenade, perfect for playing meanhearted pranks."

--- a/monkestation/code/modules/blueshift/armaments/jarnsimiour.dm
+++ b/monkestation/code/modules/blueshift/armaments/jarnsimiour.dm
@@ -24,9 +24,4 @@
 	item_type = /obj/item/storage/belt/bowie_sheath
 	cost = PAYCHECK_COMMAND * 3
 
-/datum/armament_entry/company_import/blacksteel/blade/shamshir_sabre
-	item_type = /obj/item/storage/belt/sabre/cargo
-	cost = PAYCHECK_COMMAND * 4
-
-
 

--- a/monkestation/code/modules/blueshift/items/melee.dm
+++ b/monkestation/code/modules/blueshift/items/melee.dm
@@ -14,9 +14,9 @@
 	name = "authentic shamshir sabre"
 	desc = "An expertly crafted historical human sword once used by the Persians which has recently gained traction due to Venusian historal recreation sports. One small flaw, the Taj-based company who produces these has mistaken them for British cavalry sabres akin to those used by high ranking Nanotrasen officials. Atleast it cuts the same way!"
 	icon = 'monkestation/code/modules/blueshift/icons/obj/melee.dmi'
-	force = 18
-	block_chance = 20
-	armour_penetration = 20
+	force = 17
+	block_chance = 15
+	armour_penetration = 10
 	wound_bonus = 0
 	bare_wound_bonus = 15
 


### PR DESCRIPTION

## About The Pull Request
moves the shamshir sabre to cargo goodies and locked it behind weapon access.

dropped its force to 17 from 18. block to 15 from 20. and armor penetration from 20 to 10.

## Why It's Good For The Game
it's a pretty strong weapon and currently every validhunter and their mother uses it. 

## Testing

## Changelog

:cl:
balance: moved the shamshir sabre to cargo goodies and locked it behind weapon access. dropped the sabre's force to 17 from 18. block to 15 from 20. and armor penetration from 15 to 10. Price Dropped from Command to civilian paycheck.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

