### PR TITLE
Fix mulebot movement (and set home destination)

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -495,6 +495,7 @@
 	if(!speed)//Devide by zero man bad
 		return
 	num_steps = round(10/speed) //10, 5, or 3 steps, depending on how many wires we have cut
+	datum_flags &= ~DF_ISPROCESSING // hacky fix since /mob/living already registers this to another subsystem
 	START_PROCESSING(SSfastprocess, src)
 
 /mob/living/simple_animal/bot/mulebot/process()

--- a/tgui/packages/tgui/interfaces/Mule.jsx
+++ b/tgui/packages/tgui/interfaces/Mule.jsx
@@ -121,7 +121,7 @@ export const Mule = (props) => {
                   selected={home}
                   options={destinations}
                   width="150px"
-                  onSelected={(value) => act('destination', { value })}
+                  onSelected={(value) => act('sethome', { value })}
                 />
                 <Button
                   icon="home"
@@ -133,7 +133,7 @@ export const Mule = (props) => {
                 <Button.Checkbox
                   checked={autoReturn}
                   content="Auto-Return"
-                  onClick={() => act('autored')}
+                  onClick={() => act('autoret')}
                 />
                 <br />
                 <Button.Checkbox


### PR DESCRIPTION
## About The Pull Request

closes #10543 

In #10480, `/mob/living` had a `START_PROCESSING` call added. Mulebot, other than e.g. secbots, tries to also use `START_PROCESSING` to register itself with `SSfastprocessing`. However, since it was already called `DF_ISPROCESSING` is set and thus the Mulebot call gets ignored.

The fix (suggested by Absolucy on Discord after I elaborated on the problem): Unset the `DF_ISPROCESSING` before calling `START_PROCESSING` in `mulebot.dm`
Pretty hacky admittedly, but the alternatively would likely be a rework to have it work more like secbot patrols do. Which seems a larger undertaking, for something that is supposed to be refactored into basic mobs anyway.

Also while testing I noticed I couldn't set the home destination in their UI, which I fixed as well.

## Why It's Good For The Game

Mulebots working is good for cargo deliveries

## Testing

Tested mulebots before the fix, they don't work (don't move) and I can't set a home destination
Tested mulebots after the fix, they do work and I can set a home destination
Reverted to before the PR mentioned above to compare behaviour and the behaviour after the fix was as before that PR.

## Changelog
:cl:
fix: Mulebot home destinations can now be set
fix: Mulebots move again
/:cl:


## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
