### PR TITLE
Fixes a grammatical error in Oni trait "Heavy Footed", Fixes Korta Wellington spelling

### DIFF
--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -1111,7 +1111,7 @@
 
 
 /obj/item/food/korta_wellington
-	name = "Kotra wellington"
+	name = "Korta wellington"
 	desc = "A luxurious log of beef, covered in a fine mushroom duxelle and pancetta ham, then bound in korta pastry."
 	icon = 'icons/obj/food/meat.dmi'
 	icon_state = "korta_wellington"

--- a/code/modules/mob/living/carbon/human/species_types/onis.dm
+++ b/code/modules/mob/living/carbon/human/species_types/onis.dm
@@ -65,7 +65,7 @@
 			SPECIES_PERK_TYPE = SPECIES_NEGATIVE_PERK,
 			SPECIES_PERK_ICON = "wind",
 			SPECIES_PERK_NAME = "Heavy Footed",
-			SPECIES_PERK_DESC = "You're a tad slower then the normal norman.", // 10% slower then normal.
+			SPECIES_PERK_DESC = "You're a tad slower than the normal norman.", // 10% slower then normal.
 		),
 		list(
 			SPECIES_PERK_TYPE = SPECIES_POSITIVE_PERK,


### PR DESCRIPTION

## About The Pull Request

Fixes a grammatical error in Oni trait "Heavy Footed".
fixes https://github.com/Monkestation/Monkestation2.0/issues/11305
Fixes a spelling mistake in Korta Wellington.

## Why It's Good For The Game

Heavy Footed trait description is now grammatically correct.
Korta Wellington is now spelt correctly.

## Testing

## Changelog
:cl:
spellcheck: changed "Then" to "Than" in Oni "Slow Footed" trait.
spellcheck: changed Kotra Wellington to Korta Wellington.

/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
