### PR TITLE
science bag + biosuit storage qol

### DIFF
--- a/code/__DEFINES/inventory.dm
+++ b/code/__DEFINES/inventory.dm
@@ -297,6 +297,23 @@ GLOBAL_LIST_INIT(mining_suit_allowed, list(
 	/obj/item/melee/sledgehammer,
 ))
 
+/// Allowed list for science winter coats and bio suits.
+GLOBAL_LIST_INIT(science_suit_allowed, list(
+	/obj/item/analyzer,
+	/obj/item/dnainjector,
+	/obj/item/hypospray,
+	/obj/item/paper,
+	/obj/item/reagent_containers/cup/beaker,
+	/obj/item/reagent_containers/cup/bottle,
+	/obj/item/reagent_containers/cup/tube,
+	/obj/item/reagent_containers/dropper,
+	/obj/item/reagent_containers/medipen,
+	/obj/item/reagent_containers/pill,
+	/obj/item/reagent_containers/syringe,
+	/obj/item/storage/bag/xeno,
+	/obj/item/storage/pill_bottle,
+))
+
 /// String for items placed into the left pocket.
 #define LOCATION_LPOCKET "in your left pocket"
 /// String for items placed into the right pocket

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -524,25 +524,22 @@
 	atom_storage.max_total_storage = 200
 	atom_storage.max_slots = 25
 	atom_storage.set_holdable(list(
-//MONKESTATION EDIT START
 		/obj/item/autoslime,
-//MONKESTATION EDIT END
 		/obj/item/bodypart,
 		/obj/item/food/deadmouse,
 		/obj/item/food/monkeycube,
 		/obj/item/organ,
 		/obj/item/petri_dish,
-		/obj/item/reagent_containers/dropper,
 		/obj/item/reagent_containers/cup/beaker,
 		/obj/item/reagent_containers/cup/bottle,
 		/obj/item/reagent_containers/cup/tube,
+		/obj/item/reagent_containers/dropper,
 		/obj/item/reagent_containers/syringe,
-//MONKESTATION EDIT START
-		/obj/item/slimecross,
-//MONKESTATION EDIT END
 		/obj/item/slime_extract,
+		/obj/item/slimecross,
+		/obj/item/slimepotion,
+		/obj/item/stack/biomass,
 		/obj/item/swab,
-		/obj/item/stack/biomass // monke: make science bags able to hold biomass cubes
 		))
 
 /obj/item/storage/bag/construction

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -111,6 +111,10 @@
 /obj/item/clothing/suit/bio_suit/scientist
 	icon_state = "bio_scientist"
 
+/obj/item/clothing/suit/bio_suit/scientist/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.science_suit_allowed
+
 //CMO's biosuit, blue stripe
 /obj/item/clothing/head/bio_hood/cmo
 	icon_state = "bio_cmo"

--- a/code/modules/clothing/suits/wintercoats.dm
+++ b/code/modules/clothing/suits/wintercoats.dm
@@ -379,24 +379,13 @@
 	desc = "A white winter coat with an outdated atomic model instead of a plastic zipper tab."
 	icon_state = "coatscience"
 	inhand_icon_state = "coatscience"
-	allowed = list(
-		/obj/item/analyzer,
-		/obj/item/dnainjector,
-		/obj/item/paper,
-		/obj/item/reagent_containers/dropper,
-		/obj/item/reagent_containers/cup/beaker,
-		/obj/item/reagent_containers/cup/bottle,
-		/obj/item/reagent_containers/cup/tube,
-		/obj/item/hypospray,
-		/obj/item/reagent_containers/medipen,
-		/obj/item/reagent_containers/pill,
-		/obj/item/reagent_containers/syringe,
-		/obj/item/storage/bag/xeno,
-		/obj/item/storage/pill_bottle,
-	)
 	armor_type = /datum/armor/wintercoat_science
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/science
 	species_exception = list(/datum/species/golem)
+
+/obj/item/clothing/suit/hooded/wintercoat/science/Initialize(mapload)
+	. = ..()
+	allowed += GLOB.science_suit_allowed
 
 /datum/armor/wintercoat_science
 	bomb = 10


### PR DESCRIPTION

## About The Pull Request

this does two science-related storage qol things:
- allows science bags to store slime potions (they're tiny anyways)
- allows the scientist biosuit to store anything in its suit storage that a science winter coat can (i.e science bags)

## Why It's Good For The Game

consistency and it just makes sense tbh

## Changelog
:cl:
qol: Science bags can now hold slime potions.
qol: Science biosuits can now hold anything in suit storage that science winter coats can.
/:cl:
