### PR TITLE
Adds missing space cleaner to Metastation Medical

### DIFF
--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -27011,6 +27011,9 @@
 "jtA" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue/fourcorners,
+/obj/item/reagent_containers/spray/cleaner{
+	pixel_y = 18
+	},
 /obj/item/clothing/glasses/hud/health{
 	pixel_y = 6
 	},


### PR DESCRIPTION

## About The Pull Request
adds a space cleaner spray bottle to metastation medical
## Why It's Good For The Game
typically every map has a spray bottle or two in medical, metastation was missing this. map consistency!
## Testing
<img width="141" height="204" alt="image" src="https://github.com/user-attachments/assets/ad2bde7d-c7b3-462a-b5cc-62340c786b1b" />
looks good 


## Changelog
:cl: Cujo
add: Adds missing space cleaner spray bottle to Metastation medical
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
