### PR TITLE
Blacklist healium, RDX, and TATP from lesser strange seeds

### DIFF
--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -59,6 +59,8 @@
 		/datum/reagent/reaction_agent,
 		/datum/reagent/spider_extract,
 		/datum/reagent/healium,
+		/datum/reagent/tatp,
+		/datum/reagent/rdx,
 	))
 
 /obj/item/seeds/random/lesser/pick_reagent()


### PR DESCRIPTION
## About The Pull Request
Healium is a 30s instant sleep chemical. it shouldnt exist in the first place, but untill i come up with a way to rework it im removing it from botany
RDX and TATP are both super strong explosives that probally shouldnt be mass producable

## Why It's Good For The Game
Botany probably shouldn't be able to make plants that instantly sleep everyone in their smoke cloud, that then also say, carry enough holy water to deconvert
Botany shoildnt be able to make strong explosives in massive quantites

## Testing
just adding chems to a blacklist

## Changelog

:cl:
balance: Botany can no longer get healium, RDX, or TATP through lesser strange seeds.
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
