### PR TITLE
Adds stamps to oshan's hop office and removes mindshield boxes from hop office on delta and blueshift

### DIFF
--- a/_maps/map_files/Blueshift/Blueshift.dmm
+++ b/_maps/map_files/Blueshift/Blueshift.dmm
@@ -81998,7 +81998,6 @@
 /obj/item/storage/briefcase/secure{
 	pixel_y = 5
 	},
-/obj/item/storage/lockbox/loyalty,
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -6769,7 +6769,6 @@
 "bCm" = (
 /obj/structure/table/wood,
 /obj/machinery/light/directional/north,
-/obj/item/storage/lockbox/loyalty,
 /obj/structure/secure_safe/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hop)

--- a/_maps/map_files/Oshan/Oshan.dmm
+++ b/_maps/map_files/Oshan/Oshan.dmm
@@ -70398,6 +70398,14 @@
 	pixel_x = -10;
 	pixel_y = 4
 	},
+/obj/item/stamp/granted{
+	pixel_x = -12;
+	pixel_y = 4
+	},
+/obj/item/stamp/denied{
+	pixel_x = -8;
+	pixel_y = 4
+	},
 /turf/open/floor/carpet/executive,
 /area/station/command/heads_quarters/hop)
 "wmx" = (


### PR DESCRIPTION

## About The Pull Request
adds a granted and denied stamp to hop office oshan
removes mindshield boxes from delta/blueshift
## Why It's Good For The Game
stamps good, do the paperwork
hop cannot open mindshield boxes by default, keep them in security
## Testing
it compiled i didnt test it tho
## Changelog
:cl:
add: Adds approved and denied stamps to Oshan HoP office
del: Removes mindshield boxes from HoP office on Delta and Blueshift
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
