### PR TITLE
removes joel's gun from the sectech contraband section until it is balanced better

### DIFF
--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -29,7 +29,6 @@
 		/obj/item/melee/flyswatter = 1,
 		/obj/item/clothing/head/helmet/toggleable/justice = 2,
 		/obj/item/clothing/head/helmet/toggleable/justice/escape = 2,
-		/obj/item/gun/ballistic/revolver/joel = 1,
 	)
 	premium = list(
 		/obj/item/storage/belt/security/webbing = 5,


### PR DESCRIPTION

## About The Pull Request
title

## Why It's Good For The Game
its unbalanced and the moment so im removing it temporarily until willard can rebalance it.

## Testing

## Changelog

:cl:
balance: removes joel's gun from the sectech contraband section until it is balanced better
/:cl:

## Pre-Merge Checklist

- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

