### PR TITLE
Machinery reconnects to correct powernet when cable layer is changed

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -75,6 +75,8 @@
 		return ITEM_INTERACT_BLOCKING
 
 	cable_layer = GLOB.cable_name_to_layer[choice]
+	disconnect_from_network()
+	connect_to_network()
 	balloon_alert(user, "now operating on the [choice]")
 	return ITEM_INTERACT_SUCCESS
 


### PR DESCRIPTION

## About The Pull Request

Some machinery such as emitters or tesla coils lets you adjust which powerline they take power from: Red, yellow, or blue. You can adjust that with a multitool.
The issue is that the machine only ever connects to the powernet on being secured with a wrench, not when you change the layer with the multitool.

So if you wrench a machine that is set to yellow line in, it will connect to the yellow line. You then change it to the red line with the multitool. It will say it's connected to the red line when inspecting it, but it will still draw its power from the yellow line instead.

Equally this can be confusing if you have a turf with only a red powerline. You wrench the machine to secure it and change it to red power afterwards, it will say "Disconnected from red powerline" despite being on a red power cable, and won't draw any power from it.

## Why It's Good For The Game

Less confusing to work with powerlines and machines.

## Testing

Tested before change:
* Wrench emitter on turf with red and yellow power line.
* Power yellow line, it fires.
* Change it to red line, inspect "Is connected to red powerline", still fires.
* Rewrench it, doesn't fire anymore as now it properly tries to draw from red line.
* Power red line instead, fires again.
* Change it to the (now non-powered) yellow line, it says it's connected to yellow line but still fires because it's actually connected to red.

Same test after the change, but now it correctly draws power from the right line and the inspect message works right.

Also tested a map bootup to ensure this doesn't somehow mess up machines that are connected at roundstart, they still worked fine.

## Changelog
:cl:
fix: Machinery draws power from correct powernet after cable layer has been changed with the multitool, even if the machine was already secured.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
