### PR TITLE
makes mindshield matter a bit more

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -162,10 +162,8 @@
 	if (HAS_TRAIT(current, TRAIT_CULT_HALO))
 		current.RemoveElement(/datum/element/cult_halo)
 
-/datum/antagonist/cult/on_mindshield(mob/implanter)
-	if(!silent)
-		to_chat(owner.current, span_warning("You feel something interfering with your mental conditioning, but you resist it!"))
-	return
+/datum/antagonist/cult/pre_mindshield(mob/implanter, mob/living/mob_override)
+	return COMPONENT_MINDSHIELD_RESISTED
 
 /datum/antagonist/cult/admin_add(datum/mind/new_owner,mob/admin)
 	give_equipment = FALSE

--- a/code/modules/antagonists/darkspawn/darkspawn_abilities/thrall_spells.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_abilities/thrall_spells.dm
@@ -41,6 +41,9 @@
 	if(HAS_MIND_TRAIT(target, TRAIT_UNCONVERTABLE))
 		to_chat(owner, span_velvet("This one is something else entirely. [target.p_They()] cannot be controlled."))
 		return
+	if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+		to_chat(owner, span_velvet("[target] has foreign machinery that resists our thralling."))
+		return FALSE
 	var/mob/living/existing_master = target.mind.enslaved_to?.resolve()
 	if(existing_master && !IS_DARKSPAWN_OR_THRALL(existing_master))
 		to_chat(owner, span_velvet("[target.p_Their()] mind already belongs to someone else."))
@@ -75,14 +78,6 @@
 			flavour += span_boldwarning("The creature's gaze swallows the universe into blackness.")
 
 		to_chat(target, flavour.Join("<br>"))
-		if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
-			to_chat(owner, span_warning("[target] has foreign machinery that resists our thralling, we shall attempt to destroy it."))
-			target.visible_message(span_warning("[target] seems to resist an unseen force!"))
-			if(!do_after(owner, 20 SECONDS, target, hidden = TRUE))
-				to_chat(target, span_userdanger("It cannot be permitted to succeed."))
-				return FALSE
-			for(var/obj/item/implant/mindshield/L in target)
-				qdel(L)
 
 	playsound(owner, 'sound/ambience/antag/darkspawn/veil_mind_gasp.ogg', 25)
 

--- a/code/modules/antagonists/darkspawn/darkspawn_thrall.dm
+++ b/code/modules/antagonists/darkspawn/darkspawn_thrall.dm
@@ -113,6 +113,9 @@
 	qdel(get_shadow_tumor(current_mob))
 	current_mob.update_sight()
 
+/datum/antagonist/thrall_darkspawn/pre_mindshield(mob/implanter, mob/living/mob_override)
+	return COMPONENT_MINDSHIELD_RESISTED
+
 ////////////////////////////////////////////////////////////////////////////////////
 //--------------------------------Antag hud---------------------------------------//
 ////////////////////////////////////////////////////////////////////////////////////

--- a/monkestation/code/modules/antagonists/clock_cult/antag_datums/clock_cultist.dm
+++ b/monkestation/code/modules/antagonists/clock_cult/antag_datums/clock_cultist.dm
@@ -123,10 +123,8 @@
 	var/icon/icon = render_preview_outfit(preview_outfit)
 	return finish_preview_icon(icon)
 
-/datum/antagonist/clock_cultist/on_mindshield(mob/implanter)
-	if(!silent)
-		to_chat(owner.current, span_warning("You feel something pushing away the light of Ratvar, but you resist it!"))
-	return
+/datum/antagonist/clock_cultist/pre_mindshield(mob/implanter, mob/living/mob_override)
+	return COMPONENT_MINDSHIELD_RESISTED
 
 /datum/antagonist/clock_cultist/admin_add(datum/mind/new_owner,mob/admin)
 	new_owner.add_antag_datum(src)

--- a/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
+++ b/monkestation/code/modules/bloodsuckers/structures/bloodsucker_crypt.dm
@@ -381,7 +381,6 @@
 		// Convert to Vassal!
 		bloodsuckerdatum.AddBloodVolume(-TORTURE_CONVERSION_COST)
 		if(bloodsuckerdatum.make_vassal(target))
-			remove_loyalties(target)
 			SEND_SIGNAL(bloodsuckerdatum, COMSIG_BLOODSUCKER_MADE_VASSAL, user, target)
 
 /obj/structure/bloodsucker/vassalrack/proc/do_torture(mob/living/user, mob/living/carbon/target, mult = 1, tool = null)
@@ -464,14 +463,11 @@
 		balloon_alert(user, "target has no mind!")
 		return VASSALIZATION_BANNED
 
+	if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+		return VASSALIZATION_BANNED
+
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = IS_BLOODSUCKER(user)
 	return bloodsuckerdatum.AmValidAntag(target)
-
-/obj/structure/bloodsucker/vassalrack/proc/remove_loyalties(mob/living/target)
-	// Find Mind Implant & Destroy
-	for(var/obj/item/implant/implant as anything in target.implants)
-		if(istype(implant, /obj/item/implant/mindshield) && implant.removed(target, silent = TRUE))
-			qdel(implant)
 
 /obj/structure/bloodsucker/vassalrack/proc/reset_progress()
 	convert_progress = initial(convert_progress)


### PR DESCRIPTION
## About The Pull Request

removes some conversion antags way to just break mindshields:
darkspawn can no longer thrall mindshielded people
bloodsuckers can't thrall mindshielded people nor break their implants, antags can still choose if they want to be vassalized or not

also makes some antags resist mindshield completely if their deconversion isnt related to mindshielding (i.e. to deconvert darkspawn thrall you need to cut out their tumor):
clock cult, blood cult and darkspawn thralls will all resist mindshield when attempting to implant it (so yes you cant hide the fact that you are thralled)

## Why It's Good For The Game

mindshields basically dont do anything outside of protecting from basic brainwashing since most antags can just bypass it
blood cult imo is fine because it gives you resistance to stun hand in exchange for getting gibbed on convert
security should be harder to convert than just doing a slightly longer do after anyway

its kinda double edged because it does make antags kill security more but sec being on antags side is significantly worse than them just being dead (and sec is more likely to be killed anyway)

the mindshield resisting is mostly made so you cant hide the fact that you are converted by implanting yourself and making it clear that the person isnt deconverted from the mindshield

## Testing

darkspawn
<img width="457" height="54" alt="image" src="https://github.com/user-attachments/assets/0b131d78-2be5-48b7-b01e-e1b627f7cc67" />

trying to vassalize an officer (yes i did remove extra balloon alert)
<img width="252" height="159" alt="image" src="https://github.com/user-attachments/assets/e0b0fb2f-7163-45bc-b99b-60257bd429eb" />

the mindshield resist works fine but i had to remove the special message since it would double...
<img width="524" height="48" alt="image" src="https://github.com/user-attachments/assets/0fd35eb6-42ca-4dc3-8141-9e52eb3299f2" />

## Changelog

:cl:
balance: bloodsuckers can no longer convert mindshielded people or remove their mindshield
balance: darkspawn can no longer thrall mindshielded people
balance: clock cultists, blood cultists and darkspawn thralls resist their mindshields to indicate that mindshields dont actually deconvert them
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
