### PR TITLE
remove corporate sponsorship from the random trauma pool

### DIFF
--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -339,6 +339,7 @@
 	scan_desc = "advertisement echolalia"
 	gain_text = span_warning("You feel the need to mimic advertisements.")
 	lose_text = span_notice("You no longer feel the need to mimic advertisements.")
+	trauma_flags = parent_type::trauma_flags | TRAUMA_NOT_RANDOM
 
 /datum/brain_trauma/mild/advert_force_speak/on_gain()
 	src.owner.AddComponentFrom(REF(src), /datum/component/advert_force_speak, rand(1 MINUTE))


### PR DESCRIPTION

## About The Pull Request

simply adds `TRAUMA_NOT_RANDOM` to the Advertisement Echolalia brain trauma, making it so you can't get it from random brain damage - only from the quirk or implant.

## Why It's Good For The Game

this is an annoying trauma to get randomly ngl. and it doesn't even make sense that you'd get it _randomly through brain damage_, like, it's an implant.

## Changelog
:cl:
del: You can no longer naturally get the corporate sponsorship trauma from brain damage - only from the quirk or implant.
/:cl:
