### PR TITLE
[PORT] Planetary atmos fix (fixes wings rarely not working on lavaland or icebox)

### DIFF
--- a/code/datums/atmosphere/_atmosphere.dm
+++ b/code/datums/atmosphere/_atmosphere.dm
@@ -52,6 +52,9 @@
 		ASSERT_GAS_IN_LIST(gastype, gaslist)
 		gaslist[gastype][MOLES] += amount
 
+	// Ensure that minimum_pressure is actually a hard lower limit
+	target_pressure = clamp(target_pressure, minimum_pressure + (gaslist[gastype][MOLES] * 0.1), maximum_pressure)
+
 	// That last one put us over the limit, remove some of it
 	while(gasmix.return_pressure() > target_pressure)
 		gaslist[gastype][MOLES] -= gaslist[gastype][MOLES] * 0.1


### PR DESCRIPTION

## About The Pull Request

Ports https://github.com/tgstation/tgstation/pull/78602

> The code for generating random atmospheres for lavaland and icemoon has variables that define the minimum and maximum pressure that the atmosphere can be. However, due to an oversight, it was possible for the actual pressure to be below this minimum. This caused problems for the flight potion wings, as the wings will not work if the pressure is lower than the minimum lavaland/icemoon pressure.
> 
> I tested this by making a quick test proc that would generate lavaland atmos 100 times, and count how often the final pressure was lower than the minimum pressure. I ran it a few times after making my changes, and it returned 0 failures every time, so I'm confident that my code works.

## Why It's Good For The Game

> I think its good practice for minimums and maximums variables like this to actually be hard limits. Furthermore, if there's _one_ place that mining loot should actually be useful, then its outside where you mine.

## Changelog
:cl: Absolucy, GPeckman
fix: The flight potion wings will no longer fail to work on lavaland/icemoon on rare occasions.
/:cl:
