### PR TITLE
[BOUNTY] Adds tacticool variants of syndicate engineering turtlenecks to monkecoin store

### DIFF
--- a/monkestation/code/modules/blueshift/clothing/nova_syndicate.dm
+++ b/monkestation/code/modules/blueshift/clothing/nova_syndicate.dm
@@ -113,6 +113,10 @@
 	has_sensor = HAS_SENSORS
 	can_adjust = TRUE
 
+/obj/item/clothing/under/syndicate/nova/overalls/unarmoured/tacticool
+	name = "tacticool utility turtleneck"
+	desc = "A pair of spiffy overalls with a tacticool turtleneck underneath, now with 100% more tacticool."
+
 /obj/item/clothing/under/syndicate/nova/overalls/unarmoured/skirt
 	name = "suspicious utility overalls skirtleneck"
 	desc = "A pair of spiffy overalls with a turtleneck underneath, this one is a skirt instead, breezy."
@@ -121,6 +125,10 @@
 	female_sprite_flags = FEMALE_UNIFORM_TOP_ONLY
 	dying_key = DYE_REGISTRY_JUMPSKIRT
 	supports_variations_flags = CLOTHING_DIGITIGRADE_VARIATION_NO_NEW_ICON
+
+/obj/item/clothing/under/syndicate/nova/overalls/unarmoured/skirt/tacticool
+	name = "tacticool utility skirtleneck"
+	desc = "A pair of spiffy overalls with a tacticool turtleneck underneath, now with 100% more tacticool."
 
 /obj/item/clothing/under/syndicate/nova/overalls/unarmoured/examine_more(mob/user)
 	. = ..()

--- a/monkestation/code/modules/loadouts/items/under/under.dm
+++ b/monkestation/code/modules/loadouts/items/under/under.dm
@@ -258,6 +258,13 @@ GLOBAL_LIST_INIT(loadout_miscunders, generate_loadout_items(/datum/loadout_item/
 	name = "Tacticool Skirtleneck"
 	item_path = /obj/item/clothing/under/syndicate/tacticool/skirt //This has been rebalanced in modular_skyrat\master_files\code\modules\clothing\under\syndicate.dm
 
+/datum/loadout_item/under/miscellaneous/tacticool_engi_turtleneck
+	name = "Tacticool Engineering Turtleneck"
+	item_path = /obj/item/clothing/under/syndicate/nova/overalls/unarmoured/tacticool
+
+/datum/loadout_item/under/miscellaneous/tactical_skirt_engi_turtleneck
+	name = "Tacticool Engineering Skirtleneck"
+	item_path = /obj/item/clothing/under/syndicate/nova/overalls/unarmoured/skirt/tacticool
 
 /datum/loadout_item/under/miscellaneous/gladiator
 	name = "Gladiator Uniform"

--- a/monkestation/code/modules/store/store_items/under.dm
+++ b/monkestation/code/modules/store/store_items/under.dm
@@ -206,6 +206,14 @@ GLOBAL_LIST_INIT(store_miscunders, generate_store_items(/datum/store_item/under/
 	name = "Tacticool Skirtleneck"
 	item_path = /obj/item/clothing/under/syndicate/tacticool/skirt
 
+/datum/store_item/under/miscellaneous/tacticool_engi_turtleneck
+	name = "Tacticool Engineering Turtleneck"
+	item_path = /obj/item/clothing/under/syndicate/nova/overalls/unarmoured/tacticool
+
+/datum/store_item/under/miscellaneous/tactical_skirt_engi_turtleneck
+	name = "Tacticool Engineering Skirtleneck"
+	item_path = /obj/item/clothing/under/syndicate/nova/overalls/unarmoured/skirt/tacticool
+
 
 /datum/store_item/under/miscellaneous/gladiator
 	name = "Gladiator Uniform"


### PR DESCRIPTION
## About The Pull Request
<img width="140" height="83" alt="image" src="https://github.com/user-attachments/assets/aee9a4df-41b0-435d-b4b0-13033efbab55" />
These two get added to store

## Why It's Good For The Game
Someone requested this and i dont see why not
they are now under misc jumpsuits, like the other tacticool jumpsuits
## Testing
<img width="140" height="83" alt="image" src="https://github.com/user-attachments/assets/7067c2a6-dc5d-4868-9b58-80d9ad0e71a7" />
<img width="871" height="68" alt="image" src="https://github.com/user-attachments/assets/19995d71-80f3-470c-98fa-7e9fa5a3119f" />

## Changelog

:cl:
add: Tacticool syndicate engineering jumpsuits and skirts to monkecoin store
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
