### PR TITLE
fix xenos being able to spam the roundend report

### DIFF
--- a/code/modules/antagonists/xeno/xeno.dm
+++ b/code/modules/antagonists/xeno/xeno.dm
@@ -133,6 +133,15 @@
 	var/datum/mind/progenitor
 	var/captive_xenos = 1
 
+/datum/team/xeno/captive/Destroy(force)
+	progenitor = null
+	return ..()
+
+/datum/team/xeno/captive/remove_member(datum/mind/member)
+	. = ..()
+	if(!length(members))
+		qdel(src)
+
 //XENO
 /mob/living/carbon/alien/mind_initialize()
 	..()


### PR DESCRIPTION

## About The Pull Request

Fixes https://github.com/Monkestation/Monkestation2.0/issues/11220

this just makes it so that `/datum/team/xeno/captive` will delete itself if it has no more members.

## Why It's Good For The Game

less clutter

## Changelog
:cl:
fix: Xenos can no longer clog up the roundend report by repeatedly entering and exiting xenobio containment.
/:cl: