### PR TITLE
makes paper bins, colored folders, and clipboards craftable. adds clipbaord to the sec ass detective kit

### DIFF
--- a/code/datums/components/crafting/misc.dm
+++ b/code/datums/components/crafting/misc.dm
@@ -6,6 +6,14 @@
 	result = /obj/item/paper_bin/bundlenatural
 	category = CAT_MISC
 
+/datum/crafting_recipe/clipboard
+	name = "Clipboard"
+	time = 3 SECONDS
+	reqs = list(/obj/item/stack/sheet/mineral/wood = 2, /obj/item/stack/rods = 1)
+	tool_paths = list(/obj/item/wirecutters)
+	result = /obj/item/clipboard
+	category = CAT_MISC
+
 /datum/crafting_recipe/skeleton_key
 	name = "Skeleton Key"
 	time = 3 SECONDS

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -133,6 +133,7 @@ GLOBAL_LIST_INIT(metal_recipes, list ( \
 	new/datum/stack_recipe("iron door", /obj/structure/mineral_door/iron, 20, time = 2.5 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, applies_mats = TRUE, category = CAT_DOORS), \
 	new/datum/stack_recipe("filing cabinet", /obj/structure/filingcabinet, 2, time = 10 SECONDS, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_FURNITURE), \
 	new/datum/stack_recipe("desk bell", /obj/structure/desk_bell, 2, time = 3 SECONDS, check_density = FALSE, category = CAT_FURNITURE), \
+	new/datum/stack_recipe("paper bin", /obj/item/paper_bin/empty, 2, time = 3 SECONDS, check_density = FALSE, category = CAT_FURNITURE), \
 	new/datum/stack_recipe("floodlight frame", /obj/structure/floodlight_frame, 5, one_per_turf = TRUE, on_solid_ground = TRUE, category = CAT_EQUIPMENT), \
 	new/datum/stack_recipe("voting box", /obj/structure/votebox, 15, time = 5 SECONDS, check_density = FALSE, category = CAT_ENTERTAINMENT), \
 	new/datum/stack_recipe("pestle", /obj/item/pestle, 1, time = 5 SECONDS, check_density = FALSE, category = CAT_CHEMISTRY), \
@@ -578,6 +579,10 @@ GLOBAL_LIST_INIT(cardboard_recipes, list ( \
 
 	new/datum/stack_recipe("pizza box", /obj/item/pizzabox, check_density = FALSE, category = CAT_CONTAINERS), \
 	new/datum/stack_recipe("folder", /obj/item/folder, check_density = FALSE, category = CAT_CONTAINERS), \
+	new/datum/stack_recipe("red folder", /obj/item/folder/red, check_density = FALSE, category = CAT_CONTAINERS), \
+	new/datum/stack_recipe("blue folder", /obj/item/folder/blue, check_density = FALSE, category = CAT_CONTAINERS), \
+	new/datum/stack_recipe("yellow folder", /obj/item/folder/yellow, check_density = FALSE, category = CAT_CONTAINERS), \
+	new/datum/stack_recipe("white folder", /obj/item/folder/white, check_density = FALSE, category = CAT_CONTAINERS), \
 	null, \
 	//TO-DO: Find a proper way to just change the illustration on the box. Code isn't the issue, input is.
 	new/datum/stack_recipe_list("fancy boxes", list(

--- a/code/modules/mining/voucher_sets.dm
+++ b/code/modules/mining/voucher_sets.dm
@@ -286,7 +286,7 @@
 
 /datum/voucher_set/security/utility/barrier
 	name = "Barrier Grenades"
-	description = "Two barrier grenades."
+	description = "Three barrier grenades."
 	icon = 'icons/obj/weapons/grenade.dmi'
 	icon_state = "wallbang"
 	set_items = list(
@@ -421,6 +421,7 @@
 	new /obj/item/taperecorder(src)
 	new /obj/item/tape/random(src)
 	new /obj/item/folder/red(src)
+	new /obj/item/clipboard(src)
 	new /obj/item/storage/box/evidence(src)
 	new /obj/item/toy/crayon/white(src)
 	new /obj/item/binoculars(src)

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -189,6 +189,9 @@
 	if(bin_pen)
 		. += pen_overlay
 
+/obj/item/paper_bin/empty
+	total_paper = 0
+
 /obj/item/paper_bin/construction
 	name = "construction paper bin"
 	desc = "Contains all the paper you'll never need, IN COLOR!"


### PR DESCRIPTION

## About The Pull Request
title and i also corrected a typo in the security barrier voucher option description. 
## Why It's Good For The Game
qol and a fix
## Changelog

:cl:
qol: you can craft paper bins with 2 iron sheets.
qol: you can craft colored folders with cardboard.
qol: you can craft clipboards with 2 wood planks, an iron rod, and wirecutters.
spellcheck: corrected a typo in the security barrier voucher option description.
qol: added a clipboard to the security assistant detective kit. 
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

