### PR TITLE
makes it so cult conversions will always sacrifice cult-banned people

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -285,6 +285,12 @@ structure_check() searches for nearby cultist structures required for the invoca
 		return FALSE
 	// monke end
 
+	if(is_banned_from(convertee.ckey, list(ROLE_SYNDICATE, ROLE_CULTIST)))
+		convertee.ghostize(can_reenter_corpse = FALSE)
+		convertee.death()
+		to_chat(invokers, span_narsiesmall("This one is forsaken, and cannot join us..."))
+		return do_sacrifice(convertee, invokers, cult_team)
+
 	var/brutedamage = convertee.getBruteLoss()
 	var/burndamage = convertee.getFireLoss()
 	if(brutedamage || burndamage)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

simply makes it so if a cult attempts to convert someone who is antag/cult-banned will just sac them instead (killing + ghosting them to guarantee it goes through and polls for a shade)

## Why It's Good For The Game

bc why waste their time with someone who can't play cult anyways. just give them the funny rock that a ghost can go into or whatever.

also i'm surprised this isn't how it behaved anyways.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Attempting to cult convert someone who's banned from blood cult will always sacrifice them instead.
/:cl:
