### PR TITLE
bluespace tomatos and bananas require bluespace dust to be  mutated into + infusion is easier and less rng

### DIFF
--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -11,9 +11,10 @@
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	icon_dead = "banana-dead"
 	genes = list(/datum/plant_gene/trait/slip, /datum/plant_gene/trait/repeated_harvest)
-	possible_mutations = list(/datum/hydroponics/plant_mutation/bluespace_banana, /datum/hydroponics/plant_mutation/mime_banana)
+	possible_mutations = list(/datum/hydroponics/plant_mutation/mime_banana)
 	reagents_add = list(/datum/reagent/consumable/banana = 0.1, /datum/reagent/potassium = 0.1, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.02)
 	graft_gene = /datum/plant_gene/trait/slip
+	infusion_mutations = list(/datum/hydroponics/plant_mutation/infusion/bluespace_banana)
 
 /obj/item/food/grown/banana
 	seed = /obj/item/seeds/banana

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -59,11 +59,11 @@
 	product = /obj/item/food/grown/tomato/blue
 	yield = 2
 	icon_grow = "bluetomato-grow"
-	possible_mutations = list(/datum/hydroponics/plant_mutation/bluespace_tomato)
 	genes = list(/datum/plant_gene/trait/slip, /datum/plant_gene/trait/repeated_harvest)
 	reagents_add = list(/datum/reagent/lube = 0.2, /datum/reagent/consumable/nutriment/vitamin = 0.04, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
 	graft_gene = /datum/plant_gene/trait/slip
+	infusion_mutations = list(/datum/hydroponics/plant_mutation/infusion/bluespace_tomato)
 
 /obj/item/food/grown/tomato/blue
 	seed = /obj/item/seeds/tomato/blue

--- a/code/modules/hydroponics/machines/splicer.dm
+++ b/code/modules/hydroponics/machines/splicer.dm
@@ -303,9 +303,7 @@
 			if (volume <= 0)
 				continue
 
-			var/infusion_chance = min(floor(volume / 5), 100)
-
-			if(prob(infusion_chance))
+			if(volume >= 25)
 				var/random_rate = rand(3, 25) / 100
 
 				var/datum/plant_gene/reagent/existing_gene = null
@@ -334,7 +332,7 @@
 
 				successful_reagents += reagent_instance
 			else
-				to_chat(usr, span_notice("Attempted to infuse [reagent_instance.name] into [seed_1], but it failed."))
+				to_chat(usr, span_notice("Attempted to infuse [reagent_instance.name] into [seed_1], but it failed. Infusion requires a volume of 25 units."))
 
 
 		seed_1.reagents_from_genes()

--- a/code/modules/hydroponics/machines/splicer.dm
+++ b/code/modules/hydroponics/machines/splicer.dm
@@ -303,7 +303,7 @@
 			if (volume <= 0)
 				continue
 
-			if(volume >= 25)
+			if(volume >= 100)
 				var/random_rate = rand(3, 25) / 100
 
 				var/datum/plant_gene/reagent/existing_gene = null
@@ -332,7 +332,7 @@
 
 				successful_reagents += reagent_instance
 			else
-				to_chat(usr, span_notice("Attempted to infuse [reagent_instance.name] into [seed_1], but it failed. Infusion requires a volume of 25 units."))
+				to_chat(usr, span_notice("Attempted to infuse [reagent_instance.name] into [seed_1], but it failed. Infusion requires a volume of 100 units."))
 
 
 		seed_1.reagents_from_genes()

--- a/code/modules/hydroponics/mutations/base.dm
+++ b/code/modules/hydroponics/mutations/base.dm
@@ -48,13 +48,6 @@
 	required_lifespan = list(60, 80)
 	required_potency = list(-INFINITY, 20)
 
-/datum/hydroponics/plant_mutation/bluespace_banana
-	mutates_from = list(/obj/item/seeds/banana)
-	created_product = /obj/item/food/grown/banana/bluespace
-	created_seed = /obj/item/seeds/banana/bluespace
-	required_production = list(20, 60)
-	required_potency = list(70, INFINITY)
-
 /datum/hydroponics/plant_mutation/koi_beans
 	mutates_from = list(/obj/item/seeds/soya)
 	created_product = /obj/item/food/grown/koibeans
@@ -352,12 +345,6 @@
 	created_product = /obj/item/food/grown/tomato/killer
 	created_seed = /obj/item/seeds/tomato/killer
 	required_lifespan = list(50, 90)
-
-/datum/hydroponics/plant_mutation/bluespace_tomato
-	mutates_from = list(/obj/item/seeds/tomato/blue)
-	created_product = /obj/item/food/grown/tomato/blue/bluespace
-	created_seed = /obj/item/seeds/tomato/blue/bluespace
-	required_potency = list(120, INFINITY)
 
 /datum/hydroponics/plant_mutation/steel_towercap
 	mutates_from = list(/obj/item/seeds/tower)

--- a/code/modules/hydroponics/mutations/infusions.dm
+++ b/code/modules/hydroponics/mutations/infusions.dm
@@ -15,3 +15,16 @@
 	reagent_requirement = list(/datum/reagent/gunpowder)
 	created_product = /obj/item/food/grown/shell/coconut_gun
 	created_seed = /obj/item/seeds/coconut/gun
+
+
+/datum/hydroponics/plant_mutation/infusion/bluespace_tomato
+	mutates_from = list(/obj/item/seeds/tomato/blue)
+	reagent_requirement = list(/datum/reagent/bluespace)
+	created_product = /obj/item/food/grown/tomato/blue/bluespace
+	created_seed = /obj/item/seeds/tomato/blue/bluespace
+
+/datum/hydroponics/plant_mutation/infusion/bluespace_banana
+	mutates_from = list(/obj/item/seeds/banana)
+	reagent_requirement = list(/datum/reagent/bluespace)
+	created_product = /obj/item/food/grown/banana/bluespace
+	created_seed = /obj/item/seeds/banana/bluespace


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
you now need to infuse bluespace dust into blue tomato and banana seeds respectively for their bluespace mutations to occur.

infusions are no longer RNG based and requires 100 units of the reagent listed for the infusion. 

## Why It's Good For The Game
makes it so you have to work a bit for the bluespace variants since they are a bit dangerous. also locks them out of being grown in perma as you need a splicer.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing
infused blue tomato seeds and banana seeds with bluespace dust. both gained the bluespace variants as possible mutations.
<!-- Describe the tests you ran with your addition. It is recommended to add images, videos and step-by-step explanations of conducted testing. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: you now need to infuse bluespace dust into blue tomato and banana seeds respectively for their bluespace mutations to occur.
balance: infusions are no longer RNG based and requires 100 units of the reagent listed for the infusion. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
