### PR TITLE
Makes Spaghetti and Rice take less Water to boil, also updates the chef manual a bit

### DIFF
--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -136,13 +136,13 @@
 				<h2>Basic ingredients preparation:</h2>
 
 				<b>Dough:</b> 10u water + 15u flour for simple dough.<br>
-				6u egg yolk + 12 egg white + 15u flour + 5u sugar for cake batter.<br>
-				Doughs can be transformed by using a knife and rolling pin.<br>
-				All doughs can be microwaved.<br>
+				6u egg yolk + 12 egg white (3 eggs) + 15u flour + 5u sugar for cake batter.<br>
+				Doughs can be transformed by using a rolling pin(flat dough) and knife(dough slice).<br>
+				All doughs can be baked.<br>
 				<b>Bowl:</b> Add water to it for soup preparation.<br>
 				<b>Meat:</b> Microwave it, process it, slice it into microwavable cutlets with your knife, or use it raw.<br>
-				<b>Cheese:</b> Add 5u universal enzyme (catalyst) to milk and soy milk to prepare cheese (sliceable) and tofu.<br>
-				<b>Rice:</b> Mix 10u rice with 10u water in a bowl then microwave it.
+				<b>Cheese:</b> Add 5u universal enzyme (catalyst) to 40u milk and 10u soy milk to prepare cheese (sliceable) or tofu.<br>
+				<b>Rice:</b> Mix 10u rice with 10u water, then boil in a soup pot with 25u water.
 
 				<h2>Custom food:</h2>
 				Add ingredients to a base item to prepare a custom meal.<br>
@@ -161,8 +161,22 @@
 				<h2>Table Craft:</h2>
 				Put ingredients on table, then click and drag the table onto yourself to see what recipes you can prepare.
 
+				<h2>Griddle:</h2>
+				Use it to cook food ingredients (raw meats, eggs, toast, etc...).
+				It can cook up to 7 ingredients at once.
+				Do be careful not to leave them on an active griddle for to long!
+
+				<h2>Stove:</h2>
+				Use it to boil food ingredients (rice, spaghetti, vegetables, meat, etc...) in a Soup Pot.
+
+				<h2>Oven:</h2>
+				Use it to bake food ingredients (doughs, some vegetables, etc...)
+
+				<h2>Range:</h2>
+				A combination of both the Stove and Oven, it can perform the tasks of both at the same time!
+
 				<h2>Microwave:</h2>
-				Use it to cook or boil food ingredients (meats, doughs, egg, donkpocket, etc...).
+				Use it to microwave some food ingredients (egg, donkpocket, etc...).
 				It can cook multiple items at once.
 
 				<h2>Processor:</h2>
@@ -176,14 +190,14 @@
 
 
 				<h2>Example recipes:</h2>
-				<b>Vanilla Cake</b>: Microwave cake batter.<br>
+				<b>Vanilla Cake</b>: Bake cake batter.<br>
 				<b>Burger:</b> 1 bun + 1 meat steak<br>
 				<b>Bread:</b> Microwave dough.<br>
 				<b>Waffles:</b> 2 pastry base<br>
 				<b>Popcorn:</b> Microwave corn.<br>
 				<b>Meat Steak:</b> Microwave meat.<br>
 				<b>Meat Pie:</b> 1 plain pie + 1u black pepper + 1u salt + 2 meat cutlets<br>
-				<b>Boiled Spaghetti:</b>Raw Spaghetti + 50u water at 450+K<br>
+				<b>Boiled Spaghetti:</b>Raw Spaghetti + 25u water at 450+K<br>
 				<b>Donuts:</b> 1u sugar + 1 pastry base<br>
 				<b>Fries:</b> Process potato.
 

--- a/code/modules/food_and_drinks/recipes/boiling.dm
+++ b/code/modules/food_and_drinks/recipes/boiling.dm
@@ -3,7 +3,7 @@
 		/obj/item/food/spaghetti/raw = 1
 	)
 	required_reagents = list(
-		/datum/reagent/water = 50
+		/datum/reagent/water = 25
 	)
 	resulting_food_path = /obj/item/food/spaghetti/boiledspaghetti
 	ingredient_reagent_multiplier = 0
@@ -13,7 +13,7 @@
 		/obj/item/food/uncooked_rice = 1
 	)
 	required_reagents = list(
-		/datum/reagent/water = 50
+		/datum/reagent/water = 25
 	)
 	resulting_food_path = /obj/item/food/boiledrice
 	ingredient_reagent_multiplier = 0
@@ -26,10 +26,10 @@
 	non_craftable = TRUE
 
 /datum/crafting_recipe/food/stove/boiledspaghetti
-	reqs = list(/datum/reagent/water = 50, /obj/item/reagent_containers/cup/soup_pot, /obj/item/food/spaghetti/raw = 1)
+	reqs = list(/datum/reagent/water = 25, /obj/item/reagent_containers/cup/soup_pot, /obj/item/food/spaghetti/raw = 1)
 	result = /obj/item/food/spaghetti/boiledspaghetti
 
 /datum/crafting_recipe/food/stove/boiledrice
-	reqs = list(/datum/reagent/water = 50, /obj/item/reagent_containers/cup/soup_pot, /obj/item/food/uncooked_rice = 1)
+	reqs = list(/datum/reagent/water = 25, /obj/item/reagent_containers/cup/soup_pot, /obj/item/food/uncooked_rice = 1)
 	result = /obj/item/food/boiledrice
 	category = CAT_SALAD


### PR DESCRIPTION

## About The Pull Request

Makes Uncooked Spaghetti and Uncooked Rice take 25 units of Water to boil instead of 50 units, also updates the Chef's Manual "Chef Recipes" a bit and adds the Griddle, Stove, Oven and Range. 

## Why It's Good For The Game

Uncooked Rice and Spaghetti currently both take 50 units of Water EACH to boil, and a soup pot holds 200 units of reagents max, meaning it can only cook up to 4 of either at a time, which isn't too problematic, but,

The Kitchen Sink holds 100 units of water and generates water way too slowly for more than two rice/spaghetti based soups and dishes, especially when there are two or more cooks using water.

The Chef manual is a bit outdated too yeah (we don't microwave dough and stuff anymore).
## Testing

Spawned in 2 stoves, 2 soup pots, water tank, beaker and raw spaghetti/rice
Placed 25u water in each pot and added the uncooked ingredients to each
heated them until they popped out.

spawned in Chef Manual, opened it up.
<img width="760" height="602" alt="dreamseeker_dBlJdiOtDu" src="https://github.com/user-attachments/assets/fd03d525-7f2c-4ebd-a134-4db24a0f4120" />

<img width="1298" height="1008" alt="dreamseeker_h2JVkWRhVB" src="https://github.com/user-attachments/assets/bae5acf1-1a60-4639-b162-6db1b9e4018a" />


## Changelog

:cl:

qol: halved the quantity of water required to boil Rice and Spaghetti.
qol: updated the Chef manual.

/:cl:



## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
