### PR TITLE
[TM ONLY] Revert "Use `sleep(world.tick_lag)` instead of `stoplag()` in `UNTIL` and `UNTIL_WHILE_EXISTS`"

### DIFF
--- a/code/__DEFINES/_helpers.dm
+++ b/code/__DEFINES/_helpers.dm
@@ -28,7 +28,7 @@
 #define subtypesof(typepath) ( typesof(typepath) - typepath )
 
 /// Until a condition is true, sleep
-#define UNTIL(X) while(!(X)) sleep(world.tick_lag)
+#define UNTIL(X) while(!(X)) stoplag()
 
 /// Sleep if we haven't been deleted
 /// Otherwise, return

--- a/code/__DEFINES/~monkestation/_helpers.dm
+++ b/code/__DEFINES/~monkestation/_helpers.dm
@@ -3,6 +3,6 @@
 #define UNTIL_WHILE_EXISTS(Src, Condition) \
 	while(!(Condition)) { \
 		if(QDELETED(Src)) return; \
-		sleep(world.tick_lag); \
+		stoplag(); \
 	} \
 	if(QDELETED(Src)) return;


### PR DESCRIPTION
This reverts commit 020de7df5da63f0f964639b48a8cd75faba473db.

i wanna see if this changes noticable tidi/stutter