### PR TITLE
Portapotty Ambulances, Sheet Metal Drills, and Locker Mechs no longer become invisible when an AI takes control.

### DIFF
--- a/code/modules/vehicles/mecha/working/locker_mech.dm
+++ b/code/modules/vehicles/mecha/working/locker_mech.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/mecha/mecha.dmi'
 	icon_state = "lockermech"
 	base_icon_state = "lockermech"
-	silicon_icon_state = "lockermech"
+	silicon_icon_state = null
 	max_integrity = 100 //its made of scraps
 	lights_power = 5
 	movedelay = 2 //Same speed as a ripley, for now.

--- a/code/modules/vehicles/mecha/working/makeshift_ambulance.dm
+++ b/code/modules/vehicles/mecha/working/makeshift_ambulance.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/mecha/mecha.dmi'
 	icon_state = "pottyambo"
 	base_icon_state = "pottyambo"
-	silicon_icon_state = "pottyambo"
 	max_integrity = 125
 	lights_power = 6
 	movedelay = 1.5

--- a/code/modules/vehicles/mecha/working/makeshift_drill.dm
+++ b/code/modules/vehicles/mecha/working/makeshift_drill.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/mecha/mecha.dmi'
 	icon_state = "sheetmetaldrill"
 	base_icon_state = "sheetmetaldrill"
-	silicon_icon_state = "sheetmetaldrill"
 	max_integrity = 65
 	lights_power = 8
 	movedelay = 2.5


### PR DESCRIPTION

## About The Pull Request
these mechs were given "null" the word as a silicon iconstate instead of null, so they would select an icon that does not exist, and therefore become invisible
## Why It's Good For The Game
Invisible mechs are bad.
Bug fixes are good.
## Testing
i forgot to grab an image, trust me bro
the portapotty ambulance loses their driver when it moves, but that happened with a human as well so im declaring that a bug Not For Me To Handle
## Changelog
:cl:
fix: silicons piloting Sheet Metal Drills no longer cause it to become invisible.
fix: silicons piloting Portapotty Ambulances no longer cause it to become invisible.
fix: silicons piloting Locker Mechs no longer cause it to become invisible.
/:cl:
## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
