### PR TITLE
Depot Improvements and extra Crap!

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_depot.dmm
@@ -2830,12 +2830,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/syndicate_depot/cargo_bay)
-"DY" = (
-/obj/structure/window/reinforced/spawner/directional/west,
-/obj/structure/window/reinforced/spawner/directional/north,
-/obj/machinery/computer/order_console/mining,
-/turf/open/floor/iron,
-/area/ruin/space/has_grav/syndicate_depot/cargo_bay)
 "DZ" = (
 /obj/machinery/atmospherics/components/unary/passive_vent,
 /turf/open/floor/engine/o2,
@@ -7972,7 +7966,7 @@ mz
 Nu
 IE
 XO
-DY
+Fc
 BR
 BR
 QR


### PR DESCRIPTION

## About The Pull Request
Makes some quality of life improvements and extra items added to entice more players to play on Depot station as one of the most popular ghost roles around, list of changes below!

- Moved some crates and items in cargo around, mainly the medical crates, one for dealing with all 4 typical injuries plus replaced the expedition kit with - the new combat medical kit, and reused the extra medical crate into holding the surplus meds.
- Added proper syndicate modsuit storages in the EVA room and QM room. 
- Expanded dorms and added general items for increasing base quality.
- Gave one extra box of style for the quartermaster.
- Added a syndicate inducer for recharging on late joins!
- Gave generally more items to different parts of the base that would make sense, especially for security and medical.


## Why It's Good For The Game
The Depot was quite frankly. An extremely interesting space ruin and ever since nerfing, the depot has been on occasion, fairly empty and not often do people truly play it unless the server is explicitly on highpop. With the server rules being given a change and after half a year of the depot issues being brought up I believe that it is fair to introduce some items back while adding new ones as the moderation team I believe, has been getting larger and the issue of admins being overwhelmed shouldn't apply as much in case depot members ever abuse their equipment. On top of that depot is possibly the largest syndicate ghost role for players to play around in and I believe it should be given more than other outposts or syndicate places as it is seen as the most fun role to play in, thus I believe adding more items and replacing other for the Depot would vastly increase its QOL and make it more enjoyable to be in. Plus it gets to also function more as a proper cargo bay which was its original intention. 

## Testing
<img width="589" height="663" alt="image" src="https://github.com/user-attachments/assets/8c2b6a68-f784-47ee-87d1-804607d282f1" />
<img width="336" height="308" alt="image" src="https://github.com/user-attachments/assets/316193bb-8096-4b11-b206-443861053a59" />
<img width="256" height="329" alt="image" src="https://github.com/user-attachments/assets/8289d0a3-5ed3-45b5-b2c4-cd70648df39f" />
<img width="402" height="529" alt="image" src="https://github.com/user-attachments/assets/e125878a-504f-4fee-9a50-c4447b85eb84" />
<img width="314" height="323" alt="image" src="https://github.com/user-attachments/assets/a94f6eb3-0293-4371-8e85-0e91a30b4241" />


All of these have been tested on a local server and it works perfectly fine. Simple mapping edits. 
## Changelog
:cl:
add: Added brute, burn, oxy, toxin, and robotic patch medkit inside while also replacing the expedition medkit with the combat medical medkit.
add: two legacy, two normal, a toxin, and oxygen medkit into another crate for "Surplus"
add: Box of beakers, bodybag, sterile mask, and a emergency roller bed into the medbay medical locker.
add: syndicate bodybag, security belt, box of cuffs, and a flash to the guard locker room.
add: One syndicate inducer in engineering.
add: A syndicate bunny box in QM locker. Style!
add: One extra box of deluxe parts.
removed: pipe dispencers and atmos fans.
removed: 3 gas mask and replaced with syndicate ones.
removed: Expedition medical kit.
map: Modified syndicate depot dorm rooms to be a tile longer!
map: add 3 syndicate modsuit storage units in depots EVA and quartermaster room.
map: Modified the brig bed into a shitter version. Sorry prisoners.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
