### PR TITLE
System Cleaner heals cellular damage on IPCS now

### DIFF
--- a/monkestation/code/modules/smithing/ipcs/reagents/reagents.dm
+++ b/monkestation/code/modules/smithing/ipcs/reagents/reagents.dm
@@ -26,6 +26,7 @@
 
 /datum/reagent/medicine/system_cleaner/on_mob_life(mob/living/carbon/affected_mob, seconds_per_tick, times_fired)
 	affected_mob.adjustToxLoss(-2 * REM * seconds_per_tick, 0)
+	affected_mob.adjustCloneLoss(-2 * REM * seconds_per_tick, 0)
 	affected_mob.adjust_disgust(-5 * REM * seconds_per_tick)
 	affected_mob.adjust_drunk_effect(-10 * REM * seconds_per_tick)
 	var/remove_amount = 1 * REM * seconds_per_tick;


### PR DESCRIPTION
## About The Pull Request

title. 1/10 chance this actually works im a mapper and i was a shit mapper at that i cant code i think this is right though

## Why It's Good For The Game

as is there is no ways for IPC to heal outside of niche fixes, this is bad and unfun if abductors or other methods of clone damage hit you. fixes #11182 

## Testing

lol

## Changelog

:cl:
balance: system cleaner fixes clone damage at the same rate as toxin
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
