### PR TITLE
allow ignoring bloodling thrall ghost prompts

### DIFF
--- a/code/_globalvars/lists/poll_ignore.dm
+++ b/code/_globalvars/lists/poll_ignore.dm
@@ -40,7 +40,7 @@
 #define POLL_IGNORE_DEFECTIVECLONE "defectiveclone"
 #define POLL_IGNORE_BINGLE "bingle"
 #define POLL_IGNORE_DARKSPAWN_PSYCHE "darkspawn_psyche"
-
+#define POLL_IGNORE_BLOODLING_THRALL "bloodling_thrall"
 
 GLOBAL_LIST_INIT(poll_ignore_desc, list(
 	POLL_IGNORE_ACADEMY_WIZARD = "Academy Wizard Defender",
@@ -48,6 +48,7 @@ GLOBAL_LIST_INIT(poll_ignore_desc, list(
 	POLL_IGNORE_ASH_SPIRIT = "Ash Spirit",
 	POLL_IGNORE_ASHWALKER = "Ashwalker eggs",
 	POLL_IGNORE_BLOB = "Blob spores",
+	POLL_IGNORE_BLOODLING_THRALL = "Bloodling Thrall",
 	POLL_IGNORE_BOTS = "Bots",
 	POLL_IGNORE_CARGORILLA = "Cargorilla",
 	POLL_IGNORE_CONTRACTOR_SUPPORT = "Contractor Support Unit",

--- a/monkestation/code/modules/antagonists/bloodling/abilities/give_life.dm
+++ b/monkestation/code/modules/antagonists/bloodling/abilities/give_life.dm
@@ -36,11 +36,14 @@
 	target_mob.balloon_alert(target_mob, "giving sentience to flesh...")
 
 	var/mob/living/basic/bloodling/proper/our_bloodling = owner
-	var/mob/chosen_one = SSpolling.poll_ghosts_for_target("Do you want to play as [span_notice("Bloodling Thrall")]?",
-	check_jobban = ROLE_BLOODLING_THRALL, poll_time = 10 SECONDS,
-	checked_target = target_mob,
-	alert_pic = target_mob,
-	role_name_text = "Bloodling Thrall",
+	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(
+		"Do you want to play as [span_notice("Bloodling Thrall")]?",
+		check_jobban = ROLE_BLOODLING_THRALL,
+		poll_time = 10 SECONDS,
+		ignore_category = POLL_IGNORE_BLOODLING_THRALL,
+		checked_target = target_mob,
+		alert_pic = target_mob,
+		role_name_text = "Bloodling Thrall",
 	)
 
 	if(isnull(chosen_one))

--- a/monkestation/code/modules/antagonists/bloodling/abilities/infect.dm
+++ b/monkestation/code/modules/antagonists/bloodling/abilities/infect.dm
@@ -52,10 +52,11 @@
 				chosen_one = SSpolling.poll_ghosts_for_target(
 					check_jobban = ROLE_BLOODLING_THRALL,
 					poll_time = 10 SECONDS,
+					ignore_category = POLL_IGNORE_BLOODLING_THRALL,
 					checked_target = carbon_mob,
 					alert_pic = carbon_mob,
 					role_name_text = "Bloodling Thrall",
-					)
+				)
 
 		if(isnull(chosen_one))
 			is_infecting = FALSE


### PR DESCRIPTION

## About The Pull Request

simply adds an ignore category for bloodling thralls, so they have a "never for this round" option.

## Why It's Good For The Game

I DO NOT WANT TO PLAY A BLOODLING THRALL SHUT UP GAME

## Changelog
:cl:
qol: You can now properly disable prompts for bloodling thralls as a ghost.
/:cl:
