### PR TITLE
Temporarily disabled surplus crates until I find why they are bugged

### DIFF
--- a/code/modules/uplink/uplink_items/bundle.dm
+++ b/code/modules/uplink/uplink_items/bundle.dm
@@ -71,7 +71,7 @@
 	cost = 25
 	stock_key = UPLINK_SHARED_STOCK_KITS
 	purchasable_from = ~(UPLINK_NUKE_OPS | UPLINK_CLOWN_OPS)
-
+/*
 /datum/uplink_item/bundles_tc/surplus
 	name = "Syndicate Surplus Crate"
 	desc = "A dusty crate from the back of the Syndicate warehouse delivered directly to you via Supply Pod. \
@@ -261,7 +261,7 @@
 
 	// return the source, this is so the round-end uplink section shows how many TC the traitor spent on us (20TC) and a radio icon. Instead of 0 TC and a blank one
 	return source
-
+*/
 //pain
 ///Check if we should ignore handler locked_entries or not
 /datum/uplink_item/bundles_tc/random/proc/check_ignore_locked(datum/uplink_handler/handler)


### PR DESCRIPTION

## About The Pull Request
Currently surplus crates seem to be generating like 1000 items everytime way over their TC limits, no idea why and while I look for issue, just PR to disable them for now

## Why It's Good For The Game
100000 tot items is pretty aids

## Testing
yes compiled, no errors, gone from uplink, nothing else gone
## Changelog

:cl:
fix: temporarily disabled surplus crates from uplink
/:cl:

## Pre-Merge Checklist

- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

