### PR TITLE
fixes a lint in the upcoming version of spacemandmm

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -7,7 +7,7 @@ SUBSYSTEM_DEF(research)
 	//TECHWEB STATIC
 	var/list/techweb_nodes = list() //associative id = node datum
 	var/list/techweb_designs = list() //associative id = node datum
-	var/list/datum/design/item_to_design = list() //typepath = list of design datums
+	var/list/list/datum/design/item_to_design = list() //typepath = list of design datums
 
 	///List of all techwebs.
 	var/list/datum/techweb/techwebs = list()


### PR DESCRIPTION
forgot to port this from https://github.com/tgstation/tgstation/pull/84648 and it's gonna actually be a linter error in the next version of sdmm/dreamchecker

<img width="566" height="62" alt="2026-04-16 (1776359356) ~ Code" src="https://github.com/user-attachments/assets/26d243bf-e64c-42d4-865f-56f6892f1068" />

no user-facing changes ofc - in fact does not actually change how the code functions at all, this merely makes a type definition more accurate