### PR TITLE
Deaf people no longer get notifications for PDA messages, and people with hard of hearing have a chance not to

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -527,7 +527,7 @@
 	playsound(src, sound, 50, TRUE)
 	loc.visible_message(span_notice("<img class='icon' src='\ref[src]'> \The [src] displays a [origin.filedesc] notification: [html_encode(alerttext)]"), vision_distance = vision_distance, push_appearance = src)
 
-/obj/item/modular_computer/proc/ring(ringtone, list/balloon_alertees) // bring bring
+/obj/item/modular_computer/proc/ring(ringtone, list/balloon_alertees, list/ignored_mobs) // bring bring
 	if(!use_energy(check_programs = FALSE))
 		return
 	// Get the messenger app's new sound settings || Monkestation Addition START
@@ -543,7 +543,7 @@
 	else
 		playsound(src, sound_to_play, 50, TRUE, mixer_channel = CHANNEL_RINGTONES) // Monkestation change
 	ringtone = "*[ringtone]*"
-	audible_message(ringtone)
+	audible_message(ringtone, ignored_mobs = ignored_mobs)
 	for(var/mob/living/alertee in balloon_alertees)
 		alertee.balloon_alert(alertee, ringtone)
 

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -677,6 +677,7 @@
 			viewing_messages_of = REF(chat)
 
 	var/list/mob/living/receievers = list()
+	var/list/mob/living/ring_receievers = list()
 	if(computer.inserted_pai)
 		receievers += computer.inserted_pai.pai
 	if(computer.loc && isliving(computer.loc))
@@ -709,10 +710,14 @@
 		inbound_message = emoji_parse(inbound_message)
 
 		var/photo_message = signal.data["photo"] ? " (<a href='byond://?src=[REF(src)];choice=[photo_href];skiprefresh=1;target=[REF(chat)]'>Photo Attached</a>)" : ""
-		to_chat(messaged_mob, span_infoplain("[icon2html(computer, messaged_mob)] <b>PDA message from [sender_title], </b>\"[inbound_message]\"[photo_message] [reply]"))
+		if(!messaged_mob.can_hear() || (HAS_TRAIT(messaged_mob, TRAIT_HARD_OF_HEARING) && rand(0, 3) != 0))
+            to_chat(messaged_mob, span_infoplain("You feel your PDA vibrate."))
+        else
+            to_chat(messaged_mob, span_infoplain("[icon2html(computer, messaged_mob)] <b>PDA message from [sender_title], </b>"[inbound_message]"[photo_message] [reply]"))
+            ring_receievers += messaged_mob
 
 	if (alert_able && (!alert_silenced || is_rigged))
-		computer.ring(ringtone, receievers)
+		computer.ring(ringtone, ring_receievers)
 
 	if(computer.active_program == src)
 		SStgui.update_uis(computer)

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -713,7 +713,7 @@
 		if(!messaged_mob.can_hear() || (HAS_TRAIT(messaged_mob, TRAIT_HARD_OF_HEARING) && rand(0, 3) != 0))
 			to_chat(messaged_mob, span_infoplain("You feel your PDA vibrate."))
 		else
-			to_chat(messaged_mob, span_infoplain("[icon2html(computer, messaged_mob)] <b>PDA message from [sender_title], </b>"[inbound_message]"[photo_message] [reply]"))
+			to_chat(messaged_mob, span_infoplain("[icon2html(computer, messaged_mob)] <b>PDA message from [sender_title], </b>\"[inbound_message]\"[photo_message] [reply]"))
 			ring_receievers += messaged_mob
 
 	if (alert_able && (!alert_silenced || is_rigged))

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -677,7 +677,6 @@
 			viewing_messages_of = REF(chat)
 
 	var/list/mob/living/receievers = list()
-	var/list/mob/living/ring_receievers = list()
 	if(computer.inserted_pai)
 		receievers += computer.inserted_pai.pai
 	if(computer.loc && isliving(computer.loc))
@@ -710,14 +709,17 @@
 		inbound_message = emoji_parse(inbound_message)
 
 		var/photo_message = signal.data["photo"] ? " (<a href='byond://?src=[REF(src)];choice=[photo_href];skiprefresh=1;target=[REF(chat)]'>Photo Attached</a>)" : ""
+//Check if the mob can hear or has hard of hearing and rolls a 25% chance to receive the message
+		var/list/ignored_mobs = list()
 		if(!messaged_mob.can_hear() || (HAS_TRAIT(messaged_mob, TRAIT_HARD_OF_HEARING) && rand(0, 3) != 0))
 			to_chat(messaged_mob, span_infoplain("You feel your PDA vibrate."))
+			receievers -= messaged_mob
+			ignored_mobs += messaged_mob
 		else
 			to_chat(messaged_mob, span_infoplain("[icon2html(computer, messaged_mob)] <b>PDA message from [sender_title], </b>\"[inbound_message]\"[photo_message] [reply]"))
-			ring_receievers += messaged_mob
 
 	if (alert_able && (!alert_silenced || is_rigged))
-		computer.ring(ringtone, ring_receievers)
+		computer.ring(ringtone, receievers)
 
 	if(computer.active_program == src)
 		SStgui.update_uis(computer)

--- a/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
+++ b/code/modules/modular_computers/file_system/programs/messenger/messenger_program.dm
@@ -711,10 +711,10 @@
 
 		var/photo_message = signal.data["photo"] ? " (<a href='byond://?src=[REF(src)];choice=[photo_href];skiprefresh=1;target=[REF(chat)]'>Photo Attached</a>)" : ""
 		if(!messaged_mob.can_hear() || (HAS_TRAIT(messaged_mob, TRAIT_HARD_OF_HEARING) && rand(0, 3) != 0))
-            to_chat(messaged_mob, span_infoplain("You feel your PDA vibrate."))
-        else
-            to_chat(messaged_mob, span_infoplain("[icon2html(computer, messaged_mob)] <b>PDA message from [sender_title], </b>"[inbound_message]"[photo_message] [reply]"))
-            ring_receievers += messaged_mob
+			to_chat(messaged_mob, span_infoplain("You feel your PDA vibrate."))
+		else
+			to_chat(messaged_mob, span_infoplain("[icon2html(computer, messaged_mob)] <b>PDA message from [sender_title], </b>"[inbound_message]"[photo_message] [reply]"))
+			ring_receievers += messaged_mob
 
 	if (alert_able && (!alert_silenced || is_rigged))
 		computer.ring(ringtone, ring_receievers)


### PR DESCRIPTION

## About The Pull Request
Deaf people will now no longer get a notification for PDA messages, but rather it will vibrate and give them a message about that. Hard of hearing people will have a chance, idk what the chance is but it does the same thing 

It also gets rid of the balloon popup saying your ringtone since you can't hear that either! 
## Why It's Good For The Game
Felt weird that while deaf you get a huge popup saying you got a PDA message. So now it's a little more realistic and you just feel a vibration. 

If you have hard of hearing it does the same thing sometimes, you might miss a message maybe not! 
## Testing
tested on a local host with deaf & hard of hearing trait seems good. might have some funky interactions with PAI's but who knows
## Changelog
:cl: Cujo
fix: Deaf people no longer get a notification for PDA messages, instead getting a vibration.
add: Hard of hearing now gives you a chance to not hear PDA messages 
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
