### PR TITLE
Revert "Removes nekomimetic (#11078)"

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -310,6 +310,16 @@
 	greyscale_config = null
 	greyscale_colors = null
 
+/obj/item/encryptionkey/felinid
+	name = "\improper Felinid translation key"
+	desc = "An encryption key that automatically encodes nekomimetic heard through the radio into common. The signal's rather scratchy."
+	icon_state = "translation_cypherkey"
+	language_data = list(
+		/datum/language/nekomimetic = 100,
+	)
+	greyscale_config = null
+	greyscale_colors = null
+
 /obj/item/encryptionkey/uncommon
 	name = "\improper Uncommon translation key"
 	desc = "An encryption key that automatically encodes Uncommon heard through the radio into common. The signal's rather scratchy."

--- a/code/modules/cargo/goodies.dm
+++ b/code/modules/cargo/goodies.dm
@@ -257,6 +257,12 @@
 	cost = PAYCHECK_CREW * 12
 	contains = list(/obj/item/encryptionkey/ethereal)
 
+/datum/supply_pack/goody/felinid_encryption_key
+	name = "Felinid radio encryption key"
+	desc = "A hi-tech radio encryption key that allows the wearer to understand nekomimetic when the radio is worn."
+	cost = PAYCHECK_CREW * 12
+	contains = list(/obj/item/encryptionkey/felinid)
+
 /datum/supply_pack/goody/uncommon_encryption_key
 	name = "Uncommon radio encryption key"
 	desc = "A hi-tech radio encryption key that allows the wearer to understand uncommon when the radio is worn."

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -478,6 +478,7 @@ GLOBAL_LIST_INIT(prototype_language_holders, init_language_holder_prototypes())
 		/datum/language/mushroom = list(LANGUAGE_ATOM),
 		/datum/language/monkey = list(LANGUAGE_ATOM),
 		/datum/language/goblin = list(LANGUAGE_ATOM),
+		/datum/language/nekomimetic = list(LANGUAGE_ATOM),
 		/datum/language/yangyu = list(LANGUAGE_ATOM),
 	)
 	spoken_languages = list(
@@ -494,6 +495,7 @@ GLOBAL_LIST_INIT(prototype_language_holders, init_language_holder_prototypes())
 		/datum/language/mushroom = list(LANGUAGE_ATOM),
 		/datum/language/monkey = list(LANGUAGE_ATOM),
 		/datum/language/goblin = list(LANGUAGE_ATOM),
+		/datum/language/nekomimetic = list(LANGUAGE_ATOM),
 		/datum/language/yangyu = list(LANGUAGE_ATOM),
 	)
 
@@ -590,6 +592,16 @@ GLOBAL_LIST_INIT(prototype_language_holders, init_language_holder_prototypes())
 	spoken_languages = list(
 		/datum/language/common = list(LANGUAGE_ATOM),
 		/datum/language/sylvan = list(LANGUAGE_ATOM),
+	)
+
+/datum/language_holder/felinid
+	understood_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/nekomimetic = list(LANGUAGE_ATOM),
+	)
+	spoken_languages = list(
+		/datum/language/common = list(LANGUAGE_ATOM),
+		/datum/language/nekomimetic = list(LANGUAGE_ATOM),
 	)
 
 /datum/language_holder/darkspawn

--- a/code/modules/language/language_manuals.dm
+++ b/code/modules/language/language_manuals.dm
@@ -67,6 +67,7 @@
 	. = ..()
 	language = pick( \
 		/datum/language/voltaic, \
+		/datum/language/nekomimetic, \
 		/datum/language/draconic, \
 		/datum/language/moffic, \
 		/datum/language/calcic \

--- a/code/modules/language/nekomimetic.dm
+++ b/code/modules/language/nekomimetic.dm
@@ -1,0 +1,19 @@
+/datum/language/nekomimetic
+	name = "Nekomimetic"
+	desc = "To the casual observer, this langauge is an incomprehensible mess of broken Japanese. To the felinids, it's somehow comprehensible."
+	key = "f"
+	space_chance = 15
+	sentence_chance = 0
+	between_word_sentence_chance = 10
+	between_word_space_chance = 75
+	additional_syllable_low = -1
+	additional_syllable_high = 1
+	syllables = list(
+		"neko", "nyan", "mimi", "moe", "mofu", "fuwa", "kyaa", "kawaii", "poka", "munya",
+		"puni", "munyu", "ufufu", "uhuhu", "icha", "doki", "kyun", "kusu", "nya", "nyaa",
+		"desu", "kis", "ama", "chuu", "baka", "hewo", "boop", "gato", "kit", "sune", "yori",
+		"sou", "baka", "chan", "san", "kun", "mahou", "yatta", "suki", "usagi", "domo", "ori",
+		"uwa", "zaazaa", "shiku", "puru", "ira", "heto", "etto"
+	)
+	icon_state = "neko"
+	default_priority = 90

--- a/code/modules/surgery/organs/internal/tongue/_tongue.dm
+++ b/code/modules/surgery/organs/internal/tongue/_tongue.dm
@@ -598,6 +598,14 @@ GLOBAL_LIST_INIT(english_to_zombie, list())
 /obj/item/organ/internal/tongue/ethereal/get_possible_languages()
 	return ..() + /datum/language/voltaic
 
+/obj/item/organ/internal/tongue/cat
+	name = "felinid tongue"
+	desc = "A fleshy muscle mostly used for meowing."
+	say_mod = "meows"
+	liked_foodtypes = SEAFOOD | ORANGES | BUGS | GORE
+	disliked_foodtypes = GROSS | CLOTH | RAW
+	languages_native = list(/datum/language/nekomimetic)
+
 /obj/item/organ/internal/tongue/bananium
 	name = "bananium tongue"
 	desc = "A bananium geode mostly used for honking."

--- a/monkestation/code/modules/NTSL/code/coding_language/implementations/telecomms_translator.dm
+++ b/monkestation/code/modules/NTSL/code/coding_language/implementations/telecomms_translator.dm
@@ -10,11 +10,13 @@
 #define ETHEREAN 7
 #define BONE 8
 #define MOTH 9
-#define ASH_TONGUE 10
-#define TORII 11
-#define UNCOMMON 12
-#define GOBLIN 13
-#define SLIME 14
+#define CAT 10
+#define ASH_TONGUE 11
+#define TORII 12
+#define UNCOMMON 13
+#define GOBLIN 14
+#define FELINID 15
+#define SLIME 16
 
 ///Span classes that players are allowed to set in a radio transmission.
 GLOBAL_LIST_INIT(allowed_custom_spans, list(
@@ -150,10 +152,12 @@ GLOBAL_LIST_INIT(allowed_translations, list(
 			"etherean" = ETHEREAN,
 			"bonespeak" = BONE,
 			"mothian" = MOTH,
+			"cat" = CAT,
 			"ash" = ASH_TONGUE,
 			"torii" = TORII,
 			"uncommon" = UNCOMMON,
 			"goblin" = GOBLIN,
+			"felinid" = FELINID,
 			"slime" = SLIME,
 		))
 	)
@@ -198,6 +202,8 @@ GLOBAL_LIST_INIT(allowed_translations, list(
 			oldlangbits = BONE
 		if(/datum/language/moffic)
 			oldlangbits = MOTH
+		if(/datum/language/nekomimetic)
+			oldlangbits = CAT
 		if(/datum/language/ashtongue)
 			oldlangbits = ASH_TONGUE
 		if(/datum/language/yangyu)
@@ -206,6 +212,8 @@ GLOBAL_LIST_INIT(allowed_translations, list(
 			oldlangbits = UNCOMMON
 		if(/datum/language/goblin)
 			oldlangbits = GOBLIN
+		if(/datum/language/nekomimetic)
+			oldlangbits = FELINID
 		if(/datum/language/slime)
 			oldlangbits = SLIME
 
@@ -345,6 +353,8 @@ GLOBAL_LIST_INIT(allowed_translations, list(
 			return /datum/language/calcic
 		if(MOTH)
 			return /datum/language/moffic
+		if(CAT)
+			return /datum/language/nekomimetic
 		if(ASH_TONGUE)
 			return /datum/language/ashtongue
 		if(TORII)
@@ -353,6 +363,8 @@ GLOBAL_LIST_INIT(allowed_translations, list(
 			return /datum/language/uncommon
 		if(GOBLIN)
 			return /datum/language/goblin
+		if(FELINID)
+			return /datum/language/nekomimetic
 		if(SLIME)
 			return /datum/language/slime
 
@@ -534,8 +546,10 @@ GLOBAL_LIST_INIT(allowed_translations, list(
 #undef ETHEREAN
 #undef BONE
 #undef MOTH
+#undef CAT
 #undef ASH_TONGUE
 #undef TORII
 #undef UNCOMMON
 #undef GOBLIN
+#undef FELINID
 #undef SLIME

--- a/monkestation/code/modules/blueshift/opfor/equipment/biology.dm
+++ b/monkestation/code/modules/blueshift/opfor/equipment/biology.dm
@@ -47,6 +47,11 @@
 	description = "Ook ook ook."
 	language = /datum/language/monkey
 
+/datum/opposing_force_equipment/language/nekomimetic
+	name = "Nekomimetic language"
+	description = "To the casual observer, this langauge is an incomprehensible mess of broken Japanese. To the felinids, it's somehow comprehensible."
+	language = /datum/language/nekomimetic
+
 /datum/opposing_force_equipment/language/mushroom
 	name = "Mushroom language"
 	description = "A language that consists of the sound of periodic gusts of spore-filled air being released."

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -4590,6 +4590,7 @@
 #include "code\modules\language\monkey.dm"
 #include "code\modules\language\mushroom.dm"
 #include "code\modules\language\narsian.dm"
+#include "code\modules\language\nekomimetic.dm"
 #include "code\modules\language\piratespeak.dm"
 #include "code\modules\language\shadowtongue.dm"
 #include "code\modules\language\slime.dm"

--- a/tgui/packages/tgui/interfaces/NTSLCoding.tsx
+++ b/tgui/packages/tgui/interfaces/NTSLCoding.tsx
@@ -346,11 +346,13 @@ const Guide = (props) => {
       (var = languages.language_name) <br />1 (human) <br />2 (monkey) <br />3
       (robot) <br />4 (draconic) <br />5 (beachtounge) <br />6 (sylvan) <br />7
       (etherean) <br />8 (bonespeak) <br />9 (mothian) <br />
-      10 (ash) <br />
-      11 (torii) <br />
-      12 (uncommon) <br />
-      13 (goblin) <br />
-      14 (slime) <br />
+      10 (cat) <br />
+      11 (ash) <br />
+      12 (torii) <br />
+      13 (uncommon) <br />
+      14 (goblin) <br />
+      15 (nekomimetic) <br />
+      16 (slime) <br />
       <br />
       <br />
       Broadcasted signals will not run itself through Scripts.


### PR DESCRIPTION


## About The Pull Request
This reverts commit cb0520a8c1aef3bd81cbe03650863af9567c5ae4.

## Why It's Good For The Game

The deletion of a language, however rarely used, still had an impact on the people who did use it.
It is a silly cat language, and was often combined with the anime quirk.
A number of people, myself included, have, or have had, characters based around this language.
The wholesale removal of a customisation option is not the way to go about things.

## Changelog


:cl:
add: Readded Nekomimetic

/:cl: