### PR TITLE
Makes lathes ten times faster at printing items

### DIFF
--- a/code/modules/research/machinery/_production.dm
+++ b/code/modules/research/machinery/_production.dm
@@ -24,6 +24,9 @@
 	/// Whether or not the fabricator links to the ore silo on init. Special derelict or maintanance variants should set this to FALSE.
 	var/link_on_init = TRUE
 
+	/// Multiplier for production speed.
+	var/production_speed_multiplier = 0.1
+
 /obj/machinery/rnd/production/Initialize(mapload)
 	materials = AddComponent(
 		/datum/component/remote_materials, \
@@ -345,6 +348,7 @@
 				charge_per_item += design.materials[material]
 			charge_per_item = ROUND_UP((charge_per_item / (MAX_STACK_SIZE * SHEET_MATERIAL_AMOUNT)) * coefficient * active_power_usage)
 			var/build_time_per_item = (design.construction_time * design.lathe_time_factor * efficiency_coeff) ** 0.8
+			build_time_per_item *= production_speed_multiplier
 
 			//start production
 			busy = TRUE

--- a/monkestation/code/modules/blueshift/structures/flatpacker.dm
+++ b/monkestation/code/modules/blueshift/structures/flatpacker.dm
@@ -12,6 +12,7 @@
 	light_color = LIGHT_COLOR_BRIGHT_YELLOW
 	light_power = 5
 	allowed_buildtypes = COLONY_FABRICATOR
+	production_speed_multiplier = 1
 	/// The item we turn into when repacked
 	var/repacked_type = /obj/item/flatpacked_machine
 	/// The sound loop played while the fabricator is making something


### PR DESCRIPTION
## About The Pull Request

basically a direct port of https://github.com/NovaSector/NovaSector/pull/1116

lathes/techfabs/etc now print 10x faster. rapid construction fabricators are exempt from this, however.

## Why It's Good For The Game

> Less time spent waiting because people upstream thought that waiting 5 seconds for a cell to print was peak gameplay.

## Changelog

:cl:
balance: Protolathes and techfabs should now print items ten times faster.
/:cl: