### PR TITLE
allows buttbot cascades to occur

### DIFF
--- a/monkestation/code/modules/surgery/organs/internal/butts.dm
+++ b/monkestation/code/modules/surgery/organs/internal/butts.dm
@@ -322,7 +322,7 @@
 
 /mob/living/simple_animal/bot/buttbot/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, list/message_mods, message_range)
 	. = ..()
-	if(COOLDOWN_FINISHED(src, repeat_cooldown) && prob(listen_probability) && ishuman(speaker))
+	if(COOLDOWN_FINISHED(src, repeat_cooldown) && prob(listen_probability))
 		COOLDOWN_START(src, repeat_cooldown, 2 SECONDS)
 		var/list/split_message = splittext_char(html_decode(raw_message), " ")
 		for (var/i in 1 to length(split_message))


### PR DESCRIPTION

## About The Pull Request
buttbots can parrot any speaker not just humans. a buttbot cascade occurs when a buttbot copies another buttbot then and so forth. this is limited by the fact buttbots only have a chance of parroting something.
## Why It's Good For The Game
funny

## Changelog

:cl:
add: buttbots can parrot any speaker.
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

