### PR TITLE
Kindle Jackboots Powercreep (Adds jackboot storage to kindle jackboots)

### DIFF
--- a/monkestation/code/modules/donator/code/item/clothing.dm
+++ b/monkestation/code/modules/donator/code/item/clothing.dm
@@ -512,6 +512,10 @@
 	name = "jackboot kindle kicks"
 	desc = "They look just like kindle kicks! But these are boots!"
 
+/obj/item/clothing/shoes/kindle_kicks/jackboot/Initialize(mapload)
+	. = ..()
+	create_storage(storage_type = /datum/storage/pockets/shoes)
+
 /obj/item/clothing/suit/hooded/mothysmantle
 	name = "mothys mantle"
 	desc = "A thick garment that keeps warm and protects those precious wings from harsh weather, also commonly used during festivities. Feels much heavier than it looks. This one seems as if it were specially tailored for someone and has a hood unlike others of it's type."


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

consistent features good, as these are a type of jackboot you would expect them to have this behavior.

## Testing

1 line change (i dont test my code)

## Changelog

:cl:
balance: kindle kick jackboots have normal jackboot storage
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [x] You documented all of your changes.
