### PR TITLE
Updates the Exo Tracking Beacon message formatting

### DIFF
--- a/code/modules/vehicles/mecha/mecha_control_console.dm
+++ b/code/modules/vehicles/mecha/mecha_control_console.dm
@@ -58,7 +58,7 @@
 			var/message = tgui_input_text(usr, "Input message", "Transmit message")
 			var/obj/vehicle/sealed/mecha/M = MT.chassis
 			if(trim(message) && M)
-				to_chat(M.occupants, message)
+				to_chat(M.occupants, "[span_boldnotice("Incoming message from Exosuit Control:")] [message]")
 				to_chat(usr, span_notice("Message sent."))
 				. = TRUE
 		if("shock")


### PR DESCRIPTION

## About The Pull Request

I changed the message but this is the point
<img width="310" height="61" alt="image" src="https://github.com/user-attachments/assets/37f0d724-fe1f-4a6e-94e7-f41c6d1216f0" />

The previous version was UGLY. it had NO FORMATTING AT ALL, it just sent the message plainly without any colors or anything, no indication someone actually sent it to you.
## Why It's Good For The Game
I like it when things look good
## Testing
## Changelog
:cl:
add: Added formatting to the Exo Tracking Beacon messaging, perhaps letting you know easier that you are, in fact, getting a message from someone.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
