### PR TITLE
Makes paper sensor (mechcomp) able to read paper

### DIFF
--- a/monkestation/code/modules/mech_comp/objects/messages/paper_scanner.dm
+++ b/monkestation/code/modules/mech_comp/objects/messages/paper_scanner.dm
@@ -13,7 +13,7 @@
 	MC_ADD_CONFIG("Toggle Paper Consumption", toggle_consume)
 	MC_ADD_CONFIG("Toggle Thermal Paper Usage", toggle_thermal)
 
-/obj/item/mcobject/messaging/paper_scanner/attacked_by(obj/item/attacking_item, mob/living/user)
+/obj/item/mcobject/messaging/paper_scanner/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
 	. = ..()
 	if(!istype(attacking_item, /obj/item/paper))
 		return
@@ -23,14 +23,13 @@
 		return
 
 	flick("comp_pscan1", src)
-	var/sanitized_string = strip_html(html_encode(attacked_paper.raw_text_inputs))
+	var/sanitized_string = strip_html(html_encode(attacked_paper.get_raw_text()))
 	if(!sanitized_string)
 		return
 	fire(sanitized_string)
 	if(deletes_paper)
 		qdel(attacking_item)
 	return TRUE
-
 
 /obj/item/mcobject/messaging/paper_scanner/proc/toggle_consume(mob/user, obj/item/tool)
 	deletes_paper = !deletes_paper


### PR DESCRIPTION
## About The Pull Request

The MechComp paper sensor currently doesn't work. It seems it uses the wrong proc definition (attacked_by instead of attack_by).
Even after that I noticed it just produced a string saying "/list" or so. `raw_text_inputs` appears to be a list and `html_encode` wants a string, so I'm converting it to one with `paper.get_raw_text()`.

## Why It's Good For The Game

It's good if mechcomps actually work.

## Testing

Tested before, didn't work. Tested after, did work.
No runtimes seen.

## Changelog

:cl:
fix: MechComp Paper Sensor is now able to read paper.
/:cl:



## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
