### PR TITLE
Adds a new station message hallucination

### DIFF
--- a/code/modules/hallucination/station_message.dm
+++ b/code/modules/hallucination/station_message.dm
@@ -101,6 +101,21 @@
 	to_chat(hallucinator, span_boldannounce("You feel reality distort for a moment..."))
 	return ..()
 
+/datum/hallucination/station_message/radiation_storm/
+
+/datum/hallucination/station_message/radiation_storm/start()
+	priority_announce("High levels of radiation detected near the station. Maintenance is best shielded from radiation.", \
+		"Anomaly Alert", ANNOUNCER_RADIATION, players = list(hallucinator))
+	addtimer(CALLBACK(src, PROC_REF(fake_warm_air)), 2 SECONDS)
+	return TRUE
+
+/datum/hallucination/station_message/radiation_storm/proc/fake_warm_air()
+	if(QDELETED(src) || QDELETED(hallucinator))
+		return
+
+	to_chat(hallucinator, span_warning("The air begins to grow warm."))
+	return
+
 /datum/hallucination/station_message/clock_cult_ark
 	// Clock cult's long gone, but this stays for posterity.
 	random_hallucination_weight = 0

--- a/code/modules/hallucination/station_message.dm
+++ b/code/modules/hallucination/station_message.dm
@@ -9,9 +9,8 @@
 /datum/hallucination/station_message/blob_alert
 
 /datum/hallucination/station_message/blob_alert/start()
-	to_chat(hallucinator, span_priorityannounce("Biohazard Alert"))
-	to_chat(hallucinator, span_priorityalert("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak."))
-	SEND_SOUND(hallucinator, sound(SSstation.announcer.event_sounds[ANNOUNCER_OUTBREAK5]))
+	priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", \
+		"Biohazard Alert", ANNOUNCER_OUTBREAK5, players = list(hallucinator))
 	return ..()
 
 /datum/hallucination/station_message/shuttle_dock
@@ -33,9 +32,8 @@
 	if(!(locate(/mob/living/silicon/ai) in GLOB.silicon_mobs))
 		return FALSE
 
-	to_chat(hallucinator, span_priorityannounce("Anomaly Alert"))
-	to_chat(hallucinator, span_priorityalert("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core."))
-	SEND_SOUND(hallucinator, sound(SSstation.announcer.event_sounds[ANNOUNCER_AIMALF]))
+	priority_announce("Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.", \
+		"Anomaly Alert", ANNOUNCER_AIMALF, players = list(hallucinator))
 	return ..()
 
 /datum/hallucination/station_message/heretic
@@ -92,9 +90,8 @@
 	random_hallucination_weight = 2
 
 /datum/hallucination/station_message/meteors/start()
-	to_chat(hallucinator, span_priorityannounce("Meteor Alert"))
-	to_chat(hallucinator, span_priorityalert("Meteors have been detected on collision course with the station."))
-	SEND_SOUND(hallucinator, sound(SSstation.announcer.event_sounds[ANNOUNCER_METEORS]))
+	priority_announce("Meteors have been detected on collision course with the station.", \
+		"Meteor Alert", ANNOUNCER_METEORS, players = list(hallucinator))
 	return ..()
 
 /datum/hallucination/station_message/supermatter_delam


### PR DESCRIPTION

## About The Pull Request

Blob, Malf AI and Meteors hallucinations were formatted in a different way than announcements, so I fixed them, also added a hallucination to rad storm announcement

## Why It's Good For The Game

More hallucinations to catch you off-guard, and keeping hallucinations believable. Comparison between before and after these changes:

Before
<img width="617" height="104" alt="image" src="https://github.com/user-attachments/assets/087b5cfe-d7e7-4405-a390-fb58c03a009f" />
After
<img width="671" height="128" alt="image" src="https://github.com/user-attachments/assets/67cb94e4-44aa-4863-b543-7ad15fc4ecfa" />



## Changelog
:cl:
add: A new station message hallucination based on radiation storm was added.
fix: Blobs, Malf AI and Meteors now properly get announced in their hallucinations.
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
