### PR TITLE
Fixes the description of plasmaflood license.

### DIFF
--- a/monkestation/code/game/objects/items/plasma_license.dm
+++ b/monkestation/code/game/objects/items/plasma_license.dm
@@ -1,6 +1,6 @@
 /obj/item/card/plasma_license
 	name = "License to Plasmaflood"
-	desc = "A charred contract letting the holder kill everyone they meet. Not offically recognized by Nanotrasen."
+	desc = "A charred contract letting the holder flood the halls with any number of airborne gases. Not offically recognized by Nanotrasen."
 	icon = 'monkestation/icons/obj/items/plasmalicense.dmi'
 	icon_state = "plasmalicense"
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION

## About The Pull Request
No longer contains the language of when it was temporarily made into the license to murder bone.
## Why It's Good For The Game
Just better clarity that goes along with its original and current purpose. Even if it's a messy one.
## Testing
## Changelog
:cl:
fix: License to plasmaflood no longer implies you have a license to murderbone.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
