### PR TITLE
[PORT] Fixes Dark Matter singularity getting stuck on other z levels.

### DIFF
--- a/code/modules/events/meteors/dark_matteor_event.dm
+++ b/code/modules/events/meteors/dark_matteor_event.dm
@@ -23,7 +23,7 @@
 		target = potential_target
 		break
 	//if target was never chosen the target is null aka the matteor will act as spacedust (and can technically miss)
-	spawn_meteor(list(/obj/effect/meteor/dark_matteor = 1), null, target)
+	spawn_meteor(list(/obj/effect/meteor/dark_matteor = 1), null, target, distance_from_edge = 10)
 
 /datum/round_event/dark_matteor/announce(fake)
 	priority_announce("Warning. Excessive tampering of meteor satellites has attracted a dark matt-eor. Signature approaching [GLOB.station_name]. Please brace for impact.", "Meteor Alert", 'sound/misc/airraid.ogg')

--- a/code/modules/meteors/meteor_spawning.dm
+++ b/code/modules/meteors/meteor_spawning.dm
@@ -4,7 +4,7 @@
 	for(var/i in 1 to number)
 		spawn_meteor(meteor_types, direction)
 
-/proc/spawn_meteor(list/meteor_types, direction, atom/target)
+/proc/spawn_meteor(list/meteor_types, direction, atom/target, distance_from_edge = 0)
 	if (SSmapping.is_planetary())
 		stack_trace("Tried to spawn meteors in a map which isn't in space.")
 		return // We're not going to find any space turfs here
@@ -18,7 +18,7 @@
 		else
 			start_side = pick(GLOB.cardinals)
 		var/start_Z = pick(SSmapping.levels_by_trait(ZTRAIT_STATION))
-		picked_start = spaceDebrisStartLoc(start_side, start_Z)
+		picked_start = spaceDebrisStartLoc(start_side, start_Z, distance_from_edge)
 		if(target)
 			if(!isturf(target))
 				target = get_turf(target)
@@ -31,22 +31,22 @@
 	var/new_meteor = pick_weight(meteor_types)
 	new new_meteor(picked_start, picked_goal)
 
-/proc/spaceDebrisStartLoc(start_side, Z)
+/proc/spaceDebrisStartLoc(start_side, Z, distance_from_edge = 0)
 	var/starty
 	var/startx
 	switch(start_side)
 		if(NORTH)
-			starty = world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD)
-			startx = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD))
+			starty = world.maxy - (TRANSITIONEDGE + MAP_EDGE_PAD) - distance_from_edge
+			startx = rand((TRANSITIONEDGE + MAP_EDGE_PAD + distance_from_edge), world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD + distance_from_edge))
 		if(EAST)
-			starty = rand((TRANSITIONEDGE + MAP_EDGE_PAD),world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD))
-			startx = world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD)
+			starty = rand((TRANSITIONEDGE + MAP_EDGE_PAD + distance_from_edge),world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD + distance_from_edge))
+			startx = world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD) - distance_from_edge
 		if(SOUTH)
-			starty = (TRANSITIONEDGE + MAP_EDGE_PAD)
-			startx = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD))
+			starty = (TRANSITIONEDGE + MAP_EDGE_PAD) + distance_from_edge
+			startx = rand((TRANSITIONEDGE + MAP_EDGE_PAD + distance_from_edge), world.maxx-(TRANSITIONEDGE + MAP_EDGE_PAD + distance_from_edge))
 		if(WEST)
-			starty = rand((TRANSITIONEDGE + MAP_EDGE_PAD), world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD))
-			startx = (TRANSITIONEDGE + MAP_EDGE_PAD)
+			starty = rand((TRANSITIONEDGE + MAP_EDGE_PAD + distance_from_edge), world.maxy-(TRANSITIONEDGE + MAP_EDGE_PAD + distance_from_edge))
+			startx = (TRANSITIONEDGE + MAP_EDGE_PAD) + distance_from_edge
 	. = locate(startx, starty, Z)
 
 /proc/spaceDebrisFinishLoc(startSide, Z)

--- a/code/modules/power/singularity/dark_matter_singularity.dm
+++ b/code/modules/power/singularity/dark_matter_singularity.dm
@@ -20,6 +20,9 @@
 /obj/singularity/dark_matter/Initialize(mapload, starting_energy = 250)
 	. = ..()
 	COOLDOWN_START(src, initial_explosion_immunity, 5 SECONDS)
+	var/datum/component/singularity/resolved_singularity = singularity_component.resolve()
+	resolved_singularity.chance_to_move_to_target = 100
+	addtimer(CALLBACK(src, PROC_REF(normalize_tracking)), 20 SECONDS)
 
 /obj/singularity/dark_matter/examine(mob/user)
 	. = ..()
@@ -48,5 +51,10 @@
 	name = "Dark Lord Singuloth"
 	desc = "You managed to make a singularity from dark matter, which makes no sense at all, and then you threw a supermatter into it? Are you fucking insane? Fuck it, praise Lord Singuloth."
 	consumed_supermatter = TRUE
+
+///For 20 seconds, the singularity has buffed tracking to ensure it actually makes its way to the station, normalizes after 20 seconds
+/obj/singularity/dark_matter/proc/normalize_tracking()
+	var/datum/component/singularity/resolved_singularity = singularity_component.resolve()
+	resolved_singularity.chance_to_move_to_target = consumed_supermatter ? initial(resolved_singularity.chance_to_move_to_target) + DARK_MATTER_SUPERMATTER_CHANCE_BONUS : initial(resolved_singularity.chance_to_move_to_target)
 
 #undef DARK_MATTER_SUPERMATTER_CHANCE_BONUS


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/87113

> Makes so the dark matter singularity properly reaches the station upon being summoned.

## Why It's Good For The Game
> It's not rare for the dark matter singulo to accidentally jump onto another z level or getting lost, the erratic movement combined with it being spawned at the edge of the map, would often cause it to derail onto other z levels, often requiring admin intervention in order for it to reach the station.
> 
> This Pr fixes that by having it spawn a bit closer to the station and having it guaranteed to track living things for a few seconds upon spawning.

## Changelog
:cl: EnterTheJake
fix: Dark matter singularity no longer gets stuck on other z levels when summoned.
/:cl: