### PR TITLE
Blueshield saya voodoo

### DIFF
--- a/monkestation/code/modules/cybernetics/implant_items/weapons/mantis_blade.dm
+++ b/monkestation/code/modules/cybernetics/implant_items/weapons/mantis_blade.dm
@@ -127,7 +127,7 @@
 	to_chat(user, span_notice("You stop blocking with your blades."))
 
 /obj/item/mantis_blade/shield/attack(mob/living/target, mob/living/user)
-	if(in_stance)
+	if(in_stance && iscarbon(target))
 		user.disarm(target)
 	else
 		return . = ..()


### PR DESCRIPTION

## About The Pull Request
Adds a carbon check for saya's disarm.
## Why It's Good For The Game
Saya arms cause runtimes as they call a raw disarm check on things not accounting if they are actually a carbon. This means if you shove a noncarbon. Say a cyborg, they can't clear the slowdown and forever get slowed. Fixes bugs. Is nice.
## Testing
## Changelog
:cl:
fix: SAYA Arms can no longer shove unshoveable things
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
