### PR TITLE
makes projectiles account for change in bullet speed if they didnt

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -12,7 +12,7 @@
 	wound_bonus = 0
 	wound_falloff_tile = -5
 	embed_falloff_tile = -3
-	speed = 1.7
+	speed = 1.6
 	//light_system = OVERLAY_LIGHT
 	//light_outer_range = 1.25
 	//light_power = 1

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -53,7 +53,7 @@
 	damage = 8
 	range = 10
 	damage_walls = TRUE // melt the walls
-	speed = 1.4
+	speed = 1.1
 	bare_wound_bonus = 45
 	fire_stacks = 5
 

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -37,7 +37,7 @@
 /obj/projectile/bullet/mm712x82/ap
 	name = "7.12x82mm armor-piercing bullet"
 	armour_penetration = 85
-	speed = 3.3 //monke edit
+	speed = 2 //monke edit
 
 /obj/projectile/bullet/mm712x82/hp
 	name = "7.12x82mm hollow-point bullet"
@@ -52,7 +52,7 @@
 	name = "7.12x82mm incendiary bullet"
 	damage = 15
 	fire_stacks = 3
-	speed = 1.6 //monke edit
+	speed = 1.25 //monke edit
 
 /obj/projectile/bullet/mm712x82/match
 	name = "7.12x82mm match bullet"
@@ -60,7 +60,7 @@
 	ricochet_chance = 60
 	ricochet_auto_aim_range = 4
 	ricochet_incidence_leeway = 55
-	speed = 3.3 //monke edit
+	speed = 2 //monke edit
 
 /obj/projectile/bullet/mm712x82/bouncy
 	name = "7.12x82mm rubber bullet"
@@ -70,7 +70,7 @@
 	ricochet_auto_aim_range = 4
 	ricochet_incidence_leeway = 0
 	ricochet_decay_chance = 0.9
-	speed = 1.6 //monke edit
+	speed = 1.25 //monke edit
 
 
 // 12.7x70mm (Malone / tank MG)
@@ -101,7 +101,6 @@
 			damage *= biotype_damage_multiplier
 	return ..()
 
-
 /obj/projectile/bullet/c65xeno/evil
 	name = "6.5mm FMJ round"
 	damage = 10
@@ -113,7 +112,7 @@
 /obj/projectile/bullet/c65xeno/pierce
 	name = "6.5mm subcaliber tungsten sabot round"
 	icon_state = "gaussphase"
-	speed = 3.3
+	speed = 2
 	damage = 6
 	armour_penetration = 60
 	wound_bonus = 5
@@ -136,7 +135,7 @@
 /obj/projectile/bullet/c65xeno/pierce/evil
 	name = "6.5mm UDS"
 	icon_state = "gaussphase"
-	speed = 3.3
+	speed = 2
 	damage = 7
 	armour_penetration = 60
 	wound_bonus = 10
@@ -156,7 +155,7 @@
 	icon_state = "redtrac"
 	damage = 5
 	bare_wound_bonus = 0
-	speed = 1.4 ///half of standard
+	speed = 1.1
 	/// How many firestacks the bullet should impart upon a target when impacting
 	biotype_damage_multiplier = 4
 	var/firestacks_to_give = 1
@@ -175,7 +174,7 @@
 	icon_state = "redtrac"
 	damage = 10
 	bare_wound_bonus = 0
-	speed = 1.4 ///half of standard
+	speed = 1.1
 	/// How many firestacks the bullet should impart upon a target when impacting
 	biotype_damage_multiplier = 4
 	projectile_piercing = PASSMOB

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -88,7 +88,7 @@
 /obj/projectile/bullet/c40sol/pierce
 	name = ".40 Sol match bullet"
 	icon_state = "gaussphase"
-	speed = 2
+	speed = 1.4
 	damage = 15
 	armour_penetration = 40
 	wound_bonus = -30
@@ -161,4 +161,4 @@
 	armour_penetration = 60
 	wound_falloff_tile = -2
 	wound_bonus = -45
-	speed = 3.3
+	speed = 2

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -19,7 +19,7 @@
 	name = "tungsten sabot-slug"
 	icon_state = "gauss"
 	damage = 25 //10 less than slugs.
-	speed = 4 //sub-caliber + lighter = speed.
+	speed = 2.2 //sub-caliber + lighter = speed.
 	armour_penetration = 25
 	wound_bonus = -25
 	ricochets_max = 2 //Unlike slugs which tend to squish on impact, these are hard enough to bounce rarely.

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -125,7 +125,7 @@
 /obj/projectile/bullet/p60strela // The funny thing is, these are wild but you only get three of them a magazine
 	name =".60 Strela bullet"
 	icon_state = "gaussphase"
-	speed = 0.4
+	speed = 1.6
 	damage = 50
 	armour_penetration = 80
 	wound_bonus = 10
@@ -156,7 +156,7 @@
 
 /obj/projectile/bullet/neville
 	name ="20x160mm Neville"
-	speed = 0.65
+	speed = 1.2
 	damage = 50
 	dismemberment = 25
 	armour_penetration = 85 // she may be big, but its armor piercing. less damage then the .50 cal cause of it

--- a/code/modules/projectiles/projectile/bullets/special.dm
+++ b/code/modules/projectiles/projectile/bullets/special.dm
@@ -79,7 +79,7 @@
 /obj/projectile/bullet/coin
 	name = "marksman coin"
 	icon_state = "coinshot"
-	speed = 0.33
+	speed = 1.8
 	damage = 5
 	color = "#dbdd4c"
 


### PR DESCRIPTION
## About The Pull Request

oopsie on my part i incorrectly  rounded speed of bullets when everywhere else in the code it's 1.6
also makes some monke special ammo that had their values edited slower to account of the change in speed

## Why It's Good For The Game

fixes some incorrect values

## Testing


## Changelog

:cl:
balance: some special  monke edited bullets were lowered in speed to account for slower speed of bullets in general
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
