### PR TITLE
[BOUNTY] Citationinators can now be used to fine anything and everything.

### DIFF
--- a/monkestation/code/modules/security/code/citationinator.dm
+++ b/monkestation/code/modules/security/code/citationinator.dm
@@ -29,16 +29,24 @@
 	if(!check_access(using_id))
 		to_chat(user, span_warning("Insufficient access to issue citations!"))
 		return
-	var/list/choices = list()
-	for(var/datum/record/crew/person in GLOB.manifest.general)
-		if(!person.name)
-			continue
-		choices[person.name] = person
-	var/victim_name = tgui_input_list(user, "Select crew member to fine", "Do you got a loicense for that, mate?", choices, timeout = 1 MINUTES)
+	var/victim_name
+	var/on_crew = TRUE
+	var/datum/record/crew/victim
+	switch(tgui_alert(user, "Fine recipient", "Make some sod's life worse", list("On crew manifest", "Off crew manifest / non-living recipient")))
+		if("Off crew manifest / non-living recipient")
+			on_crew = FALSE
+			victim_name = trim(tgui_input_text(user, "Name", "", encode = FALSE, timeout = 1 MINUTES))
+		if("On crew manifest")
+			var/list/choices = list()
+			for(var/datum/record/crew/person in GLOB.manifest.general)
+				if(!person.name)
+					continue
+				choices[person.name] = person
+			victim_name = tgui_input_list(user, "Select crew member to fine", "Do you got a loicense for that, mate?", choices, timeout = 1 MINUTES)
+			victim = choices[victim_name]
 	if(!victim_name)
 		return
-	var/datum/record/crew/victim = choices[victim_name]
-	if(!victim)
+	if(!victim && on_crew)
 		return
 	var/fine = tgui_input_number(user, "How many credits to fine?", "Civil Asset Forfeiture", default = 50, max_value = CONFIG_GET(number/maxfine), timeout = 1 MINUTES, round_value = 1)
 	if(!fine)
@@ -49,10 +57,11 @@
 	var/reason = trim(tgui_input_text(user, "Provide details about the citation.", "Handling a fish in suspicious circumstances", multiline = TRUE, encode = FALSE, timeout = 1 MINUTES))
 	var/issuer_name = using_id.assignment + " " + using_id.registered_name
 	var/datum/crime/citation/new_citation = new(name = citation_name, details = reason, author = issuer_name, fine = fine)
-	new_citation.alert_owner(user, src, victim.name, "You have been issued a [fine]cr citation for [citation_name] by [issuer_name]. Fines are payable at Security.")
-	victim.citations += new_citation
-	investigate_log("New Citation: <strong>[citation_name]</strong> Fine: [fine] | Added to [victim.name] by [key_name(user)]", INVESTIGATE_RECORDS)
-	SSblackbox.ReportCitation(REF(new_citation), user.ckey, user.real_name, victim.name, citation_name, fine)
+	if(on_crew)
+		new_citation.alert_owner(user, src, victim.name, "You have been issued a [fine]cr citation for [citation_name] by [issuer_name]. Fines are payable at Security.")
+		victim.citations += new_citation
+		investigate_log("New Citation: <strong>[citation_name]</strong> Fine: [fine] | Added to [victim.name] by [key_name(user)]", INVESTIGATE_RECORDS)
+		SSblackbox.ReportCitation(REF(new_citation), user.ckey, user.real_name, victim.name, citation_name, fine)
 
 	var/final_paper_text = "# <u>SECURITY CITATION</u>\n"
 	final_paper_text += "You have been issued a citation by the on-board station security department for the following offense:<br>"
@@ -68,7 +77,7 @@
 	final_paper_text += "<i>Refusing to accept this ticket, or failure to pay/dispute this citation within a reasonable timeframe, may result in you being charged with Fine Evasion (code 111) and serving time in the station brig.</i><br>"
 
 	var/obj/item/paper/slip = new(drop_location())
-	slip.name = "Citation - [victim.name] for [sanitize(new_citation.name)]"
+	slip.name = "Citation - [victim_name] for [sanitize(new_citation.name)]"
 	slip.color = COLOR_FADED_PINK
 
 	var/datum/asset/spritesheet/sheet = get_asset_datum(/datum/asset/spritesheet/simple/paper)

--- a/monkestation/code/modules/security/code/citationinator.dm
+++ b/monkestation/code/modules/security/code/citationinator.dm
@@ -13,6 +13,8 @@
 	slot_flags = ITEM_SLOT_BELT
 	req_access = list(ACCESS_SECURITY)
 	custom_price = PAYCHECK_COMMAND * 2.5 //Comes out to 50 with the security dept discount on the vendor
+	/// Skips access checks, if true
+	var/access_check_skipped = FALSE
 
 /obj/item/citationinator/attack_self(mob/living/user, modifiers)
 	if(!isliving(user))
@@ -22,12 +24,25 @@
 	issue_fine(user)
 	icon_state = initial(icon_state)
 
+/obj/item/citationinator/emag_act(mob/user, obj/item/card/emag/emag_card)
+	. = ..()
+	if(access_check_skipped)
+		balloon_alert(user, "no access locks to override!")
+	else
+		access_check_skipped = TRUE
+		balloon_alert(user, "access lock overridden")
+
+/obj/item/citationinator/examine(mob/user)
+	. = ..()
+	if(access_check_skipped)
+		. += span_notice("It's ID card reader is sparking and seems faulty.")
 /obj/item/citationinator/proc/issue_fine(mob/living/user)
 	var/obj/item/card/id/using_id = user.get_idcard()
-	if(!istype(using_id) || QDELING(using_id))
+	if((!istype(using_id) || QDELING(using_id)) && !access_check_skipped)
+		balloon_alert(user, "no ID found!")
 		return
-	if(!check_access(using_id))
-		to_chat(user, span_warning("Insufficient access to issue citations!"))
+	if(!check_access(using_id) && !access_check_skipped)
+		balloon_alert(user, "no access!")
 		return
 	var/victim_name
 	var/on_crew = TRUE


### PR DESCRIPTION
## About The Pull Request
Allows you to make fines for anything, rather than just people on the manifest. 
Allows you to emag citationinators to override the access checks

## Why It's Good For The Game
security should rightfully be able to fine gary for stealing their baton or that soap on that ground for slipping them.
so should that traitor, if they steal one and emag it.

## Testing
![dreamseeker_rM4oit06g5](https://github.com/user-attachments/assets/a0dac906-a192-41e3-8600-4a8321668620)
<img width="275" height="113" alt="image" src="https://github.com/user-attachments/assets/c0447903-5cd8-4064-aaa0-a612803ab80c" />

## Changelog

:cl:  Mantlecrawler, commissioned by Moffifuwa
add: Citationinators can now be used to fine anything, rather than only people on the manifest. Fine that door for being in your way!
add: You can now EMAG a citationinator to allow anyone to use it, rather than just those with security access
/:cl:

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
