### PR TITLE
Changes medical spray cans to use VAPOR instead of PATCH, additional synthflesh fixes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -490,6 +490,9 @@
 	if(synthflesh_amount >= SYNTHFLESH_UNHUSK_AMOUNT)
 		carbies.cure_husk(BURN)
 		carbies.visible_message(span_nicegreen("A rubbery liquid coats [carbies]'s burns. [carbies] looks a lot healthier!")) //we're avoiding using the phrases "burnt flesh" and "burnt skin" here because carbies could be a skeleton or a golem or something
+	if((methods & PATCH) && synthflesh_amount >= 60)
+		carbies.cure_husk(BURN)
+		carbies.visible_message(span_nicegreen("A rubbery liquid coats [carbies]'s burns. [carbies] looks a lot healthier!"))
 
 /******ORGAN HEALING******/
 /*Suffix: -rite*/

--- a/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/cat2_medicine_reagents.dm
@@ -487,12 +487,9 @@
 	var/synthflesh_amount = carbies.reagents.get_reagent_amount(/datum/reagent/medicine/c2/synthflesh) // Yes, this includes the amount we've added from our gel
 	if(methods & TOUCH) //touch does not apply chems to blood, we want to combine the two volumes before attempting to unhusk
 		synthflesh_amount += reac_volume
-	if(synthflesh_amount >= SYNTHFLESH_UNHUSK_AMOUNT)
+	if((synthflesh_amount >= SYNTHFLESH_UNHUSK_AMOUNT) || ((methods & VAPOR) && synthflesh_amount >= 60))
 		carbies.cure_husk(BURN)
 		carbies.visible_message(span_nicegreen("A rubbery liquid coats [carbies]'s burns. [carbies] looks a lot healthier!")) //we're avoiding using the phrases "burnt flesh" and "burnt skin" here because carbies could be a skeleton or a golem or something
-	if((methods & PATCH) && synthflesh_amount >= 60)
-		carbies.cure_husk(BURN)
-		carbies.visible_message(span_nicegreen("A rubbery liquid coats [carbies]'s burns. [carbies] looks a lot healthier!"))
 
 /******ORGAN HEALING******/
 /*Suffix: -rite*/

--- a/code/modules/reagents/reagent_containers/medigel.dm
+++ b/code/modules/reagents/reagent_containers/medigel.dm
@@ -16,11 +16,11 @@
 	throw_speed = 3
 	throw_range = 7
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10)
+	possible_transfer_amounts = list(5,10,60)
 	volume = 60
 	var/can_fill_from_container = TRUE
-	var/apply_type = PATCH
-	var/apply_method = "spray" //the thick gel is sprayed and then dries into patch like film.
+	var/apply_type = VAPOR
+	var/apply_method = "spray" //the reagents are sprayed on
 	var/self_delay = 30
 	custom_price = PAYCHECK_CREW * 2
 	unique_reskin = list(

--- a/code/modules/reagents/reagent_containers/medigel.dm
+++ b/code/modules/reagents/reagent_containers/medigel.dm
@@ -92,6 +92,20 @@
 	list_reagents = list(/datum/reagent/medicine/c2/synthflesh = 60)
 	custom_price = PAYCHECK_CREW * 5
 
+/obj/item/reagent_containers/medigel/synthflesh/examine(mob/user)
+	. = ..()
+	if(reagents.total_volume >= 60)
+		. += span_info("One full bottle can restore a corpse husked by burns.")
+
+/obj/item/reagent_containers/medigel/synthflesh/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
+	if(iscarbon(interacting_with) && reagents?.total_volume)
+		var/mob/living/carbon/carbies = interacting_with
+		if(HAS_TRAIT_FROM(carbies, TRAIT_HUSK, BURN) && carbies.getFireLoss() > UNHUSK_DAMAGE_THRESHOLD * 2.5)
+			// give them a warning if the mob is a husk but synthflesh won't unhusk yet
+			carbies.visible_message(span_boldwarning("[carbies]'s burns need to be repaired first before synthflesh will unhusk it!"))
+
+	return ..()
+
 /obj/item/reagent_containers/medigel/sterilizine
 	name = "sterilizer gel"
 	desc = "gel bottle loaded with non-toxic sterilizer. Useful in preparation for surgery."


### PR DESCRIPTION

## About The Pull Request
Partial port of https://github.com/tgstation/tgstation/pull/90514

Medical spraycans & synthflesh foam can now fix husks using only 60u of synthflesh

Changes medical spraycans to use VAPOR instead of PATCH

Hardsets synthflesh medical cans to be able to apply 5,10,60 units at once. Not really a reason to use anything inbetween that.
Probably not the best way to do this but monke doesn't have purity in a way that makes this possible like it is on TG.
## Why It's Good For The Game
Changes medical spraycans to use VAPOR instead of PATCH. I feel like this makes more sense as you are spraying the reagents on and this should be different than patches. 

Unhusking now requires either 100u of synthflesh in the bloodstream OR 60u of synthflesh applied by VAPOR, ie synthflesh foam or medical spraycans. Using the right tool for the job makes unhusking easier now. 

The synthflesh cans in the medical vendor have 60 units but you need 100 units of synthflesh to unhusk. This is kinda awkward because you have 120u total between the two cans in the vendor but can only fix one corpse - now you can fix two!

Additionally gives you a warning message when attempting to spray if the husked bodies burns are not low enough. Best to not waste synthflesh if you don't have to.
## Testing
Tested in a local host, it fixes the husk when using 60u from a medical spray can.
## Changelog
:cl: LT3, Cujo
balance: Changes medical spray cans to use VAPOR instead of PATCH
add: Synthflesh medical spray cans can now spray in 5, 10, or 60u increments
add: Unhusking a corpse now requires either 100u of synthflesh in the bloodstream OR 60u applied by vapor (spray cans or synthflesh foam)
qol: Better information and feedback about de-husking corpses
/:cl:
## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
