### PR TITLE
Feat/oven tray and crafting search

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -715,7 +715,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 		attempt_insert(thing, user)
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
-	if(!isturf(thing.loc))
+	if(!isturf(thing.loc) && !(thing.flags_1 & IS_ONTOP_1))
 		return COMPONENT_CANCEL_ATTACK_CHAIN
 
 	INVOKE_ASYNC(src, PROC_REF(collect_on_turf), thing, user)
@@ -733,6 +733,16 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 
 	var/atom/holder = thing.loc
 	var/list/pick_up = holder.contents.Copy()
+
+	// When collecting from a non-turf (e.g. a machine surface), only pick up IS_ONTOP_1 items
+	// that are not plates. Plates (like oven trays) are structural parts of machines, not loose
+	// surface items, and should not be swept up alongside items cooking on the surface.
+	if(!isturf(holder))
+		var/list/surface_items = list()
+		for(var/obj/item/surface_item in pick_up)
+			if((surface_item.flags_1 & IS_ONTOP_1) && !istype(surface_item, /obj/item/plate))
+				surface_items += surface_item
+		pick_up = surface_items
 
 	if(collection_mode == COLLECT_SAME)
 		pick_up = typecache_filter_list(pick_up, typecacheof(thing.type))

--- a/code/modules/food_and_drinks/machinery/oven.dm
+++ b/code/modules/food_and_drinks/machinery/oven.dm
@@ -99,6 +99,11 @@
 	use_energy(active_power_usage)
 
 
+/obj/machinery/oven/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!open || !used_tray || isnull(tool.atom_storage))
+		return NONE
+	return used_tray.item_interaction(user, tool, modifiers)
+
 /obj/machinery/oven/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	if(open && !used_tray && istype(attacking_item, /obj/item/plate/oven_tray))
 		if(user.transferItemToLoc(attacking_item, src, silent = FALSE))
@@ -248,6 +253,46 @@
 	icon_state = "oven_tray"
 	max_items = 6
 	biggest_w_class = WEIGHT_CLASS_BULKY
+
+/// Oven trays accept any item, not just edible ones, since you bake raw/unbaked items in an oven.
+/obj/item/plate/oven_tray/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!isnull(tool.atom_storage))
+		// Dump contents of storage container onto the tray
+		if(!istype(tool, /obj/item/storage/bag/tray))
+			to_chat(user, span_notice("You start placing items from [tool] onto [src]..."))
+			if(!do_after(user, 2 SECONDS, target = tool))
+				return ITEM_INTERACT_BLOCKING
+		var/loaded = 0
+		for(var/obj/item/stored_item in tool)
+			if(contents.len >= max_items)
+				break
+			if(stored_item.w_class > biggest_w_class)
+				continue
+			if(tool.atom_storage.attempt_remove(stored_item, src))
+				stored_item.pixel_x = rand(-max_x_offset, max_x_offset)
+				stored_item.pixel_y = rand(-3, max_height_offset)
+				AddToPlate(stored_item)
+				loaded++
+		if(loaded)
+			to_chat(user, span_notice("You place [loaded] item\s onto [src]."))
+			return ITEM_INTERACT_SUCCESS
+		balloon_alert(user, "nothing to place!")
+		return ITEM_INTERACT_BLOCKING
+	if(tool.w_class > biggest_w_class)
+		balloon_alert(user, "too big!")
+		return ITEM_INTERACT_BLOCKING
+	if(contents.len >= max_items)
+		balloon_alert(user, "can't fit!")
+		return ITEM_INTERACT_BLOCKING
+	if(!LAZYACCESS(modifiers, ICON_X) || !LAZYACCESS(modifiers, ICON_Y))
+		return ITEM_INTERACT_BLOCKING
+	if(user.transferItemToLoc(tool, src, silent = FALSE))
+		tool.pixel_x = clamp(text2num(LAZYACCESS(modifiers, ICON_X)) - 16, -max_x_offset, max_x_offset)
+		tool.pixel_y = min(text2num(LAZYACCESS(modifiers, ICON_Y)) + placement_offset, max_height_offset)
+		to_chat(user, span_notice("You place [tool] on [src]."))
+		AddToPlate(tool, user)
+		return ITEM_INTERACT_SUCCESS
+
 
 #undef OVEN_SMOKE_STATE_NONE
 #undef OVEN_SMOKE_STATE_GOOD

--- a/code/modules/vending/drinnerware.dm
+++ b/code/modules/vending/drinnerware.dm
@@ -13,7 +13,7 @@
 				/obj/item/reagent_containers/cooking_container/pan = 10,
 				/obj/item/reagent_containers/cooking_container/pot = 10,
 				/obj/item/reagent_containers/cooking_container/bowl = 10,
-				/obj/item/reagent_containers/cooking_container/oven = 10,
+				/obj/item/plate/oven_tray = 10,
 				/obj/item/reagent_containers/cooking_container/board = 10,
 				/obj/item/storage/bag/tray = 8,
 				/obj/item/reagent_containers/cup/soup_pot = 3,

--- a/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
+++ b/tgui/packages/tgui/interfaces/PersonalCrafting.tsx
@@ -216,6 +216,17 @@ export const PersonalCrafting = (props) => {
     material_occurences[0].atom_id,
   );
   const [tabMode, setTabMode] = useLocalState('tabMode', 0);
+  const visibleMaterials =
+    tabMode === TABS.material && searchText.length > 0
+      ? [
+          ...material_occurences.filter((m) => m.atom_id === activeMaterial),
+          ...material_occurences.filter((m) => {
+            if (m.atom_id === activeMaterial) return false;
+            const name = data.atom_data[Number(m.atom_id) - 1]?.name ?? '';
+            return name.toLowerCase().includes(searchText.toLowerCase());
+          }),
+        ]
+      : material_occurences;
   const searchName = createSearch(searchText, (item: Recipe) => item.name);
   let recipes = flow([
     filter<Recipe>(
@@ -372,7 +383,7 @@ export const PersonalCrafting = (props) => {
                           </Tabs.Tab>
                         ))}
                       {tabMode === TABS.material &&
-                        material_occurences.map((material) => (
+                        visibleMaterials.map((material) => (
                           <Tabs.Tab
                             key={material.atom_id}
                             selected={


### PR DESCRIPTION

## About The Pull Request
Adds several quality-of-life improvements to kitchen appliance interactions:

  - Serving tray pickup from griddle and oven tray including modes support (single item, single type, all)
  - Placing items on oven tray with serving tray 
  - Replaced the non-functiona cooking oven tray container in the Plasteel Chef's Dinnerware Vendor with the correct /obj/item/plate/oven_tray.      
  - Crafting menu search filtering by Material/Ingredient, keeps only currently active and filtered tabs.

## Why It's Good For The Game
Those changes fixes some of the issues I've been having while trying to cook and craft. I think they are really QoL improvements and they do not actully change game in any way, beside making it little more accessible

## Testing
I've tested it locally with various edge cases, everything seems to be working properly

Proper oven tray in vendomat
<img width="455" height="619" alt="image" src="https://github.com/user-attachments/assets/1528b8a7-da4a-41a5-b4ea-016e47df813d" />

Filtering ingredients in cook menu
<img width="734" height="493" alt="image" src="https://github.com/user-attachments/assets/eb2f606a-8949-4a72-8e81-ea808eab0198" />

Filtering materials in craft menu
<img width="760" height="752" alt="image" src="https://github.com/user-attachments/assets/a31b2fb0-b3ec-44b5-93a5-ed6dfbcc2e5d" />

Serving tray on griddle and oven tray


https://github.com/user-attachments/assets/d548d17d-c2c8-498f-9dca-b5a1ddca6082



## Changelog
:cl:
qol: Items on the griddle and oven tray can now be picked up using a serving tray (single, single type, and all collection modes supported)
qol: Serving tray contents can be dumped onto the oven tray by clicking the oven or oven tray with the serving tray
fix: Plasteel Chef's Dinnerware Vendor now sells the correct oven tray instead of a non-functional cooking container
qol: Material and ingredient lists in the crafting menu now filter based on search text
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
