### PR TITLE
Upstreams [Updates Greytide event to use bolt() and unbolt() rather than manually setting the locked var #87909] port

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1494,9 +1494,10 @@
 /obj/machinery/door/airlock/proc/prison_open()
 	if((obj_flags & EMAGGED) || is_probably_external_airlock()) // monkestation edit: STOP SPACING ENGI
 		return
-	locked = FALSE
+	if(locked)
+		unbolt()
 	open()
-	locked = TRUE
+	bolt()
 	return
 
 // gets called when a player uses an airlock painter on this airlock


### PR DESCRIPTION

## About The Pull Request
Uses the proc rather than manually setting variables from https://github.com/tgstation/tgstation/pull/87909
## Why It's Good For The Game
This means 
A. Door overlays will be set, meaning our bolt lights will be set.
B. Plays bolting sounds/notifications
## Testing
## Changelog
🆑 ghost
code: The Greytide event will now play bolt audio and update the icon when toggling door bolts.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
