### PR TITLE
Disable wishgranter

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -29,13 +29,13 @@
 	description = "WELCOME TO CLOWN PLANET! HONK HONK HONK etc.!"
 	suffix = "lavaland_biodome_clown_planet.dmm"
 
-/datum/map_template/ruin/lavaland/cube
-	name = "The Wishgranter Cube"
-	id = "wishgranter-cube"
-	description = "Nothing good can come from this. Learn from their mistakes and turn around."
-	suffix = "lavaland_surface_cube.dmm"
-	cost = 10
-	allow_duplicates = FALSE
+// /datum/map_template/ruin/lavaland/cube
+// 	name = "The Wishgranter Cube"
+// 	id = "wishgranter-cube"
+// 	description = "Nothing good can come from this. Learn from their mistakes and turn around."
+// 	suffix = "lavaland_surface_cube.dmm"
+// 	cost = 10
+// 	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/seed_vault
 	name = "Seed Vault"


### PR DESCRIPTION
## About The Pull Request
Disables wishgranter ruin

## Why It's Good For The Game
Wishgranter is fun for exactly one person, the person who uses it. Its a free murderbone pass that exists for no particular reason, other than to allow people to murderbone. People will find it, and then go and powergame, then go activate it, because its just a free antag

## Testing
tested, no runtimes
## Changelog

:cl:
del: Removed wishgranter
/:cl:

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
