### PR TITLE
Adds a blood cult antag granter to opfor applications (wooh yeah spikecult)

### DIFF
--- a/monkestation/code/modules/blueshift/items/syndicate.dm
+++ b/monkestation/code/modules/blueshift/items/syndicate.dm
@@ -200,6 +200,24 @@
 	antag_datum = /datum/antagonist/clock_cultist/solo
 	user_message = "A whirring fills your ears as <span class='brass'>knowledge of His Eminence fills your mind</span>."
 
+/obj/item/antag_granter/blood_cultist
+	name = "bloody knife"
+	desc = "A ancient knife, caked in blood, both fresh and dried."
+	icon = 'icons/obj/cult/items_and_weapons.dmi'
+	icon_state = "render"
+	antag_datum = /datum/antagonist/cult
+	user_message = span_cult("Ancient, bloody knoweldge floods your mind as you look into the dagger.")
+
+/obj/item/antag_granter/blood_cultist/attack_self(mob/living/carbon/user, modifiers)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/obj/item/stack/sheet/runed_metal/ten/metal = new
+	var/obj/item/melee/cultblade/dagger/knoife = new
+	user.equip_conspicuous_item(metal)
+	user.equip_conspicuous_item(knoife)
+
 /obj/item/antag_granter/clock_cultist/attack_self(mob/user, modifiers)
 	. = ..()
 	if(!.)

--- a/monkestation/code/modules/blueshift/opfor/equipment/uplinks.dm
+++ b/monkestation/code/modules/blueshift/opfor/equipment/uplinks.dm
@@ -52,6 +52,12 @@
 	description = "A cogwheel-shaped device of brass, with a glass lens floating, suspended in the center. Capable of making one become a \"Clock Cultist\"."
 	admin_note = "Clockwork Cultist (solo) antag granter."
 
+/datum/opposing_force_equipment/uplink/blood_cultist
+	item_type = /obj/item/antag_granter/blood_cultist
+	name = "Bloody Knife"
+	description = "A ancient knife, covered in blood, both fresh and dried. Capable of making one become a \"Blood Cultist\"."
+	admin_note = "Blood Cultist (solo) antag granter."
+
 //Services
 /*
 /datum/opposing_force_equipment/uplink/give_exploitables


### PR DESCRIPTION
## About The Pull Request
Adds a new equipment item to opfor applications that grants the user blood cultist, solo

## Why It's Good For The Game
we have one for clockies and one for heretics, why not one for blood cult

## Testing
tested, works fine in game

## Changelog
:cl:
add: You can now select a blood cult granter under opfor equipment
/:cl:

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
