### PR TITLE
Icebox ordnance tank fix.

### DIFF
--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -4817,6 +4817,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/mine/living_quarters)
+"bwW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/science/ordnance)
 "bxa" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -40598,11 +40607,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "mxc" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 6
 	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
@@ -42024,9 +42033,6 @@
 /turf/open/floor/plating,
 /area/station/science/ordnance/testlab)
 "mWj" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -64802,10 +64808,10 @@
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "tPG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/station/science/ordnance)
 "tPM" = (
@@ -70095,6 +70101,12 @@
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/maintenance/port/fore)
+"vxu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/station/science/ordnance)
 "vxx" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -192440,7 +192452,7 @@ nIt
 nIt
 inh
 mWj
-aNu
+hFb
 tPG
 xEQ
 qaL
@@ -192697,8 +192709,8 @@ pOL
 pOL
 opD
 mxc
-hFb
-hFb
+aNu
+vxu
 fcj
 mEL
 vqv
@@ -192953,7 +192965,7 @@ pOL
 pOL
 pOL
 opD
-jGR
+bwW
 hFb
 mzb
 rEj


### PR DESCRIPTION

## About The Pull Request

Moves the yellow output pipes to not be right next to the tank, so that they dont fill up with gas right away
## Why It's Good For The Game

gets rid small mapping issue that ordanance techs had to edit every round. 
## Testing
## Changelog
:cl:
qol: moved the yellow tank output pipes in icebox ordnance so they dont fill up right away
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
