### PR TITLE
Fix jammer bricking headsets

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -408,7 +408,7 @@ effective or pretty fucking useless.
 	for (var/obj/item/radio/radio in target_contents)
 		if((ignore_syndie && radio.syndie) || radio.ignores_radio_jammers)
 			continue
-		radio.set_broadcasting(FALSE)
+		radio.set_broadcasting(FALSE, actual_setting = FALSE)
 	for (var/obj/item/bodycam_upgrade/bodycamera in target_contents)
 		bodycamera.turn_off()
 

--- a/code/modules/cassettes/machines/radio_mic.dm
+++ b/code/modules/cassettes/machines/radio_mic.dm
@@ -44,3 +44,13 @@
 
 /obj/item/radio/screwdriver_act(mob/living/user, obj/item/tool)
 	add_fingerprint(user)
+
+/obj/item/radio/radio_mic/set_broadcasting(new_broadcasting, actual_setting = TRUE)
+	. = ..()
+	// if we get hit by a disruptor wave, automatically restart after 1 minute or so.
+	if(!new_broadcasting && !actual_setting)
+		addtimer(CALLBACK(src, PROC_REF(restart_broadcasting)), 1 MINUTES, TIMER_UNIQUE | TIMER_OVERRIDE)
+
+/obj/item/radio/radio_mic/proc/restart_broadcasting()
+	set_broadcasting(TRUE)
+	balloon_alert_to_viewers("antenna rebooted")


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/95556

in addition, this makes it so that if the curator radio mic is disabled, it will auto-reboot after a minute (as there's no way to just re-enable it normally)

## Why It's Good For The Game

radios being perma-bricked is bad.

## Changelog
:cl: Absolucy, Melbert
fix: Radio jammers no longer brick headsets forever.
/:cl: