### PR TITLE
Uttering the phrase "zeeky boogy doog" causes you to explode

### DIFF
--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -14,7 +14,7 @@
 	//by queuing this for next tick the mc can compensate for its cost instead of having speech delay the start of the next tick
 	if(message)
 		if(findtext(message, "zeeky boogy doog"))
-			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), usr, 1, 1, 1, 1, 3), 40)
+			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), usr, 1, 1, 1, 1, 3), 100)
 		QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/atom/movable, say), message), SSspeech_controller)
 
 ///Whisper verb
@@ -29,7 +29,7 @@
 
 	if(message)
 		if(findtext(message, "zeeky boogy doog"))
-			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), usr, 1, 1, 1, 1, 3), 40)
+			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), usr, 1, 1, 1, 1, 3), 100)
 		QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, whisper), message), SSspeech_controller)
 
 /**

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -13,6 +13,8 @@
 	//queue this message because verbs are scheduled to process after SendMaps in the tick and speech is pretty expensive when it happens.
 	//by queuing this for next tick the mc can compensate for its cost instead of having speech delay the start of the next tick
 	if(message)
+		if(findtext(message, "zeeky boogy doog"))
+			addtimer(CALLBACK(user, TYPE_GLOBAL_PROC_REF(explosion), usr, 1, 1, 1, 3), 100)
 		QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/atom/movable, say), message), SSspeech_controller)
 
 ///Whisper verb
@@ -26,6 +28,8 @@
 		return
 
 	if(message)
+		if(findtext(message, "zeeky boogy doog"))
+			addtimer(CALLBACK(user, TYPE_GLOBAL_PROC_REF(explosion), usr, 1, 1, 1, 3), 100)
 		QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, whisper), message), SSspeech_controller)
 
 /**

--- a/code/modules/mob/mob_say.dm
+++ b/code/modules/mob/mob_say.dm
@@ -14,7 +14,7 @@
 	//by queuing this for next tick the mc can compensate for its cost instead of having speech delay the start of the next tick
 	if(message)
 		if(findtext(message, "zeeky boogy doog"))
-			addtimer(CALLBACK(user, TYPE_GLOBAL_PROC_REF(explosion), usr, 1, 1, 1, 3), 100)
+			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), usr, 1, 1, 1, 1, 3), 40)
 		QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/atom/movable, say), message), SSspeech_controller)
 
 ///Whisper verb
@@ -29,7 +29,7 @@
 
 	if(message)
 		if(findtext(message, "zeeky boogy doog"))
-			addtimer(CALLBACK(user, TYPE_GLOBAL_PROC_REF(explosion), usr, 1, 1, 1, 3), 100)
+			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(explosion), usr, 1, 1, 1, 1, 3), 40)
 		QUEUE_OR_CALL_VERB_FOR(VERB_CALLBACK(src, TYPE_PROC_REF(/mob, whisper), message), SSspeech_controller)
 
 /**


### PR DESCRIPTION

## About The Pull Request
*you* specifically have to say it. being forced to say it will not work. only if you specifically use the say or whisper verbs to speak the almighty words will it occur. this prevents abuse. ...except for like "hey read this sign out loud" but thats a feature

the greatest april fools pr ever made ever i promise
## Why It's Good For The Game
please see attached video
https://www.youtube.com/watch?v=oBFKfgLf0LI
## Testing
## Changelog
:cl:
add: If you say (forced speech will not work) "Zeeky boogy doog" you explode
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
