### PR TITLE
The party stops when your a corspe

### DIFF
--- a/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
+++ b/monkestation/code/modules/ranching/satyr/components/living_drunk.dm
@@ -47,6 +47,10 @@
 /datum/component/living_drunk/process(seconds_per_tick)
 	if(!COOLDOWN_FINISHED(src, drank_grace))
 		return
+	var/mob/living/living = parent
+
+	if(living.stat == DEAD)
+		return
 
 	current_drunkness = max(min_drunkness, (current_drunkness -= 0.1))
 	drunkness_change_effects()


### PR DESCRIPTION

## About The Pull Request
Living drunk doesnt process if your a corspe. Suprising!
## Why It's Good For The Game
The timer shouldn't continue while your a corspe.
## Testing
## Changelog
:cl:
fix: Living Drunk no longer processes while dead.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
