### PR TITLE
fix a missing wire in the metastation xenobio hall

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -19749,6 +19749,7 @@
 	pixel_y = 2
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/breakroom)
 "hbE" = (


### PR DESCRIPTION

## About The Pull Request

fixed a missing wire that meant the apc in the xenobio hall wasn't connected to power

<img width="798" height="742" alt="2026-04-02 (1775148964) ~ strongdmm" src="https://github.com/user-attachments/assets/2e9a9879-c9b2-4e98-9825-e1ecfdd18830" />

## Changelog
:cl:
fix: Fixed a missing cable in the xenobio hallway on MetaStation.
/:cl: