### PR TITLE
Prevent shamshir sabre from being used to make a Powercrepe

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -116,6 +116,7 @@
 		/obj/item/stock_parts/power_store/cell/super =1,
 		/obj/item/melee/sabre = 1
 	)
+	blacklist = list(/obj/item/melee/sabre/cargo)
 	result = /obj/item/food/powercrepe
 	category = CAT_MISCFOOD
 


### PR DESCRIPTION

## About The Pull Request

this makes it so you need the CAPTAIN'S SABRE to make a powercrepe... not an easily orderable shamshir sabre from cargo.

## Why It's Good For The Game

no way this is intended, especially with how much the shamshir was nerfed.

## Changelog
:cl:
balance: You can no longer craft a Powercrepe using a shamshir sabre.
/:cl:

