### PR TITLE
minor qol for xenobio upgrade disks

### DIFF
--- a/monkestation/code/modules/slimecore/items/vacuum_pack.dm
+++ b/monkestation/code/modules/slimecore/items/vacuum_pack.dm
@@ -346,6 +346,8 @@
 	return NONE
 
 /obj/item/vacuum_nozzle/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(istype(interacting_with, /obj/item/disk/vacuum_upgrade))
+		return pack.item_interaction(interacting_with, user, modifiers)
 	if(!istype(interacting_with, /obj/machinery/biomass_recycler))
 		return ranged_interact_with_atom(interacting_with, user, modifiers)
 	if(!(VACUUM_PACK_UPGRADE_BIOMASS in pack.upgrades))

--- a/monkestation/code/modules/slimecore/machines/ooze_sucker.dm
+++ b/monkestation/code/modules/slimecore/machines/ooze_sucker.dm
@@ -265,7 +265,7 @@
 /obj/item/disk/sucker_upgrade
 	name = "ooze sucker upgrade disk"
 	desc = "An upgrade disk for an ooze sucker."
-	icon_state = "rndmajordisk"
+	icon_state = "cargodisk"
 
 	/// A message given to the player when they examine a sucker with this installed.
 	var/notice


### PR DESCRIPTION

## About The Pull Request

simply makes it so clicking on a vacpack upgrade disk with the nozzle inserts it into the vacpack, like how you can click on RCD upgrade disks with the RCD.

also changes the ooze sucker upgrade disks to use this sprite instead:
<img width="102" height="101" alt="image" src="https://github.com/user-attachments/assets/8fb2fd6c-4d8f-4aeb-9104-8070cf1e1da3" />

## Why It's Good For The Game

minor nicety feature, I'm used to it with the RCD.

I keep accidentally buying the wrong type of disk sometime, so using a different sprite would be neat.

## Changelog
:cl:
image: Ooze sucker upgrade disks now have a different sprite than vacuum pack upgrade disks.
qol: You can now click on vacuum pack upgrade disks with the vacpack nozzle to insert them.
/:cl:
